### PR TITLE
Update json-LD export, threshold labels and octave compatibility 

### DIFF
--- a/exporter/spm_provenance.m
+++ b/exporter/spm_provenance.m
@@ -32,10 +32,10 @@ classdef spm_provenance < handle
 % p.hadMember(collection,entity)
 % p.bundle(id,b)
 %__________________________________________________________________________
-% Copyright (C) 2013-2015 Wellcome Trust Centre for Neuroimaging
+% Copyright (C) 2013-2017 Wellcome Trust Centre for Neuroimaging
 
 % Guillaume Flandin
-% $Id: spm_provenance.m 6903 2016-10-12 11:36:41Z guillaume $
+% $Id: spm_provenance.m 7057 2017-04-13 16:45:49Z guillaume $
 
 
 %-Properties
@@ -658,6 +658,28 @@ methods (Access='private')
                     end
                 end
             end
+            % remove trailing colon
+            for n=1:numel(node)
+                if iscell(node{n})
+                    for k=1:numel(node{n})
+                        if isstruct(node{n}{k})
+                            if isfield(node{n}{k},'value') && node{n}{k}.value(end) == ':'
+                                node{n}{k}.value = node{n}{k}.value(1:end-1);
+                            elseif isfield(node{n}{k},'id') && node{n}{k}.id(end) == ':'
+                                node{n}{k}.id = node{n}{k}.id(1:end-1);
+                            end
+                        else
+                            if node{n}{k}(end) == ':'
+                                node{n}{k} = node{n}{k}(1:end-1);
+                            end
+                        end
+                    end
+                else
+                    if node{n}(end) == ':'
+                        node{n} = node{n}(1:end-1);
+                    end
+                end
+            end
             % serialize node
             str = [str o o sprintf('{\n')];
             for j=1:size(node,1)
@@ -828,7 +850,7 @@ methods (Access='private')
                         attr = obj.stack{j}{end};
                         if ~isempty(attr)
                             url_ann = sprintf('http://annot/ann%d',annn);
-                            attrlist = [];
+                            attrlist = '';
                             for k=1:2:numel(attr)
                                 attribute = attr{k};
                                 literal = attr{k+1};

--- a/exporter/spm_results_nidm.m
+++ b/exporter/spm_results_nidm.m
@@ -342,7 +342,7 @@ pp.add_namespace('nidm','http://purl.org/nidash/nidm#');
 pp.add_namespace('niiri','http://iri.nidash.org/');
 pp.add_namespace('spm','http://purl.org/nidash/spm#');
 pp.add_namespace('neurolex','http://neurolex.org/wiki/');
-pp.add_namespace('crypto','http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#');
+pp.add_namespace('crypto','http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/');
 pp.add_namespace('dct','http://purl.org/dc/terms/');
 pp.add_namespace('nfo','http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#');
 pp.add_namespace('dc','http://purl.org/dc/elements/1.1/');

--- a/spmexport/ex_spm_HRF_informed_basis/nidm.json
+++ b/spmexport/ex_spm_HRF_informed_basis/nidm.json
@@ -1,0 +1,11006 @@
+{
+  "prefix": {
+    "nidm": "http://purl.org/nidash/nidm#",
+    "niiri": "http://iri.nidash.org/",
+    "spm": "http://purl.org/nidash/spm#",
+    "neurolex": "http://neurolex.org/wiki/",
+    "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/",
+    "dct": "http://purl.org/dc/terms/",
+    "nfo": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#",
+    "dc": "http://purl.org/dc/elements/1.1/",
+    "dctype": "http://purl.org/dc/dcmitype/",
+    "obo": "http://purl.obolibrary.org/obo/",
+    "nidm_NIDMResults": "http://purl.org/nidash/nidm#NIDM_0000027",
+    "nidm_version": "http://purl.org/nidash/nidm#NIDM_0000127",
+    "nidm_spm_results_nidm": "http://purl.org/nidash/nidm#NIDM_0000168",
+    "nidm_softwareVersion": "http://purl.org/nidash/nidm#NIDM_0000122",
+    "nidm_NIDMResultsExport": "http://purl.org/nidash/nidm#NIDM_0000166"
+  },
+  "entity": {
+    "niiri:4a6924b313422b14d65ae05690ac91e1": {
+      "prov:type": [
+        {
+        "$": "prov:Bundle",
+        "type": "xsd:QName"
+        },
+        {
+        "$": "nidm_NIDMResults:",
+        "type": "xsd:QName"
+        }
+      ],
+      "prov:label": {
+        "$": "NIDM-Results",
+        "type": "xsd:string"
+      },
+      "nidm_version:": {
+        "$": "1.3.0",
+        "type": "xsd:string"
+      }
+    }
+  },
+  "activity": {
+    "niiri:abeca6887e37b18f4340b7939a0218cb": {
+      "prov:type": {
+        "$": "nidm_NIDMResultsExport:",
+        "type": "xsd:QName"
+      },
+      "prov:label": {
+        "$": "NIDM-Results export",
+        "type": "xsd:string"
+      }
+    }
+  },
+  "agent": {
+    "niiri:8261b150c67f791518958870bbf9df42": {
+      "prov:type": [
+        {
+        "$": "nidm_spm_results_nidm:",
+        "type": "xsd:QName"
+        },
+        {
+        "$": "prov:SoftwareAgent",
+        "type": "xsd:QName"
+        }
+      ],
+      "prov:label": {
+        "$": "spm_results_nidm",
+        "type": "xsd:string"
+      },
+      "nidm_softwareVersion:": {
+        "$": "12.7057",
+        "type": "xsd:string"
+      }
+    }
+  },
+  "wasGeneratedBy": {
+    "_:wGB5": {
+      "prov:entity": "niiri:4a6924b313422b14d65ae05690ac91e1",
+      "prov:activity": "niiri:abeca6887e37b18f4340b7939a0218cb",
+      "prov:time": "2017-04-19T12:17:24"
+    }
+  },
+  "wasAssociatedWith": {
+    "_:wAW4": {
+      "prov:activity": "niiri:abeca6887e37b18f4340b7939a0218cb",
+      "prov:agent": "niiri:8261b150c67f791518958870bbf9df42"
+    }
+  },
+  "bundle": {
+    "niiri:4a6924b313422b14d65ae05690ac91e1": {
+    "prefix": {
+        "nidm_softwareVersion": "http://purl.org/nidash/nidm#NIDM_0000122",
+        "nidm_CoordinateSpace": "http://purl.org/nidash/nidm#NIDM_0000016",
+        "nidm_voxelToWorldMapping": "http://purl.org/nidash/nidm#NIDM_0000132",
+        "nidm_voxelUnits": "http://purl.org/nidash/nidm#NIDM_0000133",
+        "nidm_voxelSize": "http://purl.org/nidash/nidm#NIDM_0000131",
+        "nidm_inWorldCoordinateSystem": "http://purl.org/nidash/nidm#NIDM_0000105",
+        "nidm_numberOfDimensions": "http://purl.org/nidash/nidm#NIDM_0000112",
+        "nidm_dimensionsInVoxels": "http://purl.org/nidash/nidm#NIDM_0000090",
+        "nlx_Imaginginstrument": "http://uri.neuinfo.org/nif/nifstd/birnlex_2094",
+        "nlx_Magneticresonanceimagingscanner": "http://uri.neuinfo.org/nif/nifstd/birnlex_2100",
+        "nidm_grandMeanScaling": "http://purl.org/nidash/nidm#NIDM_0000096",
+        "nidm_targetIntensity": "http://purl.org/nidash/nidm#NIDM_0000124",
+        "nidm_hasMRIProtocol": "http://purl.org/nidash/nidm#NIDM_0000172",
+        "nlx_FunctionalMRIprotocol": "http://uri.neuinfo.org/nif/nifstd/birnlex_2250",
+        "nidm_Data": "http://purl.org/nidash/nidm#NIDM_0000169",
+        "spm_DCTDriftModel": "http://purl.org/nidash/spm#SPM_0000002",
+        "spm_SPMsDriftCutoffPeriod": "http://purl.org/nidash/spm#SPM_0000001",
+        "nidm_hasDriftModel": "http://purl.org/nidash/nidm#NIDM_0000088",
+        "nidm_hasHRFBasis": "http://purl.org/nidash/nidm#NIDM_0000102",
+        "spm_SPMsCanonicalHRF": "http://purl.org/nidash/spm#SPM_0000004",
+        "spm_SPMsTemporalDerivative": "http://purl.org/nidash/spm#SPM_0000006",
+        "spm_SPMsDispersionDerivative": "http://purl.org/nidash/spm#SPM_0000003",
+        "nidm_DesignMatrix": "http://purl.org/nidash/nidm#NIDM_0000019",
+        "nidm_regressorNames": "http://purl.org/nidash/nidm#NIDM_0000021",
+        "nidm_hasErrorDependence": "http://purl.org/nidash/nidm#NIDM_0000100",
+        "obo_Toeplitzcovariancestructure": "http://purl.obolibrary.org/obo/STATO_0000357",
+        "nidm_dependenceMapWiseDependence": "http://purl.org/nidash/nidm#NIDM_0000089",
+        "nidm_ConstantParameter": "http://purl.org/nidash/nidm#NIDM_0000072",
+        "nidm_errorVarianceHomogeneous": "http://purl.org/nidash/nidm#NIDM_0000094",
+        "nidm_varianceMapWiseDependence": "http://purl.org/nidash/nidm#NIDM_0000126",
+        "nidm_IndependentParameter": "http://purl.org/nidash/nidm#NIDM_0000073",
+        "nidm_withEstimationMethod": "http://purl.org/nidash/nidm#NIDM_0000134",
+        "obo_generalizedleastsquaresestimation": "http://purl.obolibrary.org/obo/STATO_0000372",
+        "nidm_ErrorModel": "http://purl.org/nidash/nidm#NIDM_0000023",
+        "nidm_hasErrorDistribution": "http://purl.org/nidash/nidm#NIDM_0000101",
+        "obo_normaldistribution": "http://purl.obolibrary.org/obo/STATO_0000227",
+        "nidm_ModelParametersEstimation": "http://purl.org/nidash/nidm#NIDM_0000056",
+        "nidm_MaskMap": "http://purl.org/nidash/nidm#NIDM_0000054",
+        "nidm_isUserDefined": "http://purl.org/nidash/nidm#NIDM_0000106",
+        "nidm_inCoordinateSpace": "http://purl.org/nidash/nidm#NIDM_0000104",
+        "nidm_GrandMeanMap": "http://purl.org/nidash/nidm#NIDM_0000033",
+        "nidm_maskedMedian": "http://purl.org/nidash/nidm#NIDM_0000107",
+        "nidm_ParameterEstimateMap": "http://purl.org/nidash/nidm#NIDM_0000061",
+        "nidm_ResidualMeanSquaresMap": "http://purl.org/nidash/nidm#NIDM_0000066",
+        "nidm_ReselsPerVoxelMap": "http://purl.org/nidash/nidm#NIDM_0000144",
+        "obo_contrastweightmatrix": "http://purl.obolibrary.org/obo/STATO_0000323",
+        "nidm_statisticType": "http://purl.org/nidash/nidm#NIDM_0000123",
+        "obo_tstatistic": "http://purl.obolibrary.org/obo/STATO_0000176",
+        "nidm_contrastName": "http://purl.org/nidash/nidm#NIDM_0000085",
+        "nidm_ContrastEstimation": "http://purl.org/nidash/nidm#NIDM_0000001",
+        "nidm_StatisticMap": "http://purl.org/nidash/nidm#NIDM_0000076",
+        "nidm_errorDegreesOfFreedom": "http://purl.org/nidash/nidm#NIDM_0000093",
+        "nidm_effectDegreesOfFreedom": "http://purl.org/nidash/nidm#NIDM_0000091",
+        "nidm_ContrastMap": "http://purl.org/nidash/nidm#NIDM_0000002",
+        "nidm_ContrastStandardErrorMap": "http://purl.org/nidash/nidm#NIDM_0000013",
+        "obo_statistic": "http://purl.obolibrary.org/obo/STATO_0000039",
+        "nidm_PValueUncorrected": "http://purl.org/nidash/nidm#NIDM_0000160",
+        "obo_FWERadjustedpvalue": "http://purl.obolibrary.org/obo/OBI_0001265",
+        "nidm_HeightThreshold": "http://purl.org/nidash/nidm#NIDM_0000034",
+        "nidm_equivalentThreshold": "http://purl.org/nidash/nidm#NIDM_0000161",
+        "nidm_ExtentThreshold": "http://purl.org/nidash/nidm#NIDM_0000026",
+        "nidm_clusterSizeInVoxels": "http://purl.org/nidash/nidm#NIDM_0000084",
+        "nidm_clusterSizeInResels": "http://purl.org/nidash/nidm#NIDM_0000156",
+        "nidm_PeakDefinitionCriteria": "http://purl.org/nidash/nidm#NIDM_0000063",
+        "nidm_maxNumberOfPeaksPerCluster": "http://purl.org/nidash/nidm#NIDM_0000108",
+        "nidm_minDistanceBetweenPeaks": "http://purl.org/nidash/nidm#NIDM_0000109",
+        "nidm_ClusterDefinitionCriteria": "http://purl.org/nidash/nidm#NIDM_0000007",
+        "nidm_hasConnectivityCriterion": "http://purl.org/nidash/nidm#NIDM_0000099",
+        "nidm_voxel18connected": "http://purl.org/nidash/nidm#NIDM_0000128",
+        "nidm_Inference": "http://purl.org/nidash/nidm#NIDM_0000049",
+        "nidm_hasAlternativeHypothesis": "http://purl.org/nidash/nidm#NIDM_0000097",
+        "nidm_OneTailedTest": "http://purl.org/nidash/nidm#NIDM_0000060",
+        "nidm_SearchSpaceMaskMap": "http://purl.org/nidash/nidm#NIDM_0000068",
+        "nidm_searchVolumeInVoxels": "http://purl.org/nidash/nidm#NIDM_0000121",
+        "nidm_searchVolumeInUnits": "http://purl.org/nidash/nidm#NIDM_0000136",
+        "nidm_reselSizeInVoxels": "http://purl.org/nidash/nidm#NIDM_0000148",
+        "nidm_searchVolumeInResels": "http://purl.org/nidash/nidm#NIDM_0000149",
+        "spm_searchVolumeReselsGeometry": "http://purl.org/nidash/spm#SPM_0000010",
+        "nidm_noiseFWHMInVoxels": "http://purl.org/nidash/nidm#NIDM_0000159",
+        "nidm_noiseFWHMInUnits": "http://purl.org/nidash/nidm#NIDM_0000157",
+        "nidm_randomFieldStationarity": "http://purl.org/nidash/nidm#NIDM_0000120",
+        "nidm_expectedNumberOfVoxelsPerCluster": "http://purl.org/nidash/nidm#NIDM_0000143",
+        "nidm_expectedNumberOfClusters": "http://purl.org/nidash/nidm#NIDM_0000141",
+        "nidm_heightCriticalThresholdFWE05": "http://purl.org/nidash/nidm#NIDM_0000147",
+        "nidm_heightCriticalThresholdFDR05": "http://purl.org/nidash/nidm#NIDM_0000146",
+        "spm_smallestSignificantClusterSizeInVoxelsFWE05": "http://purl.org/nidash/spm#SPM_0000014",
+        "spm_smallestSignificantClusterSizeInVoxelsFDR05": "http://purl.org/nidash/spm#SPM_0000013",
+        "nidm_ExcursionSetMap": "http://purl.org/nidash/nidm#NIDM_0000025",
+        "nidm_numberOfSupraThresholdClusters": "http://purl.org/nidash/nidm#NIDM_0000111",
+        "nidm_pValue": "http://purl.org/nidash/nidm#NIDM_0000114",
+        "nidm_hasClusterLabelsMap": "http://purl.org/nidash/nidm#NIDM_0000098",
+        "nidm_hasMaximumIntensityProjection": "http://purl.org/nidash/nidm#NIDM_0000138",
+        "nidm_ClusterLabelsMap": "http://purl.org/nidash/nidm#NIDM_0000008",
+        "nidm_SupraThresholdCluster": "http://purl.org/nidash/nidm#NIDM_0000070",
+        "nidm_pValueUncorrected": "http://purl.org/nidash/nidm#NIDM_0000116",
+        "nidm_pValueFWER": "http://purl.org/nidash/nidm#NIDM_0000115",
+        "nidm_qValueFDR": "http://purl.org/nidash/nidm#NIDM_0000119",
+        "nidm_clusterLabelId": "http://purl.org/nidash/nidm#NIDM_0000082",
+        "nidm_Peak": "http://purl.org/nidash/nidm#NIDM_0000062",
+        "nidm_equivalentZStatistic": "http://purl.org/nidash/nidm#NIDM_0000092",
+        "nidm_Coordinate": "http://purl.org/nidash/nidm#NIDM_0000015",
+        "nidm_coordinateVector": "http://purl.org/nidash/nidm#NIDM_0000086"
+    },
+    "entity": {
+        "niiri:001c0dbfa3e3cb7025a88555be3739cd": {
+            "prov:type": {
+                "$": "nidm_CoordinateSpace:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Coordinate space 1",
+                "type": "xsd:string"
+            },
+            "nidm_voxelToWorldMapping:": {
+                "$": "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]",
+                "type": "xsd:string"
+            },
+            "nidm_voxelUnits:": {
+                "$": "[\"mm\", \"mm\", \"mm\"]",
+                "type": "xsd:string"
+            },
+            "nidm_voxelSize:": {
+                "$": "[2, 2, 2]",
+                "type": "xsd:string"
+            },
+            "nidm_inWorldCoordinateSystem:": {
+                "$": "nidm_Ixi549CoordinateSystem:",
+                "type": "xsd:string"
+            },
+            "nidm_numberOfDimensions:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_dimensionsInVoxels:": {
+                "$": "[79,95,79]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c1b405a8360aa137d6b3059c99d29f33": {
+            "prov:type": [
+                {
+                "$": "prov:Collection",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Data:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Data",
+                "type": "xsd:string"
+            },
+            "nidm_grandMeanScaling:": {
+                "$": "true",
+                "type": "xsd:boolean"
+            },
+            "nidm_targetIntensity:": {
+                "$": "100",
+                "type": "xsd:float"
+            },
+            "nidm_hasMRIProtocol:": {
+                "$": "nlx_FunctionalMRIprotocol:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b62a1b2d76f025e49ec6138bb72cc749": {
+            "prov:type": {
+                "$": "spm_DCTDriftModel:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "SPM's DCT Drift Model",
+                "type": "xsd:string"
+            },
+            "spm_SPMsDriftCutoffPeriod:": {
+                "$": "128",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d36d45f811e2c1d8f3d5e1b6d9405158": {
+            "prov:type": {
+                "$": "nidm_DesignMatrix:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "DesignMatrix.csv",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "DesignMatrix.csv",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "text/csv",
+                "type": "xsd:string"
+            },
+            "dc:description": {
+                "$": "niiri:6cac7ac7016b4d63113dc01cb939523d",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Design Matrix",
+                "type": "xsd:string"
+            },
+            "nidm_regressorNames:": {
+                "$": "[\"Sn(1) to*bf(1)\", \"Sn(1) to*bf(2)\", \"Sn(1) to*bf(3)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) \ntask001 co*bf(2)\", \"Sn(1) \ntask001 co*bf(3)\", \"Sn(1) constant\"]",
+                "type": "xsd:string"
+            },
+            "nidm_hasDriftModel:": {
+                "$": "niiri:b62a1b2d76f025e49ec6138bb72cc749",
+                "type": "xsd:string"
+            },
+            "nidm_hasHRFBasis:": [
+                {
+                "$": "spm_SPMsCanonicalHRF:",
+                "type": "xsd:string"
+                },
+                {
+                "$": "spm_SPMsTemporalDerivative:",
+                "type": "xsd:string"
+                },
+                {
+                "$": "spm_SPMsDispersionDerivative:",
+                "type": "xsd:string"
+                }
+            ]
+        },
+        "niiri:6cac7ac7016b4d63113dc01cb939523d": {
+            "prov:type": {
+                "$": "dctype:Image",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "DesignMatrix.png",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "DesignMatrix.png",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/png",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:61c272100996293e9d28d33c83a38df1": {
+            "prov:type": {
+                "$": "nidm_ErrorModel:",
+                "type": "xsd:QName"
+            },
+            "nidm_hasErrorDistribution:": {
+                "$": "obo_normaldistribution:",
+                "type": "xsd:string"
+            },
+            "nidm_hasErrorDependence:": {
+                "$": "obo_Toeplitzcovariancestructure:",
+                "type": "xsd:string"
+            },
+            "nidm_dependenceMapWiseDependence:": {
+                "$": "nidm_ConstantParameter:",
+                "type": "xsd:string"
+            },
+            "nidm_errorVarianceHomogeneous:": {
+                "$": "true",
+                "type": "xsd:boolean"
+            },
+            "nidm_varianceMapWiseDependence:": {
+                "$": "nidm_IndependentParameter:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7f004a26944135c1d554914761e27b2e": {
+            "prov:type": {
+                "$": "nidm_MaskMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "Mask.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nidm_isUserDefined:": {
+                "$": "false",
+                "type": "xsd:boolean"
+            },
+            "nfo:fileName": {
+                "$": "Mask.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Mask",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:001c0dbfa3e3cb7025a88555be3739cd",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a07cf2721b41e6ba9ec7e48fb167fb89": {
+            "prov:type": {
+                "$": "nidm_MaskMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "mask.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "36929e1f5f4143bd9cc818cd896a25f129961fab208c3a4438555f40444c08347b359142ee8c53ece6e8cca1627f49db0788a1fd3b9e2ecaef61999c6c6c67ac",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f5d9995c28e5cb26e1839c59c9b5bbff": {
+            "prov:type": {
+                "$": "nidm_GrandMeanMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "GrandMean.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "GrandMean.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Grand Mean Map",
+                "type": "xsd:string"
+            },
+            "nidm_maskedMedian:": {
+                "$": "116.329124450684",
+                "type": "xsd:float"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:001c0dbfa3e3cb7025a88555be3739cd",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "ec99afa6698e7e3dee3ab79feba8f2cd2a493c5697526587e163285b64c4f5e1f4ea33dde05f107f19022d0794fbd73ebedcfd84a9efa34bd37e4d1f13495c8b",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2593c500a2e3bba4242f56e76e61b2d9": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0001.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0001.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 1",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:001c0dbfa3e3cb7025a88555be3739cd",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "3497224bcc9542afe414ca8c9c2089d65f208f236583cd9e934f85d3807ee7c7b51da6a5281e4603b9dbebb087c9a69e1b328eb16c1505f10475cd22bacb5b03",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:052b380e570273544f6f2d746785485a": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0001.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "3497224bcc9542afe414ca8c9c2089d65f208f236583cd9e934f85d3807ee7c7b51da6a5281e4603b9dbebb087c9a69e1b328eb16c1505f10475cd22bacb5b03",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:dd5f95dd48f703c72358e4165ae1e39d": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0002.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0002.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 2",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:001c0dbfa3e3cb7025a88555be3739cd",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "dd73295132622e8dc5981d7ed38df121358b5db54cc7f22f1fd3e6312db59dcbefd8e4c631ef5d251f634979c0793c6c3ab96dd979eca1f0e546f4811ad7f1dd",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6278c189e4aaeee91d9763d5764523da": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0002.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "dd73295132622e8dc5981d7ed38df121358b5db54cc7f22f1fd3e6312db59dcbefd8e4c631ef5d251f634979c0793c6c3ab96dd979eca1f0e546f4811ad7f1dd",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e9cc9119a66cf374f5bd09a02cb7f0c6": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0003.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0003.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 3",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:001c0dbfa3e3cb7025a88555be3739cd",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "6370516cf48e70e7d88c496fb0763827a4522075468661c6d78139565e0213199afa65e9395ef938140ccd322f0c245fbd271aac521d3b5805aaa27422466a14",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1a2a75047181a94977af5143fbc2a3f6": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0003.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "6370516cf48e70e7d88c496fb0763827a4522075468661c6d78139565e0213199afa65e9395ef938140ccd322f0c245fbd271aac521d3b5805aaa27422466a14",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1dfac129a8bcadeb38a137a5e7f33cc7": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0004.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0004.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 4",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:001c0dbfa3e3cb7025a88555be3739cd",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "3e67878a2f7df58413a4a193334e8c451dde1eb8918edc712798901996e0a3479f7bb72c086d81a7f852058d413eac6b1644b8b02f8255e0159b41798f21713a",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:386a35d1945daf4a9951952ed1cb6ec8": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0004.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "3e67878a2f7df58413a4a193334e8c451dde1eb8918edc712798901996e0a3479f7bb72c086d81a7f852058d413eac6b1644b8b02f8255e0159b41798f21713a",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d9bf5437aa08a1459fe0182fd947a96c": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0005.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0005.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 5",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:001c0dbfa3e3cb7025a88555be3739cd",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "5b940e22ba41618a9ed4327d055717b03ce647c4cab1acf5ad139ca6721e873813a8efc4334200ea95d052590e360fa714b182bca20d0b36bf02afddbdf14ba5",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:02af90ad0dd6b14db8aaaf0f3cf245f4": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0005.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "5b940e22ba41618a9ed4327d055717b03ce647c4cab1acf5ad139ca6721e873813a8efc4334200ea95d052590e360fa714b182bca20d0b36bf02afddbdf14ba5",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4c0ab1c8535ea87131668d8df8033987": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0006.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0006.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 6",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:001c0dbfa3e3cb7025a88555be3739cd",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "2ddfa0fd58e83c5cac4bfcd3b08846aabb9a0bf0bab1b0b9d906f276fb5037e45ee37a98b676dde3c2db7570c1f383983a10d9ebc294dcce50016bb3ec31890e",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6f1af1cdc138aa878dd6288c45630725": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0006.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "2ddfa0fd58e83c5cac4bfcd3b08846aabb9a0bf0bab1b0b9d906f276fb5037e45ee37a98b676dde3c2db7570c1f383983a10d9ebc294dcce50016bb3ec31890e",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:fcd83b6089c28ff32851390322727691": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0007.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0007.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 7",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:001c0dbfa3e3cb7025a88555be3739cd",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "ec648b94e914a34b754e86a51d22e001078d5e2aabd640e2baa8de388e72c112a75aa2f709c2f8066f86a99b87026221eeaa3d5418385eae7d32a5f535924e79",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2e56c7cfc04eb22f960f4187216b007b": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0007.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "ec648b94e914a34b754e86a51d22e001078d5e2aabd640e2baa8de388e72c112a75aa2f709c2f8066f86a99b87026221eeaa3d5418385eae7d32a5f535924e79",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:634e834296ec47451bb5dba35c6ab090": {
+            "prov:type": {
+                "$": "nidm_ResidualMeanSquaresMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ResidualMeanSquares.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ResidualMeanSquares.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Residual Mean Squares Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:001c0dbfa3e3cb7025a88555be3739cd",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "ecbbff7f5c8f82725791661876f19d56ea83fabf87af9ff25e36ff5a33c0111650ca0da870a7a29bb87c6779fd36f6d12d9fa62d2251903dd498a9bec3297e1e",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:239382281394fda80fab27e1b812d896": {
+            "prov:type": {
+                "$": "nidm_ResidualMeanSquaresMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "ResMS.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "33f469f7adf069c8eeaa3dff460c85a3328dfa41621be4c0d400a832e5b2e92f671e5db6938c9a82dc16c81d4b60a3c0182c9be7723d1ad0236b249a1174a5d5",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d322a9aa3dcb86b056a502997edcb664": {
+            "prov:type": {
+                "$": "nidm_ReselsPerVoxelMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ReselsPerVoxel.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ReselsPerVoxel.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Resels per Voxel Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:001c0dbfa3e3cb7025a88555be3739cd",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "d4f5f4f076c45cc4f9481325ee5a43ca4edc8fbb928db288ee4ed93f0fa1368ef6267240398d71e7590990e133715b53d4455b95ee8a59baf13e4c6ea46e147f",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c83c0701812f37753b6efa1070796628": {
+            "prov:type": {
+                "$": "nidm_ReselsPerVoxelMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "RPV.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "7e5e04367e61ffae36c2b4af7de4b4e7c6f4877f660bb110d108a0b97a1a1f20ca9c18e49803e936dfbbf27bcf0d40918ce6daece3c736ca6056720a83964b1e",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7c291851e6747c0e2a7284a7cf2d75f4": {
+            "prov:type": {
+                "$": "obo_contrastweightmatrix:",
+                "type": "xsd:QName"
+            },
+            "nidm_statisticType:": {
+                "$": "obo_tstatistic:",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast: tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "[1, 0, 0, 0, 0, 0, 0]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:10f87872974544f0796133e8ec52cdb2": {
+            "prov:type": {
+                "$": "nidm_StatisticMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "TStatistic.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "TStatistic.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "T-Statistic Map: tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "nidm_statisticType:": {
+                "$": "obo_tstatistic:",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "nidm_errorDegreesOfFreedom:": {
+                "$": "93.9999999999637",
+                "type": "xsd:float"
+            },
+            "nidm_effectDegreesOfFreedom:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:001c0dbfa3e3cb7025a88555be3739cd",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "0a35119e4ab5eaf8da616907ac9aa8de8b5398967c85ac7a96d2bf22ced6e6f25871fd086d20db35df40bbb9015be8236120a48d04886378992fd53f27789a98",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8588d79c35677301f464c7e03b9d0496": {
+            "prov:type": {
+                "$": "nidm_StatisticMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "spmT_0001.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "1096728734b200447633666faffc81cab6f8aad61d9282f83169526dd1083f14150922528eafe7ec28f3f8c0094adb3ffd9941a696aebba046bd5c2df4966ab8",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5dae15d639ffe538568fccbf50b79da6": {
+            "prov:type": {
+                "$": "nidm_ContrastMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "Contrast.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "Contrast.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast Map: tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:001c0dbfa3e3cb7025a88555be3739cd",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "43d93cfdb352a3b8121c3e4758bd56286b7d9dfb5481860cb35941ceae021948c1cac3225a9829ceeb0997965dd1763161c4ba7db4bf47c0d2e69b5eaadd1658",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:32b2745bbaa52aa442354c21c92a29df": {
+            "prov:type": {
+                "$": "nidm_ContrastMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "con_0001.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "0f8a4e835300919afe716e102bd3b85b6c760194e65dbc88d259debb4b3976960f8cba854410eca817033e63c13824e28369fe6ba7d4fd6a8e87fecfd5b5fa88",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ebd0089167d8c9c6665b2ca9c440a044": {
+            "prov:type": {
+                "$": "nidm_ContrastStandardErrorMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ContrastStandardError.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ContrastStandardError.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast Standard Error Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:001c0dbfa3e3cb7025a88555be3739cd",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "ada9ee87facabea9234f59dc455a9cbbae3aac2e0f679b2092df326ce9aef04a46440093bbae0429482be18a2a6cac2c6773eda2c56058225c8e5b88cb3c4576",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:de3990bddd4e3e2e1f2945054f1f36a3": {
+            "prov:type": [
+                {
+                "$": "nidm_HeightThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_PValueUncorrected:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Height Threshold: p<0.001 (unc.)",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "0.000999500330571057",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentThreshold:": [
+                {
+                "$": "niiri:8afe323854d7859a15d4db33f7665a18",
+                "type": "xsd:string"
+                },
+                {
+                "$": "niiri:98610b96083c9f43ab45c0999d8fe8eb",
+                "type": "xsd:string"
+                }
+            ]
+        },
+        "niiri:8afe323854d7859a15d4db33f7665a18": {
+            "prov:type": [
+                {
+                "$": "nidm_HeightThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_statistic:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Height Threshold: T=3.179209)",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.17920858075464",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:98610b96083c9f43ab45c0999d8fe8eb": {
+            "prov:type": [
+                {
+                "$": "nidm_HeightThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_FWERadjustedpvalue:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Height Threshold: p<1.000000 (FWE)",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "0.999999999999999",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d8d46bf5012fbd722ed044231eea5a58": {
+            "prov:type": [
+                {
+                "$": "nidm_ExtentThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_statistic:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Extent Threshold: k>=0",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "0",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentThreshold:": [
+                {
+                "$": "niiri:46cd77a8cff744b6db5af8e81bd357b3",
+                "type": "xsd:string"
+                },
+                {
+                "$": "niiri:ac3e490dde5b8a24e242aeda0e6dd8ec",
+                "type": "xsd:string"
+                }
+            ]
+        },
+        "niiri:46cd77a8cff744b6db5af8e81bd357b3": {
+            "prov:type": [
+                {
+                "$": "nidm_ExtentThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_FWERadjustedpvalue:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Extent Threshold",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ac3e490dde5b8a24e242aeda0e6dd8ec": {
+            "prov:type": [
+                {
+                "$": "nidm_ExtentThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_PValueUncorrected:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Extent Threshold",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:acfbfae887d8a839f1adcb1b8b634982": {
+            "prov:type": {
+                "$": "nidm_PeakDefinitionCriteria:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak Definition Criteria",
+                "type": "xsd:string"
+            },
+            "nidm_maxNumberOfPeaksPerCluster:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_minDistanceBetweenPeaks:": {
+                "$": "8",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a3d478c3bf9b0a0df3146665a0a54e21": {
+            "prov:type": {
+                "$": "nidm_ClusterDefinitionCriteria:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Cluster Connectivity Criterion: 18",
+                "type": "xsd:string"
+            },
+            "nidm_hasConnectivityCriterion:": {
+                "$": "nidm_voxel18connected:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9806490c5d381029288eb9158bc777fc": {
+            "prov:type": {
+                "$": "nidm_SearchSpaceMaskMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "SearchSpaceMask.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "SearchSpaceMask.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Search Space Mask Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:001c0dbfa3e3cb7025a88555be3739cd",
+                "type": "xsd:string"
+            },
+            "nidm_searchVolumeInVoxels:": {
+                "$": "223057",
+                "type": "xsd:int"
+            },
+            "nidm_searchVolumeInUnits:": {
+                "$": "1784456",
+                "type": "xsd:float"
+            },
+            "nidm_reselSizeInVoxels:": {
+                "$": "64.4465447229551",
+                "type": "xsd:float"
+            },
+            "nidm_searchVolumeInResels:": {
+                "$": "3211.28154953333",
+                "type": "xsd:float"
+            },
+            "spm_searchVolumeReselsGeometry:": {
+                "$": "[6, 98.3662045394454, 977.160794848662, 3211.28154953333]",
+                "type": "xsd:string"
+            },
+            "nidm_noiseFWHMInVoxels:": {
+                "$": "[4.05938347949388, 4.00755777674972, 3.9615009606014]",
+                "type": "xsd:string"
+            },
+            "nidm_noiseFWHMInUnits:": {
+                "$": "[8.11876695898777, 8.01511555349943, 7.92300192120281]",
+                "type": "xsd:string"
+            },
+            "nidm_randomFieldStationarity:": {
+                "$": "true",
+                "type": "xsd:boolean"
+            },
+            "nidm_expectedNumberOfVoxelsPerCluster:": {
+                "$": "7.07032288352472",
+                "type": "xsd:float"
+            },
+            "nidm_expectedNumberOfClusters:": {
+                "$": "34.226779651245",
+                "type": "xsd:float"
+            },
+            "nidm_heightCriticalThresholdFWE05:": {
+                "$": "5.33200264240234",
+                "type": "xsd:float"
+            },
+            "nidm_heightCriticalThresholdFDR05:": {
+                "$": "4.72862100601196",
+                "type": "xsd:float"
+            },
+            "crypto:sha512": {
+                "$": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876",
+                "type": "xsd:string"
+            },
+            "spm_smallestSignificantClusterSizeInVoxelsFWE05:": {
+                "$": "89",
+                "type": "xsd:int"
+            },
+            "spm_smallestSignificantClusterSizeInVoxelsFDR05:": {
+                "$": "57",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:9b06d633f15370eacc4d439eebd44c49": {
+            "prov:type": {
+                "$": "nidm_ExcursionSetMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ExcursionSet.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ExcursionSet.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Excursion Set Map",
+                "type": "xsd:string"
+            },
+            "nidm_numberOfSupraThresholdClusters:": {
+                "$": "81",
+                "type": "xsd:int"
+            },
+            "nidm_pValue:": {
+                "$": "7.7268191844837e-12",
+                "type": "xsd:float"
+            },
+            "nidm_hasClusterLabelsMap:": {
+                "$": "niiri:e4fc4a47a5f1920aec26b66c27569703",
+                "type": "xsd:string"
+            },
+            "nidm_hasMaximumIntensityProjection:": {
+                "$": "niiri:9c62b1798f4f8af0cd04d4fa20563c6e",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:001c0dbfa3e3cb7025a88555be3739cd",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "39675dfc00efabc7475604def4a2e377153e063d723ca4bcab9e920bf8cb7d7451a6357e8143d3a1ad4ca53df911f5958e4104c06efd1ccdf0bd8282f7731c15",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e4fc4a47a5f1920aec26b66c27569703": {
+            "prov:type": {
+                "$": "nidm_ClusterLabelsMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ClusterLabels.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ClusterLabels.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Cluster Labels Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:001c0dbfa3e3cb7025a88555be3739cd",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "6a7560e351d44aa68539b8d837d178254fa0372d68dc9a7fb56936d90f49de9a58b6166a38670fef2966dae8b74c4c158204d3b0e441d8285a21e18bbadb3f39",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9c62b1798f4f8af0cd04d4fa20563c6e": {
+            "prov:type": {
+                "$": "dctype:Image",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "MaximumIntensityProjection.png",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "MaximumIntensityProjection.png",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/png",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:12d2dfb7ca155d963f6afeaa6467e598": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0001",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1368",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "21.2268944111869",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.72485138598936e-18",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1.11022302462516e-16",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1.10356481132569e-16",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "1",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:4c4f61059d1c51c5c453ad92e020752f": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0002",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3279",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "50.8793762969896",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.4763410441864e-32",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "2.81583624579098e-30",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "2",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:3ed2649db2465ff69f88971b546dd3be": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0003",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "373",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "5.78774240889817",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.11490153166348e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1.40839728834941e-06",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "8.33267560161855e-07",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "3",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:19dfc0bbb201d5f134704921caf5a176": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0004",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "590",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "9.15487405160837",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "9.40759361213501e-11",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "3.21991633356333e-09",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "2.54005027527645e-09",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "4",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:4ccbfde9cca6489f3110bef0431524c8": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0005",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "264",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "4.09641821970273",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.36245395227596e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "4.66313239355642e-05",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1.57655385906218e-05",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "5",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:3621a50b575ca90dbe183bb31ff4ae4a": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0006",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "289",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "4.48433661172003",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.88335668734106e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "2.01366325500718e-05",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "9.53103783349252e-06",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "6",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:7698728db1c0c3e20b495f064a9d5b55": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0007",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "126",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.95510869576721",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000261634077318802",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0089149162838621",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00235470669586922",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "7",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:379c20fa5cd6aefb39cb7419f030f9e5": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0008",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "89",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.3809894755816",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00144129625636545",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0481339228782848",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00972874973046682",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "8",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:4257936a93608ef43291e047551e5e0a": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0009",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "30",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.465502070420765",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0420589497514909",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.762963799671023",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.154853405903216",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "9",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:7017960274f85788b6b607f7d0046a76": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0010",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "57",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.884453933799453",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00774369776526604",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.232826147022924",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0448028227847535",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "10",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:a48da6310356eb94f99b1f1eb464e14b": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0011",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "266",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "4.12745169106411",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.27272470789903e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "4.35603193557066e-05",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1.57655385906218e-05",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "11",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:ada43746a7be5361f1b2127ddc7152ba": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0012",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "19",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.294817977933151",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0966300585947712",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.963386407334226",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.260901158205882",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "12",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:1c73b53acc2e3706c7dcdd4e4ed9e043": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0013",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "74",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.14823844037122",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00307403021089659",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0998682654704584",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0191535728525095",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "13",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:655978b5bff261f0bf396a1ddf498402": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0014",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "115",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.7844246032796",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000425937628174443",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0144727219239722",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00345009478821299",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "14",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:7dd3c3ae219e2bf1ef8176af9cc60fb9": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0015",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "32",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.496535541782149",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0365895245544304",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.714165296337838",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.141131023281374",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "15",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c96857fd42e1208395989b05eeab7a76": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0016",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "23",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.35688492065592",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0703481287722727",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.909985985343213",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.23742493460642",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "16",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:7a24a2bdbc61f7d8ab6a59738a57c24a": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0017",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "250",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "3.87918392017304",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.20582835219715e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "7.54955510265942e-05",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "2.23340120659961e-05",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "17",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c313dfc1d990322089b2bf63a219f16a": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0018",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "38",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.589635955866302",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.024488721191747",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.567498750748111",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.110199245362862",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "18",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:36e697e6ea3e7a7c4a67a505ebe4f340": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0019",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "39",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.605152691546994",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0229522301482354",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.544145192050433",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.109360626000416",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "19",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:ca1016af733ba1294614bfd4483de412": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0020",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "34",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.527569013143533",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0319229825328534",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.664663538653339",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.129288079258056",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "20",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:b4290f172c2ebe815ddf64763f6e95e4": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0021",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "16",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.248267770891074",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.124443287126479",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.985867709133163",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.314997070538899",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "21",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:94f389f115646fc7441e8fd9bf5ec119": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0022",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "37",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.57411922018561",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0261429923364831",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.59130676381177",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.111451704171323",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "22",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:7322fa4ccee32301d807a0b9f48ae02a": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0023",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "22",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.341368184975227",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0760173005561502",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.925862025073693",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.246296053801927",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "23",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c47c40f4ed2261336524231fb9108598": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0024",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "89",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.3809894755816",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00144129625636545",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0481339228782848",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00972874973046682",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "24",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:6c58a61aff8d76d3d5cdef392c46c0f7": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0025",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "42",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.65170289858907",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0189586344274602",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.477376000163114",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0959780867890173",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "25",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:bcf052d664b0eeef3576961aef494c62": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0026",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "44",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.682736369950455",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0167324384188216",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.435998000788451",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0903551674616366",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "26",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:d357fdfcedae064d3927d132b4915da3": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0027",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "10",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.155167356806922",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.217981749736363",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999424811828672",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.452731326375523",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "27",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:24181b91e1a2ff9fbf0d92f1f3c2fb91": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0028",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "6",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0931004140841529",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.338350015789837",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999990654647859",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.548127025579537",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "28",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:a67bcbe4c64e864d3c0091590a71ed79": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0029",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "7",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.108617149764845",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.300903995850594",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99996633240521",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.541627192531069",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "29",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:1e585aa0961f26eba6c099e7119148ec": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0030",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "5",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0775836784034608",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.383028244949947",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999997974762013",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.608338977273446",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "30",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:98543afde30df2ac94ce134cd8111cce": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0031",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "10",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.155167356806922",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.217981749736363",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999424811828672",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.452731326375523",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "31",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:3bfa5939740913923e9b589897f2c510": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0032",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "19",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.294817977933151",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0966300585947712",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.963386407334226",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.260901158205882",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "32",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:6b8ab0e3e0b633d638e47f3a9a10919b": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0033",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "7",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.108617149764845",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.300903995850594",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99996633240521",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.541627192531069",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "33",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:6029d0e967f2fb403f4a243e7a90b84c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0034",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "27",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.418951863378688",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0521437725170813",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.832154843505507",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.183636764081895",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "34",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:780f11b236810e190dea70c6c4340625": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0035",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "19",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.294817977933151",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0966300585947712",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.963386407334226",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.260901158205882",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "35",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:4a266b577331cf838f3af1933133ec8d": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0036",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "8",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.124133885445537",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.269071534113235",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999899911134192",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.518923672932668",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "36",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:b92193302c69c95fc0b8add50483e3ec": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0037",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0620669427227686",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.437360131610367",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999684601479",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.632610190364996",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "37",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:12aade66bcaf5ad22c9a147b7bac54d4": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0038",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0620669427227686",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.437360131610367",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999684601479",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.632610190364996",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "38",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:759e3fd5ac10013d9c1b96696769e455": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0039",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "13",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.201717563848998",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.162917148703869",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.996212803904192",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.388126148382747",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "39",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:b60ad51d906accfc87533b435bc4ab5f": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0040",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "21",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.325851449294535",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0822406296320071",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.94008521095715",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.256211192315099",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "40",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:5fe7263d129c8b5a1cdc4862389a329f": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0041",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "17",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.263784506571767",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.114194248436332",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.979929443300573",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.298378520107835",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "41",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:202e674801183017b435dafa4352a2f7": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0042",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "8",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.124133885445537",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.269071534113235",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999899911134192",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.518923672932668",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "42",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:63374171b8dfeb6c1b6216d9cb78dad1": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0043",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "13",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.201717563848998",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.162917148703869",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.996212803904192",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.388126148382747",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "43",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:4c28624df30b813b1284ed3adfd58c93": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0044",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "11",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.170684092487614",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.197250909946631",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.998830598770408",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.44381454737992",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "44",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:94a0a21f872815c64a69e94bd40bed9f": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0045",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "11",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.170684092487614",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.197250909946631",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.998830598770408",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.44381454737992",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "45",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:e7e4075c58abc76d658530459437df00": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0046",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "19",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.294817977933151",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0966300585947712",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.963386407334226",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.260901158205882",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "46",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:2dfef140265f92d79cbf32d31936df4d": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0047",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "10",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.155167356806922",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.217981749736363",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999424811828672",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.452731326375523",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "47",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:8fcfff082769fb86478d8224ec22e1d5": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0048",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "6",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0931004140841529",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.338350015789837",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999990654647859",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.548127025579537",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "48",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:a4a959bdb5adaac5ccc8bb0a1283b1eb": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0049",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0620669427227686",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.437360131610367",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999684601479",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.632610190364996",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "49",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:abd2bbf896a471cb7922efab5b613117": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0050",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0310334713613843",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.593940401999589",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999998516212",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.720222921163404",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "50",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:9c1cddc9922d8e70b3ba77c8f428e530": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0051",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0310334713613843",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.593940401999589",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999998516212",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.720222921163404",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "51",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:b2551e755f51f54d3855f624855bec3b": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0052",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0310334713613843",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.593940401999589",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999998516212",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.720222921163404",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "52",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:d98c34494ee425b9f343ad72efbe3802": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0053",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "6",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0931004140841529",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.338350015789837",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999990654647859",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.548127025579537",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "53",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:207cbb7814292b71aa3cbca2e251214d": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0054",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "6",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0931004140841529",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.338350015789837",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999990654647859",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.548127025579537",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "54",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:ef0e652ba790ef2ca62cbc45744044f2": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0055",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0155167356806922",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.720222921163404",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999998031",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.720222921163404",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "55",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:cdc735403e60da4bc8deca0b30c09e41": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0056",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "9",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.139650621126229",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.241710357573908",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999744673425561",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.489463474087164",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "56",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:14788c080d39de548f4f1517f2f3ecf2": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0057",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0155167356806922",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.720222921163404",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999998031",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.720222921163404",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "57",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:094abc2dabe5f1598098374da155b2d3": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0058",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0465502070420765",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.505265080891682",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999969133568",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.693669009359767",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "58",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:b0a53fec1935bbbef5f0340426dfcf5c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0059",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "6",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0931004140841529",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.338350015789837",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999990654647859",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.548127025579537",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "59",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:782cde190eab924f134e44bd95c8cd15": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0060",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0155167356806922",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.720222921163404",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999998031",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.720222921163404",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "60",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:9e85dca921757d3d2cafd0d606eb03c4": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0061",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0465502070420765",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.505265080891682",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999969133568",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.693669009359767",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "61",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:50e0654a2d55b1eb33c94eef3f0fbfc4": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0062",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0620669427227686",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.437360131610367",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999684601479",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.632610190364996",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "62",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:580546e61fe6caf5b928869b72d6563c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0063",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0465502070420765",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.505265080891682",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999969133568",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.693669009359767",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "63",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:fbb3da138dba0bffe41c80dfdc6d2813": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0064",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0155167356806922",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.720222921163404",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999998031",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.720222921163404",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "64",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:5b4ccbe46fbd067233c454fc4cd57139": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0065",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0310334713613843",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.593940401999589",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999998516212",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.720222921163404",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "65",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:4797fa2e5200fab8ae750cb321a6d94a": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0066",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "7",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.108617149764845",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.300903995850594",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99996633240521",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.541627192531069",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "66",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:e5840e49541fa7c2c73adfcf2cd18d5c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0067",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0155167356806922",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.720222921163404",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999998031",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.720222921163404",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "67",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:af9739fef5ce12c093a36fdad464fa2c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0068",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0310334713613843",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.593940401999589",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999998516212",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.720222921163404",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "68",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:4c1124c10677cacc7086dad2d88a0bd3": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0069",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0310334713613843",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.593940401999589",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999998516212",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.720222921163404",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "69",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:9a07890dc3c872a54f45939b26e95348": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0070",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0155167356806922",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.720222921163404",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999998031",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.720222921163404",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "70",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:4b972d45063ce95740be79e0f84be300": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0071",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0155167356806922",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.720222921163404",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999998031",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.720222921163404",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "71",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:6cc8de073a211f649503cbae3d7f79bb": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0072",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0620669427227686",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.437360131610367",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999684601479",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.632610190364996",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "72",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:713bd5e4d1057a61ec41d7be47cc6b30": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0073",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0155167356806922",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.720222921163404",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999998031",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.720222921163404",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "73",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f594ca28922a55744403546afac8880c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0074",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0155167356806922",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.720222921163404",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999998031",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.720222921163404",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "74",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:1f5837a9250f8adad81d9cf7febcb06c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0075",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0155167356806922",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.720222921163404",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999998031",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.720222921163404",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "75",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:4978ca959ffd9dac40bc74938928d142": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0076",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0155167356806922",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.720222921163404",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999998031",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.720222921163404",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "76",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:a8156b1e457954028b70ba39c8f61983": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0077",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0155167356806922",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.720222921163404",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999998031",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.720222921163404",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "77",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:b00bd2c845defd49f3843980d3290639": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0078",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0155167356806922",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.720222921163404",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999998031",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.720222921163404",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "78",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:0d91d576d381385281f1b2d5d2714a3f": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0079",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0310334713613843",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.593940401999589",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999998516212",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.720222921163404",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "79",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:1505e0b207a3a8175cc0be4688a0d7c4": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0080",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0155167356806922",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.720222921163404",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999998031",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.720222921163404",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "80",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:892dfa415e44d696ef37c9d6a5487e86": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0081",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0155167356806922",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.720222921163404",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999998031",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.720222921163404",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "81",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:2c0961e66823d0b4915540ec2c8e75c3": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0001",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:19d8deadd2c75bbb63869efc69e89c37",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "7.88613557815552",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "6.89124325286373",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.76534350973634e-12",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "6.16779698647818e-07",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "7.48669482771332e-06",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:19d8deadd2c75bbb63869efc69e89c37": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0001",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[46,16,24]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:dc3e0fe26c0acd9c6f782136679db557": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0002",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c19d9f98cac285d054aacbe754152f42",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "7.60659408569336",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "6.69768255888791",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.05875308520353e-11",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "2.36157334065901e-06",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1.28885586816361e-05",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c19d9f98cac285d054aacbe754152f42": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0002",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[34,24,-6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b44464753c802f3cbe64786acd87621a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0003",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4e00d7c81778064e4ade195a69b9d59f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.4533052444458",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.06995251985304",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.98957479047301e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0321858214443789",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00847322777156312",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4e00d7c81778064e4ade195a69b9d59f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0003",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[48,28,-14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:022fa4480e152e0d59d498475f76b9f0": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0004",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6d6a35e598da08a187498457924b6d27",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.8508505821228",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "6.15424052394884",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.77190612077527e-10",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "8.41349568295735e-05",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000225077260388439",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6d6a35e598da08a187498457924b6d27": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0004",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-8,12,52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d38af59f91ea10608b21a454c3db1947": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0005",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b8b98649dacb9658c6e4145e79d32fa4",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.70556163787842",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "6.04634484012323",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.40843941748892e-10",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.000165250377586079",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000249071340138561",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b8b98649dacb9658c6e4145e79d32fa4": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0005",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[8,20,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:02b9e7ac9b6dc3a6cfd2bf8d3a3e5d52": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0006",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:eead8fc2293f742ff4df91aaffb954e7",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.89195346832275",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.42145878799783",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.95573132635951e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00607574083875051",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00242918849696441",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:eead8fc2293f742ff4df91aaffb954e7": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0006",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[6,32,36]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4ef90c913a7c532cca2c6fd0f9681191": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0007",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:346c0c7ceec90148b035784c5b930f51",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.71233081817627",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "6.05139656868728",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.17977344244503e-10",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.000160149822946543",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000249071340138561",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:346c0c7ceec90148b035784c5b930f51": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0007",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[32,-90,-2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:36703567cc1d92a9cb3e152dc40b85ce": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0008",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f3c1332320c8a65eb857249d0977820a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.07869148254395",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.56799434588466",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.28844092062153e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00287395763954645",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00180477183683656",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f3c1332320c8a65eb857249d0977820a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0008",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[44,-72,-10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1aba48e406a0117ab013a8859ef28b04": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0009",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b35f033a94a89bf6738d5c904bec2b9f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.10857725143433",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.78656760604548",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.48289032462368e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.108873252801375",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0180107935900568",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b35f033a94a89bf6738d5c904bec2b9f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0009",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[28,-84,14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b5f5cf902b5b4771df855cfa8a376ac3": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0010",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f972a1eedb64fa761afd328be838d631",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.59459638595581",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.96318826880385",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.23681564989653e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.000275880338890366",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00032995692182998",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f972a1eedb64fa761afd328be838d631": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0010",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[52,-32,42]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:89bc5cfcdef0a83dbaf0b1406beae51a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0011",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:378ef40da87eb0e81caffcf1aa603cd4",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.12601184844971",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.6048323310884",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.04228329300682e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00232488579535362",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00168019830542188",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:378ef40da87eb0e81caffcf1aa603cd4": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0011",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[44,-70,50]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e9f1a1a5097af18399f0bd67a17a2cce": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0012",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ef1b9d6e9d5073cf34fe3d947b0e48b9",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.89449405670166",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.42346487564262",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.92273529822751e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0060156823124996",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00242918849696441",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ef1b9d6e9d5073cf34fe3d947b0e48b9": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0012",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[40,-62,50]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:bd38db380ba41e0ce1675948a69b7682": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0013",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4011c2782827b7caa0f649a873a23c28",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.03912734985352",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.53710291953986",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.53757930831944e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00340192895130376",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00190165765630454",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4011c2782827b7caa0f649a873a23c28": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0013",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-60,8,20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:881e790fc7e1a6f81af66a18ac093075": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0014",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f6e4f3dcf4db8f79777bc1b1b3a328ab",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.83134031295776",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.37349584041984",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.86122938067501e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0076941885115317",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0026939300902738",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f6e4f3dcf4db8f79777bc1b1b3a328ab": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0014",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-52,0,38]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e423ac92420c6449768391abb0fcedc9": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0015",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b93252e9cd350f950d0cda71d2f9ebc7",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.88419103622437",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.5987688944456",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.12497457574568e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.22375640863328",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0290725545238754",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b93252e9cd350f950d0cda71d2f9ebc7": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0015",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-46,6,28]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:edf2c8ccec7e4fd60e5909a7319ff0e6": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0016",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:9588b96c2d25cf9201a88c4be47c6c1d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.9007363319397",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.42839241341132",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.84319533472299e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00587055658900548",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00242918849696441",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:9588b96c2d25cf9201a88c4be47c6c1d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0016",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[32,4,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7c1ced347ec1ebede281534319058c3e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0017",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:82ffb9c44210599420a6de41fd0d1109",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.09700393676758",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.77694551087642",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.8988987889671e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.113189315105649",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0180107935900568",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:82ffb9c44210599420a6de41fd0d1109": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0017",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[40,24,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f17c1b76c4220010841c0f96ac1e3578": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0018",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ca3bb8d110a50afae2aead88e5bf0ca1",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.34982109069824",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.14112597656651",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.72802535455263e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.770025153200453",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.120618056446103",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ca3bb8d110a50afae2aead88e5bf0ca1": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0018",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[36,12,58]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:dbb88a311a9de3b4bed9021fb15312f5": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0019",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:02035963b589d505ac125194cd2ed04e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.83802509307861",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.37879507210251",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.74930015922814e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00749698476563887",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0026939300902738",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:02035963b589d505ac125194cd2ed04e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0019",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-28,-94,4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:73e895f0d508d2c610d6a3c106ee0716": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0020",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d23dece0568269e4842ecb6bdd2c6313",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.31375646591187",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.10972151362626",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.98068279155805e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.80686639972725",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.127448637088902",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d23dece0568269e4842ecb6bdd2c6313": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0020",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-32,-86,0]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9a97546675f609fff6f0b719b74412c8": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0021",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:57074d3ea076ff46e82b94244cdb912d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.64368534088135",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.51479672440726",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000220045357440024",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999986157595448",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.455711975517369",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:57074d3ea076ff46e82b94244cdb912d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0021",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-18,-92,6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f1fa028e954eb2428370317bd458e6d2": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0022",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f96d2bfba65dead2c46f9463120068d5",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.49678039550781",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.10524655927297",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.65181742173282e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0274162029530135",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00834610941271248",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f96d2bfba65dead2c46f9463120068d5": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0022",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-34,-2,52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8d9046504d5d30f7a737d3c5422a2f49": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0023",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a84c78c0af5824b28fc28c2b26191cf6",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.4477219581604",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.06541264724911",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.03758308892077e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0328526754070724",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00847322777156312",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a84c78c0af5824b28fc28c2b26191cf6": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0023",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-58,-30,-18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f28ae319db96c12f65d68cdf44c37228": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0024",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f6c38af20f2cc671e453a64d27f31859",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.28879737854004",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.93549802722869",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.99732443923106e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.058332304236273",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0124221993559286",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f6c38af20f2cc671e453a64d27f31859": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0024",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-62,-36,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:307f5f8fa2312eb0133eaf4fffbbeb80": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0025",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f0410a98f2844fad2156dd8693b4188f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.07126235961914",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.7555187910417",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "9.89687234609349e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.123339755499162",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0187591962334509",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f0410a98f2844fad2156dd8693b4188f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0025",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-60,-50,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a9639fbdbb1c26aee4c14242d935b468": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0026",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:32781cc47551b5a832493146ff9c76da",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.20113325119019",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.86326687921491",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.77319983152691e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0793447375400678",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0159079887522274",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:32781cc47551b5a832493146ff9c76da": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0026",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[32,40,16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1be33bac5492f3fdf9b7077a2b1176d4": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0027",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:3e74e91d33b6b30b2f135558c37b59ca",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.20966386795044",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.01871912540871",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.92576874012518e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.895902731954404",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.157816499218783",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3e74e91d33b6b30b2f135558c37b59ca": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0027",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[36,54,10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e24f477da65372897130f7d2cb1485f9": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0028",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:52e3b66db0b4b363b3aef5d680cb3d38",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.03298187255859",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.86304409189175",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.59913929287781e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.978124547666055",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.219902724174057",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:52e3b66db0b4b363b3aef5d680cb3d38": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0028",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[40,44,26]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9692edf724b92ae14d3e441c312e65cc": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0029",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:92b1a1b46104a64097b99dd6e7ca8b2b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.13718748092651",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.81032420567012",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.53428407773704e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0988296994641761",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0175971158742543",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:92b1a1b46104a64097b99dd6e7ca8b2b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0029",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-54,-46,58]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:614f41f29f9cf9d39c5a6367956b6357": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0030",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:daf4cabbd0bebc79beea7b9974028396",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.99936532974243",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.69549029807528",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.32983996270486e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.156049412961254",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.022013679767251",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:daf4cabbd0bebc79beea7b9974028396": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0030",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-36,-74,-34]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9e657853abbaa2650f24166bf90f5a81": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0031",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4558ece5294ed109fda5b20c0acd7480",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.7462682723999",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.4820421310153",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.69660714449882e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.333239579597568",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0434977534015138",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4558ece5294ed109fda5b20c0acd7480": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0031",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-36,-74,-14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2e831d1e6888a2d6174ba7de8443f206": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0032",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:3e60ee8d583858acc7f1b33e4313f57d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.14389324188232",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.96094551523189",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.73267835663826e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.93653316357533",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.176857016686839",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3e60ee8d583858acc7f1b33e4313f57d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0032",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-36,-68,-20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ed3b1a53734192dd232c2ea8bb681cb6": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0033",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:40b108d5097b549d75db0c77387e1498",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.64391040802002",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.51500008532851",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000219876923486684",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99998606648459",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.455711975517369",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:40b108d5097b549d75db0c77387e1498": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0033",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-30,-60,-16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:85627026074aa1f753b1ba3a22383b49": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0034",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4129b86d91f37cbd3cfd85da48f13011",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.72862100601196",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.46703637029677",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.96553251347243e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.349567174180407",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0444488399275926",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4129b86d91f37cbd3cfd85da48f13011": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0034",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-36,-40,-36]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5b0b1185c630b975f1f9cad7d863bc1c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0035",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f2ec576f7b577cf6e622416723b53710",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.67978620529175",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.42542829210121",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.81255631634703e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.397360911613874",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0513842337520043",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f2ec576f7b577cf6e622416723b53710": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0035",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-60,-16,26]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:fab4182c9396833dae1da711b91f9451": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0036",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:decf85102aef6761a4506398e5303491",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.54088401794434",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.30641743150185",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.29599105278689e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.55051926533838",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0758424529215363",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:decf85102aef6761a4506398e5303491": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0036",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[50,-46,-12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7e5c9c348e6bd97291db1b67455a7a1f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0037",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ec230d092645e527086b2f1dce92ba08",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.51589822769165",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.28490600256073",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "9.14082329439569e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.57981317377907",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0805429568785394",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ec230d092645e527086b2f1dce92ba08": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0037",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[60,-34,-8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:597a607f2ee07200862c89760cd037fb": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0038",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:cd92b44ba264e7cc475ed0b679367114",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.19524717330933",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.00607343097259",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.08682317079478e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.905888940180749",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.162816132797782",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:cd92b44ba264e7cc475ed0b679367114": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0038",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[56,-24,-2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a224964e93d3f6e2fff1835428d41f0b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0039",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:8f8db5ccf86c390cbae3a936ccb3061c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.51116132736206",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.28082423475359",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "9.31011908622548e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.585391408801539",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0805429568785394",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:8f8db5ccf86c390cbae3a936ccb3061c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0039",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-50,-60,54]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:33db15418b3eeb72fb3bb39cca81f286": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0040",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:5d62c65dd629aae3c79e44863f4a799b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.4765510559082",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.25096642679651",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.06425037911251e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.626226729794128",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0885762871613676",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:5d62c65dd629aae3c79e44863f4a799b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0040",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[16,14,64]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:81a9099168b6634f2d230e469992c262": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0041",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7d660acd245b9915dfc57669b02266cc",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.44478893280029",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.22351271935081",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.20261894772655e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.663529330330023",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0964832831947511",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7d660acd245b9915dfc57669b02266cc": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0041",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-46,-66,-6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:17c4f6eb3f8f149b496425d877516f57": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0042",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:957ba3e02ba9f7541dd7ea4cefdd9417",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.7491512298584",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.60983821739614",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000153194020339198",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999788466860359",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.372479477261378",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:957ba3e02ba9f7541dd7ea4cefdd9417": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0042",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-54,-64,-8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c953467c30386a10432f64759c9bb8fd": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0043",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c59f67096c4b44b8b8297453390de1f8",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.31687879562378",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.11244293455755",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.95747130057322e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.803781550096335",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.127448637088902",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c59f67096c4b44b8b8297453390de1f8": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0043",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-14,-98,-4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d71e3f367869829805aa71ff8bc7ef74": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0044",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:82a52b17a12ba7eb6db09eeafbf4fcce",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.24778032302856",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.0521041277855",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.53795317693983e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.866634079797035",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.146768392895167",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:82a52b17a12ba7eb6db09eeafbf4fcce": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0044",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-40,-40,44]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5c807bc9934434717c54df9aa0633275": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0045",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c29990573704aecde0476b3c3877f96c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.23215198516846",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.03842438550801",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.6905716773884e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.879129904028547",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.151175083557511",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c29990573704aecde0476b3c3877f96c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0045",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[22,38,12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:11314fb1e4bc9f2012db889602ef5ff2": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0046",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f117d9dc89b4a5963c653b2a0d8239cb",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.18517589569092",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.99723331404289",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.20435639625805e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.912505594315002",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.163982158985541",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f117d9dc89b4a5963c653b2a0d8239cb": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0046",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-50,-52,-18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c6737de02555142d2e915210fc79d292": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0047",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:dd04ce53e197fa1cb75e0dd575d45c3e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.12498378753662",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.94429624410211",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.00173349958122e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.945901344028104",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.182896629256048",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:dd04ce53e197fa1cb75e0dd575d45c3e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0047",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-36,-48,-18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0ff26bd6b3a8873a52756070401ef6f8": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0048",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:39f123da883019b5511ae2b52eca03b6",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.11004066467285",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.93112694489083",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.22743058098307e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.952599821815146",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.189060437644636",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:39f123da883019b5511ae2b52eca03b6": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0048",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[60,-26,-28]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d5151f32682a8c00255e289f2ab66642": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0049",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:461774f0f630ef77a6ebea4232af8dbf",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.08161401748657",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.90604483317219",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.69095562407595e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.963698528293292",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.203341942155421",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:461774f0f630ef77a6ebea4232af8dbf": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0049",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[28,44,-2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c734d9ef069f19ed65330db3f293e891": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0050",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:67d3c251cc11d74a757bc5ce9238c367",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.046302318573",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.87483340329215",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.33488348164468e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.974702494096904",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.218292566720722",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:67d3c251cc11d74a757bc5ce9238c367": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0050",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[16,-100,6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5cd01f27f303492a475bb421b406f29e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0051",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:79e6e4f920bc1f2c1afeca02a3fbd970",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.02292680740356",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.85413917587123",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.80687603349839e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.980465241104396",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.22410305589753",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:79e6e4f920bc1f2c1afeca02a3fbd970": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0051",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-26,-92,30]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b7c5e48c51f89a916bb2b9b3c7f93b74": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0052",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ffa7434855d1c324deca6f84fac4ca36",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.01148080825806",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.84399652858706",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.05233591551846e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.982890206353732",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.229310640619688",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ffa7434855d1c324deca6f84fac4ca36": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0052",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-20,-98,22]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b4420f0e3015139ac61cd59663393123": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0053",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:90c84b40485f0ed6915d0e13465ea77d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.94734573364258",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.78704871504293",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.62236103013514e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.992471615789186",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.257387912975022",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:90c84b40485f0ed6915d0e13465ea77d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0053",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-18,-60,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b3b56bbb5afa41e6dd9460c0975114ab": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0054",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7ae522397907f4441588495f10199d24",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.91909575462341",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.76190249943837",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.43128931427017e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.994989876478129",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.273662768395414",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7ae522397907f4441588495f10199d24": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0054",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-50,4,50]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d6851b62cb4fc286f889c964756f52ef": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0055",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4c35f39eeef9029f2223dd86b1ebd1fb",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.89198279380798",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.73773288062869",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "9.28435357934188e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.996706388084582",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.28517227483113",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4c35f39eeef9029f2223dd86b1ebd1fb": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0055",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[4,6,34]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d714caf4b86cd7fa8f8ed29b6c077612": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0056",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e26921989c4cf25fee3fb9b7455f0f8b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.89150333404541",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.73730515822159",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "9.30015629725389e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.996731588962573",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.28517227483113",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e26921989c4cf25fee3fb9b7455f0f8b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0056",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-22,-74,60]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:547d02c0e638d74f5478c4bc3e391238": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0057",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:090eeea9cc261f40a2ed8f97e8f80deb",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.3844006061554",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.27901971293977",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000520841795166427",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999480839",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.714388255916924",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:090eeea9cc261f40a2ed8f97e8f80deb": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0057",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-30,-72,60]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c5a8590100956ce4c92258b440677e10": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0058",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f52621a6b75d7dc6ddfd640fdb2c84ce",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.83530473709106",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.68709597748077",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000113413911399851",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.998757977658224",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.325806099959436",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f52621a6b75d7dc6ddfd640fdb2c84ce": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0058",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-4,2,74]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:53ee509e46907c679adc7597b14519f2": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0059",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b3c0287254101b42442c7845c4784807",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.75742197036743",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.61726989254514",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000148863406353339",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999745113204238",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.372479477261378",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b3c0287254101b42442c7845c4784807": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0059",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-8,-6,72]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3940947c5af9294e8c0934b07efef693": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0060",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b8afa2b7beda616a1b6fc2f491bb8265",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.81854224205017",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.67209132667056",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000120286836925998",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999094324231714",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.337078357858238",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b8afa2b7beda616a1b6fc2f491bb8265": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0060",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-48,-72,2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c871240e924a76bb776906ea43d79c79": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0061",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:59794eb1599c01a856a85fc602576319",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.79630875587463",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.65216921136221",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000130017220931533",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999416425810988",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.355160181055232",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:59794eb1599c01a856a85fc602576319": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0061",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[14,-14,72]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b36f793d8fc4b275da4f7090d0cf49c8": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0062",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:2dddcae00ff05c47e0eeb240bdd94210",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.76071834564209",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.62023097093744",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000147170075777137",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999725733828698",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.372479477261378",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:2dddcae00ff05c47e0eeb240bdd94210": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0062",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-46,-56,14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d392931d201e3f958063e45700f72974": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0063",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ef8da9c315d7acad1a19ab9b35413509",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.75727128982544",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.61713452675793",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000148941251495116",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999745969099268",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.372479477261378",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ef8da9c315d7acad1a19ab9b35413509": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0063",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-66,-46,8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6f61feacc9e404004ef84c08b36c575a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0064",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:63bc96c0a95823c38213430c25f2f3c9",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.75130581855774",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.61177452742087",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000152054461266093",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999777860131121",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.372479477261378",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:63bc96c0a95823c38213430c25f2f3c9": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0064",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[34,-54,-16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9c8f8e0534218aad4af35d8185a68335": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0065",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:01b7ff06f7596a087ca89d5ce06e2de7",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.74772572517395",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.60855701112288",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000153952428091686",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999795233014277",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.372479477261378",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:01b7ff06f7596a087ca89d5ce06e2de7": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0065",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[44,-48,-26]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7a1f1c13b6b7291045121f7d49c77262": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0066",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0aceebd02576058fb0b5ffcc450903bf",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.45268702507019",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.34140172297627",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000416782602005394",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999986590246",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.640240241586832",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0aceebd02576058fb0b5ffcc450903bf": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0066",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[48,-56,-26]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6f63dba9a2285ab4c503bd441f4a8416": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0067",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d318bbff911ff001f6ad9103b7320f90",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.74554085731506",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.60659312728381",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000155121773134592",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999805227886258",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.372479477261378",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d318bbff911ff001f6ad9103b7320f90": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0067",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[18,2,14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f5db12c15fd9930bce8083f4d4a971f8": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0068",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d1505d5bea737990bb7f479cf49edd65",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.74068021774292",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.60222331817537",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000157753568586605",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999825912392884",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.374448807900588",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d1505d5bea737990bb7f479cf49edd65": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0068",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[14,54,-12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:dc9d1a84c56c4f2e77f730ad228f6501": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0069",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:49cc2c6c43ce421c2826afdfaf669653",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.66871547698975",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.53739878996347",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000202044512556343",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999971868208055",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.439662448224178",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:49cc2c6c43ce421c2826afdfaf669653": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0069",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-52,-46,-32]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:04e4cd21e77744d001e185feea09a1c4": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0070",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:524d3966cd270740666e57867b56cf6c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.64429998397827",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.51535208387321",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000219585664636091",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999985907470966",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.455711975517369",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:524d3966cd270740666e57867b56cf6c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0070",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[6,0,-10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f51fbb3e910f71c1d52c4e2485a133b5": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0071",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a275ee630113b8202f84ea9b3759d881",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.62323594093323",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.49630996939917",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000235870182098918",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999992481636867",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.477092512968269",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a275ee630113b8202f84ea9b3759d881": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0071",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-46,-46,12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:bfde065730fee41f9a030aa1df66e0e9": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0072",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a59e7ee297d62a1742213ffbb620d2b8",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.61861133575439",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.49212659507393",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000239595538008452",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999993477073261",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.479362074336081",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a59e7ee297d62a1742213ffbb620d2b8": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0072",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[24,36,22]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:567767d337ded7d52529fde5cb620c93": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0073",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:3281d190fd64bd07e9609903623a5bbd",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.60088157653809",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.47607949453728",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000254400722538684",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999996268378967",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.49118230182513",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3281d190fd64bd07e9609903623a5bbd": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0073",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[52,-38,22]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6f329dd94a2d4db60b222ae0224476da": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0074",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6adaabf783e45104c83b07aae27cca00",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.5545506477356",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.43407908140554",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000297285352316101",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999222525781",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.537678422954754",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6adaabf783e45104c83b07aae27cca00": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0074",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-64,-34,8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:84e6ea0a18d979291bb19d28f1c5dabe": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0075",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e69a32992abb3633e42cbbc91342979b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.53580284118652",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.41705640127634",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000316510818269",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999606830839",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.556120559116339",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e69a32992abb3633e42cbbc91342979b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0075",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-54,-32,42]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:dbc772d5c9ef096bc13a4ee83b16aac6": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0076",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:240a1e650cd9f68a3dd24dc257fb8ef1",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.51030111312866",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.39387625832302",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000344554112102768",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.9999998514483",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.584915397396553",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:240a1e650cd9f68a3dd24dc257fb8ef1": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0076",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[20,-66,34]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4d40e798820a3a573c0500e58c734eec": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0077",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:aeaa37b13c920048113b7dc3f503c7bc",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.50287866592407",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.38712412459265",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000353147125455866",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999889234026",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.591889002439003",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:aeaa37b13c920048113b7dc3f503c7bc": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0077",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[12,-100,20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c5304f99a9da73415539075421788844": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0078",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b2bc9a9ccfd711a23c57794194597f43",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.48949480056763",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.3749428096037",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000369155160797496",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999935529104",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.605073490410914",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b2bc9a9ccfd711a23c57794194597f43": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0078",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[16,-44,20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4d837320d4d5094cb8cb549343505b8b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0079",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:3b2940e29d426870ed404cc739700589",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.48589444160461",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.37166460127642",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00037357688397921",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999944412109",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.605342127295634",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3b2940e29d426870ed404cc739700589": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0079",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-56,-34,22]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5652354d900526a3f326a8cf3b1d6f1f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0080",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:1efd56928f31b5312bfa21484652a1f3",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.4652099609375",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.35281990022648",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000399963700227435",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999976804491",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.628846262541795",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:1efd56928f31b5312bfa21484652a1f3": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0080",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[40,4,30]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d2d495d008345b6772c40b2b272a1585": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0081",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:2df4f858b4497bba7e71e36de77d8194",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.44595217704773",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.33525818772228",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000426101175928562",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999990072758",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.643081801836616",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:2df4f858b4497bba7e71e36de77d8194": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0081",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-22,-94,28]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:65afbe0971735e73b0b4d019a5fe1dd4": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0082",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a4a5e8556da90bc8294088347f71204f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.44062829017639",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.33040033563749",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00043360601200626",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999992196494",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.643081801836616",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a4a5e8556da90bc8294088347f71204f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0082",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-28,-66,-4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4840119095d944bfaa2277523850de52": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0083",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:171f6f283c1425e20e15c65986b75693",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.4126980304718",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.30489484520115",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000475060200800126",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999997888602",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.683890257408892",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:171f6f283c1425e20e15c65986b75693": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0083",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[22,-80,54]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d9ddb8469cbfc56cddec34eacb01fe37": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0084",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d70b502404bd88a854514ea5758a0230",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.38877391815186",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.28302091406008",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000513505230477329",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999351719",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.712882686639218",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d70b502404bd88a854514ea5758a0230": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0084",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-50,-52,20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:31a3813511b578c73de9e894b0d4b862": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0085",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b8adcd6e39a269092455531610a969af",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.38779973983765",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.28212969646231",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000515131030616733",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999382908",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.712882686639218",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b8adcd6e39a269092455531610a969af": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0085",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[64,-32,16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b08c87ff71cf5246769f7715958afa40": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0086",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:cf7ff8939962af0db57611ac57ca8321",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.37709879875183",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.27233736484586",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000533311091644562",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999643268",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.721327613515561",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:cf7ff8939962af0db57611ac57ca8321": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0086",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-66,-36,22]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a9d645704df208d9dc3fc6253c78c696": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0087",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d01630982d6562431197c9125302e72d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.37313723564148",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.26871093121603",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000540193080250551",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999709649",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.721327613515561",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d01630982d6562431197c9125302e72d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0087",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-30,-62,-40]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4db22c975766e9eb9e2f4b5beea1658f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0088",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:03d2749e759ef96f471425c46ee3f719",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.37137746810913",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.2670998163368",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000543276814982008",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999735165",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.721327613515561",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:03d2749e759ef96f471425c46ee3f719": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0088",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-62,-14,10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e29f7b67960f76bb916479e29df3f8b3": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0089",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:09a8f62d551cdcdc77118ba40ad5fa78",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.37039303779602",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.26619848595029",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000545009089568671",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999748484",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.721327613515561",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:09a8f62d551cdcdc77118ba40ad5fa78": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0089",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[22,34,56]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8ac825efe546b49dde172700cc71e2b2": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0090",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:1785d708e60ad6549b65dffa2e528466",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.30523133277893",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.20644574827441",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000671928211518624",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999993453",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.835508519228008",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:1785d708e60ad6549b65dffa2e528466": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0090",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-68,-34,-8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:22cb343d7aa6bdb3bb3a888ac82c87c0": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0091",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c6f2d80da4938d0bb9415062e7a5e502",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.2985315322876",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.20029191950919",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000686442301030654",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999995621",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.842515375542095",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c6f2d80da4938d0bb9415062e7a5e502": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0091",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[44,4,46]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1e6a6f5fdbab18ff700a1f08fa7c7542": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0092",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f601d44d414260f0726c9603cd39c49a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.29661655426025",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.19853264836728",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000690644458409051",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.9999999999961",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.842515375542095",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f601d44d414260f0726c9603cd39c49a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0092",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[24,0,4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:65926b9e3005685d9db29cdf417debc7": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0093",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4288b4766cc9e13b7d7802f0b1459329",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.27342534065247",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.1772149335255",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000743483956790469",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999073",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.873198212136066",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4288b4766cc9e13b7d7802f0b1459329": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0093",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-60,-46,0]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1832ec3bca9ab489c38af1558fa307ca": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0094",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7a4290e8d2bb1ace22685e79b5e79d1c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.27317070960999",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.17698074823278",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000744084571755788",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999088",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.873198212136066",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7a4290e8d2bb1ace22685e79b5e79d1c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0094",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-4,40,24]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:261741634aeb371107d4c36f38ee3e94": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0095",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ac0648e7d1f5b3202d8d893523a25ee3",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.27113676071167",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.17511001955929",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000748898502488382",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999199",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.873198212136066",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ac0648e7d1f5b3202d8d893523a25ee3": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0095",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[38,50,-2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:360ea334f08a7af85055b95a9386d330": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0096",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:2fdcc6e6bc5734e23a3c245ece9af37a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.24630308151245",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.15225533865243",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000810072651915683",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999841",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.917606478873846",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:2fdcc6e6bc5734e23a3c245ece9af37a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0096",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-40,-88,16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e659f5281cce04791ec12bbae45e2238": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0097",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:21d86a8c53e01ef6f95f57296de7085d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.24350714683533",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.14968061296894",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000817245211796269",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999868",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.917606478873846",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:21d86a8c53e01ef6f95f57296de7085d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0097",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-36,-56,-42]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:bc8b728ef84f6cc7d38147430d08a43e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0098",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:913d186c05f83e7d0dedd5f599c175a9",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.24193215370178",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.14823008816228",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000821311713323003",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999881",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.917606478873846",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:913d186c05f83e7d0dedd5f599c175a9": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0098",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-54,-8,46]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:26f4b6d30550bf95fa229750966ea576": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0099",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ac2f9c701365ca370e015bb1778342c0",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.22731924057007",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.1347671282846",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000859952917517393",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999956",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.937923170353275",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ac2f9c701365ca370e015bb1778342c0": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0099",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[40,-52,68]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2c4a60a71eb752e827d97c147d637ae2": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0100",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7498af8fe3f38b0a683eb4f600daedbd",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.22294282913208",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.13073340683923",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000871851865451578",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999968",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.942022979172485",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7498af8fe3f38b0a683eb4f600daedbd": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0100",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[22,44,-16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:db27722046af7c3881dc9b3f44135cdd": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0101",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:523fb1da24165c8028f86bdbbc3901e7",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.20911026000977",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.11797882010196",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000910479445198287",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999988",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.966327579886985",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:523fb1da24165c8028f86bdbbc3901e7": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0101",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-40,36,-8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:130b59f20e485841289d47a669c27dec": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0102",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c7ad57439eb1d9d0e24c8929fb4f6def",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.20072054862976",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.11023911526042",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000934679736638411",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999993",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.972457839189109",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c7ad57439eb1d9d0e24c8929fb4f6def": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0102",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-14,4,16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7d589921c2ce3d87a67549309a2ce4d9": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0103",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:5fac49fc2d94d308482a7216d1c0abcc",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.19976687431335",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.10935914676901",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000937468288822019",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999994",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.972457839189109",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:5fac49fc2d94d308482a7216d1c0abcc": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0103",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-24,54,36]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:fc5bb336fd66e8a55c0326f0b1d351e5": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0104",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:cd1b84e4c6560b33762f1d342c8d79d1",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.19748950004578",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.10725763219564",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000944158772216208",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999995",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.972457839189109",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:cd1b84e4c6560b33762f1d342c8d79d1": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0104",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[66,-34,38]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:602dbb725cf9f38cf7aa442b3a5fac1e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0105",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f21906ff37236d112d6eb7f93ae84520",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.19663214683533",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.10646642942607",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000946689027332193",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999995",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.972457839189109",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f21906ff37236d112d6eb7f93ae84520": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0105",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[12,-76,-12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:fb785c4b2387927cfcaba115b1c2b59a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0106",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f70ca813baf34973fd3495cc2097d071",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.19012331962585",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.10045882632522",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000966105376173698",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999997",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.981368933811381",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f70ca813baf34973fd3495cc2097d071": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0106",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[44,16,36]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9b7ac364d02018f5800c5cab0a832028": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0107",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4abe5383d9941f3b5b7dff4b3e6f15e8",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.18127655982971",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.09229057044228",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000993091637332855",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999998",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.9954611032935",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4abe5383d9941f3b5b7dff4b3e6f15e8": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0107",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[62,26,-24]",
+                "type": "xsd:string"
+            }
+        }
+    },
+    "activity": {
+        "niiri:e00957320cd5a93f086b03d92e906e5b": {
+            "prov:type": {
+                "$": "nidm_ModelParametersEstimation:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Model parameters estimation",
+                "type": "xsd:string"
+            },
+            "nidm_withEstimationMethod:": {
+                "$": "obo_generalizedleastsquaresestimation:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a9881c0f935d0d86cf261907ea9a9c33": {
+            "prov:type": {
+                "$": "nidm_ContrastEstimation:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Contrast estimation",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:543184be0064a6c0e9ff9e528d51cf44": {
+            "prov:type": {
+                "$": "nidm_Inference:",
+                "type": "xsd:QName"
+            },
+            "nidm_hasAlternativeHypothesis:": {
+                "$": "nidm_OneTailedTest:",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Inference",
+                "type": "xsd:string"
+            }
+        }
+    },
+    "agent": {
+        "niiri:38ff5133581fdcd984a4f1a8f23b66bc": {
+            "prov:type": [
+                {
+                "$": "src_SPM:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "prov:SoftwareAgent",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "SPM",
+                "type": "xsd:string"
+            },
+            "nidm_softwareVersion:": {
+                "$": "12.6906",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:92a315e48eb2104ecb553b5909a53206": {
+            "prov:type": [
+                {
+                "$": "nlx_Imaginginstrument:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nlx_Magneticresonanceimagingscanner:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "MRI Scanner",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:86bf7416c208bed0ed858777f7b52736": {
+            "prov:type": {
+                "$": "prov:Person",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Person",
+                "type": "xsd:string"
+            }
+        }
+    },
+    "wasGeneratedBy": {
+        "_:wGB20": {
+            "prov:entity": "niiri:7f004a26944135c1d554914761e27b2e",
+            "prov:activity": "niiri:e00957320cd5a93f086b03d92e906e5b"
+        },
+        "_:wGB22": {
+            "prov:entity": "niiri:f5d9995c28e5cb26e1839c59c9b5bbff",
+            "prov:activity": "niiri:e00957320cd5a93f086b03d92e906e5b"
+        },
+        "_:wGB26": {
+            "prov:entity": "niiri:2593c500a2e3bba4242f56e76e61b2d9",
+            "prov:activity": "niiri:e00957320cd5a93f086b03d92e906e5b"
+        },
+        "_:wGB30": {
+            "prov:entity": "niiri:dd5f95dd48f703c72358e4165ae1e39d",
+            "prov:activity": "niiri:e00957320cd5a93f086b03d92e906e5b"
+        },
+        "_:wGB34": {
+            "prov:entity": "niiri:e9cc9119a66cf374f5bd09a02cb7f0c6",
+            "prov:activity": "niiri:e00957320cd5a93f086b03d92e906e5b"
+        },
+        "_:wGB38": {
+            "prov:entity": "niiri:1dfac129a8bcadeb38a137a5e7f33cc7",
+            "prov:activity": "niiri:e00957320cd5a93f086b03d92e906e5b"
+        },
+        "_:wGB42": {
+            "prov:entity": "niiri:d9bf5437aa08a1459fe0182fd947a96c",
+            "prov:activity": "niiri:e00957320cd5a93f086b03d92e906e5b"
+        },
+        "_:wGB46": {
+            "prov:entity": "niiri:4c0ab1c8535ea87131668d8df8033987",
+            "prov:activity": "niiri:e00957320cd5a93f086b03d92e906e5b"
+        },
+        "_:wGB50": {
+            "prov:entity": "niiri:fcd83b6089c28ff32851390322727691",
+            "prov:activity": "niiri:e00957320cd5a93f086b03d92e906e5b"
+        },
+        "_:wGB54": {
+            "prov:entity": "niiri:634e834296ec47451bb5dba35c6ab090",
+            "prov:activity": "niiri:e00957320cd5a93f086b03d92e906e5b"
+        },
+        "_:wGB58": {
+            "prov:entity": "niiri:d322a9aa3dcb86b056a502997edcb664",
+            "prov:activity": "niiri:e00957320cd5a93f086b03d92e906e5b"
+        },
+        "_:wGB76": {
+            "prov:entity": "niiri:10f87872974544f0796133e8ec52cdb2",
+            "prov:activity": "niiri:a9881c0f935d0d86cf261907ea9a9c33"
+        },
+        "_:wGB80": {
+            "prov:entity": "niiri:5dae15d639ffe538568fccbf50b79da6",
+            "prov:activity": "niiri:a9881c0f935d0d86cf261907ea9a9c33"
+        },
+        "_:wGB82": {
+            "prov:entity": "niiri:ebd0089167d8c9c6665b2ca9c440a044",
+            "prov:activity": "niiri:a9881c0f935d0d86cf261907ea9a9c33"
+        },
+        "_:wGB101": {
+            "prov:entity": "niiri:9806490c5d381029288eb9158bc777fc",
+            "prov:activity": "niiri:543184be0064a6c0e9ff9e528d51cf44"
+        },
+        "_:wGB105": {
+            "prov:entity": "niiri:9b06d633f15370eacc4d439eebd44c49",
+            "prov:activity": "niiri:543184be0064a6c0e9ff9e528d51cf44"
+        }
+    },
+    "used": {
+        "_:u14": {
+            "prov:activity": "niiri:e00957320cd5a93f086b03d92e906e5b",
+            "prov:entity": "niiri:d36d45f811e2c1d8f3d5e1b6d9405158"
+        },
+        "_:u15": {
+            "prov:activity": "niiri:e00957320cd5a93f086b03d92e906e5b",
+            "prov:entity": "niiri:c1b405a8360aa137d6b3059c99d29f33"
+        },
+        "_:u16": {
+            "prov:activity": "niiri:e00957320cd5a93f086b03d92e906e5b",
+            "prov:entity": "niiri:61c272100996293e9d28d33c83a38df1"
+        },
+        "_:u62": {
+            "prov:activity": "niiri:a9881c0f935d0d86cf261907ea9a9c33",
+            "prov:entity": "niiri:7f004a26944135c1d554914761e27b2e"
+        },
+        "_:u63": {
+            "prov:activity": "niiri:a9881c0f935d0d86cf261907ea9a9c33",
+            "prov:entity": "niiri:634e834296ec47451bb5dba35c6ab090"
+        },
+        "_:u64": {
+            "prov:activity": "niiri:a9881c0f935d0d86cf261907ea9a9c33",
+            "prov:entity": "niiri:d36d45f811e2c1d8f3d5e1b6d9405158"
+        },
+        "_:u65": {
+            "prov:activity": "niiri:a9881c0f935d0d86cf261907ea9a9c33",
+            "prov:entity": "niiri:7c291851e6747c0e2a7284a7cf2d75f4"
+        },
+        "_:u66": {
+            "prov:activity": "niiri:a9881c0f935d0d86cf261907ea9a9c33",
+            "prov:entity": "niiri:2593c500a2e3bba4242f56e76e61b2d9"
+        },
+        "_:u67": {
+            "prov:activity": "niiri:a9881c0f935d0d86cf261907ea9a9c33",
+            "prov:entity": "niiri:dd5f95dd48f703c72358e4165ae1e39d"
+        },
+        "_:u68": {
+            "prov:activity": "niiri:a9881c0f935d0d86cf261907ea9a9c33",
+            "prov:entity": "niiri:e9cc9119a66cf374f5bd09a02cb7f0c6"
+        },
+        "_:u69": {
+            "prov:activity": "niiri:a9881c0f935d0d86cf261907ea9a9c33",
+            "prov:entity": "niiri:1dfac129a8bcadeb38a137a5e7f33cc7"
+        },
+        "_:u70": {
+            "prov:activity": "niiri:a9881c0f935d0d86cf261907ea9a9c33",
+            "prov:entity": "niiri:d9bf5437aa08a1459fe0182fd947a96c"
+        },
+        "_:u71": {
+            "prov:activity": "niiri:a9881c0f935d0d86cf261907ea9a9c33",
+            "prov:entity": "niiri:4c0ab1c8535ea87131668d8df8033987"
+        },
+        "_:u72": {
+            "prov:activity": "niiri:a9881c0f935d0d86cf261907ea9a9c33",
+            "prov:entity": "niiri:fcd83b6089c28ff32851390322727691"
+        },
+        "_:u93": {
+            "prov:activity": "niiri:543184be0064a6c0e9ff9e528d51cf44",
+            "prov:entity": "niiri:de3990bddd4e3e2e1f2945054f1f36a3"
+        },
+        "_:u94": {
+            "prov:activity": "niiri:543184be0064a6c0e9ff9e528d51cf44",
+            "prov:entity": "niiri:d8d46bf5012fbd722ed044231eea5a58"
+        },
+        "_:u95": {
+            "prov:activity": "niiri:543184be0064a6c0e9ff9e528d51cf44",
+            "prov:entity": "niiri:10f87872974544f0796133e8ec52cdb2"
+        },
+        "_:u96": {
+            "prov:activity": "niiri:543184be0064a6c0e9ff9e528d51cf44",
+            "prov:entity": "niiri:d322a9aa3dcb86b056a502997edcb664"
+        },
+        "_:u97": {
+            "prov:activity": "niiri:543184be0064a6c0e9ff9e528d51cf44",
+            "prov:entity": "niiri:7f004a26944135c1d554914761e27b2e"
+        },
+        "_:u98": {
+            "prov:activity": "niiri:543184be0064a6c0e9ff9e528d51cf44",
+            "prov:entity": "niiri:acfbfae887d8a839f1adcb1b8b634982"
+        },
+        "_:u99": {
+            "prov:activity": "niiri:543184be0064a6c0e9ff9e528d51cf44",
+            "prov:entity": "niiri:a3d478c3bf9b0a0df3146665a0a54e21"
+        }
+    },
+    "wasDerivedFrom": {
+        "_:wDF19": {
+            "prov:generatedEntity": "niiri:7f004a26944135c1d554914761e27b2e",
+            "prov:usedEntity": "niiri:a07cf2721b41e6ba9ec7e48fb167fb89"
+        },
+        "_:wDF25": {
+            "prov:generatedEntity": "niiri:2593c500a2e3bba4242f56e76e61b2d9",
+            "prov:usedEntity": "niiri:052b380e570273544f6f2d746785485a"
+        },
+        "_:wDF29": {
+            "prov:generatedEntity": "niiri:dd5f95dd48f703c72358e4165ae1e39d",
+            "prov:usedEntity": "niiri:6278c189e4aaeee91d9763d5764523da"
+        },
+        "_:wDF33": {
+            "prov:generatedEntity": "niiri:e9cc9119a66cf374f5bd09a02cb7f0c6",
+            "prov:usedEntity": "niiri:1a2a75047181a94977af5143fbc2a3f6"
+        },
+        "_:wDF37": {
+            "prov:generatedEntity": "niiri:1dfac129a8bcadeb38a137a5e7f33cc7",
+            "prov:usedEntity": "niiri:386a35d1945daf4a9951952ed1cb6ec8"
+        },
+        "_:wDF41": {
+            "prov:generatedEntity": "niiri:d9bf5437aa08a1459fe0182fd947a96c",
+            "prov:usedEntity": "niiri:02af90ad0dd6b14db8aaaf0f3cf245f4"
+        },
+        "_:wDF45": {
+            "prov:generatedEntity": "niiri:4c0ab1c8535ea87131668d8df8033987",
+            "prov:usedEntity": "niiri:6f1af1cdc138aa878dd6288c45630725"
+        },
+        "_:wDF49": {
+            "prov:generatedEntity": "niiri:fcd83b6089c28ff32851390322727691",
+            "prov:usedEntity": "niiri:2e56c7cfc04eb22f960f4187216b007b"
+        },
+        "_:wDF53": {
+            "prov:generatedEntity": "niiri:634e834296ec47451bb5dba35c6ab090",
+            "prov:usedEntity": "niiri:239382281394fda80fab27e1b812d896"
+        },
+        "_:wDF57": {
+            "prov:generatedEntity": "niiri:d322a9aa3dcb86b056a502997edcb664",
+            "prov:usedEntity": "niiri:c83c0701812f37753b6efa1070796628"
+        },
+        "_:wDF75": {
+            "prov:generatedEntity": "niiri:10f87872974544f0796133e8ec52cdb2",
+            "prov:usedEntity": "niiri:8588d79c35677301f464c7e03b9d0496"
+        },
+        "_:wDF79": {
+            "prov:generatedEntity": "niiri:5dae15d639ffe538568fccbf50b79da6",
+            "prov:usedEntity": "niiri:32b2745bbaa52aa442354c21c92a29df"
+        },
+        "_:wDF107": {
+            "prov:generatedEntity": "niiri:12d2dfb7ca155d963f6afeaa6467e598",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF109": {
+            "prov:generatedEntity": "niiri:4c4f61059d1c51c5c453ad92e020752f",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF111": {
+            "prov:generatedEntity": "niiri:3ed2649db2465ff69f88971b546dd3be",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF113": {
+            "prov:generatedEntity": "niiri:19dfc0bbb201d5f134704921caf5a176",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF115": {
+            "prov:generatedEntity": "niiri:4ccbfde9cca6489f3110bef0431524c8",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF117": {
+            "prov:generatedEntity": "niiri:3621a50b575ca90dbe183bb31ff4ae4a",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF119": {
+            "prov:generatedEntity": "niiri:7698728db1c0c3e20b495f064a9d5b55",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF121": {
+            "prov:generatedEntity": "niiri:379c20fa5cd6aefb39cb7419f030f9e5",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF123": {
+            "prov:generatedEntity": "niiri:4257936a93608ef43291e047551e5e0a",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF125": {
+            "prov:generatedEntity": "niiri:7017960274f85788b6b607f7d0046a76",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF127": {
+            "prov:generatedEntity": "niiri:a48da6310356eb94f99b1f1eb464e14b",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF129": {
+            "prov:generatedEntity": "niiri:ada43746a7be5361f1b2127ddc7152ba",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF131": {
+            "prov:generatedEntity": "niiri:1c73b53acc2e3706c7dcdd4e4ed9e043",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF133": {
+            "prov:generatedEntity": "niiri:655978b5bff261f0bf396a1ddf498402",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF135": {
+            "prov:generatedEntity": "niiri:7dd3c3ae219e2bf1ef8176af9cc60fb9",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF137": {
+            "prov:generatedEntity": "niiri:c96857fd42e1208395989b05eeab7a76",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF139": {
+            "prov:generatedEntity": "niiri:7a24a2bdbc61f7d8ab6a59738a57c24a",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF141": {
+            "prov:generatedEntity": "niiri:c313dfc1d990322089b2bf63a219f16a",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF143": {
+            "prov:generatedEntity": "niiri:36e697e6ea3e7a7c4a67a505ebe4f340",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF145": {
+            "prov:generatedEntity": "niiri:ca1016af733ba1294614bfd4483de412",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF147": {
+            "prov:generatedEntity": "niiri:b4290f172c2ebe815ddf64763f6e95e4",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF149": {
+            "prov:generatedEntity": "niiri:94f389f115646fc7441e8fd9bf5ec119",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF151": {
+            "prov:generatedEntity": "niiri:7322fa4ccee32301d807a0b9f48ae02a",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF153": {
+            "prov:generatedEntity": "niiri:c47c40f4ed2261336524231fb9108598",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF155": {
+            "prov:generatedEntity": "niiri:6c58a61aff8d76d3d5cdef392c46c0f7",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF157": {
+            "prov:generatedEntity": "niiri:bcf052d664b0eeef3576961aef494c62",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF159": {
+            "prov:generatedEntity": "niiri:d357fdfcedae064d3927d132b4915da3",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF161": {
+            "prov:generatedEntity": "niiri:24181b91e1a2ff9fbf0d92f1f3c2fb91",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF163": {
+            "prov:generatedEntity": "niiri:a67bcbe4c64e864d3c0091590a71ed79",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF165": {
+            "prov:generatedEntity": "niiri:1e585aa0961f26eba6c099e7119148ec",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF167": {
+            "prov:generatedEntity": "niiri:98543afde30df2ac94ce134cd8111cce",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF169": {
+            "prov:generatedEntity": "niiri:3bfa5939740913923e9b589897f2c510",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF171": {
+            "prov:generatedEntity": "niiri:6b8ab0e3e0b633d638e47f3a9a10919b",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF173": {
+            "prov:generatedEntity": "niiri:6029d0e967f2fb403f4a243e7a90b84c",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF175": {
+            "prov:generatedEntity": "niiri:780f11b236810e190dea70c6c4340625",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF177": {
+            "prov:generatedEntity": "niiri:4a266b577331cf838f3af1933133ec8d",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF179": {
+            "prov:generatedEntity": "niiri:b92193302c69c95fc0b8add50483e3ec",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF181": {
+            "prov:generatedEntity": "niiri:12aade66bcaf5ad22c9a147b7bac54d4",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF183": {
+            "prov:generatedEntity": "niiri:759e3fd5ac10013d9c1b96696769e455",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF185": {
+            "prov:generatedEntity": "niiri:b60ad51d906accfc87533b435bc4ab5f",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF187": {
+            "prov:generatedEntity": "niiri:5fe7263d129c8b5a1cdc4862389a329f",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF189": {
+            "prov:generatedEntity": "niiri:202e674801183017b435dafa4352a2f7",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF191": {
+            "prov:generatedEntity": "niiri:63374171b8dfeb6c1b6216d9cb78dad1",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF193": {
+            "prov:generatedEntity": "niiri:4c28624df30b813b1284ed3adfd58c93",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF195": {
+            "prov:generatedEntity": "niiri:94a0a21f872815c64a69e94bd40bed9f",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF197": {
+            "prov:generatedEntity": "niiri:e7e4075c58abc76d658530459437df00",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF199": {
+            "prov:generatedEntity": "niiri:2dfef140265f92d79cbf32d31936df4d",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF201": {
+            "prov:generatedEntity": "niiri:8fcfff082769fb86478d8224ec22e1d5",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF203": {
+            "prov:generatedEntity": "niiri:a4a959bdb5adaac5ccc8bb0a1283b1eb",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF205": {
+            "prov:generatedEntity": "niiri:abd2bbf896a471cb7922efab5b613117",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF207": {
+            "prov:generatedEntity": "niiri:9c1cddc9922d8e70b3ba77c8f428e530",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF209": {
+            "prov:generatedEntity": "niiri:b2551e755f51f54d3855f624855bec3b",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF211": {
+            "prov:generatedEntity": "niiri:d98c34494ee425b9f343ad72efbe3802",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF213": {
+            "prov:generatedEntity": "niiri:207cbb7814292b71aa3cbca2e251214d",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF215": {
+            "prov:generatedEntity": "niiri:ef0e652ba790ef2ca62cbc45744044f2",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF217": {
+            "prov:generatedEntity": "niiri:cdc735403e60da4bc8deca0b30c09e41",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF219": {
+            "prov:generatedEntity": "niiri:14788c080d39de548f4f1517f2f3ecf2",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF221": {
+            "prov:generatedEntity": "niiri:094abc2dabe5f1598098374da155b2d3",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF223": {
+            "prov:generatedEntity": "niiri:b0a53fec1935bbbef5f0340426dfcf5c",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF225": {
+            "prov:generatedEntity": "niiri:782cde190eab924f134e44bd95c8cd15",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF227": {
+            "prov:generatedEntity": "niiri:9e85dca921757d3d2cafd0d606eb03c4",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF229": {
+            "prov:generatedEntity": "niiri:50e0654a2d55b1eb33c94eef3f0fbfc4",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF231": {
+            "prov:generatedEntity": "niiri:580546e61fe6caf5b928869b72d6563c",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF233": {
+            "prov:generatedEntity": "niiri:fbb3da138dba0bffe41c80dfdc6d2813",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF235": {
+            "prov:generatedEntity": "niiri:5b4ccbe46fbd067233c454fc4cd57139",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF237": {
+            "prov:generatedEntity": "niiri:4797fa2e5200fab8ae750cb321a6d94a",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF239": {
+            "prov:generatedEntity": "niiri:e5840e49541fa7c2c73adfcf2cd18d5c",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF241": {
+            "prov:generatedEntity": "niiri:af9739fef5ce12c093a36fdad464fa2c",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF243": {
+            "prov:generatedEntity": "niiri:4c1124c10677cacc7086dad2d88a0bd3",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF245": {
+            "prov:generatedEntity": "niiri:9a07890dc3c872a54f45939b26e95348",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF247": {
+            "prov:generatedEntity": "niiri:4b972d45063ce95740be79e0f84be300",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF249": {
+            "prov:generatedEntity": "niiri:6cc8de073a211f649503cbae3d7f79bb",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF251": {
+            "prov:generatedEntity": "niiri:713bd5e4d1057a61ec41d7be47cc6b30",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF253": {
+            "prov:generatedEntity": "niiri:f594ca28922a55744403546afac8880c",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF255": {
+            "prov:generatedEntity": "niiri:1f5837a9250f8adad81d9cf7febcb06c",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF257": {
+            "prov:generatedEntity": "niiri:4978ca959ffd9dac40bc74938928d142",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF259": {
+            "prov:generatedEntity": "niiri:a8156b1e457954028b70ba39c8f61983",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF261": {
+            "prov:generatedEntity": "niiri:b00bd2c845defd49f3843980d3290639",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF263": {
+            "prov:generatedEntity": "niiri:0d91d576d381385281f1b2d5d2714a3f",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF265": {
+            "prov:generatedEntity": "niiri:1505e0b207a3a8175cc0be4688a0d7c4",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF267": {
+            "prov:generatedEntity": "niiri:892dfa415e44d696ef37c9d6a5487e86",
+            "prov:usedEntity": "niiri:9b06d633f15370eacc4d439eebd44c49"
+        },
+        "_:wDF270": {
+            "prov:generatedEntity": "niiri:2c0961e66823d0b4915540ec2c8e75c3",
+            "prov:usedEntity": "niiri:12d2dfb7ca155d963f6afeaa6467e598"
+        },
+        "_:wDF273": {
+            "prov:generatedEntity": "niiri:dc3e0fe26c0acd9c6f782136679db557",
+            "prov:usedEntity": "niiri:12d2dfb7ca155d963f6afeaa6467e598"
+        },
+        "_:wDF276": {
+            "prov:generatedEntity": "niiri:b44464753c802f3cbe64786acd87621a",
+            "prov:usedEntity": "niiri:12d2dfb7ca155d963f6afeaa6467e598"
+        },
+        "_:wDF279": {
+            "prov:generatedEntity": "niiri:022fa4480e152e0d59d498475f76b9f0",
+            "prov:usedEntity": "niiri:4c4f61059d1c51c5c453ad92e020752f"
+        },
+        "_:wDF282": {
+            "prov:generatedEntity": "niiri:d38af59f91ea10608b21a454c3db1947",
+            "prov:usedEntity": "niiri:4c4f61059d1c51c5c453ad92e020752f"
+        },
+        "_:wDF285": {
+            "prov:generatedEntity": "niiri:02b9e7ac9b6dc3a6cfd2bf8d3a3e5d52",
+            "prov:usedEntity": "niiri:4c4f61059d1c51c5c453ad92e020752f"
+        },
+        "_:wDF288": {
+            "prov:generatedEntity": "niiri:4ef90c913a7c532cca2c6fd0f9681191",
+            "prov:usedEntity": "niiri:3ed2649db2465ff69f88971b546dd3be"
+        },
+        "_:wDF291": {
+            "prov:generatedEntity": "niiri:36703567cc1d92a9cb3e152dc40b85ce",
+            "prov:usedEntity": "niiri:3ed2649db2465ff69f88971b546dd3be"
+        },
+        "_:wDF294": {
+            "prov:generatedEntity": "niiri:1aba48e406a0117ab013a8859ef28b04",
+            "prov:usedEntity": "niiri:3ed2649db2465ff69f88971b546dd3be"
+        },
+        "_:wDF297": {
+            "prov:generatedEntity": "niiri:b5f5cf902b5b4771df855cfa8a376ac3",
+            "prov:usedEntity": "niiri:19dfc0bbb201d5f134704921caf5a176"
+        },
+        "_:wDF300": {
+            "prov:generatedEntity": "niiri:89bc5cfcdef0a83dbaf0b1406beae51a",
+            "prov:usedEntity": "niiri:19dfc0bbb201d5f134704921caf5a176"
+        },
+        "_:wDF303": {
+            "prov:generatedEntity": "niiri:e9f1a1a5097af18399f0bd67a17a2cce",
+            "prov:usedEntity": "niiri:19dfc0bbb201d5f134704921caf5a176"
+        },
+        "_:wDF306": {
+            "prov:generatedEntity": "niiri:bd38db380ba41e0ce1675948a69b7682",
+            "prov:usedEntity": "niiri:4ccbfde9cca6489f3110bef0431524c8"
+        },
+        "_:wDF309": {
+            "prov:generatedEntity": "niiri:881e790fc7e1a6f81af66a18ac093075",
+            "prov:usedEntity": "niiri:4ccbfde9cca6489f3110bef0431524c8"
+        },
+        "_:wDF312": {
+            "prov:generatedEntity": "niiri:e423ac92420c6449768391abb0fcedc9",
+            "prov:usedEntity": "niiri:4ccbfde9cca6489f3110bef0431524c8"
+        },
+        "_:wDF315": {
+            "prov:generatedEntity": "niiri:edf2c8ccec7e4fd60e5909a7319ff0e6",
+            "prov:usedEntity": "niiri:3621a50b575ca90dbe183bb31ff4ae4a"
+        },
+        "_:wDF318": {
+            "prov:generatedEntity": "niiri:7c1ced347ec1ebede281534319058c3e",
+            "prov:usedEntity": "niiri:3621a50b575ca90dbe183bb31ff4ae4a"
+        },
+        "_:wDF321": {
+            "prov:generatedEntity": "niiri:f17c1b76c4220010841c0f96ac1e3578",
+            "prov:usedEntity": "niiri:3621a50b575ca90dbe183bb31ff4ae4a"
+        },
+        "_:wDF324": {
+            "prov:generatedEntity": "niiri:dbb88a311a9de3b4bed9021fb15312f5",
+            "prov:usedEntity": "niiri:7698728db1c0c3e20b495f064a9d5b55"
+        },
+        "_:wDF327": {
+            "prov:generatedEntity": "niiri:73e895f0d508d2c610d6a3c106ee0716",
+            "prov:usedEntity": "niiri:7698728db1c0c3e20b495f064a9d5b55"
+        },
+        "_:wDF330": {
+            "prov:generatedEntity": "niiri:9a97546675f609fff6f0b719b74412c8",
+            "prov:usedEntity": "niiri:7698728db1c0c3e20b495f064a9d5b55"
+        },
+        "_:wDF333": {
+            "prov:generatedEntity": "niiri:f1fa028e954eb2428370317bd458e6d2",
+            "prov:usedEntity": "niiri:379c20fa5cd6aefb39cb7419f030f9e5"
+        },
+        "_:wDF336": {
+            "prov:generatedEntity": "niiri:8d9046504d5d30f7a737d3c5422a2f49",
+            "prov:usedEntity": "niiri:4257936a93608ef43291e047551e5e0a"
+        },
+        "_:wDF339": {
+            "prov:generatedEntity": "niiri:f28ae319db96c12f65d68cdf44c37228",
+            "prov:usedEntity": "niiri:7017960274f85788b6b607f7d0046a76"
+        },
+        "_:wDF342": {
+            "prov:generatedEntity": "niiri:307f5f8fa2312eb0133eaf4fffbbeb80",
+            "prov:usedEntity": "niiri:7017960274f85788b6b607f7d0046a76"
+        },
+        "_:wDF345": {
+            "prov:generatedEntity": "niiri:a9639fbdbb1c26aee4c14242d935b468",
+            "prov:usedEntity": "niiri:a48da6310356eb94f99b1f1eb464e14b"
+        },
+        "_:wDF348": {
+            "prov:generatedEntity": "niiri:1be33bac5492f3fdf9b7077a2b1176d4",
+            "prov:usedEntity": "niiri:a48da6310356eb94f99b1f1eb464e14b"
+        },
+        "_:wDF351": {
+            "prov:generatedEntity": "niiri:e24f477da65372897130f7d2cb1485f9",
+            "prov:usedEntity": "niiri:a48da6310356eb94f99b1f1eb464e14b"
+        },
+        "_:wDF354": {
+            "prov:generatedEntity": "niiri:9692edf724b92ae14d3e441c312e65cc",
+            "prov:usedEntity": "niiri:ada43746a7be5361f1b2127ddc7152ba"
+        },
+        "_:wDF357": {
+            "prov:generatedEntity": "niiri:614f41f29f9cf9d39c5a6367956b6357",
+            "prov:usedEntity": "niiri:1c73b53acc2e3706c7dcdd4e4ed9e043"
+        },
+        "_:wDF360": {
+            "prov:generatedEntity": "niiri:9e657853abbaa2650f24166bf90f5a81",
+            "prov:usedEntity": "niiri:655978b5bff261f0bf396a1ddf498402"
+        },
+        "_:wDF363": {
+            "prov:generatedEntity": "niiri:2e831d1e6888a2d6174ba7de8443f206",
+            "prov:usedEntity": "niiri:655978b5bff261f0bf396a1ddf498402"
+        },
+        "_:wDF366": {
+            "prov:generatedEntity": "niiri:ed3b1a53734192dd232c2ea8bb681cb6",
+            "prov:usedEntity": "niiri:655978b5bff261f0bf396a1ddf498402"
+        },
+        "_:wDF369": {
+            "prov:generatedEntity": "niiri:85627026074aa1f753b1ba3a22383b49",
+            "prov:usedEntity": "niiri:7dd3c3ae219e2bf1ef8176af9cc60fb9"
+        },
+        "_:wDF372": {
+            "prov:generatedEntity": "niiri:5b0b1185c630b975f1f9cad7d863bc1c",
+            "prov:usedEntity": "niiri:c96857fd42e1208395989b05eeab7a76"
+        },
+        "_:wDF375": {
+            "prov:generatedEntity": "niiri:fab4182c9396833dae1da711b91f9451",
+            "prov:usedEntity": "niiri:7a24a2bdbc61f7d8ab6a59738a57c24a"
+        },
+        "_:wDF378": {
+            "prov:generatedEntity": "niiri:7e5c9c348e6bd97291db1b67455a7a1f",
+            "prov:usedEntity": "niiri:7a24a2bdbc61f7d8ab6a59738a57c24a"
+        },
+        "_:wDF381": {
+            "prov:generatedEntity": "niiri:597a607f2ee07200862c89760cd037fb",
+            "prov:usedEntity": "niiri:7a24a2bdbc61f7d8ab6a59738a57c24a"
+        },
+        "_:wDF384": {
+            "prov:generatedEntity": "niiri:a224964e93d3f6e2fff1835428d41f0b",
+            "prov:usedEntity": "niiri:c313dfc1d990322089b2bf63a219f16a"
+        },
+        "_:wDF387": {
+            "prov:generatedEntity": "niiri:33db15418b3eeb72fb3bb39cca81f286",
+            "prov:usedEntity": "niiri:36e697e6ea3e7a7c4a67a505ebe4f340"
+        },
+        "_:wDF390": {
+            "prov:generatedEntity": "niiri:81a9099168b6634f2d230e469992c262",
+            "prov:usedEntity": "niiri:ca1016af733ba1294614bfd4483de412"
+        },
+        "_:wDF393": {
+            "prov:generatedEntity": "niiri:17c4f6eb3f8f149b496425d877516f57",
+            "prov:usedEntity": "niiri:ca1016af733ba1294614bfd4483de412"
+        },
+        "_:wDF396": {
+            "prov:generatedEntity": "niiri:c953467c30386a10432f64759c9bb8fd",
+            "prov:usedEntity": "niiri:b4290f172c2ebe815ddf64763f6e95e4"
+        },
+        "_:wDF399": {
+            "prov:generatedEntity": "niiri:d71e3f367869829805aa71ff8bc7ef74",
+            "prov:usedEntity": "niiri:94f389f115646fc7441e8fd9bf5ec119"
+        },
+        "_:wDF402": {
+            "prov:generatedEntity": "niiri:5c807bc9934434717c54df9aa0633275",
+            "prov:usedEntity": "niiri:7322fa4ccee32301d807a0b9f48ae02a"
+        },
+        "_:wDF405": {
+            "prov:generatedEntity": "niiri:11314fb1e4bc9f2012db889602ef5ff2",
+            "prov:usedEntity": "niiri:c47c40f4ed2261336524231fb9108598"
+        },
+        "_:wDF408": {
+            "prov:generatedEntity": "niiri:c6737de02555142d2e915210fc79d292",
+            "prov:usedEntity": "niiri:c47c40f4ed2261336524231fb9108598"
+        },
+        "_:wDF411": {
+            "prov:generatedEntity": "niiri:0ff26bd6b3a8873a52756070401ef6f8",
+            "prov:usedEntity": "niiri:6c58a61aff8d76d3d5cdef392c46c0f7"
+        },
+        "_:wDF414": {
+            "prov:generatedEntity": "niiri:d5151f32682a8c00255e289f2ab66642",
+            "prov:usedEntity": "niiri:bcf052d664b0eeef3576961aef494c62"
+        },
+        "_:wDF417": {
+            "prov:generatedEntity": "niiri:c734d9ef069f19ed65330db3f293e891",
+            "prov:usedEntity": "niiri:d357fdfcedae064d3927d132b4915da3"
+        },
+        "_:wDF420": {
+            "prov:generatedEntity": "niiri:5cd01f27f303492a475bb421b406f29e",
+            "prov:usedEntity": "niiri:24181b91e1a2ff9fbf0d92f1f3c2fb91"
+        },
+        "_:wDF423": {
+            "prov:generatedEntity": "niiri:b7c5e48c51f89a916bb2b9b3c7f93b74",
+            "prov:usedEntity": "niiri:a67bcbe4c64e864d3c0091590a71ed79"
+        },
+        "_:wDF426": {
+            "prov:generatedEntity": "niiri:b4420f0e3015139ac61cd59663393123",
+            "prov:usedEntity": "niiri:1e585aa0961f26eba6c099e7119148ec"
+        },
+        "_:wDF429": {
+            "prov:generatedEntity": "niiri:b3b56bbb5afa41e6dd9460c0975114ab",
+            "prov:usedEntity": "niiri:98543afde30df2ac94ce134cd8111cce"
+        },
+        "_:wDF432": {
+            "prov:generatedEntity": "niiri:d6851b62cb4fc286f889c964756f52ef",
+            "prov:usedEntity": "niiri:3bfa5939740913923e9b589897f2c510"
+        },
+        "_:wDF435": {
+            "prov:generatedEntity": "niiri:d714caf4b86cd7fa8f8ed29b6c077612",
+            "prov:usedEntity": "niiri:6b8ab0e3e0b633d638e47f3a9a10919b"
+        },
+        "_:wDF438": {
+            "prov:generatedEntity": "niiri:547d02c0e638d74f5478c4bc3e391238",
+            "prov:usedEntity": "niiri:6b8ab0e3e0b633d638e47f3a9a10919b"
+        },
+        "_:wDF441": {
+            "prov:generatedEntity": "niiri:c5a8590100956ce4c92258b440677e10",
+            "prov:usedEntity": "niiri:6029d0e967f2fb403f4a243e7a90b84c"
+        },
+        "_:wDF444": {
+            "prov:generatedEntity": "niiri:53ee509e46907c679adc7597b14519f2",
+            "prov:usedEntity": "niiri:6029d0e967f2fb403f4a243e7a90b84c"
+        },
+        "_:wDF447": {
+            "prov:generatedEntity": "niiri:3940947c5af9294e8c0934b07efef693",
+            "prov:usedEntity": "niiri:780f11b236810e190dea70c6c4340625"
+        },
+        "_:wDF450": {
+            "prov:generatedEntity": "niiri:c871240e924a76bb776906ea43d79c79",
+            "prov:usedEntity": "niiri:4a266b577331cf838f3af1933133ec8d"
+        },
+        "_:wDF453": {
+            "prov:generatedEntity": "niiri:b36f793d8fc4b275da4f7090d0cf49c8",
+            "prov:usedEntity": "niiri:b92193302c69c95fc0b8add50483e3ec"
+        },
+        "_:wDF456": {
+            "prov:generatedEntity": "niiri:d392931d201e3f958063e45700f72974",
+            "prov:usedEntity": "niiri:12aade66bcaf5ad22c9a147b7bac54d4"
+        },
+        "_:wDF459": {
+            "prov:generatedEntity": "niiri:6f61feacc9e404004ef84c08b36c575a",
+            "prov:usedEntity": "niiri:759e3fd5ac10013d9c1b96696769e455"
+        },
+        "_:wDF462": {
+            "prov:generatedEntity": "niiri:9c8f8e0534218aad4af35d8185a68335",
+            "prov:usedEntity": "niiri:b60ad51d906accfc87533b435bc4ab5f"
+        },
+        "_:wDF465": {
+            "prov:generatedEntity": "niiri:7a1f1c13b6b7291045121f7d49c77262",
+            "prov:usedEntity": "niiri:b60ad51d906accfc87533b435bc4ab5f"
+        },
+        "_:wDF468": {
+            "prov:generatedEntity": "niiri:6f63dba9a2285ab4c503bd441f4a8416",
+            "prov:usedEntity": "niiri:5fe7263d129c8b5a1cdc4862389a329f"
+        },
+        "_:wDF471": {
+            "prov:generatedEntity": "niiri:f5db12c15fd9930bce8083f4d4a971f8",
+            "prov:usedEntity": "niiri:202e674801183017b435dafa4352a2f7"
+        },
+        "_:wDF474": {
+            "prov:generatedEntity": "niiri:dc9d1a84c56c4f2e77f730ad228f6501",
+            "prov:usedEntity": "niiri:63374171b8dfeb6c1b6216d9cb78dad1"
+        },
+        "_:wDF477": {
+            "prov:generatedEntity": "niiri:04e4cd21e77744d001e185feea09a1c4",
+            "prov:usedEntity": "niiri:4c28624df30b813b1284ed3adfd58c93"
+        },
+        "_:wDF480": {
+            "prov:generatedEntity": "niiri:f51fbb3e910f71c1d52c4e2485a133b5",
+            "prov:usedEntity": "niiri:94a0a21f872815c64a69e94bd40bed9f"
+        },
+        "_:wDF483": {
+            "prov:generatedEntity": "niiri:bfde065730fee41f9a030aa1df66e0e9",
+            "prov:usedEntity": "niiri:e7e4075c58abc76d658530459437df00"
+        },
+        "_:wDF486": {
+            "prov:generatedEntity": "niiri:567767d337ded7d52529fde5cb620c93",
+            "prov:usedEntity": "niiri:2dfef140265f92d79cbf32d31936df4d"
+        },
+        "_:wDF489": {
+            "prov:generatedEntity": "niiri:6f329dd94a2d4db60b222ae0224476da",
+            "prov:usedEntity": "niiri:8fcfff082769fb86478d8224ec22e1d5"
+        },
+        "_:wDF492": {
+            "prov:generatedEntity": "niiri:84e6ea0a18d979291bb19d28f1c5dabe",
+            "prov:usedEntity": "niiri:a4a959bdb5adaac5ccc8bb0a1283b1eb"
+        },
+        "_:wDF495": {
+            "prov:generatedEntity": "niiri:dbc772d5c9ef096bc13a4ee83b16aac6",
+            "prov:usedEntity": "niiri:abd2bbf896a471cb7922efab5b613117"
+        },
+        "_:wDF498": {
+            "prov:generatedEntity": "niiri:4d40e798820a3a573c0500e58c734eec",
+            "prov:usedEntity": "niiri:9c1cddc9922d8e70b3ba77c8f428e530"
+        },
+        "_:wDF501": {
+            "prov:generatedEntity": "niiri:c5304f99a9da73415539075421788844",
+            "prov:usedEntity": "niiri:b2551e755f51f54d3855f624855bec3b"
+        },
+        "_:wDF504": {
+            "prov:generatedEntity": "niiri:4d837320d4d5094cb8cb549343505b8b",
+            "prov:usedEntity": "niiri:d98c34494ee425b9f343ad72efbe3802"
+        },
+        "_:wDF507": {
+            "prov:generatedEntity": "niiri:5652354d900526a3f326a8cf3b1d6f1f",
+            "prov:usedEntity": "niiri:207cbb7814292b71aa3cbca2e251214d"
+        },
+        "_:wDF510": {
+            "prov:generatedEntity": "niiri:d2d495d008345b6772c40b2b272a1585",
+            "prov:usedEntity": "niiri:ef0e652ba790ef2ca62cbc45744044f2"
+        },
+        "_:wDF513": {
+            "prov:generatedEntity": "niiri:65afbe0971735e73b0b4d019a5fe1dd4",
+            "prov:usedEntity": "niiri:cdc735403e60da4bc8deca0b30c09e41"
+        },
+        "_:wDF516": {
+            "prov:generatedEntity": "niiri:4840119095d944bfaa2277523850de52",
+            "prov:usedEntity": "niiri:14788c080d39de548f4f1517f2f3ecf2"
+        },
+        "_:wDF519": {
+            "prov:generatedEntity": "niiri:d9ddb8469cbfc56cddec34eacb01fe37",
+            "prov:usedEntity": "niiri:094abc2dabe5f1598098374da155b2d3"
+        },
+        "_:wDF522": {
+            "prov:generatedEntity": "niiri:31a3813511b578c73de9e894b0d4b862",
+            "prov:usedEntity": "niiri:b0a53fec1935bbbef5f0340426dfcf5c"
+        },
+        "_:wDF525": {
+            "prov:generatedEntity": "niiri:b08c87ff71cf5246769f7715958afa40",
+            "prov:usedEntity": "niiri:782cde190eab924f134e44bd95c8cd15"
+        },
+        "_:wDF528": {
+            "prov:generatedEntity": "niiri:a9d645704df208d9dc3fc6253c78c696",
+            "prov:usedEntity": "niiri:9e85dca921757d3d2cafd0d606eb03c4"
+        },
+        "_:wDF531": {
+            "prov:generatedEntity": "niiri:4db22c975766e9eb9e2f4b5beea1658f",
+            "prov:usedEntity": "niiri:50e0654a2d55b1eb33c94eef3f0fbfc4"
+        },
+        "_:wDF534": {
+            "prov:generatedEntity": "niiri:e29f7b67960f76bb916479e29df3f8b3",
+            "prov:usedEntity": "niiri:580546e61fe6caf5b928869b72d6563c"
+        },
+        "_:wDF537": {
+            "prov:generatedEntity": "niiri:8ac825efe546b49dde172700cc71e2b2",
+            "prov:usedEntity": "niiri:fbb3da138dba0bffe41c80dfdc6d2813"
+        },
+        "_:wDF540": {
+            "prov:generatedEntity": "niiri:22cb343d7aa6bdb3bb3a888ac82c87c0",
+            "prov:usedEntity": "niiri:5b4ccbe46fbd067233c454fc4cd57139"
+        },
+        "_:wDF543": {
+            "prov:generatedEntity": "niiri:1e6a6f5fdbab18ff700a1f08fa7c7542",
+            "prov:usedEntity": "niiri:4797fa2e5200fab8ae750cb321a6d94a"
+        },
+        "_:wDF546": {
+            "prov:generatedEntity": "niiri:65926b9e3005685d9db29cdf417debc7",
+            "prov:usedEntity": "niiri:e5840e49541fa7c2c73adfcf2cd18d5c"
+        },
+        "_:wDF549": {
+            "prov:generatedEntity": "niiri:1832ec3bca9ab489c38af1558fa307ca",
+            "prov:usedEntity": "niiri:af9739fef5ce12c093a36fdad464fa2c"
+        },
+        "_:wDF552": {
+            "prov:generatedEntity": "niiri:261741634aeb371107d4c36f38ee3e94",
+            "prov:usedEntity": "niiri:4c1124c10677cacc7086dad2d88a0bd3"
+        },
+        "_:wDF555": {
+            "prov:generatedEntity": "niiri:360ea334f08a7af85055b95a9386d330",
+            "prov:usedEntity": "niiri:9a07890dc3c872a54f45939b26e95348"
+        },
+        "_:wDF558": {
+            "prov:generatedEntity": "niiri:e659f5281cce04791ec12bbae45e2238",
+            "prov:usedEntity": "niiri:4b972d45063ce95740be79e0f84be300"
+        },
+        "_:wDF561": {
+            "prov:generatedEntity": "niiri:bc8b728ef84f6cc7d38147430d08a43e",
+            "prov:usedEntity": "niiri:6cc8de073a211f649503cbae3d7f79bb"
+        },
+        "_:wDF564": {
+            "prov:generatedEntity": "niiri:26f4b6d30550bf95fa229750966ea576",
+            "prov:usedEntity": "niiri:713bd5e4d1057a61ec41d7be47cc6b30"
+        },
+        "_:wDF567": {
+            "prov:generatedEntity": "niiri:2c4a60a71eb752e827d97c147d637ae2",
+            "prov:usedEntity": "niiri:f594ca28922a55744403546afac8880c"
+        },
+        "_:wDF570": {
+            "prov:generatedEntity": "niiri:db27722046af7c3881dc9b3f44135cdd",
+            "prov:usedEntity": "niiri:1f5837a9250f8adad81d9cf7febcb06c"
+        },
+        "_:wDF573": {
+            "prov:generatedEntity": "niiri:130b59f20e485841289d47a669c27dec",
+            "prov:usedEntity": "niiri:4978ca959ffd9dac40bc74938928d142"
+        },
+        "_:wDF576": {
+            "prov:generatedEntity": "niiri:7d589921c2ce3d87a67549309a2ce4d9",
+            "prov:usedEntity": "niiri:a8156b1e457954028b70ba39c8f61983"
+        },
+        "_:wDF579": {
+            "prov:generatedEntity": "niiri:fc5bb336fd66e8a55c0326f0b1d351e5",
+            "prov:usedEntity": "niiri:b00bd2c845defd49f3843980d3290639"
+        },
+        "_:wDF582": {
+            "prov:generatedEntity": "niiri:602dbb725cf9f38cf7aa442b3a5fac1e",
+            "prov:usedEntity": "niiri:0d91d576d381385281f1b2d5d2714a3f"
+        },
+        "_:wDF585": {
+            "prov:generatedEntity": "niiri:fb785c4b2387927cfcaba115b1c2b59a",
+            "prov:usedEntity": "niiri:1505e0b207a3a8175cc0be4688a0d7c4"
+        },
+        "_:wDF588": {
+            "prov:generatedEntity": "niiri:9b7ac364d02018f5800c5cab0a832028",
+            "prov:usedEntity": "niiri:892dfa415e44d696ef37c9d6a5487e86"
+        }
+    },
+    "wasAttributedTo": {
+        "_:wAT6": {
+            "prov:entity": "niiri:c1b405a8360aa137d6b3059c99d29f33",
+            "prov:agent": "niiri:92a315e48eb2104ecb553b5909a53206"
+        },
+        "_:wAT7": {
+            "prov:entity": "niiri:c1b405a8360aa137d6b3059c99d29f33",
+            "prov:agent": "niiri:86bf7416c208bed0ed858777f7b52736"
+        }
+    },
+    "wasAssociatedWith": {
+        "_:wAW13": {
+            "prov:activity": "niiri:e00957320cd5a93f086b03d92e906e5b",
+            "prov:agent": "niiri:38ff5133581fdcd984a4f1a8f23b66bc"
+        },
+        "_:wAW61": {
+            "prov:activity": "niiri:a9881c0f935d0d86cf261907ea9a9c33",
+            "prov:agent": "niiri:38ff5133581fdcd984a4f1a8f23b66bc"
+        },
+        "_:wAW92": {
+            "prov:activity": "niiri:543184be0064a6c0e9ff9e528d51cf44",
+            "prov:agent": "niiri:38ff5133581fdcd984a4f1a8f23b66bc"
+        }
+    }
+    }
+  }
+}

--- a/spmexport/ex_spm_HRF_informed_basis/nidm.jsonld
+++ b/spmexport/ex_spm_HRF_informed_basis/nidm.jsonld
@@ -7,7 +7,7 @@
       "niiri": "http://iri.nidash.org/",
       "spm": "http://purl.org/nidash/spm#",
       "neurolex": "http://neurolex.org/wiki/",
-      "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#",
+      "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/",
       "dct": "http://purl.org/dc/terms/",
       "nfo": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#",
       "dc": "http://purl.org/dc/elements/1.1/",
@@ -22,32 +22,32 @@
   ],
   "@graph": [
     {
-      "@id": "niiri:c5e637758bfe8531894d8ad900899234",
-      "@type": ["prov:Entity","prov:Bundle","nidm_NIDMResults:"],
+      "@id": "niiri:4a6924b313422b14d65ae05690ac91e1",
+      "@type": ["prov:Entity","prov:Bundle","nidm_NIDMResults"],
       "rdfs:label": "NIDM-Results",
-      "nidm_version:": {"@type": "xsd:string", "@value": "1.3.0"}
+      "nidm_version": {"@type": "xsd:string", "@value": "1.3.0"}
     },
     {
-      "@id": "niiri:93ab5da6aadfc85e38cab0f71c094cd9",
-      "@type": ["prov:Agent","nidm_spm_results_nidm:","prov:SoftwareAgent"],
+      "@id": "niiri:8261b150c67f791518958870bbf9df42",
+      "@type": ["prov:Agent","nidm_spm_results_nidm","prov:SoftwareAgent"],
       "rdfs:label": "spm_results_nidm",
-      "nidm_softwareVersion:": {"@type": "xsd:string", "@value": "12.6903"}
+      "nidm_softwareVersion": {"@type": "xsd:string", "@value": "12.7057"}
     },
     {
-      "@id": "niiri:a82a8e4709f14c56d2ef353e29be8951",
-      "@type": ["prov:Activity","nidm_NIDMResultsExport:"],
+      "@id": "niiri:abeca6887e37b18f4340b7939a0218cb",
+      "@type": ["prov:Activity","nidm_NIDMResultsExport"],
       "rdfs:label": "NIDM-Results export"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:a82a8e4709f14c56d2ef353e29be8951",
-      "agent": "niiri:93ab5da6aadfc85e38cab0f71c094cd9"
+      "activity_associated": "niiri:abeca6887e37b18f4340b7939a0218cb",
+      "agent": "niiri:8261b150c67f791518958870bbf9df42"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:c5e637758bfe8531894d8ad900899234",
-      "activity": "niiri:a82a8e4709f14c56d2ef353e29be8951",
-      "atTime": "2016-12-07T16:07:28"
+      "entity_generated": "niiri:4a6924b313422b14d65ae05690ac91e1",
+      "activity": "niiri:abeca6887e37b18f4340b7939a0218cb",
+      "atTime": "2017-04-19T12:17:24"
     }
   ]
 },
@@ -160,700 +160,700 @@
       "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
     }
   ],
-  "@id": "niiri:c5e637758bfe8531894d8ad900899234",
+  "@id": "niiri:4a6924b313422b14d65ae05690ac91e1",
   "@graph": [
     {
-      "@id": "niiri:c302efbe8b4e4d5060ee5c2f1135c601",
-      "@type": ["prov:Agent","src_SPM:","prov:SoftwareAgent"],
+      "@id": "niiri:38ff5133581fdcd984a4f1a8f23b66bc",
+      "@type": ["prov:Agent","src_SPM","prov:SoftwareAgent"],
       "rdfs:label": "SPM",
-      "nidm_softwareVersion:": {"@type": "xsd:string", "@value": "12.12.2"}
+      "nidm_softwareVersion": {"@type": "xsd:string", "@value": "12.6906"}
     },
     {
-      "@id": "niiri:188b3f0dd17bb09909483ef8ba9e91bc",
-      "@type": ["prov:Entity","nidm_CoordinateSpace:"],
+      "@id": "niiri:001c0dbfa3e3cb7025a88555be3739cd",
+      "@type": ["prov:Entity","nidm_CoordinateSpace"],
       "rdfs:label": "Coordinate space 1",
-      "nidm_voxelToWorldMapping:": {"@type": "xsd:string", "@value": "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"},
-      "nidm_voxelUnits:": {"@type": "xsd:string", "@value": "[\"mm\", \"mm\", \"mm\"]"},
-      "nidm_voxelSize:": {"@type": "xsd:string", "@value": "[2, 2, 2]"},
-      "nidm_inWorldCoordinateSystem:": {"@id": "nidm_Ixi549CoordinateSystem:"},
-      "nidm_numberOfDimensions:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_dimensionsInVoxels:": {"@type": "xsd:string", "@value": "[79,95,79]"}
+      "nidm_voxelToWorldMapping": {"@type": "xsd:string", "@value": "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"},
+      "nidm_voxelUnits": {"@type": "xsd:string", "@value": "[\"mm\", \"mm\", \"mm\"]"},
+      "nidm_voxelSize": {"@type": "xsd:string", "@value": "[2, 2, 2]"},
+      "nidm_inWorldCoordinateSystem": {"@id": "nidm_Ixi549CoordinateSystem"},
+      "nidm_numberOfDimensions": {"@type": "xsd:int", "@value": "3"},
+      "nidm_dimensionsInVoxels": {"@type": "xsd:string", "@value": "[79,95,79]"}
     },
     {
-      "@id": "niiri:41358075cfc9d63b114e2c27b82e9ce4",
-      "@type": ["prov:Agent","nlx_Imaginginstrument:","nlx_Magneticresonanceimagingscanner:"],
+      "@id": "niiri:92a315e48eb2104ecb553b5909a53206",
+      "@type": ["prov:Agent","nlx_Imaginginstrument","nlx_Magneticresonanceimagingscanner"],
       "rdfs:label": "MRI Scanner"
     },
     {
-      "@id": "niiri:1240cfadabb50a38a0dc8dd35780c7a6",
+      "@id": "niiri:86bf7416c208bed0ed858777f7b52736",
       "@type": ["prov:Agent","prov:Person"],
       "rdfs:label": "Person"
     },
     {
-      "@id": "niiri:e5aea52a813e820d2c33b02b449732de",
-      "@type": ["prov:Entity","prov:Collection","nidm_Data:"],
+      "@id": "niiri:c1b405a8360aa137d6b3059c99d29f33",
+      "@type": ["prov:Entity","prov:Collection","nidm_Data"],
       "rdfs:label": "Data",
-      "nidm_grandMeanScaling:": {"@type": "xsd:boolean", "@value": "true"},
-      "nidm_targetIntensity:": {"@type": "xsd:float", "@value": "100"},
-      "nidm_hasMRIProtocol:": {"@id": "nlx_FunctionalMRIprotocol:"}
+      "nidm_grandMeanScaling": {"@type": "xsd:boolean", "@value": "true"},
+      "nidm_targetIntensity": {"@type": "xsd:float", "@value": "100"},
+      "nidm_hasMRIProtocol": {"@id": "nlx_FunctionalMRIprotocol"}
     },
     {
       "@type": "prov:Attribution",
-      "entity_attributed": "niiri:e5aea52a813e820d2c33b02b449732de",
-      "agent": "niiri:41358075cfc9d63b114e2c27b82e9ce4"
+      "entity_attributed": "niiri:c1b405a8360aa137d6b3059c99d29f33",
+      "agent": "niiri:92a315e48eb2104ecb553b5909a53206"
     },
     {
       "@type": "prov:Attribution",
-      "entity_attributed": "niiri:e5aea52a813e820d2c33b02b449732de",
-      "agent": "niiri:1240cfadabb50a38a0dc8dd35780c7a6"
+      "entity_attributed": "niiri:c1b405a8360aa137d6b3059c99d29f33",
+      "agent": "niiri:86bf7416c208bed0ed858777f7b52736"
     },
     {
-      "@id": "niiri:937076fffcf924d8b4111758049b014c",
-      "@type": ["prov:Entity","spm_DCTDriftModel:"],
+      "@id": "niiri:b62a1b2d76f025e49ec6138bb72cc749",
+      "@type": ["prov:Entity","spm_DCTDriftModel"],
       "rdfs:label": "SPM's DCT Drift Model",
-      "spm_SPMsDriftCutoffPeriod:": {"@type": "xsd:float", "@value": "128"}
+      "spm_SPMsDriftCutoffPeriod": {"@type": "xsd:float", "@value": "128"}
     },
     {
-      "@id": "niiri:d04cda6d1289e860f4b4be6577fe58c5",
-      "@type": ["prov:Entity","nidm_DesignMatrix:"],
+      "@id": "niiri:d36d45f811e2c1d8f3d5e1b6d9405158",
+      "@type": ["prov:Entity","nidm_DesignMatrix"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "DesignMatrix.csv"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "DesignMatrix.csv"},
       "dct:format": {"@type": "xsd:string", "@value": "text/csv"},
-      "dc:description": {"@id": "niiri:9d12769f59795b260753a036fbea1565"},
+      "dc:description": {"@id": "niiri:6cac7ac7016b4d63113dc01cb939523d"},
       "rdfs:label": "Design Matrix",
-      "nidm_regressorNames:": {"@type": "xsd:string", "@value": "[\"Sn(1) to*bf(1)\", \"Sn(1) to*bf(2)\", \"Sn(1) to*bf(3)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) \ntask001 co*bf(2)\", \"Sn(1) \ntask001 co*bf(3)\", \"Sn(1) constant\"]"},
-      "nidm_hasDriftModel:": {"@id": "niiri:937076fffcf924d8b4111758049b014c"},
-      "nidm_hasHRFBasis:": [{"@id": "spm_SPMsCanonicalHRF:"},{"@id": "spm_SPMsTemporalDerivative:"},{"@id": "spm_SPMsDispersionDerivative:"}]
+      "nidm_regressorNames": {"@type": "xsd:string", "@value": "[\"Sn(1) to*bf(1)\", \"Sn(1) to*bf(2)\", \"Sn(1) to*bf(3)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) \ntask001 co*bf(2)\", \"Sn(1) \ntask001 co*bf(3)\", \"Sn(1) constant\"]"},
+      "nidm_hasDriftModel": {"@id": "niiri:b62a1b2d76f025e49ec6138bb72cc749"},
+      "nidm_hasHRFBasis": [{"@id": "spm_SPMsCanonicalHRF"},{"@id": "spm_SPMsTemporalDerivative"},{"@id": "spm_SPMsDispersionDerivative"}]
     },
     {
-      "@id": "niiri:9d12769f59795b260753a036fbea1565",
+      "@id": "niiri:6cac7ac7016b4d63113dc01cb939523d",
       "@type": ["prov:Entity","dctype:Image"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "DesignMatrix.png"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "DesignMatrix.png"},
       "dct:format": {"@type": "xsd:string", "@value": "image/png"}
     },
     {
-      "@id": "niiri:01f9cb583db5694c6cde4b6362a3c5d9",
-      "@type": ["prov:Entity","nidm_ErrorModel:"],
-      "nidm_hasErrorDistribution:": {"@id": "obo_normaldistribution:"},
-      "nidm_hasErrorDependence:": {"@id": "obo_Toeplitzcovariancestructure:"},
-      "nidm_dependenceMapWiseDependence:": {"@id": "nidm_ConstantParameter:"},
-      "nidm_errorVarianceHomogeneous:": {"@type": "xsd:boolean", "@value": "true"},
-      "nidm_varianceMapWiseDependence:": {"@id": "nidm_IndependentParameter:"}
+      "@id": "niiri:61c272100996293e9d28d33c83a38df1",
+      "@type": ["prov:Entity","nidm_ErrorModel"],
+      "nidm_hasErrorDistribution": {"@id": "obo_normaldistribution"},
+      "nidm_hasErrorDependence": {"@id": "obo_Toeplitzcovariancestructure"},
+      "nidm_dependenceMapWiseDependence": {"@id": "nidm_ConstantParameter"},
+      "nidm_errorVarianceHomogeneous": {"@type": "xsd:boolean", "@value": "true"},
+      "nidm_varianceMapWiseDependence": {"@id": "nidm_IndependentParameter"}
     },
     {
-      "@id": "niiri:4bfad26596a5c6d8df54ba99dfcc1ac5",
-      "@type": ["prov:Activity","nidm_ModelParametersEstimation:"],
+      "@id": "niiri:e00957320cd5a93f086b03d92e906e5b",
+      "@type": ["prov:Activity","nidm_ModelParametersEstimation"],
       "rdfs:label": "Model parameters estimation",
-      "nidm_withEstimationMethod:": {"@id": "obo_generalizedleastsquaresestimation:"}
+      "nidm_withEstimationMethod": {"@id": "obo_generalizedleastsquaresestimation"}
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:4bfad26596a5c6d8df54ba99dfcc1ac5",
-      "agent": "niiri:c302efbe8b4e4d5060ee5c2f1135c601"
+      "activity_associated": "niiri:e00957320cd5a93f086b03d92e906e5b",
+      "agent": "niiri:38ff5133581fdcd984a4f1a8f23b66bc"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:4bfad26596a5c6d8df54ba99dfcc1ac5",
-      "entity": "niiri:d04cda6d1289e860f4b4be6577fe58c5"
+      "activity_using": "niiri:e00957320cd5a93f086b03d92e906e5b",
+      "entity": "niiri:d36d45f811e2c1d8f3d5e1b6d9405158"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:4bfad26596a5c6d8df54ba99dfcc1ac5",
-      "entity": "niiri:e5aea52a813e820d2c33b02b449732de"
+      "activity_using": "niiri:e00957320cd5a93f086b03d92e906e5b",
+      "entity": "niiri:c1b405a8360aa137d6b3059c99d29f33"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:4bfad26596a5c6d8df54ba99dfcc1ac5",
-      "entity": "niiri:01f9cb583db5694c6cde4b6362a3c5d9"
+      "activity_using": "niiri:e00957320cd5a93f086b03d92e906e5b",
+      "entity": "niiri:61c272100996293e9d28d33c83a38df1"
     },
     {
-      "@id": "niiri:92cfad48f775d3c1bb375d5594bbbe67",
-      "@type": ["prov:Entity","nidm_MaskMap:"],
+      "@id": "niiri:7f004a26944135c1d554914761e27b2e",
+      "@type": ["prov:Entity","nidm_MaskMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "Mask.nii.gz"},
-      "nidm_isUserDefined:": {"@type": "xsd:boolean", "@value": "false"},
+      "nidm_isUserDefined": {"@type": "xsd:boolean", "@value": "false"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "Mask.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Mask",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:188b3f0dd17bb09909483ef8ba9e91bc"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:001c0dbfa3e3cb7025a88555be3739cd"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876"}
     },
     {
-      "@id": "niiri:e4b5cecf835eaccf0776863dd3c51039",
-      "@type": ["prov:Entity","nidm_MaskMap:"],
+      "@id": "niiri:a07cf2721b41e6ba9ec7e48fb167fb89",
+      "@type": ["prov:Entity","nidm_MaskMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "mask.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "36929e1f5f4143bd9cc818cd896a25f129961fab208c3a4438555f40444c08347b359142ee8c53ece6e8cca1627f49db0788a1fd3b9e2ecaef61999c6c6c67ac"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:92cfad48f775d3c1bb375d5594bbbe67",
-      "entity": "niiri:e4b5cecf835eaccf0776863dd3c51039"
+      "entity_derived": "niiri:7f004a26944135c1d554914761e27b2e",
+      "entity": "niiri:a07cf2721b41e6ba9ec7e48fb167fb89"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:92cfad48f775d3c1bb375d5594bbbe67",
-      "activity": "niiri:4bfad26596a5c6d8df54ba99dfcc1ac5"
+      "entity_generated": "niiri:7f004a26944135c1d554914761e27b2e",
+      "activity": "niiri:e00957320cd5a93f086b03d92e906e5b"
     },
     {
-      "@id": "niiri:f7c42a9a4467568ceeb1993aca05147a",
-      "@type": ["prov:Entity","nidm_GrandMeanMap:"],
+      "@id": "niiri:f5d9995c28e5cb26e1839c59c9b5bbff",
+      "@type": ["prov:Entity","nidm_GrandMeanMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "GrandMean.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "GrandMean.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Grand Mean Map",
-      "nidm_maskedMedian:": {"@type": "xsd:float", "@value": "116.329124450684"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:188b3f0dd17bb09909483ef8ba9e91bc"},
+      "nidm_maskedMedian": {"@type": "xsd:float", "@value": "116.329124450684"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:001c0dbfa3e3cb7025a88555be3739cd"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "ec99afa6698e7e3dee3ab79feba8f2cd2a493c5697526587e163285b64c4f5e1f4ea33dde05f107f19022d0794fbd73ebedcfd84a9efa34bd37e4d1f13495c8b"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:f7c42a9a4467568ceeb1993aca05147a",
-      "activity": "niiri:4bfad26596a5c6d8df54ba99dfcc1ac5"
+      "entity_generated": "niiri:f5d9995c28e5cb26e1839c59c9b5bbff",
+      "activity": "niiri:e00957320cd5a93f086b03d92e906e5b"
     },
     {
-      "@id": "niiri:0d26b879da2421e4381c87acd5cb9607",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:2593c500a2e3bba4242f56e76e61b2d9",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0001.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0001.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 1",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:188b3f0dd17bb09909483ef8ba9e91bc"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:001c0dbfa3e3cb7025a88555be3739cd"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "3497224bcc9542afe414ca8c9c2089d65f208f236583cd9e934f85d3807ee7c7b51da6a5281e4603b9dbebb087c9a69e1b328eb16c1505f10475cd22bacb5b03"}
     },
     {
-      "@id": "niiri:e37c71bab163da8b5c606310ded8c6c6",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:052b380e570273544f6f2d746785485a",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0001.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "3497224bcc9542afe414ca8c9c2089d65f208f236583cd9e934f85d3807ee7c7b51da6a5281e4603b9dbebb087c9a69e1b328eb16c1505f10475cd22bacb5b03"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0d26b879da2421e4381c87acd5cb9607",
-      "entity": "niiri:e37c71bab163da8b5c606310ded8c6c6"
+      "entity_derived": "niiri:2593c500a2e3bba4242f56e76e61b2d9",
+      "entity": "niiri:052b380e570273544f6f2d746785485a"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:0d26b879da2421e4381c87acd5cb9607",
-      "activity": "niiri:4bfad26596a5c6d8df54ba99dfcc1ac5"
+      "entity_generated": "niiri:2593c500a2e3bba4242f56e76e61b2d9",
+      "activity": "niiri:e00957320cd5a93f086b03d92e906e5b"
     },
     {
-      "@id": "niiri:3503e6e10890a04d3539c21f67f250dd",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:dd5f95dd48f703c72358e4165ae1e39d",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0002.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0002.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 2",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:188b3f0dd17bb09909483ef8ba9e91bc"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:001c0dbfa3e3cb7025a88555be3739cd"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "dd73295132622e8dc5981d7ed38df121358b5db54cc7f22f1fd3e6312db59dcbefd8e4c631ef5d251f634979c0793c6c3ab96dd979eca1f0e546f4811ad7f1dd"}
     },
     {
-      "@id": "niiri:4cb802f633abf153d31bd1ff505e84f9",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:6278c189e4aaeee91d9763d5764523da",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0002.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "dd73295132622e8dc5981d7ed38df121358b5db54cc7f22f1fd3e6312db59dcbefd8e4c631ef5d251f634979c0793c6c3ab96dd979eca1f0e546f4811ad7f1dd"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3503e6e10890a04d3539c21f67f250dd",
-      "entity": "niiri:4cb802f633abf153d31bd1ff505e84f9"
+      "entity_derived": "niiri:dd5f95dd48f703c72358e4165ae1e39d",
+      "entity": "niiri:6278c189e4aaeee91d9763d5764523da"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:3503e6e10890a04d3539c21f67f250dd",
-      "activity": "niiri:4bfad26596a5c6d8df54ba99dfcc1ac5"
+      "entity_generated": "niiri:dd5f95dd48f703c72358e4165ae1e39d",
+      "activity": "niiri:e00957320cd5a93f086b03d92e906e5b"
     },
     {
-      "@id": "niiri:37f6b18b1c2a51e32387f84113f2e20a",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:e9cc9119a66cf374f5bd09a02cb7f0c6",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0003.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0003.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 3",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:188b3f0dd17bb09909483ef8ba9e91bc"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:001c0dbfa3e3cb7025a88555be3739cd"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "6370516cf48e70e7d88c496fb0763827a4522075468661c6d78139565e0213199afa65e9395ef938140ccd322f0c245fbd271aac521d3b5805aaa27422466a14"}
     },
     {
-      "@id": "niiri:1c5d1ffbae51ac5ea4489818ca10dd0e",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:1a2a75047181a94977af5143fbc2a3f6",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0003.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "6370516cf48e70e7d88c496fb0763827a4522075468661c6d78139565e0213199afa65e9395ef938140ccd322f0c245fbd271aac521d3b5805aaa27422466a14"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:37f6b18b1c2a51e32387f84113f2e20a",
-      "entity": "niiri:1c5d1ffbae51ac5ea4489818ca10dd0e"
+      "entity_derived": "niiri:e9cc9119a66cf374f5bd09a02cb7f0c6",
+      "entity": "niiri:1a2a75047181a94977af5143fbc2a3f6"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:37f6b18b1c2a51e32387f84113f2e20a",
-      "activity": "niiri:4bfad26596a5c6d8df54ba99dfcc1ac5"
+      "entity_generated": "niiri:e9cc9119a66cf374f5bd09a02cb7f0c6",
+      "activity": "niiri:e00957320cd5a93f086b03d92e906e5b"
     },
     {
-      "@id": "niiri:ec0b0abbac2426a3220447cfa9c897db",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:1dfac129a8bcadeb38a137a5e7f33cc7",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0004.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0004.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 4",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:188b3f0dd17bb09909483ef8ba9e91bc"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:001c0dbfa3e3cb7025a88555be3739cd"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "3e67878a2f7df58413a4a193334e8c451dde1eb8918edc712798901996e0a3479f7bb72c086d81a7f852058d413eac6b1644b8b02f8255e0159b41798f21713a"}
     },
     {
-      "@id": "niiri:1494239139c2299ccd56411bd7ba3d31",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:386a35d1945daf4a9951952ed1cb6ec8",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0004.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "3e67878a2f7df58413a4a193334e8c451dde1eb8918edc712798901996e0a3479f7bb72c086d81a7f852058d413eac6b1644b8b02f8255e0159b41798f21713a"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ec0b0abbac2426a3220447cfa9c897db",
-      "entity": "niiri:1494239139c2299ccd56411bd7ba3d31"
+      "entity_derived": "niiri:1dfac129a8bcadeb38a137a5e7f33cc7",
+      "entity": "niiri:386a35d1945daf4a9951952ed1cb6ec8"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:ec0b0abbac2426a3220447cfa9c897db",
-      "activity": "niiri:4bfad26596a5c6d8df54ba99dfcc1ac5"
+      "entity_generated": "niiri:1dfac129a8bcadeb38a137a5e7f33cc7",
+      "activity": "niiri:e00957320cd5a93f086b03d92e906e5b"
     },
     {
-      "@id": "niiri:4a16c89cb4f83830615f6a835c98bd87",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:d9bf5437aa08a1459fe0182fd947a96c",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0005.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0005.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 5",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:188b3f0dd17bb09909483ef8ba9e91bc"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:001c0dbfa3e3cb7025a88555be3739cd"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "5b940e22ba41618a9ed4327d055717b03ce647c4cab1acf5ad139ca6721e873813a8efc4334200ea95d052590e360fa714b182bca20d0b36bf02afddbdf14ba5"}
     },
     {
-      "@id": "niiri:8ab2b36d956eb629301d4768b4c60375",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:02af90ad0dd6b14db8aaaf0f3cf245f4",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0005.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "5b940e22ba41618a9ed4327d055717b03ce647c4cab1acf5ad139ca6721e873813a8efc4334200ea95d052590e360fa714b182bca20d0b36bf02afddbdf14ba5"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4a16c89cb4f83830615f6a835c98bd87",
-      "entity": "niiri:8ab2b36d956eb629301d4768b4c60375"
+      "entity_derived": "niiri:d9bf5437aa08a1459fe0182fd947a96c",
+      "entity": "niiri:02af90ad0dd6b14db8aaaf0f3cf245f4"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:4a16c89cb4f83830615f6a835c98bd87",
-      "activity": "niiri:4bfad26596a5c6d8df54ba99dfcc1ac5"
+      "entity_generated": "niiri:d9bf5437aa08a1459fe0182fd947a96c",
+      "activity": "niiri:e00957320cd5a93f086b03d92e906e5b"
     },
     {
-      "@id": "niiri:8c59a450b99a62f07febcaccaf31a29a",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:4c0ab1c8535ea87131668d8df8033987",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0006.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0006.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 6",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:188b3f0dd17bb09909483ef8ba9e91bc"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:001c0dbfa3e3cb7025a88555be3739cd"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "2ddfa0fd58e83c5cac4bfcd3b08846aabb9a0bf0bab1b0b9d906f276fb5037e45ee37a98b676dde3c2db7570c1f383983a10d9ebc294dcce50016bb3ec31890e"}
     },
     {
-      "@id": "niiri:b8bc7cf01edd5c3b0ada8954e4d2879b",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:6f1af1cdc138aa878dd6288c45630725",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0006.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "2ddfa0fd58e83c5cac4bfcd3b08846aabb9a0bf0bab1b0b9d906f276fb5037e45ee37a98b676dde3c2db7570c1f383983a10d9ebc294dcce50016bb3ec31890e"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8c59a450b99a62f07febcaccaf31a29a",
-      "entity": "niiri:b8bc7cf01edd5c3b0ada8954e4d2879b"
+      "entity_derived": "niiri:4c0ab1c8535ea87131668d8df8033987",
+      "entity": "niiri:6f1af1cdc138aa878dd6288c45630725"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:8c59a450b99a62f07febcaccaf31a29a",
-      "activity": "niiri:4bfad26596a5c6d8df54ba99dfcc1ac5"
+      "entity_generated": "niiri:4c0ab1c8535ea87131668d8df8033987",
+      "activity": "niiri:e00957320cd5a93f086b03d92e906e5b"
     },
     {
-      "@id": "niiri:b346966ac0ac09399e1ee677416c177e",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:fcd83b6089c28ff32851390322727691",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0007.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0007.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 7",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:188b3f0dd17bb09909483ef8ba9e91bc"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:001c0dbfa3e3cb7025a88555be3739cd"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "ec648b94e914a34b754e86a51d22e001078d5e2aabd640e2baa8de388e72c112a75aa2f709c2f8066f86a99b87026221eeaa3d5418385eae7d32a5f535924e79"}
     },
     {
-      "@id": "niiri:6b0f25c5769b95cf281b7304a4e2b112",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:2e56c7cfc04eb22f960f4187216b007b",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0007.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "ec648b94e914a34b754e86a51d22e001078d5e2aabd640e2baa8de388e72c112a75aa2f709c2f8066f86a99b87026221eeaa3d5418385eae7d32a5f535924e79"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b346966ac0ac09399e1ee677416c177e",
-      "entity": "niiri:6b0f25c5769b95cf281b7304a4e2b112"
+      "entity_derived": "niiri:fcd83b6089c28ff32851390322727691",
+      "entity": "niiri:2e56c7cfc04eb22f960f4187216b007b"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:b346966ac0ac09399e1ee677416c177e",
-      "activity": "niiri:4bfad26596a5c6d8df54ba99dfcc1ac5"
+      "entity_generated": "niiri:fcd83b6089c28ff32851390322727691",
+      "activity": "niiri:e00957320cd5a93f086b03d92e906e5b"
     },
     {
-      "@id": "niiri:d0c4815df31f7d1c3f47f162d15e211b",
-      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap:"],
+      "@id": "niiri:634e834296ec47451bb5dba35c6ab090",
+      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ResidualMeanSquares.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ResidualMeanSquares.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Residual Mean Squares Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:188b3f0dd17bb09909483ef8ba9e91bc"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:001c0dbfa3e3cb7025a88555be3739cd"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "ecbbff7f5c8f82725791661876f19d56ea83fabf87af9ff25e36ff5a33c0111650ca0da870a7a29bb87c6779fd36f6d12d9fa62d2251903dd498a9bec3297e1e"}
     },
     {
-      "@id": "niiri:67acd114b0d9caaa74d7106a87b6c787",
-      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap:"],
+      "@id": "niiri:239382281394fda80fab27e1b812d896",
+      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "ResMS.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "33f469f7adf069c8eeaa3dff460c85a3328dfa41621be4c0d400a832e5b2e92f671e5db6938c9a82dc16c81d4b60a3c0182c9be7723d1ad0236b249a1174a5d5"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d0c4815df31f7d1c3f47f162d15e211b",
-      "entity": "niiri:67acd114b0d9caaa74d7106a87b6c787"
+      "entity_derived": "niiri:634e834296ec47451bb5dba35c6ab090",
+      "entity": "niiri:239382281394fda80fab27e1b812d896"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:d0c4815df31f7d1c3f47f162d15e211b",
-      "activity": "niiri:4bfad26596a5c6d8df54ba99dfcc1ac5"
+      "entity_generated": "niiri:634e834296ec47451bb5dba35c6ab090",
+      "activity": "niiri:e00957320cd5a93f086b03d92e906e5b"
     },
     {
-      "@id": "niiri:a45c8e34d741fe2400c2d0d6befe2db2",
-      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap:"],
+      "@id": "niiri:d322a9aa3dcb86b056a502997edcb664",
+      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ReselsPerVoxel.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ReselsPerVoxel.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Resels per Voxel Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:188b3f0dd17bb09909483ef8ba9e91bc"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:001c0dbfa3e3cb7025a88555be3739cd"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "d4f5f4f076c45cc4f9481325ee5a43ca4edc8fbb928db288ee4ed93f0fa1368ef6267240398d71e7590990e133715b53d4455b95ee8a59baf13e4c6ea46e147f"}
     },
     {
-      "@id": "niiri:9b431bd488e0d1e7c63462a779e7a245",
-      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap:"],
+      "@id": "niiri:c83c0701812f37753b6efa1070796628",
+      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "RPV.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "7e5e04367e61ffae36c2b4af7de4b4e7c6f4877f660bb110d108a0b97a1a1f20ca9c18e49803e936dfbbf27bcf0d40918ce6daece3c736ca6056720a83964b1e"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a45c8e34d741fe2400c2d0d6befe2db2",
-      "entity": "niiri:9b431bd488e0d1e7c63462a779e7a245"
+      "entity_derived": "niiri:d322a9aa3dcb86b056a502997edcb664",
+      "entity": "niiri:c83c0701812f37753b6efa1070796628"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:a45c8e34d741fe2400c2d0d6befe2db2",
-      "activity": "niiri:4bfad26596a5c6d8df54ba99dfcc1ac5"
+      "entity_generated": "niiri:d322a9aa3dcb86b056a502997edcb664",
+      "activity": "niiri:e00957320cd5a93f086b03d92e906e5b"
     },
     {
-      "@id": "niiri:6ebf83091b8d27c1eaa596583e717fc6",
-      "@type": ["prov:Entity","obo_contrastweightmatrix:"],
-      "nidm_statisticType:": {"@id": "obo_tstatistic:"},
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
+      "@id": "niiri:7c291851e6747c0e2a7284a7cf2d75f4",
+      "@type": ["prov:Entity","obo_contrastweightmatrix"],
+      "nidm_statisticType": {"@id": "obo_tstatistic"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
       "rdfs:label": "Contrast: tone counting vs baseline",
       "prov:value": {"@type": "xsd:string", "@value": "[1, 0, 0, 0, 0, 0, 0]"}
     },
     {
-      "@id": "niiri:ff0be177817b503d5fb3a21c1a599d85",
-      "@type": ["prov:Activity","nidm_ContrastEstimation:"],
+      "@id": "niiri:a9881c0f935d0d86cf261907ea9a9c33",
+      "@type": ["prov:Activity","nidm_ContrastEstimation"],
       "rdfs:label": "Contrast estimation"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:ff0be177817b503d5fb3a21c1a599d85",
-      "agent": "niiri:c302efbe8b4e4d5060ee5c2f1135c601"
+      "activity_associated": "niiri:a9881c0f935d0d86cf261907ea9a9c33",
+      "agent": "niiri:38ff5133581fdcd984a4f1a8f23b66bc"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:ff0be177817b503d5fb3a21c1a599d85",
-      "entity": "niiri:92cfad48f775d3c1bb375d5594bbbe67"
+      "activity_using": "niiri:a9881c0f935d0d86cf261907ea9a9c33",
+      "entity": "niiri:7f004a26944135c1d554914761e27b2e"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:ff0be177817b503d5fb3a21c1a599d85",
-      "entity": "niiri:d0c4815df31f7d1c3f47f162d15e211b"
+      "activity_using": "niiri:a9881c0f935d0d86cf261907ea9a9c33",
+      "entity": "niiri:634e834296ec47451bb5dba35c6ab090"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:ff0be177817b503d5fb3a21c1a599d85",
-      "entity": "niiri:d04cda6d1289e860f4b4be6577fe58c5"
+      "activity_using": "niiri:a9881c0f935d0d86cf261907ea9a9c33",
+      "entity": "niiri:d36d45f811e2c1d8f3d5e1b6d9405158"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:ff0be177817b503d5fb3a21c1a599d85",
-      "entity": "niiri:6ebf83091b8d27c1eaa596583e717fc6"
+      "activity_using": "niiri:a9881c0f935d0d86cf261907ea9a9c33",
+      "entity": "niiri:7c291851e6747c0e2a7284a7cf2d75f4"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:ff0be177817b503d5fb3a21c1a599d85",
-      "entity": "niiri:0d26b879da2421e4381c87acd5cb9607"
+      "activity_using": "niiri:a9881c0f935d0d86cf261907ea9a9c33",
+      "entity": "niiri:2593c500a2e3bba4242f56e76e61b2d9"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:ff0be177817b503d5fb3a21c1a599d85",
-      "entity": "niiri:3503e6e10890a04d3539c21f67f250dd"
+      "activity_using": "niiri:a9881c0f935d0d86cf261907ea9a9c33",
+      "entity": "niiri:dd5f95dd48f703c72358e4165ae1e39d"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:ff0be177817b503d5fb3a21c1a599d85",
-      "entity": "niiri:37f6b18b1c2a51e32387f84113f2e20a"
+      "activity_using": "niiri:a9881c0f935d0d86cf261907ea9a9c33",
+      "entity": "niiri:e9cc9119a66cf374f5bd09a02cb7f0c6"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:ff0be177817b503d5fb3a21c1a599d85",
-      "entity": "niiri:ec0b0abbac2426a3220447cfa9c897db"
+      "activity_using": "niiri:a9881c0f935d0d86cf261907ea9a9c33",
+      "entity": "niiri:1dfac129a8bcadeb38a137a5e7f33cc7"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:ff0be177817b503d5fb3a21c1a599d85",
-      "entity": "niiri:4a16c89cb4f83830615f6a835c98bd87"
+      "activity_using": "niiri:a9881c0f935d0d86cf261907ea9a9c33",
+      "entity": "niiri:d9bf5437aa08a1459fe0182fd947a96c"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:ff0be177817b503d5fb3a21c1a599d85",
-      "entity": "niiri:8c59a450b99a62f07febcaccaf31a29a"
+      "activity_using": "niiri:a9881c0f935d0d86cf261907ea9a9c33",
+      "entity": "niiri:4c0ab1c8535ea87131668d8df8033987"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:ff0be177817b503d5fb3a21c1a599d85",
-      "entity": "niiri:b346966ac0ac09399e1ee677416c177e"
+      "activity_using": "niiri:a9881c0f935d0d86cf261907ea9a9c33",
+      "entity": "niiri:fcd83b6089c28ff32851390322727691"
     },
     {
-      "@id": "niiri:6ff77cd1a0e88dfed2f18485809d692d",
-      "@type": ["prov:Entity","nidm_StatisticMap:"],
+      "@id": "niiri:10f87872974544f0796133e8ec52cdb2",
+      "@type": ["prov:Entity","nidm_StatisticMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "TStatistic.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "TStatistic.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "T-Statistic Map: tone counting vs baseline",
-      "nidm_statisticType:": {"@id": "obo_tstatistic:"},
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
-      "nidm_errorDegreesOfFreedom:": {"@type": "xsd:float", "@value": "93.9999999999637"},
-      "nidm_effectDegreesOfFreedom:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:188b3f0dd17bb09909483ef8ba9e91bc"},
+      "nidm_statisticType": {"@id": "obo_tstatistic"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
+      "nidm_errorDegreesOfFreedom": {"@type": "xsd:float", "@value": "93.9999999999637"},
+      "nidm_effectDegreesOfFreedom": {"@type": "xsd:float", "@value": "1"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:001c0dbfa3e3cb7025a88555be3739cd"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "0a35119e4ab5eaf8da616907ac9aa8de8b5398967c85ac7a96d2bf22ced6e6f25871fd086d20db35df40bbb9015be8236120a48d04886378992fd53f27789a98"}
     },
     {
-      "@id": "niiri:05b4c92f8317abcb5568652197e43d10",
-      "@type": ["prov:Entity","nidm_StatisticMap:"],
+      "@id": "niiri:8588d79c35677301f464c7e03b9d0496",
+      "@type": ["prov:Entity","nidm_StatisticMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "spmT_0001.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "1096728734b200447633666faffc81cab6f8aad61d9282f83169526dd1083f14150922528eafe7ec28f3f8c0094adb3ffd9941a696aebba046bd5c2df4966ab8"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6ff77cd1a0e88dfed2f18485809d692d",
-      "entity": "niiri:05b4c92f8317abcb5568652197e43d10"
+      "entity_derived": "niiri:10f87872974544f0796133e8ec52cdb2",
+      "entity": "niiri:8588d79c35677301f464c7e03b9d0496"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:6ff77cd1a0e88dfed2f18485809d692d",
-      "activity": "niiri:ff0be177817b503d5fb3a21c1a599d85"
+      "entity_generated": "niiri:10f87872974544f0796133e8ec52cdb2",
+      "activity": "niiri:a9881c0f935d0d86cf261907ea9a9c33"
     },
     {
-      "@id": "niiri:d64a30ad6a4b2e6ba105700e31fd97e9",
-      "@type": ["prov:Entity","nidm_ContrastMap:"],
+      "@id": "niiri:5dae15d639ffe538568fccbf50b79da6",
+      "@type": ["prov:Entity","nidm_ContrastMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "Contrast.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "Contrast.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Contrast Map: tone counting vs baseline",
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:188b3f0dd17bb09909483ef8ba9e91bc"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:001c0dbfa3e3cb7025a88555be3739cd"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "43d93cfdb352a3b8121c3e4758bd56286b7d9dfb5481860cb35941ceae021948c1cac3225a9829ceeb0997965dd1763161c4ba7db4bf47c0d2e69b5eaadd1658"}
     },
     {
-      "@id": "niiri:1742b20232911a9556eb97b3407ea922",
-      "@type": ["prov:Entity","nidm_ContrastMap:"],
+      "@id": "niiri:32b2745bbaa52aa442354c21c92a29df",
+      "@type": ["prov:Entity","nidm_ContrastMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "con_0001.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "0f8a4e835300919afe716e102bd3b85b6c760194e65dbc88d259debb4b3976960f8cba854410eca817033e63c13824e28369fe6ba7d4fd6a8e87fecfd5b5fa88"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d64a30ad6a4b2e6ba105700e31fd97e9",
-      "entity": "niiri:1742b20232911a9556eb97b3407ea922"
+      "entity_derived": "niiri:5dae15d639ffe538568fccbf50b79da6",
+      "entity": "niiri:32b2745bbaa52aa442354c21c92a29df"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:d64a30ad6a4b2e6ba105700e31fd97e9",
-      "activity": "niiri:ff0be177817b503d5fb3a21c1a599d85"
+      "entity_generated": "niiri:5dae15d639ffe538568fccbf50b79da6",
+      "activity": "niiri:a9881c0f935d0d86cf261907ea9a9c33"
     },
     {
-      "@id": "niiri:b81869e2fb3bb55c52607b64105f8736",
-      "@type": ["prov:Entity","nidm_ContrastStandardErrorMap:"],
+      "@id": "niiri:ebd0089167d8c9c6665b2ca9c440a044",
+      "@type": ["prov:Entity","nidm_ContrastStandardErrorMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ContrastStandardError.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ContrastStandardError.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Contrast Standard Error Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:188b3f0dd17bb09909483ef8ba9e91bc"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:001c0dbfa3e3cb7025a88555be3739cd"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "ada9ee87facabea9234f59dc455a9cbbae3aac2e0f679b2092df326ce9aef04a46440093bbae0429482be18a2a6cac2c6773eda2c56058225c8e5b88cb3c4576"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:b81869e2fb3bb55c52607b64105f8736",
-      "activity": "niiri:ff0be177817b503d5fb3a21c1a599d85"
+      "entity_generated": "niiri:ebd0089167d8c9c6665b2ca9c440a044",
+      "activity": "niiri:a9881c0f935d0d86cf261907ea9a9c33"
     },
     {
-      "@id": "niiri:6b3d9062ad0f4483b27782aab1511478",
-      "@type": ["prov:Entity","nidm_HeightThreshold:","nidm_PValueUncorrected:"],
-      "rdfs:label": "Height Threshold: p<0.001000 (unc.)",
+      "@id": "niiri:de3990bddd4e3e2e1f2945054f1f36a3",
+      "@type": ["prov:Entity","nidm_HeightThreshold","nidm_PValueUncorrected"],
+      "rdfs:label": "Height Threshold: p<0.001 (unc.)",
       "prov:value": {"@type": "xsd:float", "@value": "0.000999500330571057"},
-      "nidm_equivalentThreshold:": [{"@id": "niiri:3d8283c34239ccfe187df9d47651390d"},{"@id": "niiri:eab332ff971408954805dad1ac5c9257"}]
+      "nidm_equivalentThreshold": [{"@id": "niiri:8afe323854d7859a15d4db33f7665a18"},{"@id": "niiri:98610b96083c9f43ab45c0999d8fe8eb"}]
     },
     {
-      "@id": "niiri:3d8283c34239ccfe187df9d47651390d",
-      "@type": ["prov:Entity","nidm_HeightThreshold:","obo_statistic:"],
-      "rdfs:label": "Height Threshold",
+      "@id": "niiri:8afe323854d7859a15d4db33f7665a18",
+      "@type": ["prov:Entity","nidm_HeightThreshold","obo_statistic"],
+      "rdfs:label": "Height Threshold: T=3.179209)",
       "prov:value": {"@type": "xsd:float", "@value": "3.17920858075464"}
     },
     {
-      "@id": "niiri:eab332ff971408954805dad1ac5c9257",
-      "@type": ["prov:Entity","nidm_HeightThreshold:","obo_FWERadjustedpvalue:"],
-      "rdfs:label": "Height Threshold",
+      "@id": "niiri:98610b96083c9f43ab45c0999d8fe8eb",
+      "@type": ["prov:Entity","nidm_HeightThreshold","obo_FWERadjustedpvalue"],
+      "rdfs:label": "Height Threshold: p<1.000000 (FWE)",
       "prov:value": {"@type": "xsd:float", "@value": "0.999999999999999"}
     },
     {
-      "@id": "niiri:84ca636b42e1c3f776d67c159ab4e94b",
-      "@type": ["prov:Entity","nidm_ExtentThreshold:","obo_statistic:"],
+      "@id": "niiri:d8d46bf5012fbd722ed044231eea5a58",
+      "@type": ["prov:Entity","nidm_ExtentThreshold","obo_statistic"],
       "rdfs:label": "Extent Threshold: k>=0",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "0"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0"},
-      "nidm_equivalentThreshold:": [{"@id": "niiri:26c34169e2fa609a6d57df3cc013e67c"},{"@id": "niiri:9d2cbbe12bedc71b01c4da002bfcb125"}]
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "0"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0"},
+      "nidm_equivalentThreshold": [{"@id": "niiri:46cd77a8cff744b6db5af8e81bd357b3"},{"@id": "niiri:ac3e490dde5b8a24e242aeda0e6dd8ec"}]
     },
     {
-      "@id": "niiri:26c34169e2fa609a6d57df3cc013e67c",
-      "@type": ["prov:Entity","nidm_ExtentThreshold:","obo_FWERadjustedpvalue:"],
+      "@id": "niiri:46cd77a8cff744b6db5af8e81bd357b3",
+      "@type": ["prov:Entity","nidm_ExtentThreshold","obo_FWERadjustedpvalue"],
       "rdfs:label": "Extent Threshold",
       "prov:value": {"@type": "xsd:float", "@value": "1"}
     },
     {
-      "@id": "niiri:9d2cbbe12bedc71b01c4da002bfcb125",
-      "@type": ["prov:Entity","nidm_ExtentThreshold:","nidm_PValueUncorrected:"],
+      "@id": "niiri:ac3e490dde5b8a24e242aeda0e6dd8ec",
+      "@type": ["prov:Entity","nidm_ExtentThreshold","nidm_PValueUncorrected"],
       "rdfs:label": "Extent Threshold",
       "prov:value": {"@type": "xsd:float", "@value": "1"}
     },
     {
-      "@id": "niiri:64db314f0363d949e8485924fa084ba6",
-      "@type": ["prov:Entity","nidm_PeakDefinitionCriteria:"],
+      "@id": "niiri:acfbfae887d8a839f1adcb1b8b634982",
+      "@type": ["prov:Entity","nidm_PeakDefinitionCriteria"],
       "rdfs:label": "Peak Definition Criteria",
-      "nidm_maxNumberOfPeaksPerCluster:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_minDistanceBetweenPeaks:": {"@type": "xsd:float", "@value": "8"}
+      "nidm_maxNumberOfPeaksPerCluster": {"@type": "xsd:int", "@value": "3"},
+      "nidm_minDistanceBetweenPeaks": {"@type": "xsd:float", "@value": "8"}
     },
     {
-      "@id": "niiri:ba6fd9b35bfa15158bba309f1799d9fb",
-      "@type": ["prov:Entity","nidm_ClusterDefinitionCriteria:"],
+      "@id": "niiri:a3d478c3bf9b0a0df3146665a0a54e21",
+      "@type": ["prov:Entity","nidm_ClusterDefinitionCriteria"],
       "rdfs:label": "Cluster Connectivity Criterion: 18",
-      "nidm_hasConnectivityCriterion:": {"@id": "nidm_voxel18connected:"}
+      "nidm_hasConnectivityCriterion": {"@id": "nidm_voxel18connected"}
     },
     {
-      "@id": "niiri:3d1ed6f2ede33334d39aa1bf3a47cae6",
-      "@type": ["prov:Activity","nidm_Inference:"],
-      "nidm_hasAlternativeHypothesis:": {"@id": "nidm_OneTailedTest:"},
+      "@id": "niiri:543184be0064a6c0e9ff9e528d51cf44",
+      "@type": ["prov:Activity","nidm_Inference"],
+      "nidm_hasAlternativeHypothesis": {"@id": "nidm_OneTailedTest"},
       "rdfs:label": "Inference"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:3d1ed6f2ede33334d39aa1bf3a47cae6",
-      "agent": "niiri:c302efbe8b4e4d5060ee5c2f1135c601"
+      "activity_associated": "niiri:543184be0064a6c0e9ff9e528d51cf44",
+      "agent": "niiri:38ff5133581fdcd984a4f1a8f23b66bc"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:3d1ed6f2ede33334d39aa1bf3a47cae6",
-      "entity": "niiri:6b3d9062ad0f4483b27782aab1511478"
+      "activity_using": "niiri:543184be0064a6c0e9ff9e528d51cf44",
+      "entity": "niiri:de3990bddd4e3e2e1f2945054f1f36a3"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:3d1ed6f2ede33334d39aa1bf3a47cae6",
-      "entity": "niiri:84ca636b42e1c3f776d67c159ab4e94b"
+      "activity_using": "niiri:543184be0064a6c0e9ff9e528d51cf44",
+      "entity": "niiri:d8d46bf5012fbd722ed044231eea5a58"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:3d1ed6f2ede33334d39aa1bf3a47cae6",
-      "entity": "niiri:6ff77cd1a0e88dfed2f18485809d692d"
+      "activity_using": "niiri:543184be0064a6c0e9ff9e528d51cf44",
+      "entity": "niiri:10f87872974544f0796133e8ec52cdb2"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:3d1ed6f2ede33334d39aa1bf3a47cae6",
-      "entity": "niiri:a45c8e34d741fe2400c2d0d6befe2db2"
+      "activity_using": "niiri:543184be0064a6c0e9ff9e528d51cf44",
+      "entity": "niiri:d322a9aa3dcb86b056a502997edcb664"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:3d1ed6f2ede33334d39aa1bf3a47cae6",
-      "entity": "niiri:92cfad48f775d3c1bb375d5594bbbe67"
+      "activity_using": "niiri:543184be0064a6c0e9ff9e528d51cf44",
+      "entity": "niiri:7f004a26944135c1d554914761e27b2e"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:3d1ed6f2ede33334d39aa1bf3a47cae6",
-      "entity": "niiri:64db314f0363d949e8485924fa084ba6"
+      "activity_using": "niiri:543184be0064a6c0e9ff9e528d51cf44",
+      "entity": "niiri:acfbfae887d8a839f1adcb1b8b634982"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:3d1ed6f2ede33334d39aa1bf3a47cae6",
-      "entity": "niiri:ba6fd9b35bfa15158bba309f1799d9fb"
+      "activity_using": "niiri:543184be0064a6c0e9ff9e528d51cf44",
+      "entity": "niiri:a3d478c3bf9b0a0df3146665a0a54e21"
     },
     {
-      "@id": "niiri:a421ac3faf40d5b3ab15ba245dbdbdae",
-      "@type": ["prov:Entity","nidm_SearchSpaceMaskMap:"],
+      "@id": "niiri:9806490c5d381029288eb9158bc777fc",
+      "@type": ["prov:Entity","nidm_SearchSpaceMaskMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "SearchSpaceMask.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "SearchSpaceMask.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Search Space Mask Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:188b3f0dd17bb09909483ef8ba9e91bc"},
-      "nidm_searchVolumeInVoxels:": {"@type": "xsd:int", "@value": "223057"},
-      "nidm_searchVolumeInUnits:": {"@type": "xsd:float", "@value": "1784456"},
-      "nidm_reselSizeInVoxels:": {"@type": "xsd:float", "@value": "64.4465447229551"},
-      "nidm_searchVolumeInResels:": {"@type": "xsd:float", "@value": "3211.28154953333"},
-      "spm_searchVolumeReselsGeometry:": {"@type": "xsd:string", "@value": "[6, 98.3662045394454, 977.160794848662, 3211.28154953333]"},
-      "nidm_noiseFWHMInVoxels:": {"@type": "xsd:string", "@value": "[4.05938347949388, 4.00755777674972, 3.9615009606014]"},
-      "nidm_noiseFWHMInUnits:": {"@type": "xsd:string", "@value": "[8.11876695898777, 8.01511555349943, 7.92300192120281]"},
-      "nidm_randomFieldStationarity:": {"@type": "xsd:boolean", "@value": "true"},
-      "nidm_expectedNumberOfVoxelsPerCluster:": {"@type": "xsd:float", "@value": "7.07032288352472"},
-      "nidm_expectedNumberOfClusters:": {"@type": "xsd:float", "@value": "34.226779651245"},
-      "nidm_heightCriticalThresholdFWE05:": {"@type": "xsd:float", "@value": "5.33200264240234"},
-      "nidm_heightCriticalThresholdFDR05:": {"@type": "xsd:float", "@value": "4.72862100601196"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:001c0dbfa3e3cb7025a88555be3739cd"},
+      "nidm_searchVolumeInVoxels": {"@type": "xsd:int", "@value": "223057"},
+      "nidm_searchVolumeInUnits": {"@type": "xsd:float", "@value": "1784456"},
+      "nidm_reselSizeInVoxels": {"@type": "xsd:float", "@value": "64.4465447229551"},
+      "nidm_searchVolumeInResels": {"@type": "xsd:float", "@value": "3211.28154953333"},
+      "spm_searchVolumeReselsGeometry": {"@type": "xsd:string", "@value": "[6, 98.3662045394454, 977.160794848662, 3211.28154953333]"},
+      "nidm_noiseFWHMInVoxels": {"@type": "xsd:string", "@value": "[4.05938347949388, 4.00755777674972, 3.9615009606014]"},
+      "nidm_noiseFWHMInUnits": {"@type": "xsd:string", "@value": "[8.11876695898777, 8.01511555349943, 7.92300192120281]"},
+      "nidm_randomFieldStationarity": {"@type": "xsd:boolean", "@value": "true"},
+      "nidm_expectedNumberOfVoxelsPerCluster": {"@type": "xsd:float", "@value": "7.07032288352472"},
+      "nidm_expectedNumberOfClusters": {"@type": "xsd:float", "@value": "34.226779651245"},
+      "nidm_heightCriticalThresholdFWE05": {"@type": "xsd:float", "@value": "5.33200264240234"},
+      "nidm_heightCriticalThresholdFDR05": {"@type": "xsd:float", "@value": "4.72862100601196"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876"},
-      "spm_smallestSignificantClusterSizeInVoxelsFWE05:": {"@type": "xsd:int", "@value": "89"},
-      "spm_smallestSignificantClusterSizeInVoxelsFDR05:": {"@type": "xsd:int", "@value": "57"}
+      "spm_smallestSignificantClusterSizeInVoxelsFWE05": {"@type": "xsd:int", "@value": "89"},
+      "spm_smallestSignificantClusterSizeInVoxelsFDR05": {"@type": "xsd:int", "@value": "57"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:a421ac3faf40d5b3ab15ba245dbdbdae",
-      "activity": "niiri:3d1ed6f2ede33334d39aa1bf3a47cae6"
+      "entity_generated": "niiri:9806490c5d381029288eb9158bc777fc",
+      "activity": "niiri:543184be0064a6c0e9ff9e528d51cf44"
     },
     {
-      "@id": "niiri:022626d941384b37aee63db114d7e263",
-      "@type": ["prov:Entity","nidm_ExcursionSetMap:"],
+      "@id": "niiri:9b06d633f15370eacc4d439eebd44c49",
+      "@type": ["prov:Entity","nidm_ExcursionSetMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ExcursionSet.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ExcursionSet.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Excursion Set Map",
-      "nidm_numberOfSupraThresholdClusters:": {"@type": "xsd:int", "@value": "81"},
-      "nidm_pValue:": {"@type": "xsd:float", "@value": "7.7268191844837e-12"},
-      "nidm_hasClusterLabelsMap:": {"@id": "niiri:537d8221e1c19a9ebfcd07d604100329"},
-      "nidm_hasMaximumIntensityProjection:": {"@id": "niiri:0e3547d6f32024a576110c0e7f2519da"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:188b3f0dd17bb09909483ef8ba9e91bc"},
+      "nidm_numberOfSupraThresholdClusters": {"@type": "xsd:int", "@value": "81"},
+      "nidm_pValue": {"@type": "xsd:float", "@value": "7.7268191844837e-12"},
+      "nidm_hasClusterLabelsMap": {"@id": "niiri:e4fc4a47a5f1920aec26b66c27569703"},
+      "nidm_hasMaximumIntensityProjection": {"@id": "niiri:9c62b1798f4f8af0cd04d4fa20563c6e"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:001c0dbfa3e3cb7025a88555be3739cd"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "39675dfc00efabc7475604def4a2e377153e063d723ca4bcab9e920bf8cb7d7451a6357e8143d3a1ad4ca53df911f5958e4104c06efd1ccdf0bd8282f7731c15"}
     },
     {
-      "@id": "niiri:537d8221e1c19a9ebfcd07d604100329",
-      "@type": ["prov:Entity","nidm_ClusterLabelsMap:"],
+      "@id": "niiri:e4fc4a47a5f1920aec26b66c27569703",
+      "@type": ["prov:Entity","nidm_ClusterLabelsMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ClusterLabels.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ClusterLabels.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Cluster Labels Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:188b3f0dd17bb09909483ef8ba9e91bc"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:001c0dbfa3e3cb7025a88555be3739cd"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "6a7560e351d44aa68539b8d837d178254fa0372d68dc9a7fb56936d90f49de9a58b6166a38670fef2966dae8b74c4c158204d3b0e441d8285a21e18bbadb3f39"}
     },
     {
-      "@id": "niiri:0e3547d6f32024a576110c0e7f2519da",
+      "@id": "niiri:9c62b1798f4f8af0cd04d4fa20563c6e",
       "@type": ["prov:Entity","dctype:Image"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "MaximumIntensityProjection.png"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "MaximumIntensityProjection.png"},
@@ -861,3658 +861,3658 @@
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:022626d941384b37aee63db114d7e263",
-      "activity": "niiri:3d1ed6f2ede33334d39aa1bf3a47cae6"
+      "entity_generated": "niiri:9b06d633f15370eacc4d439eebd44c49",
+      "activity": "niiri:543184be0064a6c0e9ff9e528d51cf44"
     },
     {
-      "@id": "niiri:53b238f4a15796bb564f209e9a20f459",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:12d2dfb7ca155d963f6afeaa6467e598",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0001",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1368"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "21.2268944111869"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.72485138598936e-18"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1.11022302462516e-16"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1.10356481132569e-16"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "1"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1368"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "21.2268944111869"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.72485138598936e-18"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1.11022302462516e-16"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1.10356481132569e-16"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "1"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:53b238f4a15796bb564f209e9a20f459",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:12d2dfb7ca155d963f6afeaa6467e598",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:cfb21df261de4e6209165b310f0b8cb9",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:4c4f61059d1c51c5c453ad92e020752f",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0002",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3279"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "50.8793762969896"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.4763410441864e-32"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "2.81583624579098e-30"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "2"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3279"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "50.8793762969896"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.4763410441864e-32"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "2.81583624579098e-30"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "2"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cfb21df261de4e6209165b310f0b8cb9",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:4c4f61059d1c51c5c453ad92e020752f",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:780f2f5e9d63466ad3c7345293e0fe5b",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:3ed2649db2465ff69f88971b546dd3be",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0003",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "373"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "5.78774240889817"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.11490153166348e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1.40839728834941e-06"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "8.33267560161855e-07"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "3"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "373"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "5.78774240889817"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.11490153166348e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1.40839728834941e-06"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "8.33267560161855e-07"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "3"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:780f2f5e9d63466ad3c7345293e0fe5b",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:3ed2649db2465ff69f88971b546dd3be",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:2695c44ad8ef77b70e478006be76ec3b",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:19dfc0bbb201d5f134704921caf5a176",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0004",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "590"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "9.15487405160837"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "9.40759361213501e-11"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "3.21991633356333e-09"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "2.54005027527645e-09"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "4"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "590"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "9.15487405160837"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "9.40759361213501e-11"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "3.21991633356333e-09"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "2.54005027527645e-09"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "4"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2695c44ad8ef77b70e478006be76ec3b",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:19dfc0bbb201d5f134704921caf5a176",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:a4131faa6f9d63d587e81683f4525aa5",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:4ccbfde9cca6489f3110bef0431524c8",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0005",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "264"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "4.09641821970273"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.36245395227596e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "4.66313239355642e-05"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1.57655385906218e-05"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "5"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "264"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "4.09641821970273"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.36245395227596e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "4.66313239355642e-05"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1.57655385906218e-05"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "5"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a4131faa6f9d63d587e81683f4525aa5",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:4ccbfde9cca6489f3110bef0431524c8",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:f1484408d6648353b40e3f793d43ba98",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:3621a50b575ca90dbe183bb31ff4ae4a",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0006",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "289"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "4.48433661172003"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.88335668734106e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "2.01366325500718e-05"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "9.53103783349252e-06"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "6"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "289"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "4.48433661172003"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.88335668734106e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "2.01366325500718e-05"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "9.53103783349252e-06"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "6"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f1484408d6648353b40e3f793d43ba98",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:3621a50b575ca90dbe183bb31ff4ae4a",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:f549b84e14efc1b6caac0a05e1a46c0d",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:7698728db1c0c3e20b495f064a9d5b55",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0007",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "126"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.95510869576721"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000261634077318802"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0089149162838621"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00235470669586922"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "7"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "126"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.95510869576721"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000261634077318802"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0089149162838621"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00235470669586922"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "7"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f549b84e14efc1b6caac0a05e1a46c0d",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:7698728db1c0c3e20b495f064a9d5b55",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:29fc425e622d8b8ded04fc6031eeff5d",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:379c20fa5cd6aefb39cb7419f030f9e5",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0008",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "89"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.3809894755816"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00144129625636545"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0481339228782848"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00972874973046682"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "8"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "89"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.3809894755816"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00144129625636545"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0481339228782848"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00972874973046682"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "8"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:29fc425e622d8b8ded04fc6031eeff5d",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:379c20fa5cd6aefb39cb7419f030f9e5",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:ddb75d1dce61c969aca0b33e4792ae0c",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:4257936a93608ef43291e047551e5e0a",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0009",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "30"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.465502070420765"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0420589497514909"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.762963799671023"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.154853405903216"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "9"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "30"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.465502070420765"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0420589497514909"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.762963799671023"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.154853405903216"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "9"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ddb75d1dce61c969aca0b33e4792ae0c",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:4257936a93608ef43291e047551e5e0a",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:9fd20bfdc1412e227a54f54ed45d5054",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:7017960274f85788b6b607f7d0046a76",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0010",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "57"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.884453933799453"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00774369776526604"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.232826147022924"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0448028227847535"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "10"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "57"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.884453933799453"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00774369776526604"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.232826147022924"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0448028227847535"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "10"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9fd20bfdc1412e227a54f54ed45d5054",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:7017960274f85788b6b607f7d0046a76",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:f0f0748bbb9066bab45490e1ba8fef31",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:a48da6310356eb94f99b1f1eb464e14b",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0011",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "266"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "4.12745169106411"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.27272470789903e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "4.35603193557066e-05"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1.57655385906218e-05"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "11"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "266"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "4.12745169106411"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.27272470789903e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "4.35603193557066e-05"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1.57655385906218e-05"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "11"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f0f0748bbb9066bab45490e1ba8fef31",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:a48da6310356eb94f99b1f1eb464e14b",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:90b4dda7962081808845a0f3dcd7ea91",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:ada43746a7be5361f1b2127ddc7152ba",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0012",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "19"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.294817977933151"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0966300585947712"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.963386407334226"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.260901158205882"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "12"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "19"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.294817977933151"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0966300585947712"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.963386407334226"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.260901158205882"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "12"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:90b4dda7962081808845a0f3dcd7ea91",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:ada43746a7be5361f1b2127ddc7152ba",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:dba4c7441ba091562d6318495ccd506b",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:1c73b53acc2e3706c7dcdd4e4ed9e043",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0013",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "74"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.14823844037122"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00307403021089659"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0998682654704584"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0191535728525095"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "13"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "74"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.14823844037122"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00307403021089659"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0998682654704584"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0191535728525095"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "13"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:dba4c7441ba091562d6318495ccd506b",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:1c73b53acc2e3706c7dcdd4e4ed9e043",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:64445ad0b45313551f83199c04675195",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:655978b5bff261f0bf396a1ddf498402",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0014",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "115"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.7844246032796"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000425937628174443"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0144727219239722"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00345009478821299"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "14"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "115"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.7844246032796"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000425937628174443"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0144727219239722"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00345009478821299"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "14"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:64445ad0b45313551f83199c04675195",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:655978b5bff261f0bf396a1ddf498402",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:bb07405375d86eb7d0603ec3197e08aa",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:7dd3c3ae219e2bf1ef8176af9cc60fb9",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0015",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "32"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.496535541782149"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0365895245544304"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.714165296337838"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.141131023281374"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "15"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "32"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.496535541782149"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0365895245544304"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.714165296337838"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.141131023281374"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "15"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:bb07405375d86eb7d0603ec3197e08aa",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:7dd3c3ae219e2bf1ef8176af9cc60fb9",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:c3428421b6744ab712756818f68e34b1",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c96857fd42e1208395989b05eeab7a76",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0016",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "23"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.35688492065592"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0703481287722727"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.909985985343213"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.23742493460642"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "16"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "23"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.35688492065592"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0703481287722727"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.909985985343213"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.23742493460642"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "16"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c3428421b6744ab712756818f68e34b1",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:c96857fd42e1208395989b05eeab7a76",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:b1e2ccb2a24225ae9297eb35470b2ef2",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:7a24a2bdbc61f7d8ab6a59738a57c24a",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0017",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "250"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "3.87918392017304"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.20582835219715e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "7.54955510265942e-05"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "2.23340120659961e-05"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "17"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "250"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "3.87918392017304"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.20582835219715e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "7.54955510265942e-05"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "2.23340120659961e-05"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "17"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b1e2ccb2a24225ae9297eb35470b2ef2",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:7a24a2bdbc61f7d8ab6a59738a57c24a",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:1c943c00f3f2e54e795e080b9d85859d",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c313dfc1d990322089b2bf63a219f16a",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0018",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "38"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.589635955866302"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.024488721191747"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.567498750748111"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.110199245362862"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "18"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "38"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.589635955866302"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.024488721191747"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.567498750748111"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.110199245362862"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "18"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1c943c00f3f2e54e795e080b9d85859d",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:c313dfc1d990322089b2bf63a219f16a",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:663b1f9b98b62235a966f9f1c5d82cb9",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:36e697e6ea3e7a7c4a67a505ebe4f340",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0019",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "39"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.605152691546994"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0229522301482354"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.544145192050433"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.109360626000416"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "19"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "39"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.605152691546994"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0229522301482354"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.544145192050433"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.109360626000416"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "19"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:663b1f9b98b62235a966f9f1c5d82cb9",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:36e697e6ea3e7a7c4a67a505ebe4f340",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:dcb1f3bd84b360ab8e8024d363c5a710",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:ca1016af733ba1294614bfd4483de412",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0020",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "34"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.527569013143533"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0319229825328534"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.664663538653339"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.129288079258056"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "20"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "34"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.527569013143533"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0319229825328534"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.664663538653339"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.129288079258056"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "20"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:dcb1f3bd84b360ab8e8024d363c5a710",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:ca1016af733ba1294614bfd4483de412",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:d5ec0fb74bfe81761c80eb8c08942466",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:b4290f172c2ebe815ddf64763f6e95e4",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0021",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "16"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.248267770891074"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.124443287126479"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.985867709133163"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.314997070538899"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "21"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "16"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.248267770891074"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.124443287126479"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.985867709133163"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.314997070538899"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "21"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d5ec0fb74bfe81761c80eb8c08942466",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:b4290f172c2ebe815ddf64763f6e95e4",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:dea3ebd7d53b9bdeb45e3fcbd12ef78f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:94f389f115646fc7441e8fd9bf5ec119",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0022",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "37"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.57411922018561"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0261429923364831"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.59130676381177"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.111451704171323"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "22"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "37"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.57411922018561"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0261429923364831"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.59130676381177"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.111451704171323"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "22"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:dea3ebd7d53b9bdeb45e3fcbd12ef78f",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:94f389f115646fc7441e8fd9bf5ec119",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:7576ce49bb83c1b874dc86b48878d37f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:7322fa4ccee32301d807a0b9f48ae02a",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0023",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "22"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.341368184975227"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0760173005561502"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.925862025073693"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.246296053801927"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "23"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "22"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.341368184975227"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0760173005561502"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.925862025073693"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.246296053801927"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "23"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7576ce49bb83c1b874dc86b48878d37f",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:7322fa4ccee32301d807a0b9f48ae02a",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:cd03d29014d461350222c98300667843",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c47c40f4ed2261336524231fb9108598",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0024",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "89"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.3809894755816"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00144129625636545"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0481339228782848"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00972874973046682"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "24"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "89"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.3809894755816"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00144129625636545"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0481339228782848"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00972874973046682"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "24"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cd03d29014d461350222c98300667843",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:c47c40f4ed2261336524231fb9108598",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:5e2e4f5da7c8d5550caebb447ece90bb",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:6c58a61aff8d76d3d5cdef392c46c0f7",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0025",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "42"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.65170289858907"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0189586344274602"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.477376000163114"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0959780867890173"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "25"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "42"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.65170289858907"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0189586344274602"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.477376000163114"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0959780867890173"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "25"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5e2e4f5da7c8d5550caebb447ece90bb",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:6c58a61aff8d76d3d5cdef392c46c0f7",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:489b086215a47551ede0b78dc2a96cbb",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:bcf052d664b0eeef3576961aef494c62",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0026",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "44"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.682736369950455"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0167324384188216"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.435998000788451"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0903551674616366"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "26"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "44"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.682736369950455"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0167324384188216"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.435998000788451"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0903551674616366"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "26"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:489b086215a47551ede0b78dc2a96cbb",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:bcf052d664b0eeef3576961aef494c62",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:e167f1fa2b99e6bc19dd1ecd0b525c28",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:d357fdfcedae064d3927d132b4915da3",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0027",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "10"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.155167356806922"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.217981749736363"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999424811828672"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.452731326375523"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "27"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "10"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.155167356806922"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.217981749736363"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999424811828672"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.452731326375523"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "27"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e167f1fa2b99e6bc19dd1ecd0b525c28",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:d357fdfcedae064d3927d132b4915da3",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:3b3edf5a98326d7f3703f9678a007546",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:24181b91e1a2ff9fbf0d92f1f3c2fb91",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0028",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "6"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0931004140841529"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.338350015789837"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999990654647859"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.548127025579537"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "28"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "6"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0931004140841529"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.338350015789837"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999990654647859"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.548127025579537"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "28"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3b3edf5a98326d7f3703f9678a007546",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:24181b91e1a2ff9fbf0d92f1f3c2fb91",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:f254618143e69b64fb1d059a5963eed1",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:a67bcbe4c64e864d3c0091590a71ed79",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0029",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "7"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.108617149764845"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.300903995850594"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99996633240521"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.541627192531069"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "29"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "7"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.108617149764845"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.300903995850594"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99996633240521"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.541627192531069"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "29"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f254618143e69b64fb1d059a5963eed1",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:a67bcbe4c64e864d3c0091590a71ed79",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:9061b512bdfd18fd0d71b5c4815f8163",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:1e585aa0961f26eba6c099e7119148ec",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0030",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "5"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0775836784034608"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.383028244949947"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999997974762013"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.608338977273446"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "30"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "5"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0775836784034608"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.383028244949947"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999997974762013"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.608338977273446"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "30"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9061b512bdfd18fd0d71b5c4815f8163",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:1e585aa0961f26eba6c099e7119148ec",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:c8fcb029f017b54563ed3b53bed1488f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:98543afde30df2ac94ce134cd8111cce",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0031",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "10"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.155167356806922"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.217981749736363"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999424811828672"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.452731326375523"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "31"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "10"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.155167356806922"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.217981749736363"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999424811828672"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.452731326375523"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "31"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c8fcb029f017b54563ed3b53bed1488f",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:98543afde30df2ac94ce134cd8111cce",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:ca05945701843dd88ebf74447398670e",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:3bfa5939740913923e9b589897f2c510",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0032",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "19"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.294817977933151"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0966300585947712"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.963386407334226"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.260901158205882"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "32"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "19"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.294817977933151"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0966300585947712"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.963386407334226"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.260901158205882"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "32"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ca05945701843dd88ebf74447398670e",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:3bfa5939740913923e9b589897f2c510",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:b1d6b0c92fb80c25d314f20c0cfa090c",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:6b8ab0e3e0b633d638e47f3a9a10919b",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0033",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "7"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.108617149764845"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.300903995850594"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99996633240521"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.541627192531069"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "33"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "7"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.108617149764845"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.300903995850594"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99996633240521"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.541627192531069"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "33"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b1d6b0c92fb80c25d314f20c0cfa090c",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:6b8ab0e3e0b633d638e47f3a9a10919b",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:cb2ae57bb539840222fcf93ce3091770",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:6029d0e967f2fb403f4a243e7a90b84c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0034",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "27"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.418951863378688"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0521437725170813"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.832154843505507"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.183636764081895"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "34"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "27"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.418951863378688"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0521437725170813"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.832154843505507"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.183636764081895"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "34"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cb2ae57bb539840222fcf93ce3091770",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:6029d0e967f2fb403f4a243e7a90b84c",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:698b3f9b2d3d5f1f578a7724a8ca8d0d",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:780f11b236810e190dea70c6c4340625",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0035",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "19"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.294817977933151"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0966300585947712"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.963386407334226"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.260901158205882"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "35"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "19"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.294817977933151"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0966300585947712"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.963386407334226"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.260901158205882"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "35"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:698b3f9b2d3d5f1f578a7724a8ca8d0d",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:780f11b236810e190dea70c6c4340625",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:d26a80bf1b2d7e97037bd7961b7f2fb9",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:4a266b577331cf838f3af1933133ec8d",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0036",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "8"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.124133885445537"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.269071534113235"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999899911134192"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.518923672932668"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "36"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "8"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.124133885445537"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.269071534113235"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999899911134192"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.518923672932668"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "36"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d26a80bf1b2d7e97037bd7961b7f2fb9",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:4a266b577331cf838f3af1933133ec8d",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:84d0f76c2451c6b80e5e965a03dc7d79",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:b92193302c69c95fc0b8add50483e3ec",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0037",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0620669427227686"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.437360131610367"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999684601479"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.632610190364996"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "37"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0620669427227686"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.437360131610367"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999684601479"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.632610190364996"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "37"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:84d0f76c2451c6b80e5e965a03dc7d79",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:b92193302c69c95fc0b8add50483e3ec",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:32e36d0494334a99543f9acc36898f2f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:12aade66bcaf5ad22c9a147b7bac54d4",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0038",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0620669427227686"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.437360131610367"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999684601479"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.632610190364996"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "38"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0620669427227686"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.437360131610367"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999684601479"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.632610190364996"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "38"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:32e36d0494334a99543f9acc36898f2f",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:12aade66bcaf5ad22c9a147b7bac54d4",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:511c490c7d9b5ae7344403faeec2f878",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:759e3fd5ac10013d9c1b96696769e455",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0039",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "13"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.201717563848998"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.162917148703869"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.996212803904192"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.388126148382747"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "39"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "13"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.201717563848998"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.162917148703869"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.996212803904192"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.388126148382747"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "39"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:511c490c7d9b5ae7344403faeec2f878",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:759e3fd5ac10013d9c1b96696769e455",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:9950c7205c20af075ae5465eeb0630ec",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:b60ad51d906accfc87533b435bc4ab5f",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0040",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "21"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.325851449294535"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0822406296320071"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.94008521095715"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.256211192315099"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "40"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "21"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.325851449294535"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0822406296320071"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.94008521095715"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.256211192315099"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "40"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9950c7205c20af075ae5465eeb0630ec",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:b60ad51d906accfc87533b435bc4ab5f",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:59e8f07020483e79cce0a7ee24a67d9d",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:5fe7263d129c8b5a1cdc4862389a329f",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0041",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "17"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.263784506571767"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.114194248436332"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.979929443300573"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.298378520107835"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "41"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "17"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.263784506571767"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.114194248436332"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.979929443300573"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.298378520107835"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "41"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:59e8f07020483e79cce0a7ee24a67d9d",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:5fe7263d129c8b5a1cdc4862389a329f",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:8d67481af449856aae39018568cd0118",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:202e674801183017b435dafa4352a2f7",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0042",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "8"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.124133885445537"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.269071534113235"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999899911134192"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.518923672932668"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "42"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "8"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.124133885445537"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.269071534113235"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999899911134192"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.518923672932668"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "42"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8d67481af449856aae39018568cd0118",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:202e674801183017b435dafa4352a2f7",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:f927b5bbd3f555c57b4e6e01ec9b523e",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:63374171b8dfeb6c1b6216d9cb78dad1",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0043",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "13"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.201717563848998"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.162917148703869"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.996212803904192"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.388126148382747"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "43"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "13"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.201717563848998"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.162917148703869"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.996212803904192"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.388126148382747"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "43"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f927b5bbd3f555c57b4e6e01ec9b523e",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:63374171b8dfeb6c1b6216d9cb78dad1",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:8ab71917d880813a7ac3044279de7b31",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:4c28624df30b813b1284ed3adfd58c93",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0044",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "11"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.170684092487614"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.197250909946631"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.998830598770408"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.44381454737992"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "44"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "11"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.170684092487614"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.197250909946631"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.998830598770408"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.44381454737992"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "44"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8ab71917d880813a7ac3044279de7b31",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:4c28624df30b813b1284ed3adfd58c93",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:7bdadf7ae2bdb4f39bf9f8fbe5fe1ea5",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:94a0a21f872815c64a69e94bd40bed9f",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0045",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "11"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.170684092487614"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.197250909946631"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.998830598770408"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.44381454737992"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "45"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "11"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.170684092487614"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.197250909946631"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.998830598770408"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.44381454737992"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "45"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7bdadf7ae2bdb4f39bf9f8fbe5fe1ea5",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:94a0a21f872815c64a69e94bd40bed9f",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:aa7cba01da25024bc05a9e45cd79a837",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:e7e4075c58abc76d658530459437df00",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0046",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "19"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.294817977933151"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0966300585947712"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.963386407334226"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.260901158205882"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "46"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "19"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.294817977933151"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0966300585947712"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.963386407334226"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.260901158205882"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "46"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:aa7cba01da25024bc05a9e45cd79a837",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:e7e4075c58abc76d658530459437df00",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:2630e4b92c9db9a6beb0787bffe7a7fb",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:2dfef140265f92d79cbf32d31936df4d",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0047",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "10"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.155167356806922"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.217981749736363"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999424811828672"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.452731326375523"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "47"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "10"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.155167356806922"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.217981749736363"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999424811828672"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.452731326375523"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "47"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2630e4b92c9db9a6beb0787bffe7a7fb",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:2dfef140265f92d79cbf32d31936df4d",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:cbd611e1237a5ec814b81bcfe9552f0e",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:8fcfff082769fb86478d8224ec22e1d5",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0048",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "6"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0931004140841529"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.338350015789837"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999990654647859"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.548127025579537"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "48"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "6"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0931004140841529"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.338350015789837"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999990654647859"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.548127025579537"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "48"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cbd611e1237a5ec814b81bcfe9552f0e",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:8fcfff082769fb86478d8224ec22e1d5",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:481718c39416a3d61a910542ffd5f170",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:a4a959bdb5adaac5ccc8bb0a1283b1eb",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0049",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0620669427227686"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.437360131610367"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999684601479"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.632610190364996"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "49"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0620669427227686"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.437360131610367"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999684601479"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.632610190364996"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "49"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:481718c39416a3d61a910542ffd5f170",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:a4a959bdb5adaac5ccc8bb0a1283b1eb",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:7bcbc9953403229f0db979d92436612d",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:abd2bbf896a471cb7922efab5b613117",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0050",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0310334713613843"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.593940401999589"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999998516212"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.720222921163404"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "50"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0310334713613843"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.593940401999589"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999998516212"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.720222921163404"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "50"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7bcbc9953403229f0db979d92436612d",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:abd2bbf896a471cb7922efab5b613117",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:7c32a1d0e82c311426243c91cc091275",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:9c1cddc9922d8e70b3ba77c8f428e530",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0051",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0310334713613843"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.593940401999589"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999998516212"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.720222921163404"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "51"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0310334713613843"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.593940401999589"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999998516212"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.720222921163404"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "51"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7c32a1d0e82c311426243c91cc091275",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:9c1cddc9922d8e70b3ba77c8f428e530",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:82069b48f32f7007fb477a55996a5a26",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:b2551e755f51f54d3855f624855bec3b",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0052",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0310334713613843"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.593940401999589"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999998516212"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.720222921163404"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "52"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0310334713613843"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.593940401999589"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999998516212"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.720222921163404"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "52"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:82069b48f32f7007fb477a55996a5a26",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:b2551e755f51f54d3855f624855bec3b",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:7480c4974cded55a669a9f676f7183d3",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:d98c34494ee425b9f343ad72efbe3802",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0053",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "6"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0931004140841529"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.338350015789837"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999990654647859"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.548127025579537"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "53"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "6"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0931004140841529"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.338350015789837"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999990654647859"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.548127025579537"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "53"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7480c4974cded55a669a9f676f7183d3",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:d98c34494ee425b9f343ad72efbe3802",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:7dbb86d35f9a3f5e15ce1fcaf1b4ac57",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:207cbb7814292b71aa3cbca2e251214d",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0054",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "6"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0931004140841529"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.338350015789837"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999990654647859"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.548127025579537"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "54"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "6"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0931004140841529"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.338350015789837"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999990654647859"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.548127025579537"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "54"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7dbb86d35f9a3f5e15ce1fcaf1b4ac57",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:207cbb7814292b71aa3cbca2e251214d",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:1871a215e9872f3a52537c8c1a760f0a",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:ef0e652ba790ef2ca62cbc45744044f2",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0055",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0155167356806922"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.720222921163404"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999998031"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.720222921163404"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "55"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0155167356806922"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.720222921163404"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999998031"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.720222921163404"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "55"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1871a215e9872f3a52537c8c1a760f0a",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:ef0e652ba790ef2ca62cbc45744044f2",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:3ad5cc979a530fd4daa32be10f10bc51",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:cdc735403e60da4bc8deca0b30c09e41",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0056",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "9"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.139650621126229"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.241710357573908"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999744673425561"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.489463474087164"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "56"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "9"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.139650621126229"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.241710357573908"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999744673425561"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.489463474087164"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "56"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3ad5cc979a530fd4daa32be10f10bc51",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:cdc735403e60da4bc8deca0b30c09e41",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:b808d08cb809cd1546fc7c1d23c712ad",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:14788c080d39de548f4f1517f2f3ecf2",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0057",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0155167356806922"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.720222921163404"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999998031"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.720222921163404"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "57"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0155167356806922"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.720222921163404"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999998031"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.720222921163404"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "57"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b808d08cb809cd1546fc7c1d23c712ad",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:14788c080d39de548f4f1517f2f3ecf2",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:2502ea528f067f61a192d4d910eaaac2",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:094abc2dabe5f1598098374da155b2d3",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0058",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0465502070420765"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.505265080891682"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999969133568"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.693669009359767"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "58"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0465502070420765"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.505265080891682"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999969133568"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.693669009359767"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "58"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2502ea528f067f61a192d4d910eaaac2",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:094abc2dabe5f1598098374da155b2d3",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:d44962b9e9395d5d42a56ab76170cf9a",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:b0a53fec1935bbbef5f0340426dfcf5c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0059",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "6"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0931004140841529"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.338350015789837"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999990654647859"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.548127025579537"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "59"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "6"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0931004140841529"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.338350015789837"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999990654647859"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.548127025579537"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "59"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d44962b9e9395d5d42a56ab76170cf9a",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:b0a53fec1935bbbef5f0340426dfcf5c",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:f59a3e7afba6bebbf0a007c0f8c78d53",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:782cde190eab924f134e44bd95c8cd15",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0060",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0155167356806922"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.720222921163404"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999998031"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.720222921163404"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "60"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0155167356806922"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.720222921163404"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999998031"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.720222921163404"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "60"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f59a3e7afba6bebbf0a007c0f8c78d53",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:782cde190eab924f134e44bd95c8cd15",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:b1fa22ed23a8d70bc9e4dd151a589e2f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:9e85dca921757d3d2cafd0d606eb03c4",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0061",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0465502070420765"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.505265080891682"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999969133568"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.693669009359767"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "61"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0465502070420765"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.505265080891682"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999969133568"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.693669009359767"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "61"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b1fa22ed23a8d70bc9e4dd151a589e2f",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:9e85dca921757d3d2cafd0d606eb03c4",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:0cd710e9d7cad8f485a36862bb45dad3",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:50e0654a2d55b1eb33c94eef3f0fbfc4",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0062",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0620669427227686"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.437360131610367"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999684601479"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.632610190364996"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "62"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0620669427227686"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.437360131610367"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999684601479"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.632610190364996"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "62"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0cd710e9d7cad8f485a36862bb45dad3",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:50e0654a2d55b1eb33c94eef3f0fbfc4",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:cc7d3451a39fd4cca99275e6219b8f5d",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:580546e61fe6caf5b928869b72d6563c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0063",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0465502070420765"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.505265080891682"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999969133568"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.693669009359767"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "63"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0465502070420765"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.505265080891682"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999969133568"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.693669009359767"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "63"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cc7d3451a39fd4cca99275e6219b8f5d",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:580546e61fe6caf5b928869b72d6563c",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:e8b4547e2bb998c3a0e5c80f5add7395",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:fbb3da138dba0bffe41c80dfdc6d2813",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0064",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0155167356806922"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.720222921163404"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999998031"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.720222921163404"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "64"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0155167356806922"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.720222921163404"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999998031"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.720222921163404"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "64"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e8b4547e2bb998c3a0e5c80f5add7395",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:fbb3da138dba0bffe41c80dfdc6d2813",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:194d5b586416a3affff5759f1f6f1f22",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:5b4ccbe46fbd067233c454fc4cd57139",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0065",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0310334713613843"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.593940401999589"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999998516212"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.720222921163404"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "65"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0310334713613843"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.593940401999589"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999998516212"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.720222921163404"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "65"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:194d5b586416a3affff5759f1f6f1f22",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:5b4ccbe46fbd067233c454fc4cd57139",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:172068f882b44c7f3f286732e95fd333",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:4797fa2e5200fab8ae750cb321a6d94a",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0066",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "7"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.108617149764845"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.300903995850594"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99996633240521"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.541627192531069"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "66"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "7"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.108617149764845"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.300903995850594"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99996633240521"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.541627192531069"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "66"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:172068f882b44c7f3f286732e95fd333",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:4797fa2e5200fab8ae750cb321a6d94a",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:ce513aeb315d021861a6c316bf4ef052",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:e5840e49541fa7c2c73adfcf2cd18d5c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0067",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0155167356806922"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.720222921163404"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999998031"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.720222921163404"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "67"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0155167356806922"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.720222921163404"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999998031"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.720222921163404"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "67"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ce513aeb315d021861a6c316bf4ef052",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:e5840e49541fa7c2c73adfcf2cd18d5c",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:31c5179c3ed19f375fed1f038a132ca0",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:af9739fef5ce12c093a36fdad464fa2c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0068",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0310334713613843"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.593940401999589"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999998516212"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.720222921163404"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "68"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0310334713613843"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.593940401999589"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999998516212"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.720222921163404"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "68"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:31c5179c3ed19f375fed1f038a132ca0",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:af9739fef5ce12c093a36fdad464fa2c",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:fef2c17abe57bc62290ea323944b2b06",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:4c1124c10677cacc7086dad2d88a0bd3",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0069",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0310334713613843"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.593940401999589"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999998516212"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.720222921163404"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "69"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0310334713613843"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.593940401999589"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999998516212"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.720222921163404"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "69"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:fef2c17abe57bc62290ea323944b2b06",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:4c1124c10677cacc7086dad2d88a0bd3",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:101d5a9adb5897de8e974a6c450bccef",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:9a07890dc3c872a54f45939b26e95348",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0070",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0155167356806922"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.720222921163404"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999998031"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.720222921163404"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "70"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0155167356806922"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.720222921163404"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999998031"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.720222921163404"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "70"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:101d5a9adb5897de8e974a6c450bccef",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:9a07890dc3c872a54f45939b26e95348",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:79ae18cf89e6f66ce4c5070153fae100",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:4b972d45063ce95740be79e0f84be300",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0071",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0155167356806922"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.720222921163404"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999998031"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.720222921163404"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "71"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0155167356806922"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.720222921163404"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999998031"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.720222921163404"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "71"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:79ae18cf89e6f66ce4c5070153fae100",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:4b972d45063ce95740be79e0f84be300",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:1c0685623290eeb06ef6f4bdbffafd31",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:6cc8de073a211f649503cbae3d7f79bb",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0072",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0620669427227686"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.437360131610367"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999684601479"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.632610190364996"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "72"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0620669427227686"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.437360131610367"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999684601479"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.632610190364996"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "72"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1c0685623290eeb06ef6f4bdbffafd31",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:6cc8de073a211f649503cbae3d7f79bb",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:e333891aa2a7cc8b78b7b091053068d6",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:713bd5e4d1057a61ec41d7be47cc6b30",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0073",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0155167356806922"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.720222921163404"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999998031"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.720222921163404"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "73"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0155167356806922"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.720222921163404"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999998031"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.720222921163404"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "73"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e333891aa2a7cc8b78b7b091053068d6",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:713bd5e4d1057a61ec41d7be47cc6b30",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:ae3b028a4da5be96010d12d3d7dfdafd",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f594ca28922a55744403546afac8880c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0074",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0155167356806922"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.720222921163404"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999998031"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.720222921163404"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "74"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0155167356806922"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.720222921163404"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999998031"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.720222921163404"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "74"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ae3b028a4da5be96010d12d3d7dfdafd",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:f594ca28922a55744403546afac8880c",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:0f488c10355ed316636cfd8bb54904ac",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:1f5837a9250f8adad81d9cf7febcb06c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0075",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0155167356806922"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.720222921163404"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999998031"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.720222921163404"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "75"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0155167356806922"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.720222921163404"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999998031"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.720222921163404"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "75"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0f488c10355ed316636cfd8bb54904ac",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:1f5837a9250f8adad81d9cf7febcb06c",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:b7030530775d914be5aedf430467d831",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:4978ca959ffd9dac40bc74938928d142",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0076",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0155167356806922"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.720222921163404"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999998031"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.720222921163404"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "76"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0155167356806922"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.720222921163404"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999998031"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.720222921163404"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "76"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b7030530775d914be5aedf430467d831",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:4978ca959ffd9dac40bc74938928d142",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:caff2c2f2a15419f2f382bc662c24e14",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:a8156b1e457954028b70ba39c8f61983",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0077",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0155167356806922"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.720222921163404"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999998031"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.720222921163404"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "77"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0155167356806922"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.720222921163404"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999998031"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.720222921163404"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "77"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:caff2c2f2a15419f2f382bc662c24e14",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:a8156b1e457954028b70ba39c8f61983",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:e65b059d6c1f15bf2f6b2d744c2f1518",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:b00bd2c845defd49f3843980d3290639",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0078",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0155167356806922"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.720222921163404"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999998031"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.720222921163404"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "78"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0155167356806922"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.720222921163404"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999998031"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.720222921163404"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "78"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e65b059d6c1f15bf2f6b2d744c2f1518",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:b00bd2c845defd49f3843980d3290639",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:8ea6fb6f8438207d256aefd11c3b906b",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:0d91d576d381385281f1b2d5d2714a3f",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0079",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0310334713613843"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.593940401999589"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999998516212"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.720222921163404"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "79"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0310334713613843"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.593940401999589"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999998516212"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.720222921163404"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "79"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8ea6fb6f8438207d256aefd11c3b906b",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:0d91d576d381385281f1b2d5d2714a3f",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:700b2ca023302ca89c9a6e4ffdd8374f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:1505e0b207a3a8175cc0be4688a0d7c4",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0080",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0155167356806922"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.720222921163404"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999998031"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.720222921163404"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "80"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0155167356806922"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.720222921163404"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999998031"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.720222921163404"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "80"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:700b2ca023302ca89c9a6e4ffdd8374f",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:1505e0b207a3a8175cc0be4688a0d7c4",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:14e4f41a62e6164ce237a2e322e60826",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:892dfa415e44d696ef37c9d6a5487e86",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0081",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0155167356806922"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.720222921163404"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999998031"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.720222921163404"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "81"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0155167356806922"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.720222921163404"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999998031"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.720222921163404"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "81"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:14e4f41a62e6164ce237a2e322e60826",
-      "entity": "niiri:022626d941384b37aee63db114d7e263"
+      "entity_derived": "niiri:892dfa415e44d696ef37c9d6a5487e86",
+      "entity": "niiri:9b06d633f15370eacc4d439eebd44c49"
     },
     {
-      "@id": "niiri:8c2011e2205ed468c4f35aa7c23ba0d5",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:2c0961e66823d0b4915540ec2c8e75c3",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0001",
-      "prov:atLocation": {"@id": "niiri:fe5c4fd20c90fb15f9b8589b0cb19caf"},
+      "prov:atLocation": {"@id": "niiri:19d8deadd2c75bbb63869efc69e89c37"},
       "prov:value": {"@type": "xsd:float", "@value": "7.88613557815552"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "6.89124325286373"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.76534350973634e-12"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "6.16779698647818e-07"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "7.48669482771332e-06"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "6.89124325286373"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.76534350973634e-12"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "6.16779698647818e-07"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "7.48669482771332e-06"}
     },
     {
-      "@id": "niiri:fe5c4fd20c90fb15f9b8589b0cb19caf",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:19d8deadd2c75bbb63869efc69e89c37",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0001",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[46,16,24]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[46,16,24]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8c2011e2205ed468c4f35aa7c23ba0d5",
-      "entity": "niiri:53b238f4a15796bb564f209e9a20f459"
+      "entity_derived": "niiri:2c0961e66823d0b4915540ec2c8e75c3",
+      "entity": "niiri:12d2dfb7ca155d963f6afeaa6467e598"
     },
     {
-      "@id": "niiri:071bea4f427742579e7684f455db31a3",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:dc3e0fe26c0acd9c6f782136679db557",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0002",
-      "prov:atLocation": {"@id": "niiri:fbcedf8ab584123788bab734421a5e0c"},
+      "prov:atLocation": {"@id": "niiri:c19d9f98cac285d054aacbe754152f42"},
       "prov:value": {"@type": "xsd:float", "@value": "7.60659408569336"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "6.69768255888791"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.05875308520353e-11"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "2.36157334065901e-06"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1.28885586816361e-05"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "6.69768255888791"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.05875308520353e-11"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "2.36157334065901e-06"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1.28885586816361e-05"}
     },
     {
-      "@id": "niiri:fbcedf8ab584123788bab734421a5e0c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c19d9f98cac285d054aacbe754152f42",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0002",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[34,24,-6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[34,24,-6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:071bea4f427742579e7684f455db31a3",
-      "entity": "niiri:53b238f4a15796bb564f209e9a20f459"
+      "entity_derived": "niiri:dc3e0fe26c0acd9c6f782136679db557",
+      "entity": "niiri:12d2dfb7ca155d963f6afeaa6467e598"
     },
     {
-      "@id": "niiri:b2204b24486b0fd1f536d75033ffedea",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b44464753c802f3cbe64786acd87621a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0003",
-      "prov:atLocation": {"@id": "niiri:3afc3673cd6ac53aa12f250c5b0e8789"},
+      "prov:atLocation": {"@id": "niiri:4e00d7c81778064e4ade195a69b9d59f"},
       "prov:value": {"@type": "xsd:float", "@value": "5.4533052444458"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.06995251985304"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.98957479047301e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0321858214443789"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00847322777156312"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.06995251985304"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.98957479047301e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0321858214443789"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00847322777156312"}
     },
     {
-      "@id": "niiri:3afc3673cd6ac53aa12f250c5b0e8789",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4e00d7c81778064e4ade195a69b9d59f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0003",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[48,28,-14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[48,28,-14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b2204b24486b0fd1f536d75033ffedea",
-      "entity": "niiri:53b238f4a15796bb564f209e9a20f459"
+      "entity_derived": "niiri:b44464753c802f3cbe64786acd87621a",
+      "entity": "niiri:12d2dfb7ca155d963f6afeaa6467e598"
     },
     {
-      "@id": "niiri:7a4259089e9dd69fed1713edd46a91be",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:022fa4480e152e0d59d498475f76b9f0",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0004",
-      "prov:atLocation": {"@id": "niiri:e367487baf4427fb9ba1566a63a50817"},
+      "prov:atLocation": {"@id": "niiri:6d6a35e598da08a187498457924b6d27"},
       "prov:value": {"@type": "xsd:float", "@value": "6.8508505821228"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "6.15424052394884"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.77190612077527e-10"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "8.41349568295735e-05"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000225077260388439"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "6.15424052394884"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.77190612077527e-10"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "8.41349568295735e-05"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000225077260388439"}
     },
     {
-      "@id": "niiri:e367487baf4427fb9ba1566a63a50817",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6d6a35e598da08a187498457924b6d27",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0004",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-8,12,52]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-8,12,52]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7a4259089e9dd69fed1713edd46a91be",
-      "entity": "niiri:cfb21df261de4e6209165b310f0b8cb9"
+      "entity_derived": "niiri:022fa4480e152e0d59d498475f76b9f0",
+      "entity": "niiri:4c4f61059d1c51c5c453ad92e020752f"
     },
     {
-      "@id": "niiri:b9cc6bd680cdcc9ea05b4611d138fe48",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d38af59f91ea10608b21a454c3db1947",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0005",
-      "prov:atLocation": {"@id": "niiri:7026c6a83c6858cec46bdf75dc74326f"},
+      "prov:atLocation": {"@id": "niiri:b8b98649dacb9658c6e4145e79d32fa4"},
       "prov:value": {"@type": "xsd:float", "@value": "6.70556163787842"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "6.04634484012323"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.40843941748892e-10"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.000165250377586079"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000249071340138561"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "6.04634484012323"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.40843941748892e-10"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.000165250377586079"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000249071340138561"}
     },
     {
-      "@id": "niiri:7026c6a83c6858cec46bdf75dc74326f",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b8b98649dacb9658c6e4145e79d32fa4",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0005",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[8,20,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[8,20,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b9cc6bd680cdcc9ea05b4611d138fe48",
-      "entity": "niiri:cfb21df261de4e6209165b310f0b8cb9"
+      "entity_derived": "niiri:d38af59f91ea10608b21a454c3db1947",
+      "entity": "niiri:4c4f61059d1c51c5c453ad92e020752f"
     },
     {
-      "@id": "niiri:23ced658a0f882e4d2640c480347e555",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:02b9e7ac9b6dc3a6cfd2bf8d3a3e5d52",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0006",
-      "prov:atLocation": {"@id": "niiri:eefcd3fdc1161f40fc80c6bb8a107df0"},
+      "prov:atLocation": {"@id": "niiri:eead8fc2293f742ff4df91aaffb954e7"},
       "prov:value": {"@type": "xsd:float", "@value": "5.89195346832275"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.42145878799783"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.95573132635951e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00607574083875051"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00242918849696441"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.42145878799783"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.95573132635951e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00607574083875051"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00242918849696441"}
     },
     {
-      "@id": "niiri:eefcd3fdc1161f40fc80c6bb8a107df0",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:eead8fc2293f742ff4df91aaffb954e7",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0006",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[6,32,36]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[6,32,36]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:23ced658a0f882e4d2640c480347e555",
-      "entity": "niiri:cfb21df261de4e6209165b310f0b8cb9"
+      "entity_derived": "niiri:02b9e7ac9b6dc3a6cfd2bf8d3a3e5d52",
+      "entity": "niiri:4c4f61059d1c51c5c453ad92e020752f"
     },
     {
-      "@id": "niiri:8c721ca02074789cc8f4d2a02b887b41",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:4ef90c913a7c532cca2c6fd0f9681191",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0007",
-      "prov:atLocation": {"@id": "niiri:a43a97777ebdb4ce39296602eba0eee8"},
+      "prov:atLocation": {"@id": "niiri:346c0c7ceec90148b035784c5b930f51"},
       "prov:value": {"@type": "xsd:float", "@value": "6.71233081817627"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "6.05139656868728"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.17977344244503e-10"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.000160149822946543"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000249071340138561"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "6.05139656868728"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.17977344244503e-10"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.000160149822946543"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000249071340138561"}
     },
     {
-      "@id": "niiri:a43a97777ebdb4ce39296602eba0eee8",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:346c0c7ceec90148b035784c5b930f51",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0007",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[32,-90,-2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[32,-90,-2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8c721ca02074789cc8f4d2a02b887b41",
-      "entity": "niiri:780f2f5e9d63466ad3c7345293e0fe5b"
+      "entity_derived": "niiri:4ef90c913a7c532cca2c6fd0f9681191",
+      "entity": "niiri:3ed2649db2465ff69f88971b546dd3be"
     },
     {
-      "@id": "niiri:384474972c1b58360a8a2fcd9e0901de",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:36703567cc1d92a9cb3e152dc40b85ce",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0008",
-      "prov:atLocation": {"@id": "niiri:32a1ff2c84613105934c95e42a36e4b8"},
+      "prov:atLocation": {"@id": "niiri:f3c1332320c8a65eb857249d0977820a"},
       "prov:value": {"@type": "xsd:float", "@value": "6.07869148254395"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.56799434588466"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.28844092062153e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00287395763954645"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00180477183683656"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.56799434588466"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.28844092062153e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00287395763954645"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00180477183683656"}
     },
     {
-      "@id": "niiri:32a1ff2c84613105934c95e42a36e4b8",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f3c1332320c8a65eb857249d0977820a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0008",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[44,-72,-10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[44,-72,-10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:384474972c1b58360a8a2fcd9e0901de",
-      "entity": "niiri:780f2f5e9d63466ad3c7345293e0fe5b"
+      "entity_derived": "niiri:36703567cc1d92a9cb3e152dc40b85ce",
+      "entity": "niiri:3ed2649db2465ff69f88971b546dd3be"
     },
     {
-      "@id": "niiri:eb5125f50058b0fe1dc51a3c0aef6983",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:1aba48e406a0117ab013a8859ef28b04",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0009",
-      "prov:atLocation": {"@id": "niiri:70f9ba688514fb0a0defd1a1bd6b7917"},
+      "prov:atLocation": {"@id": "niiri:b35f033a94a89bf6738d5c904bec2b9f"},
       "prov:value": {"@type": "xsd:float", "@value": "5.10857725143433"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.78656760604548"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.48289032462368e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.108873252801375"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0180107935900568"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.78656760604548"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.48289032462368e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.108873252801375"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0180107935900568"}
     },
     {
-      "@id": "niiri:70f9ba688514fb0a0defd1a1bd6b7917",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b35f033a94a89bf6738d5c904bec2b9f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0009",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[28,-84,14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[28,-84,14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:eb5125f50058b0fe1dc51a3c0aef6983",
-      "entity": "niiri:780f2f5e9d63466ad3c7345293e0fe5b"
+      "entity_derived": "niiri:1aba48e406a0117ab013a8859ef28b04",
+      "entity": "niiri:3ed2649db2465ff69f88971b546dd3be"
     },
     {
-      "@id": "niiri:f3383c28faeb655173bf2995e04855fb",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b5f5cf902b5b4771df855cfa8a376ac3",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0010",
-      "prov:atLocation": {"@id": "niiri:3908520dcc2e14d02d9eab3148fc8a07"},
+      "prov:atLocation": {"@id": "niiri:f972a1eedb64fa761afd328be838d631"},
       "prov:value": {"@type": "xsd:float", "@value": "6.59459638595581"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.96318826880385"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.23681564989653e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.000275880338890366"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00032995692182998"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.96318826880385"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.23681564989653e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.000275880338890366"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00032995692182998"}
     },
     {
-      "@id": "niiri:3908520dcc2e14d02d9eab3148fc8a07",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f972a1eedb64fa761afd328be838d631",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0010",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[52,-32,42]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[52,-32,42]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f3383c28faeb655173bf2995e04855fb",
-      "entity": "niiri:2695c44ad8ef77b70e478006be76ec3b"
+      "entity_derived": "niiri:b5f5cf902b5b4771df855cfa8a376ac3",
+      "entity": "niiri:19dfc0bbb201d5f134704921caf5a176"
     },
     {
-      "@id": "niiri:3cc6a6e3471089d2fb2acf707242d17e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:89bc5cfcdef0a83dbaf0b1406beae51a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0011",
-      "prov:atLocation": {"@id": "niiri:bed6dc7f81a19e9aa36101f8e19ff3f2"},
+      "prov:atLocation": {"@id": "niiri:378ef40da87eb0e81caffcf1aa603cd4"},
       "prov:value": {"@type": "xsd:float", "@value": "6.12601184844971"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.6048323310884"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.04228329300682e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00232488579535362"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00168019830542188"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.6048323310884"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.04228329300682e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00232488579535362"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00168019830542188"}
     },
     {
-      "@id": "niiri:bed6dc7f81a19e9aa36101f8e19ff3f2",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:378ef40da87eb0e81caffcf1aa603cd4",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0011",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[44,-70,50]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[44,-70,50]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3cc6a6e3471089d2fb2acf707242d17e",
-      "entity": "niiri:2695c44ad8ef77b70e478006be76ec3b"
+      "entity_derived": "niiri:89bc5cfcdef0a83dbaf0b1406beae51a",
+      "entity": "niiri:19dfc0bbb201d5f134704921caf5a176"
     },
     {
-      "@id": "niiri:6b5426692f8fc30c257d8076b8f80f0b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e9f1a1a5097af18399f0bd67a17a2cce",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0012",
-      "prov:atLocation": {"@id": "niiri:57e5df2ad0825e50532905e4eccad98a"},
+      "prov:atLocation": {"@id": "niiri:ef1b9d6e9d5073cf34fe3d947b0e48b9"},
       "prov:value": {"@type": "xsd:float", "@value": "5.89449405670166"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.42346487564262"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.92273529822751e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0060156823124996"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00242918849696441"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.42346487564262"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.92273529822751e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0060156823124996"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00242918849696441"}
     },
     {
-      "@id": "niiri:57e5df2ad0825e50532905e4eccad98a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ef1b9d6e9d5073cf34fe3d947b0e48b9",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0012",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[40,-62,50]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[40,-62,50]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6b5426692f8fc30c257d8076b8f80f0b",
-      "entity": "niiri:2695c44ad8ef77b70e478006be76ec3b"
+      "entity_derived": "niiri:e9f1a1a5097af18399f0bd67a17a2cce",
+      "entity": "niiri:19dfc0bbb201d5f134704921caf5a176"
     },
     {
-      "@id": "niiri:e488978bb4b1f52c9230d2f5097db9c1",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:bd38db380ba41e0ce1675948a69b7682",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0013",
-      "prov:atLocation": {"@id": "niiri:cf20d034a9e3237f117fdbb72bb2cf70"},
+      "prov:atLocation": {"@id": "niiri:4011c2782827b7caa0f649a873a23c28"},
       "prov:value": {"@type": "xsd:float", "@value": "6.03912734985352"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.53710291953986"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.53757930831944e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00340192895130376"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00190165765630454"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.53710291953986"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.53757930831944e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00340192895130376"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00190165765630454"}
     },
     {
-      "@id": "niiri:cf20d034a9e3237f117fdbb72bb2cf70",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4011c2782827b7caa0f649a873a23c28",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0013",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-60,8,20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-60,8,20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e488978bb4b1f52c9230d2f5097db9c1",
-      "entity": "niiri:a4131faa6f9d63d587e81683f4525aa5"
+      "entity_derived": "niiri:bd38db380ba41e0ce1675948a69b7682",
+      "entity": "niiri:4ccbfde9cca6489f3110bef0431524c8"
     },
     {
-      "@id": "niiri:42021911e82362627bbd5064efc113b4",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:881e790fc7e1a6f81af66a18ac093075",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0014",
-      "prov:atLocation": {"@id": "niiri:320c3f376c5460a5ef805683acb42025"},
+      "prov:atLocation": {"@id": "niiri:f6e4f3dcf4db8f79777bc1b1b3a328ab"},
       "prov:value": {"@type": "xsd:float", "@value": "5.83134031295776"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.37349584041984"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.86122938067501e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0076941885115317"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0026939300902738"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.37349584041984"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.86122938067501e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0076941885115317"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0026939300902738"}
     },
     {
-      "@id": "niiri:320c3f376c5460a5ef805683acb42025",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f6e4f3dcf4db8f79777bc1b1b3a328ab",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0014",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-52,0,38]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-52,0,38]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:42021911e82362627bbd5064efc113b4",
-      "entity": "niiri:a4131faa6f9d63d587e81683f4525aa5"
+      "entity_derived": "niiri:881e790fc7e1a6f81af66a18ac093075",
+      "entity": "niiri:4ccbfde9cca6489f3110bef0431524c8"
     },
     {
-      "@id": "niiri:cf31a4865ea1af28c8e2e659a12ac34b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e423ac92420c6449768391abb0fcedc9",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0015",
-      "prov:atLocation": {"@id": "niiri:9f095b268dc4b7317eba04950dd041db"},
+      "prov:atLocation": {"@id": "niiri:b93252e9cd350f950d0cda71d2f9ebc7"},
       "prov:value": {"@type": "xsd:float", "@value": "4.88419103622437"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.5987688944456"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.12497457574568e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.22375640863328"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0290725545238754"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.5987688944456"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.12497457574568e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.22375640863328"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0290725545238754"}
     },
     {
-      "@id": "niiri:9f095b268dc4b7317eba04950dd041db",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b93252e9cd350f950d0cda71d2f9ebc7",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0015",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-46,6,28]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-46,6,28]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cf31a4865ea1af28c8e2e659a12ac34b",
-      "entity": "niiri:a4131faa6f9d63d587e81683f4525aa5"
+      "entity_derived": "niiri:e423ac92420c6449768391abb0fcedc9",
+      "entity": "niiri:4ccbfde9cca6489f3110bef0431524c8"
     },
     {
-      "@id": "niiri:e9a51b2eac641ac30c06796bdf1340cb",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:edf2c8ccec7e4fd60e5909a7319ff0e6",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0016",
-      "prov:atLocation": {"@id": "niiri:27e7ba757343881a748fdd85abfe17d8"},
+      "prov:atLocation": {"@id": "niiri:9588b96c2d25cf9201a88c4be47c6c1d"},
       "prov:value": {"@type": "xsd:float", "@value": "5.9007363319397"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.42839241341132"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.84319533472299e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00587055658900548"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00242918849696441"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.42839241341132"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.84319533472299e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00587055658900548"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00242918849696441"}
     },
     {
-      "@id": "niiri:27e7ba757343881a748fdd85abfe17d8",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:9588b96c2d25cf9201a88c4be47c6c1d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0016",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[32,4,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[32,4,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e9a51b2eac641ac30c06796bdf1340cb",
-      "entity": "niiri:f1484408d6648353b40e3f793d43ba98"
+      "entity_derived": "niiri:edf2c8ccec7e4fd60e5909a7319ff0e6",
+      "entity": "niiri:3621a50b575ca90dbe183bb31ff4ae4a"
     },
     {
-      "@id": "niiri:95088c2d8ffd46f3669857e0f4b096d5",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:7c1ced347ec1ebede281534319058c3e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0017",
-      "prov:atLocation": {"@id": "niiri:b2c0b8c40937bcc536592b8863b23ad3"},
+      "prov:atLocation": {"@id": "niiri:82ffb9c44210599420a6de41fd0d1109"},
       "prov:value": {"@type": "xsd:float", "@value": "5.09700393676758"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.77694551087642"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.8988987889671e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.113189315105649"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0180107935900568"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.77694551087642"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.8988987889671e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.113189315105649"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0180107935900568"}
     },
     {
-      "@id": "niiri:b2c0b8c40937bcc536592b8863b23ad3",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:82ffb9c44210599420a6de41fd0d1109",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0017",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[40,24,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[40,24,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:95088c2d8ffd46f3669857e0f4b096d5",
-      "entity": "niiri:f1484408d6648353b40e3f793d43ba98"
+      "entity_derived": "niiri:7c1ced347ec1ebede281534319058c3e",
+      "entity": "niiri:3621a50b575ca90dbe183bb31ff4ae4a"
     },
     {
-      "@id": "niiri:1a8e05fc22f5aa6f473e39fa2ccd2c0c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f17c1b76c4220010841c0f96ac1e3578",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0018",
-      "prov:atLocation": {"@id": "niiri:643e041750ee728554c920cfd5b116c8"},
+      "prov:atLocation": {"@id": "niiri:ca3bb8d110a50afae2aead88e5bf0ca1"},
       "prov:value": {"@type": "xsd:float", "@value": "4.34982109069824"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.14112597656651"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.72802535455263e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.770025153200453"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.120618056446103"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.14112597656651"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.72802535455263e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.770025153200453"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.120618056446103"}
     },
     {
-      "@id": "niiri:643e041750ee728554c920cfd5b116c8",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ca3bb8d110a50afae2aead88e5bf0ca1",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0018",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[36,12,58]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[36,12,58]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1a8e05fc22f5aa6f473e39fa2ccd2c0c",
-      "entity": "niiri:f1484408d6648353b40e3f793d43ba98"
+      "entity_derived": "niiri:f17c1b76c4220010841c0f96ac1e3578",
+      "entity": "niiri:3621a50b575ca90dbe183bb31ff4ae4a"
     },
     {
-      "@id": "niiri:714fa69947cd59c6835cdab3b75583fe",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:dbb88a311a9de3b4bed9021fb15312f5",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0019",
-      "prov:atLocation": {"@id": "niiri:7372779136b70720b7b0ae181d3e41c3"},
+      "prov:atLocation": {"@id": "niiri:02035963b589d505ac125194cd2ed04e"},
       "prov:value": {"@type": "xsd:float", "@value": "5.83802509307861"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.37879507210251"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.74930015922814e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00749698476563887"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0026939300902738"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.37879507210251"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.74930015922814e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00749698476563887"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0026939300902738"}
     },
     {
-      "@id": "niiri:7372779136b70720b7b0ae181d3e41c3",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:02035963b589d505ac125194cd2ed04e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0019",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-28,-94,4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-28,-94,4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:714fa69947cd59c6835cdab3b75583fe",
-      "entity": "niiri:f549b84e14efc1b6caac0a05e1a46c0d"
+      "entity_derived": "niiri:dbb88a311a9de3b4bed9021fb15312f5",
+      "entity": "niiri:7698728db1c0c3e20b495f064a9d5b55"
     },
     {
-      "@id": "niiri:f2fb13a784fffbece388d6bd7ec06eb6",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:73e895f0d508d2c610d6a3c106ee0716",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0020",
-      "prov:atLocation": {"@id": "niiri:879ea167901069a60718b85f829a4cad"},
+      "prov:atLocation": {"@id": "niiri:d23dece0568269e4842ecb6bdd2c6313"},
       "prov:value": {"@type": "xsd:float", "@value": "4.31375646591187"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.10972151362626"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.98068279155805e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.80686639972725"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.127448637088902"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.10972151362626"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.98068279155805e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.80686639972725"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.127448637088902"}
     },
     {
-      "@id": "niiri:879ea167901069a60718b85f829a4cad",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d23dece0568269e4842ecb6bdd2c6313",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0020",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-32,-86,0]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-32,-86,0]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f2fb13a784fffbece388d6bd7ec06eb6",
-      "entity": "niiri:f549b84e14efc1b6caac0a05e1a46c0d"
+      "entity_derived": "niiri:73e895f0d508d2c610d6a3c106ee0716",
+      "entity": "niiri:7698728db1c0c3e20b495f064a9d5b55"
     },
     {
-      "@id": "niiri:6e1a6aa978266fb830cf4d32afb6d7b5",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:9a97546675f609fff6f0b719b74412c8",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0021",
-      "prov:atLocation": {"@id": "niiri:89d89b40909aeec6e9aea30261598f84"},
+      "prov:atLocation": {"@id": "niiri:57074d3ea076ff46e82b94244cdb912d"},
       "prov:value": {"@type": "xsd:float", "@value": "3.64368534088135"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.51479672440726"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000220045357440024"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999986157595448"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.455711975517369"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.51479672440726"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000220045357440024"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999986157595448"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.455711975517369"}
     },
     {
-      "@id": "niiri:89d89b40909aeec6e9aea30261598f84",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:57074d3ea076ff46e82b94244cdb912d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0021",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-18,-92,6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-18,-92,6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6e1a6aa978266fb830cf4d32afb6d7b5",
-      "entity": "niiri:f549b84e14efc1b6caac0a05e1a46c0d"
+      "entity_derived": "niiri:9a97546675f609fff6f0b719b74412c8",
+      "entity": "niiri:7698728db1c0c3e20b495f064a9d5b55"
     },
     {
-      "@id": "niiri:962fc6d94c839838915a9e3626147461",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f1fa028e954eb2428370317bd458e6d2",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0022",
-      "prov:atLocation": {"@id": "niiri:15ff27094138e8ec92b8c1e7e07e84b5"},
+      "prov:atLocation": {"@id": "niiri:f96d2bfba65dead2c46f9463120068d5"},
       "prov:value": {"@type": "xsd:float", "@value": "5.49678039550781"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.10524655927297"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.65181742173282e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0274162029530135"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00834610941271248"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.10524655927297"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.65181742173282e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0274162029530135"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00834610941271248"}
     },
     {
-      "@id": "niiri:15ff27094138e8ec92b8c1e7e07e84b5",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f96d2bfba65dead2c46f9463120068d5",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0022",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-34,-2,52]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-34,-2,52]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:962fc6d94c839838915a9e3626147461",
-      "entity": "niiri:29fc425e622d8b8ded04fc6031eeff5d"
+      "entity_derived": "niiri:f1fa028e954eb2428370317bd458e6d2",
+      "entity": "niiri:379c20fa5cd6aefb39cb7419f030f9e5"
     },
     {
-      "@id": "niiri:b68df6e58131eeb0d2aaa7f6ef8a3c0c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:8d9046504d5d30f7a737d3c5422a2f49",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0023",
-      "prov:atLocation": {"@id": "niiri:fc6fe63052b7924151c57b49b1dde635"},
+      "prov:atLocation": {"@id": "niiri:a84c78c0af5824b28fc28c2b26191cf6"},
       "prov:value": {"@type": "xsd:float", "@value": "5.4477219581604"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.06541264724911"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.03758308892077e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0328526754070724"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00847322777156312"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.06541264724911"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.03758308892077e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0328526754070724"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00847322777156312"}
     },
     {
-      "@id": "niiri:fc6fe63052b7924151c57b49b1dde635",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a84c78c0af5824b28fc28c2b26191cf6",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0023",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-58,-30,-18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-58,-30,-18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b68df6e58131eeb0d2aaa7f6ef8a3c0c",
-      "entity": "niiri:ddb75d1dce61c969aca0b33e4792ae0c"
+      "entity_derived": "niiri:8d9046504d5d30f7a737d3c5422a2f49",
+      "entity": "niiri:4257936a93608ef43291e047551e5e0a"
     },
     {
-      "@id": "niiri:c8c2b9d4bf8e1f00d52a528322b07233",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f28ae319db96c12f65d68cdf44c37228",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0024",
-      "prov:atLocation": {"@id": "niiri:c8ac24d80011470a9cfa9933360dd6e8"},
+      "prov:atLocation": {"@id": "niiri:f6c38af20f2cc671e453a64d27f31859"},
       "prov:value": {"@type": "xsd:float", "@value": "5.28879737854004"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.93549802722869"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.99732443923106e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.058332304236273"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0124221993559286"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.93549802722869"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.99732443923106e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.058332304236273"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0124221993559286"}
     },
     {
-      "@id": "niiri:c8ac24d80011470a9cfa9933360dd6e8",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f6c38af20f2cc671e453a64d27f31859",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0024",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-62,-36,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-62,-36,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c8c2b9d4bf8e1f00d52a528322b07233",
-      "entity": "niiri:9fd20bfdc1412e227a54f54ed45d5054"
+      "entity_derived": "niiri:f28ae319db96c12f65d68cdf44c37228",
+      "entity": "niiri:7017960274f85788b6b607f7d0046a76"
     },
     {
-      "@id": "niiri:7040757a9ca777a1ca655c03cc4d41fd",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:307f5f8fa2312eb0133eaf4fffbbeb80",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0025",
-      "prov:atLocation": {"@id": "niiri:7069f38da8f59b73a94c4ca24a4b8295"},
+      "prov:atLocation": {"@id": "niiri:f0410a98f2844fad2156dd8693b4188f"},
       "prov:value": {"@type": "xsd:float", "@value": "5.07126235961914"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.7555187910417"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "9.89687234609349e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.123339755499162"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0187591962334509"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.7555187910417"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "9.89687234609349e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.123339755499162"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0187591962334509"}
     },
     {
-      "@id": "niiri:7069f38da8f59b73a94c4ca24a4b8295",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f0410a98f2844fad2156dd8693b4188f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0025",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-60,-50,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-60,-50,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7040757a9ca777a1ca655c03cc4d41fd",
-      "entity": "niiri:9fd20bfdc1412e227a54f54ed45d5054"
+      "entity_derived": "niiri:307f5f8fa2312eb0133eaf4fffbbeb80",
+      "entity": "niiri:7017960274f85788b6b607f7d0046a76"
     },
     {
-      "@id": "niiri:d2ba7095e5b6f91c6352fbfb87a4fa62",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a9639fbdbb1c26aee4c14242d935b468",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0026",
-      "prov:atLocation": {"@id": "niiri:1d888cfd09eba5c400d1b55ff180d5cf"},
+      "prov:atLocation": {"@id": "niiri:32781cc47551b5a832493146ff9c76da"},
       "prov:value": {"@type": "xsd:float", "@value": "5.20113325119019"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.86326687921491"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.77319983152691e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0793447375400678"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0159079887522274"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.86326687921491"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.77319983152691e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0793447375400678"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0159079887522274"}
     },
     {
-      "@id": "niiri:1d888cfd09eba5c400d1b55ff180d5cf",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:32781cc47551b5a832493146ff9c76da",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0026",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[32,40,16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[32,40,16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d2ba7095e5b6f91c6352fbfb87a4fa62",
-      "entity": "niiri:f0f0748bbb9066bab45490e1ba8fef31"
+      "entity_derived": "niiri:a9639fbdbb1c26aee4c14242d935b468",
+      "entity": "niiri:a48da6310356eb94f99b1f1eb464e14b"
     },
     {
-      "@id": "niiri:1a90c94823489843eaef3560026a07b2",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:1be33bac5492f3fdf9b7077a2b1176d4",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0027",
-      "prov:atLocation": {"@id": "niiri:179eec3c1632e860b697e1ec02b244ef"},
+      "prov:atLocation": {"@id": "niiri:3e74e91d33b6b30b2f135558c37b59ca"},
       "prov:value": {"@type": "xsd:float", "@value": "4.20966386795044"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.01871912540871"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.92576874012518e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.895902731954404"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.157816499218783"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.01871912540871"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.92576874012518e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.895902731954404"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.157816499218783"}
     },
     {
-      "@id": "niiri:179eec3c1632e860b697e1ec02b244ef",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:3e74e91d33b6b30b2f135558c37b59ca",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0027",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[36,54,10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[36,54,10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1a90c94823489843eaef3560026a07b2",
-      "entity": "niiri:f0f0748bbb9066bab45490e1ba8fef31"
+      "entity_derived": "niiri:1be33bac5492f3fdf9b7077a2b1176d4",
+      "entity": "niiri:a48da6310356eb94f99b1f1eb464e14b"
     },
     {
-      "@id": "niiri:3b48fce461eb5c4f30ca5336d6229d5b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e24f477da65372897130f7d2cb1485f9",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0028",
-      "prov:atLocation": {"@id": "niiri:32e153dc173a6b545e34387a0e12b3e7"},
+      "prov:atLocation": {"@id": "niiri:52e3b66db0b4b363b3aef5d680cb3d38"},
       "prov:value": {"@type": "xsd:float", "@value": "4.03298187255859"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.86304409189175"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.59913929287781e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.978124547666055"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.219902724174057"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.86304409189175"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.59913929287781e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.978124547666055"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.219902724174057"}
     },
     {
-      "@id": "niiri:32e153dc173a6b545e34387a0e12b3e7",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:52e3b66db0b4b363b3aef5d680cb3d38",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0028",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[40,44,26]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[40,44,26]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3b48fce461eb5c4f30ca5336d6229d5b",
-      "entity": "niiri:f0f0748bbb9066bab45490e1ba8fef31"
+      "entity_derived": "niiri:e24f477da65372897130f7d2cb1485f9",
+      "entity": "niiri:a48da6310356eb94f99b1f1eb464e14b"
     },
     {
-      "@id": "niiri:92237d84748d6f3f8c6b981716eba365",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:9692edf724b92ae14d3e441c312e65cc",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0029",
-      "prov:atLocation": {"@id": "niiri:83dff9c3cca90de02ae8b211edee7a74"},
+      "prov:atLocation": {"@id": "niiri:92b1a1b46104a64097b99dd6e7ca8b2b"},
       "prov:value": {"@type": "xsd:float", "@value": "5.13718748092651"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.81032420567012"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.53428407773704e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0988296994641761"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0175971158742543"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.81032420567012"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.53428407773704e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0988296994641761"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0175971158742543"}
     },
     {
-      "@id": "niiri:83dff9c3cca90de02ae8b211edee7a74",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:92b1a1b46104a64097b99dd6e7ca8b2b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0029",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-54,-46,58]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-54,-46,58]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:92237d84748d6f3f8c6b981716eba365",
-      "entity": "niiri:90b4dda7962081808845a0f3dcd7ea91"
+      "entity_derived": "niiri:9692edf724b92ae14d3e441c312e65cc",
+      "entity": "niiri:ada43746a7be5361f1b2127ddc7152ba"
     },
     {
-      "@id": "niiri:e27a5b9903f7214c4043fb9b311140d8",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:614f41f29f9cf9d39c5a6367956b6357",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0030",
-      "prov:atLocation": {"@id": "niiri:5368f1bafa1cdcb731c02d2882a686f5"},
+      "prov:atLocation": {"@id": "niiri:daf4cabbd0bebc79beea7b9974028396"},
       "prov:value": {"@type": "xsd:float", "@value": "4.99936532974243"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.69549029807528"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.32983996270486e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.156049412961254"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.022013679767251"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.69549029807528"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.32983996270486e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.156049412961254"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.022013679767251"}
     },
     {
-      "@id": "niiri:5368f1bafa1cdcb731c02d2882a686f5",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:daf4cabbd0bebc79beea7b9974028396",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0030",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-36,-74,-34]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-36,-74,-34]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e27a5b9903f7214c4043fb9b311140d8",
-      "entity": "niiri:dba4c7441ba091562d6318495ccd506b"
+      "entity_derived": "niiri:614f41f29f9cf9d39c5a6367956b6357",
+      "entity": "niiri:1c73b53acc2e3706c7dcdd4e4ed9e043"
     },
     {
-      "@id": "niiri:267f4307b61db4da72cc002b7230f73b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:9e657853abbaa2650f24166bf90f5a81",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0031",
-      "prov:atLocation": {"@id": "niiri:5dc94dda962cb792f857e921d307b625"},
+      "prov:atLocation": {"@id": "niiri:4558ece5294ed109fda5b20c0acd7480"},
       "prov:value": {"@type": "xsd:float", "@value": "4.7462682723999"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.4820421310153"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.69660714449882e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.333239579597568"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0434977534015138"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.4820421310153"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.69660714449882e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.333239579597568"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0434977534015138"}
     },
     {
-      "@id": "niiri:5dc94dda962cb792f857e921d307b625",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4558ece5294ed109fda5b20c0acd7480",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0031",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-36,-74,-14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-36,-74,-14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:267f4307b61db4da72cc002b7230f73b",
-      "entity": "niiri:64445ad0b45313551f83199c04675195"
+      "entity_derived": "niiri:9e657853abbaa2650f24166bf90f5a81",
+      "entity": "niiri:655978b5bff261f0bf396a1ddf498402"
     },
     {
-      "@id": "niiri:876e16d1a925e329e869d825ab936517",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:2e831d1e6888a2d6174ba7de8443f206",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0032",
-      "prov:atLocation": {"@id": "niiri:068ab6c480d2cc19beff86341a70859b"},
+      "prov:atLocation": {"@id": "niiri:3e60ee8d583858acc7f1b33e4313f57d"},
       "prov:value": {"@type": "xsd:float", "@value": "4.14389324188232"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.96094551523189"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.73267835663826e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.93653316357533"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.176857016686839"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.96094551523189"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.73267835663826e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.93653316357533"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.176857016686839"}
     },
     {
-      "@id": "niiri:068ab6c480d2cc19beff86341a70859b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:3e60ee8d583858acc7f1b33e4313f57d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0032",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-36,-68,-20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-36,-68,-20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:876e16d1a925e329e869d825ab936517",
-      "entity": "niiri:64445ad0b45313551f83199c04675195"
+      "entity_derived": "niiri:2e831d1e6888a2d6174ba7de8443f206",
+      "entity": "niiri:655978b5bff261f0bf396a1ddf498402"
     },
     {
-      "@id": "niiri:7e80a9cfd879b25b0fd51b485bdca983",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ed3b1a53734192dd232c2ea8bb681cb6",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0033",
-      "prov:atLocation": {"@id": "niiri:ecb8277acf6f3ee57c04aac0f4c251f6"},
+      "prov:atLocation": {"@id": "niiri:40b108d5097b549d75db0c77387e1498"},
       "prov:value": {"@type": "xsd:float", "@value": "3.64391040802002"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.51500008532851"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000219876923486684"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99998606648459"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.455711975517369"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.51500008532851"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000219876923486684"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99998606648459"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.455711975517369"}
     },
     {
-      "@id": "niiri:ecb8277acf6f3ee57c04aac0f4c251f6",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:40b108d5097b549d75db0c77387e1498",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0033",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-30,-60,-16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-30,-60,-16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7e80a9cfd879b25b0fd51b485bdca983",
-      "entity": "niiri:64445ad0b45313551f83199c04675195"
+      "entity_derived": "niiri:ed3b1a53734192dd232c2ea8bb681cb6",
+      "entity": "niiri:655978b5bff261f0bf396a1ddf498402"
     },
     {
-      "@id": "niiri:eea76345d819ddb84d70309298fdc5ef",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:85627026074aa1f753b1ba3a22383b49",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0034",
-      "prov:atLocation": {"@id": "niiri:3d26739f1b78d5891209231c981f476f"},
+      "prov:atLocation": {"@id": "niiri:4129b86d91f37cbd3cfd85da48f13011"},
       "prov:value": {"@type": "xsd:float", "@value": "4.72862100601196"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.46703637029677"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.96553251347243e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.349567174180407"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0444488399275926"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.46703637029677"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.96553251347243e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.349567174180407"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0444488399275926"}
     },
     {
-      "@id": "niiri:3d26739f1b78d5891209231c981f476f",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4129b86d91f37cbd3cfd85da48f13011",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0034",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-36,-40,-36]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-36,-40,-36]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:eea76345d819ddb84d70309298fdc5ef",
-      "entity": "niiri:bb07405375d86eb7d0603ec3197e08aa"
+      "entity_derived": "niiri:85627026074aa1f753b1ba3a22383b49",
+      "entity": "niiri:7dd3c3ae219e2bf1ef8176af9cc60fb9"
     },
     {
-      "@id": "niiri:452d9b09d7396a9f81a5b87912bff906",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5b0b1185c630b975f1f9cad7d863bc1c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0035",
-      "prov:atLocation": {"@id": "niiri:f864956bd553611927d721a757c5205e"},
+      "prov:atLocation": {"@id": "niiri:f2ec576f7b577cf6e622416723b53710"},
       "prov:value": {"@type": "xsd:float", "@value": "4.67978620529175"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.42542829210121"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.81255631634703e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.397360911613874"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0513842337520043"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.42542829210121"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.81255631634703e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.397360911613874"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0513842337520043"}
     },
     {
-      "@id": "niiri:f864956bd553611927d721a757c5205e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f2ec576f7b577cf6e622416723b53710",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0035",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-60,-16,26]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-60,-16,26]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:452d9b09d7396a9f81a5b87912bff906",
-      "entity": "niiri:c3428421b6744ab712756818f68e34b1"
+      "entity_derived": "niiri:5b0b1185c630b975f1f9cad7d863bc1c",
+      "entity": "niiri:c96857fd42e1208395989b05eeab7a76"
     },
     {
-      "@id": "niiri:6976e4a8741e464109bad66646a99778",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:fab4182c9396833dae1da711b91f9451",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0036",
-      "prov:atLocation": {"@id": "niiri:f353b396c05bc94f28065bda9ac87d70"},
+      "prov:atLocation": {"@id": "niiri:decf85102aef6761a4506398e5303491"},
       "prov:value": {"@type": "xsd:float", "@value": "4.54088401794434"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.30641743150185"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.29599105278689e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.55051926533838"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0758424529215363"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.30641743150185"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.29599105278689e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.55051926533838"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0758424529215363"}
     },
     {
-      "@id": "niiri:f353b396c05bc94f28065bda9ac87d70",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:decf85102aef6761a4506398e5303491",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0036",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[50,-46,-12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[50,-46,-12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6976e4a8741e464109bad66646a99778",
-      "entity": "niiri:b1e2ccb2a24225ae9297eb35470b2ef2"
+      "entity_derived": "niiri:fab4182c9396833dae1da711b91f9451",
+      "entity": "niiri:7a24a2bdbc61f7d8ab6a59738a57c24a"
     },
     {
-      "@id": "niiri:055e6c9815fd249e085a1c8b2513c464",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:7e5c9c348e6bd97291db1b67455a7a1f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0037",
-      "prov:atLocation": {"@id": "niiri:d6646951cc4cd490b932d5d5aaff3a2d"},
+      "prov:atLocation": {"@id": "niiri:ec230d092645e527086b2f1dce92ba08"},
       "prov:value": {"@type": "xsd:float", "@value": "4.51589822769165"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.28490600256073"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "9.14082329439569e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.57981317377907"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0805429568785394"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.28490600256073"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "9.14082329439569e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.57981317377907"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0805429568785394"}
     },
     {
-      "@id": "niiri:d6646951cc4cd490b932d5d5aaff3a2d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ec230d092645e527086b2f1dce92ba08",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0037",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[60,-34,-8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[60,-34,-8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:055e6c9815fd249e085a1c8b2513c464",
-      "entity": "niiri:b1e2ccb2a24225ae9297eb35470b2ef2"
+      "entity_derived": "niiri:7e5c9c348e6bd97291db1b67455a7a1f",
+      "entity": "niiri:7a24a2bdbc61f7d8ab6a59738a57c24a"
     },
     {
-      "@id": "niiri:e099daf51f20dabc5419c618d55cc84c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:597a607f2ee07200862c89760cd037fb",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0038",
-      "prov:atLocation": {"@id": "niiri:dcb827ef44b14c270428f7f5af60b5d4"},
+      "prov:atLocation": {"@id": "niiri:cd92b44ba264e7cc475ed0b679367114"},
       "prov:value": {"@type": "xsd:float", "@value": "4.19524717330933"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.00607343097259"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.08682317079478e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.905888940180749"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.162816132797782"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.00607343097259"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.08682317079478e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.905888940180749"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.162816132797782"}
     },
     {
-      "@id": "niiri:dcb827ef44b14c270428f7f5af60b5d4",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:cd92b44ba264e7cc475ed0b679367114",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0038",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[56,-24,-2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[56,-24,-2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e099daf51f20dabc5419c618d55cc84c",
-      "entity": "niiri:b1e2ccb2a24225ae9297eb35470b2ef2"
+      "entity_derived": "niiri:597a607f2ee07200862c89760cd037fb",
+      "entity": "niiri:7a24a2bdbc61f7d8ab6a59738a57c24a"
     },
     {
-      "@id": "niiri:41395efbdd9161254d3e7e8d187a9973",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a224964e93d3f6e2fff1835428d41f0b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0039",
-      "prov:atLocation": {"@id": "niiri:88a50a520abaaee3fd4b820c9e7299a6"},
+      "prov:atLocation": {"@id": "niiri:8f8db5ccf86c390cbae3a936ccb3061c"},
       "prov:value": {"@type": "xsd:float", "@value": "4.51116132736206"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.28082423475359"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "9.31011908622548e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.585391408801539"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0805429568785394"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.28082423475359"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "9.31011908622548e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.585391408801539"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0805429568785394"}
     },
     {
-      "@id": "niiri:88a50a520abaaee3fd4b820c9e7299a6",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:8f8db5ccf86c390cbae3a936ccb3061c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0039",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-50,-60,54]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-50,-60,54]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:41395efbdd9161254d3e7e8d187a9973",
-      "entity": "niiri:1c943c00f3f2e54e795e080b9d85859d"
+      "entity_derived": "niiri:a224964e93d3f6e2fff1835428d41f0b",
+      "entity": "niiri:c313dfc1d990322089b2bf63a219f16a"
     },
     {
-      "@id": "niiri:23907cd2cf132152d4d44a81416b52e1",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:33db15418b3eeb72fb3bb39cca81f286",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0040",
-      "prov:atLocation": {"@id": "niiri:7884ffb448fbacbb5b22b29865ef146e"},
+      "prov:atLocation": {"@id": "niiri:5d62c65dd629aae3c79e44863f4a799b"},
       "prov:value": {"@type": "xsd:float", "@value": "4.4765510559082"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.25096642679651"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.06425037911251e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.626226729794128"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0885762871613676"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.25096642679651"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.06425037911251e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.626226729794128"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0885762871613676"}
     },
     {
-      "@id": "niiri:7884ffb448fbacbb5b22b29865ef146e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:5d62c65dd629aae3c79e44863f4a799b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0040",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[16,14,64]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[16,14,64]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:23907cd2cf132152d4d44a81416b52e1",
-      "entity": "niiri:663b1f9b98b62235a966f9f1c5d82cb9"
+      "entity_derived": "niiri:33db15418b3eeb72fb3bb39cca81f286",
+      "entity": "niiri:36e697e6ea3e7a7c4a67a505ebe4f340"
     },
     {
-      "@id": "niiri:fbc2d4dfc55166343559ff0cebc38c1b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:81a9099168b6634f2d230e469992c262",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0041",
-      "prov:atLocation": {"@id": "niiri:ae99486ea14d7a23320257512769f605"},
+      "prov:atLocation": {"@id": "niiri:7d660acd245b9915dfc57669b02266cc"},
       "prov:value": {"@type": "xsd:float", "@value": "4.44478893280029"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.22351271935081"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.20261894772655e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.663529330330023"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0964832831947511"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.22351271935081"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.20261894772655e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.663529330330023"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0964832831947511"}
     },
     {
-      "@id": "niiri:ae99486ea14d7a23320257512769f605",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7d660acd245b9915dfc57669b02266cc",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0041",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-46,-66,-6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-46,-66,-6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:fbc2d4dfc55166343559ff0cebc38c1b",
-      "entity": "niiri:dcb1f3bd84b360ab8e8024d363c5a710"
+      "entity_derived": "niiri:81a9099168b6634f2d230e469992c262",
+      "entity": "niiri:ca1016af733ba1294614bfd4483de412"
     },
     {
-      "@id": "niiri:a2ddb6595db38bd193b22a48a684d46e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:17c4f6eb3f8f149b496425d877516f57",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0042",
-      "prov:atLocation": {"@id": "niiri:46ac02735e9f404103690f54ac6a2e17"},
+      "prov:atLocation": {"@id": "niiri:957ba3e02ba9f7541dd7ea4cefdd9417"},
       "prov:value": {"@type": "xsd:float", "@value": "3.7491512298584"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.60983821739614"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000153194020339198"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999788466860359"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.372479477261378"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.60983821739614"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000153194020339198"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999788466860359"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.372479477261378"}
     },
     {
-      "@id": "niiri:46ac02735e9f404103690f54ac6a2e17",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:957ba3e02ba9f7541dd7ea4cefdd9417",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0042",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-54,-64,-8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-54,-64,-8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a2ddb6595db38bd193b22a48a684d46e",
-      "entity": "niiri:dcb1f3bd84b360ab8e8024d363c5a710"
+      "entity_derived": "niiri:17c4f6eb3f8f149b496425d877516f57",
+      "entity": "niiri:ca1016af733ba1294614bfd4483de412"
     },
     {
-      "@id": "niiri:87c3e25eefd7f8f64f744a0782f0db22",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c953467c30386a10432f64759c9bb8fd",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0043",
-      "prov:atLocation": {"@id": "niiri:457ddb16da4054b4d082af48dd946ecf"},
+      "prov:atLocation": {"@id": "niiri:c59f67096c4b44b8b8297453390de1f8"},
       "prov:value": {"@type": "xsd:float", "@value": "4.31687879562378"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.11244293455755"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.95747130057322e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.803781550096335"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.127448637088902"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.11244293455755"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.95747130057322e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.803781550096335"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.127448637088902"}
     },
     {
-      "@id": "niiri:457ddb16da4054b4d082af48dd946ecf",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c59f67096c4b44b8b8297453390de1f8",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0043",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-14,-98,-4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-14,-98,-4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:87c3e25eefd7f8f64f744a0782f0db22",
-      "entity": "niiri:d5ec0fb74bfe81761c80eb8c08942466"
+      "entity_derived": "niiri:c953467c30386a10432f64759c9bb8fd",
+      "entity": "niiri:b4290f172c2ebe815ddf64763f6e95e4"
     },
     {
-      "@id": "niiri:7a46567fbaf54f67faa965af4c842832",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d71e3f367869829805aa71ff8bc7ef74",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0044",
-      "prov:atLocation": {"@id": "niiri:d041758727ae46806768921d5143d522"},
+      "prov:atLocation": {"@id": "niiri:82a52b17a12ba7eb6db09eeafbf4fcce"},
       "prov:value": {"@type": "xsd:float", "@value": "4.24778032302856"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.0521041277855"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.53795317693983e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.866634079797035"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.146768392895167"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.0521041277855"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.53795317693983e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.866634079797035"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.146768392895167"}
     },
     {
-      "@id": "niiri:d041758727ae46806768921d5143d522",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:82a52b17a12ba7eb6db09eeafbf4fcce",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0044",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-40,-40,44]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-40,-40,44]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7a46567fbaf54f67faa965af4c842832",
-      "entity": "niiri:dea3ebd7d53b9bdeb45e3fcbd12ef78f"
+      "entity_derived": "niiri:d71e3f367869829805aa71ff8bc7ef74",
+      "entity": "niiri:94f389f115646fc7441e8fd9bf5ec119"
     },
     {
-      "@id": "niiri:1ddf9076db1e3fdf9f2b2dd4e071445d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5c807bc9934434717c54df9aa0633275",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0045",
-      "prov:atLocation": {"@id": "niiri:ae09c7158dbfdfd6a108b27a0654d6f0"},
+      "prov:atLocation": {"@id": "niiri:c29990573704aecde0476b3c3877f96c"},
       "prov:value": {"@type": "xsd:float", "@value": "4.23215198516846"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.03842438550801"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.6905716773884e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.879129904028547"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.151175083557511"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.03842438550801"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.6905716773884e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.879129904028547"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.151175083557511"}
     },
     {
-      "@id": "niiri:ae09c7158dbfdfd6a108b27a0654d6f0",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c29990573704aecde0476b3c3877f96c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0045",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[22,38,12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[22,38,12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1ddf9076db1e3fdf9f2b2dd4e071445d",
-      "entity": "niiri:7576ce49bb83c1b874dc86b48878d37f"
+      "entity_derived": "niiri:5c807bc9934434717c54df9aa0633275",
+      "entity": "niiri:7322fa4ccee32301d807a0b9f48ae02a"
     },
     {
-      "@id": "niiri:e690ada88ee99e4df6c72fc539716ff4",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:11314fb1e4bc9f2012db889602ef5ff2",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0046",
-      "prov:atLocation": {"@id": "niiri:c36559ffbaf05c6691d8765722c9633e"},
+      "prov:atLocation": {"@id": "niiri:f117d9dc89b4a5963c653b2a0d8239cb"},
       "prov:value": {"@type": "xsd:float", "@value": "4.18517589569092"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.99723331404289"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.20435639625805e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.912505594315002"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.163982158985541"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.99723331404289"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.20435639625805e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.912505594315002"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.163982158985541"}
     },
     {
-      "@id": "niiri:c36559ffbaf05c6691d8765722c9633e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f117d9dc89b4a5963c653b2a0d8239cb",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0046",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-50,-52,-18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-50,-52,-18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e690ada88ee99e4df6c72fc539716ff4",
-      "entity": "niiri:cd03d29014d461350222c98300667843"
+      "entity_derived": "niiri:11314fb1e4bc9f2012db889602ef5ff2",
+      "entity": "niiri:c47c40f4ed2261336524231fb9108598"
     },
     {
-      "@id": "niiri:7d8f63a82c119daaf2afab4bf3ac06c2",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c6737de02555142d2e915210fc79d292",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0047",
-      "prov:atLocation": {"@id": "niiri:e24c92503be7f0b2f9dd799084c58154"},
+      "prov:atLocation": {"@id": "niiri:dd04ce53e197fa1cb75e0dd575d45c3e"},
       "prov:value": {"@type": "xsd:float", "@value": "4.12498378753662"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.94429624410211"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.00173349958122e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.945901344028104"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.182896629256048"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.94429624410211"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.00173349958122e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.945901344028104"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.182896629256048"}
     },
     {
-      "@id": "niiri:e24c92503be7f0b2f9dd799084c58154",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:dd04ce53e197fa1cb75e0dd575d45c3e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0047",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-36,-48,-18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-36,-48,-18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7d8f63a82c119daaf2afab4bf3ac06c2",
-      "entity": "niiri:cd03d29014d461350222c98300667843"
+      "entity_derived": "niiri:c6737de02555142d2e915210fc79d292",
+      "entity": "niiri:c47c40f4ed2261336524231fb9108598"
     },
     {
-      "@id": "niiri:05dfbc43da831c04830c1025f33c1cdd",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0ff26bd6b3a8873a52756070401ef6f8",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0048",
-      "prov:atLocation": {"@id": "niiri:7d0e502a1a660044dd8f7a9f7e1b277a"},
+      "prov:atLocation": {"@id": "niiri:39f123da883019b5511ae2b52eca03b6"},
       "prov:value": {"@type": "xsd:float", "@value": "4.11004066467285"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.93112694489083"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.22743058098307e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.952599821815146"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.189060437644636"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.93112694489083"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.22743058098307e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.952599821815146"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.189060437644636"}
     },
     {
-      "@id": "niiri:7d0e502a1a660044dd8f7a9f7e1b277a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:39f123da883019b5511ae2b52eca03b6",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0048",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[60,-26,-28]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[60,-26,-28]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:05dfbc43da831c04830c1025f33c1cdd",
-      "entity": "niiri:5e2e4f5da7c8d5550caebb447ece90bb"
+      "entity_derived": "niiri:0ff26bd6b3a8873a52756070401ef6f8",
+      "entity": "niiri:6c58a61aff8d76d3d5cdef392c46c0f7"
     },
     {
-      "@id": "niiri:4081a2194723009110061ee43bb061d9",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d5151f32682a8c00255e289f2ab66642",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0049",
-      "prov:atLocation": {"@id": "niiri:0f2ddb2b0e4bb59a51dd987cd60314ed"},
+      "prov:atLocation": {"@id": "niiri:461774f0f630ef77a6ebea4232af8dbf"},
       "prov:value": {"@type": "xsd:float", "@value": "4.08161401748657"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.90604483317219"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.69095562407595e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.963698528293292"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.203341942155421"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.90604483317219"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.69095562407595e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.963698528293292"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.203341942155421"}
     },
     {
-      "@id": "niiri:0f2ddb2b0e4bb59a51dd987cd60314ed",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:461774f0f630ef77a6ebea4232af8dbf",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0049",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[28,44,-2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[28,44,-2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4081a2194723009110061ee43bb061d9",
-      "entity": "niiri:489b086215a47551ede0b78dc2a96cbb"
+      "entity_derived": "niiri:d5151f32682a8c00255e289f2ab66642",
+      "entity": "niiri:bcf052d664b0eeef3576961aef494c62"
     },
     {
-      "@id": "niiri:8424435be347491e1894e81cdc6b4a48",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c734d9ef069f19ed65330db3f293e891",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0050",
-      "prov:atLocation": {"@id": "niiri:5038e601f830ac9ae819534714bb9363"},
+      "prov:atLocation": {"@id": "niiri:67d3c251cc11d74a757bc5ce9238c367"},
       "prov:value": {"@type": "xsd:float", "@value": "4.046302318573"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.87483340329215"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.33488348164468e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.974702494096904"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.218292566720722"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.87483340329215"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.33488348164468e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.974702494096904"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.218292566720722"}
     },
     {
-      "@id": "niiri:5038e601f830ac9ae819534714bb9363",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:67d3c251cc11d74a757bc5ce9238c367",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0050",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[16,-100,6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[16,-100,6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8424435be347491e1894e81cdc6b4a48",
-      "entity": "niiri:e167f1fa2b99e6bc19dd1ecd0b525c28"
+      "entity_derived": "niiri:c734d9ef069f19ed65330db3f293e891",
+      "entity": "niiri:d357fdfcedae064d3927d132b4915da3"
     },
     {
-      "@id": "niiri:df894a2c9efd8fb089c5712831742758",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5cd01f27f303492a475bb421b406f29e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0051",
-      "prov:atLocation": {"@id": "niiri:23e10ed27cf1990467f7bd6fa91cf230"},
+      "prov:atLocation": {"@id": "niiri:79e6e4f920bc1f2c1afeca02a3fbd970"},
       "prov:value": {"@type": "xsd:float", "@value": "4.02292680740356"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.85413917587123"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.80687603349839e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.980465241104396"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.22410305589753"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.85413917587123"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.80687603349839e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.980465241104396"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.22410305589753"}
     },
     {
-      "@id": "niiri:23e10ed27cf1990467f7bd6fa91cf230",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:79e6e4f920bc1f2c1afeca02a3fbd970",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0051",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-26,-92,30]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-26,-92,30]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:df894a2c9efd8fb089c5712831742758",
-      "entity": "niiri:3b3edf5a98326d7f3703f9678a007546"
+      "entity_derived": "niiri:5cd01f27f303492a475bb421b406f29e",
+      "entity": "niiri:24181b91e1a2ff9fbf0d92f1f3c2fb91"
     },
     {
-      "@id": "niiri:29d2c4519f31a3576e049e55b0290855",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b7c5e48c51f89a916bb2b9b3c7f93b74",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0052",
-      "prov:atLocation": {"@id": "niiri:4ffc60198b2eed473361368c08946427"},
+      "prov:atLocation": {"@id": "niiri:ffa7434855d1c324deca6f84fac4ca36"},
       "prov:value": {"@type": "xsd:float", "@value": "4.01148080825806"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.84399652858706"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.05233591551846e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.982890206353732"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.229310640619688"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.84399652858706"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.05233591551846e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.982890206353732"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.229310640619688"}
     },
     {
-      "@id": "niiri:4ffc60198b2eed473361368c08946427",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ffa7434855d1c324deca6f84fac4ca36",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0052",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-20,-98,22]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-20,-98,22]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:29d2c4519f31a3576e049e55b0290855",
-      "entity": "niiri:f254618143e69b64fb1d059a5963eed1"
+      "entity_derived": "niiri:b7c5e48c51f89a916bb2b9b3c7f93b74",
+      "entity": "niiri:a67bcbe4c64e864d3c0091590a71ed79"
     },
     {
-      "@id": "niiri:4b3301ead0d37019b50b00a50b447b00",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b4420f0e3015139ac61cd59663393123",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0053",
-      "prov:atLocation": {"@id": "niiri:7f5ef82036fd2cca1d22a272403a67aa"},
+      "prov:atLocation": {"@id": "niiri:90c84b40485f0ed6915d0e13465ea77d"},
       "prov:value": {"@type": "xsd:float", "@value": "3.94734573364258"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.78704871504293"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.62236103013514e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.992471615789186"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.257387912975022"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.78704871504293"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.62236103013514e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.992471615789186"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.257387912975022"}
     },
     {
-      "@id": "niiri:7f5ef82036fd2cca1d22a272403a67aa",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:90c84b40485f0ed6915d0e13465ea77d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0053",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-18,-60,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-18,-60,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4b3301ead0d37019b50b00a50b447b00",
-      "entity": "niiri:9061b512bdfd18fd0d71b5c4815f8163"
+      "entity_derived": "niiri:b4420f0e3015139ac61cd59663393123",
+      "entity": "niiri:1e585aa0961f26eba6c099e7119148ec"
     },
     {
-      "@id": "niiri:7ec273373ca8cb9eb93141e73f0b1efd",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b3b56bbb5afa41e6dd9460c0975114ab",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0054",
-      "prov:atLocation": {"@id": "niiri:68917202c3f236872fc5e59c8f0a9013"},
+      "prov:atLocation": {"@id": "niiri:7ae522397907f4441588495f10199d24"},
       "prov:value": {"@type": "xsd:float", "@value": "3.91909575462341"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.76190249943837"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.43128931427017e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.994989876478129"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.273662768395414"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.76190249943837"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.43128931427017e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.994989876478129"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.273662768395414"}
     },
     {
-      "@id": "niiri:68917202c3f236872fc5e59c8f0a9013",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7ae522397907f4441588495f10199d24",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0054",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-50,4,50]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-50,4,50]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7ec273373ca8cb9eb93141e73f0b1efd",
-      "entity": "niiri:c8fcb029f017b54563ed3b53bed1488f"
+      "entity_derived": "niiri:b3b56bbb5afa41e6dd9460c0975114ab",
+      "entity": "niiri:98543afde30df2ac94ce134cd8111cce"
     },
     {
-      "@id": "niiri:cdc716dd96e545570854cfbfc98e9aff",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d6851b62cb4fc286f889c964756f52ef",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0055",
-      "prov:atLocation": {"@id": "niiri:0a392e962bdfea486620d2bda30057d2"},
+      "prov:atLocation": {"@id": "niiri:4c35f39eeef9029f2223dd86b1ebd1fb"},
       "prov:value": {"@type": "xsd:float", "@value": "3.89198279380798"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.73773288062869"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "9.28435357934188e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.996706388084582"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.28517227483113"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.73773288062869"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "9.28435357934188e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.996706388084582"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.28517227483113"}
     },
     {
-      "@id": "niiri:0a392e962bdfea486620d2bda30057d2",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4c35f39eeef9029f2223dd86b1ebd1fb",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0055",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[4,6,34]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[4,6,34]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cdc716dd96e545570854cfbfc98e9aff",
-      "entity": "niiri:ca05945701843dd88ebf74447398670e"
+      "entity_derived": "niiri:d6851b62cb4fc286f889c964756f52ef",
+      "entity": "niiri:3bfa5939740913923e9b589897f2c510"
     },
     {
-      "@id": "niiri:0fa7bb39653758e6f292bdc911942f55",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d714caf4b86cd7fa8f8ed29b6c077612",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0056",
-      "prov:atLocation": {"@id": "niiri:b6428c4303d96c88f9c3d864d91aea97"},
+      "prov:atLocation": {"@id": "niiri:e26921989c4cf25fee3fb9b7455f0f8b"},
       "prov:value": {"@type": "xsd:float", "@value": "3.89150333404541"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.73730515822159"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "9.30015629725389e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.996731588962573"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.28517227483113"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.73730515822159"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "9.30015629725389e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.996731588962573"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.28517227483113"}
     },
     {
-      "@id": "niiri:b6428c4303d96c88f9c3d864d91aea97",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e26921989c4cf25fee3fb9b7455f0f8b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0056",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-22,-74,60]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-22,-74,60]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0fa7bb39653758e6f292bdc911942f55",
-      "entity": "niiri:b1d6b0c92fb80c25d314f20c0cfa090c"
+      "entity_derived": "niiri:d714caf4b86cd7fa8f8ed29b6c077612",
+      "entity": "niiri:6b8ab0e3e0b633d638e47f3a9a10919b"
     },
     {
-      "@id": "niiri:8f12ec634da94c8f499910e77a5dc600",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:547d02c0e638d74f5478c4bc3e391238",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0057",
-      "prov:atLocation": {"@id": "niiri:fab6ab4663f8327e8390b8544e8ce726"},
+      "prov:atLocation": {"@id": "niiri:090eeea9cc261f40a2ed8f97e8f80deb"},
       "prov:value": {"@type": "xsd:float", "@value": "3.3844006061554"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.27901971293977"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000520841795166427"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999480839"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.714388255916924"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.27901971293977"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000520841795166427"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999480839"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.714388255916924"}
     },
     {
-      "@id": "niiri:fab6ab4663f8327e8390b8544e8ce726",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:090eeea9cc261f40a2ed8f97e8f80deb",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0057",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-30,-72,60]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-30,-72,60]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8f12ec634da94c8f499910e77a5dc600",
-      "entity": "niiri:b1d6b0c92fb80c25d314f20c0cfa090c"
+      "entity_derived": "niiri:547d02c0e638d74f5478c4bc3e391238",
+      "entity": "niiri:6b8ab0e3e0b633d638e47f3a9a10919b"
     },
     {
-      "@id": "niiri:1a803bc72ca0bf7a669590a344f1c36b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c5a8590100956ce4c92258b440677e10",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0058",
-      "prov:atLocation": {"@id": "niiri:ea5d97630b3729c0b0eef856a08e8d66"},
+      "prov:atLocation": {"@id": "niiri:f52621a6b75d7dc6ddfd640fdb2c84ce"},
       "prov:value": {"@type": "xsd:float", "@value": "3.83530473709106"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.68709597748077"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000113413911399851"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.998757977658224"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.325806099959436"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.68709597748077"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000113413911399851"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.998757977658224"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.325806099959436"}
     },
     {
-      "@id": "niiri:ea5d97630b3729c0b0eef856a08e8d66",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f52621a6b75d7dc6ddfd640fdb2c84ce",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0058",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-4,2,74]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-4,2,74]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1a803bc72ca0bf7a669590a344f1c36b",
-      "entity": "niiri:cb2ae57bb539840222fcf93ce3091770"
+      "entity_derived": "niiri:c5a8590100956ce4c92258b440677e10",
+      "entity": "niiri:6029d0e967f2fb403f4a243e7a90b84c"
     },
     {
-      "@id": "niiri:45b51b8ba66e38bfa92fa7f36ae4789c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:53ee509e46907c679adc7597b14519f2",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0059",
-      "prov:atLocation": {"@id": "niiri:99a9a6915383bb2d92d8004f890abae9"},
+      "prov:atLocation": {"@id": "niiri:b3c0287254101b42442c7845c4784807"},
       "prov:value": {"@type": "xsd:float", "@value": "3.75742197036743"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.61726989254514"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000148863406353339"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999745113204238"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.372479477261378"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.61726989254514"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000148863406353339"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999745113204238"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.372479477261378"}
     },
     {
-      "@id": "niiri:99a9a6915383bb2d92d8004f890abae9",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b3c0287254101b42442c7845c4784807",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0059",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-8,-6,72]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-8,-6,72]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:45b51b8ba66e38bfa92fa7f36ae4789c",
-      "entity": "niiri:cb2ae57bb539840222fcf93ce3091770"
+      "entity_derived": "niiri:53ee509e46907c679adc7597b14519f2",
+      "entity": "niiri:6029d0e967f2fb403f4a243e7a90b84c"
     },
     {
-      "@id": "niiri:8d70d7e28fee86c144031d05a4a8ef0b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3940947c5af9294e8c0934b07efef693",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0060",
-      "prov:atLocation": {"@id": "niiri:09d1a11f15917cd0c0f26159679fa263"},
+      "prov:atLocation": {"@id": "niiri:b8afa2b7beda616a1b6fc2f491bb8265"},
       "prov:value": {"@type": "xsd:float", "@value": "3.81854224205017"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.67209132667056"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000120286836925998"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999094324231714"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.337078357858238"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.67209132667056"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000120286836925998"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999094324231714"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.337078357858238"}
     },
     {
-      "@id": "niiri:09d1a11f15917cd0c0f26159679fa263",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b8afa2b7beda616a1b6fc2f491bb8265",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0060",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-48,-72,2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-48,-72,2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8d70d7e28fee86c144031d05a4a8ef0b",
-      "entity": "niiri:698b3f9b2d3d5f1f578a7724a8ca8d0d"
+      "entity_derived": "niiri:3940947c5af9294e8c0934b07efef693",
+      "entity": "niiri:780f11b236810e190dea70c6c4340625"
     },
     {
-      "@id": "niiri:209b0b1a99bc16beb4ac795c77390c77",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c871240e924a76bb776906ea43d79c79",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0061",
-      "prov:atLocation": {"@id": "niiri:a80b16974b50ea86e5db7ca7abfb0e94"},
+      "prov:atLocation": {"@id": "niiri:59794eb1599c01a856a85fc602576319"},
       "prov:value": {"@type": "xsd:float", "@value": "3.79630875587463"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.65216921136221"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000130017220931533"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999416425810988"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.355160181055232"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.65216921136221"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000130017220931533"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999416425810988"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.355160181055232"}
     },
     {
-      "@id": "niiri:a80b16974b50ea86e5db7ca7abfb0e94",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:59794eb1599c01a856a85fc602576319",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0061",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[14,-14,72]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[14,-14,72]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:209b0b1a99bc16beb4ac795c77390c77",
-      "entity": "niiri:d26a80bf1b2d7e97037bd7961b7f2fb9"
+      "entity_derived": "niiri:c871240e924a76bb776906ea43d79c79",
+      "entity": "niiri:4a266b577331cf838f3af1933133ec8d"
     },
     {
-      "@id": "niiri:942455b8641e6c997e34f7a82f249e20",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b36f793d8fc4b275da4f7090d0cf49c8",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0062",
-      "prov:atLocation": {"@id": "niiri:4dcbb2a59634794440ee403d018d7e21"},
+      "prov:atLocation": {"@id": "niiri:2dddcae00ff05c47e0eeb240bdd94210"},
       "prov:value": {"@type": "xsd:float", "@value": "3.76071834564209"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.62023097093744"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000147170075777137"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999725733828698"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.372479477261378"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.62023097093744"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000147170075777137"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999725733828698"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.372479477261378"}
     },
     {
-      "@id": "niiri:4dcbb2a59634794440ee403d018d7e21",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:2dddcae00ff05c47e0eeb240bdd94210",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0062",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-46,-56,14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-46,-56,14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:942455b8641e6c997e34f7a82f249e20",
-      "entity": "niiri:84d0f76c2451c6b80e5e965a03dc7d79"
+      "entity_derived": "niiri:b36f793d8fc4b275da4f7090d0cf49c8",
+      "entity": "niiri:b92193302c69c95fc0b8add50483e3ec"
     },
     {
-      "@id": "niiri:0852bc1e66ff82544a73cd299eb53620",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d392931d201e3f958063e45700f72974",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0063",
-      "prov:atLocation": {"@id": "niiri:3e8c1a8951b552f718e6424740cabfcb"},
+      "prov:atLocation": {"@id": "niiri:ef8da9c315d7acad1a19ab9b35413509"},
       "prov:value": {"@type": "xsd:float", "@value": "3.75727128982544"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.61713452675793"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000148941251495116"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999745969099268"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.372479477261378"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.61713452675793"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000148941251495116"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999745969099268"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.372479477261378"}
     },
     {
-      "@id": "niiri:3e8c1a8951b552f718e6424740cabfcb",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ef8da9c315d7acad1a19ab9b35413509",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0063",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-66,-46,8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-66,-46,8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0852bc1e66ff82544a73cd299eb53620",
-      "entity": "niiri:32e36d0494334a99543f9acc36898f2f"
+      "entity_derived": "niiri:d392931d201e3f958063e45700f72974",
+      "entity": "niiri:12aade66bcaf5ad22c9a147b7bac54d4"
     },
     {
-      "@id": "niiri:fe10fdb9491e3622d95faa41c586fde0",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:6f61feacc9e404004ef84c08b36c575a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0064",
-      "prov:atLocation": {"@id": "niiri:6769856fcf5cdbfdbf520b87da66032a"},
+      "prov:atLocation": {"@id": "niiri:63bc96c0a95823c38213430c25f2f3c9"},
       "prov:value": {"@type": "xsd:float", "@value": "3.75130581855774"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.61177452742087"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000152054461266093"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999777860131121"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.372479477261378"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.61177452742087"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000152054461266093"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999777860131121"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.372479477261378"}
     },
     {
-      "@id": "niiri:6769856fcf5cdbfdbf520b87da66032a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:63bc96c0a95823c38213430c25f2f3c9",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0064",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[34,-54,-16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[34,-54,-16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:fe10fdb9491e3622d95faa41c586fde0",
-      "entity": "niiri:511c490c7d9b5ae7344403faeec2f878"
+      "entity_derived": "niiri:6f61feacc9e404004ef84c08b36c575a",
+      "entity": "niiri:759e3fd5ac10013d9c1b96696769e455"
     },
     {
-      "@id": "niiri:dff25b0472c7b7f4d4f517985acf2d48",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:9c8f8e0534218aad4af35d8185a68335",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0065",
-      "prov:atLocation": {"@id": "niiri:a7bddef51d3360d13c60a90961e6c394"},
+      "prov:atLocation": {"@id": "niiri:01b7ff06f7596a087ca89d5ce06e2de7"},
       "prov:value": {"@type": "xsd:float", "@value": "3.74772572517395"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.60855701112288"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000153952428091686"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999795233014277"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.372479477261378"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.60855701112288"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000153952428091686"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999795233014277"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.372479477261378"}
     },
     {
-      "@id": "niiri:a7bddef51d3360d13c60a90961e6c394",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:01b7ff06f7596a087ca89d5ce06e2de7",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0065",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[44,-48,-26]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[44,-48,-26]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:dff25b0472c7b7f4d4f517985acf2d48",
-      "entity": "niiri:9950c7205c20af075ae5465eeb0630ec"
+      "entity_derived": "niiri:9c8f8e0534218aad4af35d8185a68335",
+      "entity": "niiri:b60ad51d906accfc87533b435bc4ab5f"
     },
     {
-      "@id": "niiri:72a44105c9c54ca6195586fda566f844",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:7a1f1c13b6b7291045121f7d49c77262",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0066",
-      "prov:atLocation": {"@id": "niiri:362f4ffca1f9228d79a5f87ac7df774d"},
+      "prov:atLocation": {"@id": "niiri:0aceebd02576058fb0b5ffcc450903bf"},
       "prov:value": {"@type": "xsd:float", "@value": "3.45268702507019"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.34140172297627"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000416782602005394"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999986590246"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.640240241586832"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.34140172297627"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000416782602005394"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999986590246"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.640240241586832"}
     },
     {
-      "@id": "niiri:362f4ffca1f9228d79a5f87ac7df774d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0aceebd02576058fb0b5ffcc450903bf",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0066",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[48,-56,-26]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[48,-56,-26]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:72a44105c9c54ca6195586fda566f844",
-      "entity": "niiri:9950c7205c20af075ae5465eeb0630ec"
+      "entity_derived": "niiri:7a1f1c13b6b7291045121f7d49c77262",
+      "entity": "niiri:b60ad51d906accfc87533b435bc4ab5f"
     },
     {
-      "@id": "niiri:8e9d3b9bd8f56c67304b1f4958a78f1c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:6f63dba9a2285ab4c503bd441f4a8416",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0067",
-      "prov:atLocation": {"@id": "niiri:6c9ef58153ef36f6abafddffac0ecd6b"},
+      "prov:atLocation": {"@id": "niiri:d318bbff911ff001f6ad9103b7320f90"},
       "prov:value": {"@type": "xsd:float", "@value": "3.74554085731506"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.60659312728381"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000155121773134592"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999805227886258"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.372479477261378"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.60659312728381"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000155121773134592"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999805227886258"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.372479477261378"}
     },
     {
-      "@id": "niiri:6c9ef58153ef36f6abafddffac0ecd6b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d318bbff911ff001f6ad9103b7320f90",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0067",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[18,2,14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[18,2,14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8e9d3b9bd8f56c67304b1f4958a78f1c",
-      "entity": "niiri:59e8f07020483e79cce0a7ee24a67d9d"
+      "entity_derived": "niiri:6f63dba9a2285ab4c503bd441f4a8416",
+      "entity": "niiri:5fe7263d129c8b5a1cdc4862389a329f"
     },
     {
-      "@id": "niiri:010e9208f818ba736d4f079715aefebf",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f5db12c15fd9930bce8083f4d4a971f8",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0068",
-      "prov:atLocation": {"@id": "niiri:eaee052ba126ae71bf3f156bc43c446a"},
+      "prov:atLocation": {"@id": "niiri:d1505d5bea737990bb7f479cf49edd65"},
       "prov:value": {"@type": "xsd:float", "@value": "3.74068021774292"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.60222331817537"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000157753568586605"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999825912392884"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.374448807900588"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.60222331817537"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000157753568586605"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999825912392884"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.374448807900588"}
     },
     {
-      "@id": "niiri:eaee052ba126ae71bf3f156bc43c446a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d1505d5bea737990bb7f479cf49edd65",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0068",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[14,54,-12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[14,54,-12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:010e9208f818ba736d4f079715aefebf",
-      "entity": "niiri:8d67481af449856aae39018568cd0118"
+      "entity_derived": "niiri:f5db12c15fd9930bce8083f4d4a971f8",
+      "entity": "niiri:202e674801183017b435dafa4352a2f7"
     },
     {
-      "@id": "niiri:e2d4f8ce47496da9fd30d625dfcf06aa",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:dc9d1a84c56c4f2e77f730ad228f6501",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0069",
-      "prov:atLocation": {"@id": "niiri:99d7970fb363a6940c739d7b1c430c94"},
+      "prov:atLocation": {"@id": "niiri:49cc2c6c43ce421c2826afdfaf669653"},
       "prov:value": {"@type": "xsd:float", "@value": "3.66871547698975"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.53739878996347"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000202044512556343"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999971868208055"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.439662448224178"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.53739878996347"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000202044512556343"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999971868208055"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.439662448224178"}
     },
     {
-      "@id": "niiri:99d7970fb363a6940c739d7b1c430c94",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:49cc2c6c43ce421c2826afdfaf669653",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0069",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-52,-46,-32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-52,-46,-32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e2d4f8ce47496da9fd30d625dfcf06aa",
-      "entity": "niiri:f927b5bbd3f555c57b4e6e01ec9b523e"
+      "entity_derived": "niiri:dc9d1a84c56c4f2e77f730ad228f6501",
+      "entity": "niiri:63374171b8dfeb6c1b6216d9cb78dad1"
     },
     {
-      "@id": "niiri:fa5dd8fb10a6ac6c9561207f1102d939",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:04e4cd21e77744d001e185feea09a1c4",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0070",
-      "prov:atLocation": {"@id": "niiri:818d01aa20e5fe4b662b6c27cace488e"},
+      "prov:atLocation": {"@id": "niiri:524d3966cd270740666e57867b56cf6c"},
       "prov:value": {"@type": "xsd:float", "@value": "3.64429998397827"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.51535208387321"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000219585664636091"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999985907470966"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.455711975517369"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.51535208387321"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000219585664636091"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999985907470966"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.455711975517369"}
     },
     {
-      "@id": "niiri:818d01aa20e5fe4b662b6c27cace488e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:524d3966cd270740666e57867b56cf6c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0070",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[6,0,-10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[6,0,-10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:fa5dd8fb10a6ac6c9561207f1102d939",
-      "entity": "niiri:8ab71917d880813a7ac3044279de7b31"
+      "entity_derived": "niiri:04e4cd21e77744d001e185feea09a1c4",
+      "entity": "niiri:4c28624df30b813b1284ed3adfd58c93"
     },
     {
-      "@id": "niiri:22d8bcd737ac9403b965a7b8937e9065",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f51fbb3e910f71c1d52c4e2485a133b5",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0071",
-      "prov:atLocation": {"@id": "niiri:fd343ed47155feeec882aa2cec69369f"},
+      "prov:atLocation": {"@id": "niiri:a275ee630113b8202f84ea9b3759d881"},
       "prov:value": {"@type": "xsd:float", "@value": "3.62323594093323"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.49630996939917"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000235870182098918"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999992481636867"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.477092512968269"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.49630996939917"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000235870182098918"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999992481636867"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.477092512968269"}
     },
     {
-      "@id": "niiri:fd343ed47155feeec882aa2cec69369f",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a275ee630113b8202f84ea9b3759d881",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0071",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-46,-46,12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-46,-46,12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:22d8bcd737ac9403b965a7b8937e9065",
-      "entity": "niiri:7bdadf7ae2bdb4f39bf9f8fbe5fe1ea5"
+      "entity_derived": "niiri:f51fbb3e910f71c1d52c4e2485a133b5",
+      "entity": "niiri:94a0a21f872815c64a69e94bd40bed9f"
     },
     {
-      "@id": "niiri:541d3f352ad4910af6d028db4900ba3d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:bfde065730fee41f9a030aa1df66e0e9",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0072",
-      "prov:atLocation": {"@id": "niiri:8505c01da3577ab7daf9234fefca724a"},
+      "prov:atLocation": {"@id": "niiri:a59e7ee297d62a1742213ffbb620d2b8"},
       "prov:value": {"@type": "xsd:float", "@value": "3.61861133575439"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.49212659507393"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000239595538008452"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999993477073261"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.479362074336081"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.49212659507393"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000239595538008452"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999993477073261"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.479362074336081"}
     },
     {
-      "@id": "niiri:8505c01da3577ab7daf9234fefca724a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a59e7ee297d62a1742213ffbb620d2b8",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0072",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[24,36,22]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[24,36,22]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:541d3f352ad4910af6d028db4900ba3d",
-      "entity": "niiri:aa7cba01da25024bc05a9e45cd79a837"
+      "entity_derived": "niiri:bfde065730fee41f9a030aa1df66e0e9",
+      "entity": "niiri:e7e4075c58abc76d658530459437df00"
     },
     {
-      "@id": "niiri:64f35ff15eebe6181abff219e19b04c3",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:567767d337ded7d52529fde5cb620c93",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0073",
-      "prov:atLocation": {"@id": "niiri:129aef1faff68739c4894fd6e9a2a2dd"},
+      "prov:atLocation": {"@id": "niiri:3281d190fd64bd07e9609903623a5bbd"},
       "prov:value": {"@type": "xsd:float", "@value": "3.60088157653809"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.47607949453728"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000254400722538684"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999996268378967"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.49118230182513"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.47607949453728"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000254400722538684"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999996268378967"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.49118230182513"}
     },
     {
-      "@id": "niiri:129aef1faff68739c4894fd6e9a2a2dd",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:3281d190fd64bd07e9609903623a5bbd",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0073",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[52,-38,22]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[52,-38,22]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:64f35ff15eebe6181abff219e19b04c3",
-      "entity": "niiri:2630e4b92c9db9a6beb0787bffe7a7fb"
+      "entity_derived": "niiri:567767d337ded7d52529fde5cb620c93",
+      "entity": "niiri:2dfef140265f92d79cbf32d31936df4d"
     },
     {
-      "@id": "niiri:728968929121fb47a345cd7d9cd0f48a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:6f329dd94a2d4db60b222ae0224476da",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0074",
-      "prov:atLocation": {"@id": "niiri:4351f9f2f28b9b626ac0806ea2d5fe02"},
+      "prov:atLocation": {"@id": "niiri:6adaabf783e45104c83b07aae27cca00"},
       "prov:value": {"@type": "xsd:float", "@value": "3.5545506477356"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.43407908140554"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000297285352316101"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999222525781"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.537678422954754"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.43407908140554"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000297285352316101"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999222525781"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.537678422954754"}
     },
     {
-      "@id": "niiri:4351f9f2f28b9b626ac0806ea2d5fe02",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6adaabf783e45104c83b07aae27cca00",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0074",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-64,-34,8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-64,-34,8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:728968929121fb47a345cd7d9cd0f48a",
-      "entity": "niiri:cbd611e1237a5ec814b81bcfe9552f0e"
+      "entity_derived": "niiri:6f329dd94a2d4db60b222ae0224476da",
+      "entity": "niiri:8fcfff082769fb86478d8224ec22e1d5"
     },
     {
-      "@id": "niiri:7f1b574eb7c2e47b683c9d8cfc46fed3",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:84e6ea0a18d979291bb19d28f1c5dabe",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0075",
-      "prov:atLocation": {"@id": "niiri:c9bc69aeed7369e2823d08d02f250712"},
+      "prov:atLocation": {"@id": "niiri:e69a32992abb3633e42cbbc91342979b"},
       "prov:value": {"@type": "xsd:float", "@value": "3.53580284118652"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.41705640127634"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000316510818269"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999606830839"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.556120559116339"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.41705640127634"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000316510818269"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999606830839"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.556120559116339"}
     },
     {
-      "@id": "niiri:c9bc69aeed7369e2823d08d02f250712",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e69a32992abb3633e42cbbc91342979b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0075",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-54,-32,42]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-54,-32,42]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7f1b574eb7c2e47b683c9d8cfc46fed3",
-      "entity": "niiri:481718c39416a3d61a910542ffd5f170"
+      "entity_derived": "niiri:84e6ea0a18d979291bb19d28f1c5dabe",
+      "entity": "niiri:a4a959bdb5adaac5ccc8bb0a1283b1eb"
     },
     {
-      "@id": "niiri:5659d46311e2c9bf456cd43b88de72f8",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:dbc772d5c9ef096bc13a4ee83b16aac6",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0076",
-      "prov:atLocation": {"@id": "niiri:09bba4f7e1d012246c80ca52b523c190"},
+      "prov:atLocation": {"@id": "niiri:240a1e650cd9f68a3dd24dc257fb8ef1"},
       "prov:value": {"@type": "xsd:float", "@value": "3.51030111312866"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.39387625832302"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000344554112102768"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.9999998514483"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.584915397396553"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.39387625832302"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000344554112102768"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.9999998514483"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.584915397396553"}
     },
     {
-      "@id": "niiri:09bba4f7e1d012246c80ca52b523c190",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:240a1e650cd9f68a3dd24dc257fb8ef1",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0076",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[20,-66,34]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[20,-66,34]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5659d46311e2c9bf456cd43b88de72f8",
-      "entity": "niiri:7bcbc9953403229f0db979d92436612d"
+      "entity_derived": "niiri:dbc772d5c9ef096bc13a4ee83b16aac6",
+      "entity": "niiri:abd2bbf896a471cb7922efab5b613117"
     },
     {
-      "@id": "niiri:0dcb8a73e6de5485e8257f03451a6130",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:4d40e798820a3a573c0500e58c734eec",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0077",
-      "prov:atLocation": {"@id": "niiri:62c4a23583195c288a79370eb2a52e6e"},
+      "prov:atLocation": {"@id": "niiri:aeaa37b13c920048113b7dc3f503c7bc"},
       "prov:value": {"@type": "xsd:float", "@value": "3.50287866592407"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.38712412459265"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000353147125455866"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999889234026"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.591889002439003"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.38712412459265"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000353147125455866"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999889234026"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.591889002439003"}
     },
     {
-      "@id": "niiri:62c4a23583195c288a79370eb2a52e6e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:aeaa37b13c920048113b7dc3f503c7bc",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0077",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[12,-100,20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[12,-100,20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0dcb8a73e6de5485e8257f03451a6130",
-      "entity": "niiri:7c32a1d0e82c311426243c91cc091275"
+      "entity_derived": "niiri:4d40e798820a3a573c0500e58c734eec",
+      "entity": "niiri:9c1cddc9922d8e70b3ba77c8f428e530"
     },
     {
-      "@id": "niiri:8cce7e704870581863815ccef2761c15",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c5304f99a9da73415539075421788844",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0078",
-      "prov:atLocation": {"@id": "niiri:81ab8a072da2ae005ddbc4a211b83a2a"},
+      "prov:atLocation": {"@id": "niiri:b2bc9a9ccfd711a23c57794194597f43"},
       "prov:value": {"@type": "xsd:float", "@value": "3.48949480056763"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.3749428096037"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000369155160797496"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999935529104"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.605073490410914"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.3749428096037"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000369155160797496"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999935529104"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.605073490410914"}
     },
     {
-      "@id": "niiri:81ab8a072da2ae005ddbc4a211b83a2a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b2bc9a9ccfd711a23c57794194597f43",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0078",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[16,-44,20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[16,-44,20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8cce7e704870581863815ccef2761c15",
-      "entity": "niiri:82069b48f32f7007fb477a55996a5a26"
+      "entity_derived": "niiri:c5304f99a9da73415539075421788844",
+      "entity": "niiri:b2551e755f51f54d3855f624855bec3b"
     },
     {
-      "@id": "niiri:e300699edf58b4d1bb3b6b4de2367ca4",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:4d837320d4d5094cb8cb549343505b8b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0079",
-      "prov:atLocation": {"@id": "niiri:ce6c0db57472c62f97e856a813e3f7fa"},
+      "prov:atLocation": {"@id": "niiri:3b2940e29d426870ed404cc739700589"},
       "prov:value": {"@type": "xsd:float", "@value": "3.48589444160461"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.37166460127642"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00037357688397921"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999944412109"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.605342127295634"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.37166460127642"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00037357688397921"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999944412109"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.605342127295634"}
     },
     {
-      "@id": "niiri:ce6c0db57472c62f97e856a813e3f7fa",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:3b2940e29d426870ed404cc739700589",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0079",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-56,-34,22]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-56,-34,22]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e300699edf58b4d1bb3b6b4de2367ca4",
-      "entity": "niiri:7480c4974cded55a669a9f676f7183d3"
+      "entity_derived": "niiri:4d837320d4d5094cb8cb549343505b8b",
+      "entity": "niiri:d98c34494ee425b9f343ad72efbe3802"
     },
     {
-      "@id": "niiri:070c9ad134040135864a0addf74ffb50",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5652354d900526a3f326a8cf3b1d6f1f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0080",
-      "prov:atLocation": {"@id": "niiri:6b6897b839efc10c3bff4a181d9778b7"},
+      "prov:atLocation": {"@id": "niiri:1efd56928f31b5312bfa21484652a1f3"},
       "prov:value": {"@type": "xsd:float", "@value": "3.4652099609375"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.35281990022648"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000399963700227435"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999976804491"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.628846262541795"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.35281990022648"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000399963700227435"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999976804491"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.628846262541795"}
     },
     {
-      "@id": "niiri:6b6897b839efc10c3bff4a181d9778b7",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:1efd56928f31b5312bfa21484652a1f3",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0080",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[40,4,30]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[40,4,30]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:070c9ad134040135864a0addf74ffb50",
-      "entity": "niiri:7dbb86d35f9a3f5e15ce1fcaf1b4ac57"
+      "entity_derived": "niiri:5652354d900526a3f326a8cf3b1d6f1f",
+      "entity": "niiri:207cbb7814292b71aa3cbca2e251214d"
     },
     {
-      "@id": "niiri:13d680b7d3981f675b37a21fc4787aed",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d2d495d008345b6772c40b2b272a1585",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0081",
-      "prov:atLocation": {"@id": "niiri:1370d3c9ba9670b3d0c941f2285d3f97"},
+      "prov:atLocation": {"@id": "niiri:2df4f858b4497bba7e71e36de77d8194"},
       "prov:value": {"@type": "xsd:float", "@value": "3.44595217704773"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.33525818772228"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000426101175928562"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999990072758"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.643081801836616"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.33525818772228"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000426101175928562"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999990072758"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.643081801836616"}
     },
     {
-      "@id": "niiri:1370d3c9ba9670b3d0c941f2285d3f97",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:2df4f858b4497bba7e71e36de77d8194",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0081",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-22,-94,28]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-22,-94,28]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:13d680b7d3981f675b37a21fc4787aed",
-      "entity": "niiri:1871a215e9872f3a52537c8c1a760f0a"
+      "entity_derived": "niiri:d2d495d008345b6772c40b2b272a1585",
+      "entity": "niiri:ef0e652ba790ef2ca62cbc45744044f2"
     },
     {
-      "@id": "niiri:4571137ac30bbff2d6db403186670e72",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:65afbe0971735e73b0b4d019a5fe1dd4",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0082",
-      "prov:atLocation": {"@id": "niiri:05cc0a6b452f196de2c80d32256254c3"},
+      "prov:atLocation": {"@id": "niiri:a4a5e8556da90bc8294088347f71204f"},
       "prov:value": {"@type": "xsd:float", "@value": "3.44062829017639"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.33040033563749"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00043360601200626"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999992196494"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.643081801836616"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.33040033563749"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00043360601200626"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999992196494"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.643081801836616"}
     },
     {
-      "@id": "niiri:05cc0a6b452f196de2c80d32256254c3",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a4a5e8556da90bc8294088347f71204f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0082",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-28,-66,-4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-28,-66,-4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4571137ac30bbff2d6db403186670e72",
-      "entity": "niiri:3ad5cc979a530fd4daa32be10f10bc51"
+      "entity_derived": "niiri:65afbe0971735e73b0b4d019a5fe1dd4",
+      "entity": "niiri:cdc735403e60da4bc8deca0b30c09e41"
     },
     {
-      "@id": "niiri:a72563a4578d11c37af74d67bb8b0960",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:4840119095d944bfaa2277523850de52",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0083",
-      "prov:atLocation": {"@id": "niiri:7f436859691dfa579add6f2b4286b94c"},
+      "prov:atLocation": {"@id": "niiri:171f6f283c1425e20e15c65986b75693"},
       "prov:value": {"@type": "xsd:float", "@value": "3.4126980304718"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.30489484520115"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000475060200800126"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999997888602"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.683890257408892"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.30489484520115"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000475060200800126"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999997888602"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.683890257408892"}
     },
     {
-      "@id": "niiri:7f436859691dfa579add6f2b4286b94c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:171f6f283c1425e20e15c65986b75693",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0083",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[22,-80,54]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[22,-80,54]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a72563a4578d11c37af74d67bb8b0960",
-      "entity": "niiri:b808d08cb809cd1546fc7c1d23c712ad"
+      "entity_derived": "niiri:4840119095d944bfaa2277523850de52",
+      "entity": "niiri:14788c080d39de548f4f1517f2f3ecf2"
     },
     {
-      "@id": "niiri:2a29da45de0d63a244cd859e275bdca1",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d9ddb8469cbfc56cddec34eacb01fe37",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0084",
-      "prov:atLocation": {"@id": "niiri:9e93e4a979461fb19e7696d5279f3459"},
+      "prov:atLocation": {"@id": "niiri:d70b502404bd88a854514ea5758a0230"},
       "prov:value": {"@type": "xsd:float", "@value": "3.38877391815186"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.28302091406008"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000513505230477329"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999351719"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.712882686639218"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.28302091406008"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000513505230477329"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999351719"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.712882686639218"}
     },
     {
-      "@id": "niiri:9e93e4a979461fb19e7696d5279f3459",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d70b502404bd88a854514ea5758a0230",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0084",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-50,-52,20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-50,-52,20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2a29da45de0d63a244cd859e275bdca1",
-      "entity": "niiri:2502ea528f067f61a192d4d910eaaac2"
+      "entity_derived": "niiri:d9ddb8469cbfc56cddec34eacb01fe37",
+      "entity": "niiri:094abc2dabe5f1598098374da155b2d3"
     },
     {
-      "@id": "niiri:8babbf8e12493e91e0385d603330b610",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:31a3813511b578c73de9e894b0d4b862",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0085",
-      "prov:atLocation": {"@id": "niiri:f6845913c82a1225e1daea5eebd8a1c1"},
+      "prov:atLocation": {"@id": "niiri:b8adcd6e39a269092455531610a969af"},
       "prov:value": {"@type": "xsd:float", "@value": "3.38779973983765"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.28212969646231"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000515131030616733"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999382908"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.712882686639218"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.28212969646231"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000515131030616733"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999382908"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.712882686639218"}
     },
     {
-      "@id": "niiri:f6845913c82a1225e1daea5eebd8a1c1",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b8adcd6e39a269092455531610a969af",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0085",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[64,-32,16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[64,-32,16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8babbf8e12493e91e0385d603330b610",
-      "entity": "niiri:d44962b9e9395d5d42a56ab76170cf9a"
+      "entity_derived": "niiri:31a3813511b578c73de9e894b0d4b862",
+      "entity": "niiri:b0a53fec1935bbbef5f0340426dfcf5c"
     },
     {
-      "@id": "niiri:c200ec026fbb20c6694036c1175fc2e8",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b08c87ff71cf5246769f7715958afa40",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0086",
-      "prov:atLocation": {"@id": "niiri:f10a46d09110e46aafc8192b4e3b5c8e"},
+      "prov:atLocation": {"@id": "niiri:cf7ff8939962af0db57611ac57ca8321"},
       "prov:value": {"@type": "xsd:float", "@value": "3.37709879875183"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.27233736484586"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000533311091644562"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999643268"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.721327613515561"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.27233736484586"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000533311091644562"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999643268"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.721327613515561"}
     },
     {
-      "@id": "niiri:f10a46d09110e46aafc8192b4e3b5c8e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:cf7ff8939962af0db57611ac57ca8321",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0086",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-66,-36,22]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-66,-36,22]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c200ec026fbb20c6694036c1175fc2e8",
-      "entity": "niiri:f59a3e7afba6bebbf0a007c0f8c78d53"
+      "entity_derived": "niiri:b08c87ff71cf5246769f7715958afa40",
+      "entity": "niiri:782cde190eab924f134e44bd95c8cd15"
     },
     {
-      "@id": "niiri:d00eda502b77d6c6936fcd79ef00684f",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a9d645704df208d9dc3fc6253c78c696",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0087",
-      "prov:atLocation": {"@id": "niiri:d546b23144d1ab6370ebb14a8e7d5454"},
+      "prov:atLocation": {"@id": "niiri:d01630982d6562431197c9125302e72d"},
       "prov:value": {"@type": "xsd:float", "@value": "3.37313723564148"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.26871093121603"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000540193080250551"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999709649"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.721327613515561"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.26871093121603"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000540193080250551"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999709649"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.721327613515561"}
     },
     {
-      "@id": "niiri:d546b23144d1ab6370ebb14a8e7d5454",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d01630982d6562431197c9125302e72d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0087",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-30,-62,-40]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-30,-62,-40]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d00eda502b77d6c6936fcd79ef00684f",
-      "entity": "niiri:b1fa22ed23a8d70bc9e4dd151a589e2f"
+      "entity_derived": "niiri:a9d645704df208d9dc3fc6253c78c696",
+      "entity": "niiri:9e85dca921757d3d2cafd0d606eb03c4"
     },
     {
-      "@id": "niiri:2063c79290c50e61487b5221d7c31d04",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:4db22c975766e9eb9e2f4b5beea1658f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0088",
-      "prov:atLocation": {"@id": "niiri:f426a2fb12545e24f4b7931c41ca77e7"},
+      "prov:atLocation": {"@id": "niiri:03d2749e759ef96f471425c46ee3f719"},
       "prov:value": {"@type": "xsd:float", "@value": "3.37137746810913"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.2670998163368"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000543276814982008"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999735165"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.721327613515561"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.2670998163368"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000543276814982008"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999735165"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.721327613515561"}
     },
     {
-      "@id": "niiri:f426a2fb12545e24f4b7931c41ca77e7",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:03d2749e759ef96f471425c46ee3f719",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0088",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-62,-14,10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-62,-14,10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2063c79290c50e61487b5221d7c31d04",
-      "entity": "niiri:0cd710e9d7cad8f485a36862bb45dad3"
+      "entity_derived": "niiri:4db22c975766e9eb9e2f4b5beea1658f",
+      "entity": "niiri:50e0654a2d55b1eb33c94eef3f0fbfc4"
     },
     {
-      "@id": "niiri:d09284c06fe1179817219f8b367cf653",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e29f7b67960f76bb916479e29df3f8b3",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0089",
-      "prov:atLocation": {"@id": "niiri:59ddf2283254cca38e2dc189fed56754"},
+      "prov:atLocation": {"@id": "niiri:09a8f62d551cdcdc77118ba40ad5fa78"},
       "prov:value": {"@type": "xsd:float", "@value": "3.37039303779602"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.26619848595029"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000545009089568671"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999748484"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.721327613515561"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.26619848595029"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000545009089568671"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999748484"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.721327613515561"}
     },
     {
-      "@id": "niiri:59ddf2283254cca38e2dc189fed56754",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:09a8f62d551cdcdc77118ba40ad5fa78",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0089",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[22,34,56]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[22,34,56]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d09284c06fe1179817219f8b367cf653",
-      "entity": "niiri:cc7d3451a39fd4cca99275e6219b8f5d"
+      "entity_derived": "niiri:e29f7b67960f76bb916479e29df3f8b3",
+      "entity": "niiri:580546e61fe6caf5b928869b72d6563c"
     },
     {
-      "@id": "niiri:0727fda215a3ce885ff443d10e1e526f",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:8ac825efe546b49dde172700cc71e2b2",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0090",
-      "prov:atLocation": {"@id": "niiri:4db32998eccf9df85ddc26e29594d8db"},
+      "prov:atLocation": {"@id": "niiri:1785d708e60ad6549b65dffa2e528466"},
       "prov:value": {"@type": "xsd:float", "@value": "3.30523133277893"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.20644574827441"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000671928211518624"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999993453"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.835508519228008"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.20644574827441"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000671928211518624"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999993453"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.835508519228008"}
     },
     {
-      "@id": "niiri:4db32998eccf9df85ddc26e29594d8db",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:1785d708e60ad6549b65dffa2e528466",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0090",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-68,-34,-8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-68,-34,-8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0727fda215a3ce885ff443d10e1e526f",
-      "entity": "niiri:e8b4547e2bb998c3a0e5c80f5add7395"
+      "entity_derived": "niiri:8ac825efe546b49dde172700cc71e2b2",
+      "entity": "niiri:fbb3da138dba0bffe41c80dfdc6d2813"
     },
     {
-      "@id": "niiri:6268970793f0490b6632512bab3da67e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:22cb343d7aa6bdb3bb3a888ac82c87c0",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0091",
-      "prov:atLocation": {"@id": "niiri:260f856ee4f0ff313ce4100fd943eaf7"},
+      "prov:atLocation": {"@id": "niiri:c6f2d80da4938d0bb9415062e7a5e502"},
       "prov:value": {"@type": "xsd:float", "@value": "3.2985315322876"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.20029191950919"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000686442301030654"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999995621"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.842515375542095"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.20029191950919"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000686442301030654"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999995621"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.842515375542095"}
     },
     {
-      "@id": "niiri:260f856ee4f0ff313ce4100fd943eaf7",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c6f2d80da4938d0bb9415062e7a5e502",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0091",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[44,4,46]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[44,4,46]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6268970793f0490b6632512bab3da67e",
-      "entity": "niiri:194d5b586416a3affff5759f1f6f1f22"
+      "entity_derived": "niiri:22cb343d7aa6bdb3bb3a888ac82c87c0",
+      "entity": "niiri:5b4ccbe46fbd067233c454fc4cd57139"
     },
     {
-      "@id": "niiri:8dafc007cbf2b67abe04c83653e139d3",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:1e6a6f5fdbab18ff700a1f08fa7c7542",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0092",
-      "prov:atLocation": {"@id": "niiri:2ccad00390c934c82f456da3ce66cd8d"},
+      "prov:atLocation": {"@id": "niiri:f601d44d414260f0726c9603cd39c49a"},
       "prov:value": {"@type": "xsd:float", "@value": "3.29661655426025"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.19853264836728"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000690644458409051"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.9999999999961"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.842515375542095"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.19853264836728"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000690644458409051"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.9999999999961"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.842515375542095"}
     },
     {
-      "@id": "niiri:2ccad00390c934c82f456da3ce66cd8d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f601d44d414260f0726c9603cd39c49a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0092",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[24,0,4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[24,0,4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8dafc007cbf2b67abe04c83653e139d3",
-      "entity": "niiri:172068f882b44c7f3f286732e95fd333"
+      "entity_derived": "niiri:1e6a6f5fdbab18ff700a1f08fa7c7542",
+      "entity": "niiri:4797fa2e5200fab8ae750cb321a6d94a"
     },
     {
-      "@id": "niiri:3acc1d1106d3e32b8c795b28bdb63277",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:65926b9e3005685d9db29cdf417debc7",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0093",
-      "prov:atLocation": {"@id": "niiri:a7353c0c6459c8182bac71063d3cb6f5"},
+      "prov:atLocation": {"@id": "niiri:4288b4766cc9e13b7d7802f0b1459329"},
       "prov:value": {"@type": "xsd:float", "@value": "3.27342534065247"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.1772149335255"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000743483956790469"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999073"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.873198212136066"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.1772149335255"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000743483956790469"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999073"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.873198212136066"}
     },
     {
-      "@id": "niiri:a7353c0c6459c8182bac71063d3cb6f5",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4288b4766cc9e13b7d7802f0b1459329",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0093",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-60,-46,0]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-60,-46,0]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3acc1d1106d3e32b8c795b28bdb63277",
-      "entity": "niiri:ce513aeb315d021861a6c316bf4ef052"
+      "entity_derived": "niiri:65926b9e3005685d9db29cdf417debc7",
+      "entity": "niiri:e5840e49541fa7c2c73adfcf2cd18d5c"
     },
     {
-      "@id": "niiri:a0ff2b4a57976ac7036b83db31208885",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:1832ec3bca9ab489c38af1558fa307ca",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0094",
-      "prov:atLocation": {"@id": "niiri:293866a4cfd9548dda020df3e35e16f9"},
+      "prov:atLocation": {"@id": "niiri:7a4290e8d2bb1ace22685e79b5e79d1c"},
       "prov:value": {"@type": "xsd:float", "@value": "3.27317070960999"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.17698074823278"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000744084571755788"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999088"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.873198212136066"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.17698074823278"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000744084571755788"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999088"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.873198212136066"}
     },
     {
-      "@id": "niiri:293866a4cfd9548dda020df3e35e16f9",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7a4290e8d2bb1ace22685e79b5e79d1c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0094",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-4,40,24]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-4,40,24]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a0ff2b4a57976ac7036b83db31208885",
-      "entity": "niiri:31c5179c3ed19f375fed1f038a132ca0"
+      "entity_derived": "niiri:1832ec3bca9ab489c38af1558fa307ca",
+      "entity": "niiri:af9739fef5ce12c093a36fdad464fa2c"
     },
     {
-      "@id": "niiri:7f51472217732464bb53a8dc92ab30a6",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:261741634aeb371107d4c36f38ee3e94",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0095",
-      "prov:atLocation": {"@id": "niiri:924880d0bf78a807a5960f7f39764c82"},
+      "prov:atLocation": {"@id": "niiri:ac0648e7d1f5b3202d8d893523a25ee3"},
       "prov:value": {"@type": "xsd:float", "@value": "3.27113676071167"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.17511001955929"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000748898502488382"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999199"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.873198212136066"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.17511001955929"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000748898502488382"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999199"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.873198212136066"}
     },
     {
-      "@id": "niiri:924880d0bf78a807a5960f7f39764c82",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ac0648e7d1f5b3202d8d893523a25ee3",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0095",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[38,50,-2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[38,50,-2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7f51472217732464bb53a8dc92ab30a6",
-      "entity": "niiri:fef2c17abe57bc62290ea323944b2b06"
+      "entity_derived": "niiri:261741634aeb371107d4c36f38ee3e94",
+      "entity": "niiri:4c1124c10677cacc7086dad2d88a0bd3"
     },
     {
-      "@id": "niiri:8cb7151dc4e5b5abf4637542977159ac",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:360ea334f08a7af85055b95a9386d330",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0096",
-      "prov:atLocation": {"@id": "niiri:d16bffb3aa4600f0d29685486734c699"},
+      "prov:atLocation": {"@id": "niiri:2fdcc6e6bc5734e23a3c245ece9af37a"},
       "prov:value": {"@type": "xsd:float", "@value": "3.24630308151245"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.15225533865243"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000810072651915683"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999841"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.917606478873846"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.15225533865243"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000810072651915683"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999841"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.917606478873846"}
     },
     {
-      "@id": "niiri:d16bffb3aa4600f0d29685486734c699",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:2fdcc6e6bc5734e23a3c245ece9af37a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0096",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-40,-88,16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-40,-88,16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8cb7151dc4e5b5abf4637542977159ac",
-      "entity": "niiri:101d5a9adb5897de8e974a6c450bccef"
+      "entity_derived": "niiri:360ea334f08a7af85055b95a9386d330",
+      "entity": "niiri:9a07890dc3c872a54f45939b26e95348"
     },
     {
-      "@id": "niiri:5672847823d49fce37d1e0b2ad951aaf",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e659f5281cce04791ec12bbae45e2238",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0097",
-      "prov:atLocation": {"@id": "niiri:bbe7f807319bc80dccfa49a8357c3406"},
+      "prov:atLocation": {"@id": "niiri:21d86a8c53e01ef6f95f57296de7085d"},
       "prov:value": {"@type": "xsd:float", "@value": "3.24350714683533"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.14968061296894"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000817245211796269"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999868"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.917606478873846"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.14968061296894"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000817245211796269"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999868"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.917606478873846"}
     },
     {
-      "@id": "niiri:bbe7f807319bc80dccfa49a8357c3406",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:21d86a8c53e01ef6f95f57296de7085d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0097",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-36,-56,-42]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-36,-56,-42]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5672847823d49fce37d1e0b2ad951aaf",
-      "entity": "niiri:79ae18cf89e6f66ce4c5070153fae100"
+      "entity_derived": "niiri:e659f5281cce04791ec12bbae45e2238",
+      "entity": "niiri:4b972d45063ce95740be79e0f84be300"
     },
     {
-      "@id": "niiri:6657cac48a435b24dec977df072d82d8",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:bc8b728ef84f6cc7d38147430d08a43e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0098",
-      "prov:atLocation": {"@id": "niiri:44589d5bcfec959b42053b5dda636988"},
+      "prov:atLocation": {"@id": "niiri:913d186c05f83e7d0dedd5f599c175a9"},
       "prov:value": {"@type": "xsd:float", "@value": "3.24193215370178"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.14823008816228"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000821311713323003"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999881"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.917606478873846"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.14823008816228"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000821311713323003"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999881"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.917606478873846"}
     },
     {
-      "@id": "niiri:44589d5bcfec959b42053b5dda636988",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:913d186c05f83e7d0dedd5f599c175a9",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0098",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-54,-8,46]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-54,-8,46]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6657cac48a435b24dec977df072d82d8",
-      "entity": "niiri:1c0685623290eeb06ef6f4bdbffafd31"
+      "entity_derived": "niiri:bc8b728ef84f6cc7d38147430d08a43e",
+      "entity": "niiri:6cc8de073a211f649503cbae3d7f79bb"
     },
     {
-      "@id": "niiri:049323d04b482659a1c4c2bb4060101d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:26f4b6d30550bf95fa229750966ea576",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0099",
-      "prov:atLocation": {"@id": "niiri:a2e9a49bfcc3043b02563ef5bc1bb5b7"},
+      "prov:atLocation": {"@id": "niiri:ac2f9c701365ca370e015bb1778342c0"},
       "prov:value": {"@type": "xsd:float", "@value": "3.22731924057007"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.1347671282846"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000859952917517393"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999956"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.937923170353275"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.1347671282846"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000859952917517393"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999956"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.937923170353275"}
     },
     {
-      "@id": "niiri:a2e9a49bfcc3043b02563ef5bc1bb5b7",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ac2f9c701365ca370e015bb1778342c0",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0099",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[40,-52,68]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[40,-52,68]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:049323d04b482659a1c4c2bb4060101d",
-      "entity": "niiri:e333891aa2a7cc8b78b7b091053068d6"
+      "entity_derived": "niiri:26f4b6d30550bf95fa229750966ea576",
+      "entity": "niiri:713bd5e4d1057a61ec41d7be47cc6b30"
     },
     {
-      "@id": "niiri:0381cfb61f7454d8d1ed99376692368c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:2c4a60a71eb752e827d97c147d637ae2",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0100",
-      "prov:atLocation": {"@id": "niiri:4f8ede499166df3259682391f04c88b5"},
+      "prov:atLocation": {"@id": "niiri:7498af8fe3f38b0a683eb4f600daedbd"},
       "prov:value": {"@type": "xsd:float", "@value": "3.22294282913208"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.13073340683923"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000871851865451578"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999968"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.942022979172485"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.13073340683923"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000871851865451578"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999968"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.942022979172485"}
     },
     {
-      "@id": "niiri:4f8ede499166df3259682391f04c88b5",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7498af8fe3f38b0a683eb4f600daedbd",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0100",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[22,44,-16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[22,44,-16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0381cfb61f7454d8d1ed99376692368c",
-      "entity": "niiri:ae3b028a4da5be96010d12d3d7dfdafd"
+      "entity_derived": "niiri:2c4a60a71eb752e827d97c147d637ae2",
+      "entity": "niiri:f594ca28922a55744403546afac8880c"
     },
     {
-      "@id": "niiri:b9b307152bda4d6811d3c3859d0c91ab",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:db27722046af7c3881dc9b3f44135cdd",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0101",
-      "prov:atLocation": {"@id": "niiri:bd22f507a7a824f7592dd40eef4dfb63"},
+      "prov:atLocation": {"@id": "niiri:523fb1da24165c8028f86bdbbc3901e7"},
       "prov:value": {"@type": "xsd:float", "@value": "3.20911026000977"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.11797882010196"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000910479445198287"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999988"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.966327579886985"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.11797882010196"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000910479445198287"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999988"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.966327579886985"}
     },
     {
-      "@id": "niiri:bd22f507a7a824f7592dd40eef4dfb63",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:523fb1da24165c8028f86bdbbc3901e7",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0101",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-40,36,-8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-40,36,-8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b9b307152bda4d6811d3c3859d0c91ab",
-      "entity": "niiri:0f488c10355ed316636cfd8bb54904ac"
+      "entity_derived": "niiri:db27722046af7c3881dc9b3f44135cdd",
+      "entity": "niiri:1f5837a9250f8adad81d9cf7febcb06c"
     },
     {
-      "@id": "niiri:77fcc6941bcf921edd72dead3f3b4e6d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:130b59f20e485841289d47a669c27dec",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0102",
-      "prov:atLocation": {"@id": "niiri:195dc505ac953c8a3f4b2871a69b9911"},
+      "prov:atLocation": {"@id": "niiri:c7ad57439eb1d9d0e24c8929fb4f6def"},
       "prov:value": {"@type": "xsd:float", "@value": "3.20072054862976"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.11023911526042"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000934679736638411"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999993"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.972457839189109"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.11023911526042"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000934679736638411"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999993"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.972457839189109"}
     },
     {
-      "@id": "niiri:195dc505ac953c8a3f4b2871a69b9911",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c7ad57439eb1d9d0e24c8929fb4f6def",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0102",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-14,4,16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-14,4,16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:77fcc6941bcf921edd72dead3f3b4e6d",
-      "entity": "niiri:b7030530775d914be5aedf430467d831"
+      "entity_derived": "niiri:130b59f20e485841289d47a669c27dec",
+      "entity": "niiri:4978ca959ffd9dac40bc74938928d142"
     },
     {
-      "@id": "niiri:53a19a80ca4b419204df77ae0f0a23a9",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:7d589921c2ce3d87a67549309a2ce4d9",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0103",
-      "prov:atLocation": {"@id": "niiri:e2e458115471a4af2cfc7c4615a9e9b1"},
+      "prov:atLocation": {"@id": "niiri:5fac49fc2d94d308482a7216d1c0abcc"},
       "prov:value": {"@type": "xsd:float", "@value": "3.19976687431335"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.10935914676901"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000937468288822019"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999994"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.972457839189109"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.10935914676901"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000937468288822019"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999994"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.972457839189109"}
     },
     {
-      "@id": "niiri:e2e458115471a4af2cfc7c4615a9e9b1",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:5fac49fc2d94d308482a7216d1c0abcc",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0103",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-24,54,36]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-24,54,36]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:53a19a80ca4b419204df77ae0f0a23a9",
-      "entity": "niiri:caff2c2f2a15419f2f382bc662c24e14"
+      "entity_derived": "niiri:7d589921c2ce3d87a67549309a2ce4d9",
+      "entity": "niiri:a8156b1e457954028b70ba39c8f61983"
     },
     {
-      "@id": "niiri:7ee33f6809535b7ae13ff8531c24abbd",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:fc5bb336fd66e8a55c0326f0b1d351e5",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0104",
-      "prov:atLocation": {"@id": "niiri:7629dd1756b23d156f7a279839c298c8"},
+      "prov:atLocation": {"@id": "niiri:cd1b84e4c6560b33762f1d342c8d79d1"},
       "prov:value": {"@type": "xsd:float", "@value": "3.19748950004578"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.10725763219564"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000944158772216208"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999995"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.972457839189109"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.10725763219564"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000944158772216208"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999995"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.972457839189109"}
     },
     {
-      "@id": "niiri:7629dd1756b23d156f7a279839c298c8",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:cd1b84e4c6560b33762f1d342c8d79d1",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0104",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[66,-34,38]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[66,-34,38]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7ee33f6809535b7ae13ff8531c24abbd",
-      "entity": "niiri:e65b059d6c1f15bf2f6b2d744c2f1518"
+      "entity_derived": "niiri:fc5bb336fd66e8a55c0326f0b1d351e5",
+      "entity": "niiri:b00bd2c845defd49f3843980d3290639"
     },
     {
-      "@id": "niiri:6555926789979687a510b0a6e93b6fce",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:602dbb725cf9f38cf7aa442b3a5fac1e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0105",
-      "prov:atLocation": {"@id": "niiri:11cbf762207bc831a4dbb30f836b87c5"},
+      "prov:atLocation": {"@id": "niiri:f21906ff37236d112d6eb7f93ae84520"},
       "prov:value": {"@type": "xsd:float", "@value": "3.19663214683533"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.10646642942607"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000946689027332193"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999995"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.972457839189109"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.10646642942607"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000946689027332193"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999995"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.972457839189109"}
     },
     {
-      "@id": "niiri:11cbf762207bc831a4dbb30f836b87c5",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f21906ff37236d112d6eb7f93ae84520",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0105",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[12,-76,-12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[12,-76,-12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6555926789979687a510b0a6e93b6fce",
-      "entity": "niiri:8ea6fb6f8438207d256aefd11c3b906b"
+      "entity_derived": "niiri:602dbb725cf9f38cf7aa442b3a5fac1e",
+      "entity": "niiri:0d91d576d381385281f1b2d5d2714a3f"
     },
     {
-      "@id": "niiri:30b9a8c74c68ae15db443872e1b6be12",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:fb785c4b2387927cfcaba115b1c2b59a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0106",
-      "prov:atLocation": {"@id": "niiri:3fd01dc771a46ee5143965a0c03a9edd"},
+      "prov:atLocation": {"@id": "niiri:f70ca813baf34973fd3495cc2097d071"},
       "prov:value": {"@type": "xsd:float", "@value": "3.19012331962585"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.10045882632522"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000966105376173698"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999997"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.981368933811381"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.10045882632522"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000966105376173698"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999997"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.981368933811381"}
     },
     {
-      "@id": "niiri:3fd01dc771a46ee5143965a0c03a9edd",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f70ca813baf34973fd3495cc2097d071",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0106",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[44,16,36]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[44,16,36]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:30b9a8c74c68ae15db443872e1b6be12",
-      "entity": "niiri:700b2ca023302ca89c9a6e4ffdd8374f"
+      "entity_derived": "niiri:fb785c4b2387927cfcaba115b1c2b59a",
+      "entity": "niiri:1505e0b207a3a8175cc0be4688a0d7c4"
     },
     {
-      "@id": "niiri:ba0d1cacc0f1f06491d9d37fb11c94cd",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:9b7ac364d02018f5800c5cab0a832028",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0107",
-      "prov:atLocation": {"@id": "niiri:3304ca04091f210e6a051412f9842254"},
+      "prov:atLocation": {"@id": "niiri:4abe5383d9941f3b5b7dff4b3e6f15e8"},
       "prov:value": {"@type": "xsd:float", "@value": "3.18127655982971"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.09229057044228"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000993091637332855"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999998"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.9954611032935"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.09229057044228"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000993091637332855"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999998"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.9954611032935"}
     },
     {
-      "@id": "niiri:3304ca04091f210e6a051412f9842254",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4abe5383d9941f3b5b7dff4b3e6f15e8",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0107",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[62,26,-24]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[62,26,-24]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ba0d1cacc0f1f06491d9d37fb11c94cd",
-      "entity": "niiri:14e4f41a62e6164ce237a2e322e60826"
+      "entity_derived": "niiri:9b7ac364d02018f5800c5cab0a832028",
+      "entity": "niiri:892dfa415e44d696ef37c9d6a5487e86"
     }
   ]
 }

--- a/spmexport/ex_spm_HRF_informed_basis/nidm.ttl
+++ b/spmexport/ex_spm_HRF_informed_basis/nidm.ttl
@@ -4,7 +4,7 @@
 @prefix niiri: <http://iri.nidash.org/> .
 @prefix spm: <http://purl.org/nidash/spm#> .
 @prefix neurolex: <http://neurolex.org/wiki/> .
-@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#> .
+@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
@@ -17,27 +17,27 @@
 @prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-niiri:c5e637758bfe8531894d8ad900899234
+niiri:4a6924b313422b14d65ae05690ac91e1
   a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
   rdfs:label "NIDM-Results" ;
   nidm_version: "1.3.0"^^xsd:string .
 
-niiri:93ab5da6aadfc85e38cab0f71c094cd9
+niiri:8261b150c67f791518958870bbf9df42
   a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
   rdfs:label "spm_results_nidm" ;
-  nidm_softwareVersion: "12.6903"^^xsd:string .
+  nidm_softwareVersion: "12.7057"^^xsd:string .
 
-niiri:a82a8e4709f14c56d2ef353e29be8951
+niiri:abeca6887e37b18f4340b7939a0218cb
   a prov:Activity, nidm_NIDMResultsExport: ; 
   rdfs:label "NIDM-Results export" .
 
-niiri:a82a8e4709f14c56d2ef353e29be8951 prov:wasAssociatedWith niiri:93ab5da6aadfc85e38cab0f71c094cd9 .
+niiri:abeca6887e37b18f4340b7939a0218cb prov:wasAssociatedWith niiri:8261b150c67f791518958870bbf9df42 .
 
 _:blank5 a prov:Generation .
 
-niiri:c5e637758bfe8531894d8ad900899234 prov:qualifiedGeneration _:blank5 .
+niiri:4a6924b313422b14d65ae05690ac91e1 prov:qualifiedGeneration _:blank5 .
 
-_:blank5 prov:atTime "2016-12-07T16:07:28"^^xsd:dateTime .
+_:blank5 prov:atTime "2017-04-19T12:17:24"^^xsd:dateTime .
 
 @prefix nidm_Ixi549CoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000050> .
 @prefix src_SPM: <http://scicrunch.org/resolver/SCR_007037> .
@@ -144,12 +144,12 @@ _:blank5 prov:atTime "2016-12-07T16:07:28"^^xsd:dateTime .
 @prefix nidm_Coordinate: <http://purl.org/nidash/nidm#NIDM_0000015> .
 @prefix nidm_coordinateVector: <http://purl.org/nidash/nidm#NIDM_0000086> .
 
-niiri:c302efbe8b4e4d5060ee5c2f1135c601
+niiri:38ff5133581fdcd984a4f1a8f23b66bc
     a prov:Agent, src_SPM:, prov:SoftwareAgent ; 
     rdfs:label "SPM" ;
-    nidm_softwareVersion: "12.12.2"^^xsd:string .
+    nidm_softwareVersion: "12.6906"^^xsd:string .
 
-niiri:188b3f0dd17bb09909483ef8ba9e91bc
+niiri:001c0dbfa3e3cb7025a88555be3739cd
     a prov:Entity, nidm_CoordinateSpace: ; 
     rdfs:label "Coordinate space 1" ;
     nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
@@ -159,50 +159,50 @@ niiri:188b3f0dd17bb09909483ef8ba9e91bc
     nidm_numberOfDimensions: "3"^^xsd:int ;
     nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
 
-niiri:41358075cfc9d63b114e2c27b82e9ce4
+niiri:92a315e48eb2104ecb553b5909a53206
     a prov:Agent, nlx_Imaginginstrument:, nlx_Magneticresonanceimagingscanner: ; 
     rdfs:label "MRI Scanner" .
 
-niiri:1240cfadabb50a38a0dc8dd35780c7a6
+niiri:86bf7416c208bed0ed858777f7b52736
     a prov:Agent, prov:Person ; 
     rdfs:label "Person" .
 
-niiri:e5aea52a813e820d2c33b02b449732de
+niiri:c1b405a8360aa137d6b3059c99d29f33
     a prov:Entity, prov:Collection, nidm_Data: ; 
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "true"^^xsd:boolean ;
     nidm_targetIntensity: "100"^^xsd:float ;
     nidm_hasMRIProtocol: nlx_FunctionalMRIprotocol: .
 
-niiri:e5aea52a813e820d2c33b02b449732de prov:wasAttributedTo niiri:41358075cfc9d63b114e2c27b82e9ce4 .
+niiri:c1b405a8360aa137d6b3059c99d29f33 prov:wasAttributedTo niiri:92a315e48eb2104ecb553b5909a53206 .
 
-niiri:e5aea52a813e820d2c33b02b449732de prov:wasAttributedTo niiri:1240cfadabb50a38a0dc8dd35780c7a6 .
+niiri:c1b405a8360aa137d6b3059c99d29f33 prov:wasAttributedTo niiri:86bf7416c208bed0ed858777f7b52736 .
 
-niiri:937076fffcf924d8b4111758049b014c
+niiri:b62a1b2d76f025e49ec6138bb72cc749
     a prov:Entity, spm_DCTDriftModel: ; 
     rdfs:label "SPM's DCT Drift Model" ;
     spm_SPMsDriftCutoffPeriod: "128"^^xsd:float .
 
-niiri:d04cda6d1289e860f4b4be6577fe58c5
+niiri:d36d45f811e2c1d8f3d5e1b6d9405158
     a prov:Entity, nidm_DesignMatrix: ; 
     prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.csv"^^xsd:string ;
     dct:format "text/csv"^^xsd:string ;
-    dc:description niiri:9d12769f59795b260753a036fbea1565 ;
+    dc:description niiri:6cac7ac7016b4d63113dc01cb939523d ;
     rdfs:label "Design Matrix" ;
     nidm_regressorNames: "[\"Sn(1) to*bf(1)\", \"Sn(1) to*bf(2)\", \"Sn(1) to*bf(3)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) \ntask001 co*bf(2)\", \"Sn(1) \ntask001 co*bf(3)\", \"Sn(1) constant\"]"^^xsd:string ;
-    nidm_hasDriftModel: niiri:937076fffcf924d8b4111758049b014c ;
+    nidm_hasDriftModel: niiri:b62a1b2d76f025e49ec6138bb72cc749 ;
     nidm_hasHRFBasis: spm_SPMsCanonicalHRF: ;
     nidm_hasHRFBasis: spm_SPMsTemporalDerivative: ;
     nidm_hasHRFBasis: spm_SPMsDispersionDerivative: .
 
-niiri:9d12769f59795b260753a036fbea1565
+niiri:6cac7ac7016b4d63113dc01cb939523d
     a prov:Entity, dctype:Image ; 
     prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:01f9cb583db5694c6cde4b6362a3c5d9
+niiri:61c272100996293e9d28d33c83a38df1
     a prov:Entity, nidm_ErrorModel: ; 
     nidm_hasErrorDistribution: obo_normaldistribution: ;
     nidm_hasErrorDependence: obo_Toeplitzcovariancestructure: ;
@@ -210,258 +210,258 @@ niiri:01f9cb583db5694c6cde4b6362a3c5d9
     nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
     nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
 
-niiri:4bfad26596a5c6d8df54ba99dfcc1ac5
+niiri:e00957320cd5a93f086b03d92e906e5b
     a prov:Activity, nidm_ModelParametersEstimation: ; 
     rdfs:label "Model parameters estimation" ;
     nidm_withEstimationMethod: obo_generalizedleastsquaresestimation: .
 
-niiri:4bfad26596a5c6d8df54ba99dfcc1ac5 prov:wasAssociatedWith niiri:c302efbe8b4e4d5060ee5c2f1135c601 .
+niiri:e00957320cd5a93f086b03d92e906e5b prov:wasAssociatedWith niiri:38ff5133581fdcd984a4f1a8f23b66bc .
 
-niiri:4bfad26596a5c6d8df54ba99dfcc1ac5 prov:used niiri:d04cda6d1289e860f4b4be6577fe58c5 .
+niiri:e00957320cd5a93f086b03d92e906e5b prov:used niiri:d36d45f811e2c1d8f3d5e1b6d9405158 .
 
-niiri:4bfad26596a5c6d8df54ba99dfcc1ac5 prov:used niiri:e5aea52a813e820d2c33b02b449732de .
+niiri:e00957320cd5a93f086b03d92e906e5b prov:used niiri:c1b405a8360aa137d6b3059c99d29f33 .
 
-niiri:4bfad26596a5c6d8df54ba99dfcc1ac5 prov:used niiri:01f9cb583db5694c6cde4b6362a3c5d9 .
+niiri:e00957320cd5a93f086b03d92e906e5b prov:used niiri:61c272100996293e9d28d33c83a38df1 .
 
-niiri:92cfad48f775d3c1bb375d5594bbbe67
+niiri:7f004a26944135c1d554914761e27b2e
     a prov:Entity, nidm_MaskMap: ; 
     prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
     nidm_isUserDefined: "false"^^xsd:boolean ;
     nfo:fileName "Mask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Mask" ;
-    nidm_inCoordinateSpace: niiri:188b3f0dd17bb09909483ef8ba9e91bc ;
+    nidm_inCoordinateSpace: niiri:001c0dbfa3e3cb7025a88555be3739cd ;
     crypto:sha512 "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876"^^xsd:string .
 
-niiri:e4b5cecf835eaccf0776863dd3c51039
+niiri:a07cf2721b41e6ba9ec7e48fb167fb89
     a prov:Entity, nidm_MaskMap: ; 
     nfo:fileName "mask.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "36929e1f5f4143bd9cc818cd896a25f129961fab208c3a4438555f40444c08347b359142ee8c53ece6e8cca1627f49db0788a1fd3b9e2ecaef61999c6c6c67ac"^^xsd:string .
 
-niiri:92cfad48f775d3c1bb375d5594bbbe67 prov:wasDerivedFrom niiri:e4b5cecf835eaccf0776863dd3c51039 .
+niiri:7f004a26944135c1d554914761e27b2e prov:wasDerivedFrom niiri:a07cf2721b41e6ba9ec7e48fb167fb89 .
 
-niiri:92cfad48f775d3c1bb375d5594bbbe67 prov:wasGeneratedBy niiri:4bfad26596a5c6d8df54ba99dfcc1ac5 .
+niiri:7f004a26944135c1d554914761e27b2e prov:wasGeneratedBy niiri:e00957320cd5a93f086b03d92e906e5b .
 
-niiri:f7c42a9a4467568ceeb1993aca05147a
+niiri:f5d9995c28e5cb26e1839c59c9b5bbff
     a prov:Entity, nidm_GrandMeanMap: ; 
     prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
     nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Grand Mean Map" ;
     nidm_maskedMedian: "116.329124450684"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:188b3f0dd17bb09909483ef8ba9e91bc ;
+    nidm_inCoordinateSpace: niiri:001c0dbfa3e3cb7025a88555be3739cd ;
     crypto:sha512 "ec99afa6698e7e3dee3ab79feba8f2cd2a493c5697526587e163285b64c4f5e1f4ea33dde05f107f19022d0794fbd73ebedcfd84a9efa34bd37e4d1f13495c8b"^^xsd:string .
 
-niiri:f7c42a9a4467568ceeb1993aca05147a prov:wasGeneratedBy niiri:4bfad26596a5c6d8df54ba99dfcc1ac5 .
+niiri:f5d9995c28e5cb26e1839c59c9b5bbff prov:wasGeneratedBy niiri:e00957320cd5a93f086b03d92e906e5b .
 
-niiri:0d26b879da2421e4381c87acd5cb9607
+niiri:2593c500a2e3bba4242f56e76e61b2d9
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0001.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0001.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 1" ;
-    nidm_inCoordinateSpace: niiri:188b3f0dd17bb09909483ef8ba9e91bc ;
+    nidm_inCoordinateSpace: niiri:001c0dbfa3e3cb7025a88555be3739cd ;
     crypto:sha512 "3497224bcc9542afe414ca8c9c2089d65f208f236583cd9e934f85d3807ee7c7b51da6a5281e4603b9dbebb087c9a69e1b328eb16c1505f10475cd22bacb5b03"^^xsd:string .
 
-niiri:e37c71bab163da8b5c606310ded8c6c6
+niiri:052b380e570273544f6f2d746785485a
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "3497224bcc9542afe414ca8c9c2089d65f208f236583cd9e934f85d3807ee7c7b51da6a5281e4603b9dbebb087c9a69e1b328eb16c1505f10475cd22bacb5b03"^^xsd:string .
 
-niiri:0d26b879da2421e4381c87acd5cb9607 prov:wasDerivedFrom niiri:e37c71bab163da8b5c606310ded8c6c6 .
+niiri:2593c500a2e3bba4242f56e76e61b2d9 prov:wasDerivedFrom niiri:052b380e570273544f6f2d746785485a .
 
-niiri:0d26b879da2421e4381c87acd5cb9607 prov:wasGeneratedBy niiri:4bfad26596a5c6d8df54ba99dfcc1ac5 .
+niiri:2593c500a2e3bba4242f56e76e61b2d9 prov:wasGeneratedBy niiri:e00957320cd5a93f086b03d92e906e5b .
 
-niiri:3503e6e10890a04d3539c21f67f250dd
+niiri:dd5f95dd48f703c72358e4165ae1e39d
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0002.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0002.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 2" ;
-    nidm_inCoordinateSpace: niiri:188b3f0dd17bb09909483ef8ba9e91bc ;
+    nidm_inCoordinateSpace: niiri:001c0dbfa3e3cb7025a88555be3739cd ;
     crypto:sha512 "dd73295132622e8dc5981d7ed38df121358b5db54cc7f22f1fd3e6312db59dcbefd8e4c631ef5d251f634979c0793c6c3ab96dd979eca1f0e546f4811ad7f1dd"^^xsd:string .
 
-niiri:4cb802f633abf153d31bd1ff505e84f9
+niiri:6278c189e4aaeee91d9763d5764523da
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0002.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "dd73295132622e8dc5981d7ed38df121358b5db54cc7f22f1fd3e6312db59dcbefd8e4c631ef5d251f634979c0793c6c3ab96dd979eca1f0e546f4811ad7f1dd"^^xsd:string .
 
-niiri:3503e6e10890a04d3539c21f67f250dd prov:wasDerivedFrom niiri:4cb802f633abf153d31bd1ff505e84f9 .
+niiri:dd5f95dd48f703c72358e4165ae1e39d prov:wasDerivedFrom niiri:6278c189e4aaeee91d9763d5764523da .
 
-niiri:3503e6e10890a04d3539c21f67f250dd prov:wasGeneratedBy niiri:4bfad26596a5c6d8df54ba99dfcc1ac5 .
+niiri:dd5f95dd48f703c72358e4165ae1e39d prov:wasGeneratedBy niiri:e00957320cd5a93f086b03d92e906e5b .
 
-niiri:37f6b18b1c2a51e32387f84113f2e20a
+niiri:e9cc9119a66cf374f5bd09a02cb7f0c6
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0003.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0003.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 3" ;
-    nidm_inCoordinateSpace: niiri:188b3f0dd17bb09909483ef8ba9e91bc ;
+    nidm_inCoordinateSpace: niiri:001c0dbfa3e3cb7025a88555be3739cd ;
     crypto:sha512 "6370516cf48e70e7d88c496fb0763827a4522075468661c6d78139565e0213199afa65e9395ef938140ccd322f0c245fbd271aac521d3b5805aaa27422466a14"^^xsd:string .
 
-niiri:1c5d1ffbae51ac5ea4489818ca10dd0e
+niiri:1a2a75047181a94977af5143fbc2a3f6
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0003.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "6370516cf48e70e7d88c496fb0763827a4522075468661c6d78139565e0213199afa65e9395ef938140ccd322f0c245fbd271aac521d3b5805aaa27422466a14"^^xsd:string .
 
-niiri:37f6b18b1c2a51e32387f84113f2e20a prov:wasDerivedFrom niiri:1c5d1ffbae51ac5ea4489818ca10dd0e .
+niiri:e9cc9119a66cf374f5bd09a02cb7f0c6 prov:wasDerivedFrom niiri:1a2a75047181a94977af5143fbc2a3f6 .
 
-niiri:37f6b18b1c2a51e32387f84113f2e20a prov:wasGeneratedBy niiri:4bfad26596a5c6d8df54ba99dfcc1ac5 .
+niiri:e9cc9119a66cf374f5bd09a02cb7f0c6 prov:wasGeneratedBy niiri:e00957320cd5a93f086b03d92e906e5b .
 
-niiri:ec0b0abbac2426a3220447cfa9c897db
+niiri:1dfac129a8bcadeb38a137a5e7f33cc7
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0004.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0004.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 4" ;
-    nidm_inCoordinateSpace: niiri:188b3f0dd17bb09909483ef8ba9e91bc ;
+    nidm_inCoordinateSpace: niiri:001c0dbfa3e3cb7025a88555be3739cd ;
     crypto:sha512 "3e67878a2f7df58413a4a193334e8c451dde1eb8918edc712798901996e0a3479f7bb72c086d81a7f852058d413eac6b1644b8b02f8255e0159b41798f21713a"^^xsd:string .
 
-niiri:1494239139c2299ccd56411bd7ba3d31
+niiri:386a35d1945daf4a9951952ed1cb6ec8
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0004.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "3e67878a2f7df58413a4a193334e8c451dde1eb8918edc712798901996e0a3479f7bb72c086d81a7f852058d413eac6b1644b8b02f8255e0159b41798f21713a"^^xsd:string .
 
-niiri:ec0b0abbac2426a3220447cfa9c897db prov:wasDerivedFrom niiri:1494239139c2299ccd56411bd7ba3d31 .
+niiri:1dfac129a8bcadeb38a137a5e7f33cc7 prov:wasDerivedFrom niiri:386a35d1945daf4a9951952ed1cb6ec8 .
 
-niiri:ec0b0abbac2426a3220447cfa9c897db prov:wasGeneratedBy niiri:4bfad26596a5c6d8df54ba99dfcc1ac5 .
+niiri:1dfac129a8bcadeb38a137a5e7f33cc7 prov:wasGeneratedBy niiri:e00957320cd5a93f086b03d92e906e5b .
 
-niiri:4a16c89cb4f83830615f6a835c98bd87
+niiri:d9bf5437aa08a1459fe0182fd947a96c
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0005.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0005.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 5" ;
-    nidm_inCoordinateSpace: niiri:188b3f0dd17bb09909483ef8ba9e91bc ;
+    nidm_inCoordinateSpace: niiri:001c0dbfa3e3cb7025a88555be3739cd ;
     crypto:sha512 "5b940e22ba41618a9ed4327d055717b03ce647c4cab1acf5ad139ca6721e873813a8efc4334200ea95d052590e360fa714b182bca20d0b36bf02afddbdf14ba5"^^xsd:string .
 
-niiri:8ab2b36d956eb629301d4768b4c60375
+niiri:02af90ad0dd6b14db8aaaf0f3cf245f4
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0005.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "5b940e22ba41618a9ed4327d055717b03ce647c4cab1acf5ad139ca6721e873813a8efc4334200ea95d052590e360fa714b182bca20d0b36bf02afddbdf14ba5"^^xsd:string .
 
-niiri:4a16c89cb4f83830615f6a835c98bd87 prov:wasDerivedFrom niiri:8ab2b36d956eb629301d4768b4c60375 .
+niiri:d9bf5437aa08a1459fe0182fd947a96c prov:wasDerivedFrom niiri:02af90ad0dd6b14db8aaaf0f3cf245f4 .
 
-niiri:4a16c89cb4f83830615f6a835c98bd87 prov:wasGeneratedBy niiri:4bfad26596a5c6d8df54ba99dfcc1ac5 .
+niiri:d9bf5437aa08a1459fe0182fd947a96c prov:wasGeneratedBy niiri:e00957320cd5a93f086b03d92e906e5b .
 
-niiri:8c59a450b99a62f07febcaccaf31a29a
+niiri:4c0ab1c8535ea87131668d8df8033987
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0006.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0006.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 6" ;
-    nidm_inCoordinateSpace: niiri:188b3f0dd17bb09909483ef8ba9e91bc ;
+    nidm_inCoordinateSpace: niiri:001c0dbfa3e3cb7025a88555be3739cd ;
     crypto:sha512 "2ddfa0fd58e83c5cac4bfcd3b08846aabb9a0bf0bab1b0b9d906f276fb5037e45ee37a98b676dde3c2db7570c1f383983a10d9ebc294dcce50016bb3ec31890e"^^xsd:string .
 
-niiri:b8bc7cf01edd5c3b0ada8954e4d2879b
+niiri:6f1af1cdc138aa878dd6288c45630725
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0006.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "2ddfa0fd58e83c5cac4bfcd3b08846aabb9a0bf0bab1b0b9d906f276fb5037e45ee37a98b676dde3c2db7570c1f383983a10d9ebc294dcce50016bb3ec31890e"^^xsd:string .
 
-niiri:8c59a450b99a62f07febcaccaf31a29a prov:wasDerivedFrom niiri:b8bc7cf01edd5c3b0ada8954e4d2879b .
+niiri:4c0ab1c8535ea87131668d8df8033987 prov:wasDerivedFrom niiri:6f1af1cdc138aa878dd6288c45630725 .
 
-niiri:8c59a450b99a62f07febcaccaf31a29a prov:wasGeneratedBy niiri:4bfad26596a5c6d8df54ba99dfcc1ac5 .
+niiri:4c0ab1c8535ea87131668d8df8033987 prov:wasGeneratedBy niiri:e00957320cd5a93f086b03d92e906e5b .
 
-niiri:b346966ac0ac09399e1ee677416c177e
+niiri:fcd83b6089c28ff32851390322727691
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0007.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0007.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 7" ;
-    nidm_inCoordinateSpace: niiri:188b3f0dd17bb09909483ef8ba9e91bc ;
+    nidm_inCoordinateSpace: niiri:001c0dbfa3e3cb7025a88555be3739cd ;
     crypto:sha512 "ec648b94e914a34b754e86a51d22e001078d5e2aabd640e2baa8de388e72c112a75aa2f709c2f8066f86a99b87026221eeaa3d5418385eae7d32a5f535924e79"^^xsd:string .
 
-niiri:6b0f25c5769b95cf281b7304a4e2b112
+niiri:2e56c7cfc04eb22f960f4187216b007b
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0007.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "ec648b94e914a34b754e86a51d22e001078d5e2aabd640e2baa8de388e72c112a75aa2f709c2f8066f86a99b87026221eeaa3d5418385eae7d32a5f535924e79"^^xsd:string .
 
-niiri:b346966ac0ac09399e1ee677416c177e prov:wasDerivedFrom niiri:6b0f25c5769b95cf281b7304a4e2b112 .
+niiri:fcd83b6089c28ff32851390322727691 prov:wasDerivedFrom niiri:2e56c7cfc04eb22f960f4187216b007b .
 
-niiri:b346966ac0ac09399e1ee677416c177e prov:wasGeneratedBy niiri:4bfad26596a5c6d8df54ba99dfcc1ac5 .
+niiri:fcd83b6089c28ff32851390322727691 prov:wasGeneratedBy niiri:e00957320cd5a93f086b03d92e906e5b .
 
-niiri:d0c4815df31f7d1c3f47f162d15e211b
+niiri:634e834296ec47451bb5dba35c6ab090
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Residual Mean Squares Map" ;
-    nidm_inCoordinateSpace: niiri:188b3f0dd17bb09909483ef8ba9e91bc ;
+    nidm_inCoordinateSpace: niiri:001c0dbfa3e3cb7025a88555be3739cd ;
     crypto:sha512 "ecbbff7f5c8f82725791661876f19d56ea83fabf87af9ff25e36ff5a33c0111650ca0da870a7a29bb87c6779fd36f6d12d9fa62d2251903dd498a9bec3297e1e"^^xsd:string .
 
-niiri:67acd114b0d9caaa74d7106a87b6c787
+niiri:239382281394fda80fab27e1b812d896
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     nfo:fileName "ResMS.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "33f469f7adf069c8eeaa3dff460c85a3328dfa41621be4c0d400a832e5b2e92f671e5db6938c9a82dc16c81d4b60a3c0182c9be7723d1ad0236b249a1174a5d5"^^xsd:string .
 
-niiri:d0c4815df31f7d1c3f47f162d15e211b prov:wasDerivedFrom niiri:67acd114b0d9caaa74d7106a87b6c787 .
+niiri:634e834296ec47451bb5dba35c6ab090 prov:wasDerivedFrom niiri:239382281394fda80fab27e1b812d896 .
 
-niiri:d0c4815df31f7d1c3f47f162d15e211b prov:wasGeneratedBy niiri:4bfad26596a5c6d8df54ba99dfcc1ac5 .
+niiri:634e834296ec47451bb5dba35c6ab090 prov:wasGeneratedBy niiri:e00957320cd5a93f086b03d92e906e5b .
 
-niiri:a45c8e34d741fe2400c2d0d6befe2db2
+niiri:d322a9aa3dcb86b056a502997edcb664
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Resels per Voxel Map" ;
-    nidm_inCoordinateSpace: niiri:188b3f0dd17bb09909483ef8ba9e91bc ;
+    nidm_inCoordinateSpace: niiri:001c0dbfa3e3cb7025a88555be3739cd ;
     crypto:sha512 "d4f5f4f076c45cc4f9481325ee5a43ca4edc8fbb928db288ee4ed93f0fa1368ef6267240398d71e7590990e133715b53d4455b95ee8a59baf13e4c6ea46e147f"^^xsd:string .
 
-niiri:9b431bd488e0d1e7c63462a779e7a245
+niiri:c83c0701812f37753b6efa1070796628
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     nfo:fileName "RPV.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "7e5e04367e61ffae36c2b4af7de4b4e7c6f4877f660bb110d108a0b97a1a1f20ca9c18e49803e936dfbbf27bcf0d40918ce6daece3c736ca6056720a83964b1e"^^xsd:string .
 
-niiri:a45c8e34d741fe2400c2d0d6befe2db2 prov:wasDerivedFrom niiri:9b431bd488e0d1e7c63462a779e7a245 .
+niiri:d322a9aa3dcb86b056a502997edcb664 prov:wasDerivedFrom niiri:c83c0701812f37753b6efa1070796628 .
 
-niiri:a45c8e34d741fe2400c2d0d6befe2db2 prov:wasGeneratedBy niiri:4bfad26596a5c6d8df54ba99dfcc1ac5 .
+niiri:d322a9aa3dcb86b056a502997edcb664 prov:wasGeneratedBy niiri:e00957320cd5a93f086b03d92e906e5b .
 
-niiri:6ebf83091b8d27c1eaa596583e717fc6
+niiri:7c291851e6747c0e2a7284a7cf2d75f4
     a prov:Entity, obo_contrastweightmatrix: ; 
     nidm_statisticType: obo_tstatistic: ;
     nidm_contrastName: "tone counting vs baseline"^^xsd:string ;
     rdfs:label "Contrast: tone counting vs baseline" ;
     prov:value "[1, 0, 0, 0, 0, 0, 0]"^^xsd:string .
 
-niiri:ff0be177817b503d5fb3a21c1a599d85
+niiri:a9881c0f935d0d86cf261907ea9a9c33
     a prov:Activity, nidm_ContrastEstimation: ; 
     rdfs:label "Contrast estimation" .
 
-niiri:ff0be177817b503d5fb3a21c1a599d85 prov:wasAssociatedWith niiri:c302efbe8b4e4d5060ee5c2f1135c601 .
+niiri:a9881c0f935d0d86cf261907ea9a9c33 prov:wasAssociatedWith niiri:38ff5133581fdcd984a4f1a8f23b66bc .
 
-niiri:ff0be177817b503d5fb3a21c1a599d85 prov:used niiri:92cfad48f775d3c1bb375d5594bbbe67 .
+niiri:a9881c0f935d0d86cf261907ea9a9c33 prov:used niiri:7f004a26944135c1d554914761e27b2e .
 
-niiri:ff0be177817b503d5fb3a21c1a599d85 prov:used niiri:d0c4815df31f7d1c3f47f162d15e211b .
+niiri:a9881c0f935d0d86cf261907ea9a9c33 prov:used niiri:634e834296ec47451bb5dba35c6ab090 .
 
-niiri:ff0be177817b503d5fb3a21c1a599d85 prov:used niiri:d04cda6d1289e860f4b4be6577fe58c5 .
+niiri:a9881c0f935d0d86cf261907ea9a9c33 prov:used niiri:d36d45f811e2c1d8f3d5e1b6d9405158 .
 
-niiri:ff0be177817b503d5fb3a21c1a599d85 prov:used niiri:6ebf83091b8d27c1eaa596583e717fc6 .
+niiri:a9881c0f935d0d86cf261907ea9a9c33 prov:used niiri:7c291851e6747c0e2a7284a7cf2d75f4 .
 
-niiri:ff0be177817b503d5fb3a21c1a599d85 prov:used niiri:0d26b879da2421e4381c87acd5cb9607 .
+niiri:a9881c0f935d0d86cf261907ea9a9c33 prov:used niiri:2593c500a2e3bba4242f56e76e61b2d9 .
 
-niiri:ff0be177817b503d5fb3a21c1a599d85 prov:used niiri:3503e6e10890a04d3539c21f67f250dd .
+niiri:a9881c0f935d0d86cf261907ea9a9c33 prov:used niiri:dd5f95dd48f703c72358e4165ae1e39d .
 
-niiri:ff0be177817b503d5fb3a21c1a599d85 prov:used niiri:37f6b18b1c2a51e32387f84113f2e20a .
+niiri:a9881c0f935d0d86cf261907ea9a9c33 prov:used niiri:e9cc9119a66cf374f5bd09a02cb7f0c6 .
 
-niiri:ff0be177817b503d5fb3a21c1a599d85 prov:used niiri:ec0b0abbac2426a3220447cfa9c897db .
+niiri:a9881c0f935d0d86cf261907ea9a9c33 prov:used niiri:1dfac129a8bcadeb38a137a5e7f33cc7 .
 
-niiri:ff0be177817b503d5fb3a21c1a599d85 prov:used niiri:4a16c89cb4f83830615f6a835c98bd87 .
+niiri:a9881c0f935d0d86cf261907ea9a9c33 prov:used niiri:d9bf5437aa08a1459fe0182fd947a96c .
 
-niiri:ff0be177817b503d5fb3a21c1a599d85 prov:used niiri:8c59a450b99a62f07febcaccaf31a29a .
+niiri:a9881c0f935d0d86cf261907ea9a9c33 prov:used niiri:4c0ab1c8535ea87131668d8df8033987 .
 
-niiri:ff0be177817b503d5fb3a21c1a599d85 prov:used niiri:b346966ac0ac09399e1ee677416c177e .
+niiri:a9881c0f935d0d86cf261907ea9a9c33 prov:used niiri:fcd83b6089c28ff32851390322727691 .
 
-niiri:6ff77cd1a0e88dfed2f18485809d692d
+niiri:10f87872974544f0796133e8ec52cdb2
     a prov:Entity, nidm_StatisticMap: ; 
     prov:atLocation "TStatistic.nii.gz"^^xsd:anyURI ;
     nfo:fileName "TStatistic.nii.gz"^^xsd:string ;
@@ -471,124 +471,124 @@ niiri:6ff77cd1a0e88dfed2f18485809d692d
     nidm_contrastName: "tone counting vs baseline"^^xsd:string ;
     nidm_errorDegreesOfFreedom: "93.9999999999637"^^xsd:float ;
     nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:188b3f0dd17bb09909483ef8ba9e91bc ;
+    nidm_inCoordinateSpace: niiri:001c0dbfa3e3cb7025a88555be3739cd ;
     crypto:sha512 "0a35119e4ab5eaf8da616907ac9aa8de8b5398967c85ac7a96d2bf22ced6e6f25871fd086d20db35df40bbb9015be8236120a48d04886378992fd53f27789a98"^^xsd:string .
 
-niiri:05b4c92f8317abcb5568652197e43d10
+niiri:8588d79c35677301f464c7e03b9d0496
     a prov:Entity, nidm_StatisticMap: ; 
     nfo:fileName "spmT_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "1096728734b200447633666faffc81cab6f8aad61d9282f83169526dd1083f14150922528eafe7ec28f3f8c0094adb3ffd9941a696aebba046bd5c2df4966ab8"^^xsd:string .
 
-niiri:6ff77cd1a0e88dfed2f18485809d692d prov:wasDerivedFrom niiri:05b4c92f8317abcb5568652197e43d10 .
+niiri:10f87872974544f0796133e8ec52cdb2 prov:wasDerivedFrom niiri:8588d79c35677301f464c7e03b9d0496 .
 
-niiri:6ff77cd1a0e88dfed2f18485809d692d prov:wasGeneratedBy niiri:ff0be177817b503d5fb3a21c1a599d85 .
+niiri:10f87872974544f0796133e8ec52cdb2 prov:wasGeneratedBy niiri:a9881c0f935d0d86cf261907ea9a9c33 .
 
-niiri:d64a30ad6a4b2e6ba105700e31fd97e9
+niiri:5dae15d639ffe538568fccbf50b79da6
     a prov:Entity, nidm_ContrastMap: ; 
     prov:atLocation "Contrast.nii.gz"^^xsd:anyURI ;
     nfo:fileName "Contrast.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Map: tone counting vs baseline" ;
     nidm_contrastName: "tone counting vs baseline"^^xsd:string ;
-    nidm_inCoordinateSpace: niiri:188b3f0dd17bb09909483ef8ba9e91bc ;
+    nidm_inCoordinateSpace: niiri:001c0dbfa3e3cb7025a88555be3739cd ;
     crypto:sha512 "43d93cfdb352a3b8121c3e4758bd56286b7d9dfb5481860cb35941ceae021948c1cac3225a9829ceeb0997965dd1763161c4ba7db4bf47c0d2e69b5eaadd1658"^^xsd:string .
 
-niiri:1742b20232911a9556eb97b3407ea922
+niiri:32b2745bbaa52aa442354c21c92a29df
     a prov:Entity, nidm_ContrastMap: ; 
     nfo:fileName "con_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "0f8a4e835300919afe716e102bd3b85b6c760194e65dbc88d259debb4b3976960f8cba854410eca817033e63c13824e28369fe6ba7d4fd6a8e87fecfd5b5fa88"^^xsd:string .
 
-niiri:d64a30ad6a4b2e6ba105700e31fd97e9 prov:wasDerivedFrom niiri:1742b20232911a9556eb97b3407ea922 .
+niiri:5dae15d639ffe538568fccbf50b79da6 prov:wasDerivedFrom niiri:32b2745bbaa52aa442354c21c92a29df .
 
-niiri:d64a30ad6a4b2e6ba105700e31fd97e9 prov:wasGeneratedBy niiri:ff0be177817b503d5fb3a21c1a599d85 .
+niiri:5dae15d639ffe538568fccbf50b79da6 prov:wasGeneratedBy niiri:a9881c0f935d0d86cf261907ea9a9c33 .
 
-niiri:b81869e2fb3bb55c52607b64105f8736
+niiri:ebd0089167d8c9c6665b2ca9c440a044
     a prov:Entity, nidm_ContrastStandardErrorMap: ; 
     prov:atLocation "ContrastStandardError.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ContrastStandardError.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Standard Error Map" ;
-    nidm_inCoordinateSpace: niiri:188b3f0dd17bb09909483ef8ba9e91bc ;
+    nidm_inCoordinateSpace: niiri:001c0dbfa3e3cb7025a88555be3739cd ;
     crypto:sha512 "ada9ee87facabea9234f59dc455a9cbbae3aac2e0f679b2092df326ce9aef04a46440093bbae0429482be18a2a6cac2c6773eda2c56058225c8e5b88cb3c4576"^^xsd:string .
 
-niiri:b81869e2fb3bb55c52607b64105f8736 prov:wasGeneratedBy niiri:ff0be177817b503d5fb3a21c1a599d85 .
+niiri:ebd0089167d8c9c6665b2ca9c440a044 prov:wasGeneratedBy niiri:a9881c0f935d0d86cf261907ea9a9c33 .
 
-niiri:6b3d9062ad0f4483b27782aab1511478
+niiri:de3990bddd4e3e2e1f2945054f1f36a3
     a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
-    rdfs:label "Height Threshold: p<0.001000 (unc.)" ;
+    rdfs:label "Height Threshold: p<0.001 (unc.)" ;
     prov:value "0.000999500330571057"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:3d8283c34239ccfe187df9d47651390d ;
-    nidm_equivalentThreshold: niiri:eab332ff971408954805dad1ac5c9257 .
+    nidm_equivalentThreshold: niiri:8afe323854d7859a15d4db33f7665a18 ;
+    nidm_equivalentThreshold: niiri:98610b96083c9f43ab45c0999d8fe8eb .
 
-niiri:3d8283c34239ccfe187df9d47651390d
+niiri:8afe323854d7859a15d4db33f7665a18
     a prov:Entity, nidm_HeightThreshold:, obo_statistic: ; 
-    rdfs:label "Height Threshold" ;
+    rdfs:label "Height Threshold: T=3.179209)" ;
     prov:value "3.17920858075464"^^xsd:float .
 
-niiri:eab332ff971408954805dad1ac5c9257
+niiri:98610b96083c9f43ab45c0999d8fe8eb
     a prov:Entity, nidm_HeightThreshold:, obo_FWERadjustedpvalue: ; 
-    rdfs:label "Height Threshold" ;
+    rdfs:label "Height Threshold: p<1.000000 (FWE)" ;
     prov:value "0.999999999999999"^^xsd:float .
 
-niiri:84ca636b42e1c3f776d67c159ab4e94b
+niiri:d8d46bf5012fbd722ed044231eea5a58
     a prov:Entity, nidm_ExtentThreshold:, obo_statistic: ; 
     rdfs:label "Extent Threshold: k>=0" ;
     nidm_clusterSizeInVoxels: "0"^^xsd:int ;
     nidm_clusterSizeInResels: "0"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:26c34169e2fa609a6d57df3cc013e67c ;
-    nidm_equivalentThreshold: niiri:9d2cbbe12bedc71b01c4da002bfcb125 .
+    nidm_equivalentThreshold: niiri:46cd77a8cff744b6db5af8e81bd357b3 ;
+    nidm_equivalentThreshold: niiri:ac3e490dde5b8a24e242aeda0e6dd8ec .
 
-niiri:26c34169e2fa609a6d57df3cc013e67c
+niiri:46cd77a8cff744b6db5af8e81bd357b3
     a prov:Entity, nidm_ExtentThreshold:, obo_FWERadjustedpvalue: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:9d2cbbe12bedc71b01c4da002bfcb125
+niiri:ac3e490dde5b8a24e242aeda0e6dd8ec
     a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:64db314f0363d949e8485924fa084ba6
+niiri:acfbfae887d8a839f1adcb1b8b634982
     a prov:Entity, nidm_PeakDefinitionCriteria: ; 
     rdfs:label "Peak Definition Criteria" ;
     nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
     nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
 
-niiri:ba6fd9b35bfa15158bba309f1799d9fb
+niiri:a3d478c3bf9b0a0df3146665a0a54e21
     a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
     rdfs:label "Cluster Connectivity Criterion: 18" ;
     nidm_hasConnectivityCriterion: nidm_voxel18connected: .
 
-niiri:3d1ed6f2ede33334d39aa1bf3a47cae6
+niiri:543184be0064a6c0e9ff9e528d51cf44
     a prov:Activity, nidm_Inference: ; 
     nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
     rdfs:label "Inference" .
 
-niiri:3d1ed6f2ede33334d39aa1bf3a47cae6 prov:wasAssociatedWith niiri:c302efbe8b4e4d5060ee5c2f1135c601 .
+niiri:543184be0064a6c0e9ff9e528d51cf44 prov:wasAssociatedWith niiri:38ff5133581fdcd984a4f1a8f23b66bc .
 
-niiri:3d1ed6f2ede33334d39aa1bf3a47cae6 prov:used niiri:6b3d9062ad0f4483b27782aab1511478 .
+niiri:543184be0064a6c0e9ff9e528d51cf44 prov:used niiri:de3990bddd4e3e2e1f2945054f1f36a3 .
 
-niiri:3d1ed6f2ede33334d39aa1bf3a47cae6 prov:used niiri:84ca636b42e1c3f776d67c159ab4e94b .
+niiri:543184be0064a6c0e9ff9e528d51cf44 prov:used niiri:d8d46bf5012fbd722ed044231eea5a58 .
 
-niiri:3d1ed6f2ede33334d39aa1bf3a47cae6 prov:used niiri:6ff77cd1a0e88dfed2f18485809d692d .
+niiri:543184be0064a6c0e9ff9e528d51cf44 prov:used niiri:10f87872974544f0796133e8ec52cdb2 .
 
-niiri:3d1ed6f2ede33334d39aa1bf3a47cae6 prov:used niiri:a45c8e34d741fe2400c2d0d6befe2db2 .
+niiri:543184be0064a6c0e9ff9e528d51cf44 prov:used niiri:d322a9aa3dcb86b056a502997edcb664 .
 
-niiri:3d1ed6f2ede33334d39aa1bf3a47cae6 prov:used niiri:92cfad48f775d3c1bb375d5594bbbe67 .
+niiri:543184be0064a6c0e9ff9e528d51cf44 prov:used niiri:7f004a26944135c1d554914761e27b2e .
 
-niiri:3d1ed6f2ede33334d39aa1bf3a47cae6 prov:used niiri:64db314f0363d949e8485924fa084ba6 .
+niiri:543184be0064a6c0e9ff9e528d51cf44 prov:used niiri:acfbfae887d8a839f1adcb1b8b634982 .
 
-niiri:3d1ed6f2ede33334d39aa1bf3a47cae6 prov:used niiri:ba6fd9b35bfa15158bba309f1799d9fb .
+niiri:543184be0064a6c0e9ff9e528d51cf44 prov:used niiri:a3d478c3bf9b0a0df3146665a0a54e21 .
 
-niiri:a421ac3faf40d5b3ab15ba245dbdbdae
+niiri:9806490c5d381029288eb9158bc777fc
     a prov:Entity, nidm_SearchSpaceMaskMap: ; 
     prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
     nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Search Space Mask Map" ;
-    nidm_inCoordinateSpace: niiri:188b3f0dd17bb09909483ef8ba9e91bc ;
+    nidm_inCoordinateSpace: niiri:001c0dbfa3e3cb7025a88555be3739cd ;
     nidm_searchVolumeInVoxels: "223057"^^xsd:int ;
     nidm_searchVolumeInUnits: "1784456"^^xsd:float ;
     nidm_reselSizeInVoxels: "64.4465447229551"^^xsd:float ;
@@ -605,9 +605,9 @@ niiri:a421ac3faf40d5b3ab15ba245dbdbdae
     spm_smallestSignificantClusterSizeInVoxelsFWE05: "89"^^xsd:int ;
     spm_smallestSignificantClusterSizeInVoxelsFDR05: "57"^^xsd:int .
 
-niiri:a421ac3faf40d5b3ab15ba245dbdbdae prov:wasGeneratedBy niiri:3d1ed6f2ede33334d39aa1bf3a47cae6 .
+niiri:9806490c5d381029288eb9158bc777fc prov:wasGeneratedBy niiri:543184be0064a6c0e9ff9e528d51cf44 .
 
-niiri:022626d941384b37aee63db114d7e263
+niiri:9b06d633f15370eacc4d439eebd44c49
     a prov:Entity, nidm_ExcursionSetMap: ; 
     prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
@@ -615,29 +615,29 @@ niiri:022626d941384b37aee63db114d7e263
     rdfs:label "Excursion Set Map" ;
     nidm_numberOfSupraThresholdClusters: "81"^^xsd:int ;
     nidm_pValue: "7.7268191844837e-12"^^xsd:float ;
-    nidm_hasClusterLabelsMap: niiri:537d8221e1c19a9ebfcd07d604100329 ;
-    nidm_hasMaximumIntensityProjection: niiri:0e3547d6f32024a576110c0e7f2519da ;
-    nidm_inCoordinateSpace: niiri:188b3f0dd17bb09909483ef8ba9e91bc ;
+    nidm_hasClusterLabelsMap: niiri:e4fc4a47a5f1920aec26b66c27569703 ;
+    nidm_hasMaximumIntensityProjection: niiri:9c62b1798f4f8af0cd04d4fa20563c6e ;
+    nidm_inCoordinateSpace: niiri:001c0dbfa3e3cb7025a88555be3739cd ;
     crypto:sha512 "39675dfc00efabc7475604def4a2e377153e063d723ca4bcab9e920bf8cb7d7451a6357e8143d3a1ad4ca53df911f5958e4104c06efd1ccdf0bd8282f7731c15"^^xsd:string .
 
-niiri:537d8221e1c19a9ebfcd07d604100329
+niiri:e4fc4a47a5f1920aec26b66c27569703
     a prov:Entity, nidm_ClusterLabelsMap: ; 
     prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Cluster Labels Map" ;
-    nidm_inCoordinateSpace: niiri:188b3f0dd17bb09909483ef8ba9e91bc ;
+    nidm_inCoordinateSpace: niiri:001c0dbfa3e3cb7025a88555be3739cd ;
     crypto:sha512 "6a7560e351d44aa68539b8d837d178254fa0372d68dc9a7fb56936d90f49de9a58b6166a38670fef2966dae8b74c4c158204d3b0e441d8285a21e18bbadb3f39"^^xsd:string .
 
-niiri:0e3547d6f32024a576110c0e7f2519da
+niiri:9c62b1798f4f8af0cd04d4fa20563c6e
     a prov:Entity, dctype:Image ; 
     prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
     nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:022626d941384b37aee63db114d7e263 prov:wasGeneratedBy niiri:3d1ed6f2ede33334d39aa1bf3a47cae6 .
+niiri:9b06d633f15370eacc4d439eebd44c49 prov:wasGeneratedBy niiri:543184be0064a6c0e9ff9e528d51cf44 .
 
-niiri:53b238f4a15796bb564f209e9a20f459
+niiri:12d2dfb7ca155d963f6afeaa6467e598
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0001" ;
     nidm_clusterSizeInVoxels: "1368"^^xsd:int ;
@@ -647,9 +647,9 @@ niiri:53b238f4a15796bb564f209e9a20f459
     nidm_qValueFDR: "1.10356481132569e-16"^^xsd:float ;
     nidm_clusterLabelId: "1"^^xsd:int .
 
-niiri:53b238f4a15796bb564f209e9a20f459 prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:12d2dfb7ca155d963f6afeaa6467e598 prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:cfb21df261de4e6209165b310f0b8cb9
+niiri:4c4f61059d1c51c5c453ad92e020752f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0002" ;
     nidm_clusterSizeInVoxels: "3279"^^xsd:int ;
@@ -659,9 +659,9 @@ niiri:cfb21df261de4e6209165b310f0b8cb9
     nidm_qValueFDR: "2.81583624579098e-30"^^xsd:float ;
     nidm_clusterLabelId: "2"^^xsd:int .
 
-niiri:cfb21df261de4e6209165b310f0b8cb9 prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:4c4f61059d1c51c5c453ad92e020752f prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:780f2f5e9d63466ad3c7345293e0fe5b
+niiri:3ed2649db2465ff69f88971b546dd3be
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0003" ;
     nidm_clusterSizeInVoxels: "373"^^xsd:int ;
@@ -671,9 +671,9 @@ niiri:780f2f5e9d63466ad3c7345293e0fe5b
     nidm_qValueFDR: "8.33267560161855e-07"^^xsd:float ;
     nidm_clusterLabelId: "3"^^xsd:int .
 
-niiri:780f2f5e9d63466ad3c7345293e0fe5b prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:3ed2649db2465ff69f88971b546dd3be prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:2695c44ad8ef77b70e478006be76ec3b
+niiri:19dfc0bbb201d5f134704921caf5a176
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0004" ;
     nidm_clusterSizeInVoxels: "590"^^xsd:int ;
@@ -683,9 +683,9 @@ niiri:2695c44ad8ef77b70e478006be76ec3b
     nidm_qValueFDR: "2.54005027527645e-09"^^xsd:float ;
     nidm_clusterLabelId: "4"^^xsd:int .
 
-niiri:2695c44ad8ef77b70e478006be76ec3b prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:19dfc0bbb201d5f134704921caf5a176 prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:a4131faa6f9d63d587e81683f4525aa5
+niiri:4ccbfde9cca6489f3110bef0431524c8
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0005" ;
     nidm_clusterSizeInVoxels: "264"^^xsd:int ;
@@ -695,9 +695,9 @@ niiri:a4131faa6f9d63d587e81683f4525aa5
     nidm_qValueFDR: "1.57655385906218e-05"^^xsd:float ;
     nidm_clusterLabelId: "5"^^xsd:int .
 
-niiri:a4131faa6f9d63d587e81683f4525aa5 prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:4ccbfde9cca6489f3110bef0431524c8 prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:f1484408d6648353b40e3f793d43ba98
+niiri:3621a50b575ca90dbe183bb31ff4ae4a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0006" ;
     nidm_clusterSizeInVoxels: "289"^^xsd:int ;
@@ -707,9 +707,9 @@ niiri:f1484408d6648353b40e3f793d43ba98
     nidm_qValueFDR: "9.53103783349252e-06"^^xsd:float ;
     nidm_clusterLabelId: "6"^^xsd:int .
 
-niiri:f1484408d6648353b40e3f793d43ba98 prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:3621a50b575ca90dbe183bb31ff4ae4a prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:f549b84e14efc1b6caac0a05e1a46c0d
+niiri:7698728db1c0c3e20b495f064a9d5b55
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0007" ;
     nidm_clusterSizeInVoxels: "126"^^xsd:int ;
@@ -719,9 +719,9 @@ niiri:f549b84e14efc1b6caac0a05e1a46c0d
     nidm_qValueFDR: "0.00235470669586922"^^xsd:float ;
     nidm_clusterLabelId: "7"^^xsd:int .
 
-niiri:f549b84e14efc1b6caac0a05e1a46c0d prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:7698728db1c0c3e20b495f064a9d5b55 prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:29fc425e622d8b8ded04fc6031eeff5d
+niiri:379c20fa5cd6aefb39cb7419f030f9e5
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0008" ;
     nidm_clusterSizeInVoxels: "89"^^xsd:int ;
@@ -731,9 +731,9 @@ niiri:29fc425e622d8b8ded04fc6031eeff5d
     nidm_qValueFDR: "0.00972874973046682"^^xsd:float ;
     nidm_clusterLabelId: "8"^^xsd:int .
 
-niiri:29fc425e622d8b8ded04fc6031eeff5d prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:379c20fa5cd6aefb39cb7419f030f9e5 prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:ddb75d1dce61c969aca0b33e4792ae0c
+niiri:4257936a93608ef43291e047551e5e0a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0009" ;
     nidm_clusterSizeInVoxels: "30"^^xsd:int ;
@@ -743,9 +743,9 @@ niiri:ddb75d1dce61c969aca0b33e4792ae0c
     nidm_qValueFDR: "0.154853405903216"^^xsd:float ;
     nidm_clusterLabelId: "9"^^xsd:int .
 
-niiri:ddb75d1dce61c969aca0b33e4792ae0c prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:4257936a93608ef43291e047551e5e0a prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:9fd20bfdc1412e227a54f54ed45d5054
+niiri:7017960274f85788b6b607f7d0046a76
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0010" ;
     nidm_clusterSizeInVoxels: "57"^^xsd:int ;
@@ -755,9 +755,9 @@ niiri:9fd20bfdc1412e227a54f54ed45d5054
     nidm_qValueFDR: "0.0448028227847535"^^xsd:float ;
     nidm_clusterLabelId: "10"^^xsd:int .
 
-niiri:9fd20bfdc1412e227a54f54ed45d5054 prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:7017960274f85788b6b607f7d0046a76 prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:f0f0748bbb9066bab45490e1ba8fef31
+niiri:a48da6310356eb94f99b1f1eb464e14b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0011" ;
     nidm_clusterSizeInVoxels: "266"^^xsd:int ;
@@ -767,9 +767,9 @@ niiri:f0f0748bbb9066bab45490e1ba8fef31
     nidm_qValueFDR: "1.57655385906218e-05"^^xsd:float ;
     nidm_clusterLabelId: "11"^^xsd:int .
 
-niiri:f0f0748bbb9066bab45490e1ba8fef31 prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:a48da6310356eb94f99b1f1eb464e14b prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:90b4dda7962081808845a0f3dcd7ea91
+niiri:ada43746a7be5361f1b2127ddc7152ba
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0012" ;
     nidm_clusterSizeInVoxels: "19"^^xsd:int ;
@@ -779,9 +779,9 @@ niiri:90b4dda7962081808845a0f3dcd7ea91
     nidm_qValueFDR: "0.260901158205882"^^xsd:float ;
     nidm_clusterLabelId: "12"^^xsd:int .
 
-niiri:90b4dda7962081808845a0f3dcd7ea91 prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:ada43746a7be5361f1b2127ddc7152ba prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:dba4c7441ba091562d6318495ccd506b
+niiri:1c73b53acc2e3706c7dcdd4e4ed9e043
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0013" ;
     nidm_clusterSizeInVoxels: "74"^^xsd:int ;
@@ -791,9 +791,9 @@ niiri:dba4c7441ba091562d6318495ccd506b
     nidm_qValueFDR: "0.0191535728525095"^^xsd:float ;
     nidm_clusterLabelId: "13"^^xsd:int .
 
-niiri:dba4c7441ba091562d6318495ccd506b prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:1c73b53acc2e3706c7dcdd4e4ed9e043 prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:64445ad0b45313551f83199c04675195
+niiri:655978b5bff261f0bf396a1ddf498402
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0014" ;
     nidm_clusterSizeInVoxels: "115"^^xsd:int ;
@@ -803,9 +803,9 @@ niiri:64445ad0b45313551f83199c04675195
     nidm_qValueFDR: "0.00345009478821299"^^xsd:float ;
     nidm_clusterLabelId: "14"^^xsd:int .
 
-niiri:64445ad0b45313551f83199c04675195 prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:655978b5bff261f0bf396a1ddf498402 prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:bb07405375d86eb7d0603ec3197e08aa
+niiri:7dd3c3ae219e2bf1ef8176af9cc60fb9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0015" ;
     nidm_clusterSizeInVoxels: "32"^^xsd:int ;
@@ -815,9 +815,9 @@ niiri:bb07405375d86eb7d0603ec3197e08aa
     nidm_qValueFDR: "0.141131023281374"^^xsd:float ;
     nidm_clusterLabelId: "15"^^xsd:int .
 
-niiri:bb07405375d86eb7d0603ec3197e08aa prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:7dd3c3ae219e2bf1ef8176af9cc60fb9 prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:c3428421b6744ab712756818f68e34b1
+niiri:c96857fd42e1208395989b05eeab7a76
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0016" ;
     nidm_clusterSizeInVoxels: "23"^^xsd:int ;
@@ -827,9 +827,9 @@ niiri:c3428421b6744ab712756818f68e34b1
     nidm_qValueFDR: "0.23742493460642"^^xsd:float ;
     nidm_clusterLabelId: "16"^^xsd:int .
 
-niiri:c3428421b6744ab712756818f68e34b1 prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:c96857fd42e1208395989b05eeab7a76 prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:b1e2ccb2a24225ae9297eb35470b2ef2
+niiri:7a24a2bdbc61f7d8ab6a59738a57c24a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0017" ;
     nidm_clusterSizeInVoxels: "250"^^xsd:int ;
@@ -839,9 +839,9 @@ niiri:b1e2ccb2a24225ae9297eb35470b2ef2
     nidm_qValueFDR: "2.23340120659961e-05"^^xsd:float ;
     nidm_clusterLabelId: "17"^^xsd:int .
 
-niiri:b1e2ccb2a24225ae9297eb35470b2ef2 prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:7a24a2bdbc61f7d8ab6a59738a57c24a prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:1c943c00f3f2e54e795e080b9d85859d
+niiri:c313dfc1d990322089b2bf63a219f16a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0018" ;
     nidm_clusterSizeInVoxels: "38"^^xsd:int ;
@@ -851,9 +851,9 @@ niiri:1c943c00f3f2e54e795e080b9d85859d
     nidm_qValueFDR: "0.110199245362862"^^xsd:float ;
     nidm_clusterLabelId: "18"^^xsd:int .
 
-niiri:1c943c00f3f2e54e795e080b9d85859d prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:c313dfc1d990322089b2bf63a219f16a prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:663b1f9b98b62235a966f9f1c5d82cb9
+niiri:36e697e6ea3e7a7c4a67a505ebe4f340
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0019" ;
     nidm_clusterSizeInVoxels: "39"^^xsd:int ;
@@ -863,9 +863,9 @@ niiri:663b1f9b98b62235a966f9f1c5d82cb9
     nidm_qValueFDR: "0.109360626000416"^^xsd:float ;
     nidm_clusterLabelId: "19"^^xsd:int .
 
-niiri:663b1f9b98b62235a966f9f1c5d82cb9 prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:36e697e6ea3e7a7c4a67a505ebe4f340 prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:dcb1f3bd84b360ab8e8024d363c5a710
+niiri:ca1016af733ba1294614bfd4483de412
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0020" ;
     nidm_clusterSizeInVoxels: "34"^^xsd:int ;
@@ -875,9 +875,9 @@ niiri:dcb1f3bd84b360ab8e8024d363c5a710
     nidm_qValueFDR: "0.129288079258056"^^xsd:float ;
     nidm_clusterLabelId: "20"^^xsd:int .
 
-niiri:dcb1f3bd84b360ab8e8024d363c5a710 prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:ca1016af733ba1294614bfd4483de412 prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:d5ec0fb74bfe81761c80eb8c08942466
+niiri:b4290f172c2ebe815ddf64763f6e95e4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0021" ;
     nidm_clusterSizeInVoxels: "16"^^xsd:int ;
@@ -887,9 +887,9 @@ niiri:d5ec0fb74bfe81761c80eb8c08942466
     nidm_qValueFDR: "0.314997070538899"^^xsd:float ;
     nidm_clusterLabelId: "21"^^xsd:int .
 
-niiri:d5ec0fb74bfe81761c80eb8c08942466 prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:b4290f172c2ebe815ddf64763f6e95e4 prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:dea3ebd7d53b9bdeb45e3fcbd12ef78f
+niiri:94f389f115646fc7441e8fd9bf5ec119
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0022" ;
     nidm_clusterSizeInVoxels: "37"^^xsd:int ;
@@ -899,9 +899,9 @@ niiri:dea3ebd7d53b9bdeb45e3fcbd12ef78f
     nidm_qValueFDR: "0.111451704171323"^^xsd:float ;
     nidm_clusterLabelId: "22"^^xsd:int .
 
-niiri:dea3ebd7d53b9bdeb45e3fcbd12ef78f prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:94f389f115646fc7441e8fd9bf5ec119 prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:7576ce49bb83c1b874dc86b48878d37f
+niiri:7322fa4ccee32301d807a0b9f48ae02a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0023" ;
     nidm_clusterSizeInVoxels: "22"^^xsd:int ;
@@ -911,9 +911,9 @@ niiri:7576ce49bb83c1b874dc86b48878d37f
     nidm_qValueFDR: "0.246296053801927"^^xsd:float ;
     nidm_clusterLabelId: "23"^^xsd:int .
 
-niiri:7576ce49bb83c1b874dc86b48878d37f prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:7322fa4ccee32301d807a0b9f48ae02a prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:cd03d29014d461350222c98300667843
+niiri:c47c40f4ed2261336524231fb9108598
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0024" ;
     nidm_clusterSizeInVoxels: "89"^^xsd:int ;
@@ -923,9 +923,9 @@ niiri:cd03d29014d461350222c98300667843
     nidm_qValueFDR: "0.00972874973046682"^^xsd:float ;
     nidm_clusterLabelId: "24"^^xsd:int .
 
-niiri:cd03d29014d461350222c98300667843 prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:c47c40f4ed2261336524231fb9108598 prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:5e2e4f5da7c8d5550caebb447ece90bb
+niiri:6c58a61aff8d76d3d5cdef392c46c0f7
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0025" ;
     nidm_clusterSizeInVoxels: "42"^^xsd:int ;
@@ -935,9 +935,9 @@ niiri:5e2e4f5da7c8d5550caebb447ece90bb
     nidm_qValueFDR: "0.0959780867890173"^^xsd:float ;
     nidm_clusterLabelId: "25"^^xsd:int .
 
-niiri:5e2e4f5da7c8d5550caebb447ece90bb prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:6c58a61aff8d76d3d5cdef392c46c0f7 prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:489b086215a47551ede0b78dc2a96cbb
+niiri:bcf052d664b0eeef3576961aef494c62
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0026" ;
     nidm_clusterSizeInVoxels: "44"^^xsd:int ;
@@ -947,9 +947,9 @@ niiri:489b086215a47551ede0b78dc2a96cbb
     nidm_qValueFDR: "0.0903551674616366"^^xsd:float ;
     nidm_clusterLabelId: "26"^^xsd:int .
 
-niiri:489b086215a47551ede0b78dc2a96cbb prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:bcf052d664b0eeef3576961aef494c62 prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:e167f1fa2b99e6bc19dd1ecd0b525c28
+niiri:d357fdfcedae064d3927d132b4915da3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0027" ;
     nidm_clusterSizeInVoxels: "10"^^xsd:int ;
@@ -959,9 +959,9 @@ niiri:e167f1fa2b99e6bc19dd1ecd0b525c28
     nidm_qValueFDR: "0.452731326375523"^^xsd:float ;
     nidm_clusterLabelId: "27"^^xsd:int .
 
-niiri:e167f1fa2b99e6bc19dd1ecd0b525c28 prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:d357fdfcedae064d3927d132b4915da3 prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:3b3edf5a98326d7f3703f9678a007546
+niiri:24181b91e1a2ff9fbf0d92f1f3c2fb91
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0028" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -971,9 +971,9 @@ niiri:3b3edf5a98326d7f3703f9678a007546
     nidm_qValueFDR: "0.548127025579537"^^xsd:float ;
     nidm_clusterLabelId: "28"^^xsd:int .
 
-niiri:3b3edf5a98326d7f3703f9678a007546 prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:24181b91e1a2ff9fbf0d92f1f3c2fb91 prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:f254618143e69b64fb1d059a5963eed1
+niiri:a67bcbe4c64e864d3c0091590a71ed79
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0029" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -983,9 +983,9 @@ niiri:f254618143e69b64fb1d059a5963eed1
     nidm_qValueFDR: "0.541627192531069"^^xsd:float ;
     nidm_clusterLabelId: "29"^^xsd:int .
 
-niiri:f254618143e69b64fb1d059a5963eed1 prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:a67bcbe4c64e864d3c0091590a71ed79 prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:9061b512bdfd18fd0d71b5c4815f8163
+niiri:1e585aa0961f26eba6c099e7119148ec
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0030" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -995,9 +995,9 @@ niiri:9061b512bdfd18fd0d71b5c4815f8163
     nidm_qValueFDR: "0.608338977273446"^^xsd:float ;
     nidm_clusterLabelId: "30"^^xsd:int .
 
-niiri:9061b512bdfd18fd0d71b5c4815f8163 prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:1e585aa0961f26eba6c099e7119148ec prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:c8fcb029f017b54563ed3b53bed1488f
+niiri:98543afde30df2ac94ce134cd8111cce
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0031" ;
     nidm_clusterSizeInVoxels: "10"^^xsd:int ;
@@ -1007,9 +1007,9 @@ niiri:c8fcb029f017b54563ed3b53bed1488f
     nidm_qValueFDR: "0.452731326375523"^^xsd:float ;
     nidm_clusterLabelId: "31"^^xsd:int .
 
-niiri:c8fcb029f017b54563ed3b53bed1488f prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:98543afde30df2ac94ce134cd8111cce prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:ca05945701843dd88ebf74447398670e
+niiri:3bfa5939740913923e9b589897f2c510
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0032" ;
     nidm_clusterSizeInVoxels: "19"^^xsd:int ;
@@ -1019,9 +1019,9 @@ niiri:ca05945701843dd88ebf74447398670e
     nidm_qValueFDR: "0.260901158205882"^^xsd:float ;
     nidm_clusterLabelId: "32"^^xsd:int .
 
-niiri:ca05945701843dd88ebf74447398670e prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:3bfa5939740913923e9b589897f2c510 prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:b1d6b0c92fb80c25d314f20c0cfa090c
+niiri:6b8ab0e3e0b633d638e47f3a9a10919b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0033" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -1031,9 +1031,9 @@ niiri:b1d6b0c92fb80c25d314f20c0cfa090c
     nidm_qValueFDR: "0.541627192531069"^^xsd:float ;
     nidm_clusterLabelId: "33"^^xsd:int .
 
-niiri:b1d6b0c92fb80c25d314f20c0cfa090c prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:6b8ab0e3e0b633d638e47f3a9a10919b prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:cb2ae57bb539840222fcf93ce3091770
+niiri:6029d0e967f2fb403f4a243e7a90b84c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0034" ;
     nidm_clusterSizeInVoxels: "27"^^xsd:int ;
@@ -1043,9 +1043,9 @@ niiri:cb2ae57bb539840222fcf93ce3091770
     nidm_qValueFDR: "0.183636764081895"^^xsd:float ;
     nidm_clusterLabelId: "34"^^xsd:int .
 
-niiri:cb2ae57bb539840222fcf93ce3091770 prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:6029d0e967f2fb403f4a243e7a90b84c prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:698b3f9b2d3d5f1f578a7724a8ca8d0d
+niiri:780f11b236810e190dea70c6c4340625
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0035" ;
     nidm_clusterSizeInVoxels: "19"^^xsd:int ;
@@ -1055,9 +1055,9 @@ niiri:698b3f9b2d3d5f1f578a7724a8ca8d0d
     nidm_qValueFDR: "0.260901158205882"^^xsd:float ;
     nidm_clusterLabelId: "35"^^xsd:int .
 
-niiri:698b3f9b2d3d5f1f578a7724a8ca8d0d prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:780f11b236810e190dea70c6c4340625 prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:d26a80bf1b2d7e97037bd7961b7f2fb9
+niiri:4a266b577331cf838f3af1933133ec8d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0036" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -1067,9 +1067,9 @@ niiri:d26a80bf1b2d7e97037bd7961b7f2fb9
     nidm_qValueFDR: "0.518923672932668"^^xsd:float ;
     nidm_clusterLabelId: "36"^^xsd:int .
 
-niiri:d26a80bf1b2d7e97037bd7961b7f2fb9 prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:4a266b577331cf838f3af1933133ec8d prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:84d0f76c2451c6b80e5e965a03dc7d79
+niiri:b92193302c69c95fc0b8add50483e3ec
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0037" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1079,9 +1079,9 @@ niiri:84d0f76c2451c6b80e5e965a03dc7d79
     nidm_qValueFDR: "0.632610190364996"^^xsd:float ;
     nidm_clusterLabelId: "37"^^xsd:int .
 
-niiri:84d0f76c2451c6b80e5e965a03dc7d79 prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:b92193302c69c95fc0b8add50483e3ec prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:32e36d0494334a99543f9acc36898f2f
+niiri:12aade66bcaf5ad22c9a147b7bac54d4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0038" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1091,9 +1091,9 @@ niiri:32e36d0494334a99543f9acc36898f2f
     nidm_qValueFDR: "0.632610190364996"^^xsd:float ;
     nidm_clusterLabelId: "38"^^xsd:int .
 
-niiri:32e36d0494334a99543f9acc36898f2f prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:12aade66bcaf5ad22c9a147b7bac54d4 prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:511c490c7d9b5ae7344403faeec2f878
+niiri:759e3fd5ac10013d9c1b96696769e455
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0039" ;
     nidm_clusterSizeInVoxels: "13"^^xsd:int ;
@@ -1103,9 +1103,9 @@ niiri:511c490c7d9b5ae7344403faeec2f878
     nidm_qValueFDR: "0.388126148382747"^^xsd:float ;
     nidm_clusterLabelId: "39"^^xsd:int .
 
-niiri:511c490c7d9b5ae7344403faeec2f878 prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:759e3fd5ac10013d9c1b96696769e455 prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:9950c7205c20af075ae5465eeb0630ec
+niiri:b60ad51d906accfc87533b435bc4ab5f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0040" ;
     nidm_clusterSizeInVoxels: "21"^^xsd:int ;
@@ -1115,9 +1115,9 @@ niiri:9950c7205c20af075ae5465eeb0630ec
     nidm_qValueFDR: "0.256211192315099"^^xsd:float ;
     nidm_clusterLabelId: "40"^^xsd:int .
 
-niiri:9950c7205c20af075ae5465eeb0630ec prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:b60ad51d906accfc87533b435bc4ab5f prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:59e8f07020483e79cce0a7ee24a67d9d
+niiri:5fe7263d129c8b5a1cdc4862389a329f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0041" ;
     nidm_clusterSizeInVoxels: "17"^^xsd:int ;
@@ -1127,9 +1127,9 @@ niiri:59e8f07020483e79cce0a7ee24a67d9d
     nidm_qValueFDR: "0.298378520107835"^^xsd:float ;
     nidm_clusterLabelId: "41"^^xsd:int .
 
-niiri:59e8f07020483e79cce0a7ee24a67d9d prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:5fe7263d129c8b5a1cdc4862389a329f prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:8d67481af449856aae39018568cd0118
+niiri:202e674801183017b435dafa4352a2f7
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0042" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -1139,9 +1139,9 @@ niiri:8d67481af449856aae39018568cd0118
     nidm_qValueFDR: "0.518923672932668"^^xsd:float ;
     nidm_clusterLabelId: "42"^^xsd:int .
 
-niiri:8d67481af449856aae39018568cd0118 prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:202e674801183017b435dafa4352a2f7 prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:f927b5bbd3f555c57b4e6e01ec9b523e
+niiri:63374171b8dfeb6c1b6216d9cb78dad1
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0043" ;
     nidm_clusterSizeInVoxels: "13"^^xsd:int ;
@@ -1151,9 +1151,9 @@ niiri:f927b5bbd3f555c57b4e6e01ec9b523e
     nidm_qValueFDR: "0.388126148382747"^^xsd:float ;
     nidm_clusterLabelId: "43"^^xsd:int .
 
-niiri:f927b5bbd3f555c57b4e6e01ec9b523e prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:63374171b8dfeb6c1b6216d9cb78dad1 prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:8ab71917d880813a7ac3044279de7b31
+niiri:4c28624df30b813b1284ed3adfd58c93
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0044" ;
     nidm_clusterSizeInVoxels: "11"^^xsd:int ;
@@ -1163,9 +1163,9 @@ niiri:8ab71917d880813a7ac3044279de7b31
     nidm_qValueFDR: "0.44381454737992"^^xsd:float ;
     nidm_clusterLabelId: "44"^^xsd:int .
 
-niiri:8ab71917d880813a7ac3044279de7b31 prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:4c28624df30b813b1284ed3adfd58c93 prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:7bdadf7ae2bdb4f39bf9f8fbe5fe1ea5
+niiri:94a0a21f872815c64a69e94bd40bed9f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0045" ;
     nidm_clusterSizeInVoxels: "11"^^xsd:int ;
@@ -1175,9 +1175,9 @@ niiri:7bdadf7ae2bdb4f39bf9f8fbe5fe1ea5
     nidm_qValueFDR: "0.44381454737992"^^xsd:float ;
     nidm_clusterLabelId: "45"^^xsd:int .
 
-niiri:7bdadf7ae2bdb4f39bf9f8fbe5fe1ea5 prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:94a0a21f872815c64a69e94bd40bed9f prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:aa7cba01da25024bc05a9e45cd79a837
+niiri:e7e4075c58abc76d658530459437df00
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0046" ;
     nidm_clusterSizeInVoxels: "19"^^xsd:int ;
@@ -1187,9 +1187,9 @@ niiri:aa7cba01da25024bc05a9e45cd79a837
     nidm_qValueFDR: "0.260901158205882"^^xsd:float ;
     nidm_clusterLabelId: "46"^^xsd:int .
 
-niiri:aa7cba01da25024bc05a9e45cd79a837 prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:e7e4075c58abc76d658530459437df00 prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:2630e4b92c9db9a6beb0787bffe7a7fb
+niiri:2dfef140265f92d79cbf32d31936df4d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0047" ;
     nidm_clusterSizeInVoxels: "10"^^xsd:int ;
@@ -1199,9 +1199,9 @@ niiri:2630e4b92c9db9a6beb0787bffe7a7fb
     nidm_qValueFDR: "0.452731326375523"^^xsd:float ;
     nidm_clusterLabelId: "47"^^xsd:int .
 
-niiri:2630e4b92c9db9a6beb0787bffe7a7fb prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:2dfef140265f92d79cbf32d31936df4d prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:cbd611e1237a5ec814b81bcfe9552f0e
+niiri:8fcfff082769fb86478d8224ec22e1d5
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0048" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -1211,9 +1211,9 @@ niiri:cbd611e1237a5ec814b81bcfe9552f0e
     nidm_qValueFDR: "0.548127025579537"^^xsd:float ;
     nidm_clusterLabelId: "48"^^xsd:int .
 
-niiri:cbd611e1237a5ec814b81bcfe9552f0e prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:8fcfff082769fb86478d8224ec22e1d5 prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:481718c39416a3d61a910542ffd5f170
+niiri:a4a959bdb5adaac5ccc8bb0a1283b1eb
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0049" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1223,9 +1223,9 @@ niiri:481718c39416a3d61a910542ffd5f170
     nidm_qValueFDR: "0.632610190364996"^^xsd:float ;
     nidm_clusterLabelId: "49"^^xsd:int .
 
-niiri:481718c39416a3d61a910542ffd5f170 prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:a4a959bdb5adaac5ccc8bb0a1283b1eb prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:7bcbc9953403229f0db979d92436612d
+niiri:abd2bbf896a471cb7922efab5b613117
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0050" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1235,9 +1235,9 @@ niiri:7bcbc9953403229f0db979d92436612d
     nidm_qValueFDR: "0.720222921163404"^^xsd:float ;
     nidm_clusterLabelId: "50"^^xsd:int .
 
-niiri:7bcbc9953403229f0db979d92436612d prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:abd2bbf896a471cb7922efab5b613117 prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:7c32a1d0e82c311426243c91cc091275
+niiri:9c1cddc9922d8e70b3ba77c8f428e530
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0051" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1247,9 +1247,9 @@ niiri:7c32a1d0e82c311426243c91cc091275
     nidm_qValueFDR: "0.720222921163404"^^xsd:float ;
     nidm_clusterLabelId: "51"^^xsd:int .
 
-niiri:7c32a1d0e82c311426243c91cc091275 prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:9c1cddc9922d8e70b3ba77c8f428e530 prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:82069b48f32f7007fb477a55996a5a26
+niiri:b2551e755f51f54d3855f624855bec3b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0052" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1259,9 +1259,9 @@ niiri:82069b48f32f7007fb477a55996a5a26
     nidm_qValueFDR: "0.720222921163404"^^xsd:float ;
     nidm_clusterLabelId: "52"^^xsd:int .
 
-niiri:82069b48f32f7007fb477a55996a5a26 prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:b2551e755f51f54d3855f624855bec3b prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:7480c4974cded55a669a9f676f7183d3
+niiri:d98c34494ee425b9f343ad72efbe3802
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0053" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -1271,9 +1271,9 @@ niiri:7480c4974cded55a669a9f676f7183d3
     nidm_qValueFDR: "0.548127025579537"^^xsd:float ;
     nidm_clusterLabelId: "53"^^xsd:int .
 
-niiri:7480c4974cded55a669a9f676f7183d3 prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:d98c34494ee425b9f343ad72efbe3802 prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:7dbb86d35f9a3f5e15ce1fcaf1b4ac57
+niiri:207cbb7814292b71aa3cbca2e251214d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0054" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -1283,9 +1283,9 @@ niiri:7dbb86d35f9a3f5e15ce1fcaf1b4ac57
     nidm_qValueFDR: "0.548127025579537"^^xsd:float ;
     nidm_clusterLabelId: "54"^^xsd:int .
 
-niiri:7dbb86d35f9a3f5e15ce1fcaf1b4ac57 prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:207cbb7814292b71aa3cbca2e251214d prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:1871a215e9872f3a52537c8c1a760f0a
+niiri:ef0e652ba790ef2ca62cbc45744044f2
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0055" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1295,9 +1295,9 @@ niiri:1871a215e9872f3a52537c8c1a760f0a
     nidm_qValueFDR: "0.720222921163404"^^xsd:float ;
     nidm_clusterLabelId: "55"^^xsd:int .
 
-niiri:1871a215e9872f3a52537c8c1a760f0a prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:ef0e652ba790ef2ca62cbc45744044f2 prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:3ad5cc979a530fd4daa32be10f10bc51
+niiri:cdc735403e60da4bc8deca0b30c09e41
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0056" ;
     nidm_clusterSizeInVoxels: "9"^^xsd:int ;
@@ -1307,9 +1307,9 @@ niiri:3ad5cc979a530fd4daa32be10f10bc51
     nidm_qValueFDR: "0.489463474087164"^^xsd:float ;
     nidm_clusterLabelId: "56"^^xsd:int .
 
-niiri:3ad5cc979a530fd4daa32be10f10bc51 prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:cdc735403e60da4bc8deca0b30c09e41 prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:b808d08cb809cd1546fc7c1d23c712ad
+niiri:14788c080d39de548f4f1517f2f3ecf2
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0057" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1319,9 +1319,9 @@ niiri:b808d08cb809cd1546fc7c1d23c712ad
     nidm_qValueFDR: "0.720222921163404"^^xsd:float ;
     nidm_clusterLabelId: "57"^^xsd:int .
 
-niiri:b808d08cb809cd1546fc7c1d23c712ad prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:14788c080d39de548f4f1517f2f3ecf2 prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:2502ea528f067f61a192d4d910eaaac2
+niiri:094abc2dabe5f1598098374da155b2d3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0058" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1331,9 +1331,9 @@ niiri:2502ea528f067f61a192d4d910eaaac2
     nidm_qValueFDR: "0.693669009359767"^^xsd:float ;
     nidm_clusterLabelId: "58"^^xsd:int .
 
-niiri:2502ea528f067f61a192d4d910eaaac2 prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:094abc2dabe5f1598098374da155b2d3 prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:d44962b9e9395d5d42a56ab76170cf9a
+niiri:b0a53fec1935bbbef5f0340426dfcf5c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0059" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -1343,9 +1343,9 @@ niiri:d44962b9e9395d5d42a56ab76170cf9a
     nidm_qValueFDR: "0.548127025579537"^^xsd:float ;
     nidm_clusterLabelId: "59"^^xsd:int .
 
-niiri:d44962b9e9395d5d42a56ab76170cf9a prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:b0a53fec1935bbbef5f0340426dfcf5c prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:f59a3e7afba6bebbf0a007c0f8c78d53
+niiri:782cde190eab924f134e44bd95c8cd15
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0060" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1355,9 +1355,9 @@ niiri:f59a3e7afba6bebbf0a007c0f8c78d53
     nidm_qValueFDR: "0.720222921163404"^^xsd:float ;
     nidm_clusterLabelId: "60"^^xsd:int .
 
-niiri:f59a3e7afba6bebbf0a007c0f8c78d53 prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:782cde190eab924f134e44bd95c8cd15 prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:b1fa22ed23a8d70bc9e4dd151a589e2f
+niiri:9e85dca921757d3d2cafd0d606eb03c4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0061" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1367,9 +1367,9 @@ niiri:b1fa22ed23a8d70bc9e4dd151a589e2f
     nidm_qValueFDR: "0.693669009359767"^^xsd:float ;
     nidm_clusterLabelId: "61"^^xsd:int .
 
-niiri:b1fa22ed23a8d70bc9e4dd151a589e2f prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:9e85dca921757d3d2cafd0d606eb03c4 prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:0cd710e9d7cad8f485a36862bb45dad3
+niiri:50e0654a2d55b1eb33c94eef3f0fbfc4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0062" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1379,9 +1379,9 @@ niiri:0cd710e9d7cad8f485a36862bb45dad3
     nidm_qValueFDR: "0.632610190364996"^^xsd:float ;
     nidm_clusterLabelId: "62"^^xsd:int .
 
-niiri:0cd710e9d7cad8f485a36862bb45dad3 prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:50e0654a2d55b1eb33c94eef3f0fbfc4 prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:cc7d3451a39fd4cca99275e6219b8f5d
+niiri:580546e61fe6caf5b928869b72d6563c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0063" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1391,9 +1391,9 @@ niiri:cc7d3451a39fd4cca99275e6219b8f5d
     nidm_qValueFDR: "0.693669009359767"^^xsd:float ;
     nidm_clusterLabelId: "63"^^xsd:int .
 
-niiri:cc7d3451a39fd4cca99275e6219b8f5d prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:580546e61fe6caf5b928869b72d6563c prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:e8b4547e2bb998c3a0e5c80f5add7395
+niiri:fbb3da138dba0bffe41c80dfdc6d2813
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0064" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1403,9 +1403,9 @@ niiri:e8b4547e2bb998c3a0e5c80f5add7395
     nidm_qValueFDR: "0.720222921163404"^^xsd:float ;
     nidm_clusterLabelId: "64"^^xsd:int .
 
-niiri:e8b4547e2bb998c3a0e5c80f5add7395 prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:fbb3da138dba0bffe41c80dfdc6d2813 prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:194d5b586416a3affff5759f1f6f1f22
+niiri:5b4ccbe46fbd067233c454fc4cd57139
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0065" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1415,9 +1415,9 @@ niiri:194d5b586416a3affff5759f1f6f1f22
     nidm_qValueFDR: "0.720222921163404"^^xsd:float ;
     nidm_clusterLabelId: "65"^^xsd:int .
 
-niiri:194d5b586416a3affff5759f1f6f1f22 prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:5b4ccbe46fbd067233c454fc4cd57139 prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:172068f882b44c7f3f286732e95fd333
+niiri:4797fa2e5200fab8ae750cb321a6d94a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0066" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -1427,9 +1427,9 @@ niiri:172068f882b44c7f3f286732e95fd333
     nidm_qValueFDR: "0.541627192531069"^^xsd:float ;
     nidm_clusterLabelId: "66"^^xsd:int .
 
-niiri:172068f882b44c7f3f286732e95fd333 prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:4797fa2e5200fab8ae750cb321a6d94a prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:ce513aeb315d021861a6c316bf4ef052
+niiri:e5840e49541fa7c2c73adfcf2cd18d5c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0067" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1439,9 +1439,9 @@ niiri:ce513aeb315d021861a6c316bf4ef052
     nidm_qValueFDR: "0.720222921163404"^^xsd:float ;
     nidm_clusterLabelId: "67"^^xsd:int .
 
-niiri:ce513aeb315d021861a6c316bf4ef052 prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:e5840e49541fa7c2c73adfcf2cd18d5c prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:31c5179c3ed19f375fed1f038a132ca0
+niiri:af9739fef5ce12c093a36fdad464fa2c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0068" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1451,9 +1451,9 @@ niiri:31c5179c3ed19f375fed1f038a132ca0
     nidm_qValueFDR: "0.720222921163404"^^xsd:float ;
     nidm_clusterLabelId: "68"^^xsd:int .
 
-niiri:31c5179c3ed19f375fed1f038a132ca0 prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:af9739fef5ce12c093a36fdad464fa2c prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:fef2c17abe57bc62290ea323944b2b06
+niiri:4c1124c10677cacc7086dad2d88a0bd3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0069" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1463,9 +1463,9 @@ niiri:fef2c17abe57bc62290ea323944b2b06
     nidm_qValueFDR: "0.720222921163404"^^xsd:float ;
     nidm_clusterLabelId: "69"^^xsd:int .
 
-niiri:fef2c17abe57bc62290ea323944b2b06 prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:4c1124c10677cacc7086dad2d88a0bd3 prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:101d5a9adb5897de8e974a6c450bccef
+niiri:9a07890dc3c872a54f45939b26e95348
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0070" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1475,9 +1475,9 @@ niiri:101d5a9adb5897de8e974a6c450bccef
     nidm_qValueFDR: "0.720222921163404"^^xsd:float ;
     nidm_clusterLabelId: "70"^^xsd:int .
 
-niiri:101d5a9adb5897de8e974a6c450bccef prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:9a07890dc3c872a54f45939b26e95348 prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:79ae18cf89e6f66ce4c5070153fae100
+niiri:4b972d45063ce95740be79e0f84be300
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0071" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1487,9 +1487,9 @@ niiri:79ae18cf89e6f66ce4c5070153fae100
     nidm_qValueFDR: "0.720222921163404"^^xsd:float ;
     nidm_clusterLabelId: "71"^^xsd:int .
 
-niiri:79ae18cf89e6f66ce4c5070153fae100 prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:4b972d45063ce95740be79e0f84be300 prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:1c0685623290eeb06ef6f4bdbffafd31
+niiri:6cc8de073a211f649503cbae3d7f79bb
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0072" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1499,9 +1499,9 @@ niiri:1c0685623290eeb06ef6f4bdbffafd31
     nidm_qValueFDR: "0.632610190364996"^^xsd:float ;
     nidm_clusterLabelId: "72"^^xsd:int .
 
-niiri:1c0685623290eeb06ef6f4bdbffafd31 prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:6cc8de073a211f649503cbae3d7f79bb prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:e333891aa2a7cc8b78b7b091053068d6
+niiri:713bd5e4d1057a61ec41d7be47cc6b30
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0073" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1511,9 +1511,9 @@ niiri:e333891aa2a7cc8b78b7b091053068d6
     nidm_qValueFDR: "0.720222921163404"^^xsd:float ;
     nidm_clusterLabelId: "73"^^xsd:int .
 
-niiri:e333891aa2a7cc8b78b7b091053068d6 prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:713bd5e4d1057a61ec41d7be47cc6b30 prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:ae3b028a4da5be96010d12d3d7dfdafd
+niiri:f594ca28922a55744403546afac8880c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0074" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1523,9 +1523,9 @@ niiri:ae3b028a4da5be96010d12d3d7dfdafd
     nidm_qValueFDR: "0.720222921163404"^^xsd:float ;
     nidm_clusterLabelId: "74"^^xsd:int .
 
-niiri:ae3b028a4da5be96010d12d3d7dfdafd prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:f594ca28922a55744403546afac8880c prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:0f488c10355ed316636cfd8bb54904ac
+niiri:1f5837a9250f8adad81d9cf7febcb06c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0075" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1535,9 +1535,9 @@ niiri:0f488c10355ed316636cfd8bb54904ac
     nidm_qValueFDR: "0.720222921163404"^^xsd:float ;
     nidm_clusterLabelId: "75"^^xsd:int .
 
-niiri:0f488c10355ed316636cfd8bb54904ac prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:1f5837a9250f8adad81d9cf7febcb06c prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:b7030530775d914be5aedf430467d831
+niiri:4978ca959ffd9dac40bc74938928d142
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0076" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1547,9 +1547,9 @@ niiri:b7030530775d914be5aedf430467d831
     nidm_qValueFDR: "0.720222921163404"^^xsd:float ;
     nidm_clusterLabelId: "76"^^xsd:int .
 
-niiri:b7030530775d914be5aedf430467d831 prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:4978ca959ffd9dac40bc74938928d142 prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:caff2c2f2a15419f2f382bc662c24e14
+niiri:a8156b1e457954028b70ba39c8f61983
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0077" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1559,9 +1559,9 @@ niiri:caff2c2f2a15419f2f382bc662c24e14
     nidm_qValueFDR: "0.720222921163404"^^xsd:float ;
     nidm_clusterLabelId: "77"^^xsd:int .
 
-niiri:caff2c2f2a15419f2f382bc662c24e14 prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:a8156b1e457954028b70ba39c8f61983 prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:e65b059d6c1f15bf2f6b2d744c2f1518
+niiri:b00bd2c845defd49f3843980d3290639
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0078" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1571,9 +1571,9 @@ niiri:e65b059d6c1f15bf2f6b2d744c2f1518
     nidm_qValueFDR: "0.720222921163404"^^xsd:float ;
     nidm_clusterLabelId: "78"^^xsd:int .
 
-niiri:e65b059d6c1f15bf2f6b2d744c2f1518 prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:b00bd2c845defd49f3843980d3290639 prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:8ea6fb6f8438207d256aefd11c3b906b
+niiri:0d91d576d381385281f1b2d5d2714a3f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0079" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1583,9 +1583,9 @@ niiri:8ea6fb6f8438207d256aefd11c3b906b
     nidm_qValueFDR: "0.720222921163404"^^xsd:float ;
     nidm_clusterLabelId: "79"^^xsd:int .
 
-niiri:8ea6fb6f8438207d256aefd11c3b906b prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:0d91d576d381385281f1b2d5d2714a3f prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:700b2ca023302ca89c9a6e4ffdd8374f
+niiri:1505e0b207a3a8175cc0be4688a0d7c4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0080" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1595,9 +1595,9 @@ niiri:700b2ca023302ca89c9a6e4ffdd8374f
     nidm_qValueFDR: "0.720222921163404"^^xsd:float ;
     nidm_clusterLabelId: "80"^^xsd:int .
 
-niiri:700b2ca023302ca89c9a6e4ffdd8374f prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:1505e0b207a3a8175cc0be4688a0d7c4 prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:14e4f41a62e6164ce237a2e322e60826
+niiri:892dfa415e44d696ef37c9d6a5487e86
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0081" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1607,1824 +1607,1824 @@ niiri:14e4f41a62e6164ce237a2e322e60826
     nidm_qValueFDR: "0.720222921163404"^^xsd:float ;
     nidm_clusterLabelId: "81"^^xsd:int .
 
-niiri:14e4f41a62e6164ce237a2e322e60826 prov:wasDerivedFrom niiri:022626d941384b37aee63db114d7e263 .
+niiri:892dfa415e44d696ef37c9d6a5487e86 prov:wasDerivedFrom niiri:9b06d633f15370eacc4d439eebd44c49 .
 
-niiri:8c2011e2205ed468c4f35aa7c23ba0d5
+niiri:2c0961e66823d0b4915540ec2c8e75c3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0001" ;
-    prov:atLocation niiri:fe5c4fd20c90fb15f9b8589b0cb19caf ;
+    prov:atLocation niiri:19d8deadd2c75bbb63869efc69e89c37 ;
     prov:value "7.88613557815552"^^xsd:float ;
     nidm_equivalentZStatistic: "6.89124325286373"^^xsd:float ;
     nidm_pValueUncorrected: "2.76534350973634e-12"^^xsd:float ;
     nidm_pValueFWER: "6.16779698647818e-07"^^xsd:float ;
     nidm_qValueFDR: "7.48669482771332e-06"^^xsd:float .
 
-niiri:fe5c4fd20c90fb15f9b8589b0cb19caf
+niiri:19d8deadd2c75bbb63869efc69e89c37
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0001" ;
     nidm_coordinateVector: "[46,16,24]"^^xsd:string .
 
-niiri:8c2011e2205ed468c4f35aa7c23ba0d5 prov:wasDerivedFrom niiri:53b238f4a15796bb564f209e9a20f459 .
+niiri:2c0961e66823d0b4915540ec2c8e75c3 prov:wasDerivedFrom niiri:12d2dfb7ca155d963f6afeaa6467e598 .
 
-niiri:071bea4f427742579e7684f455db31a3
+niiri:dc3e0fe26c0acd9c6f782136679db557
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0002" ;
-    prov:atLocation niiri:fbcedf8ab584123788bab734421a5e0c ;
+    prov:atLocation niiri:c19d9f98cac285d054aacbe754152f42 ;
     prov:value "7.60659408569336"^^xsd:float ;
     nidm_equivalentZStatistic: "6.69768255888791"^^xsd:float ;
     nidm_pValueUncorrected: "1.05875308520353e-11"^^xsd:float ;
     nidm_pValueFWER: "2.36157334065901e-06"^^xsd:float ;
     nidm_qValueFDR: "1.28885586816361e-05"^^xsd:float .
 
-niiri:fbcedf8ab584123788bab734421a5e0c
+niiri:c19d9f98cac285d054aacbe754152f42
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0002" ;
     nidm_coordinateVector: "[34,24,-6]"^^xsd:string .
 
-niiri:071bea4f427742579e7684f455db31a3 prov:wasDerivedFrom niiri:53b238f4a15796bb564f209e9a20f459 .
+niiri:dc3e0fe26c0acd9c6f782136679db557 prov:wasDerivedFrom niiri:12d2dfb7ca155d963f6afeaa6467e598 .
 
-niiri:b2204b24486b0fd1f536d75033ffedea
+niiri:b44464753c802f3cbe64786acd87621a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0003" ;
-    prov:atLocation niiri:3afc3673cd6ac53aa12f250c5b0e8789 ;
+    prov:atLocation niiri:4e00d7c81778064e4ade195a69b9d59f ;
     prov:value "5.4533052444458"^^xsd:float ;
     nidm_equivalentZStatistic: "5.06995251985304"^^xsd:float ;
     nidm_pValueUncorrected: "1.98957479047301e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0321858214443789"^^xsd:float ;
     nidm_qValueFDR: "0.00847322777156312"^^xsd:float .
 
-niiri:3afc3673cd6ac53aa12f250c5b0e8789
+niiri:4e00d7c81778064e4ade195a69b9d59f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0003" ;
     nidm_coordinateVector: "[48,28,-14]"^^xsd:string .
 
-niiri:b2204b24486b0fd1f536d75033ffedea prov:wasDerivedFrom niiri:53b238f4a15796bb564f209e9a20f459 .
+niiri:b44464753c802f3cbe64786acd87621a prov:wasDerivedFrom niiri:12d2dfb7ca155d963f6afeaa6467e598 .
 
-niiri:7a4259089e9dd69fed1713edd46a91be
+niiri:022fa4480e152e0d59d498475f76b9f0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0004" ;
-    prov:atLocation niiri:e367487baf4427fb9ba1566a63a50817 ;
+    prov:atLocation niiri:6d6a35e598da08a187498457924b6d27 ;
     prov:value "6.8508505821228"^^xsd:float ;
     nidm_equivalentZStatistic: "6.15424052394884"^^xsd:float ;
     nidm_pValueUncorrected: "3.77190612077527e-10"^^xsd:float ;
     nidm_pValueFWER: "8.41349568295735e-05"^^xsd:float ;
     nidm_qValueFDR: "0.000225077260388439"^^xsd:float .
 
-niiri:e367487baf4427fb9ba1566a63a50817
+niiri:6d6a35e598da08a187498457924b6d27
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0004" ;
     nidm_coordinateVector: "[-8,12,52]"^^xsd:string .
 
-niiri:7a4259089e9dd69fed1713edd46a91be prov:wasDerivedFrom niiri:cfb21df261de4e6209165b310f0b8cb9 .
+niiri:022fa4480e152e0d59d498475f76b9f0 prov:wasDerivedFrom niiri:4c4f61059d1c51c5c453ad92e020752f .
 
-niiri:b9cc6bd680cdcc9ea05b4611d138fe48
+niiri:d38af59f91ea10608b21a454c3db1947
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0005" ;
-    prov:atLocation niiri:7026c6a83c6858cec46bdf75dc74326f ;
+    prov:atLocation niiri:b8b98649dacb9658c6e4145e79d32fa4 ;
     prov:value "6.70556163787842"^^xsd:float ;
     nidm_equivalentZStatistic: "6.04634484012323"^^xsd:float ;
     nidm_pValueUncorrected: "7.40843941748892e-10"^^xsd:float ;
     nidm_pValueFWER: "0.000165250377586079"^^xsd:float ;
     nidm_qValueFDR: "0.000249071340138561"^^xsd:float .
 
-niiri:7026c6a83c6858cec46bdf75dc74326f
+niiri:b8b98649dacb9658c6e4145e79d32fa4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0005" ;
     nidm_coordinateVector: "[8,20,48]"^^xsd:string .
 
-niiri:b9cc6bd680cdcc9ea05b4611d138fe48 prov:wasDerivedFrom niiri:cfb21df261de4e6209165b310f0b8cb9 .
+niiri:d38af59f91ea10608b21a454c3db1947 prov:wasDerivedFrom niiri:4c4f61059d1c51c5c453ad92e020752f .
 
-niiri:23ced658a0f882e4d2640c480347e555
+niiri:02b9e7ac9b6dc3a6cfd2bf8d3a3e5d52
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0006" ;
-    prov:atLocation niiri:eefcd3fdc1161f40fc80c6bb8a107df0 ;
+    prov:atLocation niiri:eead8fc2293f742ff4df91aaffb954e7 ;
     prov:value "5.89195346832275"^^xsd:float ;
     nidm_equivalentZStatistic: "5.42145878799783"^^xsd:float ;
     nidm_pValueUncorrected: "2.95573132635951e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00607574083875051"^^xsd:float ;
     nidm_qValueFDR: "0.00242918849696441"^^xsd:float .
 
-niiri:eefcd3fdc1161f40fc80c6bb8a107df0
+niiri:eead8fc2293f742ff4df91aaffb954e7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0006" ;
     nidm_coordinateVector: "[6,32,36]"^^xsd:string .
 
-niiri:23ced658a0f882e4d2640c480347e555 prov:wasDerivedFrom niiri:cfb21df261de4e6209165b310f0b8cb9 .
+niiri:02b9e7ac9b6dc3a6cfd2bf8d3a3e5d52 prov:wasDerivedFrom niiri:4c4f61059d1c51c5c453ad92e020752f .
 
-niiri:8c721ca02074789cc8f4d2a02b887b41
+niiri:4ef90c913a7c532cca2c6fd0f9681191
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0007" ;
-    prov:atLocation niiri:a43a97777ebdb4ce39296602eba0eee8 ;
+    prov:atLocation niiri:346c0c7ceec90148b035784c5b930f51 ;
     prov:value "6.71233081817627"^^xsd:float ;
     nidm_equivalentZStatistic: "6.05139656868728"^^xsd:float ;
     nidm_pValueUncorrected: "7.17977344244503e-10"^^xsd:float ;
     nidm_pValueFWER: "0.000160149822946543"^^xsd:float ;
     nidm_qValueFDR: "0.000249071340138561"^^xsd:float .
 
-niiri:a43a97777ebdb4ce39296602eba0eee8
+niiri:346c0c7ceec90148b035784c5b930f51
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0007" ;
     nidm_coordinateVector: "[32,-90,-2]"^^xsd:string .
 
-niiri:8c721ca02074789cc8f4d2a02b887b41 prov:wasDerivedFrom niiri:780f2f5e9d63466ad3c7345293e0fe5b .
+niiri:4ef90c913a7c532cca2c6fd0f9681191 prov:wasDerivedFrom niiri:3ed2649db2465ff69f88971b546dd3be .
 
-niiri:384474972c1b58360a8a2fcd9e0901de
+niiri:36703567cc1d92a9cb3e152dc40b85ce
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0008" ;
-    prov:atLocation niiri:32a1ff2c84613105934c95e42a36e4b8 ;
+    prov:atLocation niiri:f3c1332320c8a65eb857249d0977820a ;
     prov:value "6.07869148254395"^^xsd:float ;
     nidm_equivalentZStatistic: "5.56799434588466"^^xsd:float ;
     nidm_pValueUncorrected: "1.28844092062153e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00287395763954645"^^xsd:float ;
     nidm_qValueFDR: "0.00180477183683656"^^xsd:float .
 
-niiri:32a1ff2c84613105934c95e42a36e4b8
+niiri:f3c1332320c8a65eb857249d0977820a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0008" ;
     nidm_coordinateVector: "[44,-72,-10]"^^xsd:string .
 
-niiri:384474972c1b58360a8a2fcd9e0901de prov:wasDerivedFrom niiri:780f2f5e9d63466ad3c7345293e0fe5b .
+niiri:36703567cc1d92a9cb3e152dc40b85ce prov:wasDerivedFrom niiri:3ed2649db2465ff69f88971b546dd3be .
 
-niiri:eb5125f50058b0fe1dc51a3c0aef6983
+niiri:1aba48e406a0117ab013a8859ef28b04
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0009" ;
-    prov:atLocation niiri:70f9ba688514fb0a0defd1a1bd6b7917 ;
+    prov:atLocation niiri:b35f033a94a89bf6738d5c904bec2b9f ;
     prov:value "5.10857725143433"^^xsd:float ;
     nidm_equivalentZStatistic: "4.78656760604548"^^xsd:float ;
     nidm_pValueUncorrected: "8.48289032462368e-07"^^xsd:float ;
     nidm_pValueFWER: "0.108873252801375"^^xsd:float ;
     nidm_qValueFDR: "0.0180107935900568"^^xsd:float .
 
-niiri:70f9ba688514fb0a0defd1a1bd6b7917
+niiri:b35f033a94a89bf6738d5c904bec2b9f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0009" ;
     nidm_coordinateVector: "[28,-84,14]"^^xsd:string .
 
-niiri:eb5125f50058b0fe1dc51a3c0aef6983 prov:wasDerivedFrom niiri:780f2f5e9d63466ad3c7345293e0fe5b .
+niiri:1aba48e406a0117ab013a8859ef28b04 prov:wasDerivedFrom niiri:3ed2649db2465ff69f88971b546dd3be .
 
-niiri:f3383c28faeb655173bf2995e04855fb
+niiri:b5f5cf902b5b4771df855cfa8a376ac3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0010" ;
-    prov:atLocation niiri:3908520dcc2e14d02d9eab3148fc8a07 ;
+    prov:atLocation niiri:f972a1eedb64fa761afd328be838d631 ;
     prov:value "6.59459638595581"^^xsd:float ;
     nidm_equivalentZStatistic: "5.96318826880385"^^xsd:float ;
     nidm_pValueUncorrected: "1.23681564989653e-09"^^xsd:float ;
     nidm_pValueFWER: "0.000275880338890366"^^xsd:float ;
     nidm_qValueFDR: "0.00032995692182998"^^xsd:float .
 
-niiri:3908520dcc2e14d02d9eab3148fc8a07
+niiri:f972a1eedb64fa761afd328be838d631
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0010" ;
     nidm_coordinateVector: "[52,-32,42]"^^xsd:string .
 
-niiri:f3383c28faeb655173bf2995e04855fb prov:wasDerivedFrom niiri:2695c44ad8ef77b70e478006be76ec3b .
+niiri:b5f5cf902b5b4771df855cfa8a376ac3 prov:wasDerivedFrom niiri:19dfc0bbb201d5f134704921caf5a176 .
 
-niiri:3cc6a6e3471089d2fb2acf707242d17e
+niiri:89bc5cfcdef0a83dbaf0b1406beae51a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0011" ;
-    prov:atLocation niiri:bed6dc7f81a19e9aa36101f8e19ff3f2 ;
+    prov:atLocation niiri:378ef40da87eb0e81caffcf1aa603cd4 ;
     prov:value "6.12601184844971"^^xsd:float ;
     nidm_equivalentZStatistic: "5.6048323310884"^^xsd:float ;
     nidm_pValueUncorrected: "1.04228329300682e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00232488579535362"^^xsd:float ;
     nidm_qValueFDR: "0.00168019830542188"^^xsd:float .
 
-niiri:bed6dc7f81a19e9aa36101f8e19ff3f2
+niiri:378ef40da87eb0e81caffcf1aa603cd4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0011" ;
     nidm_coordinateVector: "[44,-70,50]"^^xsd:string .
 
-niiri:3cc6a6e3471089d2fb2acf707242d17e prov:wasDerivedFrom niiri:2695c44ad8ef77b70e478006be76ec3b .
+niiri:89bc5cfcdef0a83dbaf0b1406beae51a prov:wasDerivedFrom niiri:19dfc0bbb201d5f134704921caf5a176 .
 
-niiri:6b5426692f8fc30c257d8076b8f80f0b
+niiri:e9f1a1a5097af18399f0bd67a17a2cce
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0012" ;
-    prov:atLocation niiri:57e5df2ad0825e50532905e4eccad98a ;
+    prov:atLocation niiri:ef1b9d6e9d5073cf34fe3d947b0e48b9 ;
     prov:value "5.89449405670166"^^xsd:float ;
     nidm_equivalentZStatistic: "5.42346487564262"^^xsd:float ;
     nidm_pValueUncorrected: "2.92273529822751e-08"^^xsd:float ;
     nidm_pValueFWER: "0.0060156823124996"^^xsd:float ;
     nidm_qValueFDR: "0.00242918849696441"^^xsd:float .
 
-niiri:57e5df2ad0825e50532905e4eccad98a
+niiri:ef1b9d6e9d5073cf34fe3d947b0e48b9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0012" ;
     nidm_coordinateVector: "[40,-62,50]"^^xsd:string .
 
-niiri:6b5426692f8fc30c257d8076b8f80f0b prov:wasDerivedFrom niiri:2695c44ad8ef77b70e478006be76ec3b .
+niiri:e9f1a1a5097af18399f0bd67a17a2cce prov:wasDerivedFrom niiri:19dfc0bbb201d5f134704921caf5a176 .
 
-niiri:e488978bb4b1f52c9230d2f5097db9c1
+niiri:bd38db380ba41e0ce1675948a69b7682
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0013" ;
-    prov:atLocation niiri:cf20d034a9e3237f117fdbb72bb2cf70 ;
+    prov:atLocation niiri:4011c2782827b7caa0f649a873a23c28 ;
     prov:value "6.03912734985352"^^xsd:float ;
     nidm_equivalentZStatistic: "5.53710291953986"^^xsd:float ;
     nidm_pValueUncorrected: "1.53757930831944e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00340192895130376"^^xsd:float ;
     nidm_qValueFDR: "0.00190165765630454"^^xsd:float .
 
-niiri:cf20d034a9e3237f117fdbb72bb2cf70
+niiri:4011c2782827b7caa0f649a873a23c28
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0013" ;
     nidm_coordinateVector: "[-60,8,20]"^^xsd:string .
 
-niiri:e488978bb4b1f52c9230d2f5097db9c1 prov:wasDerivedFrom niiri:a4131faa6f9d63d587e81683f4525aa5 .
+niiri:bd38db380ba41e0ce1675948a69b7682 prov:wasDerivedFrom niiri:4ccbfde9cca6489f3110bef0431524c8 .
 
-niiri:42021911e82362627bbd5064efc113b4
+niiri:881e790fc7e1a6f81af66a18ac093075
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0014" ;
-    prov:atLocation niiri:320c3f376c5460a5ef805683acb42025 ;
+    prov:atLocation niiri:f6e4f3dcf4db8f79777bc1b1b3a328ab ;
     prov:value "5.83134031295776"^^xsd:float ;
     nidm_equivalentZStatistic: "5.37349584041984"^^xsd:float ;
     nidm_pValueUncorrected: "3.86122938067501e-08"^^xsd:float ;
     nidm_pValueFWER: "0.0076941885115317"^^xsd:float ;
     nidm_qValueFDR: "0.0026939300902738"^^xsd:float .
 
-niiri:320c3f376c5460a5ef805683acb42025
+niiri:f6e4f3dcf4db8f79777bc1b1b3a328ab
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0014" ;
     nidm_coordinateVector: "[-52,0,38]"^^xsd:string .
 
-niiri:42021911e82362627bbd5064efc113b4 prov:wasDerivedFrom niiri:a4131faa6f9d63d587e81683f4525aa5 .
+niiri:881e790fc7e1a6f81af66a18ac093075 prov:wasDerivedFrom niiri:4ccbfde9cca6489f3110bef0431524c8 .
 
-niiri:cf31a4865ea1af28c8e2e659a12ac34b
+niiri:e423ac92420c6449768391abb0fcedc9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0015" ;
-    prov:atLocation niiri:9f095b268dc4b7317eba04950dd041db ;
+    prov:atLocation niiri:b93252e9cd350f950d0cda71d2f9ebc7 ;
     prov:value "4.88419103622437"^^xsd:float ;
     nidm_equivalentZStatistic: "4.5987688944456"^^xsd:float ;
     nidm_pValueUncorrected: "2.12497457574568e-06"^^xsd:float ;
     nidm_pValueFWER: "0.22375640863328"^^xsd:float ;
     nidm_qValueFDR: "0.0290725545238754"^^xsd:float .
 
-niiri:9f095b268dc4b7317eba04950dd041db
+niiri:b93252e9cd350f950d0cda71d2f9ebc7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0015" ;
     nidm_coordinateVector: "[-46,6,28]"^^xsd:string .
 
-niiri:cf31a4865ea1af28c8e2e659a12ac34b prov:wasDerivedFrom niiri:a4131faa6f9d63d587e81683f4525aa5 .
+niiri:e423ac92420c6449768391abb0fcedc9 prov:wasDerivedFrom niiri:4ccbfde9cca6489f3110bef0431524c8 .
 
-niiri:e9a51b2eac641ac30c06796bdf1340cb
+niiri:edf2c8ccec7e4fd60e5909a7319ff0e6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0016" ;
-    prov:atLocation niiri:27e7ba757343881a748fdd85abfe17d8 ;
+    prov:atLocation niiri:9588b96c2d25cf9201a88c4be47c6c1d ;
     prov:value "5.9007363319397"^^xsd:float ;
     nidm_equivalentZStatistic: "5.42839241341132"^^xsd:float ;
     nidm_pValueUncorrected: "2.84319533472299e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00587055658900548"^^xsd:float ;
     nidm_qValueFDR: "0.00242918849696441"^^xsd:float .
 
-niiri:27e7ba757343881a748fdd85abfe17d8
+niiri:9588b96c2d25cf9201a88c4be47c6c1d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0016" ;
     nidm_coordinateVector: "[32,4,48]"^^xsd:string .
 
-niiri:e9a51b2eac641ac30c06796bdf1340cb prov:wasDerivedFrom niiri:f1484408d6648353b40e3f793d43ba98 .
+niiri:edf2c8ccec7e4fd60e5909a7319ff0e6 prov:wasDerivedFrom niiri:3621a50b575ca90dbe183bb31ff4ae4a .
 
-niiri:95088c2d8ffd46f3669857e0f4b096d5
+niiri:7c1ced347ec1ebede281534319058c3e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0017" ;
-    prov:atLocation niiri:b2c0b8c40937bcc536592b8863b23ad3 ;
+    prov:atLocation niiri:82ffb9c44210599420a6de41fd0d1109 ;
     prov:value "5.09700393676758"^^xsd:float ;
     nidm_equivalentZStatistic: "4.77694551087642"^^xsd:float ;
     nidm_pValueUncorrected: "8.8988987889671e-07"^^xsd:float ;
     nidm_pValueFWER: "0.113189315105649"^^xsd:float ;
     nidm_qValueFDR: "0.0180107935900568"^^xsd:float .
 
-niiri:b2c0b8c40937bcc536592b8863b23ad3
+niiri:82ffb9c44210599420a6de41fd0d1109
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0017" ;
     nidm_coordinateVector: "[40,24,48]"^^xsd:string .
 
-niiri:95088c2d8ffd46f3669857e0f4b096d5 prov:wasDerivedFrom niiri:f1484408d6648353b40e3f793d43ba98 .
+niiri:7c1ced347ec1ebede281534319058c3e prov:wasDerivedFrom niiri:3621a50b575ca90dbe183bb31ff4ae4a .
 
-niiri:1a8e05fc22f5aa6f473e39fa2ccd2c0c
+niiri:f17c1b76c4220010841c0f96ac1e3578
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0018" ;
-    prov:atLocation niiri:643e041750ee728554c920cfd5b116c8 ;
+    prov:atLocation niiri:ca3bb8d110a50afae2aead88e5bf0ca1 ;
     prov:value "4.34982109069824"^^xsd:float ;
     nidm_equivalentZStatistic: "4.14112597656651"^^xsd:float ;
     nidm_pValueUncorrected: "1.72802535455263e-05"^^xsd:float ;
     nidm_pValueFWER: "0.770025153200453"^^xsd:float ;
     nidm_qValueFDR: "0.120618056446103"^^xsd:float .
 
-niiri:643e041750ee728554c920cfd5b116c8
+niiri:ca3bb8d110a50afae2aead88e5bf0ca1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0018" ;
     nidm_coordinateVector: "[36,12,58]"^^xsd:string .
 
-niiri:1a8e05fc22f5aa6f473e39fa2ccd2c0c prov:wasDerivedFrom niiri:f1484408d6648353b40e3f793d43ba98 .
+niiri:f17c1b76c4220010841c0f96ac1e3578 prov:wasDerivedFrom niiri:3621a50b575ca90dbe183bb31ff4ae4a .
 
-niiri:714fa69947cd59c6835cdab3b75583fe
+niiri:dbb88a311a9de3b4bed9021fb15312f5
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0019" ;
-    prov:atLocation niiri:7372779136b70720b7b0ae181d3e41c3 ;
+    prov:atLocation niiri:02035963b589d505ac125194cd2ed04e ;
     prov:value "5.83802509307861"^^xsd:float ;
     nidm_equivalentZStatistic: "5.37879507210251"^^xsd:float ;
     nidm_pValueUncorrected: "3.74930015922814e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00749698476563887"^^xsd:float ;
     nidm_qValueFDR: "0.0026939300902738"^^xsd:float .
 
-niiri:7372779136b70720b7b0ae181d3e41c3
+niiri:02035963b589d505ac125194cd2ed04e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0019" ;
     nidm_coordinateVector: "[-28,-94,4]"^^xsd:string .
 
-niiri:714fa69947cd59c6835cdab3b75583fe prov:wasDerivedFrom niiri:f549b84e14efc1b6caac0a05e1a46c0d .
+niiri:dbb88a311a9de3b4bed9021fb15312f5 prov:wasDerivedFrom niiri:7698728db1c0c3e20b495f064a9d5b55 .
 
-niiri:f2fb13a784fffbece388d6bd7ec06eb6
+niiri:73e895f0d508d2c610d6a3c106ee0716
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0020" ;
-    prov:atLocation niiri:879ea167901069a60718b85f829a4cad ;
+    prov:atLocation niiri:d23dece0568269e4842ecb6bdd2c6313 ;
     prov:value "4.31375646591187"^^xsd:float ;
     nidm_equivalentZStatistic: "4.10972151362626"^^xsd:float ;
     nidm_pValueUncorrected: "1.98068279155805e-05"^^xsd:float ;
     nidm_pValueFWER: "0.80686639972725"^^xsd:float ;
     nidm_qValueFDR: "0.127448637088902"^^xsd:float .
 
-niiri:879ea167901069a60718b85f829a4cad
+niiri:d23dece0568269e4842ecb6bdd2c6313
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0020" ;
     nidm_coordinateVector: "[-32,-86,0]"^^xsd:string .
 
-niiri:f2fb13a784fffbece388d6bd7ec06eb6 prov:wasDerivedFrom niiri:f549b84e14efc1b6caac0a05e1a46c0d .
+niiri:73e895f0d508d2c610d6a3c106ee0716 prov:wasDerivedFrom niiri:7698728db1c0c3e20b495f064a9d5b55 .
 
-niiri:6e1a6aa978266fb830cf4d32afb6d7b5
+niiri:9a97546675f609fff6f0b719b74412c8
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0021" ;
-    prov:atLocation niiri:89d89b40909aeec6e9aea30261598f84 ;
+    prov:atLocation niiri:57074d3ea076ff46e82b94244cdb912d ;
     prov:value "3.64368534088135"^^xsd:float ;
     nidm_equivalentZStatistic: "3.51479672440726"^^xsd:float ;
     nidm_pValueUncorrected: "0.000220045357440024"^^xsd:float ;
     nidm_pValueFWER: "0.999986157595448"^^xsd:float ;
     nidm_qValueFDR: "0.455711975517369"^^xsd:float .
 
-niiri:89d89b40909aeec6e9aea30261598f84
+niiri:57074d3ea076ff46e82b94244cdb912d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0021" ;
     nidm_coordinateVector: "[-18,-92,6]"^^xsd:string .
 
-niiri:6e1a6aa978266fb830cf4d32afb6d7b5 prov:wasDerivedFrom niiri:f549b84e14efc1b6caac0a05e1a46c0d .
+niiri:9a97546675f609fff6f0b719b74412c8 prov:wasDerivedFrom niiri:7698728db1c0c3e20b495f064a9d5b55 .
 
-niiri:962fc6d94c839838915a9e3626147461
+niiri:f1fa028e954eb2428370317bd458e6d2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0022" ;
-    prov:atLocation niiri:15ff27094138e8ec92b8c1e7e07e84b5 ;
+    prov:atLocation niiri:f96d2bfba65dead2c46f9463120068d5 ;
     prov:value "5.49678039550781"^^xsd:float ;
     nidm_equivalentZStatistic: "5.10524655927297"^^xsd:float ;
     nidm_pValueUncorrected: "1.65181742173282e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0274162029530135"^^xsd:float ;
     nidm_qValueFDR: "0.00834610941271248"^^xsd:float .
 
-niiri:15ff27094138e8ec92b8c1e7e07e84b5
+niiri:f96d2bfba65dead2c46f9463120068d5
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0022" ;
     nidm_coordinateVector: "[-34,-2,52]"^^xsd:string .
 
-niiri:962fc6d94c839838915a9e3626147461 prov:wasDerivedFrom niiri:29fc425e622d8b8ded04fc6031eeff5d .
+niiri:f1fa028e954eb2428370317bd458e6d2 prov:wasDerivedFrom niiri:379c20fa5cd6aefb39cb7419f030f9e5 .
 
-niiri:b68df6e58131eeb0d2aaa7f6ef8a3c0c
+niiri:8d9046504d5d30f7a737d3c5422a2f49
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0023" ;
-    prov:atLocation niiri:fc6fe63052b7924151c57b49b1dde635 ;
+    prov:atLocation niiri:a84c78c0af5824b28fc28c2b26191cf6 ;
     prov:value "5.4477219581604"^^xsd:float ;
     nidm_equivalentZStatistic: "5.06541264724911"^^xsd:float ;
     nidm_pValueUncorrected: "2.03758308892077e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0328526754070724"^^xsd:float ;
     nidm_qValueFDR: "0.00847322777156312"^^xsd:float .
 
-niiri:fc6fe63052b7924151c57b49b1dde635
+niiri:a84c78c0af5824b28fc28c2b26191cf6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0023" ;
     nidm_coordinateVector: "[-58,-30,-18]"^^xsd:string .
 
-niiri:b68df6e58131eeb0d2aaa7f6ef8a3c0c prov:wasDerivedFrom niiri:ddb75d1dce61c969aca0b33e4792ae0c .
+niiri:8d9046504d5d30f7a737d3c5422a2f49 prov:wasDerivedFrom niiri:4257936a93608ef43291e047551e5e0a .
 
-niiri:c8c2b9d4bf8e1f00d52a528322b07233
+niiri:f28ae319db96c12f65d68cdf44c37228
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0024" ;
-    prov:atLocation niiri:c8ac24d80011470a9cfa9933360dd6e8 ;
+    prov:atLocation niiri:f6c38af20f2cc671e453a64d27f31859 ;
     prov:value "5.28879737854004"^^xsd:float ;
     nidm_equivalentZStatistic: "4.93549802722869"^^xsd:float ;
     nidm_pValueUncorrected: "3.99732443923106e-07"^^xsd:float ;
     nidm_pValueFWER: "0.058332304236273"^^xsd:float ;
     nidm_qValueFDR: "0.0124221993559286"^^xsd:float .
 
-niiri:c8ac24d80011470a9cfa9933360dd6e8
+niiri:f6c38af20f2cc671e453a64d27f31859
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0024" ;
     nidm_coordinateVector: "[-62,-36,48]"^^xsd:string .
 
-niiri:c8c2b9d4bf8e1f00d52a528322b07233 prov:wasDerivedFrom niiri:9fd20bfdc1412e227a54f54ed45d5054 .
+niiri:f28ae319db96c12f65d68cdf44c37228 prov:wasDerivedFrom niiri:7017960274f85788b6b607f7d0046a76 .
 
-niiri:7040757a9ca777a1ca655c03cc4d41fd
+niiri:307f5f8fa2312eb0133eaf4fffbbeb80
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0025" ;
-    prov:atLocation niiri:7069f38da8f59b73a94c4ca24a4b8295 ;
+    prov:atLocation niiri:f0410a98f2844fad2156dd8693b4188f ;
     prov:value "5.07126235961914"^^xsd:float ;
     nidm_equivalentZStatistic: "4.7555187910417"^^xsd:float ;
     nidm_pValueUncorrected: "9.89687234609349e-07"^^xsd:float ;
     nidm_pValueFWER: "0.123339755499162"^^xsd:float ;
     nidm_qValueFDR: "0.0187591962334509"^^xsd:float .
 
-niiri:7069f38da8f59b73a94c4ca24a4b8295
+niiri:f0410a98f2844fad2156dd8693b4188f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0025" ;
     nidm_coordinateVector: "[-60,-50,48]"^^xsd:string .
 
-niiri:7040757a9ca777a1ca655c03cc4d41fd prov:wasDerivedFrom niiri:9fd20bfdc1412e227a54f54ed45d5054 .
+niiri:307f5f8fa2312eb0133eaf4fffbbeb80 prov:wasDerivedFrom niiri:7017960274f85788b6b607f7d0046a76 .
 
-niiri:d2ba7095e5b6f91c6352fbfb87a4fa62
+niiri:a9639fbdbb1c26aee4c14242d935b468
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0026" ;
-    prov:atLocation niiri:1d888cfd09eba5c400d1b55ff180d5cf ;
+    prov:atLocation niiri:32781cc47551b5a832493146ff9c76da ;
     prov:value "5.20113325119019"^^xsd:float ;
     nidm_equivalentZStatistic: "4.86326687921491"^^xsd:float ;
     nidm_pValueUncorrected: "5.77319983152691e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0793447375400678"^^xsd:float ;
     nidm_qValueFDR: "0.0159079887522274"^^xsd:float .
 
-niiri:1d888cfd09eba5c400d1b55ff180d5cf
+niiri:32781cc47551b5a832493146ff9c76da
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0026" ;
     nidm_coordinateVector: "[32,40,16]"^^xsd:string .
 
-niiri:d2ba7095e5b6f91c6352fbfb87a4fa62 prov:wasDerivedFrom niiri:f0f0748bbb9066bab45490e1ba8fef31 .
+niiri:a9639fbdbb1c26aee4c14242d935b468 prov:wasDerivedFrom niiri:a48da6310356eb94f99b1f1eb464e14b .
 
-niiri:1a90c94823489843eaef3560026a07b2
+niiri:1be33bac5492f3fdf9b7077a2b1176d4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0027" ;
-    prov:atLocation niiri:179eec3c1632e860b697e1ec02b244ef ;
+    prov:atLocation niiri:3e74e91d33b6b30b2f135558c37b59ca ;
     prov:value "4.20966386795044"^^xsd:float ;
     nidm_equivalentZStatistic: "4.01871912540871"^^xsd:float ;
     nidm_pValueUncorrected: "2.92576874012518e-05"^^xsd:float ;
     nidm_pValueFWER: "0.895902731954404"^^xsd:float ;
     nidm_qValueFDR: "0.157816499218783"^^xsd:float .
 
-niiri:179eec3c1632e860b697e1ec02b244ef
+niiri:3e74e91d33b6b30b2f135558c37b59ca
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0027" ;
     nidm_coordinateVector: "[36,54,10]"^^xsd:string .
 
-niiri:1a90c94823489843eaef3560026a07b2 prov:wasDerivedFrom niiri:f0f0748bbb9066bab45490e1ba8fef31 .
+niiri:1be33bac5492f3fdf9b7077a2b1176d4 prov:wasDerivedFrom niiri:a48da6310356eb94f99b1f1eb464e14b .
 
-niiri:3b48fce461eb5c4f30ca5336d6229d5b
+niiri:e24f477da65372897130f7d2cb1485f9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0028" ;
-    prov:atLocation niiri:32e153dc173a6b545e34387a0e12b3e7 ;
+    prov:atLocation niiri:52e3b66db0b4b363b3aef5d680cb3d38 ;
     prov:value "4.03298187255859"^^xsd:float ;
     nidm_equivalentZStatistic: "3.86304409189175"^^xsd:float ;
     nidm_pValueUncorrected: "5.59913929287781e-05"^^xsd:float ;
     nidm_pValueFWER: "0.978124547666055"^^xsd:float ;
     nidm_qValueFDR: "0.219902724174057"^^xsd:float .
 
-niiri:32e153dc173a6b545e34387a0e12b3e7
+niiri:52e3b66db0b4b363b3aef5d680cb3d38
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0028" ;
     nidm_coordinateVector: "[40,44,26]"^^xsd:string .
 
-niiri:3b48fce461eb5c4f30ca5336d6229d5b prov:wasDerivedFrom niiri:f0f0748bbb9066bab45490e1ba8fef31 .
+niiri:e24f477da65372897130f7d2cb1485f9 prov:wasDerivedFrom niiri:a48da6310356eb94f99b1f1eb464e14b .
 
-niiri:92237d84748d6f3f8c6b981716eba365
+niiri:9692edf724b92ae14d3e441c312e65cc
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0029" ;
-    prov:atLocation niiri:83dff9c3cca90de02ae8b211edee7a74 ;
+    prov:atLocation niiri:92b1a1b46104a64097b99dd6e7ca8b2b ;
     prov:value "5.13718748092651"^^xsd:float ;
     nidm_equivalentZStatistic: "4.81032420567012"^^xsd:float ;
     nidm_pValueUncorrected: "7.53428407773704e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0988296994641761"^^xsd:float ;
     nidm_qValueFDR: "0.0175971158742543"^^xsd:float .
 
-niiri:83dff9c3cca90de02ae8b211edee7a74
+niiri:92b1a1b46104a64097b99dd6e7ca8b2b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0029" ;
     nidm_coordinateVector: "[-54,-46,58]"^^xsd:string .
 
-niiri:92237d84748d6f3f8c6b981716eba365 prov:wasDerivedFrom niiri:90b4dda7962081808845a0f3dcd7ea91 .
+niiri:9692edf724b92ae14d3e441c312e65cc prov:wasDerivedFrom niiri:ada43746a7be5361f1b2127ddc7152ba .
 
-niiri:e27a5b9903f7214c4043fb9b311140d8
+niiri:614f41f29f9cf9d39c5a6367956b6357
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0030" ;
-    prov:atLocation niiri:5368f1bafa1cdcb731c02d2882a686f5 ;
+    prov:atLocation niiri:daf4cabbd0bebc79beea7b9974028396 ;
     prov:value "4.99936532974243"^^xsd:float ;
     nidm_equivalentZStatistic: "4.69549029807528"^^xsd:float ;
     nidm_pValueUncorrected: "1.32983996270486e-06"^^xsd:float ;
     nidm_pValueFWER: "0.156049412961254"^^xsd:float ;
     nidm_qValueFDR: "0.022013679767251"^^xsd:float .
 
-niiri:5368f1bafa1cdcb731c02d2882a686f5
+niiri:daf4cabbd0bebc79beea7b9974028396
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0030" ;
     nidm_coordinateVector: "[-36,-74,-34]"^^xsd:string .
 
-niiri:e27a5b9903f7214c4043fb9b311140d8 prov:wasDerivedFrom niiri:dba4c7441ba091562d6318495ccd506b .
+niiri:614f41f29f9cf9d39c5a6367956b6357 prov:wasDerivedFrom niiri:1c73b53acc2e3706c7dcdd4e4ed9e043 .
 
-niiri:267f4307b61db4da72cc002b7230f73b
+niiri:9e657853abbaa2650f24166bf90f5a81
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0031" ;
-    prov:atLocation niiri:5dc94dda962cb792f857e921d307b625 ;
+    prov:atLocation niiri:4558ece5294ed109fda5b20c0acd7480 ;
     prov:value "4.7462682723999"^^xsd:float ;
     nidm_equivalentZStatistic: "4.4820421310153"^^xsd:float ;
     nidm_pValueUncorrected: "3.69660714449882e-06"^^xsd:float ;
     nidm_pValueFWER: "0.333239579597568"^^xsd:float ;
     nidm_qValueFDR: "0.0434977534015138"^^xsd:float .
 
-niiri:5dc94dda962cb792f857e921d307b625
+niiri:4558ece5294ed109fda5b20c0acd7480
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0031" ;
     nidm_coordinateVector: "[-36,-74,-14]"^^xsd:string .
 
-niiri:267f4307b61db4da72cc002b7230f73b prov:wasDerivedFrom niiri:64445ad0b45313551f83199c04675195 .
+niiri:9e657853abbaa2650f24166bf90f5a81 prov:wasDerivedFrom niiri:655978b5bff261f0bf396a1ddf498402 .
 
-niiri:876e16d1a925e329e869d825ab936517
+niiri:2e831d1e6888a2d6174ba7de8443f206
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0032" ;
-    prov:atLocation niiri:068ab6c480d2cc19beff86341a70859b ;
+    prov:atLocation niiri:3e60ee8d583858acc7f1b33e4313f57d ;
     prov:value "4.14389324188232"^^xsd:float ;
     nidm_equivalentZStatistic: "3.96094551523189"^^xsd:float ;
     nidm_pValueUncorrected: "3.73267835663826e-05"^^xsd:float ;
     nidm_pValueFWER: "0.93653316357533"^^xsd:float ;
     nidm_qValueFDR: "0.176857016686839"^^xsd:float .
 
-niiri:068ab6c480d2cc19beff86341a70859b
+niiri:3e60ee8d583858acc7f1b33e4313f57d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0032" ;
     nidm_coordinateVector: "[-36,-68,-20]"^^xsd:string .
 
-niiri:876e16d1a925e329e869d825ab936517 prov:wasDerivedFrom niiri:64445ad0b45313551f83199c04675195 .
+niiri:2e831d1e6888a2d6174ba7de8443f206 prov:wasDerivedFrom niiri:655978b5bff261f0bf396a1ddf498402 .
 
-niiri:7e80a9cfd879b25b0fd51b485bdca983
+niiri:ed3b1a53734192dd232c2ea8bb681cb6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0033" ;
-    prov:atLocation niiri:ecb8277acf6f3ee57c04aac0f4c251f6 ;
+    prov:atLocation niiri:40b108d5097b549d75db0c77387e1498 ;
     prov:value "3.64391040802002"^^xsd:float ;
     nidm_equivalentZStatistic: "3.51500008532851"^^xsd:float ;
     nidm_pValueUncorrected: "0.000219876923486684"^^xsd:float ;
     nidm_pValueFWER: "0.99998606648459"^^xsd:float ;
     nidm_qValueFDR: "0.455711975517369"^^xsd:float .
 
-niiri:ecb8277acf6f3ee57c04aac0f4c251f6
+niiri:40b108d5097b549d75db0c77387e1498
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0033" ;
     nidm_coordinateVector: "[-30,-60,-16]"^^xsd:string .
 
-niiri:7e80a9cfd879b25b0fd51b485bdca983 prov:wasDerivedFrom niiri:64445ad0b45313551f83199c04675195 .
+niiri:ed3b1a53734192dd232c2ea8bb681cb6 prov:wasDerivedFrom niiri:655978b5bff261f0bf396a1ddf498402 .
 
-niiri:eea76345d819ddb84d70309298fdc5ef
+niiri:85627026074aa1f753b1ba3a22383b49
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0034" ;
-    prov:atLocation niiri:3d26739f1b78d5891209231c981f476f ;
+    prov:atLocation niiri:4129b86d91f37cbd3cfd85da48f13011 ;
     prov:value "4.72862100601196"^^xsd:float ;
     nidm_equivalentZStatistic: "4.46703637029677"^^xsd:float ;
     nidm_pValueUncorrected: "3.96553251347243e-06"^^xsd:float ;
     nidm_pValueFWER: "0.349567174180407"^^xsd:float ;
     nidm_qValueFDR: "0.0444488399275926"^^xsd:float .
 
-niiri:3d26739f1b78d5891209231c981f476f
+niiri:4129b86d91f37cbd3cfd85da48f13011
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0034" ;
     nidm_coordinateVector: "[-36,-40,-36]"^^xsd:string .
 
-niiri:eea76345d819ddb84d70309298fdc5ef prov:wasDerivedFrom niiri:bb07405375d86eb7d0603ec3197e08aa .
+niiri:85627026074aa1f753b1ba3a22383b49 prov:wasDerivedFrom niiri:7dd3c3ae219e2bf1ef8176af9cc60fb9 .
 
-niiri:452d9b09d7396a9f81a5b87912bff906
+niiri:5b0b1185c630b975f1f9cad7d863bc1c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0035" ;
-    prov:atLocation niiri:f864956bd553611927d721a757c5205e ;
+    prov:atLocation niiri:f2ec576f7b577cf6e622416723b53710 ;
     prov:value "4.67978620529175"^^xsd:float ;
     nidm_equivalentZStatistic: "4.42542829210121"^^xsd:float ;
     nidm_pValueUncorrected: "4.81255631634703e-06"^^xsd:float ;
     nidm_pValueFWER: "0.397360911613874"^^xsd:float ;
     nidm_qValueFDR: "0.0513842337520043"^^xsd:float .
 
-niiri:f864956bd553611927d721a757c5205e
+niiri:f2ec576f7b577cf6e622416723b53710
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0035" ;
     nidm_coordinateVector: "[-60,-16,26]"^^xsd:string .
 
-niiri:452d9b09d7396a9f81a5b87912bff906 prov:wasDerivedFrom niiri:c3428421b6744ab712756818f68e34b1 .
+niiri:5b0b1185c630b975f1f9cad7d863bc1c prov:wasDerivedFrom niiri:c96857fd42e1208395989b05eeab7a76 .
 
-niiri:6976e4a8741e464109bad66646a99778
+niiri:fab4182c9396833dae1da711b91f9451
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0036" ;
-    prov:atLocation niiri:f353b396c05bc94f28065bda9ac87d70 ;
+    prov:atLocation niiri:decf85102aef6761a4506398e5303491 ;
     prov:value "4.54088401794434"^^xsd:float ;
     nidm_equivalentZStatistic: "4.30641743150185"^^xsd:float ;
     nidm_pValueUncorrected: "8.29599105278689e-06"^^xsd:float ;
     nidm_pValueFWER: "0.55051926533838"^^xsd:float ;
     nidm_qValueFDR: "0.0758424529215363"^^xsd:float .
 
-niiri:f353b396c05bc94f28065bda9ac87d70
+niiri:decf85102aef6761a4506398e5303491
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0036" ;
     nidm_coordinateVector: "[50,-46,-12]"^^xsd:string .
 
-niiri:6976e4a8741e464109bad66646a99778 prov:wasDerivedFrom niiri:b1e2ccb2a24225ae9297eb35470b2ef2 .
+niiri:fab4182c9396833dae1da711b91f9451 prov:wasDerivedFrom niiri:7a24a2bdbc61f7d8ab6a59738a57c24a .
 
-niiri:055e6c9815fd249e085a1c8b2513c464
+niiri:7e5c9c348e6bd97291db1b67455a7a1f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0037" ;
-    prov:atLocation niiri:d6646951cc4cd490b932d5d5aaff3a2d ;
+    prov:atLocation niiri:ec230d092645e527086b2f1dce92ba08 ;
     prov:value "4.51589822769165"^^xsd:float ;
     nidm_equivalentZStatistic: "4.28490600256073"^^xsd:float ;
     nidm_pValueUncorrected: "9.14082329439569e-06"^^xsd:float ;
     nidm_pValueFWER: "0.57981317377907"^^xsd:float ;
     nidm_qValueFDR: "0.0805429568785394"^^xsd:float .
 
-niiri:d6646951cc4cd490b932d5d5aaff3a2d
+niiri:ec230d092645e527086b2f1dce92ba08
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0037" ;
     nidm_coordinateVector: "[60,-34,-8]"^^xsd:string .
 
-niiri:055e6c9815fd249e085a1c8b2513c464 prov:wasDerivedFrom niiri:b1e2ccb2a24225ae9297eb35470b2ef2 .
+niiri:7e5c9c348e6bd97291db1b67455a7a1f prov:wasDerivedFrom niiri:7a24a2bdbc61f7d8ab6a59738a57c24a .
 
-niiri:e099daf51f20dabc5419c618d55cc84c
+niiri:597a607f2ee07200862c89760cd037fb
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0038" ;
-    prov:atLocation niiri:dcb827ef44b14c270428f7f5af60b5d4 ;
+    prov:atLocation niiri:cd92b44ba264e7cc475ed0b679367114 ;
     prov:value "4.19524717330933"^^xsd:float ;
     nidm_equivalentZStatistic: "4.00607343097259"^^xsd:float ;
     nidm_pValueUncorrected: "3.08682317079478e-05"^^xsd:float ;
     nidm_pValueFWER: "0.905888940180749"^^xsd:float ;
     nidm_qValueFDR: "0.162816132797782"^^xsd:float .
 
-niiri:dcb827ef44b14c270428f7f5af60b5d4
+niiri:cd92b44ba264e7cc475ed0b679367114
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0038" ;
     nidm_coordinateVector: "[56,-24,-2]"^^xsd:string .
 
-niiri:e099daf51f20dabc5419c618d55cc84c prov:wasDerivedFrom niiri:b1e2ccb2a24225ae9297eb35470b2ef2 .
+niiri:597a607f2ee07200862c89760cd037fb prov:wasDerivedFrom niiri:7a24a2bdbc61f7d8ab6a59738a57c24a .
 
-niiri:41395efbdd9161254d3e7e8d187a9973
+niiri:a224964e93d3f6e2fff1835428d41f0b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0039" ;
-    prov:atLocation niiri:88a50a520abaaee3fd4b820c9e7299a6 ;
+    prov:atLocation niiri:8f8db5ccf86c390cbae3a936ccb3061c ;
     prov:value "4.51116132736206"^^xsd:float ;
     nidm_equivalentZStatistic: "4.28082423475359"^^xsd:float ;
     nidm_pValueUncorrected: "9.31011908622548e-06"^^xsd:float ;
     nidm_pValueFWER: "0.585391408801539"^^xsd:float ;
     nidm_qValueFDR: "0.0805429568785394"^^xsd:float .
 
-niiri:88a50a520abaaee3fd4b820c9e7299a6
+niiri:8f8db5ccf86c390cbae3a936ccb3061c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0039" ;
     nidm_coordinateVector: "[-50,-60,54]"^^xsd:string .
 
-niiri:41395efbdd9161254d3e7e8d187a9973 prov:wasDerivedFrom niiri:1c943c00f3f2e54e795e080b9d85859d .
+niiri:a224964e93d3f6e2fff1835428d41f0b prov:wasDerivedFrom niiri:c313dfc1d990322089b2bf63a219f16a .
 
-niiri:23907cd2cf132152d4d44a81416b52e1
+niiri:33db15418b3eeb72fb3bb39cca81f286
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0040" ;
-    prov:atLocation niiri:7884ffb448fbacbb5b22b29865ef146e ;
+    prov:atLocation niiri:5d62c65dd629aae3c79e44863f4a799b ;
     prov:value "4.4765510559082"^^xsd:float ;
     nidm_equivalentZStatistic: "4.25096642679651"^^xsd:float ;
     nidm_pValueUncorrected: "1.06425037911251e-05"^^xsd:float ;
     nidm_pValueFWER: "0.626226729794128"^^xsd:float ;
     nidm_qValueFDR: "0.0885762871613676"^^xsd:float .
 
-niiri:7884ffb448fbacbb5b22b29865ef146e
+niiri:5d62c65dd629aae3c79e44863f4a799b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0040" ;
     nidm_coordinateVector: "[16,14,64]"^^xsd:string .
 
-niiri:23907cd2cf132152d4d44a81416b52e1 prov:wasDerivedFrom niiri:663b1f9b98b62235a966f9f1c5d82cb9 .
+niiri:33db15418b3eeb72fb3bb39cca81f286 prov:wasDerivedFrom niiri:36e697e6ea3e7a7c4a67a505ebe4f340 .
 
-niiri:fbc2d4dfc55166343559ff0cebc38c1b
+niiri:81a9099168b6634f2d230e469992c262
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0041" ;
-    prov:atLocation niiri:ae99486ea14d7a23320257512769f605 ;
+    prov:atLocation niiri:7d660acd245b9915dfc57669b02266cc ;
     prov:value "4.44478893280029"^^xsd:float ;
     nidm_equivalentZStatistic: "4.22351271935081"^^xsd:float ;
     nidm_pValueUncorrected: "1.20261894772655e-05"^^xsd:float ;
     nidm_pValueFWER: "0.663529330330023"^^xsd:float ;
     nidm_qValueFDR: "0.0964832831947511"^^xsd:float .
 
-niiri:ae99486ea14d7a23320257512769f605
+niiri:7d660acd245b9915dfc57669b02266cc
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0041" ;
     nidm_coordinateVector: "[-46,-66,-6]"^^xsd:string .
 
-niiri:fbc2d4dfc55166343559ff0cebc38c1b prov:wasDerivedFrom niiri:dcb1f3bd84b360ab8e8024d363c5a710 .
+niiri:81a9099168b6634f2d230e469992c262 prov:wasDerivedFrom niiri:ca1016af733ba1294614bfd4483de412 .
 
-niiri:a2ddb6595db38bd193b22a48a684d46e
+niiri:17c4f6eb3f8f149b496425d877516f57
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0042" ;
-    prov:atLocation niiri:46ac02735e9f404103690f54ac6a2e17 ;
+    prov:atLocation niiri:957ba3e02ba9f7541dd7ea4cefdd9417 ;
     prov:value "3.7491512298584"^^xsd:float ;
     nidm_equivalentZStatistic: "3.60983821739614"^^xsd:float ;
     nidm_pValueUncorrected: "0.000153194020339198"^^xsd:float ;
     nidm_pValueFWER: "0.999788466860359"^^xsd:float ;
     nidm_qValueFDR: "0.372479477261378"^^xsd:float .
 
-niiri:46ac02735e9f404103690f54ac6a2e17
+niiri:957ba3e02ba9f7541dd7ea4cefdd9417
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0042" ;
     nidm_coordinateVector: "[-54,-64,-8]"^^xsd:string .
 
-niiri:a2ddb6595db38bd193b22a48a684d46e prov:wasDerivedFrom niiri:dcb1f3bd84b360ab8e8024d363c5a710 .
+niiri:17c4f6eb3f8f149b496425d877516f57 prov:wasDerivedFrom niiri:ca1016af733ba1294614bfd4483de412 .
 
-niiri:87c3e25eefd7f8f64f744a0782f0db22
+niiri:c953467c30386a10432f64759c9bb8fd
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0043" ;
-    prov:atLocation niiri:457ddb16da4054b4d082af48dd946ecf ;
+    prov:atLocation niiri:c59f67096c4b44b8b8297453390de1f8 ;
     prov:value "4.31687879562378"^^xsd:float ;
     nidm_equivalentZStatistic: "4.11244293455755"^^xsd:float ;
     nidm_pValueUncorrected: "1.95747130057322e-05"^^xsd:float ;
     nidm_pValueFWER: "0.803781550096335"^^xsd:float ;
     nidm_qValueFDR: "0.127448637088902"^^xsd:float .
 
-niiri:457ddb16da4054b4d082af48dd946ecf
+niiri:c59f67096c4b44b8b8297453390de1f8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0043" ;
     nidm_coordinateVector: "[-14,-98,-4]"^^xsd:string .
 
-niiri:87c3e25eefd7f8f64f744a0782f0db22 prov:wasDerivedFrom niiri:d5ec0fb74bfe81761c80eb8c08942466 .
+niiri:c953467c30386a10432f64759c9bb8fd prov:wasDerivedFrom niiri:b4290f172c2ebe815ddf64763f6e95e4 .
 
-niiri:7a46567fbaf54f67faa965af4c842832
+niiri:d71e3f367869829805aa71ff8bc7ef74
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0044" ;
-    prov:atLocation niiri:d041758727ae46806768921d5143d522 ;
+    prov:atLocation niiri:82a52b17a12ba7eb6db09eeafbf4fcce ;
     prov:value "4.24778032302856"^^xsd:float ;
     nidm_equivalentZStatistic: "4.0521041277855"^^xsd:float ;
     nidm_pValueUncorrected: "2.53795317693983e-05"^^xsd:float ;
     nidm_pValueFWER: "0.866634079797035"^^xsd:float ;
     nidm_qValueFDR: "0.146768392895167"^^xsd:float .
 
-niiri:d041758727ae46806768921d5143d522
+niiri:82a52b17a12ba7eb6db09eeafbf4fcce
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0044" ;
     nidm_coordinateVector: "[-40,-40,44]"^^xsd:string .
 
-niiri:7a46567fbaf54f67faa965af4c842832 prov:wasDerivedFrom niiri:dea3ebd7d53b9bdeb45e3fcbd12ef78f .
+niiri:d71e3f367869829805aa71ff8bc7ef74 prov:wasDerivedFrom niiri:94f389f115646fc7441e8fd9bf5ec119 .
 
-niiri:1ddf9076db1e3fdf9f2b2dd4e071445d
+niiri:5c807bc9934434717c54df9aa0633275
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0045" ;
-    prov:atLocation niiri:ae09c7158dbfdfd6a108b27a0654d6f0 ;
+    prov:atLocation niiri:c29990573704aecde0476b3c3877f96c ;
     prov:value "4.23215198516846"^^xsd:float ;
     nidm_equivalentZStatistic: "4.03842438550801"^^xsd:float ;
     nidm_pValueUncorrected: "2.6905716773884e-05"^^xsd:float ;
     nidm_pValueFWER: "0.879129904028547"^^xsd:float ;
     nidm_qValueFDR: "0.151175083557511"^^xsd:float .
 
-niiri:ae09c7158dbfdfd6a108b27a0654d6f0
+niiri:c29990573704aecde0476b3c3877f96c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0045" ;
     nidm_coordinateVector: "[22,38,12]"^^xsd:string .
 
-niiri:1ddf9076db1e3fdf9f2b2dd4e071445d prov:wasDerivedFrom niiri:7576ce49bb83c1b874dc86b48878d37f .
+niiri:5c807bc9934434717c54df9aa0633275 prov:wasDerivedFrom niiri:7322fa4ccee32301d807a0b9f48ae02a .
 
-niiri:e690ada88ee99e4df6c72fc539716ff4
+niiri:11314fb1e4bc9f2012db889602ef5ff2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0046" ;
-    prov:atLocation niiri:c36559ffbaf05c6691d8765722c9633e ;
+    prov:atLocation niiri:f117d9dc89b4a5963c653b2a0d8239cb ;
     prov:value "4.18517589569092"^^xsd:float ;
     nidm_equivalentZStatistic: "3.99723331404289"^^xsd:float ;
     nidm_pValueUncorrected: "3.20435639625805e-05"^^xsd:float ;
     nidm_pValueFWER: "0.912505594315002"^^xsd:float ;
     nidm_qValueFDR: "0.163982158985541"^^xsd:float .
 
-niiri:c36559ffbaf05c6691d8765722c9633e
+niiri:f117d9dc89b4a5963c653b2a0d8239cb
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0046" ;
     nidm_coordinateVector: "[-50,-52,-18]"^^xsd:string .
 
-niiri:e690ada88ee99e4df6c72fc539716ff4 prov:wasDerivedFrom niiri:cd03d29014d461350222c98300667843 .
+niiri:11314fb1e4bc9f2012db889602ef5ff2 prov:wasDerivedFrom niiri:c47c40f4ed2261336524231fb9108598 .
 
-niiri:7d8f63a82c119daaf2afab4bf3ac06c2
+niiri:c6737de02555142d2e915210fc79d292
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0047" ;
-    prov:atLocation niiri:e24c92503be7f0b2f9dd799084c58154 ;
+    prov:atLocation niiri:dd04ce53e197fa1cb75e0dd575d45c3e ;
     prov:value "4.12498378753662"^^xsd:float ;
     nidm_equivalentZStatistic: "3.94429624410211"^^xsd:float ;
     nidm_pValueUncorrected: "4.00173349958122e-05"^^xsd:float ;
     nidm_pValueFWER: "0.945901344028104"^^xsd:float ;
     nidm_qValueFDR: "0.182896629256048"^^xsd:float .
 
-niiri:e24c92503be7f0b2f9dd799084c58154
+niiri:dd04ce53e197fa1cb75e0dd575d45c3e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0047" ;
     nidm_coordinateVector: "[-36,-48,-18]"^^xsd:string .
 
-niiri:7d8f63a82c119daaf2afab4bf3ac06c2 prov:wasDerivedFrom niiri:cd03d29014d461350222c98300667843 .
+niiri:c6737de02555142d2e915210fc79d292 prov:wasDerivedFrom niiri:c47c40f4ed2261336524231fb9108598 .
 
-niiri:05dfbc43da831c04830c1025f33c1cdd
+niiri:0ff26bd6b3a8873a52756070401ef6f8
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0048" ;
-    prov:atLocation niiri:7d0e502a1a660044dd8f7a9f7e1b277a ;
+    prov:atLocation niiri:39f123da883019b5511ae2b52eca03b6 ;
     prov:value "4.11004066467285"^^xsd:float ;
     nidm_equivalentZStatistic: "3.93112694489083"^^xsd:float ;
     nidm_pValueUncorrected: "4.22743058098307e-05"^^xsd:float ;
     nidm_pValueFWER: "0.952599821815146"^^xsd:float ;
     nidm_qValueFDR: "0.189060437644636"^^xsd:float .
 
-niiri:7d0e502a1a660044dd8f7a9f7e1b277a
+niiri:39f123da883019b5511ae2b52eca03b6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0048" ;
     nidm_coordinateVector: "[60,-26,-28]"^^xsd:string .
 
-niiri:05dfbc43da831c04830c1025f33c1cdd prov:wasDerivedFrom niiri:5e2e4f5da7c8d5550caebb447ece90bb .
+niiri:0ff26bd6b3a8873a52756070401ef6f8 prov:wasDerivedFrom niiri:6c58a61aff8d76d3d5cdef392c46c0f7 .
 
-niiri:4081a2194723009110061ee43bb061d9
+niiri:d5151f32682a8c00255e289f2ab66642
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0049" ;
-    prov:atLocation niiri:0f2ddb2b0e4bb59a51dd987cd60314ed ;
+    prov:atLocation niiri:461774f0f630ef77a6ebea4232af8dbf ;
     prov:value "4.08161401748657"^^xsd:float ;
     nidm_equivalentZStatistic: "3.90604483317219"^^xsd:float ;
     nidm_pValueUncorrected: "4.69095562407595e-05"^^xsd:float ;
     nidm_pValueFWER: "0.963698528293292"^^xsd:float ;
     nidm_qValueFDR: "0.203341942155421"^^xsd:float .
 
-niiri:0f2ddb2b0e4bb59a51dd987cd60314ed
+niiri:461774f0f630ef77a6ebea4232af8dbf
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0049" ;
     nidm_coordinateVector: "[28,44,-2]"^^xsd:string .
 
-niiri:4081a2194723009110061ee43bb061d9 prov:wasDerivedFrom niiri:489b086215a47551ede0b78dc2a96cbb .
+niiri:d5151f32682a8c00255e289f2ab66642 prov:wasDerivedFrom niiri:bcf052d664b0eeef3576961aef494c62 .
 
-niiri:8424435be347491e1894e81cdc6b4a48
+niiri:c734d9ef069f19ed65330db3f293e891
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0050" ;
-    prov:atLocation niiri:5038e601f830ac9ae819534714bb9363 ;
+    prov:atLocation niiri:67d3c251cc11d74a757bc5ce9238c367 ;
     prov:value "4.046302318573"^^xsd:float ;
     nidm_equivalentZStatistic: "3.87483340329215"^^xsd:float ;
     nidm_pValueUncorrected: "5.33488348164468e-05"^^xsd:float ;
     nidm_pValueFWER: "0.974702494096904"^^xsd:float ;
     nidm_qValueFDR: "0.218292566720722"^^xsd:float .
 
-niiri:5038e601f830ac9ae819534714bb9363
+niiri:67d3c251cc11d74a757bc5ce9238c367
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0050" ;
     nidm_coordinateVector: "[16,-100,6]"^^xsd:string .
 
-niiri:8424435be347491e1894e81cdc6b4a48 prov:wasDerivedFrom niiri:e167f1fa2b99e6bc19dd1ecd0b525c28 .
+niiri:c734d9ef069f19ed65330db3f293e891 prov:wasDerivedFrom niiri:d357fdfcedae064d3927d132b4915da3 .
 
-niiri:df894a2c9efd8fb089c5712831742758
+niiri:5cd01f27f303492a475bb421b406f29e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0051" ;
-    prov:atLocation niiri:23e10ed27cf1990467f7bd6fa91cf230 ;
+    prov:atLocation niiri:79e6e4f920bc1f2c1afeca02a3fbd970 ;
     prov:value "4.02292680740356"^^xsd:float ;
     nidm_equivalentZStatistic: "3.85413917587123"^^xsd:float ;
     nidm_pValueUncorrected: "5.80687603349839e-05"^^xsd:float ;
     nidm_pValueFWER: "0.980465241104396"^^xsd:float ;
     nidm_qValueFDR: "0.22410305589753"^^xsd:float .
 
-niiri:23e10ed27cf1990467f7bd6fa91cf230
+niiri:79e6e4f920bc1f2c1afeca02a3fbd970
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0051" ;
     nidm_coordinateVector: "[-26,-92,30]"^^xsd:string .
 
-niiri:df894a2c9efd8fb089c5712831742758 prov:wasDerivedFrom niiri:3b3edf5a98326d7f3703f9678a007546 .
+niiri:5cd01f27f303492a475bb421b406f29e prov:wasDerivedFrom niiri:24181b91e1a2ff9fbf0d92f1f3c2fb91 .
 
-niiri:29d2c4519f31a3576e049e55b0290855
+niiri:b7c5e48c51f89a916bb2b9b3c7f93b74
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0052" ;
-    prov:atLocation niiri:4ffc60198b2eed473361368c08946427 ;
+    prov:atLocation niiri:ffa7434855d1c324deca6f84fac4ca36 ;
     prov:value "4.01148080825806"^^xsd:float ;
     nidm_equivalentZStatistic: "3.84399652858706"^^xsd:float ;
     nidm_pValueUncorrected: "6.05233591551846e-05"^^xsd:float ;
     nidm_pValueFWER: "0.982890206353732"^^xsd:float ;
     nidm_qValueFDR: "0.229310640619688"^^xsd:float .
 
-niiri:4ffc60198b2eed473361368c08946427
+niiri:ffa7434855d1c324deca6f84fac4ca36
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0052" ;
     nidm_coordinateVector: "[-20,-98,22]"^^xsd:string .
 
-niiri:29d2c4519f31a3576e049e55b0290855 prov:wasDerivedFrom niiri:f254618143e69b64fb1d059a5963eed1 .
+niiri:b7c5e48c51f89a916bb2b9b3c7f93b74 prov:wasDerivedFrom niiri:a67bcbe4c64e864d3c0091590a71ed79 .
 
-niiri:4b3301ead0d37019b50b00a50b447b00
+niiri:b4420f0e3015139ac61cd59663393123
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0053" ;
-    prov:atLocation niiri:7f5ef82036fd2cca1d22a272403a67aa ;
+    prov:atLocation niiri:90c84b40485f0ed6915d0e13465ea77d ;
     prov:value "3.94734573364258"^^xsd:float ;
     nidm_equivalentZStatistic: "3.78704871504293"^^xsd:float ;
     nidm_pValueUncorrected: "7.62236103013514e-05"^^xsd:float ;
     nidm_pValueFWER: "0.992471615789186"^^xsd:float ;
     nidm_qValueFDR: "0.257387912975022"^^xsd:float .
 
-niiri:7f5ef82036fd2cca1d22a272403a67aa
+niiri:90c84b40485f0ed6915d0e13465ea77d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0053" ;
     nidm_coordinateVector: "[-18,-60,48]"^^xsd:string .
 
-niiri:4b3301ead0d37019b50b00a50b447b00 prov:wasDerivedFrom niiri:9061b512bdfd18fd0d71b5c4815f8163 .
+niiri:b4420f0e3015139ac61cd59663393123 prov:wasDerivedFrom niiri:1e585aa0961f26eba6c099e7119148ec .
 
-niiri:7ec273373ca8cb9eb93141e73f0b1efd
+niiri:b3b56bbb5afa41e6dd9460c0975114ab
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0054" ;
-    prov:atLocation niiri:68917202c3f236872fc5e59c8f0a9013 ;
+    prov:atLocation niiri:7ae522397907f4441588495f10199d24 ;
     prov:value "3.91909575462341"^^xsd:float ;
     nidm_equivalentZStatistic: "3.76190249943837"^^xsd:float ;
     nidm_pValueUncorrected: "8.43128931427017e-05"^^xsd:float ;
     nidm_pValueFWER: "0.994989876478129"^^xsd:float ;
     nidm_qValueFDR: "0.273662768395414"^^xsd:float .
 
-niiri:68917202c3f236872fc5e59c8f0a9013
+niiri:7ae522397907f4441588495f10199d24
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0054" ;
     nidm_coordinateVector: "[-50,4,50]"^^xsd:string .
 
-niiri:7ec273373ca8cb9eb93141e73f0b1efd prov:wasDerivedFrom niiri:c8fcb029f017b54563ed3b53bed1488f .
+niiri:b3b56bbb5afa41e6dd9460c0975114ab prov:wasDerivedFrom niiri:98543afde30df2ac94ce134cd8111cce .
 
-niiri:cdc716dd96e545570854cfbfc98e9aff
+niiri:d6851b62cb4fc286f889c964756f52ef
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0055" ;
-    prov:atLocation niiri:0a392e962bdfea486620d2bda30057d2 ;
+    prov:atLocation niiri:4c35f39eeef9029f2223dd86b1ebd1fb ;
     prov:value "3.89198279380798"^^xsd:float ;
     nidm_equivalentZStatistic: "3.73773288062869"^^xsd:float ;
     nidm_pValueUncorrected: "9.28435357934188e-05"^^xsd:float ;
     nidm_pValueFWER: "0.996706388084582"^^xsd:float ;
     nidm_qValueFDR: "0.28517227483113"^^xsd:float .
 
-niiri:0a392e962bdfea486620d2bda30057d2
+niiri:4c35f39eeef9029f2223dd86b1ebd1fb
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0055" ;
     nidm_coordinateVector: "[4,6,34]"^^xsd:string .
 
-niiri:cdc716dd96e545570854cfbfc98e9aff prov:wasDerivedFrom niiri:ca05945701843dd88ebf74447398670e .
+niiri:d6851b62cb4fc286f889c964756f52ef prov:wasDerivedFrom niiri:3bfa5939740913923e9b589897f2c510 .
 
-niiri:0fa7bb39653758e6f292bdc911942f55
+niiri:d714caf4b86cd7fa8f8ed29b6c077612
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0056" ;
-    prov:atLocation niiri:b6428c4303d96c88f9c3d864d91aea97 ;
+    prov:atLocation niiri:e26921989c4cf25fee3fb9b7455f0f8b ;
     prov:value "3.89150333404541"^^xsd:float ;
     nidm_equivalentZStatistic: "3.73730515822159"^^xsd:float ;
     nidm_pValueUncorrected: "9.30015629725389e-05"^^xsd:float ;
     nidm_pValueFWER: "0.996731588962573"^^xsd:float ;
     nidm_qValueFDR: "0.28517227483113"^^xsd:float .
 
-niiri:b6428c4303d96c88f9c3d864d91aea97
+niiri:e26921989c4cf25fee3fb9b7455f0f8b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0056" ;
     nidm_coordinateVector: "[-22,-74,60]"^^xsd:string .
 
-niiri:0fa7bb39653758e6f292bdc911942f55 prov:wasDerivedFrom niiri:b1d6b0c92fb80c25d314f20c0cfa090c .
+niiri:d714caf4b86cd7fa8f8ed29b6c077612 prov:wasDerivedFrom niiri:6b8ab0e3e0b633d638e47f3a9a10919b .
 
-niiri:8f12ec634da94c8f499910e77a5dc600
+niiri:547d02c0e638d74f5478c4bc3e391238
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0057" ;
-    prov:atLocation niiri:fab6ab4663f8327e8390b8544e8ce726 ;
+    prov:atLocation niiri:090eeea9cc261f40a2ed8f97e8f80deb ;
     prov:value "3.3844006061554"^^xsd:float ;
     nidm_equivalentZStatistic: "3.27901971293977"^^xsd:float ;
     nidm_pValueUncorrected: "0.000520841795166427"^^xsd:float ;
     nidm_pValueFWER: "0.999999999480839"^^xsd:float ;
     nidm_qValueFDR: "0.714388255916924"^^xsd:float .
 
-niiri:fab6ab4663f8327e8390b8544e8ce726
+niiri:090eeea9cc261f40a2ed8f97e8f80deb
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0057" ;
     nidm_coordinateVector: "[-30,-72,60]"^^xsd:string .
 
-niiri:8f12ec634da94c8f499910e77a5dc600 prov:wasDerivedFrom niiri:b1d6b0c92fb80c25d314f20c0cfa090c .
+niiri:547d02c0e638d74f5478c4bc3e391238 prov:wasDerivedFrom niiri:6b8ab0e3e0b633d638e47f3a9a10919b .
 
-niiri:1a803bc72ca0bf7a669590a344f1c36b
+niiri:c5a8590100956ce4c92258b440677e10
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0058" ;
-    prov:atLocation niiri:ea5d97630b3729c0b0eef856a08e8d66 ;
+    prov:atLocation niiri:f52621a6b75d7dc6ddfd640fdb2c84ce ;
     prov:value "3.83530473709106"^^xsd:float ;
     nidm_equivalentZStatistic: "3.68709597748077"^^xsd:float ;
     nidm_pValueUncorrected: "0.000113413911399851"^^xsd:float ;
     nidm_pValueFWER: "0.998757977658224"^^xsd:float ;
     nidm_qValueFDR: "0.325806099959436"^^xsd:float .
 
-niiri:ea5d97630b3729c0b0eef856a08e8d66
+niiri:f52621a6b75d7dc6ddfd640fdb2c84ce
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0058" ;
     nidm_coordinateVector: "[-4,2,74]"^^xsd:string .
 
-niiri:1a803bc72ca0bf7a669590a344f1c36b prov:wasDerivedFrom niiri:cb2ae57bb539840222fcf93ce3091770 .
+niiri:c5a8590100956ce4c92258b440677e10 prov:wasDerivedFrom niiri:6029d0e967f2fb403f4a243e7a90b84c .
 
-niiri:45b51b8ba66e38bfa92fa7f36ae4789c
+niiri:53ee509e46907c679adc7597b14519f2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0059" ;
-    prov:atLocation niiri:99a9a6915383bb2d92d8004f890abae9 ;
+    prov:atLocation niiri:b3c0287254101b42442c7845c4784807 ;
     prov:value "3.75742197036743"^^xsd:float ;
     nidm_equivalentZStatistic: "3.61726989254514"^^xsd:float ;
     nidm_pValueUncorrected: "0.000148863406353339"^^xsd:float ;
     nidm_pValueFWER: "0.999745113204238"^^xsd:float ;
     nidm_qValueFDR: "0.372479477261378"^^xsd:float .
 
-niiri:99a9a6915383bb2d92d8004f890abae9
+niiri:b3c0287254101b42442c7845c4784807
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0059" ;
     nidm_coordinateVector: "[-8,-6,72]"^^xsd:string .
 
-niiri:45b51b8ba66e38bfa92fa7f36ae4789c prov:wasDerivedFrom niiri:cb2ae57bb539840222fcf93ce3091770 .
+niiri:53ee509e46907c679adc7597b14519f2 prov:wasDerivedFrom niiri:6029d0e967f2fb403f4a243e7a90b84c .
 
-niiri:8d70d7e28fee86c144031d05a4a8ef0b
+niiri:3940947c5af9294e8c0934b07efef693
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0060" ;
-    prov:atLocation niiri:09d1a11f15917cd0c0f26159679fa263 ;
+    prov:atLocation niiri:b8afa2b7beda616a1b6fc2f491bb8265 ;
     prov:value "3.81854224205017"^^xsd:float ;
     nidm_equivalentZStatistic: "3.67209132667056"^^xsd:float ;
     nidm_pValueUncorrected: "0.000120286836925998"^^xsd:float ;
     nidm_pValueFWER: "0.999094324231714"^^xsd:float ;
     nidm_qValueFDR: "0.337078357858238"^^xsd:float .
 
-niiri:09d1a11f15917cd0c0f26159679fa263
+niiri:b8afa2b7beda616a1b6fc2f491bb8265
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0060" ;
     nidm_coordinateVector: "[-48,-72,2]"^^xsd:string .
 
-niiri:8d70d7e28fee86c144031d05a4a8ef0b prov:wasDerivedFrom niiri:698b3f9b2d3d5f1f578a7724a8ca8d0d .
+niiri:3940947c5af9294e8c0934b07efef693 prov:wasDerivedFrom niiri:780f11b236810e190dea70c6c4340625 .
 
-niiri:209b0b1a99bc16beb4ac795c77390c77
+niiri:c871240e924a76bb776906ea43d79c79
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0061" ;
-    prov:atLocation niiri:a80b16974b50ea86e5db7ca7abfb0e94 ;
+    prov:atLocation niiri:59794eb1599c01a856a85fc602576319 ;
     prov:value "3.79630875587463"^^xsd:float ;
     nidm_equivalentZStatistic: "3.65216921136221"^^xsd:float ;
     nidm_pValueUncorrected: "0.000130017220931533"^^xsd:float ;
     nidm_pValueFWER: "0.999416425810988"^^xsd:float ;
     nidm_qValueFDR: "0.355160181055232"^^xsd:float .
 
-niiri:a80b16974b50ea86e5db7ca7abfb0e94
+niiri:59794eb1599c01a856a85fc602576319
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0061" ;
     nidm_coordinateVector: "[14,-14,72]"^^xsd:string .
 
-niiri:209b0b1a99bc16beb4ac795c77390c77 prov:wasDerivedFrom niiri:d26a80bf1b2d7e97037bd7961b7f2fb9 .
+niiri:c871240e924a76bb776906ea43d79c79 prov:wasDerivedFrom niiri:4a266b577331cf838f3af1933133ec8d .
 
-niiri:942455b8641e6c997e34f7a82f249e20
+niiri:b36f793d8fc4b275da4f7090d0cf49c8
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0062" ;
-    prov:atLocation niiri:4dcbb2a59634794440ee403d018d7e21 ;
+    prov:atLocation niiri:2dddcae00ff05c47e0eeb240bdd94210 ;
     prov:value "3.76071834564209"^^xsd:float ;
     nidm_equivalentZStatistic: "3.62023097093744"^^xsd:float ;
     nidm_pValueUncorrected: "0.000147170075777137"^^xsd:float ;
     nidm_pValueFWER: "0.999725733828698"^^xsd:float ;
     nidm_qValueFDR: "0.372479477261378"^^xsd:float .
 
-niiri:4dcbb2a59634794440ee403d018d7e21
+niiri:2dddcae00ff05c47e0eeb240bdd94210
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0062" ;
     nidm_coordinateVector: "[-46,-56,14]"^^xsd:string .
 
-niiri:942455b8641e6c997e34f7a82f249e20 prov:wasDerivedFrom niiri:84d0f76c2451c6b80e5e965a03dc7d79 .
+niiri:b36f793d8fc4b275da4f7090d0cf49c8 prov:wasDerivedFrom niiri:b92193302c69c95fc0b8add50483e3ec .
 
-niiri:0852bc1e66ff82544a73cd299eb53620
+niiri:d392931d201e3f958063e45700f72974
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0063" ;
-    prov:atLocation niiri:3e8c1a8951b552f718e6424740cabfcb ;
+    prov:atLocation niiri:ef8da9c315d7acad1a19ab9b35413509 ;
     prov:value "3.75727128982544"^^xsd:float ;
     nidm_equivalentZStatistic: "3.61713452675793"^^xsd:float ;
     nidm_pValueUncorrected: "0.000148941251495116"^^xsd:float ;
     nidm_pValueFWER: "0.999745969099268"^^xsd:float ;
     nidm_qValueFDR: "0.372479477261378"^^xsd:float .
 
-niiri:3e8c1a8951b552f718e6424740cabfcb
+niiri:ef8da9c315d7acad1a19ab9b35413509
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0063" ;
     nidm_coordinateVector: "[-66,-46,8]"^^xsd:string .
 
-niiri:0852bc1e66ff82544a73cd299eb53620 prov:wasDerivedFrom niiri:32e36d0494334a99543f9acc36898f2f .
+niiri:d392931d201e3f958063e45700f72974 prov:wasDerivedFrom niiri:12aade66bcaf5ad22c9a147b7bac54d4 .
 
-niiri:fe10fdb9491e3622d95faa41c586fde0
+niiri:6f61feacc9e404004ef84c08b36c575a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0064" ;
-    prov:atLocation niiri:6769856fcf5cdbfdbf520b87da66032a ;
+    prov:atLocation niiri:63bc96c0a95823c38213430c25f2f3c9 ;
     prov:value "3.75130581855774"^^xsd:float ;
     nidm_equivalentZStatistic: "3.61177452742087"^^xsd:float ;
     nidm_pValueUncorrected: "0.000152054461266093"^^xsd:float ;
     nidm_pValueFWER: "0.999777860131121"^^xsd:float ;
     nidm_qValueFDR: "0.372479477261378"^^xsd:float .
 
-niiri:6769856fcf5cdbfdbf520b87da66032a
+niiri:63bc96c0a95823c38213430c25f2f3c9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0064" ;
     nidm_coordinateVector: "[34,-54,-16]"^^xsd:string .
 
-niiri:fe10fdb9491e3622d95faa41c586fde0 prov:wasDerivedFrom niiri:511c490c7d9b5ae7344403faeec2f878 .
+niiri:6f61feacc9e404004ef84c08b36c575a prov:wasDerivedFrom niiri:759e3fd5ac10013d9c1b96696769e455 .
 
-niiri:dff25b0472c7b7f4d4f517985acf2d48
+niiri:9c8f8e0534218aad4af35d8185a68335
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0065" ;
-    prov:atLocation niiri:a7bddef51d3360d13c60a90961e6c394 ;
+    prov:atLocation niiri:01b7ff06f7596a087ca89d5ce06e2de7 ;
     prov:value "3.74772572517395"^^xsd:float ;
     nidm_equivalentZStatistic: "3.60855701112288"^^xsd:float ;
     nidm_pValueUncorrected: "0.000153952428091686"^^xsd:float ;
     nidm_pValueFWER: "0.999795233014277"^^xsd:float ;
     nidm_qValueFDR: "0.372479477261378"^^xsd:float .
 
-niiri:a7bddef51d3360d13c60a90961e6c394
+niiri:01b7ff06f7596a087ca89d5ce06e2de7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0065" ;
     nidm_coordinateVector: "[44,-48,-26]"^^xsd:string .
 
-niiri:dff25b0472c7b7f4d4f517985acf2d48 prov:wasDerivedFrom niiri:9950c7205c20af075ae5465eeb0630ec .
+niiri:9c8f8e0534218aad4af35d8185a68335 prov:wasDerivedFrom niiri:b60ad51d906accfc87533b435bc4ab5f .
 
-niiri:72a44105c9c54ca6195586fda566f844
+niiri:7a1f1c13b6b7291045121f7d49c77262
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0066" ;
-    prov:atLocation niiri:362f4ffca1f9228d79a5f87ac7df774d ;
+    prov:atLocation niiri:0aceebd02576058fb0b5ffcc450903bf ;
     prov:value "3.45268702507019"^^xsd:float ;
     nidm_equivalentZStatistic: "3.34140172297627"^^xsd:float ;
     nidm_pValueUncorrected: "0.000416782602005394"^^xsd:float ;
     nidm_pValueFWER: "0.999999986590246"^^xsd:float ;
     nidm_qValueFDR: "0.640240241586832"^^xsd:float .
 
-niiri:362f4ffca1f9228d79a5f87ac7df774d
+niiri:0aceebd02576058fb0b5ffcc450903bf
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0066" ;
     nidm_coordinateVector: "[48,-56,-26]"^^xsd:string .
 
-niiri:72a44105c9c54ca6195586fda566f844 prov:wasDerivedFrom niiri:9950c7205c20af075ae5465eeb0630ec .
+niiri:7a1f1c13b6b7291045121f7d49c77262 prov:wasDerivedFrom niiri:b60ad51d906accfc87533b435bc4ab5f .
 
-niiri:8e9d3b9bd8f56c67304b1f4958a78f1c
+niiri:6f63dba9a2285ab4c503bd441f4a8416
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0067" ;
-    prov:atLocation niiri:6c9ef58153ef36f6abafddffac0ecd6b ;
+    prov:atLocation niiri:d318bbff911ff001f6ad9103b7320f90 ;
     prov:value "3.74554085731506"^^xsd:float ;
     nidm_equivalentZStatistic: "3.60659312728381"^^xsd:float ;
     nidm_pValueUncorrected: "0.000155121773134592"^^xsd:float ;
     nidm_pValueFWER: "0.999805227886258"^^xsd:float ;
     nidm_qValueFDR: "0.372479477261378"^^xsd:float .
 
-niiri:6c9ef58153ef36f6abafddffac0ecd6b
+niiri:d318bbff911ff001f6ad9103b7320f90
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0067" ;
     nidm_coordinateVector: "[18,2,14]"^^xsd:string .
 
-niiri:8e9d3b9bd8f56c67304b1f4958a78f1c prov:wasDerivedFrom niiri:59e8f07020483e79cce0a7ee24a67d9d .
+niiri:6f63dba9a2285ab4c503bd441f4a8416 prov:wasDerivedFrom niiri:5fe7263d129c8b5a1cdc4862389a329f .
 
-niiri:010e9208f818ba736d4f079715aefebf
+niiri:f5db12c15fd9930bce8083f4d4a971f8
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0068" ;
-    prov:atLocation niiri:eaee052ba126ae71bf3f156bc43c446a ;
+    prov:atLocation niiri:d1505d5bea737990bb7f479cf49edd65 ;
     prov:value "3.74068021774292"^^xsd:float ;
     nidm_equivalentZStatistic: "3.60222331817537"^^xsd:float ;
     nidm_pValueUncorrected: "0.000157753568586605"^^xsd:float ;
     nidm_pValueFWER: "0.999825912392884"^^xsd:float ;
     nidm_qValueFDR: "0.374448807900588"^^xsd:float .
 
-niiri:eaee052ba126ae71bf3f156bc43c446a
+niiri:d1505d5bea737990bb7f479cf49edd65
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0068" ;
     nidm_coordinateVector: "[14,54,-12]"^^xsd:string .
 
-niiri:010e9208f818ba736d4f079715aefebf prov:wasDerivedFrom niiri:8d67481af449856aae39018568cd0118 .
+niiri:f5db12c15fd9930bce8083f4d4a971f8 prov:wasDerivedFrom niiri:202e674801183017b435dafa4352a2f7 .
 
-niiri:e2d4f8ce47496da9fd30d625dfcf06aa
+niiri:dc9d1a84c56c4f2e77f730ad228f6501
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0069" ;
-    prov:atLocation niiri:99d7970fb363a6940c739d7b1c430c94 ;
+    prov:atLocation niiri:49cc2c6c43ce421c2826afdfaf669653 ;
     prov:value "3.66871547698975"^^xsd:float ;
     nidm_equivalentZStatistic: "3.53739878996347"^^xsd:float ;
     nidm_pValueUncorrected: "0.000202044512556343"^^xsd:float ;
     nidm_pValueFWER: "0.999971868208055"^^xsd:float ;
     nidm_qValueFDR: "0.439662448224178"^^xsd:float .
 
-niiri:99d7970fb363a6940c739d7b1c430c94
+niiri:49cc2c6c43ce421c2826afdfaf669653
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0069" ;
     nidm_coordinateVector: "[-52,-46,-32]"^^xsd:string .
 
-niiri:e2d4f8ce47496da9fd30d625dfcf06aa prov:wasDerivedFrom niiri:f927b5bbd3f555c57b4e6e01ec9b523e .
+niiri:dc9d1a84c56c4f2e77f730ad228f6501 prov:wasDerivedFrom niiri:63374171b8dfeb6c1b6216d9cb78dad1 .
 
-niiri:fa5dd8fb10a6ac6c9561207f1102d939
+niiri:04e4cd21e77744d001e185feea09a1c4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0070" ;
-    prov:atLocation niiri:818d01aa20e5fe4b662b6c27cace488e ;
+    prov:atLocation niiri:524d3966cd270740666e57867b56cf6c ;
     prov:value "3.64429998397827"^^xsd:float ;
     nidm_equivalentZStatistic: "3.51535208387321"^^xsd:float ;
     nidm_pValueUncorrected: "0.000219585664636091"^^xsd:float ;
     nidm_pValueFWER: "0.999985907470966"^^xsd:float ;
     nidm_qValueFDR: "0.455711975517369"^^xsd:float .
 
-niiri:818d01aa20e5fe4b662b6c27cace488e
+niiri:524d3966cd270740666e57867b56cf6c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0070" ;
     nidm_coordinateVector: "[6,0,-10]"^^xsd:string .
 
-niiri:fa5dd8fb10a6ac6c9561207f1102d939 prov:wasDerivedFrom niiri:8ab71917d880813a7ac3044279de7b31 .
+niiri:04e4cd21e77744d001e185feea09a1c4 prov:wasDerivedFrom niiri:4c28624df30b813b1284ed3adfd58c93 .
 
-niiri:22d8bcd737ac9403b965a7b8937e9065
+niiri:f51fbb3e910f71c1d52c4e2485a133b5
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0071" ;
-    prov:atLocation niiri:fd343ed47155feeec882aa2cec69369f ;
+    prov:atLocation niiri:a275ee630113b8202f84ea9b3759d881 ;
     prov:value "3.62323594093323"^^xsd:float ;
     nidm_equivalentZStatistic: "3.49630996939917"^^xsd:float ;
     nidm_pValueUncorrected: "0.000235870182098918"^^xsd:float ;
     nidm_pValueFWER: "0.999992481636867"^^xsd:float ;
     nidm_qValueFDR: "0.477092512968269"^^xsd:float .
 
-niiri:fd343ed47155feeec882aa2cec69369f
+niiri:a275ee630113b8202f84ea9b3759d881
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0071" ;
     nidm_coordinateVector: "[-46,-46,12]"^^xsd:string .
 
-niiri:22d8bcd737ac9403b965a7b8937e9065 prov:wasDerivedFrom niiri:7bdadf7ae2bdb4f39bf9f8fbe5fe1ea5 .
+niiri:f51fbb3e910f71c1d52c4e2485a133b5 prov:wasDerivedFrom niiri:94a0a21f872815c64a69e94bd40bed9f .
 
-niiri:541d3f352ad4910af6d028db4900ba3d
+niiri:bfde065730fee41f9a030aa1df66e0e9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0072" ;
-    prov:atLocation niiri:8505c01da3577ab7daf9234fefca724a ;
+    prov:atLocation niiri:a59e7ee297d62a1742213ffbb620d2b8 ;
     prov:value "3.61861133575439"^^xsd:float ;
     nidm_equivalentZStatistic: "3.49212659507393"^^xsd:float ;
     nidm_pValueUncorrected: "0.000239595538008452"^^xsd:float ;
     nidm_pValueFWER: "0.999993477073261"^^xsd:float ;
     nidm_qValueFDR: "0.479362074336081"^^xsd:float .
 
-niiri:8505c01da3577ab7daf9234fefca724a
+niiri:a59e7ee297d62a1742213ffbb620d2b8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0072" ;
     nidm_coordinateVector: "[24,36,22]"^^xsd:string .
 
-niiri:541d3f352ad4910af6d028db4900ba3d prov:wasDerivedFrom niiri:aa7cba01da25024bc05a9e45cd79a837 .
+niiri:bfde065730fee41f9a030aa1df66e0e9 prov:wasDerivedFrom niiri:e7e4075c58abc76d658530459437df00 .
 
-niiri:64f35ff15eebe6181abff219e19b04c3
+niiri:567767d337ded7d52529fde5cb620c93
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0073" ;
-    prov:atLocation niiri:129aef1faff68739c4894fd6e9a2a2dd ;
+    prov:atLocation niiri:3281d190fd64bd07e9609903623a5bbd ;
     prov:value "3.60088157653809"^^xsd:float ;
     nidm_equivalentZStatistic: "3.47607949453728"^^xsd:float ;
     nidm_pValueUncorrected: "0.000254400722538684"^^xsd:float ;
     nidm_pValueFWER: "0.999996268378967"^^xsd:float ;
     nidm_qValueFDR: "0.49118230182513"^^xsd:float .
 
-niiri:129aef1faff68739c4894fd6e9a2a2dd
+niiri:3281d190fd64bd07e9609903623a5bbd
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0073" ;
     nidm_coordinateVector: "[52,-38,22]"^^xsd:string .
 
-niiri:64f35ff15eebe6181abff219e19b04c3 prov:wasDerivedFrom niiri:2630e4b92c9db9a6beb0787bffe7a7fb .
+niiri:567767d337ded7d52529fde5cb620c93 prov:wasDerivedFrom niiri:2dfef140265f92d79cbf32d31936df4d .
 
-niiri:728968929121fb47a345cd7d9cd0f48a
+niiri:6f329dd94a2d4db60b222ae0224476da
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0074" ;
-    prov:atLocation niiri:4351f9f2f28b9b626ac0806ea2d5fe02 ;
+    prov:atLocation niiri:6adaabf783e45104c83b07aae27cca00 ;
     prov:value "3.5545506477356"^^xsd:float ;
     nidm_equivalentZStatistic: "3.43407908140554"^^xsd:float ;
     nidm_pValueUncorrected: "0.000297285352316101"^^xsd:float ;
     nidm_pValueFWER: "0.999999222525781"^^xsd:float ;
     nidm_qValueFDR: "0.537678422954754"^^xsd:float .
 
-niiri:4351f9f2f28b9b626ac0806ea2d5fe02
+niiri:6adaabf783e45104c83b07aae27cca00
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0074" ;
     nidm_coordinateVector: "[-64,-34,8]"^^xsd:string .
 
-niiri:728968929121fb47a345cd7d9cd0f48a prov:wasDerivedFrom niiri:cbd611e1237a5ec814b81bcfe9552f0e .
+niiri:6f329dd94a2d4db60b222ae0224476da prov:wasDerivedFrom niiri:8fcfff082769fb86478d8224ec22e1d5 .
 
-niiri:7f1b574eb7c2e47b683c9d8cfc46fed3
+niiri:84e6ea0a18d979291bb19d28f1c5dabe
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0075" ;
-    prov:atLocation niiri:c9bc69aeed7369e2823d08d02f250712 ;
+    prov:atLocation niiri:e69a32992abb3633e42cbbc91342979b ;
     prov:value "3.53580284118652"^^xsd:float ;
     nidm_equivalentZStatistic: "3.41705640127634"^^xsd:float ;
     nidm_pValueUncorrected: "0.000316510818269"^^xsd:float ;
     nidm_pValueFWER: "0.999999606830839"^^xsd:float ;
     nidm_qValueFDR: "0.556120559116339"^^xsd:float .
 
-niiri:c9bc69aeed7369e2823d08d02f250712
+niiri:e69a32992abb3633e42cbbc91342979b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0075" ;
     nidm_coordinateVector: "[-54,-32,42]"^^xsd:string .
 
-niiri:7f1b574eb7c2e47b683c9d8cfc46fed3 prov:wasDerivedFrom niiri:481718c39416a3d61a910542ffd5f170 .
+niiri:84e6ea0a18d979291bb19d28f1c5dabe prov:wasDerivedFrom niiri:a4a959bdb5adaac5ccc8bb0a1283b1eb .
 
-niiri:5659d46311e2c9bf456cd43b88de72f8
+niiri:dbc772d5c9ef096bc13a4ee83b16aac6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0076" ;
-    prov:atLocation niiri:09bba4f7e1d012246c80ca52b523c190 ;
+    prov:atLocation niiri:240a1e650cd9f68a3dd24dc257fb8ef1 ;
     prov:value "3.51030111312866"^^xsd:float ;
     nidm_equivalentZStatistic: "3.39387625832302"^^xsd:float ;
     nidm_pValueUncorrected: "0.000344554112102768"^^xsd:float ;
     nidm_pValueFWER: "0.9999998514483"^^xsd:float ;
     nidm_qValueFDR: "0.584915397396553"^^xsd:float .
 
-niiri:09bba4f7e1d012246c80ca52b523c190
+niiri:240a1e650cd9f68a3dd24dc257fb8ef1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0076" ;
     nidm_coordinateVector: "[20,-66,34]"^^xsd:string .
 
-niiri:5659d46311e2c9bf456cd43b88de72f8 prov:wasDerivedFrom niiri:7bcbc9953403229f0db979d92436612d .
+niiri:dbc772d5c9ef096bc13a4ee83b16aac6 prov:wasDerivedFrom niiri:abd2bbf896a471cb7922efab5b613117 .
 
-niiri:0dcb8a73e6de5485e8257f03451a6130
+niiri:4d40e798820a3a573c0500e58c734eec
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0077" ;
-    prov:atLocation niiri:62c4a23583195c288a79370eb2a52e6e ;
+    prov:atLocation niiri:aeaa37b13c920048113b7dc3f503c7bc ;
     prov:value "3.50287866592407"^^xsd:float ;
     nidm_equivalentZStatistic: "3.38712412459265"^^xsd:float ;
     nidm_pValueUncorrected: "0.000353147125455866"^^xsd:float ;
     nidm_pValueFWER: "0.999999889234026"^^xsd:float ;
     nidm_qValueFDR: "0.591889002439003"^^xsd:float .
 
-niiri:62c4a23583195c288a79370eb2a52e6e
+niiri:aeaa37b13c920048113b7dc3f503c7bc
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0077" ;
     nidm_coordinateVector: "[12,-100,20]"^^xsd:string .
 
-niiri:0dcb8a73e6de5485e8257f03451a6130 prov:wasDerivedFrom niiri:7c32a1d0e82c311426243c91cc091275 .
+niiri:4d40e798820a3a573c0500e58c734eec prov:wasDerivedFrom niiri:9c1cddc9922d8e70b3ba77c8f428e530 .
 
-niiri:8cce7e704870581863815ccef2761c15
+niiri:c5304f99a9da73415539075421788844
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0078" ;
-    prov:atLocation niiri:81ab8a072da2ae005ddbc4a211b83a2a ;
+    prov:atLocation niiri:b2bc9a9ccfd711a23c57794194597f43 ;
     prov:value "3.48949480056763"^^xsd:float ;
     nidm_equivalentZStatistic: "3.3749428096037"^^xsd:float ;
     nidm_pValueUncorrected: "0.000369155160797496"^^xsd:float ;
     nidm_pValueFWER: "0.999999935529104"^^xsd:float ;
     nidm_qValueFDR: "0.605073490410914"^^xsd:float .
 
-niiri:81ab8a072da2ae005ddbc4a211b83a2a
+niiri:b2bc9a9ccfd711a23c57794194597f43
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0078" ;
     nidm_coordinateVector: "[16,-44,20]"^^xsd:string .
 
-niiri:8cce7e704870581863815ccef2761c15 prov:wasDerivedFrom niiri:82069b48f32f7007fb477a55996a5a26 .
+niiri:c5304f99a9da73415539075421788844 prov:wasDerivedFrom niiri:b2551e755f51f54d3855f624855bec3b .
 
-niiri:e300699edf58b4d1bb3b6b4de2367ca4
+niiri:4d837320d4d5094cb8cb549343505b8b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0079" ;
-    prov:atLocation niiri:ce6c0db57472c62f97e856a813e3f7fa ;
+    prov:atLocation niiri:3b2940e29d426870ed404cc739700589 ;
     prov:value "3.48589444160461"^^xsd:float ;
     nidm_equivalentZStatistic: "3.37166460127642"^^xsd:float ;
     nidm_pValueUncorrected: "0.00037357688397921"^^xsd:float ;
     nidm_pValueFWER: "0.999999944412109"^^xsd:float ;
     nidm_qValueFDR: "0.605342127295634"^^xsd:float .
 
-niiri:ce6c0db57472c62f97e856a813e3f7fa
+niiri:3b2940e29d426870ed404cc739700589
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0079" ;
     nidm_coordinateVector: "[-56,-34,22]"^^xsd:string .
 
-niiri:e300699edf58b4d1bb3b6b4de2367ca4 prov:wasDerivedFrom niiri:7480c4974cded55a669a9f676f7183d3 .
+niiri:4d837320d4d5094cb8cb549343505b8b prov:wasDerivedFrom niiri:d98c34494ee425b9f343ad72efbe3802 .
 
-niiri:070c9ad134040135864a0addf74ffb50
+niiri:5652354d900526a3f326a8cf3b1d6f1f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0080" ;
-    prov:atLocation niiri:6b6897b839efc10c3bff4a181d9778b7 ;
+    prov:atLocation niiri:1efd56928f31b5312bfa21484652a1f3 ;
     prov:value "3.4652099609375"^^xsd:float ;
     nidm_equivalentZStatistic: "3.35281990022648"^^xsd:float ;
     nidm_pValueUncorrected: "0.000399963700227435"^^xsd:float ;
     nidm_pValueFWER: "0.999999976804491"^^xsd:float ;
     nidm_qValueFDR: "0.628846262541795"^^xsd:float .
 
-niiri:6b6897b839efc10c3bff4a181d9778b7
+niiri:1efd56928f31b5312bfa21484652a1f3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0080" ;
     nidm_coordinateVector: "[40,4,30]"^^xsd:string .
 
-niiri:070c9ad134040135864a0addf74ffb50 prov:wasDerivedFrom niiri:7dbb86d35f9a3f5e15ce1fcaf1b4ac57 .
+niiri:5652354d900526a3f326a8cf3b1d6f1f prov:wasDerivedFrom niiri:207cbb7814292b71aa3cbca2e251214d .
 
-niiri:13d680b7d3981f675b37a21fc4787aed
+niiri:d2d495d008345b6772c40b2b272a1585
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0081" ;
-    prov:atLocation niiri:1370d3c9ba9670b3d0c941f2285d3f97 ;
+    prov:atLocation niiri:2df4f858b4497bba7e71e36de77d8194 ;
     prov:value "3.44595217704773"^^xsd:float ;
     nidm_equivalentZStatistic: "3.33525818772228"^^xsd:float ;
     nidm_pValueUncorrected: "0.000426101175928562"^^xsd:float ;
     nidm_pValueFWER: "0.999999990072758"^^xsd:float ;
     nidm_qValueFDR: "0.643081801836616"^^xsd:float .
 
-niiri:1370d3c9ba9670b3d0c941f2285d3f97
+niiri:2df4f858b4497bba7e71e36de77d8194
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0081" ;
     nidm_coordinateVector: "[-22,-94,28]"^^xsd:string .
 
-niiri:13d680b7d3981f675b37a21fc4787aed prov:wasDerivedFrom niiri:1871a215e9872f3a52537c8c1a760f0a .
+niiri:d2d495d008345b6772c40b2b272a1585 prov:wasDerivedFrom niiri:ef0e652ba790ef2ca62cbc45744044f2 .
 
-niiri:4571137ac30bbff2d6db403186670e72
+niiri:65afbe0971735e73b0b4d019a5fe1dd4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0082" ;
-    prov:atLocation niiri:05cc0a6b452f196de2c80d32256254c3 ;
+    prov:atLocation niiri:a4a5e8556da90bc8294088347f71204f ;
     prov:value "3.44062829017639"^^xsd:float ;
     nidm_equivalentZStatistic: "3.33040033563749"^^xsd:float ;
     nidm_pValueUncorrected: "0.00043360601200626"^^xsd:float ;
     nidm_pValueFWER: "0.999999992196494"^^xsd:float ;
     nidm_qValueFDR: "0.643081801836616"^^xsd:float .
 
-niiri:05cc0a6b452f196de2c80d32256254c3
+niiri:a4a5e8556da90bc8294088347f71204f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0082" ;
     nidm_coordinateVector: "[-28,-66,-4]"^^xsd:string .
 
-niiri:4571137ac30bbff2d6db403186670e72 prov:wasDerivedFrom niiri:3ad5cc979a530fd4daa32be10f10bc51 .
+niiri:65afbe0971735e73b0b4d019a5fe1dd4 prov:wasDerivedFrom niiri:cdc735403e60da4bc8deca0b30c09e41 .
 
-niiri:a72563a4578d11c37af74d67bb8b0960
+niiri:4840119095d944bfaa2277523850de52
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0083" ;
-    prov:atLocation niiri:7f436859691dfa579add6f2b4286b94c ;
+    prov:atLocation niiri:171f6f283c1425e20e15c65986b75693 ;
     prov:value "3.4126980304718"^^xsd:float ;
     nidm_equivalentZStatistic: "3.30489484520115"^^xsd:float ;
     nidm_pValueUncorrected: "0.000475060200800126"^^xsd:float ;
     nidm_pValueFWER: "0.999999997888602"^^xsd:float ;
     nidm_qValueFDR: "0.683890257408892"^^xsd:float .
 
-niiri:7f436859691dfa579add6f2b4286b94c
+niiri:171f6f283c1425e20e15c65986b75693
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0083" ;
     nidm_coordinateVector: "[22,-80,54]"^^xsd:string .
 
-niiri:a72563a4578d11c37af74d67bb8b0960 prov:wasDerivedFrom niiri:b808d08cb809cd1546fc7c1d23c712ad .
+niiri:4840119095d944bfaa2277523850de52 prov:wasDerivedFrom niiri:14788c080d39de548f4f1517f2f3ecf2 .
 
-niiri:2a29da45de0d63a244cd859e275bdca1
+niiri:d9ddb8469cbfc56cddec34eacb01fe37
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0084" ;
-    prov:atLocation niiri:9e93e4a979461fb19e7696d5279f3459 ;
+    prov:atLocation niiri:d70b502404bd88a854514ea5758a0230 ;
     prov:value "3.38877391815186"^^xsd:float ;
     nidm_equivalentZStatistic: "3.28302091406008"^^xsd:float ;
     nidm_pValueUncorrected: "0.000513505230477329"^^xsd:float ;
     nidm_pValueFWER: "0.999999999351719"^^xsd:float ;
     nidm_qValueFDR: "0.712882686639218"^^xsd:float .
 
-niiri:9e93e4a979461fb19e7696d5279f3459
+niiri:d70b502404bd88a854514ea5758a0230
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0084" ;
     nidm_coordinateVector: "[-50,-52,20]"^^xsd:string .
 
-niiri:2a29da45de0d63a244cd859e275bdca1 prov:wasDerivedFrom niiri:2502ea528f067f61a192d4d910eaaac2 .
+niiri:d9ddb8469cbfc56cddec34eacb01fe37 prov:wasDerivedFrom niiri:094abc2dabe5f1598098374da155b2d3 .
 
-niiri:8babbf8e12493e91e0385d603330b610
+niiri:31a3813511b578c73de9e894b0d4b862
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0085" ;
-    prov:atLocation niiri:f6845913c82a1225e1daea5eebd8a1c1 ;
+    prov:atLocation niiri:b8adcd6e39a269092455531610a969af ;
     prov:value "3.38779973983765"^^xsd:float ;
     nidm_equivalentZStatistic: "3.28212969646231"^^xsd:float ;
     nidm_pValueUncorrected: "0.000515131030616733"^^xsd:float ;
     nidm_pValueFWER: "0.999999999382908"^^xsd:float ;
     nidm_qValueFDR: "0.712882686639218"^^xsd:float .
 
-niiri:f6845913c82a1225e1daea5eebd8a1c1
+niiri:b8adcd6e39a269092455531610a969af
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0085" ;
     nidm_coordinateVector: "[64,-32,16]"^^xsd:string .
 
-niiri:8babbf8e12493e91e0385d603330b610 prov:wasDerivedFrom niiri:d44962b9e9395d5d42a56ab76170cf9a .
+niiri:31a3813511b578c73de9e894b0d4b862 prov:wasDerivedFrom niiri:b0a53fec1935bbbef5f0340426dfcf5c .
 
-niiri:c200ec026fbb20c6694036c1175fc2e8
+niiri:b08c87ff71cf5246769f7715958afa40
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0086" ;
-    prov:atLocation niiri:f10a46d09110e46aafc8192b4e3b5c8e ;
+    prov:atLocation niiri:cf7ff8939962af0db57611ac57ca8321 ;
     prov:value "3.37709879875183"^^xsd:float ;
     nidm_equivalentZStatistic: "3.27233736484586"^^xsd:float ;
     nidm_pValueUncorrected: "0.000533311091644562"^^xsd:float ;
     nidm_pValueFWER: "0.999999999643268"^^xsd:float ;
     nidm_qValueFDR: "0.721327613515561"^^xsd:float .
 
-niiri:f10a46d09110e46aafc8192b4e3b5c8e
+niiri:cf7ff8939962af0db57611ac57ca8321
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0086" ;
     nidm_coordinateVector: "[-66,-36,22]"^^xsd:string .
 
-niiri:c200ec026fbb20c6694036c1175fc2e8 prov:wasDerivedFrom niiri:f59a3e7afba6bebbf0a007c0f8c78d53 .
+niiri:b08c87ff71cf5246769f7715958afa40 prov:wasDerivedFrom niiri:782cde190eab924f134e44bd95c8cd15 .
 
-niiri:d00eda502b77d6c6936fcd79ef00684f
+niiri:a9d645704df208d9dc3fc6253c78c696
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0087" ;
-    prov:atLocation niiri:d546b23144d1ab6370ebb14a8e7d5454 ;
+    prov:atLocation niiri:d01630982d6562431197c9125302e72d ;
     prov:value "3.37313723564148"^^xsd:float ;
     nidm_equivalentZStatistic: "3.26871093121603"^^xsd:float ;
     nidm_pValueUncorrected: "0.000540193080250551"^^xsd:float ;
     nidm_pValueFWER: "0.999999999709649"^^xsd:float ;
     nidm_qValueFDR: "0.721327613515561"^^xsd:float .
 
-niiri:d546b23144d1ab6370ebb14a8e7d5454
+niiri:d01630982d6562431197c9125302e72d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0087" ;
     nidm_coordinateVector: "[-30,-62,-40]"^^xsd:string .
 
-niiri:d00eda502b77d6c6936fcd79ef00684f prov:wasDerivedFrom niiri:b1fa22ed23a8d70bc9e4dd151a589e2f .
+niiri:a9d645704df208d9dc3fc6253c78c696 prov:wasDerivedFrom niiri:9e85dca921757d3d2cafd0d606eb03c4 .
 
-niiri:2063c79290c50e61487b5221d7c31d04
+niiri:4db22c975766e9eb9e2f4b5beea1658f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0088" ;
-    prov:atLocation niiri:f426a2fb12545e24f4b7931c41ca77e7 ;
+    prov:atLocation niiri:03d2749e759ef96f471425c46ee3f719 ;
     prov:value "3.37137746810913"^^xsd:float ;
     nidm_equivalentZStatistic: "3.2670998163368"^^xsd:float ;
     nidm_pValueUncorrected: "0.000543276814982008"^^xsd:float ;
     nidm_pValueFWER: "0.999999999735165"^^xsd:float ;
     nidm_qValueFDR: "0.721327613515561"^^xsd:float .
 
-niiri:f426a2fb12545e24f4b7931c41ca77e7
+niiri:03d2749e759ef96f471425c46ee3f719
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0088" ;
     nidm_coordinateVector: "[-62,-14,10]"^^xsd:string .
 
-niiri:2063c79290c50e61487b5221d7c31d04 prov:wasDerivedFrom niiri:0cd710e9d7cad8f485a36862bb45dad3 .
+niiri:4db22c975766e9eb9e2f4b5beea1658f prov:wasDerivedFrom niiri:50e0654a2d55b1eb33c94eef3f0fbfc4 .
 
-niiri:d09284c06fe1179817219f8b367cf653
+niiri:e29f7b67960f76bb916479e29df3f8b3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0089" ;
-    prov:atLocation niiri:59ddf2283254cca38e2dc189fed56754 ;
+    prov:atLocation niiri:09a8f62d551cdcdc77118ba40ad5fa78 ;
     prov:value "3.37039303779602"^^xsd:float ;
     nidm_equivalentZStatistic: "3.26619848595029"^^xsd:float ;
     nidm_pValueUncorrected: "0.000545009089568671"^^xsd:float ;
     nidm_pValueFWER: "0.999999999748484"^^xsd:float ;
     nidm_qValueFDR: "0.721327613515561"^^xsd:float .
 
-niiri:59ddf2283254cca38e2dc189fed56754
+niiri:09a8f62d551cdcdc77118ba40ad5fa78
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0089" ;
     nidm_coordinateVector: "[22,34,56]"^^xsd:string .
 
-niiri:d09284c06fe1179817219f8b367cf653 prov:wasDerivedFrom niiri:cc7d3451a39fd4cca99275e6219b8f5d .
+niiri:e29f7b67960f76bb916479e29df3f8b3 prov:wasDerivedFrom niiri:580546e61fe6caf5b928869b72d6563c .
 
-niiri:0727fda215a3ce885ff443d10e1e526f
+niiri:8ac825efe546b49dde172700cc71e2b2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0090" ;
-    prov:atLocation niiri:4db32998eccf9df85ddc26e29594d8db ;
+    prov:atLocation niiri:1785d708e60ad6549b65dffa2e528466 ;
     prov:value "3.30523133277893"^^xsd:float ;
     nidm_equivalentZStatistic: "3.20644574827441"^^xsd:float ;
     nidm_pValueUncorrected: "0.000671928211518624"^^xsd:float ;
     nidm_pValueFWER: "0.999999999993453"^^xsd:float ;
     nidm_qValueFDR: "0.835508519228008"^^xsd:float .
 
-niiri:4db32998eccf9df85ddc26e29594d8db
+niiri:1785d708e60ad6549b65dffa2e528466
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0090" ;
     nidm_coordinateVector: "[-68,-34,-8]"^^xsd:string .
 
-niiri:0727fda215a3ce885ff443d10e1e526f prov:wasDerivedFrom niiri:e8b4547e2bb998c3a0e5c80f5add7395 .
+niiri:8ac825efe546b49dde172700cc71e2b2 prov:wasDerivedFrom niiri:fbb3da138dba0bffe41c80dfdc6d2813 .
 
-niiri:6268970793f0490b6632512bab3da67e
+niiri:22cb343d7aa6bdb3bb3a888ac82c87c0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0091" ;
-    prov:atLocation niiri:260f856ee4f0ff313ce4100fd943eaf7 ;
+    prov:atLocation niiri:c6f2d80da4938d0bb9415062e7a5e502 ;
     prov:value "3.2985315322876"^^xsd:float ;
     nidm_equivalentZStatistic: "3.20029191950919"^^xsd:float ;
     nidm_pValueUncorrected: "0.000686442301030654"^^xsd:float ;
     nidm_pValueFWER: "0.999999999995621"^^xsd:float ;
     nidm_qValueFDR: "0.842515375542095"^^xsd:float .
 
-niiri:260f856ee4f0ff313ce4100fd943eaf7
+niiri:c6f2d80da4938d0bb9415062e7a5e502
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0091" ;
     nidm_coordinateVector: "[44,4,46]"^^xsd:string .
 
-niiri:6268970793f0490b6632512bab3da67e prov:wasDerivedFrom niiri:194d5b586416a3affff5759f1f6f1f22 .
+niiri:22cb343d7aa6bdb3bb3a888ac82c87c0 prov:wasDerivedFrom niiri:5b4ccbe46fbd067233c454fc4cd57139 .
 
-niiri:8dafc007cbf2b67abe04c83653e139d3
+niiri:1e6a6f5fdbab18ff700a1f08fa7c7542
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0092" ;
-    prov:atLocation niiri:2ccad00390c934c82f456da3ce66cd8d ;
+    prov:atLocation niiri:f601d44d414260f0726c9603cd39c49a ;
     prov:value "3.29661655426025"^^xsd:float ;
     nidm_equivalentZStatistic: "3.19853264836728"^^xsd:float ;
     nidm_pValueUncorrected: "0.000690644458409051"^^xsd:float ;
     nidm_pValueFWER: "0.9999999999961"^^xsd:float ;
     nidm_qValueFDR: "0.842515375542095"^^xsd:float .
 
-niiri:2ccad00390c934c82f456da3ce66cd8d
+niiri:f601d44d414260f0726c9603cd39c49a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0092" ;
     nidm_coordinateVector: "[24,0,4]"^^xsd:string .
 
-niiri:8dafc007cbf2b67abe04c83653e139d3 prov:wasDerivedFrom niiri:172068f882b44c7f3f286732e95fd333 .
+niiri:1e6a6f5fdbab18ff700a1f08fa7c7542 prov:wasDerivedFrom niiri:4797fa2e5200fab8ae750cb321a6d94a .
 
-niiri:3acc1d1106d3e32b8c795b28bdb63277
+niiri:65926b9e3005685d9db29cdf417debc7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0093" ;
-    prov:atLocation niiri:a7353c0c6459c8182bac71063d3cb6f5 ;
+    prov:atLocation niiri:4288b4766cc9e13b7d7802f0b1459329 ;
     prov:value "3.27342534065247"^^xsd:float ;
     nidm_equivalentZStatistic: "3.1772149335255"^^xsd:float ;
     nidm_pValueUncorrected: "0.000743483956790469"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999073"^^xsd:float ;
     nidm_qValueFDR: "0.873198212136066"^^xsd:float .
 
-niiri:a7353c0c6459c8182bac71063d3cb6f5
+niiri:4288b4766cc9e13b7d7802f0b1459329
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0093" ;
     nidm_coordinateVector: "[-60,-46,0]"^^xsd:string .
 
-niiri:3acc1d1106d3e32b8c795b28bdb63277 prov:wasDerivedFrom niiri:ce513aeb315d021861a6c316bf4ef052 .
+niiri:65926b9e3005685d9db29cdf417debc7 prov:wasDerivedFrom niiri:e5840e49541fa7c2c73adfcf2cd18d5c .
 
-niiri:a0ff2b4a57976ac7036b83db31208885
+niiri:1832ec3bca9ab489c38af1558fa307ca
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0094" ;
-    prov:atLocation niiri:293866a4cfd9548dda020df3e35e16f9 ;
+    prov:atLocation niiri:7a4290e8d2bb1ace22685e79b5e79d1c ;
     prov:value "3.27317070960999"^^xsd:float ;
     nidm_equivalentZStatistic: "3.17698074823278"^^xsd:float ;
     nidm_pValueUncorrected: "0.000744084571755788"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999088"^^xsd:float ;
     nidm_qValueFDR: "0.873198212136066"^^xsd:float .
 
-niiri:293866a4cfd9548dda020df3e35e16f9
+niiri:7a4290e8d2bb1ace22685e79b5e79d1c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0094" ;
     nidm_coordinateVector: "[-4,40,24]"^^xsd:string .
 
-niiri:a0ff2b4a57976ac7036b83db31208885 prov:wasDerivedFrom niiri:31c5179c3ed19f375fed1f038a132ca0 .
+niiri:1832ec3bca9ab489c38af1558fa307ca prov:wasDerivedFrom niiri:af9739fef5ce12c093a36fdad464fa2c .
 
-niiri:7f51472217732464bb53a8dc92ab30a6
+niiri:261741634aeb371107d4c36f38ee3e94
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0095" ;
-    prov:atLocation niiri:924880d0bf78a807a5960f7f39764c82 ;
+    prov:atLocation niiri:ac0648e7d1f5b3202d8d893523a25ee3 ;
     prov:value "3.27113676071167"^^xsd:float ;
     nidm_equivalentZStatistic: "3.17511001955929"^^xsd:float ;
     nidm_pValueUncorrected: "0.000748898502488382"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999199"^^xsd:float ;
     nidm_qValueFDR: "0.873198212136066"^^xsd:float .
 
-niiri:924880d0bf78a807a5960f7f39764c82
+niiri:ac0648e7d1f5b3202d8d893523a25ee3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0095" ;
     nidm_coordinateVector: "[38,50,-2]"^^xsd:string .
 
-niiri:7f51472217732464bb53a8dc92ab30a6 prov:wasDerivedFrom niiri:fef2c17abe57bc62290ea323944b2b06 .
+niiri:261741634aeb371107d4c36f38ee3e94 prov:wasDerivedFrom niiri:4c1124c10677cacc7086dad2d88a0bd3 .
 
-niiri:8cb7151dc4e5b5abf4637542977159ac
+niiri:360ea334f08a7af85055b95a9386d330
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0096" ;
-    prov:atLocation niiri:d16bffb3aa4600f0d29685486734c699 ;
+    prov:atLocation niiri:2fdcc6e6bc5734e23a3c245ece9af37a ;
     prov:value "3.24630308151245"^^xsd:float ;
     nidm_equivalentZStatistic: "3.15225533865243"^^xsd:float ;
     nidm_pValueUncorrected: "0.000810072651915683"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999841"^^xsd:float ;
     nidm_qValueFDR: "0.917606478873846"^^xsd:float .
 
-niiri:d16bffb3aa4600f0d29685486734c699
+niiri:2fdcc6e6bc5734e23a3c245ece9af37a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0096" ;
     nidm_coordinateVector: "[-40,-88,16]"^^xsd:string .
 
-niiri:8cb7151dc4e5b5abf4637542977159ac prov:wasDerivedFrom niiri:101d5a9adb5897de8e974a6c450bccef .
+niiri:360ea334f08a7af85055b95a9386d330 prov:wasDerivedFrom niiri:9a07890dc3c872a54f45939b26e95348 .
 
-niiri:5672847823d49fce37d1e0b2ad951aaf
+niiri:e659f5281cce04791ec12bbae45e2238
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0097" ;
-    prov:atLocation niiri:bbe7f807319bc80dccfa49a8357c3406 ;
+    prov:atLocation niiri:21d86a8c53e01ef6f95f57296de7085d ;
     prov:value "3.24350714683533"^^xsd:float ;
     nidm_equivalentZStatistic: "3.14968061296894"^^xsd:float ;
     nidm_pValueUncorrected: "0.000817245211796269"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999868"^^xsd:float ;
     nidm_qValueFDR: "0.917606478873846"^^xsd:float .
 
-niiri:bbe7f807319bc80dccfa49a8357c3406
+niiri:21d86a8c53e01ef6f95f57296de7085d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0097" ;
     nidm_coordinateVector: "[-36,-56,-42]"^^xsd:string .
 
-niiri:5672847823d49fce37d1e0b2ad951aaf prov:wasDerivedFrom niiri:79ae18cf89e6f66ce4c5070153fae100 .
+niiri:e659f5281cce04791ec12bbae45e2238 prov:wasDerivedFrom niiri:4b972d45063ce95740be79e0f84be300 .
 
-niiri:6657cac48a435b24dec977df072d82d8
+niiri:bc8b728ef84f6cc7d38147430d08a43e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0098" ;
-    prov:atLocation niiri:44589d5bcfec959b42053b5dda636988 ;
+    prov:atLocation niiri:913d186c05f83e7d0dedd5f599c175a9 ;
     prov:value "3.24193215370178"^^xsd:float ;
     nidm_equivalentZStatistic: "3.14823008816228"^^xsd:float ;
     nidm_pValueUncorrected: "0.000821311713323003"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999881"^^xsd:float ;
     nidm_qValueFDR: "0.917606478873846"^^xsd:float .
 
-niiri:44589d5bcfec959b42053b5dda636988
+niiri:913d186c05f83e7d0dedd5f599c175a9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0098" ;
     nidm_coordinateVector: "[-54,-8,46]"^^xsd:string .
 
-niiri:6657cac48a435b24dec977df072d82d8 prov:wasDerivedFrom niiri:1c0685623290eeb06ef6f4bdbffafd31 .
+niiri:bc8b728ef84f6cc7d38147430d08a43e prov:wasDerivedFrom niiri:6cc8de073a211f649503cbae3d7f79bb .
 
-niiri:049323d04b482659a1c4c2bb4060101d
+niiri:26f4b6d30550bf95fa229750966ea576
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0099" ;
-    prov:atLocation niiri:a2e9a49bfcc3043b02563ef5bc1bb5b7 ;
+    prov:atLocation niiri:ac2f9c701365ca370e015bb1778342c0 ;
     prov:value "3.22731924057007"^^xsd:float ;
     nidm_equivalentZStatistic: "3.1347671282846"^^xsd:float ;
     nidm_pValueUncorrected: "0.000859952917517393"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999956"^^xsd:float ;
     nidm_qValueFDR: "0.937923170353275"^^xsd:float .
 
-niiri:a2e9a49bfcc3043b02563ef5bc1bb5b7
+niiri:ac2f9c701365ca370e015bb1778342c0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0099" ;
     nidm_coordinateVector: "[40,-52,68]"^^xsd:string .
 
-niiri:049323d04b482659a1c4c2bb4060101d prov:wasDerivedFrom niiri:e333891aa2a7cc8b78b7b091053068d6 .
+niiri:26f4b6d30550bf95fa229750966ea576 prov:wasDerivedFrom niiri:713bd5e4d1057a61ec41d7be47cc6b30 .
 
-niiri:0381cfb61f7454d8d1ed99376692368c
+niiri:2c4a60a71eb752e827d97c147d637ae2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0100" ;
-    prov:atLocation niiri:4f8ede499166df3259682391f04c88b5 ;
+    prov:atLocation niiri:7498af8fe3f38b0a683eb4f600daedbd ;
     prov:value "3.22294282913208"^^xsd:float ;
     nidm_equivalentZStatistic: "3.13073340683923"^^xsd:float ;
     nidm_pValueUncorrected: "0.000871851865451578"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999968"^^xsd:float ;
     nidm_qValueFDR: "0.942022979172485"^^xsd:float .
 
-niiri:4f8ede499166df3259682391f04c88b5
+niiri:7498af8fe3f38b0a683eb4f600daedbd
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0100" ;
     nidm_coordinateVector: "[22,44,-16]"^^xsd:string .
 
-niiri:0381cfb61f7454d8d1ed99376692368c prov:wasDerivedFrom niiri:ae3b028a4da5be96010d12d3d7dfdafd .
+niiri:2c4a60a71eb752e827d97c147d637ae2 prov:wasDerivedFrom niiri:f594ca28922a55744403546afac8880c .
 
-niiri:b9b307152bda4d6811d3c3859d0c91ab
+niiri:db27722046af7c3881dc9b3f44135cdd
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0101" ;
-    prov:atLocation niiri:bd22f507a7a824f7592dd40eef4dfb63 ;
+    prov:atLocation niiri:523fb1da24165c8028f86bdbbc3901e7 ;
     prov:value "3.20911026000977"^^xsd:float ;
     nidm_equivalentZStatistic: "3.11797882010196"^^xsd:float ;
     nidm_pValueUncorrected: "0.000910479445198287"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999988"^^xsd:float ;
     nidm_qValueFDR: "0.966327579886985"^^xsd:float .
 
-niiri:bd22f507a7a824f7592dd40eef4dfb63
+niiri:523fb1da24165c8028f86bdbbc3901e7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0101" ;
     nidm_coordinateVector: "[-40,36,-8]"^^xsd:string .
 
-niiri:b9b307152bda4d6811d3c3859d0c91ab prov:wasDerivedFrom niiri:0f488c10355ed316636cfd8bb54904ac .
+niiri:db27722046af7c3881dc9b3f44135cdd prov:wasDerivedFrom niiri:1f5837a9250f8adad81d9cf7febcb06c .
 
-niiri:77fcc6941bcf921edd72dead3f3b4e6d
+niiri:130b59f20e485841289d47a669c27dec
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0102" ;
-    prov:atLocation niiri:195dc505ac953c8a3f4b2871a69b9911 ;
+    prov:atLocation niiri:c7ad57439eb1d9d0e24c8929fb4f6def ;
     prov:value "3.20072054862976"^^xsd:float ;
     nidm_equivalentZStatistic: "3.11023911526042"^^xsd:float ;
     nidm_pValueUncorrected: "0.000934679736638411"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999993"^^xsd:float ;
     nidm_qValueFDR: "0.972457839189109"^^xsd:float .
 
-niiri:195dc505ac953c8a3f4b2871a69b9911
+niiri:c7ad57439eb1d9d0e24c8929fb4f6def
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0102" ;
     nidm_coordinateVector: "[-14,4,16]"^^xsd:string .
 
-niiri:77fcc6941bcf921edd72dead3f3b4e6d prov:wasDerivedFrom niiri:b7030530775d914be5aedf430467d831 .
+niiri:130b59f20e485841289d47a669c27dec prov:wasDerivedFrom niiri:4978ca959ffd9dac40bc74938928d142 .
 
-niiri:53a19a80ca4b419204df77ae0f0a23a9
+niiri:7d589921c2ce3d87a67549309a2ce4d9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0103" ;
-    prov:atLocation niiri:e2e458115471a4af2cfc7c4615a9e9b1 ;
+    prov:atLocation niiri:5fac49fc2d94d308482a7216d1c0abcc ;
     prov:value "3.19976687431335"^^xsd:float ;
     nidm_equivalentZStatistic: "3.10935914676901"^^xsd:float ;
     nidm_pValueUncorrected: "0.000937468288822019"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999994"^^xsd:float ;
     nidm_qValueFDR: "0.972457839189109"^^xsd:float .
 
-niiri:e2e458115471a4af2cfc7c4615a9e9b1
+niiri:5fac49fc2d94d308482a7216d1c0abcc
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0103" ;
     nidm_coordinateVector: "[-24,54,36]"^^xsd:string .
 
-niiri:53a19a80ca4b419204df77ae0f0a23a9 prov:wasDerivedFrom niiri:caff2c2f2a15419f2f382bc662c24e14 .
+niiri:7d589921c2ce3d87a67549309a2ce4d9 prov:wasDerivedFrom niiri:a8156b1e457954028b70ba39c8f61983 .
 
-niiri:7ee33f6809535b7ae13ff8531c24abbd
+niiri:fc5bb336fd66e8a55c0326f0b1d351e5
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0104" ;
-    prov:atLocation niiri:7629dd1756b23d156f7a279839c298c8 ;
+    prov:atLocation niiri:cd1b84e4c6560b33762f1d342c8d79d1 ;
     prov:value "3.19748950004578"^^xsd:float ;
     nidm_equivalentZStatistic: "3.10725763219564"^^xsd:float ;
     nidm_pValueUncorrected: "0.000944158772216208"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999995"^^xsd:float ;
     nidm_qValueFDR: "0.972457839189109"^^xsd:float .
 
-niiri:7629dd1756b23d156f7a279839c298c8
+niiri:cd1b84e4c6560b33762f1d342c8d79d1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0104" ;
     nidm_coordinateVector: "[66,-34,38]"^^xsd:string .
 
-niiri:7ee33f6809535b7ae13ff8531c24abbd prov:wasDerivedFrom niiri:e65b059d6c1f15bf2f6b2d744c2f1518 .
+niiri:fc5bb336fd66e8a55c0326f0b1d351e5 prov:wasDerivedFrom niiri:b00bd2c845defd49f3843980d3290639 .
 
-niiri:6555926789979687a510b0a6e93b6fce
+niiri:602dbb725cf9f38cf7aa442b3a5fac1e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0105" ;
-    prov:atLocation niiri:11cbf762207bc831a4dbb30f836b87c5 ;
+    prov:atLocation niiri:f21906ff37236d112d6eb7f93ae84520 ;
     prov:value "3.19663214683533"^^xsd:float ;
     nidm_equivalentZStatistic: "3.10646642942607"^^xsd:float ;
     nidm_pValueUncorrected: "0.000946689027332193"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999995"^^xsd:float ;
     nidm_qValueFDR: "0.972457839189109"^^xsd:float .
 
-niiri:11cbf762207bc831a4dbb30f836b87c5
+niiri:f21906ff37236d112d6eb7f93ae84520
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0105" ;
     nidm_coordinateVector: "[12,-76,-12]"^^xsd:string .
 
-niiri:6555926789979687a510b0a6e93b6fce prov:wasDerivedFrom niiri:8ea6fb6f8438207d256aefd11c3b906b .
+niiri:602dbb725cf9f38cf7aa442b3a5fac1e prov:wasDerivedFrom niiri:0d91d576d381385281f1b2d5d2714a3f .
 
-niiri:30b9a8c74c68ae15db443872e1b6be12
+niiri:fb785c4b2387927cfcaba115b1c2b59a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0106" ;
-    prov:atLocation niiri:3fd01dc771a46ee5143965a0c03a9edd ;
+    prov:atLocation niiri:f70ca813baf34973fd3495cc2097d071 ;
     prov:value "3.19012331962585"^^xsd:float ;
     nidm_equivalentZStatistic: "3.10045882632522"^^xsd:float ;
     nidm_pValueUncorrected: "0.000966105376173698"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999997"^^xsd:float ;
     nidm_qValueFDR: "0.981368933811381"^^xsd:float .
 
-niiri:3fd01dc771a46ee5143965a0c03a9edd
+niiri:f70ca813baf34973fd3495cc2097d071
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0106" ;
     nidm_coordinateVector: "[44,16,36]"^^xsd:string .
 
-niiri:30b9a8c74c68ae15db443872e1b6be12 prov:wasDerivedFrom niiri:700b2ca023302ca89c9a6e4ffdd8374f .
+niiri:fb785c4b2387927cfcaba115b1c2b59a prov:wasDerivedFrom niiri:1505e0b207a3a8175cc0be4688a0d7c4 .
 
-niiri:ba0d1cacc0f1f06491d9d37fb11c94cd
+niiri:9b7ac364d02018f5800c5cab0a832028
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0107" ;
-    prov:atLocation niiri:3304ca04091f210e6a051412f9842254 ;
+    prov:atLocation niiri:4abe5383d9941f3b5b7dff4b3e6f15e8 ;
     prov:value "3.18127655982971"^^xsd:float ;
     nidm_equivalentZStatistic: "3.09229057044228"^^xsd:float ;
     nidm_pValueUncorrected: "0.000993091637332855"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999998"^^xsd:float ;
     nidm_qValueFDR: "0.9954611032935"^^xsd:float .
 
-niiri:3304ca04091f210e6a051412f9842254
+niiri:4abe5383d9941f3b5b7dff4b3e6f15e8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0107" ;
     nidm_coordinateVector: "[62,26,-24]"^^xsd:string .
 
-niiri:ba0d1cacc0f1f06491d9d37fb11c94cd prov:wasDerivedFrom niiri:14e4f41a62e6164ce237a2e322e60826 .
+niiri:9b7ac364d02018f5800c5cab0a832028 prov:wasDerivedFrom niiri:892dfa415e44d696ef37c9d6a5487e86 .
 

--- a/spmexport/ex_spm_con_f/nidm.json
+++ b/spmexport/ex_spm_con_f/nidm.json
@@ -1,0 +1,22553 @@
+{
+  "prefix": {
+    "nidm": "http://purl.org/nidash/nidm#",
+    "niiri": "http://iri.nidash.org/",
+    "spm": "http://purl.org/nidash/spm#",
+    "neurolex": "http://neurolex.org/wiki/",
+    "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/",
+    "dct": "http://purl.org/dc/terms/",
+    "nfo": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#",
+    "dc": "http://purl.org/dc/elements/1.1/",
+    "dctype": "http://purl.org/dc/dcmitype/",
+    "obo": "http://purl.obolibrary.org/obo/",
+    "nidm_NIDMResults": "http://purl.org/nidash/nidm#NIDM_0000027",
+    "nidm_version": "http://purl.org/nidash/nidm#NIDM_0000127",
+    "nidm_spm_results_nidm": "http://purl.org/nidash/nidm#NIDM_0000168",
+    "nidm_softwareVersion": "http://purl.org/nidash/nidm#NIDM_0000122",
+    "nidm_NIDMResultsExport": "http://purl.org/nidash/nidm#NIDM_0000166"
+  },
+  "entity": {
+    "niiri:a792e7640ea680e887ff5fb67a74d579": {
+      "prov:type": [
+        {
+        "$": "prov:Bundle",
+        "type": "xsd:QName"
+        },
+        {
+        "$": "nidm_NIDMResults:",
+        "type": "xsd:QName"
+        }
+      ],
+      "prov:label": {
+        "$": "NIDM-Results",
+        "type": "xsd:string"
+      },
+      "nidm_version:": {
+        "$": "1.3.0",
+        "type": "xsd:string"
+      }
+    }
+  },
+  "activity": {
+    "niiri:34e091da330b63901082b65ed57e7701": {
+      "prov:type": {
+        "$": "nidm_NIDMResultsExport:",
+        "type": "xsd:QName"
+      },
+      "prov:label": {
+        "$": "NIDM-Results export",
+        "type": "xsd:string"
+      }
+    }
+  },
+  "agent": {
+    "niiri:6899857b8c32ae5b43d240b4f06f2892": {
+      "prov:type": [
+        {
+        "$": "nidm_spm_results_nidm:",
+        "type": "xsd:QName"
+        },
+        {
+        "$": "prov:SoftwareAgent",
+        "type": "xsd:QName"
+        }
+      ],
+      "prov:label": {
+        "$": "spm_results_nidm",
+        "type": "xsd:string"
+      },
+      "nidm_softwareVersion:": {
+        "$": "12.7057",
+        "type": "xsd:string"
+      }
+    }
+  },
+  "wasGeneratedBy": {
+    "_:wGB5": {
+      "prov:entity": "niiri:a792e7640ea680e887ff5fb67a74d579",
+      "prov:activity": "niiri:34e091da330b63901082b65ed57e7701",
+      "prov:time": "2017-04-19T12:17:33"
+    }
+  },
+  "wasAssociatedWith": {
+    "_:wAW4": {
+      "prov:activity": "niiri:34e091da330b63901082b65ed57e7701",
+      "prov:agent": "niiri:6899857b8c32ae5b43d240b4f06f2892"
+    }
+  },
+  "bundle": {
+    "niiri:a792e7640ea680e887ff5fb67a74d579": {
+    "prefix": {
+        "nidm_softwareVersion": "http://purl.org/nidash/nidm#NIDM_0000122",
+        "nidm_CoordinateSpace": "http://purl.org/nidash/nidm#NIDM_0000016",
+        "nidm_voxelToWorldMapping": "http://purl.org/nidash/nidm#NIDM_0000132",
+        "nidm_voxelUnits": "http://purl.org/nidash/nidm#NIDM_0000133",
+        "nidm_voxelSize": "http://purl.org/nidash/nidm#NIDM_0000131",
+        "nidm_inWorldCoordinateSystem": "http://purl.org/nidash/nidm#NIDM_0000105",
+        "nidm_numberOfDimensions": "http://purl.org/nidash/nidm#NIDM_0000112",
+        "nidm_dimensionsInVoxels": "http://purl.org/nidash/nidm#NIDM_0000090",
+        "nlx_Imaginginstrument": "http://uri.neuinfo.org/nif/nifstd/birnlex_2094",
+        "nlx_Magneticresonanceimagingscanner": "http://uri.neuinfo.org/nif/nifstd/birnlex_2100",
+        "nidm_grandMeanScaling": "http://purl.org/nidash/nidm#NIDM_0000096",
+        "nidm_targetIntensity": "http://purl.org/nidash/nidm#NIDM_0000124",
+        "nidm_hasMRIProtocol": "http://purl.org/nidash/nidm#NIDM_0000172",
+        "nlx_FunctionalMRIprotocol": "http://uri.neuinfo.org/nif/nifstd/birnlex_2250",
+        "nidm_Data": "http://purl.org/nidash/nidm#NIDM_0000169",
+        "spm_DCTDriftModel": "http://purl.org/nidash/spm#SPM_0000002",
+        "spm_SPMsDriftCutoffPeriod": "http://purl.org/nidash/spm#SPM_0000001",
+        "nidm_hasDriftModel": "http://purl.org/nidash/nidm#NIDM_0000088",
+        "nidm_hasHRFBasis": "http://purl.org/nidash/nidm#NIDM_0000102",
+        "spm_SPMsCanonicalHRF": "http://purl.org/nidash/spm#SPM_0000004",
+        "nidm_DesignMatrix": "http://purl.org/nidash/nidm#NIDM_0000019",
+        "nidm_regressorNames": "http://purl.org/nidash/nidm#NIDM_0000021",
+        "nidm_hasErrorDependence": "http://purl.org/nidash/nidm#NIDM_0000100",
+        "obo_Toeplitzcovariancestructure": "http://purl.obolibrary.org/obo/STATO_0000357",
+        "nidm_dependenceMapWiseDependence": "http://purl.org/nidash/nidm#NIDM_0000089",
+        "nidm_ConstantParameter": "http://purl.org/nidash/nidm#NIDM_0000072",
+        "nidm_errorVarianceHomogeneous": "http://purl.org/nidash/nidm#NIDM_0000094",
+        "nidm_varianceMapWiseDependence": "http://purl.org/nidash/nidm#NIDM_0000126",
+        "nidm_IndependentParameter": "http://purl.org/nidash/nidm#NIDM_0000073",
+        "nidm_withEstimationMethod": "http://purl.org/nidash/nidm#NIDM_0000134",
+        "obo_generalizedleastsquaresestimation": "http://purl.obolibrary.org/obo/STATO_0000372",
+        "nidm_ErrorModel": "http://purl.org/nidash/nidm#NIDM_0000023",
+        "nidm_hasErrorDistribution": "http://purl.org/nidash/nidm#NIDM_0000101",
+        "obo_normaldistribution": "http://purl.obolibrary.org/obo/STATO_0000227",
+        "nidm_ModelParametersEstimation": "http://purl.org/nidash/nidm#NIDM_0000056",
+        "nidm_MaskMap": "http://purl.org/nidash/nidm#NIDM_0000054",
+        "nidm_isUserDefined": "http://purl.org/nidash/nidm#NIDM_0000106",
+        "nidm_inCoordinateSpace": "http://purl.org/nidash/nidm#NIDM_0000104",
+        "nidm_GrandMeanMap": "http://purl.org/nidash/nidm#NIDM_0000033",
+        "nidm_maskedMedian": "http://purl.org/nidash/nidm#NIDM_0000107",
+        "nidm_ParameterEstimateMap": "http://purl.org/nidash/nidm#NIDM_0000061",
+        "nidm_ResidualMeanSquaresMap": "http://purl.org/nidash/nidm#NIDM_0000066",
+        "nidm_ReselsPerVoxelMap": "http://purl.org/nidash/nidm#NIDM_0000144",
+        "obo_contrastweightmatrix": "http://purl.obolibrary.org/obo/STATO_0000323",
+        "nidm_statisticType": "http://purl.org/nidash/nidm#NIDM_0000123",
+        "obo_Fstatistic": "http://purl.obolibrary.org/obo/STATO_0000282",
+        "nidm_contrastName": "http://purl.org/nidash/nidm#NIDM_0000085",
+        "nidm_ContrastEstimation": "http://purl.org/nidash/nidm#NIDM_0000001",
+        "nidm_StatisticMap": "http://purl.org/nidash/nidm#NIDM_0000076",
+        "nidm_errorDegreesOfFreedom": "http://purl.org/nidash/nidm#NIDM_0000093",
+        "nidm_effectDegreesOfFreedom": "http://purl.org/nidash/nidm#NIDM_0000091",
+        "nidm_ContrastExplainedMeanSquareMap": "http://purl.org/nidash/nidm#NIDM_0000163",
+        "obo_statistic": "http://purl.obolibrary.org/obo/STATO_0000039",
+        "nidm_PValueUncorrected": "http://purl.org/nidash/nidm#NIDM_0000160",
+        "obo_FWERadjustedpvalue": "http://purl.obolibrary.org/obo/OBI_0001265",
+        "nidm_HeightThreshold": "http://purl.org/nidash/nidm#NIDM_0000034",
+        "nidm_equivalentThreshold": "http://purl.org/nidash/nidm#NIDM_0000161",
+        "nidm_ExtentThreshold": "http://purl.org/nidash/nidm#NIDM_0000026",
+        "nidm_clusterSizeInVoxels": "http://purl.org/nidash/nidm#NIDM_0000084",
+        "nidm_clusterSizeInResels": "http://purl.org/nidash/nidm#NIDM_0000156",
+        "nidm_PeakDefinitionCriteria": "http://purl.org/nidash/nidm#NIDM_0000063",
+        "nidm_maxNumberOfPeaksPerCluster": "http://purl.org/nidash/nidm#NIDM_0000108",
+        "nidm_minDistanceBetweenPeaks": "http://purl.org/nidash/nidm#NIDM_0000109",
+        "nidm_ClusterDefinitionCriteria": "http://purl.org/nidash/nidm#NIDM_0000007",
+        "nidm_hasConnectivityCriterion": "http://purl.org/nidash/nidm#NIDM_0000099",
+        "nidm_voxel18connected": "http://purl.org/nidash/nidm#NIDM_0000128",
+        "nidm_Inference": "http://purl.org/nidash/nidm#NIDM_0000049",
+        "nidm_hasAlternativeHypothesis": "http://purl.org/nidash/nidm#NIDM_0000097",
+        "nidm_OneTailedTest": "http://purl.org/nidash/nidm#NIDM_0000060",
+        "nidm_SearchSpaceMaskMap": "http://purl.org/nidash/nidm#NIDM_0000068",
+        "nidm_searchVolumeInVoxels": "http://purl.org/nidash/nidm#NIDM_0000121",
+        "nidm_searchVolumeInUnits": "http://purl.org/nidash/nidm#NIDM_0000136",
+        "nidm_reselSizeInVoxels": "http://purl.org/nidash/nidm#NIDM_0000148",
+        "nidm_searchVolumeInResels": "http://purl.org/nidash/nidm#NIDM_0000149",
+        "spm_searchVolumeReselsGeometry": "http://purl.org/nidash/spm#SPM_0000010",
+        "nidm_noiseFWHMInVoxels": "http://purl.org/nidash/nidm#NIDM_0000159",
+        "nidm_noiseFWHMInUnits": "http://purl.org/nidash/nidm#NIDM_0000157",
+        "nidm_randomFieldStationarity": "http://purl.org/nidash/nidm#NIDM_0000120",
+        "nidm_expectedNumberOfVoxelsPerCluster": "http://purl.org/nidash/nidm#NIDM_0000143",
+        "nidm_expectedNumberOfClusters": "http://purl.org/nidash/nidm#NIDM_0000141",
+        "nidm_heightCriticalThresholdFWE05": "http://purl.org/nidash/nidm#NIDM_0000147",
+        "nidm_heightCriticalThresholdFDR05": "http://purl.org/nidash/nidm#NIDM_0000146",
+        "spm_smallestSignificantClusterSizeInVoxelsFWE05": "http://purl.org/nidash/spm#SPM_0000014",
+        "spm_smallestSignificantClusterSizeInVoxelsFDR05": "http://purl.org/nidash/spm#SPM_0000013",
+        "nidm_ExcursionSetMap": "http://purl.org/nidash/nidm#NIDM_0000025",
+        "nidm_numberOfSupraThresholdClusters": "http://purl.org/nidash/nidm#NIDM_0000111",
+        "nidm_pValue": "http://purl.org/nidash/nidm#NIDM_0000114",
+        "nidm_hasClusterLabelsMap": "http://purl.org/nidash/nidm#NIDM_0000098",
+        "nidm_hasMaximumIntensityProjection": "http://purl.org/nidash/nidm#NIDM_0000138",
+        "nidm_ClusterLabelsMap": "http://purl.org/nidash/nidm#NIDM_0000008",
+        "nidm_SupraThresholdCluster": "http://purl.org/nidash/nidm#NIDM_0000070",
+        "nidm_pValueUncorrected": "http://purl.org/nidash/nidm#NIDM_0000116",
+        "nidm_pValueFWER": "http://purl.org/nidash/nidm#NIDM_0000115",
+        "nidm_qValueFDR": "http://purl.org/nidash/nidm#NIDM_0000119",
+        "nidm_clusterLabelId": "http://purl.org/nidash/nidm#NIDM_0000082",
+        "nidm_Peak": "http://purl.org/nidash/nidm#NIDM_0000062",
+        "nidm_equivalentZStatistic": "http://purl.org/nidash/nidm#NIDM_0000092",
+        "nidm_Coordinate": "http://purl.org/nidash/nidm#NIDM_0000015",
+        "nidm_coordinateVector": "http://purl.org/nidash/nidm#NIDM_0000086"
+    },
+    "entity": {
+        "niiri:e85365bb21fa161b4325e2ba8cd4fd25": {
+            "prov:type": {
+                "$": "nidm_CoordinateSpace:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Coordinate space 1",
+                "type": "xsd:string"
+            },
+            "nidm_voxelToWorldMapping:": {
+                "$": "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]",
+                "type": "xsd:string"
+            },
+            "nidm_voxelUnits:": {
+                "$": "[\"mm\", \"mm\", \"mm\"]",
+                "type": "xsd:string"
+            },
+            "nidm_voxelSize:": {
+                "$": "[2, 2, 2]",
+                "type": "xsd:string"
+            },
+            "nidm_inWorldCoordinateSystem:": {
+                "$": "nidm_Ixi549CoordinateSystem:",
+                "type": "xsd:string"
+            },
+            "nidm_numberOfDimensions:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_dimensionsInVoxels:": {
+                "$": "[79,95,79]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e2f4df9e4df57e86b857fd981bd770f4": {
+            "prov:type": [
+                {
+                "$": "prov:Collection",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Data:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Data",
+                "type": "xsd:string"
+            },
+            "nidm_grandMeanScaling:": {
+                "$": "true",
+                "type": "xsd:boolean"
+            },
+            "nidm_targetIntensity:": {
+                "$": "100",
+                "type": "xsd:float"
+            },
+            "nidm_hasMRIProtocol:": {
+                "$": "nlx_FunctionalMRIprotocol:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:84c830ff207d2b79a733f2225b489cae": {
+            "prov:type": {
+                "$": "spm_DCTDriftModel:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "SPM's DCT Drift Model",
+                "type": "xsd:string"
+            },
+            "spm_SPMsDriftCutoffPeriod:": {
+                "$": "128",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c48b8f1c4db4fafced12fe461ce9d3ba": {
+            "prov:type": {
+                "$": "nidm_DesignMatrix:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "DesignMatrix.csv",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "DesignMatrix.csv",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "text/csv",
+                "type": "xsd:string"
+            },
+            "dc:description": {
+                "$": "niiri:82527de1b9c5a981fb6b965a6f20adc2",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Design Matrix",
+                "type": "xsd:string"
+            },
+            "nidm_regressorNames:": {
+                "$": "[\"Sn(1) to*bf(1)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) constant\"]",
+                "type": "xsd:string"
+            },
+            "nidm_hasDriftModel:": {
+                "$": "niiri:84c830ff207d2b79a733f2225b489cae",
+                "type": "xsd:string"
+            },
+            "nidm_hasHRFBasis:": {
+                "$": "spm_SPMsCanonicalHRF:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:82527de1b9c5a981fb6b965a6f20adc2": {
+            "prov:type": {
+                "$": "dctype:Image",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "DesignMatrix.png",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "DesignMatrix.png",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/png",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:cc140a0d6189b0430c070bd23d6ca3d0": {
+            "prov:type": {
+                "$": "nidm_ErrorModel:",
+                "type": "xsd:QName"
+            },
+            "nidm_hasErrorDistribution:": {
+                "$": "obo_normaldistribution:",
+                "type": "xsd:string"
+            },
+            "nidm_hasErrorDependence:": {
+                "$": "obo_Toeplitzcovariancestructure:",
+                "type": "xsd:string"
+            },
+            "nidm_dependenceMapWiseDependence:": {
+                "$": "nidm_ConstantParameter:",
+                "type": "xsd:string"
+            },
+            "nidm_errorVarianceHomogeneous:": {
+                "$": "true",
+                "type": "xsd:boolean"
+            },
+            "nidm_varianceMapWiseDependence:": {
+                "$": "nidm_IndependentParameter:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2966074b9e21383f6f55902411f9d3e2": {
+            "prov:type": {
+                "$": "nidm_MaskMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "Mask.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nidm_isUserDefined:": {
+                "$": "false",
+                "type": "xsd:boolean"
+            },
+            "nfo:fileName": {
+                "$": "Mask.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Mask",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:e85365bb21fa161b4325e2ba8cd4fd25",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c4fb2761d2a5b5a53b14dfb73eb55ec9": {
+            "prov:type": {
+                "$": "nidm_MaskMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "mask.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "36929e1f5f4143bd9cc818cd896a25f129961fab208c3a4438555f40444c08347b359142ee8c53ece6e8cca1627f49db0788a1fd3b9e2ecaef61999c6c6c67ac",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:41db56fb656683f93922ac7c8120201a": {
+            "prov:type": {
+                "$": "nidm_GrandMeanMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "GrandMean.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "GrandMean.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Grand Mean Map",
+                "type": "xsd:string"
+            },
+            "nidm_maskedMedian:": {
+                "$": "111.557487487793",
+                "type": "xsd:float"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:e85365bb21fa161b4325e2ba8cd4fd25",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "512157cc6bff89d9343a09b4068226eb3edd64a8cbcee861f06231767fae6f8d4819921182adebee083a9bf309afd65529ab04a92f0aa6b0038c8098550f6124",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e53ec83adf28281a0da4fb79bd6f8d37": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0001.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0001.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 1",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:e85365bb21fa161b4325e2ba8cd4fd25",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a303f093674cfea3af31e31f0b993403": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0001.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:72b76763a43f712d064e7ff5a0abf2f4": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0002.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0002.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 2",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:e85365bb21fa161b4325e2ba8cd4fd25",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3832b1c295247b7ad30eeb6b6a356d9a": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0002.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4e1dd7422d51470871328ffe1585b00e": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0003.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0003.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 3",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:e85365bb21fa161b4325e2ba8cd4fd25",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:132d0cc169a2090d70bcc3a2cf72ef78": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0003.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5838dc3694e3780735e8138028cf3030": {
+            "prov:type": {
+                "$": "nidm_ResidualMeanSquaresMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ResidualMeanSquares.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ResidualMeanSquares.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Residual Mean Squares Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:e85365bb21fa161b4325e2ba8cd4fd25",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "991abf563d795a43b1e2eef8643e57023f2e0b090b2031f05f839321fc0643df6f71d423486a1021519b6dc82f6b0f563e19f3fbd50cb16063bed54a0e192d3e",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:bc3cced01cc00b56e891f3591686d4d7": {
+            "prov:type": {
+                "$": "nidm_ResidualMeanSquaresMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "ResMS.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "40b28d03fcf9a2f60b11f10d7fb83bf3618b234fb5aedf09df644cb7cbb6aab8c9f468897c1078166d455a3d04a83f4e3bf762cfca0b4ea982d7a4e406849f18",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c7a291c12eb2c6c7e9ebcb9759d8ea7c": {
+            "prov:type": {
+                "$": "nidm_ReselsPerVoxelMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ReselsPerVoxel.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ReselsPerVoxel.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Resels per Voxel Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:e85365bb21fa161b4325e2ba8cd4fd25",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "1a3f9216e145249ccc0b14b2bc337d6b38b81ad45e32768001fb22b35f0c2c0f3e2bce013b40c85f7dc0fc62723ac761ee7f7e1e6aff128a05f0ba7b8b8202a3",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:37ab6fc51451696d75a2fb041b423fb9": {
+            "prov:type": {
+                "$": "nidm_ReselsPerVoxelMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "RPV.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "4f76663162857f6b38b2a45a63b15a23b2ca8b338c283b69c1e71f2ea2f43797d045a733cd14e845be9c12f8b8f84d3931c599a08e8f6d77e99fab46ad87ab8f",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:543c3abe649faffdd9de4655fb735982": {
+            "prov:type": {
+                "$": "obo_contrastweightmatrix:",
+                "type": "xsd:QName"
+            },
+            "nidm_statisticType:": {
+                "$": "obo_Fstatistic:",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast: tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "[1, 0, 0]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:22b2d246ca83f9742df6152441f4821f": {
+            "prov:type": {
+                "$": "nidm_StatisticMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "FStatistic.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "FStatistic.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "F-Statistic Map: tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "nidm_statisticType:": {
+                "$": "obo_Fstatistic:",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "nidm_errorDegreesOfFreedom:": {
+                "$": "97.9999999998522",
+                "type": "xsd:float"
+            },
+            "nidm_effectDegreesOfFreedom:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:e85365bb21fa161b4325e2ba8cd4fd25",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "04986199ffcd3f12e4ccd95adf79d83627b3cc230969d1c39bfbb2732235f2ce33e15a0bcbfc7b892ccc17b17b2563de2a83d05e06944ea0d017558021d3a502",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e3f29dfdfad324d9c4f41fb318e668b4": {
+            "prov:type": {
+                "$": "nidm_StatisticMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "spmF_0001.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "c8f88ccb9f7c33bd901d8af4b0078e409ac7f4b037ee840cfbb528f918f0c27d651e201bcc709cd7bfc442c8057b377aa6f3e36afee8d3ade5ce8de5f7d65166",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7f4cdffd78ae5971875e37f617e84f61": {
+            "prov:type": {
+                "$": "nidm_ContrastExplainedMeanSquareMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ContrastExplainedMeanSquare.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ContrastExplainedMeanSquare.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast Explained Mean Square Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:e85365bb21fa161b4325e2ba8cd4fd25",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "9c0fc116d1bdba4d13d20c49c9ab93b22d60636dd953d081d8e8cd5f488bd427bfb32339578346aad9a8f54a907cb00a74e8a0a0758786ffb6c633730ff94774",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c90905a2f9fd05b279e167b48e9e991b": {
+            "prov:type": [
+                {
+                "$": "nidm_HeightThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_PValueUncorrected:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Height Threshold: p<0.001 (unc.)",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "0.000999500134086118",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentThreshold:": [
+                {
+                "$": "niiri:242e46f10e864dfba4d04608f5933a37",
+                "type": "xsd:string"
+                },
+                {
+                "$": "niiri:ee1543686e6a6f4ecaabc7f8fed88df7",
+                "type": "xsd:string"
+                }
+            ]
+        },
+        "niiri:242e46f10e864dfba4d04608f5933a37": {
+            "prov:type": [
+                {
+                "$": "nidm_HeightThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_statistic:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Height Threshold: F=11.509654)",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "11.5096541798536",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ee1543686e6a6f4ecaabc7f8fed88df7": {
+            "prov:type": [
+                {
+                "$": "nidm_HeightThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_FWERadjustedpvalue:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Height Threshold: p<1.000000 (FWE)",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3f89804bcbc35a20ed10f6065ed6f45f": {
+            "prov:type": [
+                {
+                "$": "nidm_ExtentThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_statistic:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Extent Threshold: k>=0",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "0",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentThreshold:": [
+                {
+                "$": "niiri:dfd666502d3a5b4e831a683a161e814b",
+                "type": "xsd:string"
+                },
+                {
+                "$": "niiri:ef06cbe71e52afe55ddec88cd1796f92",
+                "type": "xsd:string"
+                }
+            ]
+        },
+        "niiri:dfd666502d3a5b4e831a683a161e814b": {
+            "prov:type": [
+                {
+                "$": "nidm_ExtentThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_FWERadjustedpvalue:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Extent Threshold",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ef06cbe71e52afe55ddec88cd1796f92": {
+            "prov:type": [
+                {
+                "$": "nidm_ExtentThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_PValueUncorrected:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Extent Threshold",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6e55046381e462ccd425414e6c6e55df": {
+            "prov:type": {
+                "$": "nidm_PeakDefinitionCriteria:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak Definition Criteria",
+                "type": "xsd:string"
+            },
+            "nidm_maxNumberOfPeaksPerCluster:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_minDistanceBetweenPeaks:": {
+                "$": "8",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:1c65c77d484fdd55f58d632b3d659641": {
+            "prov:type": {
+                "$": "nidm_ClusterDefinitionCriteria:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Cluster Connectivity Criterion: 18",
+                "type": "xsd:string"
+            },
+            "nidm_hasConnectivityCriterion:": {
+                "$": "nidm_voxel18connected:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:78e99904e3bcdd85e6a94fdbda3413d3": {
+            "prov:type": {
+                "$": "nidm_SearchSpaceMaskMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "SearchSpaceMask.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "SearchSpaceMask.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Search Space Mask Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:e85365bb21fa161b4325e2ba8cd4fd25",
+                "type": "xsd:string"
+            },
+            "nidm_searchVolumeInVoxels:": {
+                "$": "223057",
+                "type": "xsd:int"
+            },
+            "nidm_searchVolumeInUnits:": {
+                "$": "1784456",
+                "type": "xsd:float"
+            },
+            "nidm_reselSizeInVoxels:": {
+                "$": "65.5786964036542",
+                "type": "xsd:float"
+            },
+            "nidm_searchVolumeInResels:": {
+                "$": "3155.84193266257",
+                "type": "xsd:float"
+            },
+            "spm_searchVolumeReselsGeometry:": {
+                "$": "[6, 97.8140592306853, 965.938819261507, 3155.84193266257]",
+                "type": "xsd:string"
+            },
+            "nidm_noiseFWHMInVoxels:": {
+                "$": "[4.09118640605185, 4.0346308705955, 3.97291894351243]",
+                "type": "xsd:string"
+            },
+            "nidm_noiseFWHMInUnits:": {
+                "$": "[8.18237281210369, 8.069261741191, 7.94583788702486]",
+                "type": "xsd:string"
+            },
+            "nidm_randomFieldStationarity:": {
+                "$": "true",
+                "type": "xsd:boolean"
+            },
+            "nidm_expectedNumberOfVoxelsPerCluster:": {
+                "$": "5.88889159437044",
+                "type": "xsd:float"
+            },
+            "nidm_expectedNumberOfClusters:": {
+                "$": "40.6597852835614",
+                "type": "xsd:float"
+            },
+            "nidm_heightCriticalThresholdFWE05:": {
+                "$": "30.1873792634448",
+                "type": "xsd:float"
+            },
+            "nidm_heightCriticalThresholdFDR05:": {
+                "$": "22.5453071594238",
+                "type": "xsd:float"
+            },
+            "crypto:sha512": {
+                "$": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876",
+                "type": "xsd:string"
+            },
+            "spm_smallestSignificantClusterSizeInVoxelsFWE05:": {
+                "$": "86",
+                "type": "xsd:int"
+            },
+            "spm_smallestSignificantClusterSizeInVoxelsFDR05:": {
+                "$": "51",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:4391a2ef60f122937f69c2336ae7251d": {
+            "prov:type": {
+                "$": "nidm_ExcursionSetMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ExcursionSet.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ExcursionSet.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Excursion Set Map",
+                "type": "xsd:string"
+            },
+            "nidm_numberOfSupraThresholdClusters:": {
+                "$": "184",
+                "type": "xsd:int"
+            },
+            "nidm_pValue:": {
+                "$": "0",
+                "type": "xsd:float"
+            },
+            "nidm_hasClusterLabelsMap:": {
+                "$": "niiri:2b1331d80daab9b0cd80c884a151f411",
+                "type": "xsd:string"
+            },
+            "nidm_hasMaximumIntensityProjection:": {
+                "$": "niiri:ffeb9e623c6efb2a5664eb58fcae60d1",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:e85365bb21fa161b4325e2ba8cd4fd25",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "059b760592f8180167aef22914cae89482e9a83c8b1a3d01ed8e313c99bf4e1dbbf1e70e4100dfc87789c5dc1571a71e7d7122be0a817ee2fba7c35c6638dd66",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2b1331d80daab9b0cd80c884a151f411": {
+            "prov:type": {
+                "$": "nidm_ClusterLabelsMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ClusterLabels.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ClusterLabels.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Cluster Labels Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:e85365bb21fa161b4325e2ba8cd4fd25",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "b3175bc7185eccf2b55e86c7cb8166bc41c808e3a44971eabd71190fd50bdf8d6d8b820bb69a70ed7b8c5ec063a8523f3640529894dd0b1cdb1a8621ee1f30df",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ffeb9e623c6efb2a5664eb58fcae60d1": {
+            "prov:type": {
+                "$": "dctype:Image",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "MaximumIntensityProjection.png",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "MaximumIntensityProjection.png",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/png",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a02993e23816e346753a88b23cc8928d": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0001",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1212",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "18.4816116584541",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.97791594741181e-19",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "2.28984133580943e-17",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "1",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:1fb6d1d0216b48739f26ab81c9d1d36e": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0002",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4556",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "69.4737811187434",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.62965270678044e-45",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1.0358560980476e-42",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "2",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:513b4dd1fd53a8b3917570bbd44a1da7": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0003",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "725",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "11.0554195151644",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.01378007680423e-13",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "4.12203604582828e-12",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "3.10892556886631e-12",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "3",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:0383eb2fc5ee76be5634bfee80f2ca3b": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0004",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "153",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "2.33307473906228",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.47804175343133e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00100705903153597",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000253310934795202",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "4",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:e67cada24205233131c2bfe154669c61": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0005",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "313",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "4.77289145965028",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.78025631888379e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1.53704292116252e-06",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "5.54898403464322e-07",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "5",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:a3635579e9882ee1f3c09824008b66b4": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0006",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1743",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "26.5787533999056",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.79274571779028e-24",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "2.93955070691137e-22",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "6",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c50d34609678664d461509f54c79eea7": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0007",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "203",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "3.09551746424603",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.74542128986256e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.000111622009958512",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "2.97151480785124e-05",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "7",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:86785a60d43172b11448d491c5ae96dc": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0008",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "415",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "6.32827461902514",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.10116908495443e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "4.47732975139559e-08",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "2.25127901812905e-08",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "8",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:dded355a673488279610ef537e861858": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0009",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "755",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "11.5128851502746",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.46595915881099e-14",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1.81588077907691e-12",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1.64347297044244e-12",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "9",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c1b3c9780e84e1bcfb3c612aa647510e": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0010",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "101",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.54013430487118",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000322150104613025",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0130131413575594",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00246981746869986",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "10",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:86886012c734f3d338a1efb48a81145a": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0011",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4088",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "62.3373172110235",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.84129160432794e-42",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "6.2939882759817e-40",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "11",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:e25e46750ed6706bcfbfa5e14d55d777": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0012",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "649",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "9.89650657288509",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.52486281845645e-13",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "3.46619399849146e-11",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "2.24082108370855e-11",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "12",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:e2ac8194c797871c399100cc42929140": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0013",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "40",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.609954180147001",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0130862767797146",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.412621113012691",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0650777007423645",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "13",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:e480d8d12a9dc866e99b7a65d64c73b5": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0014",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "226",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "3.44624111783056",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.06192606997673e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "4.31767538493499e-05",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1.22121498047324e-05",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "14",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:82f170400f1b69cc64c4688f03080756": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0015",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "113",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.72312055891528",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000172454772843055",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00698744750493652",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00137963818274444",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "15",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c7d451f7f453a0be61177b599ede33a5": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0016",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "312",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "4.75764260514661",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.92047785056314e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1.59405660560274e-06",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "5.54898403464322e-07",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "16",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:37926699687cca9b9dd0b742b092ff48": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0017",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "341",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "5.19985938575318",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.38423708416377e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "5.6282766780491e-07",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "2.31545112260121e-07",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "17",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:e7fc074f64298360eb2c7ffbcb4e63aa": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0018",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "32",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.487963344117601",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0238298502170892",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.620506038183986",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0932913285094554",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "18",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:617a58ee9ff77a4075c0708ea690d16c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0019",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "119",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.81461368593733",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000127236609479189",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00516005416668353",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00111483505448432",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "19",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:fd34291df44a2d10645e6546a1593a1c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0020",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "86",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.31140148731605",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000729410759827573",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0292222114056673",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00516198383877974",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "20",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:8677fb654966f35b2ba255c1e63d1cb1": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0021",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "500",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "7.62442725183751",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.19462568299287e-11",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "2.92531932011286e-09",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1.65476390708836e-09",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "21",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:545f94f2d451c1c902303c221a0a1089": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0022",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "96",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.4638900323528",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000420994377301339",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0169718682525768",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00309851861693785",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "22",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f9a9c037c3239038fee46308d6b9feba": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0023",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "17",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.259230526562475",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0861954671385755",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.969943886254665",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.233234793433793",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "23",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:6441c160dec1271f21351fe6ca31e10a": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0024",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "232",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "3.53773424485261",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.33343104779995e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "3.38829776668215e-05",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1.02223420853013e-05",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "24",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:2872350aa13a26854db92f5a27149fe1": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0025",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "39",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.594705325643326",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0140713171349931",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.435681648303699",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0663877526368907",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "25",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:e3742b34c6808b2398052ec8dae20d8c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0026",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "282",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "4.30017697003636",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.19145699221196e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "4.8444268134773e-06",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1.56591490405001e-06",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "26",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:002a4160ef17e67bfe8f93c22d701531": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0027",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "14",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.21348396305145",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.116072048788839",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.991080046819058",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.28101653917298",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "27",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:88b01b8106ca0618c3b109ef9140a77a": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0028",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "131",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.99759993998143",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.02994857850605e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00285428077037841",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00068079502023427",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "28",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:5b45e4eea89f71e19bb39684bf2f0eb7": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0029",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "19",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.289728235569826",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0713756287874445",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.945093181573621",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.215296978637538",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "29",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c3da843e94fc98cca5669ae4eef8d2ed": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0030",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "12",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.1829862540441",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.143241570472552",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.997044748433009",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.325388258851229",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "30",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:5d3257a6906cc23f21f8344f8a202720": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0031",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "116",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.7688671224263",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00014803315627116",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00600091847870632",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00123809548881334",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "31",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f9cfce19a79a082c82d2f3a6386b09c9": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0032",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "128",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.9518533764704",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.13957933683974e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00330406500536851",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000748841298989256",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "32",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:36f4c495e82ce16bc5e3538ec47db115": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0033",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "341",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "5.19985938575318",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.38423708416377e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "5.6282766780491e-07",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "2.31545112260121e-07",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "33",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f3db818d25677c7c9807d3bc465f0dec": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0034",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "15",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.228732817555125",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.104882953664569",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.985941363519183",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.26079004694974",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "34",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:16cd91852662e2b6fb06dce21defbb02": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0035",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "36",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.548958762132301",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0175611492050606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.510334393232324",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0751453826449104",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "35",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:d1f64d168706b2b7b1ea74aeb9acf76d": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0036",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "43",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.655700743658026",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0105632193593491",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.34916441811034",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0588979503672797",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "36",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:81dc6b3cbc9f571d3c373afc2c155834": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0037",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "21",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.320225944577176",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0594903493216948",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.910977384061662",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.199022259548943",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "37",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:5c83c29ecdf61abf3b54b84749525008": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0038",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "42",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.640451889154351",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0113384872261853",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.369360223137178",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0613612249887678",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "38",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:01690965efcb17bbde83102ddcb2faab": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0039",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "29",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.442216780606576",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0302138425428038",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.7072652442307",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.113456061793386",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "39",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:06b13cc33465cdc0e1390a27c23a9ac4": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0040",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "39",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.594705325643326",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0140713171349931",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.435681648303699",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0663877526368907",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "40",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:7f6f25f12f4270c6aaed0a3240d5a8a1": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0041",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "29",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.442216780606576",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0302138425428038",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.7072652442307",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.113456061793386",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "41",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:8f37ccae34c7cba6e277659e1d99e2a9": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0042",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "40",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.609954180147001",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0130862767797146",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.412621113012691",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0650777007423645",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "42",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:3acfc147a4a82a0c9064e4e844ecc743": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0043",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "37",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.564207616635976",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0163002147678929",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.484574874552217",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0731521833485923",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "43",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:bb2efddb865295f983adb4172abe81b6": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0044",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "43",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.655700743658026",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0105632193593491",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.34916441811034",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0588979503672797",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "44",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:29b1a5a35e558ec0833c58691621c112": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0045",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "53",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.808189288694776",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00534811305849296",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.1954346848858",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0339328552676794",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "45",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:16e2e680906eb7d77a0f37a900f566bb": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0046",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "43",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.655700743658026",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0105632193593491",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.34916441811034",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0588979503672797",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "46",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:160595535853afe9f10e3ba4462634ee": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0047",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "51",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.777691579687426",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00610545983579011",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.219832536837772",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0374468203261794",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "47",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:5bea9c455010164eafb48efd433d0b3b": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0048",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "64",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.975926688235202",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00265363180882805",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.102279134829792",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0180840093638652",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "48",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:54acd58c8408a4a54a5d29cdbcf77a2a": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0049",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "12",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.1829862540441",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.143241570472552",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.997044748433009",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.325388258851229",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "49",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:e0f95b0e95e26dd40bce67d69e9c88a7": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0050",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "20",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0651131165511113",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.929170899457028",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.2101897095685",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "50",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:e1915181e888f91227f9d80a2ceda361": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0051",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "12",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.1829862540441",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.143241570472552",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.997044748433009",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.325388258851229",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "51",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:059524711a78d34f86f9ff7484d30c28": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0052",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "20",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0651131165511113",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.929170899457028",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.2101897095685",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "52",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f80c4f725486ccc8cbc7ca97e9202b10": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0053",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "32",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.487963344117601",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0238298502170892",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.620506038183986",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0932913285094554",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "53",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:4fc2bcbe1574c654541b41942566af13": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0054",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "23",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.350723653584526",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0498676814730745",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.868350109038333",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.173125535680108",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "54",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:dff2d5252e6112d696cc75e19b35b055": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0055",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "10",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.15248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.178919623096924",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999307244516111",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.374104666475387",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "55",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c1d3f6f0f50baea1174f7ada78444ce5": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0056",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "19",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.289728235569826",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0713756287874445",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.945093181573621",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.215296978637538",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "56",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:ac01f2a6f9677b631c38f9d1203db903": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0057",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "23",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.350723653584526",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0498676814730745",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.868350109038333",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.173125535680108",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "57",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:6ac4331664607b2b0b57f58303204021": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0058",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "18",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.27447938106615",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0783677980047555",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.958680380360757",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.225307419263672",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "58",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:df3a63e829a4b0144a3bd3a075d00d6a": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0059",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "56",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.853935852205802",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00439806211087432",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.16374715135319",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0289015510143169",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "59",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:de4cddb037f1620436ef1889e1446b84": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0060",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "23",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.350723653584526",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0498676814730745",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.868350109038333",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.173125535680108",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "60",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:70eb10d3df67eb20319350b5182c2674": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0061",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "15",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.228732817555125",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.104882953664569",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.985941363519183",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.26079004694974",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "61",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:0c6701f42b3e926640123461fe2991bd": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0062",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0609954180147001",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.392898461436365",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999884635261",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.60244430753576",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "62",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:ff9cac1254b9e415d2191f7775b434dc": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0063",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "17",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.259230526562475",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0861954671385755",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.969943886254665",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.233234793433793",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "63",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:42811518fc15bbd0a0761ed04fef9d90": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0064",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "5",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0762442725183751",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.338223691582417",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999998934538669",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.576232956029303",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "64",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:dd408b7babb59101191c5fa3158193a1": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0065",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "11",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.167737399540425",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.159819830652318",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.998493912421707",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.35008153380984",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "65",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:99548a2427d673d5bd15c691076864b1": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0066",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "5",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0762442725183751",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.338223691582417",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999998934538669",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.576232956029303",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "66",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:7a1eb6258840314d739698ecb8549782": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0067",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "18",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.27447938106615",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0783677980047555",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.958680380360757",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.225307419263672",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "67",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:d766f0de412bd93d96229079d9de064c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0068",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "6",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0914931270220502",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.294006431429813",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999993568085853",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.520165224837362",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "68",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:8661090d64b5d8ebc0a4bd8254976fb2": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0069",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "32",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.487963344117601",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0238298502170892",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.620506038183986",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0932913285094554",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "69",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:52941f17d3d4d9019f15d6efbca27815": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0070",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "34",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.518461053124951",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0204261661708045",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.564178939107314",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0854185130779095",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "70",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:65bb243af8ca1e554de57b71bb66bc25": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0071",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "40",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.609954180147001",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0130862767797146",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.412621113012691",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0650777007423645",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "71",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:eb7b45334c4709abfab6a80cdaa2bc22": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0072",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "16",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.2439816720588",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0949840077331822",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.978974711675474",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.24967224889865",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "72",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:afbff827e6265de5fc31843cacb634e6": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0073",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "16",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.2439816720588",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0949840077331822",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.978974711675474",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.24967224889865",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "73",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:44d83170827403caee586f5f0c738aff": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0074",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "7",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.106741981525725",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.257522594755246",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999971648012046",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.483511810560871",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "74",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:2d968184be68de22a2c6d1f79a1a3779": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0075",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "19",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.289728235569826",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0713756287874445",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.945093181573621",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.215296978637538",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "75",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:8c5cc0e6fb31318c9adb3b82365f2ae6": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0076",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "6",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0914931270220502",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.294006431429813",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999993568085853",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.520165224837362",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "76",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:db5e02d87132e15c42c39a266963eb55": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0077",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "19",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.289728235569826",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0713756287874445",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.945093181573621",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.215296978637538",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "77",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:6e1483cf3114e5bdc77f5e480decfc71": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0078",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0609954180147001",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.392898461436365",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999884635261",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.60244430753576",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "78",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:1eb993430541f6c2dc79f73b3a96decc": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0079",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "11",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.167737399540425",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.159819830652318",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.998493912421707",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.35008153380984",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "79",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:e576b0cc1b6a471310c83c2e65672f5f": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0080",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "10",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.15248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.178919623096924",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999307244516111",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.374104666475387",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "80",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:01a6664df87623bed0fd193f07c04638": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0081",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "6",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0914931270220502",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.294006431429813",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999993568085853",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.520165224837362",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "81",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:9fbbe8461310da88b0ce5b0b68e8e62c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0082",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "38",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.579456471139651",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0151399339386457",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.459676077699012",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0696436961177701",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "82",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:ae14e5d65d87b53bd2bbf000849a1635": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0083",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0609954180147001",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.392898461436365",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999884635261",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.60244430753576",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "83",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:40d7f1124d8e7cab0c81135fe2f535ad": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0084",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "6",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0914931270220502",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.294006431429813",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999993568085853",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.520165224837362",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "84",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:3383de798490342ce6540ea70b023ffa": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0085",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "24",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.365972508088201",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0457449503010114",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.844324233893837",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.168341417107722",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "85",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:4bcfe0e6f6bc971e3e914655ca98bf82": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0086",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "11",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.167737399540425",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.159819830652318",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.998493912421707",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.35008153380984",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "86",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:bbf13cce053679ff04cb1b23082b44ac": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0087",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "9",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.137239690533075",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.201071431446766",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999718540285087",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.411079370957833",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "87",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:2151f348776220c1024fdc2f0b0bc92f": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0088",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0609954180147001",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.392898461436365",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999884635261",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.60244430753576",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "88",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:8ccfe08eafd83c22c7082eb44f58a70f": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0089",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "36",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.548958762132301",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0175611492050606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.510334393232324",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0751453826449104",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "89",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:bad308d46fbeeacaf458653ab9b853d6": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0090",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "17",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.259230526562475",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0861954671385755",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.969943886254665",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.233234793433793",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "90",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:687916ac6701ade9ca268dec72dc0c0d": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0091",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0609954180147001",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.392898461436365",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999884635261",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.60244430753576",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "91",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:9071142b0c2683c96f4377cdddced1d0": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0092",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "22",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.335474799080851",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0544305197907388",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.89064253285737",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.185466956323999",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "92",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:884f659ac62495dd158e264f576d0fc2": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0093",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "6",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0914931270220502",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.294006431429813",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999993568085853",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.520165224837362",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "93",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:2088eea3a39320e89e2a625ec7e9f82e": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0094",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "12",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.1829862540441",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.143241570472552",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.997044748433009",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.325388258851229",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "94",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:7fc88d60dca200d4c67a0a607a345633": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0095",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "18",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.27447938106615",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0783677980047555",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.958680380360757",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.225307419263672",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "95",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:ca1da2e7a46f823f402d9c62e070d0fc": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0096",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "7",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.106741981525725",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.257522594755246",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999971648012046",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.483511810560871",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "96",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:ea6ee099e3b8edbdd2bde04e8682a6ce": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0097",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "9",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.137239690533075",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.201071431446766",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999718540285087",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.411079370957833",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "97",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:1ef7113e2a59f273a63186ced0b0fc6b": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0098",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "15",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.228732817555125",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.104882953664569",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.985941363519183",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.26079004694974",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "98",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:02f0aee7ff558248fe49e5f3579c0585": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0099",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "8",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.1219908360294",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.22696566672688",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999901787324827",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.453931333453761",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "99",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c2cda63a78bcde6ae7a69f7ab8eadb2c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0100",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "10",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.15248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.178919623096924",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999307244516111",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.374104666475387",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "100",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:2c7f2ff6921dbb36e89f44a3a1dd839b": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0101",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0457465635110251",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.462472368627877",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999993184233",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.654795742860352",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "101",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:03e03b97c9ae144949ccd274ec79dd81": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0102",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "7",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.106741981525725",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.257522594755246",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999971648012046",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.483511810560871",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "102",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:036f2836a317a98100c1a6652ab21784": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0103",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "13",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.198235108547775",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.128769259078544",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.994677064942681",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.30770835935652",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "103",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:a029a63406d370c8869c59656bb90a54": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0104",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0609954180147001",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.392898461436365",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999884635261",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.60244430753576",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "104",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c429131bcf59cefceae4a934fd1aa80a": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0105",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.555152912425081",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999842626",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.654795742860352",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "105",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:9ac7226087de1c45b555519c1250dc59": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0106",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "17",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.259230526562475",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0861954671385755",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.969943886254665",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.233234793433793",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "106",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:9c1fe61e0e5d7d3b62e90ebdfdb9d4d4": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0107",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "14",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.21348396305145",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.116072048788839",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.991080046819058",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.28101653917298",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "107",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:7489f5e950ff72b41ea437f2c2026c6f": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0108",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0609954180147001",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.392898461436365",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999884635261",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.60244430753576",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "108",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:e83b9cd4cb9554eedc76bd43c766b08d": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0109",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.555152912425081",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999842626",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.654795742860352",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "109",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:6f3ca580fb0dafec12bb76f49a9e660f": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0110",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "8",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.1219908360294",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.22696566672688",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999901787324827",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.453931333453761",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "110",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:37ee2d388f0d21999c13e5808ab4abaa": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0111",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "7",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.106741981525725",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.257522594755246",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999971648012046",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.483511810560871",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "111",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:17c3d65f0a2dd8b609c3139c41ebf930": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0112",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "7",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.106741981525725",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.257522594755246",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999971648012046",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.483511810560871",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "112",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:bbd0acc33408cc31d2590c5760c85985": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0113",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0609954180147001",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.392898461436365",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999884635261",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.60244430753576",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "113",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:04aa6294da937ca4a062fce158511fb6": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0114",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999352",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "114",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:6e2a6189013a78c14191e7633ed21b0a": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0115",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0609954180147001",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.392898461436365",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999884635261",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.60244430753576",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "115",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:81840f3ae0159e07fac81fc13e72fbf5": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0116",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0609954180147001",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.392898461436365",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999884635261",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.60244430753576",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "116",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:dd602a84f4dd916125d3c669097eec23": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0117",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "10",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.15248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.178919623096924",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999307244516111",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.374104666475387",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "117",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:1c2363e827044fb757d9bf0cf8e052e5": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0118",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0457465635110251",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.462472368627877",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999993184233",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.654795742860352",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "118",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:45132e41bd386f5b430c16f7c2c90e0a": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0119",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "5",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0762442725183751",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.338223691582417",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999998934538669",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.576232956029303",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "119",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c4e5f3528c31047605f368909a0632ee": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0120",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "15",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.228732817555125",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.104882953664569",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.985941363519183",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.26079004694974",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "120",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:1355ee0795599ee6287d2b70ebc8d729": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0121",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0609954180147001",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.392898461436365",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999884635261",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.60244430753576",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "121",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:370789fb0338d1e1885081e0362c340f": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0122",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0457465635110251",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.462472368627877",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999993184233",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.654795742860352",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "122",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:40392b1ab652b1fe41dac16581269fb2": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0123",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.555152912425081",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999842626",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.654795742860352",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "123",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:65ef2c95ae3f51b5861bb20b84514bd9": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0124",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999352",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "124",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:5cc71319d109fdb0ef9f0f9c7bd41492": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0125",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999352",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "125",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:4bf75a353d782554be968730ac4840cd": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0126",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0457465635110251",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.462472368627877",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999993184233",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.654795742860352",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "126",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:332041ad6aeaf3a74891ecd53c374a96": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0127",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.555152912425081",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999842626",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.654795742860352",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "127",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:b47672c30d95e784941e629a0021b66b": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0128",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0457465635110251",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.462472368627877",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999993184233",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.654795742860352",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "128",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:4ade8b0865402c36f9bde1298af17ab4": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0129",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.555152912425081",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999842626",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.654795742860352",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "129",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:8d46ffe6156e40b274554eb8fc558f49": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0130",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "7",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.106741981525725",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.257522594755246",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999971648012046",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.483511810560871",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "130",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:4d3c4f523d2ecfeb9befc1c5babb099d": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0131",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.555152912425081",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999842626",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.654795742860352",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "131",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:24a29d9d6136d7a26f77ad7395967c47": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0132",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999352",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "132",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:7289b1de1e9e889ff1fb5691142cd967": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0133",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999352",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "133",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:4465bf32a18439b39ae380aba9c3f3b0": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0134",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.555152912425081",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999842626",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.654795742860352",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "134",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:1cd15156a67e7cd4faba9f06d50293c8": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0135",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999352",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "135",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:ad7c299b4aa35cd98fdbd415f19783a7": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0136",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999352",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "136",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:fe8b635d8a705b40fb4ced016e9d726a": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0137",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.555152912425081",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999842626",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.654795742860352",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "137",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:71e15e602f95bdd78bc912bf527abf9d": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0138",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999352",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "138",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:46e2492f096548abf33dea89e7a868bc": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0139",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999352",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "139",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f234bb306a90feca64756c5add571e95": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0140",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.555152912425081",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999842626",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.654795742860352",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "140",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:9a23d6bdea30bc505d71bdea4b14cc81": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0141",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.555152912425081",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999842626",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.654795742860352",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "141",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:55a2e8a69b22f0385eb446ff36f57cd5": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0142",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999352",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "142",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c1b67e6fa1bc1b0441ef946f06fc7939": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0143",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999352",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "143",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:598d8f8cb448fe66f29b80c3e9c6b8c7": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0144",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0609954180147001",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.392898461436365",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999884635261",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.60244430753576",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "144",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:9e74994c43b00fa8f3c04ed564b75259": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0145",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999352",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "145",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:59f7c04e9a6910158fa3c13760b2a417": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0146",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.555152912425081",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999842626",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.654795742860352",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "146",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:81a8b467cb1446f1ff5cdaa2c7d6e479": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0147",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.555152912425081",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999842626",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.654795742860352",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "147",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:b6cb8a909916808e62aec6d7aa7ee1b8": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0148",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999352",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "148",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:50e1d73ec7323535a313db319aa8fda1": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0149",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "6",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0914931270220502",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.294006431429813",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999993568085853",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.520165224837362",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "149",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:7dcc4c8a94cbe8b1b1f9e1f46a8741d3": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0150",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.555152912425081",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999842626",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.654795742860352",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "150",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:b54fdacdf6871d0d178386e52e6bcf8e": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0151",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0457465635110251",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.462472368627877",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999993184233",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.654795742860352",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "151",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:22043ef18c61c537ac8a05e639b5f722": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0152",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "5",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0762442725183751",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.338223691582417",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999998934538669",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.576232956029303",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "152",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:fd886d44827bbf7fd4cd36a6fa24a0dc": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0153",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999352",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "153",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:e782c57868e4be48647d27ca19f3f3c2": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0154",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0457465635110251",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.462472368627877",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999993184233",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.654795742860352",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "154",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f434c353ca0df61bb269a9c7f670117c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0155",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.555152912425081",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999842626",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.654795742860352",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "155",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:0ccff4009d26155a785837676412d40e": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0156",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.555152912425081",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999842626",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.654795742860352",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "156",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:800c8b037dc30701b156bb7c32952fad": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0157",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.555152912425081",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999842626",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.654795742860352",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "157",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:783b5fc0e23ce088341f9b979cd6ab07": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0158",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999352",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "158",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:eeecebef37458a809e6ef90a22514949": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0159",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.555152912425081",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999842626",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.654795742860352",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "159",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:9e9084297f3aec6679c40f52af1c9c5c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0160",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.555152912425081",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999842626",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.654795742860352",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "160",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:dc54137a08092762cc961c9285859566": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0161",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999352",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "161",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:9ff86139e0b5b4951d06b07e9a923ed4": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0162",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999352",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "162",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:8a8ea66289482bc8790b162d4c9789ef": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0163",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.555152912425081",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999842626",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.654795742860352",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "163",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:05c885a40fe6550c25d2a55d7c3808dc": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0164",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.555152912425081",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999842626",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.654795742860352",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "164",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:1285ada80442ae469e874ddbb7e341cc": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0165",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.555152912425081",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999842626",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.654795742860352",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "165",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:7fb9b0874581a71159fdd853f93751f2": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0166",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999352",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "166",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:62b88250957696695608f4f9d5c33c94": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0167",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.555152912425081",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999842626",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.654795742860352",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "167",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:11a529a736c285cc9a00cdcf5fb4962d": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0168",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.555152912425081",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999842626",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.654795742860352",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "168",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:56c0d386be3b33d6180c1118121d2610": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0169",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999352",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "169",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:d285ba30108c36cd9e0a52ef7d0d4cec": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0170",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0457465635110251",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.462472368627877",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999993184233",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.654795742860352",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "170",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:d38a6da35a3b35e251b575be2481d895": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0171",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.555152912425081",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999842626",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.654795742860352",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "171",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:4f56e832e623fb38abb2d199755b3aa5": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0172",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999352",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "172",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:92f563ca517a60ccfbb3ef7b2af62dac": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0173",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999352",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "173",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:8600387b3b7cea249641e5cdebba0daa": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0174",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999352",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "174",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:0f7371e43c32093550d9b7e335f29fdd": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0175",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0457465635110251",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.462472368627877",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999993184233",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.654795742860352",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "175",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:60ee0a470203bf71030d2277a3fde6c3": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0176",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.555152912425081",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999842626",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.654795742860352",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "176",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:7cded2bfb4aacaabc3212bf6e55636da": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0177",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.555152912425081",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999842626",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.654795742860352",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "177",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:56d77ed8a1025508e9f36442b2aa1001": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0178",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.555152912425081",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999842626",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.654795742860352",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "178",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:5debe73d92bf3a2e632b239ed32da2c4": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0179",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999352",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "179",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f3bc76ba4a3df529282c2ee84c68df86": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0180",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999352",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "180",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:28bbba0604724f0b5ea3c95637660afa": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0181",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999352",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "181",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:e2e08d4842a9d04eb18949c6410171c2": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0182",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999352",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "182",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:21fbadccdcf80825edc168ed54a646dd": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0183",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999352",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "183",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:37a7db920a02cc0218b6f2862406e37a": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0184",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999352",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.690223976658915",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "184",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:15408ee32b85d99dd9469a376a205277": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0001",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0641f44bc1cc38d2f46b260ac05dd0d0",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "63.4091377258301",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "6.87763687596762",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.0426772212877e-12",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "6.78640924345331e-07",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "7.69046642070356e-06",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0641f44bc1cc38d2f46b260ac05dd0d0": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0001",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[30,-82,-32]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6339834c453190a84e0be6fb23a08d7b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0002",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a391976265e9c457b429d33fcbc53448",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "34.330680847168",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.28627890808187",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.24147619143756e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0123751495969127",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00298745408887002",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a391976265e9c457b429d33fcbc53448": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0002",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[30,-74,-20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:fc608ab17d14b0216545bc760bc76351": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0003",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:458bef7562a6ed14ea6c60927fd8bf32",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "32.5551681518555",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.16035838696565",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.2323877274234e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0224930278720513",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00456113578807012",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:458bef7562a6ed14ea6c60927fd8bf32": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0003",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[54,-56,-34]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:360c87bfdf28bfd144d5781923cd8ac1": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0004",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4f45e9467d9e02d216ecae26355acbf6",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "63.223461151123",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "6.86947288292734",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.22197823976467e-12",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "7.18635271623747e-07",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "7.69046642070356e-06",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4f45e9467d9e02d216ecae26355acbf6": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0004",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-4,-86,42]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a998ae1169d6a1bfd5bc42c534c9ce86": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0005",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:1d2c00421e4eb30b21b92956b0d1a751",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "59.1932106018066",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "6.68743781613539",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.1355583140471e-11",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "2.5328927799606e-06",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1.2812091676231e-05",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:1d2c00421e4eb30b21b92956b0d1a751": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0005",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-4,-64,62]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8c4b10f0f0d23304c6889f254b8b1f11": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0006",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4513a5af88ce9b4dea2229e2abbdb320",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "54.7871932983398",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "6.47692789306752",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.680444920524e-11",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1.04400104977698e-05",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "3.92759435111279e-05",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4513a5af88ce9b4dea2229e2abbdb320": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0006",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-30,-80,46]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:fd91d07679d40254e3422190a6146551": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0007",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:8163502ef4eb2bd47c0afd06aa34e260",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "62.7276649475098",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "6.84758591415851",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.75532938079459e-12",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "8.37602977088459e-07",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "7.69046642070356e-06",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:8163502ef4eb2bd47c0afd06aa34e260": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0007",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[46,16,24]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:78698a7744e2e52357780a5302642060": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0008",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:98338f9e531b28eb906487132e15e34f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "24.248779296875",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.49788176431045",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.43169230909712e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.337713339570932",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0315627223093611",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:98338f9e531b28eb906487132e15e34f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0008",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[52,30,20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7b293150101749bc3e0a5b062221e484": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0009",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a69afafa9366b5b57795632c3b4e962c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "23.2752456665039",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.41058321872095",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.15462881078843e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.441809153541913",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0401580107168157",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a69afafa9366b5b57795632c3b4e962c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0009",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[56,18,8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d13ff858d119b29455bfd66007ccda04": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0010",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4b5f03880a32d3c6ecb349f93624a7fa",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "53.7021408081055",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "6.4230764301046",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.67736976822653e-11",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1.48942911553096e-05",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "4.66369239309748e-05",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4b5f03880a32d3c6ecb349f93624a7fa": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0010",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-46,-78,24]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:fd5511cc6e2bfdffd9438532ea9e531a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0011",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0e6a1706845dc9fd273961896d6d0a14",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "50.6493988037109",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "6.26694330529563",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.84102066924652e-10",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "4.10652052134086e-05",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "9.17691949136767e-05",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0e6a1706845dc9fd273961896d6d0a14": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0011",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[34,-88,-2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c5b79c6acbda7306e022436ba2ff08ea": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0012",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:1c858f13a6a8dd1ed4f691dbb61441ff",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "42.0282821655273",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.78380990161557",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.65137320379461e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00081446430319021",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000655649142634339",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:1c858f13a6a8dd1ed4f691dbb61441ff": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0012",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[42,-72,-10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:93f22f5d612344b81124870b08ecc87e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0013",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:8c19f2d54053cf0b01e427341923ddb7",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "27.3277149200439",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.75932547479613",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "9.71204984545615e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.129624789952327",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0155044826465378",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:8c19f2d54053cf0b01e427341923ddb7": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0013",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[34,-86,12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:46fc5c23e8aa00759077219a8ff53cba": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0014",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e72913318bdae423d898d64f71c73ee3",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "49.6541976928711",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "6.21449041258159",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.574573887415e-10",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "5.74276232319093e-05",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000101984986721175",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e72913318bdae423d898d64f71c73ee3": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0014",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[20,-58,-50]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7908619b88ba244bd93c6dba0bbb87e6": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0015",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c1e24413c80edd5055adad6446606542",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "37.7286491394043",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.51490684020097",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.74482378545449e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00389195156635691",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00135850417567201",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c1e24413c80edd5055adad6446606542": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0015",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-28,-46,-44]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c5f3e3a0fd6c3b436aae4cb7598c34c9": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0016",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:100f5aac01b00bba82ce7d02dad389fd",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "36.3174209594727",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.42181897111099",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.94978058645867e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0063697813576209",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00184664824144078",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:100f5aac01b00bba82ce7d02dad389fd": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0016",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[24,-48,-52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a49cb1b476653b5bd0a7cc950718a0ff": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0017",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:bbb63b81e8f877c8efc6acbf7b6623b9",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "46.5456809997559",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "6.04535479047381",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.45407846558521e-10",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.000166268388501201",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000246160584800799",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:bbb63b81e8f877c8efc6acbf7b6623b9": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0017",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-32,-90,22]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3e717c804be08adc2679246149af5db7": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0018",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:101ef180b33241930bb79e194dcbbed9",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "41.0003623962402",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.72141667593276",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.28197319216162e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00117818104479539",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000789910490520138",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:101ef180b33241930bb79e194dcbbed9": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0018",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-18,-100,14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2d6ad9f56e2f5b6c94d89c1ef5625631": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0019",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d479bae72ae64f4cf25acf6fbff4867f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "30.2211799621582",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.9872751544685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.06184112175423e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0494340056154295",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00803010760019555",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d479bae72ae64f4cf25acf6fbff4867f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0019",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-30,-92,12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e8ccf7a91909009975707eb5438a1c41": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0020",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c8e15c365b5b224e2797ad45cf7f4de2",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "41.3373107910156",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.74199410170229",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.67840410856013e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00104355073571449",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000741810621169375",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c8e15c365b5b224e2797ad45cf7f4de2": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0020",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-40,-82,-8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7ebb22fd72bd0789f6bd1e8550c7084c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0021",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:59238a22c085684ec58ad478012612fb",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "39.6630401611328",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.63850646223464",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.57656923258787e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00191306375378475",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0009870871843719",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:59238a22c085684ec58ad478012612fb": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0021",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-34,-68,-10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:92d02c82b7f90dbed092d3b95cad4470": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0022",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:733e8754b4ff170374623f8b270dad17",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "34.0695152282715",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.26805007110655",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.89402515074988e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0135093653627159",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00308832183253126",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:733e8754b4ff170374623f8b270dad17": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0022",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-40,-76,-22]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ac1f6889a3b03207d78c9ad5528f9b90": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0023",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:838ab3f78f4c999519706107ecaa6651",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "39.8922958374023",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.65286295967349",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.88985576871681e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00175988750867406",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0009870871843719",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:838ab3f78f4c999519706107ecaa6651": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0023",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[32,24,-4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d9645c1bc51e20ae6eda890163cdd768": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0024",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:9aa5edc1fd84dac2c53c7ba42b273db8",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "32.3555946350098",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.14590447978288",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.33117438405606e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0240593381842931",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00469183536701006",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:9aa5edc1fd84dac2c53c7ba42b273db8": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0024",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[18,16,4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:14dc5bbb6203781bf94b7883581e8d1b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0025",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:aff5a93c627ebd7f5b8c391f53c40006",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "26.9382591247559",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.72739751788369",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.13707888627079e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.147150618143017",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0165894956342347",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:aff5a93c627ebd7f5b8c391f53c40006": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0025",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[48,28,-14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4833f73495c82243b6bcc3fb9a23ef06": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0026",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7b97acac961566aab143009298852de2",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "39.4447784423828",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.62478222171801",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "9.28710763847818e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00207155431898742",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0009870871843719",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7b97acac961566aab143009298852de2": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0026",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-26,54,-44]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a037c89bf27b3fb47dd39ef32c69f1e8": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0027",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e1f6f1196ac80f76a0456036af7a4b8b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "23.9405002593994",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.47049572345504",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.90192522159438e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.368629337644182",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0337742742636344",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e1f6f1196ac80f76a0456036af7a4b8b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0027",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-32,50,-34]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a30cccdb175a9992ba9c54a7f5f86040": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0028",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:5b912d29fd13e7d63c52b495d006664f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "39.4393730163574",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.62444163011351",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "9.30544841182268e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00207564535686733",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0009870871843719",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:5b912d29fd13e7d63c52b495d006664f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0028",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[8,18,50]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f41be624e1053c51fdbdb702c880be11": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0029",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e9b06bf73aae5f22582fa6e9a26ee0d0",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "37.8498382568359",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.52278322654796",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.66835655290853e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00372138605145689",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00135850417567201",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e9b06bf73aae5f22582fa6e9a26ee0d0": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0029",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-6,12,52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:30a835006f53ac1656aa862dc46eefb1": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0030",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:668b668695b4f9c1225911b2e3aafc5f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "35.8222694396973",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.38854316616903",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.55155518327877e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00751236362554308",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00208265173602203",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:668b668695b4f9c1225911b2e3aafc5f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0030",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[8,32,38]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0f9e5faadc247bb0f606f8f2783c5dfc": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0031",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:19ae5d9dd47ddd4d5cf6d132960e4df6",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "39.0784225463867",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.60162129933516",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.06178051906269e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00236837574764137",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00100197986852916",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:19ae5d9dd47ddd4d5cf6d132960e4df6": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0031",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[52,-32,42]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5833c7ef6fbc97e336c4176bdd68792a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0032",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0e8cee08b4f95550d2575f9157d645ee",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "39.0315551757812",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.59864699876771",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.08015588695665e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00240936329200458",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00100197986852916",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0e8cee08b4f95550d2575f9157d645ee": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0032",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[40,-62,50]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e161d7cffaa802baa8842dbbc2ff600e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0033",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f26173f80e46fa5a537d30b91a145a04",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "32.5285148620605",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.15843165663784",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.24513486854383e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0226961325651858",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00456113578807012",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f26173f80e46fa5a537d30b91a145a04": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0033",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[56,-44,52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5922bca96de375a1c4dae7b56d92f626": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0034",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b342d1a5b119cd356d082e704609a7af",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "37.8682479858398",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.52397812994418",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.65704366894559e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00369615187187566",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00135850417567201",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b342d1a5b119cd356d082e704609a7af": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0034",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-28,-94,4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a4cb37e2bdfafa8de612a84fcbdf3e3e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0035",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e6af297a793f37a7c50553e7b57ac4f4",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "13.7997980117798",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.39898111375179",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000338186933782514",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999983062369",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.517098903229732",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e6af297a793f37a7c50553e7b57ac4f4": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0035",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-34,-84,-2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5f5bff873009036bef971ae6521ab438": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0036",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7d85c1d7748a0e2b666ce05b7a08b3b3",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "37.2234077453613",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.48187213205114",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.1042418696382e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00469365878715888",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00150767324732148",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7d85c1d7748a0e2b666ce05b7a08b3b3": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0036",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[32,2,46]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8981157e9a4e6b5b093e68b901438bad": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0037",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:1f9e20630d2591abc7429d5b071cfdfd",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "21.2399845123291",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.21989878746824",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.22206011216042e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.701750105433623",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0674703024550716",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:1f9e20630d2591abc7429d5b071cfdfd": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0037",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[28,4,58]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2c14d6250d370f445e78b4505c0ef514": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0038",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a105d9481745a29ec63afc10e1ef6b75",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "15.9035987854004",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.65519960348906",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000128490978751894",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999764209794947",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.29501424528785",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a105d9481745a29ec63afc10e1ef6b75": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0038",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[42,4,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c76586b39c4dce8e30ab4aec2bd0cfe3": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0039",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6710a695671f6faba8360e71e27233bc",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "37.0886573791504",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.47300715255656",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.21231123420651e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00493011007616861",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00153274880779606",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6710a695671f6faba8360e71e27233bc": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0039",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[36,-86,24]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:cbb5e181055a603b555fe4e31c70e6db": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0040",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:78e5b9b06ac93d423a8111be3ef702c4",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "22.2462520599365",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.31562212585875",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.95770158346087e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.569468011037952",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0515172252256118",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:78e5b9b06ac93d423a8111be3ef702c4": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0040",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[40,-82,32]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:66ffbe934050578ca7c698d14aa85d25": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0041",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b75d0a763814255b3c3a4c299253e49e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "21.6013984680176",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.25461718208726",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.04703485692692e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.654350531154308",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0608459925765272",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b75d0a763814255b3c3a4c299253e49e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0041",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[28,-92,26]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c141baff99ff608f6fd42bbe6f81dd32": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0042",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e06c4859c1235e6e7a24c07d2a8f9420",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "35.8021011352539",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.38718083940908",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.57857066202172e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00756307748953688",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00208265173602203",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e06c4859c1235e6e7a24c07d2a8f9420": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0042",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-52,0,38]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b7060223bff407a13eb216f455300b91": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0043",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d91a8f2dc685df25dd670f56364b8b27",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "27.304349899292",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.75741877507894",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "9.80420573615248e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.130618606044682",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0155044826465378",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d91a8f2dc685df25dd670f56364b8b27": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0043",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-60,8,20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:25383c240e64533096acb91f30ed5f79": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0044",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:2312acaca8091779181ea64815241be7",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "24.8951110839844",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.55454903196731",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.62490395575021e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.279280704231587",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0268577436307079",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:2312acaca8091779181ea64815241be7": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0044",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-44,6,28]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:68ea392bb49f24d944e1b260af098020": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0045",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e4d53353bebc01fea518333458b6e995",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "35.5708847045898",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.37152336467669",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.90371248659704e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00816987841831085",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00217310121107197",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e4d53353bebc01fea518333458b6e995": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0045",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[30,-66,-6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1735ae6e0d994f082ddd12a7f2621f0a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0046",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e9dbabf41ff4b3cbd53c7a1462ebfaab",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "35.2681846618652",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.350915057242",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.3755296941228e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00903953548239023",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00235638277703814",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e9dbabf41ff4b3cbd53c7a1462ebfaab": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0046",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[24,-54,-16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:93b54ac55b78a51e2a8346189557574f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0047",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f253c7c3034017bc1e14b769c4a9f665",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "33.5431251525879",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.23100638995574",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.42948405521682e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.016124846685693",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00349953417360534",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f253c7c3034017bc1e14b769c4a9f665": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0047",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[18,-54,-6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5766230ffa1accb71218f9a65385d08e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0048",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ceca5eb2386bd4c4e47d2c0c586a097d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "34.9530181884766",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.32932369363006",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.92895819714789e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0100448972767031",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00246864149540014",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ceca5eb2386bd4c4e47d2c0c586a097d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0048",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[16,-84,44]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b7d8fb60227ddc169d23c315114e2e40": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0049",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:20089fd71414202501ea181905ceda27",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "34.2299766540527",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.27926163486319",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.48527449520486e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0128006355440512",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00299523511468489",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:20089fd71414202501ea181905ceda27": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0049",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-48,-52,-26]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:be6ef07847d5a11377cd20e3bf142605": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0050",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7a0a448d7f559d689b8d444542976a30",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "25.4968433380127",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.60642227215859",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.04828043492977e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.232501903028901",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0230459220332407",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7a0a448d7f559d689b8d444542976a30": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0050",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-34,-42,-28]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:270434b20e00025409cc3402d4134104": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0051",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:dde4c1281c1e7730093e357f4c333b57",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "33.9315414428711",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.2583798008004",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.26650642990379e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0141503991863343",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00317914466289153",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:dde4c1281c1e7730093e357f4c333b57": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0051",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[58,12,-20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:dd6a5e6b2dd23e0f9e80ac6bfc81c96b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0052",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:cbc78a2103930efca8b6cba5d06325aa",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "19.0596389770508",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.00175558310566",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.14371148909531e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.929942403817741",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.124351274352918",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:cbc78a2103930efca8b6cba5d06325aa": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0052",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[60,-2,-16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:39553cd2909fb4f309850bc50283f969": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0053",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a51d05f416df644328a6cb3628a53340",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "16.95458984375",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.77515624884835",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.99536997647676e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.996665924683688",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.218440612600676",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a51d05f416df644328a6cb3628a53340": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0053",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[60,4,-22]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:829cbe8430fd88bbc00d346769721904": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0054",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:004948ca236c52cf9756f94713a6c2af",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "33.4968719482422",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.22773182499393",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.58010831272793e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0163777835136855",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00349953417360534",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:004948ca236c52cf9756f94713a6c2af": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0054",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-8,50,14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:779dd8335e4fd65858941476e998673b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0055",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:54043a6e802dade52c783cf91d848c19",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "29.9832496643066",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.96911405212995",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.36297509062611e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0535569381204491",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00813843087070338",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:54043a6e802dade52c783cf91d848c19": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0055",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[0,64,14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:03c31dd1111118a4d4e27639746be972": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0056",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:abb708694b565836e1566ffb6107e47f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "22.9387531280518",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.37984280105142",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.93824767269879e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.481901129565415",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0438469723479488",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:abb708694b565836e1566ffb6107e47f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0056",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-20,44,-16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f29776971e9edeb3024d30c38070b4fe": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0057",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4caf6e61318e78b90d840ebd45b97e54",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "33.4191627502441",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.22222309196889",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.83939008655688e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.016811779659474",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00353415653584831",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4caf6e61318e78b90d840ebd45b97e54": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0057",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-34,-2,52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4f203f7fbd8966e70a518b7a5098265c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0058",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:840423c9f78860e1bbacbdb8430b4cb1",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "29.2642135620117",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.91361665883884",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.47057450281285e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0681879801861663",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00986818968821408",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:840423c9f78860e1bbacbdb8430b4cb1": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0058",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-54,-46,58]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7ab50e444de918ebf5bcfdebceaf9ad0": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0059",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:73c5ac956eca1bb030453396f1ae3059",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "28.8472003936768",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.88099763110222",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.2775255054982e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0783986768366318",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0110008671467558",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:73c5ac956eca1bb030453396f1ae3059": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0059",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[34,-42,70]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:48472e5c0e95db5f72001e9bbdb54075": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0060",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c39236425bbf9b6441d6709219569da0",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "27.9873161315918",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.81269831822163",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.44529926488546e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.104344146902035",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0136039810527477",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c39236425bbf9b6441d6709219569da0": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0060",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[22,-52,72]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5ddd28f08b4c942fd117d28ee9faac64": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0061",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:42db9c9a0d0502948e4fee8df9e3124e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "27.299201965332",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.75699852876781",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "9.82463004728373e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.130838529326203",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0155044826465378",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:42db9c9a0d0502948e4fee8df9e3124e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0061",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[40,-44,62]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2b3ce71bfa91fff55105d339fbbdbe2b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0062",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:91623ffcf878c645ac2db15bb89ab96c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "28.2855854034424",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.83655063572385",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.60558149623292e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0945247092312007",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0127733737382444",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:91623ffcf878c645ac2db15bb89ab96c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0062",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-62,-38,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f2be8929a3710e3a368deadf13c7b07c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0063",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ae22616a0f065e3a7f82a19748390b4d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "20.8939819335938",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.18629418105686",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.41772903717863e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.745987987161102",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0747839778627127",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ae22616a0f065e3a7f82a19748390b4d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0063",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-60,-50,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6beebfb6b83f4e4fbc1d0fabd13b2921": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0064",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:3de11b76086fc65df36803e9e359450b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "28.164192199707",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.82686385572958",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.93499344617265e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0984091095914084",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0131723064509997",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3de11b76086fc65df36803e9e359450b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0064",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[32,40,16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:514baf9fb6cc825d6a8ed488bfd99826": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0065",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:265726ad7fe9d9c8c3951257f3edcbe3",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "20.7001953125",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.16731300977185",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.54105576545271e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.769962873085872",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0785095339135121",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:265726ad7fe9d9c8c3951257f3edcbe3": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0065",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[40,46,12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c2a20f1f60d0404677a01e0473330666": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0066",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:61822c3ab944ea0faa2fcde49bf6928c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "18.6263465881348",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.9564888351335",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.80297206890035e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.955406749953662",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.140236437115493",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:61822c3ab944ea0faa2fcde49bf6928c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0066",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[36,54,6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a7269318ead6ea41a838413495ff7e57": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0067",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b998be76596a69687ddc0d63f339c66f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "27.7903442382812",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.79685095721308",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.05897185318649e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.111355921927938",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0142325796838019",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b998be76596a69687ddc0d63f339c66f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0067",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-4,-50,74]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:357040efdf37bc34eb1815732a22e3e1": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0068",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7ec9e9fcf91f20c5fd87870401d2533a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "27.776086807251",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.79570089443694",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.10535070061569e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.111880510607324",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0142325796838019",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7ec9e9fcf91f20c5fd87870401d2533a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0068",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[40,26,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4a825f1cb4eb89df074bde02c951cda0": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0069",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:36f52911aa619b4ef4106054a1fc54dd",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "27.7102565765381",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.79038551132749",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.32305908970987e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.114333288035698",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0142910518357785",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:36f52911aa619b4ef4106054a1fc54dd": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0069",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-12,-26,84]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2f6549876aed12baa3dab8de8273d38a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0070",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:44b1830cba35547169ca826553dd909c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "27.1838035583496",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.74756386643394",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.02940694712839e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.13586045231926",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0157421086869962",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:44b1830cba35547169ca826553dd909c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0070",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[22,-16,80]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f1895be0d1633922d7667327f8d09e70": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0071",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b006146ea3a6c5cef54d99ae22492584",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "26.9941082000732",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.73199532964814",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.11161764859702e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.144508578107306",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.016538239689936",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b006146ea3a6c5cef54d99ae22492584": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0071",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-20,22,-10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:adea458f35a2dd3e503f5b76a33ccca9": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0072",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:8498f671244493e5dccddbfdee69de45",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "22.6613578796387",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.35427468283891",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.67541091325941e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.516272526829242",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0461712684947748",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:8498f671244493e5dccddbfdee69de45": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0072",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-20,22,-20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b2abdbde6951cc3df4267da78e9eab09": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0073",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:2c46ac4fa1bcf476c140cdc40fa6d0cf",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "16.1252555847168",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.68091120119901",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00011620096893894",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999550326152138",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.274499735322593",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:2c46ac4fa1bcf476c140cdc40fa6d0cf": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0073",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-28,36,-14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ce8e5b9eaf298dd260287509743e52a9": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0074",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:fa7acea05fec3c868da9178c655ffd07",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "26.7744998931885",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.71387838295499",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.21522879270586e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.155157441670289",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0172891722870727",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:fa7acea05fec3c868da9178c655ffd07": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0074",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-60,-52,18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3b07b1d9d18e5301a1eddd1ed55de100": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0075",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4935504f2ca9890d702d363dd7b1d03f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "24.3260192871094",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.50470678054082",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.3232325669097e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.330274885793216",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0310816877190926",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4935504f2ca9890d702d363dd7b1d03f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0075",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-58,-64,12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:68ccf59f802d72bf9d431b3b294d2c32": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0076",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:1e60d9d582eaec821f0d35b91631e387",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "14.2642917633057",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.45757108528077",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000272534210682851",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999731150238",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.453704488417404",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:1e60d9d582eaec821f0d35b91631e387": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0076",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-66,-44,16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:90812b753072fe6baba25b8214327983": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0077",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:2e7dbc2e92942cb373a386b48d8ab2ae",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "26.5194854736328",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.69271316665315",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.34802686679869e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.168426938943843",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0184657823782908",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:2e7dbc2e92942cb373a386b48d8ab2ae": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0077",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-48,28,2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:19c2eb940423bd075119228e3100f958": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0078",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:cbe4d401b56f46238b61ab011826b9de",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "25.691427230835",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.62301960855807",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.89096978542302e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.218875206501387",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0221192226146001",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:cbe4d401b56f46238b61ab011826b9de": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0078",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-26,30,36]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:45fb7b2544c4802833f71463702fb573": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0079",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:826ac32082a51738929fdbd7249ac832",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "19.5458869934082",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.05176480514799",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.54163753627967e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.892419390862991",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.108193496757792",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:826ac32082a51738929fdbd7249ac832": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0079",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-12,18,18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ae25400879fdbbd71ea06f98f2949c87": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0080",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d6cf34caaee1bde6a1304bf6965b1515",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "25.5991687774658",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.61516091591235",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.96395429286067e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.225247536188687",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0225353109118294",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d6cf34caaee1bde6a1304bf6965b1515": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0080",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-16,-94,-10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:dbfa2e37fc9b5cbbd31da892e2cc2e8a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0081",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:81d3490604ccd120799925539af20ef2",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "25.4056377410889",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.59861326841205",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.12656228593122e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.239135795532846",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0234803184814089",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:81d3490604ccd120799925539af20ef2": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0081",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[30,48,-36]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c98e1abf15afafba77dc2a1b5bccdb07": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0082",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:191de3f73a536af56269b0d980e647bf",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "25.2654209136963",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.58657091932872",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.25292694944201e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.249647931424908",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0240262284056265",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:191de3f73a536af56269b0d980e647bf": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0082",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[2,38,-14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:11bc9e8dccdea4c6f0576729732a26b1": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0083",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:fee409d8fb1182c19595120e80d6f171",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "18.0576820373535",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.89603144574785",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.88908495202001e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.97812034582109",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.163088144322206",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:fee409d8fb1182c19595120e80d6f171": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0083",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[8,46,-18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9eaf1659f6e51a24c9b5249d9eca8663": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0084",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:3e306b247465821a8416bea1f0792417",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "24.3388156890869",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.50583608073911",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.30560549555159e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.32905451036308",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0310816877190926",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3e306b247465821a8416bea1f0792417": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0084",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-58,-30,-18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:df657fae07b6aff0d6f00ce65dfc1a80": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0085",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:00f8a5c75c390f4c4a77aa0c74938e09",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "24.2647590637207",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.4992949508152",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.40896034356497e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.336164282110146",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0315627223093611",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:00f8a5c75c390f4c4a77aa0c74938e09": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0085",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[28,10,-48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:cd2b04f2aeb928b0be2c2b49a81c72cc": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0086",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7945a1875a4816413138667329ef1f28",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "23.435432434082",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.42511309261812",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.8195886048763e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.423415338028086",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0388969248253009",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7945a1875a4816413138667329ef1f28": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0086",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-48,18,-36]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:176829804e5fc15b1d1a6c6d59815463": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0087",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0bd53d1e4f2f294994607ed9b19f0de8",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "22.7630805969238",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.36367473144233",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.39478488917433e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.503542709649183",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0453548437799061",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0bd53d1e4f2f294994607ed9b19f0de8": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0087",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-32,-22,-20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0b19217ec62c40e969523b448d183a81": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0088",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:8902a12641b236a6f0e57e20ffe1b3d9",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "22.6970634460449",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.35757737148877",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.57550076188507e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.511788595032734",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0458137283186348",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:8902a12641b236a6f0e57e20ffe1b3d9": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0088",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-46,-66,-6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:fb41e19cf49308d445b6143dd6530c16": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0089",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a75a3a79996c194090886fd73b647151",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "14.1656980514526",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.44523640108096",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000285280079043382",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999844740898",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.467962708438717",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a75a3a79996c194090886fd73b647151": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0089",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-54,-64,-8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e444cfdfe2f6cbaf0481b63d2834fda6": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0090",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4353faa47737a9ce68ee616b1f970063",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "22.5773677825928",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.34649211997001",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.91660093510293e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.526883623410185",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0471103061870597",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4353faa47737a9ce68ee616b1f970063": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0090",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-48,-58,26]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5cdb4e3e9ed6941e49fa8b89c908661b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0091",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:8a6f228a2d58da780f109d6dee18edb2",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "18.1794853210449",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.909083502135",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.6323469247822e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.974191386889975",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.158566450522772",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:8a6f228a2d58da780f109d6dee18edb2": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0091",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-40,-54,24]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:dd4fd70f165a7929f76cd0a4dfbf5059": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0092",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:21f3959c2cd89d63592ed6a03bacfca5",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "22.300386428833",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.3206898346505",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.77710889177108e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.562434726478465",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0510171908662791",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:21f3959c2cd89d63592ed6a03bacfca5": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0092",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[58,-38,6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6263d0bf0edefd0d5b70b55319094a47": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0093",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e989bd9b9d36dcbd27f6bb25eecabde9",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "22.2661895751953",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.31748949702426",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.89069578244206e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.566874895647931",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.051397236162478",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e989bd9b9d36dcbd27f6bb25eecabde9": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0093",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[42,-66,6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a05276936cf0d417dc5ca6d7a0d6a3f9": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0094",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:cc95f61fed018b19add13d2f5b0ea062",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "22.1354484558105",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.30522386387639",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.34084780676481e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.583932942615046",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0533499015486859",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:cc95f61fed018b19add13d2f5b0ea062": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0094",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-36,-74,-14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3ccae7f904d1cb2d10acffdcfadc8f10": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0095",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c9b5f5d788c682c3f5ede975be932a63",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "16.7093238830566",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.7475977576799",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.92681312850696e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99803966762084",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.231798608212325",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c9b5f5d788c682c3f5ede975be932a63": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0095",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-36,-68,-20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8e4ca43f93486def424cfb00d341a82e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0096",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:9362a39a8676e78d5f782844a37c400b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "22.009162902832",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.29333057860161",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.80063176944557e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.600511384577349",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0552945360022594",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:9362a39a8676e78d5f782844a37c400b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0096",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[20,52,-8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e5b709733a7a64fd4daeb683bb3734c7": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0097",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:93c38f3e63878c9d511e15582b642126",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "19.9573459625244",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.09345225838168",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.12498807569128e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.853596609416469",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0969483313559081",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:93c38f3e63878c9d511e15582b642126": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0097",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[8,66,-12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c9aaa481cdfc446e54553d8f78ce6094": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0098",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:66687a1556cf944ab251cc50c5a1afec",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "21.6827297210693",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.26237714614837",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.01131850654967e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.643607390332145",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0595012953349514",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:66687a1556cf944ab251cc50c5a1afec": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0098",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-50,-56,-46]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6197fba6e2664d7308395423fa054a5a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0099",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:59ccd11f545a7e2d5564defe74cdf344",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "20.8459243774414",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.18159782528346",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.44733828864041e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.751996552599621",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0757651987419718",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:59ccd11f545a7e2d5564defe74cdf344": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0099",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-54,-60,-34]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:665564fcd3b0c01a2d413f93a062d71e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0100",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:13a8380ee841694a3439ded70c91247f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "21.6761283874512",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.26174801852479",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.01417038346208e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.644479756447942",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0595012953349514",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:13a8380ee841694a3439ded70c91247f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0100",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-6,22,-4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d510f031f5c43274a32cc49cf1f3f001": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0101",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:891a5976572946a7b565dcbdfa45714d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "16.2054805755615",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.69016146811634",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000112055876962391",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999439014335705",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.269643439858175",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:891a5976572946a7b565dcbdfa45714d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0101",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[2,24,-10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:31b0c9c2327a4d798a48c9c2cca5ac27": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0102",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f74543d456ae0968251bded2c0a3475d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "21.5253620147705",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.24734493361237",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.08159392907536e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.664379439585423",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0622520078187919",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f74543d456ae0968251bded2c0a3475d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0102",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-4,58,40]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d3aa0d69a7eaa43c7b928709eff2bf3c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0103",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e26583fef812bde0be11d99cc55cdd5b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "21.3095722198486",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.22661368779567",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.18617218586303e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.692690637306793",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.066091397071435",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e26583fef812bde0be11d99cc55cdd5b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0103",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[56,-66,28]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d97a5111c9a07f3911f9566bb4f817b7": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0104",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0baf1fce706fc700d3c2c6983653cd7c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "21.1252059936523",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.20879143363758",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.28370116740939e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.716590361946796",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0697051976348589",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0baf1fce706fc700d3c2c6983653cd7c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0104",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[16,-98,6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:142389ac0cc7b6ad0aefee61aaa19f01": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0105",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:96c31dac1b644e65f3fac10a4bcdf913",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "20.9664764404297",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.19336518197686",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.3742322497845e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.736853371757955",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0731699937068361",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:96c31dac1b644e65f3fac10a4bcdf913": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0105",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-60,-16,28]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:55baaf76e4730532805f8f2d9564575f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0106",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:326c1f2b49a399f5d14885efa0367044",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "20.4901485443115",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.14660690773876",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.68719329129985e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.795085603917253",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0839823722931768",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:326c1f2b49a399f5d14885efa0367044": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0106",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[16,14,62]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f5c396305d9d8b59e0f1de9b43bc1c04": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0107",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:251fea1831ca94c94c0699f4dbebb262",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "20.1859455108643",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.11637075760553",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.92442496569356e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.829516805025193",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0918155656683619",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:251fea1831ca94c94c0699f4dbebb262": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0107",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-46,-32,58]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b17798d8da7350fcfdb2da256f317589": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0108",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:78af07cd6758279fa7f56ce54921d1cb",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "19.9081478118896",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.08849741803632",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.17088189312653e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.858555794271687",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0982970474931675",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:78af07cd6758279fa7f56ce54921d1cb": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0108",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[38,-82,10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:606ad57a2c441571f0c00836b6a11960": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0109",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ecb1b99ed2d95e871037822a0cde1bff",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "19.88161277771",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.08582170061298",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.19605490655583e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.861196205689319",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0988533813000291",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ecb1b99ed2d95e871037822a0cde1bff": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0109",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[38,-78,44]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:44957024e6a6c3a8d350f2182ed7669b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0110",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:db64ae2b2c4d3bcd61012d22f3845781",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "19.6855850219727",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.0659821671938",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.39152966687861e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.879930855992272",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.104063286439229",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:db64ae2b2c4d3bcd61012d22f3845781": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0110",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-14,68,12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7a1f7b35bf5c2e76842344547587ee88": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0111",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:1726de2b89d7e8b3dd5c75339c03089a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "15.3516979217529",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.59017266008559",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000165229496364216",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999962977415156",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.336130452148725",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:1726de2b89d7e8b3dd5c75339c03089a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0111",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-18,66,26]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:52798f01ae0c76b1a815825b938124bf": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0112",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ddba1731b4fb95f8dc592e2e1dff8512",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "19.3617496490479",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.0329231622068",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.75436479366675e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.907734095795052",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.114345300686635",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ddba1731b4fb95f8dc592e2e1dff8512": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0112",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[14,-66,-12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ac84790ec5fc05c9de4754f79ac66e49": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0113",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:08c5e7ad57bb2c8bbad532efbb58aec7",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "19.3172149658203",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.0283486821653",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.80849975954345e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.911237684671062",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.115154016069316",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:08c5e7ad57bb2c8bbad532efbb58aec7": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0113",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[44,26,-30]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e6936b16ba6c2d4218eb760cf497ca0c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0114",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6f85ca7632c41f1bfb8b8f02fb275c74",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "18.8370418548584",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.9785849448618",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.46633215003722e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.943955324716031",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.133237780105225",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6f85ca7632c41f1bfb8b8f02fb275c74": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0114",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[36,24,-28]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:843790c8e8f506cec84c62b4bdaa4286": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0115",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:1a20382ea26ff7dfc455a550e14bb2cb",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "18.5280513763428",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.94612490561611",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.97130955323011e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.960162786431476",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.143791985595671",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:1a20382ea26ff7dfc455a550e14bb2cb": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0115",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[38,18,-34]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0a719e8098002e353003ba2a27b073c0": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0116",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:3f13732ea3fe61d9c16166a94afce717",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "19.0981063842773",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.00574189150977",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.09115647554314e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.927318703179416",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.123657042203662",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3f13732ea3fe61d9c16166a94afce717": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0116",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-52,-62,52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:43e979b3f8840ac3905a6f8a4407fcd5": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0117",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:72836d9af30b43e0ac21adb81f3ce707",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "18.9605255126953",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.99146047420243",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.28338171369236e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.936427564303669",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.128343860654482",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:72836d9af30b43e0ac21adb81f3ce707": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0117",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-30,-50,2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:eceeb78780be64894e966537ab3cb8b4": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0118",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:8c4301dda467a2d0ec1f85c4f2963cca",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "18.5464344024658",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.9480658572893",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.93925668565887e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.95930107827696",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.143340168336726",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:8c4301dda467a2d0ec1f85c4f2963cca": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0118",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-26,-92,32]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ed981c1dca3ea9b8e6dca05eddddb42e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0119",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b842305f64b7dc7dc554a449bebc0d75",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "18.5085258483887",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.94406195686995",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.00564728540997e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.961064206627909",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.144306772236207",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b842305f64b7dc7dc554a449bebc0d75": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0119",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-64,-24,18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f1d40c82f153f10f701e991dc46bf76c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0120",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:1bac7263c1c3b607ba8edd87055ad184",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "18.1724834442139",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.90833473727659",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.64672426668811e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.97443020941977",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.158566450522772",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:1bac7263c1c3b607ba8edd87055ad184": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0120",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-48,-80,6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:90a42fb8b7ab15a0fc7f9593788fd0d8": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0121",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d1e7b6efc3415e116d507bcdb32379a9",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "18.1425399780273",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.90513054435556",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.70872668005828e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.975433443618306",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.159647764898926",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d1e7b6efc3415e116d507bcdb32379a9": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0121",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-52,22,-20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:977335353dc773fc7bbc24036d48d077": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0122",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e0be6cf70dbd9397b6107de3bded3c2c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "18.022855758667",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.89228911595248",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.96514030533524e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.979157897585619",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.164060003510711",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e0be6cf70dbd9397b6107de3bded3c2c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0122",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-18,-60,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3c8fb8a88e5e0426d1a5f92207ba17b9": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0123",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:01f90b37285ec72c334de342360ab244",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "17.9444541931152",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.88384718470911",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.14082712614883e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.981359691584305",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.167674319621895",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:01f90b37285ec72c334de342360ab244": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0123",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-48,-60,-12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:98867af87517f1e98b09c71216997a9b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0124",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a625149c64d12d1f3e068260e53f8b7c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "12.8559341430664",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.27598947955534",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000526462414867646",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999987892",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.682960649498925",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a625149c64d12d1f3e068260e53f8b7c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0124",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-56,-58,-14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:33190d6d2e32f171dd46bc01760c790f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0125",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:eb5117c3c1e358890a16b2a446aebe1c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "17.8700103759766",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.87580933368031",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.31354385788774e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.983284702748605",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.170688289174118",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:eb5117c3c1e358890a16b2a446aebe1c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0125",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-20,-98,22]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:89a194ad515e6bc3d514f374a7c0b423": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0126",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:55087ecc6cef2182a564f80c0e849e24",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "17.8590641021729",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.87462562045091",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.33943727588637e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.983554595306202",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.170688289174118",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:55087ecc6cef2182a564f80c0e849e24": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0126",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-36,-74,-34]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8ae3f86dbfbb937f245ae840af8b5c49": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0127",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:61c92221d1b627be5d2a89643880952c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "17.8335304260254",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.87186262680309",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.40034110888543e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.98417134410357",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.171220146803025",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:61c92221d1b627be5d2a89643880952c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0127",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[38,42,30]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3dd185a366e3d00acea89b72842526fa": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0128",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d9d89e136ea97b0a6bb9498f7668246d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "17.8262977600098",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.87107951763206",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.41772180187028e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.984342815309589",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.171220146803025",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d9d89e136ea97b0a6bb9498f7668246d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0128",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-6,8,-14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0071dedc5b10c2348b38dd7fd1f3af16": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0129",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c3d13d62a8ef6f9f67c2b84365de7ab2",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "12.8113403320312",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.27004069778544",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000537660061517675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999999193",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.68956410159948",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c3d13d62a8ef6f9f67c2b84365de7ab2": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0129",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-14,10,-20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:73dbca8a980ae25e2ff56feb2e61e1f1": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0130",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:187769859be171e252e8f9d09cb2f452",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "17.6728630065918",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.85441801648814",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.80026235302844e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.987658348187978",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.17739917442045",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:187769859be171e252e8f9d09cb2f452": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0130",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[34,-54,-16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:85b1cb20bd5854a8141f9a51241094c0": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0131",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f239b5bb600b66b26ae2b541d5f0205c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "17.5372142791748",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.83961006214911",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.16149383911857e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.990112599467216",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.183733780945217",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f239b5bb600b66b26ae2b541d5f0205c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0131",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[2,56,-20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:80c689d708c2928c17585d1c5c63574b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0132",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:873406fbc3b5a81d2e3a4e71e24d489e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "17.5327644348145",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.83912305138784",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.17372699829311e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.990186087413737",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.183733780945217",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:873406fbc3b5a81d2e3a4e71e24d489e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0132",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[12,-100,20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:68c2fcab274675b0f794f0f1b1cef55a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0133",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:81c9356383fb408177b2b19cfcec8486",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "17.4226627349854",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.82704759724244",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.48447222785231e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.991871994244491",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.190627577478618",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:81c9356383fb408177b2b19cfcec8486": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0133",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-40,-38,44]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:543cc9adfb564a9668b2518ca40bcc25": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0134",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:12d35d58ccbb85001b356a289c171fb3",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "17.1287994384766",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.79457571367347",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.39480733209508e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.995271127156069",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.20629819959706",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:12d35d58ccbb85001b356a289c171fb3": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0134",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-4,-60,-60]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2db3c23fc333f8331cda3b16530368ad": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0135",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4d8f35cbbd84a090f57d6ed9ea09084e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "16.9863605499268",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.7787073073582",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.88222920551362e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.996440597738596",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.216588338073415",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4d8f35cbbd84a090f57d6ed9ea09084e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0135",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-48,-72,2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:953c82968cbb8941046013eaafb134b0": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0136",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:afa42bca2bc4c889ad1a2eea4afff83b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "16.8094520568848",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.75887945181758",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.53380207227472e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.997551066032961",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.228878695263587",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:afa42bca2bc4c889ad1a2eea4afff83b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0136",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-26,-66,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3cabe98da9708d5c6d9ef929b06fe15d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0137",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:eff0511f81e80158699d68bd98fa9405",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "16.7728652954102",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.75476213591481",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.67530868189359e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.997740205701951",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.230558109866913",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:eff0511f81e80158699d68bd98fa9405": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0137",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[28,-78,-4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0483d1896bdb7110c7c114277f735ab9": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0138",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:5a911e435abed8cd7a26c34c1d6c107f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "16.7388191223145",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.75092555231661",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.809150518585e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.997905089099941",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.231105699024221",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:5a911e435abed8cd7a26c34c1d6c107f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0138",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-32,16,-46]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e91d29fc9817e2a7b36fc978ba3fe7d8": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0139",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:33167c8e22920a525f3568a883d101c6",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "16.59206199646",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.7343303583498",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "9.41076528112594e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.998505188879306",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.241173215874839",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:33167c8e22920a525f3568a883d101c6": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0139",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[20,-66,34]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c156e4600d2260f008778fbfcc998fb4": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0140",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:005224864c46a4f96af3799c87601109",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "16.4643402099609",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.71981100422245",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "9.96859555968399e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.998902236749178",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.250667985672322",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:005224864c46a4f96af3799c87601109": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0140",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-46,-56,14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ec175136c213f64b6858d2d67479878d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0141",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b19e011215edc6c32c1ec6d92455e9ed",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "15.7879962921143",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.64169928081447",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000135422173195066",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999835135686248",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.302609017771479",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b19e011215edc6c32c1ec6d92455e9ed": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0141",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-50,-50,20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1a52e7aaf9f3a5bd152c0ebd9fcef4fd": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0142",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:87d81140c3614e8c44dfad60899c3eba",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "16.4616966247559",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.71950972254369",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "9.98049320762862e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.998909395230241",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.250667985672322",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:87d81140c3614e8c44dfad60899c3eba": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0142",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[54,-70,10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2c83e3b2c475480b66ada9ebc6da746b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0143",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:1b509c10d0feceee9f9e723c8315cfc9",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "16.4018669128418",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.71268281226793",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000102536916068097",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999061078942832",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.255433180603606",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:1b509c10d0feceee9f9e723c8315cfc9": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0143",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-30,-10,66]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c0b01d212ef6b8d37eb57b24d78fab11": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0144",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7ac3c69eacd73432ce5a57cff71ee461",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "16.3890476226807",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.71121798724803",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000103132189635535",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999091114381714",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.255887110131141",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7ac3c69eacd73432ce5a57cff71ee461": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0144",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-10,42,4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:861c2c7575cf5f18aa4f01bea0b82135": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0145",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:3817f54a70e50af79f9a6b8831c78d7a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "16.298921585083",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.70089879419966",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000107418577610985",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999279946312565",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.26288576268692",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3817f54a70e50af79f9a6b8831c78d7a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0145",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-48,2,50]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a5987a6772c4cd944a2d21945bf8cc08": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0146",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c934c3e1b26d7a3234b6656c39cdea38",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "16.1748123168945",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.68662875371095",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000113622246557199",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999484104559633",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.271891418707172",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c934c3e1b26d7a3234b6656c39cdea38": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0146",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-36,-40,-36]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9a723a9a2cf5ca36130eb2146162ff79": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0147",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:5375c6e20f2ad76e7323a119f4565a0a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "16.1662578582764",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.68564259218778",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00011406315591389",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999496106370773",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.271968636129453",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:5375c6e20f2ad76e7323a119f4565a0a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0147",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[8,-16,80]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:419f74c7325474e8e1f981e499bf215a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0148",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4a3926792d8bd2558570215cd1dfc6df",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "15.8700971603394",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.65129366161918",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000130461342294219",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999787108603416",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.297253203818069",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4a3926792d8bd2558570215cd1dfc6df": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0148",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[64,-30,-4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3877f612a4c9aaac9336d7f9e3e88d69": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0149",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e4fc36d8eddefb2f351cae894068f752",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "15.8040924072266",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.64358278828341",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000134434558439089",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999826557542014",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.302499842954719",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e4fc36d8eddefb2f351cae894068f752": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0149",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-24,58,2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8637dbbca99c6bf52067de598426c4d0": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0150",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:07a3802a0d3e86c0622c2132242acb1c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "14.5666723251343",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.49506845160221",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000236970094563582",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999998710493543",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.419549680505734",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:07a3802a0d3e86c0622c2132242acb1c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0150",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-22,64,8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2e6563d391260b35c952b660146494c2": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0151",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:817ffa699ebce4b3995e88c66ffdd822",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "15.7909498214722",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.64204498343963",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000135240396418101",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999833590389148",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.302609017771479",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:817ffa699ebce4b3995e88c66ffdd822": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0151",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-64,-46,40]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2d7a05b0881bcaf974a82728c80d267b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0152",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f16a8477087128670c6728a97eaa864d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "15.7291193008423",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.63479927525788",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000139098574372776",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999863401028703",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.306447101172765",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f16a8477087128670c6728a97eaa864d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0152",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[2,-44,56]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3daa0fd1f3c9c061fc41328ca9438a27": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0153",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:8611ef160b9557309f5e6ad3264be190",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "15.7138509750366",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.6330072403139",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000140068577241359",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999869988931104",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.306447101172765",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:8611ef160b9557309f5e6ad3264be190": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0153",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[18,12,-20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2e8cafa261c265066c3b0c06f8f7546a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0154",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:59510129aa2ba33613be10e00d44383a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "15.708869934082",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.6324223784443",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000140386524073888",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999872076198509",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.306447101172765",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:59510129aa2ba33613be10e00d44383a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0154",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[4,6,32]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8139ce719a3bbb4c2ad3027af6da9b91": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0155",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6159441b4ec9659addc0939d61b94795",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "15.701042175293",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.6315030231558",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000140887678002244",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999875296214591",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.306447101172765",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6159441b4ec9659addc0939d61b94795": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0155",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-50,-48,-16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f80978e3da40bc3e863003eb710a4f97": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0156",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:eeb84644b683af6ceb08368cba83a580",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "15.676775932312",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.62865114343584",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000142452965301465",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999884825274485",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.308330257911763",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:eeb84644b683af6ceb08368cba83a580": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0156",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[4,-96,8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4e7e46ac0c58102be99f07a84d8b80ce": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0157",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:9b468a9909484a871d5fb8ff8e97d872",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "15.6319704055786",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.62337799963497",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00014539019458093",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999900731149395",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.312547307242678",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:9b468a9909484a871d5fb8ff8e97d872": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0157",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-68,-28,0]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a61c69f7358597f7aa5c12a588c1ce7c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0158",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:2fda99f58ae75a6c5ac429d5b6053dc7",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "15.4950304031372",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.60720172487664",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000154758512821873",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999937921710337",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.325857771765735",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:2fda99f58ae75a6c5ac429d5b6053dc7": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0158",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-48,-50,-38]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ab548589200676685973c248e76b07b4": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0159",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:de558f593a64c3e86a629fa5e4ec3f3b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "15.4388980865479",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.60054472544061",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000158775598232741",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99994913578297",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.329941167587052",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:de558f593a64c3e86a629fa5e4ec3f3b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0159",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[28,-62,52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6d8e54d85422fdb3fc4d40dcb8a7528b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0160",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e79376ec4a6c43b7e658f206276a73d8",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "15.4314498901367",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.59966025263468",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000159316609409377",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999950477945125",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.329967567413556",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e79376ec4a6c43b7e658f206276a73d8": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0160",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-26,-50,-26]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5deeb5d90a0af409b6cff616354e11a7": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0161",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:2bde547f7aec22d7518accdce026c12c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "15.3998956680298",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.59591017819407",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000161629666827423",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999955817597174",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.332893773024534",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:2bde547f7aec22d7518accdce026c12c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0161",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[34,12,64]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b9a1b6a6a5bd0918b2da9d95b2f3281d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0162",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7c7a24b9cb1d730e5e18aacc805d3ce2",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "15.3762083053589",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.59309183388917",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000163388677505649",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999959478963553",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.334848055204527",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7c7a24b9cb1d730e5e18aacc805d3ce2": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0162",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[12,-60,2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:77808b7180e73fc3945d40bbbd602a7c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0163",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4e4841b781aab4f23390e4712c5dd517",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "15.2871723175049",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.58247351023423",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000170178069703208",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999970922373423",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.343198560123146",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4e4841b781aab4f23390e4712c5dd517": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0163",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[54,-24,-2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:07c12d4cbb23e86fca36208cc6a9eb4f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0164",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:93e589f292425b950a446aa909654e13",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "15.2692956924438",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.58033683390377",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00017157578503435",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999972831864908",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.344539994060292",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:93e589f292425b950a446aa909654e13": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0164",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-14,-98,-4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3a4c88d5e566a02cdf99eb0ce85232b0": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0165",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:33e9c66b8f9fafa079d5d5d649b33e95",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "15.2561340332031",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.57876269120649",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000172612379221393",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999974164363014",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.34525482719666",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:33e9c66b8f9fafa079d5d5d649b33e95": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0165",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[52,40,-32]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:24b5fea160dd2add4c0826068ad6d59a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0166",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c1c6a7167e5e88a6a1b5357f8dc99d2c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "15.2322616577148",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.57590533845626",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000174508968234677",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999976431095502",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.345634100571722",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c1c6a7167e5e88a6a1b5357f8dc99d2c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0166",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-36,-46,-18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1b0c82bff8134900d83ca4ab18a5f9a1": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0167",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:41ce647be65b12c740f9a69ac2bc2072",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "15.106840133667",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.56084639153832",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000184830650378665",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999985642365922",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.357155778315693",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:41ce647be65b12c740f9a69ac2bc2072": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0167",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-50,-46,-32]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:52d92ac8e74231b2934c36f68802206e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0168",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7cb75652d69e9abf19d2ee2c4fa1e4fb",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "15.0247755050659",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.55095019170042",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000191921525476424",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999989746346377",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.366093757282605",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7cb75652d69e9abf19d2ee2c4fa1e4fb": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0168",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[16,-80,34]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d117036fe64a05a3b7c805f5ca53e73e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0169",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:9a1e586581e6bddb054aee681f832543",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "14.9055671691895",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.53651359109015",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00020272281950362",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999993824799586",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.380347203516888",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:9a1e586581e6bddb054aee681f832543": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0169",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[64,-30,-22]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c1fb5dac9debfbd27cdbf2c5644bd72c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0170",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d8e46fdef899ea7ef1ae4932eb2a23ab",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "14.8710918426514",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.53232486243101",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000205961489586182",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999468897041",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.384169468988064",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d8e46fdef899ea7ef1ae4932eb2a23ab": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0170",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-10,0,-26]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3b66a36836011aa9090bd0e7407688b5": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0171",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0709e326475b1e5b4645c9564c8fc035",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "14.7261476516724",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.51464664736948",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000220169736176778",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999997240347399",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.402613109615176",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0709e326475b1e5b4645c9564c8fc035": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0171",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[6,-86,-14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8de26e655b38ebe0ae823a3c6315b489": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0172",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:8e522834b8f477e782bc23a55b9554cb",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "14.6060304641724",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.49991285381712",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000232705141600564",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999998437784089",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.414927735129735",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:8e522834b8f477e782bc23a55b9554cb": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0172",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[12,52,-12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3a28b75034719222480546a8f248e93d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0173",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:54cd1db3599f092f7c78fff2e8d1615a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "14.5363855361938",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.49133496134193",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000240306645747146",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999998889540591",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.422120265651345",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:54cd1db3599f092f7c78fff2e8d1615a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0173",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[36,54,20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:12ba61b8d3db496fc57a6862ebafea4f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0174",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:9fd3a79c0e2a551ded703808f3d2e025",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "14.4983959197998",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.48664497650161",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0002445600975165",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999081527317",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.425901789152019",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:9fd3a79c0e2a551ded703808f3d2e025": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0174",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[22,-80,54]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1ca1bec4b1e87f060081099329ba04c7": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0175",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:039763d5557fd6b882a82f1f2fa88193",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "14.4410257339478",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.4795476354157",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00025113053481729",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999313840959",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.433055163923937",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:039763d5557fd6b882a82f1f2fa88193": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0175",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-22,-36,76]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5570619f587edcedc3276cafac9a60e6": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0176",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f0ea17a233eefa7eab37721460a7244a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "14.4293870925903",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.47810563161417",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000252485443433037",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999353730622",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.43353733164354",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f0ea17a233eefa7eab37721460a7244a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0176",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[26,62,6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:191389c9f10b0de3fdc2d8f22b74563e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0177",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:1ebed5337c4efa7db3bac190a73c4a66",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "14.3534603118896",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.46868038509791",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000261510638276841",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999565455566",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.443489346067816",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:1ebed5337c4efa7db3bac190a73c4a66": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0177",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[22,40,26]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:aedad9f4ec6caede41f6dc10a706c84d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0178",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ac86a4452eca6d7e0a7b5e876240c351",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "14.3390064239502",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.46688257307826",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000263265928860834",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999959757588",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.443939228312532",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ac86a4452eca6d7e0a7b5e876240c351": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0178",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-22,-74,60]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4c440fe68b006ba088752502fc89d323": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0179",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:22107ce4b501a53fc85295e23a1ea347",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "14.3375244140625",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.46669817220102",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000263446587826399",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999600741004",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.443939228312532",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:22107ce4b501a53fc85295e23a1ea347": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0179",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[60,-58,-2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:293fb40452e1ad24570cc1435e986bc8": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0180",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ecdd542cc1f75543496cd4ccdffb2154",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "14.3194494247437",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.46444820092492",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000265660226814735",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999637520677",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.445794785853199",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ecdd542cc1f75543496cd4ccdffb2154": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0180",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[20,-72,10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:29f6517310b6e9273df1d8b7f169679e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0181",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:30293dec841bdf9cee0f1f324755eb67",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "13.9198055267334",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.41423607996236",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000319805638077209",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999996382628",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.505510989298795",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:30293dec841bdf9cee0f1f324755eb67": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0181",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[20,18,-16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:542b8ad9afd2cc487bc118184a9d1898": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0182",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:2ca2e43070b78c6b911a95ec58c54372",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "13.8895444869995",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.41039722335618",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000324341637228609",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999970034447",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.508910387235141",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:2ca2e43070b78c6b911a95ec58c54372": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0182",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[30,-94,14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6b45ddf4564bf60372a7295ba801c752": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0183",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c6f990446c1cd96198a4848a9a3e7916",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "13.8777379989624",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.40889804768482",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000326129256370655",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999972172211",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.508910387235141",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c6f990446c1cd96198a4848a9a3e7916": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0183",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[52,40,-8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:31f0e1886831f0a1dbaaece14761126e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0184",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:acfb6cd2464d523732fc5c4f75550cbe",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "13.8520250320435",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.4056302617749",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000330057567596631",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999976340597",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.510923995091643",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:acfb6cd2464d523732fc5c4f75550cbe": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0184",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[46,-76,-16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e272d51328812cf371cc587ac58a5526": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0185",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:fc79049bf5c6c73ad72ccc47fa125036",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "13.8400564193726",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.4041079037944",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00033190262699101",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999978073029",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.511965057359758",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:fc79049bf5c6c73ad72ccc47fa125036": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0185",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-40,-38,66]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4e23f38355e282e3d94d0ca850cd592a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0186",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:bc1ed1b5f884be34190d17a6a34ea467",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "13.7650365829468",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.39454677341543",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000343711482697406",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999998648758",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.521258506668093",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:bc1ed1b5f884be34190d17a6a34ea467": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0186",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-30,-58,-16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a5d23eefb67d323e152120970fdbfb9b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0187",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f40ad9017c1996f81d9a6de18883ece2",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "13.6462821960449",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.37934453884673",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000363294438112227",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999993887608",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.54285139155384",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f40ad9017c1996f81d9a6de18883ece2": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0187",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[50,46,-12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b2d310b49e85f22bad1ac328ed239ef7": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0188",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:3188ca18da93c376e8b714dde85b69f9",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "13.6285772323608",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.37707094032846",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00036631076264837",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999458514",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.545098853746109",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3188ca18da93c376e8b714dde85b69f9": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0188",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-20,-14,70]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ae8fdbe9961a1dc724d425e20affb4ad": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0189",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:8d02755a1dc43a17d77f1edd70edbda3",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "13.5882997512817",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.37189174994258",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000373268921653791",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999995901462",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.550594852089412",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:8d02755a1dc43a17d77f1edd70edbda3": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0189",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-24,-28,80]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:02fa43a4dca1b09dd2c3be30a44755f8": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0190",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4d13638d382a0721c68d1709aab16557",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "13.3802738189697",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.34498751004771",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000411431379332639",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999088907",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.589500594790403",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4d13638d382a0721c68d1709aab16557": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0190",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[52,-46,-12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1bb674b1760d589a90a0632e34f21e8a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0191",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f167259377277e0b37c958e0f7afe5bc",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "13.3560466766357",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.34183716228186",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000416129350639172",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999240863",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.59334627957149",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f167259377277e0b37c958e0f7afe5bc": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0191",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[54,8,-36]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7af7dc9d762aed03c62f1ccb4dc9f1b1": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0192",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ddcb77e03b58b0ecad10fb686502cb55",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "13.2219953536987",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.324340860909",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000443138995409265",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999731254",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.61993269765931",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ddcb77e03b58b0ecad10fb686502cb55": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0192",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[2,-78,-20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:75daec94f2d9f1cbc921b112d9ef9ce2": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0193",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:89d682f2aee216c11881fb170e685723",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "13.1609621047974",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.3163379950432",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000456027248061708",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999835257",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.629521256290025",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:89d682f2aee216c11881fb170e685723": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0193",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-30,-44,54]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:faf603f8089ae20ce68bd6964020283e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0194",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a73940ea69cb3b5a0586787884ed744a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "13.1470022201538",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.31450426670224",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000459028893888824",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999852923",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.6313035812178",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a73940ea69cb3b5a0586787884ed744a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0194",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-34,-32,-10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d1bf63b81607321155f8338c282e59b2": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0195",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:2828b9a85d8b30329115bf86cdec2f09",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "13.1295585632324",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.31221120560286",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000462808186444841",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999872459",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.63388766436911",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:2828b9a85d8b30329115bf86cdec2f09": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0195",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[52,-74,-4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ad40b53c8dd4e2ab45b2ef401a4c24fc": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0196",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0e0b46edbad1d5cc68e5d1a4a943c4e2",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "13.1201601028442",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.31097493716214",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000464857675592345",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999988193",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.634645676204038",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0e0b46edbad1d5cc68e5d1a4a943c4e2": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0196",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[24,-76,6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d5a95ad6a90a7c4b7b4c65611bcfb3ee": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0197",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e87409f2102a691e85a72e6831af93bd",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "13.046257019043",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.30123438509586",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000481302154360597",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999936213",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.650319788160183",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e87409f2102a691e85a72e6831af93bd": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0197",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-60,-4,-10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a4bd9f4aa32c821fe2cb97c3309c18de": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0198",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:963a82208403e301602399f8ef788246",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "13.0227518081665",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.29812912032221",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000486656828599608",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999947735",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.654413109208221",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:963a82208403e301602399f8ef788246": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0198",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[40,-52,68]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:60b2aa1e5a1e97e22c14f51ae12c8d5c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0199",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:121190025dfe1a383743f7fbe9664dc2",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "12.9725027084351",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.29147894602831",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000498310382184619",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999966052",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.66402192610552",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:121190025dfe1a383743f7fbe9664dc2": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0199",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-14,58,10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:98e838a33321e9ba14f44d7f98af1258": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0200",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d06b3cad307d15a0de08951bdf20ae6a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "12.9253482818604",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.28522365934433",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000509507233156237",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999977514",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.670440081569804",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d06b3cad307d15a0de08951bdf20ae6a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0200",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-28,-42,-20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b33c6c90358c64f445051a6f1ddaa146": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0201",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:804b433957f0b0751f8e56a78e15792f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "12.9120073318481",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.28345132118853",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000512721763674673",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999980013",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.672215583608969",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:804b433957f0b0751f8e56a78e15792f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0201",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-30,64,10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6c21781a2f968dd6b89eb9acbab79c64": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0202",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e72f5cd5280ab8a81cdb28854ee6c88b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "12.8873691558838",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.28017513962894",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000518713316777997",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999983944",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.676739301292717",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e72f5cd5280ab8a81cdb28854ee6c88b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0202",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-66,-36,22]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1b91a4eb434472d16421d0c377206835": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0203",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:3c19d9ef241dff3575137612c854cd2f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "12.8246231079102",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.271813961984",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00053429933476512",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999990888",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.687743631356335",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3c19d9ef241dff3575137612c854cd2f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0203",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[44,-60,-52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7d02ed7f20eb6fe558766caecf63c155": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0204",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:28f4e80afae132d68d4b5232d5c0653c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "12.7540121078491",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.26237411173788",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000552416159637859",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999995255",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.700439054447179",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:28f4e80afae132d68d4b5232d5c0653c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0204",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[48,-36,62]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:81902bcb64a59f174ed4a22dc2692239": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0205",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0d290b8bc5ddb3996222710a9c2aa917",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "12.7177801132202",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.25751764552706",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000561956352459259",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999996627",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.707106764798581",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0d290b8bc5ddb3996222710a9c2aa917": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0205",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[46,-74,-34]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4302df4d2f6614b3486ee45c6c620874": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0206",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:2607c517e39ded7c56c566e9062d1286",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "12.7100811004639",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.25648457184145",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000564005302693849",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999996865",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.707573008885887",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:2607c517e39ded7c56c566e9062d1286": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0206",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-56,-60,0]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:abd2f7443e3cc8dca0d22ff7fa5b1665": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0207",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:455db5fb74827a39d068ce266c9b9900",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "12.6978673934937",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.25484490255242",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000567271531173308",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999997209",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.709190250795189",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:455db5fb74827a39d068ce266c9b9900": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0207",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[18,60,12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:eb863adb5a212bbe0de0abe4fb289aad": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0208",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:2c125691782263a2065a16349878da2b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "12.640664100647",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.24715232109298",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000582829932485596",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999998392",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.722376235864621",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:2c125691782263a2065a16349878da2b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0208",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-64,-34,8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f5b6dec4e6c487fdf092083f6476a41e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0209",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:73c80915e2c2b11251a84ba8336fa798",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "12.6130704879761",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.24343381706964",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000590491220582523",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999998772",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.726684303777293",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:73c80915e2c2b11251a84ba8336fa798": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0209",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[64,-34,16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6d3f27e6e0aa864aa68bacd72871f8c3": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0210",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:231abd23ef63978da267e6cf949efc2d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "12.6124353408813",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.2433481651477",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000590668781873749",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999999878",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.726684303777293",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:231abd23ef63978da267e6cf949efc2d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0210",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-28,-72,62]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a5774a9de179c5a31a4170040a80ba30": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0211",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:57002557123aec38be66fd4d6c272034",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "12.5952806472778",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.24103377259091",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00059548536599352",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999999897",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.728854295079526",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:57002557123aec38be66fd4d6c272034": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0211",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-68,-2,-12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:abdd30b092a8fb58bf5083e43d76564b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0212",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:46d5e8ac330814012d725b0adff81c3c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "12.5901155471802",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.24033654772109",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000596943488260782",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999021",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.728854295079526",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:46d5e8ac330814012d725b0adff81c3c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0212",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[4,6,-12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:853d2a530b3a85eb977c69e3afe8644a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0213",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:79927a4241953f4159a3cdc9b5130fc5",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "12.583477973938",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.23944029497736",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000598822687494338",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999084",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.728854295079526",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:79927a4241953f4159a3cdc9b5130fc5": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0213",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[2,64,32]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:906ee563af4ace86c7988da22e67ae3f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0214",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e0df519bf861a9890d949691d5d8d5dd",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "12.5809669494629",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.23910116152933",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000599535182603472",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999106",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.728854295079526",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e0df519bf861a9890d949691d5d8d5dd": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0214",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-4,32,62]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0a50255f519e99d47205e1125596b9b6": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0215",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:daef6d48a716dbb207fa790aef629485",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "12.5469427108765",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.2345017532799",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000609275862458403",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999364",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.736274936039545",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:daef6d48a716dbb207fa790aef629485": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0215",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-58,-32,22]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:296160c26ce8de6d4816b73bc3fcbc6a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0216",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:660279d86c93ff3310e9a91bc4f125db",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "12.524956703186",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.23152553702292",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000615656604518122",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999491",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.740571104544667",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:660279d86c93ff3310e9a91bc4f125db": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0216",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[10,-28,82]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:59f7ae9e78c57e6eb798ea767f4fd090": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0217",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:9e4bdcd20187d0bbf232df192ad15318",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "12.4362440109253",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.21948340596333",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000642108966113164",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999796",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.762909381039546",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:9e4bdcd20187d0bbf232df192ad15318": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0217",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-56,-6,42]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2c74c9e73a8754c200410a8ddc063874": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0218",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ab6fb86002fd943cb7cf666f118a55db",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "12.3832416534424",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.21226312911464",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000658468484597718",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999883",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.775928724251441",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ab6fb86002fd943cb7cf666f118a55db": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0218",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-18,-74,-2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:54ccde113afb801a2d42f17bcc407213": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0219",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a3ceb25dee9ea36b3e29d0facc7e028f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "12.3691940307617",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.21034625579366",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000662875839162802",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.9999999999999",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.778244481400815",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a3ceb25dee9ea36b3e29d0facc7e028f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0219",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[30,48,-14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:443bd980ef1188caf910159d88fbb606": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0220",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e363d467ac24834cdb9d83f9fcca7984",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "12.3557033538818",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.20850410332099",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00066713702624499",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999913",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.780414436307547",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e363d467ac24834cdb9d83f9fcca7984": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0220",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-50,-28,50]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:fad207295de11587bdc4ed90e387142b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0221",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:04e3ef7c6e8524c62cde0d3294ee3869",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "12.3468074798584",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.20728868558414",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000669962300702265",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999921",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.781198266304304",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:04e3ef7c6e8524c62cde0d3294ee3869": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0221",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[48,12,50]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:63f4617c03904f8fe616125bfc5a9e72": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0222",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:52831440b618015383f7181f6b5b4b26",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "12.3028221130371",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.20127105926381",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000684113775728967",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999951",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.789536719399159",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:52831440b618015383f7181f6b5b4b26": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0222",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[60,-40,-12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a6f44d12d066b455d18d5cf9ff1bdaee": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0223",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a8e775408cf4088e2ab46f7c20423ab9",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "12.3004894256592",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.20095155097531",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000684872807174552",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999952",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.789536719399159",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a8e775408cf4088e2ab46f7c20423ab9": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0223",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-62,-50,-10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:182ba929021f340ee67f2468e637cc44": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0224",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b4e52186e6b0a6847c84cc50c415fc7e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "12.2552633285522",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.19474945772007",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000699761387021658",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999971",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.80078769815287",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b4e52186e6b0a6847c84cc50c415fc7e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0224",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-2,58,32]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f240087ba6b26ab0e7705cb6916792eb": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0225",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:51d8d61148f300b8db3cd50807339c24",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "12.0593566894531",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.16771793453572",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000768202532788531",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999997",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.853659787459179",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:51d8d61148f300b8db3cd50807339c24": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0225",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[20,16,50]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:01c2ba3dcb7343112c96e480784b9ad1": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0226",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ccf7f33772892b6927718a745ad9c44b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "12.0245819091797",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.16289116572021",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000781053593003622",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999998",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.861413078419457",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ccf7f33772892b6927718a745ad9c44b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0226",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-12,-78,56]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:cd8669b3a66c8ac45b3908124a6c355e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0227",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c1e93dd2175b8f1a8aacb7c865e765d0",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "12.0227870941162",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.16264180848804",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000781722842800425",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999998",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.861413078419457",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c1e93dd2175b8f1a8aacb7c865e765d0": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0227",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[14,-14,72]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:71daf19003d4f9dfcddcf08cbdd35abd": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0228",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a3c7efc0ca1f4ef769468595f11497ea",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "12.0113868713379",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.16105741225029",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000785987554661749",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999998",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.862288646172828",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a3c7efc0ca1f4ef769468595f11497ea": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0228",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[8,-54,-34]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3057043901ea2a078a58803f5a56dec7": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0229",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c9498ecd645e8ee7c1b2854ae6ad27b0",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "12.00501537323",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.16017149794514",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000788381493643353",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999998",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.862288646172828",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c9498ecd645e8ee7c1b2854ae6ad27b0": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0229",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-8,-40,78]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f5292c900080c8c0ef7cf8ec19aa3697": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0230",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4de46218eaea869bbf89aff4b4ac9b02",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "12.0031709671021",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.15991499103056",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000789075885015644",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999998",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.862288646172828",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4de46218eaea869bbf89aff4b4ac9b02": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0230",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-60,-60,26]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:30a84acd12436a2955bf4b443a3b850c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0231",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:3581a3e4b5344f48549574e9392dca58",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "11.9899396896362",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.15807416017948",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000794075753797419",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999999",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.864648849849365",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3581a3e4b5344f48549574e9392dca58": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0231",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[48,-80,10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:03b8a2fea9829914437905e68925e360": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0232",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f028b4f21a1973e22582d89d86a59e4c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "11.9840250015259",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.1572508576916",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000796321345690965",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999999",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.864758992605231",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f028b4f21a1973e22582d89d86a59e4c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0232",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[62,-54,-8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c88d9634fff92159e1df0499f5d4e04b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0233",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:1851842618253ccc503cfb02e8736641",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "11.93297290802",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.15013407761285",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000815977744435759",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999999",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.878904312044662",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:1851842618253ccc503cfb02e8736641": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0233",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-38,-54,-42]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2a999512422d958e9dd451fe676d13a1": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0234",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:691ae2c0b1d9726dd204612040f5685f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "11.8026752471924",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.13188412058022",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000868442069883013",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.916815339863787",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:691ae2c0b1d9726dd204612040f5685f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0234",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[22,44,-16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f985f79075267f7e7ea06f7a3d3b4fd0": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0235",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7cda6698f70c94692a960278e4b33bf9",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "11.7988748550415",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.13134995085887",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000870023394025643",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.916815339863787",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7cda6698f70c94692a960278e4b33bf9": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0235",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[24,68,20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f181b589179ed8f92f3f7f4795974d3e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0236",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:429847480689f42655b6238b01c24ecf",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "11.7978382110596",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.13120422529702",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000870455250713387",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.916815339863787",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:429847480689f42655b6238b01c24ecf": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0236",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-36,-32,-22]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b24deafd5ea91430bd7b734255475770": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0237",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:060b7e14bd3b6dc2f252c0b0afc1d7a1",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "11.7785091400146",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.12848559662294",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000878548112890121",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.921335336720806",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:060b7e14bd3b6dc2f252c0b0afc1d7a1": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0237",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[42,-42,14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ed3e68d921eeb26ff4420aa1da45f707": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0238",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:729a7087b921fe5cd9363facfa24c6f0",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "11.7414026260376",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.12325880540281",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000894301978610734",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.931755566916896",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:729a7087b921fe5cd9363facfa24c6f0": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0238",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[42,46,-12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5d28dbbc72458950d35719ada2f35c1d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0239",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:24cc5c274366ef4b77b9970877943695",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "11.6729784011841",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.1135936902341",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000924119094904752",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.952845585496322",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:24cc5c274366ef4b77b9970877943695": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0239",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[32,28,-24]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:49fa6fc625869e411d951c76ea01f001": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0240",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7341e654c7650694fa4a633b7d57e71c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "11.648645401001",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.11014811684365",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000934967749947835",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.959250568995591",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7341e654c7650694fa4a633b7d57e71c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0240",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[42,20,-14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7047971620448cda11f6eecfb2f451f4": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0241",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4b469a270ee563c51daff07a0ec32f1e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "11.6256742477417",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.1068912843889",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000945329574052578",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.963708379847036",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4b469a270ee563c51daff07a0ec32f1e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0241",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-22,-82,0]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:27fc8dfd0e287d18ed37abcd26235c8c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0242",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:1477eff6e204f38ed59b87445071b9ed",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "11.6246528625488",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.10674638057242",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000945793036476794",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.963708379847036",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:1477eff6e204f38ed59b87445071b9ed": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0242",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[2,-42,-62]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c78a4edd720ceef3e574dba70e0cc9fc": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0243",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0b8fbe19681a8a8318549ff8c0485803",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "11.586296081543",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.10129898410053",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000963368201000958",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.975038721030712",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0b8fbe19681a8a8318549ff8c0485803": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0243",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[52,-42,18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a9c0e06b74f100f91729fb0b3f27bb2e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0244",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0885c3bb08b39c786df94baf46e2a0c6",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "11.5521640777588",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.09644218031477",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000979290273004696",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.985021600249525",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0885c3bb08b39c786df94baf46e2a0c6": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0244",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[54,44,14]",
+                "type": "xsd:string"
+            }
+        }
+    },
+    "activity": {
+        "niiri:af398ef47bafd7ba0d7a56b68ea654a5": {
+            "prov:type": {
+                "$": "nidm_ModelParametersEstimation:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Model parameters estimation",
+                "type": "xsd:string"
+            },
+            "nidm_withEstimationMethod:": {
+                "$": "obo_generalizedleastsquaresestimation:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d56c7f996ee59831f6e800e8e38c6886": {
+            "prov:type": {
+                "$": "nidm_ContrastEstimation:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Contrast estimation",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:acd80690d12cb39b6a731ff1e4c00286": {
+            "prov:type": {
+                "$": "nidm_Inference:",
+                "type": "xsd:QName"
+            },
+            "nidm_hasAlternativeHypothesis:": {
+                "$": "nidm_OneTailedTest:",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Inference",
+                "type": "xsd:string"
+            }
+        }
+    },
+    "agent": {
+        "niiri:108629946ef3459712b1ceefc5a31493": {
+            "prov:type": [
+                {
+                "$": "src_SPM:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "prov:SoftwareAgent",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "SPM",
+                "type": "xsd:string"
+            },
+            "nidm_softwareVersion:": {
+                "$": "12.6906",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:06a12d76cf24728b70559a82704e66d8": {
+            "prov:type": [
+                {
+                "$": "nlx_Imaginginstrument:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nlx_Magneticresonanceimagingscanner:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "MRI Scanner",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:78ef43d31af19b56191d7258da75b6e0": {
+            "prov:type": {
+                "$": "prov:Person",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Person",
+                "type": "xsd:string"
+            }
+        }
+    },
+    "wasGeneratedBy": {
+        "_:wGB20": {
+            "prov:entity": "niiri:2966074b9e21383f6f55902411f9d3e2",
+            "prov:activity": "niiri:af398ef47bafd7ba0d7a56b68ea654a5"
+        },
+        "_:wGB22": {
+            "prov:entity": "niiri:41db56fb656683f93922ac7c8120201a",
+            "prov:activity": "niiri:af398ef47bafd7ba0d7a56b68ea654a5"
+        },
+        "_:wGB26": {
+            "prov:entity": "niiri:e53ec83adf28281a0da4fb79bd6f8d37",
+            "prov:activity": "niiri:af398ef47bafd7ba0d7a56b68ea654a5"
+        },
+        "_:wGB30": {
+            "prov:entity": "niiri:72b76763a43f712d064e7ff5a0abf2f4",
+            "prov:activity": "niiri:af398ef47bafd7ba0d7a56b68ea654a5"
+        },
+        "_:wGB34": {
+            "prov:entity": "niiri:4e1dd7422d51470871328ffe1585b00e",
+            "prov:activity": "niiri:af398ef47bafd7ba0d7a56b68ea654a5"
+        },
+        "_:wGB38": {
+            "prov:entity": "niiri:5838dc3694e3780735e8138028cf3030",
+            "prov:activity": "niiri:af398ef47bafd7ba0d7a56b68ea654a5"
+        },
+        "_:wGB42": {
+            "prov:entity": "niiri:c7a291c12eb2c6c7e9ebcb9759d8ea7c",
+            "prov:activity": "niiri:af398ef47bafd7ba0d7a56b68ea654a5"
+        },
+        "_:wGB56": {
+            "prov:entity": "niiri:22b2d246ca83f9742df6152441f4821f",
+            "prov:activity": "niiri:d56c7f996ee59831f6e800e8e38c6886"
+        },
+        "_:wGB58": {
+            "prov:entity": "niiri:7f4cdffd78ae5971875e37f617e84f61",
+            "prov:activity": "niiri:d56c7f996ee59831f6e800e8e38c6886"
+        },
+        "_:wGB77": {
+            "prov:entity": "niiri:78e99904e3bcdd85e6a94fdbda3413d3",
+            "prov:activity": "niiri:acd80690d12cb39b6a731ff1e4c00286"
+        },
+        "_:wGB81": {
+            "prov:entity": "niiri:4391a2ef60f122937f69c2336ae7251d",
+            "prov:activity": "niiri:acd80690d12cb39b6a731ff1e4c00286"
+        }
+    },
+    "used": {
+        "_:u14": {
+            "prov:activity": "niiri:af398ef47bafd7ba0d7a56b68ea654a5",
+            "prov:entity": "niiri:c48b8f1c4db4fafced12fe461ce9d3ba"
+        },
+        "_:u15": {
+            "prov:activity": "niiri:af398ef47bafd7ba0d7a56b68ea654a5",
+            "prov:entity": "niiri:e2f4df9e4df57e86b857fd981bd770f4"
+        },
+        "_:u16": {
+            "prov:activity": "niiri:af398ef47bafd7ba0d7a56b68ea654a5",
+            "prov:entity": "niiri:cc140a0d6189b0430c070bd23d6ca3d0"
+        },
+        "_:u46": {
+            "prov:activity": "niiri:d56c7f996ee59831f6e800e8e38c6886",
+            "prov:entity": "niiri:2966074b9e21383f6f55902411f9d3e2"
+        },
+        "_:u47": {
+            "prov:activity": "niiri:d56c7f996ee59831f6e800e8e38c6886",
+            "prov:entity": "niiri:5838dc3694e3780735e8138028cf3030"
+        },
+        "_:u48": {
+            "prov:activity": "niiri:d56c7f996ee59831f6e800e8e38c6886",
+            "prov:entity": "niiri:c48b8f1c4db4fafced12fe461ce9d3ba"
+        },
+        "_:u49": {
+            "prov:activity": "niiri:d56c7f996ee59831f6e800e8e38c6886",
+            "prov:entity": "niiri:543c3abe649faffdd9de4655fb735982"
+        },
+        "_:u50": {
+            "prov:activity": "niiri:d56c7f996ee59831f6e800e8e38c6886",
+            "prov:entity": "niiri:e53ec83adf28281a0da4fb79bd6f8d37"
+        },
+        "_:u51": {
+            "prov:activity": "niiri:d56c7f996ee59831f6e800e8e38c6886",
+            "prov:entity": "niiri:72b76763a43f712d064e7ff5a0abf2f4"
+        },
+        "_:u52": {
+            "prov:activity": "niiri:d56c7f996ee59831f6e800e8e38c6886",
+            "prov:entity": "niiri:4e1dd7422d51470871328ffe1585b00e"
+        },
+        "_:u69": {
+            "prov:activity": "niiri:acd80690d12cb39b6a731ff1e4c00286",
+            "prov:entity": "niiri:c90905a2f9fd05b279e167b48e9e991b"
+        },
+        "_:u70": {
+            "prov:activity": "niiri:acd80690d12cb39b6a731ff1e4c00286",
+            "prov:entity": "niiri:3f89804bcbc35a20ed10f6065ed6f45f"
+        },
+        "_:u71": {
+            "prov:activity": "niiri:acd80690d12cb39b6a731ff1e4c00286",
+            "prov:entity": "niiri:22b2d246ca83f9742df6152441f4821f"
+        },
+        "_:u72": {
+            "prov:activity": "niiri:acd80690d12cb39b6a731ff1e4c00286",
+            "prov:entity": "niiri:c7a291c12eb2c6c7e9ebcb9759d8ea7c"
+        },
+        "_:u73": {
+            "prov:activity": "niiri:acd80690d12cb39b6a731ff1e4c00286",
+            "prov:entity": "niiri:2966074b9e21383f6f55902411f9d3e2"
+        },
+        "_:u74": {
+            "prov:activity": "niiri:acd80690d12cb39b6a731ff1e4c00286",
+            "prov:entity": "niiri:6e55046381e462ccd425414e6c6e55df"
+        },
+        "_:u75": {
+            "prov:activity": "niiri:acd80690d12cb39b6a731ff1e4c00286",
+            "prov:entity": "niiri:1c65c77d484fdd55f58d632b3d659641"
+        }
+    },
+    "wasDerivedFrom": {
+        "_:wDF19": {
+            "prov:generatedEntity": "niiri:2966074b9e21383f6f55902411f9d3e2",
+            "prov:usedEntity": "niiri:c4fb2761d2a5b5a53b14dfb73eb55ec9"
+        },
+        "_:wDF25": {
+            "prov:generatedEntity": "niiri:e53ec83adf28281a0da4fb79bd6f8d37",
+            "prov:usedEntity": "niiri:a303f093674cfea3af31e31f0b993403"
+        },
+        "_:wDF29": {
+            "prov:generatedEntity": "niiri:72b76763a43f712d064e7ff5a0abf2f4",
+            "prov:usedEntity": "niiri:3832b1c295247b7ad30eeb6b6a356d9a"
+        },
+        "_:wDF33": {
+            "prov:generatedEntity": "niiri:4e1dd7422d51470871328ffe1585b00e",
+            "prov:usedEntity": "niiri:132d0cc169a2090d70bcc3a2cf72ef78"
+        },
+        "_:wDF37": {
+            "prov:generatedEntity": "niiri:5838dc3694e3780735e8138028cf3030",
+            "prov:usedEntity": "niiri:bc3cced01cc00b56e891f3591686d4d7"
+        },
+        "_:wDF41": {
+            "prov:generatedEntity": "niiri:c7a291c12eb2c6c7e9ebcb9759d8ea7c",
+            "prov:usedEntity": "niiri:37ab6fc51451696d75a2fb041b423fb9"
+        },
+        "_:wDF55": {
+            "prov:generatedEntity": "niiri:22b2d246ca83f9742df6152441f4821f",
+            "prov:usedEntity": "niiri:e3f29dfdfad324d9c4f41fb318e668b4"
+        },
+        "_:wDF83": {
+            "prov:generatedEntity": "niiri:a02993e23816e346753a88b23cc8928d",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF85": {
+            "prov:generatedEntity": "niiri:1fb6d1d0216b48739f26ab81c9d1d36e",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF87": {
+            "prov:generatedEntity": "niiri:513b4dd1fd53a8b3917570bbd44a1da7",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF89": {
+            "prov:generatedEntity": "niiri:0383eb2fc5ee76be5634bfee80f2ca3b",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF91": {
+            "prov:generatedEntity": "niiri:e67cada24205233131c2bfe154669c61",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF93": {
+            "prov:generatedEntity": "niiri:a3635579e9882ee1f3c09824008b66b4",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF95": {
+            "prov:generatedEntity": "niiri:c50d34609678664d461509f54c79eea7",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF97": {
+            "prov:generatedEntity": "niiri:86785a60d43172b11448d491c5ae96dc",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF99": {
+            "prov:generatedEntity": "niiri:dded355a673488279610ef537e861858",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF101": {
+            "prov:generatedEntity": "niiri:c1b3c9780e84e1bcfb3c612aa647510e",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF103": {
+            "prov:generatedEntity": "niiri:86886012c734f3d338a1efb48a81145a",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF105": {
+            "prov:generatedEntity": "niiri:e25e46750ed6706bcfbfa5e14d55d777",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF107": {
+            "prov:generatedEntity": "niiri:e2ac8194c797871c399100cc42929140",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF109": {
+            "prov:generatedEntity": "niiri:e480d8d12a9dc866e99b7a65d64c73b5",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF111": {
+            "prov:generatedEntity": "niiri:82f170400f1b69cc64c4688f03080756",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF113": {
+            "prov:generatedEntity": "niiri:c7d451f7f453a0be61177b599ede33a5",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF115": {
+            "prov:generatedEntity": "niiri:37926699687cca9b9dd0b742b092ff48",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF117": {
+            "prov:generatedEntity": "niiri:e7fc074f64298360eb2c7ffbcb4e63aa",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF119": {
+            "prov:generatedEntity": "niiri:617a58ee9ff77a4075c0708ea690d16c",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF121": {
+            "prov:generatedEntity": "niiri:fd34291df44a2d10645e6546a1593a1c",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF123": {
+            "prov:generatedEntity": "niiri:8677fb654966f35b2ba255c1e63d1cb1",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF125": {
+            "prov:generatedEntity": "niiri:545f94f2d451c1c902303c221a0a1089",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF127": {
+            "prov:generatedEntity": "niiri:f9a9c037c3239038fee46308d6b9feba",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF129": {
+            "prov:generatedEntity": "niiri:6441c160dec1271f21351fe6ca31e10a",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF131": {
+            "prov:generatedEntity": "niiri:2872350aa13a26854db92f5a27149fe1",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF133": {
+            "prov:generatedEntity": "niiri:e3742b34c6808b2398052ec8dae20d8c",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF135": {
+            "prov:generatedEntity": "niiri:002a4160ef17e67bfe8f93c22d701531",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF137": {
+            "prov:generatedEntity": "niiri:88b01b8106ca0618c3b109ef9140a77a",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF139": {
+            "prov:generatedEntity": "niiri:5b45e4eea89f71e19bb39684bf2f0eb7",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF141": {
+            "prov:generatedEntity": "niiri:c3da843e94fc98cca5669ae4eef8d2ed",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF143": {
+            "prov:generatedEntity": "niiri:5d3257a6906cc23f21f8344f8a202720",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF145": {
+            "prov:generatedEntity": "niiri:f9cfce19a79a082c82d2f3a6386b09c9",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF147": {
+            "prov:generatedEntity": "niiri:36f4c495e82ce16bc5e3538ec47db115",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF149": {
+            "prov:generatedEntity": "niiri:f3db818d25677c7c9807d3bc465f0dec",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF151": {
+            "prov:generatedEntity": "niiri:16cd91852662e2b6fb06dce21defbb02",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF153": {
+            "prov:generatedEntity": "niiri:d1f64d168706b2b7b1ea74aeb9acf76d",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF155": {
+            "prov:generatedEntity": "niiri:81dc6b3cbc9f571d3c373afc2c155834",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF157": {
+            "prov:generatedEntity": "niiri:5c83c29ecdf61abf3b54b84749525008",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF159": {
+            "prov:generatedEntity": "niiri:01690965efcb17bbde83102ddcb2faab",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF161": {
+            "prov:generatedEntity": "niiri:06b13cc33465cdc0e1390a27c23a9ac4",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF163": {
+            "prov:generatedEntity": "niiri:7f6f25f12f4270c6aaed0a3240d5a8a1",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF165": {
+            "prov:generatedEntity": "niiri:8f37ccae34c7cba6e277659e1d99e2a9",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF167": {
+            "prov:generatedEntity": "niiri:3acfc147a4a82a0c9064e4e844ecc743",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF169": {
+            "prov:generatedEntity": "niiri:bb2efddb865295f983adb4172abe81b6",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF171": {
+            "prov:generatedEntity": "niiri:29b1a5a35e558ec0833c58691621c112",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF173": {
+            "prov:generatedEntity": "niiri:16e2e680906eb7d77a0f37a900f566bb",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF175": {
+            "prov:generatedEntity": "niiri:160595535853afe9f10e3ba4462634ee",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF177": {
+            "prov:generatedEntity": "niiri:5bea9c455010164eafb48efd433d0b3b",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF179": {
+            "prov:generatedEntity": "niiri:54acd58c8408a4a54a5d29cdbcf77a2a",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF181": {
+            "prov:generatedEntity": "niiri:e0f95b0e95e26dd40bce67d69e9c88a7",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF183": {
+            "prov:generatedEntity": "niiri:e1915181e888f91227f9d80a2ceda361",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF185": {
+            "prov:generatedEntity": "niiri:059524711a78d34f86f9ff7484d30c28",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF187": {
+            "prov:generatedEntity": "niiri:f80c4f725486ccc8cbc7ca97e9202b10",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF189": {
+            "prov:generatedEntity": "niiri:4fc2bcbe1574c654541b41942566af13",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF191": {
+            "prov:generatedEntity": "niiri:dff2d5252e6112d696cc75e19b35b055",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF193": {
+            "prov:generatedEntity": "niiri:c1d3f6f0f50baea1174f7ada78444ce5",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF195": {
+            "prov:generatedEntity": "niiri:ac01f2a6f9677b631c38f9d1203db903",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF197": {
+            "prov:generatedEntity": "niiri:6ac4331664607b2b0b57f58303204021",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF199": {
+            "prov:generatedEntity": "niiri:df3a63e829a4b0144a3bd3a075d00d6a",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF201": {
+            "prov:generatedEntity": "niiri:de4cddb037f1620436ef1889e1446b84",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF203": {
+            "prov:generatedEntity": "niiri:70eb10d3df67eb20319350b5182c2674",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF205": {
+            "prov:generatedEntity": "niiri:0c6701f42b3e926640123461fe2991bd",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF207": {
+            "prov:generatedEntity": "niiri:ff9cac1254b9e415d2191f7775b434dc",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF209": {
+            "prov:generatedEntity": "niiri:42811518fc15bbd0a0761ed04fef9d90",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF211": {
+            "prov:generatedEntity": "niiri:dd408b7babb59101191c5fa3158193a1",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF213": {
+            "prov:generatedEntity": "niiri:99548a2427d673d5bd15c691076864b1",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF215": {
+            "prov:generatedEntity": "niiri:7a1eb6258840314d739698ecb8549782",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF217": {
+            "prov:generatedEntity": "niiri:d766f0de412bd93d96229079d9de064c",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF219": {
+            "prov:generatedEntity": "niiri:8661090d64b5d8ebc0a4bd8254976fb2",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF221": {
+            "prov:generatedEntity": "niiri:52941f17d3d4d9019f15d6efbca27815",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF223": {
+            "prov:generatedEntity": "niiri:65bb243af8ca1e554de57b71bb66bc25",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF225": {
+            "prov:generatedEntity": "niiri:eb7b45334c4709abfab6a80cdaa2bc22",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF227": {
+            "prov:generatedEntity": "niiri:afbff827e6265de5fc31843cacb634e6",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF229": {
+            "prov:generatedEntity": "niiri:44d83170827403caee586f5f0c738aff",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF231": {
+            "prov:generatedEntity": "niiri:2d968184be68de22a2c6d1f79a1a3779",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF233": {
+            "prov:generatedEntity": "niiri:8c5cc0e6fb31318c9adb3b82365f2ae6",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF235": {
+            "prov:generatedEntity": "niiri:db5e02d87132e15c42c39a266963eb55",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF237": {
+            "prov:generatedEntity": "niiri:6e1483cf3114e5bdc77f5e480decfc71",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF239": {
+            "prov:generatedEntity": "niiri:1eb993430541f6c2dc79f73b3a96decc",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF241": {
+            "prov:generatedEntity": "niiri:e576b0cc1b6a471310c83c2e65672f5f",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF243": {
+            "prov:generatedEntity": "niiri:01a6664df87623bed0fd193f07c04638",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF245": {
+            "prov:generatedEntity": "niiri:9fbbe8461310da88b0ce5b0b68e8e62c",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF247": {
+            "prov:generatedEntity": "niiri:ae14e5d65d87b53bd2bbf000849a1635",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF249": {
+            "prov:generatedEntity": "niiri:40d7f1124d8e7cab0c81135fe2f535ad",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF251": {
+            "prov:generatedEntity": "niiri:3383de798490342ce6540ea70b023ffa",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF253": {
+            "prov:generatedEntity": "niiri:4bcfe0e6f6bc971e3e914655ca98bf82",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF255": {
+            "prov:generatedEntity": "niiri:bbf13cce053679ff04cb1b23082b44ac",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF257": {
+            "prov:generatedEntity": "niiri:2151f348776220c1024fdc2f0b0bc92f",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF259": {
+            "prov:generatedEntity": "niiri:8ccfe08eafd83c22c7082eb44f58a70f",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF261": {
+            "prov:generatedEntity": "niiri:bad308d46fbeeacaf458653ab9b853d6",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF263": {
+            "prov:generatedEntity": "niiri:687916ac6701ade9ca268dec72dc0c0d",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF265": {
+            "prov:generatedEntity": "niiri:9071142b0c2683c96f4377cdddced1d0",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF267": {
+            "prov:generatedEntity": "niiri:884f659ac62495dd158e264f576d0fc2",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF269": {
+            "prov:generatedEntity": "niiri:2088eea3a39320e89e2a625ec7e9f82e",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF271": {
+            "prov:generatedEntity": "niiri:7fc88d60dca200d4c67a0a607a345633",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF273": {
+            "prov:generatedEntity": "niiri:ca1da2e7a46f823f402d9c62e070d0fc",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF275": {
+            "prov:generatedEntity": "niiri:ea6ee099e3b8edbdd2bde04e8682a6ce",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF277": {
+            "prov:generatedEntity": "niiri:1ef7113e2a59f273a63186ced0b0fc6b",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF279": {
+            "prov:generatedEntity": "niiri:02f0aee7ff558248fe49e5f3579c0585",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF281": {
+            "prov:generatedEntity": "niiri:c2cda63a78bcde6ae7a69f7ab8eadb2c",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF283": {
+            "prov:generatedEntity": "niiri:2c7f2ff6921dbb36e89f44a3a1dd839b",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF285": {
+            "prov:generatedEntity": "niiri:03e03b97c9ae144949ccd274ec79dd81",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF287": {
+            "prov:generatedEntity": "niiri:036f2836a317a98100c1a6652ab21784",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF289": {
+            "prov:generatedEntity": "niiri:a029a63406d370c8869c59656bb90a54",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF291": {
+            "prov:generatedEntity": "niiri:c429131bcf59cefceae4a934fd1aa80a",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF293": {
+            "prov:generatedEntity": "niiri:9ac7226087de1c45b555519c1250dc59",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF295": {
+            "prov:generatedEntity": "niiri:9c1fe61e0e5d7d3b62e90ebdfdb9d4d4",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF297": {
+            "prov:generatedEntity": "niiri:7489f5e950ff72b41ea437f2c2026c6f",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF299": {
+            "prov:generatedEntity": "niiri:e83b9cd4cb9554eedc76bd43c766b08d",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF301": {
+            "prov:generatedEntity": "niiri:6f3ca580fb0dafec12bb76f49a9e660f",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF303": {
+            "prov:generatedEntity": "niiri:37ee2d388f0d21999c13e5808ab4abaa",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF305": {
+            "prov:generatedEntity": "niiri:17c3d65f0a2dd8b609c3139c41ebf930",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF307": {
+            "prov:generatedEntity": "niiri:bbd0acc33408cc31d2590c5760c85985",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF309": {
+            "prov:generatedEntity": "niiri:04aa6294da937ca4a062fce158511fb6",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF311": {
+            "prov:generatedEntity": "niiri:6e2a6189013a78c14191e7633ed21b0a",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF313": {
+            "prov:generatedEntity": "niiri:81840f3ae0159e07fac81fc13e72fbf5",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF315": {
+            "prov:generatedEntity": "niiri:dd602a84f4dd916125d3c669097eec23",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF317": {
+            "prov:generatedEntity": "niiri:1c2363e827044fb757d9bf0cf8e052e5",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF319": {
+            "prov:generatedEntity": "niiri:45132e41bd386f5b430c16f7c2c90e0a",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF321": {
+            "prov:generatedEntity": "niiri:c4e5f3528c31047605f368909a0632ee",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF323": {
+            "prov:generatedEntity": "niiri:1355ee0795599ee6287d2b70ebc8d729",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF325": {
+            "prov:generatedEntity": "niiri:370789fb0338d1e1885081e0362c340f",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF327": {
+            "prov:generatedEntity": "niiri:40392b1ab652b1fe41dac16581269fb2",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF329": {
+            "prov:generatedEntity": "niiri:65ef2c95ae3f51b5861bb20b84514bd9",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF331": {
+            "prov:generatedEntity": "niiri:5cc71319d109fdb0ef9f0f9c7bd41492",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF333": {
+            "prov:generatedEntity": "niiri:4bf75a353d782554be968730ac4840cd",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF335": {
+            "prov:generatedEntity": "niiri:332041ad6aeaf3a74891ecd53c374a96",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF337": {
+            "prov:generatedEntity": "niiri:b47672c30d95e784941e629a0021b66b",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF339": {
+            "prov:generatedEntity": "niiri:4ade8b0865402c36f9bde1298af17ab4",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF341": {
+            "prov:generatedEntity": "niiri:8d46ffe6156e40b274554eb8fc558f49",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF343": {
+            "prov:generatedEntity": "niiri:4d3c4f523d2ecfeb9befc1c5babb099d",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF345": {
+            "prov:generatedEntity": "niiri:24a29d9d6136d7a26f77ad7395967c47",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF347": {
+            "prov:generatedEntity": "niiri:7289b1de1e9e889ff1fb5691142cd967",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF349": {
+            "prov:generatedEntity": "niiri:4465bf32a18439b39ae380aba9c3f3b0",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF351": {
+            "prov:generatedEntity": "niiri:1cd15156a67e7cd4faba9f06d50293c8",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF353": {
+            "prov:generatedEntity": "niiri:ad7c299b4aa35cd98fdbd415f19783a7",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF355": {
+            "prov:generatedEntity": "niiri:fe8b635d8a705b40fb4ced016e9d726a",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF357": {
+            "prov:generatedEntity": "niiri:71e15e602f95bdd78bc912bf527abf9d",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF359": {
+            "prov:generatedEntity": "niiri:46e2492f096548abf33dea89e7a868bc",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF361": {
+            "prov:generatedEntity": "niiri:f234bb306a90feca64756c5add571e95",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF363": {
+            "prov:generatedEntity": "niiri:9a23d6bdea30bc505d71bdea4b14cc81",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF365": {
+            "prov:generatedEntity": "niiri:55a2e8a69b22f0385eb446ff36f57cd5",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF367": {
+            "prov:generatedEntity": "niiri:c1b67e6fa1bc1b0441ef946f06fc7939",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF369": {
+            "prov:generatedEntity": "niiri:598d8f8cb448fe66f29b80c3e9c6b8c7",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF371": {
+            "prov:generatedEntity": "niiri:9e74994c43b00fa8f3c04ed564b75259",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF373": {
+            "prov:generatedEntity": "niiri:59f7c04e9a6910158fa3c13760b2a417",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF375": {
+            "prov:generatedEntity": "niiri:81a8b467cb1446f1ff5cdaa2c7d6e479",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF377": {
+            "prov:generatedEntity": "niiri:b6cb8a909916808e62aec6d7aa7ee1b8",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF379": {
+            "prov:generatedEntity": "niiri:50e1d73ec7323535a313db319aa8fda1",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF381": {
+            "prov:generatedEntity": "niiri:7dcc4c8a94cbe8b1b1f9e1f46a8741d3",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF383": {
+            "prov:generatedEntity": "niiri:b54fdacdf6871d0d178386e52e6bcf8e",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF385": {
+            "prov:generatedEntity": "niiri:22043ef18c61c537ac8a05e639b5f722",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF387": {
+            "prov:generatedEntity": "niiri:fd886d44827bbf7fd4cd36a6fa24a0dc",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF389": {
+            "prov:generatedEntity": "niiri:e782c57868e4be48647d27ca19f3f3c2",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF391": {
+            "prov:generatedEntity": "niiri:f434c353ca0df61bb269a9c7f670117c",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF393": {
+            "prov:generatedEntity": "niiri:0ccff4009d26155a785837676412d40e",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF395": {
+            "prov:generatedEntity": "niiri:800c8b037dc30701b156bb7c32952fad",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF397": {
+            "prov:generatedEntity": "niiri:783b5fc0e23ce088341f9b979cd6ab07",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF399": {
+            "prov:generatedEntity": "niiri:eeecebef37458a809e6ef90a22514949",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF401": {
+            "prov:generatedEntity": "niiri:9e9084297f3aec6679c40f52af1c9c5c",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF403": {
+            "prov:generatedEntity": "niiri:dc54137a08092762cc961c9285859566",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF405": {
+            "prov:generatedEntity": "niiri:9ff86139e0b5b4951d06b07e9a923ed4",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF407": {
+            "prov:generatedEntity": "niiri:8a8ea66289482bc8790b162d4c9789ef",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF409": {
+            "prov:generatedEntity": "niiri:05c885a40fe6550c25d2a55d7c3808dc",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF411": {
+            "prov:generatedEntity": "niiri:1285ada80442ae469e874ddbb7e341cc",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF413": {
+            "prov:generatedEntity": "niiri:7fb9b0874581a71159fdd853f93751f2",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF415": {
+            "prov:generatedEntity": "niiri:62b88250957696695608f4f9d5c33c94",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF417": {
+            "prov:generatedEntity": "niiri:11a529a736c285cc9a00cdcf5fb4962d",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF419": {
+            "prov:generatedEntity": "niiri:56c0d386be3b33d6180c1118121d2610",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF421": {
+            "prov:generatedEntity": "niiri:d285ba30108c36cd9e0a52ef7d0d4cec",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF423": {
+            "prov:generatedEntity": "niiri:d38a6da35a3b35e251b575be2481d895",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF425": {
+            "prov:generatedEntity": "niiri:4f56e832e623fb38abb2d199755b3aa5",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF427": {
+            "prov:generatedEntity": "niiri:92f563ca517a60ccfbb3ef7b2af62dac",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF429": {
+            "prov:generatedEntity": "niiri:8600387b3b7cea249641e5cdebba0daa",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF431": {
+            "prov:generatedEntity": "niiri:0f7371e43c32093550d9b7e335f29fdd",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF433": {
+            "prov:generatedEntity": "niiri:60ee0a470203bf71030d2277a3fde6c3",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF435": {
+            "prov:generatedEntity": "niiri:7cded2bfb4aacaabc3212bf6e55636da",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF437": {
+            "prov:generatedEntity": "niiri:56d77ed8a1025508e9f36442b2aa1001",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF439": {
+            "prov:generatedEntity": "niiri:5debe73d92bf3a2e632b239ed32da2c4",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF441": {
+            "prov:generatedEntity": "niiri:f3bc76ba4a3df529282c2ee84c68df86",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF443": {
+            "prov:generatedEntity": "niiri:28bbba0604724f0b5ea3c95637660afa",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF445": {
+            "prov:generatedEntity": "niiri:e2e08d4842a9d04eb18949c6410171c2",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF447": {
+            "prov:generatedEntity": "niiri:21fbadccdcf80825edc168ed54a646dd",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF449": {
+            "prov:generatedEntity": "niiri:37a7db920a02cc0218b6f2862406e37a",
+            "prov:usedEntity": "niiri:4391a2ef60f122937f69c2336ae7251d"
+        },
+        "_:wDF452": {
+            "prov:generatedEntity": "niiri:15408ee32b85d99dd9469a376a205277",
+            "prov:usedEntity": "niiri:a02993e23816e346753a88b23cc8928d"
+        },
+        "_:wDF455": {
+            "prov:generatedEntity": "niiri:6339834c453190a84e0be6fb23a08d7b",
+            "prov:usedEntity": "niiri:a02993e23816e346753a88b23cc8928d"
+        },
+        "_:wDF458": {
+            "prov:generatedEntity": "niiri:fc608ab17d14b0216545bc760bc76351",
+            "prov:usedEntity": "niiri:a02993e23816e346753a88b23cc8928d"
+        },
+        "_:wDF461": {
+            "prov:generatedEntity": "niiri:360c87bfdf28bfd144d5781923cd8ac1",
+            "prov:usedEntity": "niiri:1fb6d1d0216b48739f26ab81c9d1d36e"
+        },
+        "_:wDF464": {
+            "prov:generatedEntity": "niiri:a998ae1169d6a1bfd5bc42c534c9ce86",
+            "prov:usedEntity": "niiri:1fb6d1d0216b48739f26ab81c9d1d36e"
+        },
+        "_:wDF467": {
+            "prov:generatedEntity": "niiri:8c4b10f0f0d23304c6889f254b8b1f11",
+            "prov:usedEntity": "niiri:1fb6d1d0216b48739f26ab81c9d1d36e"
+        },
+        "_:wDF470": {
+            "prov:generatedEntity": "niiri:fd91d07679d40254e3422190a6146551",
+            "prov:usedEntity": "niiri:513b4dd1fd53a8b3917570bbd44a1da7"
+        },
+        "_:wDF473": {
+            "prov:generatedEntity": "niiri:78698a7744e2e52357780a5302642060",
+            "prov:usedEntity": "niiri:513b4dd1fd53a8b3917570bbd44a1da7"
+        },
+        "_:wDF476": {
+            "prov:generatedEntity": "niiri:7b293150101749bc3e0a5b062221e484",
+            "prov:usedEntity": "niiri:513b4dd1fd53a8b3917570bbd44a1da7"
+        },
+        "_:wDF479": {
+            "prov:generatedEntity": "niiri:d13ff858d119b29455bfd66007ccda04",
+            "prov:usedEntity": "niiri:0383eb2fc5ee76be5634bfee80f2ca3b"
+        },
+        "_:wDF482": {
+            "prov:generatedEntity": "niiri:fd5511cc6e2bfdffd9438532ea9e531a",
+            "prov:usedEntity": "niiri:e67cada24205233131c2bfe154669c61"
+        },
+        "_:wDF485": {
+            "prov:generatedEntity": "niiri:c5b79c6acbda7306e022436ba2ff08ea",
+            "prov:usedEntity": "niiri:e67cada24205233131c2bfe154669c61"
+        },
+        "_:wDF488": {
+            "prov:generatedEntity": "niiri:93f22f5d612344b81124870b08ecc87e",
+            "prov:usedEntity": "niiri:e67cada24205233131c2bfe154669c61"
+        },
+        "_:wDF491": {
+            "prov:generatedEntity": "niiri:46fc5c23e8aa00759077219a8ff53cba",
+            "prov:usedEntity": "niiri:a3635579e9882ee1f3c09824008b66b4"
+        },
+        "_:wDF494": {
+            "prov:generatedEntity": "niiri:7908619b88ba244bd93c6dba0bbb87e6",
+            "prov:usedEntity": "niiri:a3635579e9882ee1f3c09824008b66b4"
+        },
+        "_:wDF497": {
+            "prov:generatedEntity": "niiri:c5f3e3a0fd6c3b436aae4cb7598c34c9",
+            "prov:usedEntity": "niiri:a3635579e9882ee1f3c09824008b66b4"
+        },
+        "_:wDF500": {
+            "prov:generatedEntity": "niiri:a49cb1b476653b5bd0a7cc950718a0ff",
+            "prov:usedEntity": "niiri:c50d34609678664d461509f54c79eea7"
+        },
+        "_:wDF503": {
+            "prov:generatedEntity": "niiri:3e717c804be08adc2679246149af5db7",
+            "prov:usedEntity": "niiri:c50d34609678664d461509f54c79eea7"
+        },
+        "_:wDF506": {
+            "prov:generatedEntity": "niiri:2d6ad9f56e2f5b6c94d89c1ef5625631",
+            "prov:usedEntity": "niiri:c50d34609678664d461509f54c79eea7"
+        },
+        "_:wDF509": {
+            "prov:generatedEntity": "niiri:e8ccf7a91909009975707eb5438a1c41",
+            "prov:usedEntity": "niiri:86785a60d43172b11448d491c5ae96dc"
+        },
+        "_:wDF512": {
+            "prov:generatedEntity": "niiri:7ebb22fd72bd0789f6bd1e8550c7084c",
+            "prov:usedEntity": "niiri:86785a60d43172b11448d491c5ae96dc"
+        },
+        "_:wDF515": {
+            "prov:generatedEntity": "niiri:92d02c82b7f90dbed092d3b95cad4470",
+            "prov:usedEntity": "niiri:86785a60d43172b11448d491c5ae96dc"
+        },
+        "_:wDF518": {
+            "prov:generatedEntity": "niiri:ac1f6889a3b03207d78c9ad5528f9b90",
+            "prov:usedEntity": "niiri:dded355a673488279610ef537e861858"
+        },
+        "_:wDF521": {
+            "prov:generatedEntity": "niiri:d9645c1bc51e20ae6eda890163cdd768",
+            "prov:usedEntity": "niiri:dded355a673488279610ef537e861858"
+        },
+        "_:wDF524": {
+            "prov:generatedEntity": "niiri:14dc5bbb6203781bf94b7883581e8d1b",
+            "prov:usedEntity": "niiri:dded355a673488279610ef537e861858"
+        },
+        "_:wDF527": {
+            "prov:generatedEntity": "niiri:4833f73495c82243b6bcc3fb9a23ef06",
+            "prov:usedEntity": "niiri:c1b3c9780e84e1bcfb3c612aa647510e"
+        },
+        "_:wDF530": {
+            "prov:generatedEntity": "niiri:a037c89bf27b3fb47dd39ef32c69f1e8",
+            "prov:usedEntity": "niiri:c1b3c9780e84e1bcfb3c612aa647510e"
+        },
+        "_:wDF533": {
+            "prov:generatedEntity": "niiri:a30cccdb175a9992ba9c54a7f5f86040",
+            "prov:usedEntity": "niiri:86886012c734f3d338a1efb48a81145a"
+        },
+        "_:wDF536": {
+            "prov:generatedEntity": "niiri:f41be624e1053c51fdbdb702c880be11",
+            "prov:usedEntity": "niiri:86886012c734f3d338a1efb48a81145a"
+        },
+        "_:wDF539": {
+            "prov:generatedEntity": "niiri:30a835006f53ac1656aa862dc46eefb1",
+            "prov:usedEntity": "niiri:86886012c734f3d338a1efb48a81145a"
+        },
+        "_:wDF542": {
+            "prov:generatedEntity": "niiri:0f9e5faadc247bb0f606f8f2783c5dfc",
+            "prov:usedEntity": "niiri:e25e46750ed6706bcfbfa5e14d55d777"
+        },
+        "_:wDF545": {
+            "prov:generatedEntity": "niiri:5833c7ef6fbc97e336c4176bdd68792a",
+            "prov:usedEntity": "niiri:e25e46750ed6706bcfbfa5e14d55d777"
+        },
+        "_:wDF548": {
+            "prov:generatedEntity": "niiri:e161d7cffaa802baa8842dbbc2ff600e",
+            "prov:usedEntity": "niiri:e25e46750ed6706bcfbfa5e14d55d777"
+        },
+        "_:wDF551": {
+            "prov:generatedEntity": "niiri:5922bca96de375a1c4dae7b56d92f626",
+            "prov:usedEntity": "niiri:e2ac8194c797871c399100cc42929140"
+        },
+        "_:wDF554": {
+            "prov:generatedEntity": "niiri:a4cb37e2bdfafa8de612a84fcbdf3e3e",
+            "prov:usedEntity": "niiri:e2ac8194c797871c399100cc42929140"
+        },
+        "_:wDF557": {
+            "prov:generatedEntity": "niiri:5f5bff873009036bef971ae6521ab438",
+            "prov:usedEntity": "niiri:e480d8d12a9dc866e99b7a65d64c73b5"
+        },
+        "_:wDF560": {
+            "prov:generatedEntity": "niiri:8981157e9a4e6b5b093e68b901438bad",
+            "prov:usedEntity": "niiri:e480d8d12a9dc866e99b7a65d64c73b5"
+        },
+        "_:wDF563": {
+            "prov:generatedEntity": "niiri:2c14d6250d370f445e78b4505c0ef514",
+            "prov:usedEntity": "niiri:e480d8d12a9dc866e99b7a65d64c73b5"
+        },
+        "_:wDF566": {
+            "prov:generatedEntity": "niiri:c76586b39c4dce8e30ab4aec2bd0cfe3",
+            "prov:usedEntity": "niiri:82f170400f1b69cc64c4688f03080756"
+        },
+        "_:wDF569": {
+            "prov:generatedEntity": "niiri:cbb5e181055a603b555fe4e31c70e6db",
+            "prov:usedEntity": "niiri:82f170400f1b69cc64c4688f03080756"
+        },
+        "_:wDF572": {
+            "prov:generatedEntity": "niiri:66ffbe934050578ca7c698d14aa85d25",
+            "prov:usedEntity": "niiri:82f170400f1b69cc64c4688f03080756"
+        },
+        "_:wDF575": {
+            "prov:generatedEntity": "niiri:c141baff99ff608f6fd42bbe6f81dd32",
+            "prov:usedEntity": "niiri:c7d451f7f453a0be61177b599ede33a5"
+        },
+        "_:wDF578": {
+            "prov:generatedEntity": "niiri:b7060223bff407a13eb216f455300b91",
+            "prov:usedEntity": "niiri:c7d451f7f453a0be61177b599ede33a5"
+        },
+        "_:wDF581": {
+            "prov:generatedEntity": "niiri:25383c240e64533096acb91f30ed5f79",
+            "prov:usedEntity": "niiri:c7d451f7f453a0be61177b599ede33a5"
+        },
+        "_:wDF584": {
+            "prov:generatedEntity": "niiri:68ea392bb49f24d944e1b260af098020",
+            "prov:usedEntity": "niiri:37926699687cca9b9dd0b742b092ff48"
+        },
+        "_:wDF587": {
+            "prov:generatedEntity": "niiri:1735ae6e0d994f082ddd12a7f2621f0a",
+            "prov:usedEntity": "niiri:37926699687cca9b9dd0b742b092ff48"
+        },
+        "_:wDF590": {
+            "prov:generatedEntity": "niiri:93b54ac55b78a51e2a8346189557574f",
+            "prov:usedEntity": "niiri:37926699687cca9b9dd0b742b092ff48"
+        },
+        "_:wDF593": {
+            "prov:generatedEntity": "niiri:5766230ffa1accb71218f9a65385d08e",
+            "prov:usedEntity": "niiri:e7fc074f64298360eb2c7ffbcb4e63aa"
+        },
+        "_:wDF596": {
+            "prov:generatedEntity": "niiri:b7d8fb60227ddc169d23c315114e2e40",
+            "prov:usedEntity": "niiri:617a58ee9ff77a4075c0708ea690d16c"
+        },
+        "_:wDF599": {
+            "prov:generatedEntity": "niiri:be6ef07847d5a11377cd20e3bf142605",
+            "prov:usedEntity": "niiri:617a58ee9ff77a4075c0708ea690d16c"
+        },
+        "_:wDF602": {
+            "prov:generatedEntity": "niiri:270434b20e00025409cc3402d4134104",
+            "prov:usedEntity": "niiri:fd34291df44a2d10645e6546a1593a1c"
+        },
+        "_:wDF605": {
+            "prov:generatedEntity": "niiri:dd6a5e6b2dd23e0f9e80ac6bfc81c96b",
+            "prov:usedEntity": "niiri:fd34291df44a2d10645e6546a1593a1c"
+        },
+        "_:wDF608": {
+            "prov:generatedEntity": "niiri:39553cd2909fb4f309850bc50283f969",
+            "prov:usedEntity": "niiri:fd34291df44a2d10645e6546a1593a1c"
+        },
+        "_:wDF611": {
+            "prov:generatedEntity": "niiri:829cbe8430fd88bbc00d346769721904",
+            "prov:usedEntity": "niiri:8677fb654966f35b2ba255c1e63d1cb1"
+        },
+        "_:wDF614": {
+            "prov:generatedEntity": "niiri:779dd8335e4fd65858941476e998673b",
+            "prov:usedEntity": "niiri:8677fb654966f35b2ba255c1e63d1cb1"
+        },
+        "_:wDF617": {
+            "prov:generatedEntity": "niiri:03c31dd1111118a4d4e27639746be972",
+            "prov:usedEntity": "niiri:8677fb654966f35b2ba255c1e63d1cb1"
+        },
+        "_:wDF620": {
+            "prov:generatedEntity": "niiri:f29776971e9edeb3024d30c38070b4fe",
+            "prov:usedEntity": "niiri:545f94f2d451c1c902303c221a0a1089"
+        },
+        "_:wDF623": {
+            "prov:generatedEntity": "niiri:4f203f7fbd8966e70a518b7a5098265c",
+            "prov:usedEntity": "niiri:f9a9c037c3239038fee46308d6b9feba"
+        },
+        "_:wDF626": {
+            "prov:generatedEntity": "niiri:7ab50e444de918ebf5bcfdebceaf9ad0",
+            "prov:usedEntity": "niiri:6441c160dec1271f21351fe6ca31e10a"
+        },
+        "_:wDF629": {
+            "prov:generatedEntity": "niiri:48472e5c0e95db5f72001e9bbdb54075",
+            "prov:usedEntity": "niiri:6441c160dec1271f21351fe6ca31e10a"
+        },
+        "_:wDF632": {
+            "prov:generatedEntity": "niiri:5ddd28f08b4c942fd117d28ee9faac64",
+            "prov:usedEntity": "niiri:6441c160dec1271f21351fe6ca31e10a"
+        },
+        "_:wDF635": {
+            "prov:generatedEntity": "niiri:2b3ce71bfa91fff55105d339fbbdbe2b",
+            "prov:usedEntity": "niiri:2872350aa13a26854db92f5a27149fe1"
+        },
+        "_:wDF638": {
+            "prov:generatedEntity": "niiri:f2be8929a3710e3a368deadf13c7b07c",
+            "prov:usedEntity": "niiri:2872350aa13a26854db92f5a27149fe1"
+        },
+        "_:wDF641": {
+            "prov:generatedEntity": "niiri:6beebfb6b83f4e4fbc1d0fabd13b2921",
+            "prov:usedEntity": "niiri:e3742b34c6808b2398052ec8dae20d8c"
+        },
+        "_:wDF644": {
+            "prov:generatedEntity": "niiri:514baf9fb6cc825d6a8ed488bfd99826",
+            "prov:usedEntity": "niiri:e3742b34c6808b2398052ec8dae20d8c"
+        },
+        "_:wDF647": {
+            "prov:generatedEntity": "niiri:c2a20f1f60d0404677a01e0473330666",
+            "prov:usedEntity": "niiri:e3742b34c6808b2398052ec8dae20d8c"
+        },
+        "_:wDF650": {
+            "prov:generatedEntity": "niiri:a7269318ead6ea41a838413495ff7e57",
+            "prov:usedEntity": "niiri:002a4160ef17e67bfe8f93c22d701531"
+        },
+        "_:wDF653": {
+            "prov:generatedEntity": "niiri:357040efdf37bc34eb1815732a22e3e1",
+            "prov:usedEntity": "niiri:88b01b8106ca0618c3b109ef9140a77a"
+        },
+        "_:wDF656": {
+            "prov:generatedEntity": "niiri:4a825f1cb4eb89df074bde02c951cda0",
+            "prov:usedEntity": "niiri:5b45e4eea89f71e19bb39684bf2f0eb7"
+        },
+        "_:wDF659": {
+            "prov:generatedEntity": "niiri:2f6549876aed12baa3dab8de8273d38a",
+            "prov:usedEntity": "niiri:c3da843e94fc98cca5669ae4eef8d2ed"
+        },
+        "_:wDF662": {
+            "prov:generatedEntity": "niiri:f1895be0d1633922d7667327f8d09e70",
+            "prov:usedEntity": "niiri:5d3257a6906cc23f21f8344f8a202720"
+        },
+        "_:wDF665": {
+            "prov:generatedEntity": "niiri:adea458f35a2dd3e503f5b76a33ccca9",
+            "prov:usedEntity": "niiri:5d3257a6906cc23f21f8344f8a202720"
+        },
+        "_:wDF668": {
+            "prov:generatedEntity": "niiri:b2abdbde6951cc3df4267da78e9eab09",
+            "prov:usedEntity": "niiri:5d3257a6906cc23f21f8344f8a202720"
+        },
+        "_:wDF671": {
+            "prov:generatedEntity": "niiri:ce8e5b9eaf298dd260287509743e52a9",
+            "prov:usedEntity": "niiri:f9cfce19a79a082c82d2f3a6386b09c9"
+        },
+        "_:wDF674": {
+            "prov:generatedEntity": "niiri:3b07b1d9d18e5301a1eddd1ed55de100",
+            "prov:usedEntity": "niiri:f9cfce19a79a082c82d2f3a6386b09c9"
+        },
+        "_:wDF677": {
+            "prov:generatedEntity": "niiri:68ccf59f802d72bf9d431b3b294d2c32",
+            "prov:usedEntity": "niiri:f9cfce19a79a082c82d2f3a6386b09c9"
+        },
+        "_:wDF680": {
+            "prov:generatedEntity": "niiri:90812b753072fe6baba25b8214327983",
+            "prov:usedEntity": "niiri:36f4c495e82ce16bc5e3538ec47db115"
+        },
+        "_:wDF683": {
+            "prov:generatedEntity": "niiri:19c2eb940423bd075119228e3100f958",
+            "prov:usedEntity": "niiri:36f4c495e82ce16bc5e3538ec47db115"
+        },
+        "_:wDF686": {
+            "prov:generatedEntity": "niiri:45fb7b2544c4802833f71463702fb573",
+            "prov:usedEntity": "niiri:36f4c495e82ce16bc5e3538ec47db115"
+        },
+        "_:wDF689": {
+            "prov:generatedEntity": "niiri:ae25400879fdbbd71ea06f98f2949c87",
+            "prov:usedEntity": "niiri:f3db818d25677c7c9807d3bc465f0dec"
+        },
+        "_:wDF692": {
+            "prov:generatedEntity": "niiri:dbfa2e37fc9b5cbbd31da892e2cc2e8a",
+            "prov:usedEntity": "niiri:16cd91852662e2b6fb06dce21defbb02"
+        },
+        "_:wDF695": {
+            "prov:generatedEntity": "niiri:c98e1abf15afafba77dc2a1b5bccdb07",
+            "prov:usedEntity": "niiri:d1f64d168706b2b7b1ea74aeb9acf76d"
+        },
+        "_:wDF698": {
+            "prov:generatedEntity": "niiri:11bc9e8dccdea4c6f0576729732a26b1",
+            "prov:usedEntity": "niiri:d1f64d168706b2b7b1ea74aeb9acf76d"
+        },
+        "_:wDF701": {
+            "prov:generatedEntity": "niiri:9eaf1659f6e51a24c9b5249d9eca8663",
+            "prov:usedEntity": "niiri:81dc6b3cbc9f571d3c373afc2c155834"
+        },
+        "_:wDF704": {
+            "prov:generatedEntity": "niiri:df657fae07b6aff0d6f00ce65dfc1a80",
+            "prov:usedEntity": "niiri:5c83c29ecdf61abf3b54b84749525008"
+        },
+        "_:wDF707": {
+            "prov:generatedEntity": "niiri:cd2b04f2aeb928b0be2c2b49a81c72cc",
+            "prov:usedEntity": "niiri:01690965efcb17bbde83102ddcb2faab"
+        },
+        "_:wDF710": {
+            "prov:generatedEntity": "niiri:176829804e5fc15b1d1a6c6d59815463",
+            "prov:usedEntity": "niiri:06b13cc33465cdc0e1390a27c23a9ac4"
+        },
+        "_:wDF713": {
+            "prov:generatedEntity": "niiri:0b19217ec62c40e969523b448d183a81",
+            "prov:usedEntity": "niiri:7f6f25f12f4270c6aaed0a3240d5a8a1"
+        },
+        "_:wDF716": {
+            "prov:generatedEntity": "niiri:fb41e19cf49308d445b6143dd6530c16",
+            "prov:usedEntity": "niiri:7f6f25f12f4270c6aaed0a3240d5a8a1"
+        },
+        "_:wDF719": {
+            "prov:generatedEntity": "niiri:e444cfdfe2f6cbaf0481b63d2834fda6",
+            "prov:usedEntity": "niiri:8f37ccae34c7cba6e277659e1d99e2a9"
+        },
+        "_:wDF722": {
+            "prov:generatedEntity": "niiri:5cdb4e3e9ed6941e49fa8b89c908661b",
+            "prov:usedEntity": "niiri:8f37ccae34c7cba6e277659e1d99e2a9"
+        },
+        "_:wDF725": {
+            "prov:generatedEntity": "niiri:dd4fd70f165a7929f76cd0a4dfbf5059",
+            "prov:usedEntity": "niiri:3acfc147a4a82a0c9064e4e844ecc743"
+        },
+        "_:wDF728": {
+            "prov:generatedEntity": "niiri:6263d0bf0edefd0d5b70b55319094a47",
+            "prov:usedEntity": "niiri:bb2efddb865295f983adb4172abe81b6"
+        },
+        "_:wDF731": {
+            "prov:generatedEntity": "niiri:a05276936cf0d417dc5ca6d7a0d6a3f9",
+            "prov:usedEntity": "niiri:29b1a5a35e558ec0833c58691621c112"
+        },
+        "_:wDF734": {
+            "prov:generatedEntity": "niiri:3ccae7f904d1cb2d10acffdcfadc8f10",
+            "prov:usedEntity": "niiri:29b1a5a35e558ec0833c58691621c112"
+        },
+        "_:wDF737": {
+            "prov:generatedEntity": "niiri:8e4ca43f93486def424cfb00d341a82e",
+            "prov:usedEntity": "niiri:16e2e680906eb7d77a0f37a900f566bb"
+        },
+        "_:wDF740": {
+            "prov:generatedEntity": "niiri:e5b709733a7a64fd4daeb683bb3734c7",
+            "prov:usedEntity": "niiri:16e2e680906eb7d77a0f37a900f566bb"
+        },
+        "_:wDF743": {
+            "prov:generatedEntity": "niiri:c9aaa481cdfc446e54553d8f78ce6094",
+            "prov:usedEntity": "niiri:160595535853afe9f10e3ba4462634ee"
+        },
+        "_:wDF746": {
+            "prov:generatedEntity": "niiri:6197fba6e2664d7308395423fa054a5a",
+            "prov:usedEntity": "niiri:160595535853afe9f10e3ba4462634ee"
+        },
+        "_:wDF749": {
+            "prov:generatedEntity": "niiri:665564fcd3b0c01a2d413f93a062d71e",
+            "prov:usedEntity": "niiri:5bea9c455010164eafb48efd433d0b3b"
+        },
+        "_:wDF752": {
+            "prov:generatedEntity": "niiri:d510f031f5c43274a32cc49cf1f3f001",
+            "prov:usedEntity": "niiri:5bea9c455010164eafb48efd433d0b3b"
+        },
+        "_:wDF755": {
+            "prov:generatedEntity": "niiri:31b0c9c2327a4d798a48c9c2cca5ac27",
+            "prov:usedEntity": "niiri:54acd58c8408a4a54a5d29cdbcf77a2a"
+        },
+        "_:wDF758": {
+            "prov:generatedEntity": "niiri:d3aa0d69a7eaa43c7b928709eff2bf3c",
+            "prov:usedEntity": "niiri:e0f95b0e95e26dd40bce67d69e9c88a7"
+        },
+        "_:wDF761": {
+            "prov:generatedEntity": "niiri:d97a5111c9a07f3911f9566bb4f817b7",
+            "prov:usedEntity": "niiri:e1915181e888f91227f9d80a2ceda361"
+        },
+        "_:wDF764": {
+            "prov:generatedEntity": "niiri:142389ac0cc7b6ad0aefee61aaa19f01",
+            "prov:usedEntity": "niiri:059524711a78d34f86f9ff7484d30c28"
+        },
+        "_:wDF767": {
+            "prov:generatedEntity": "niiri:55baaf76e4730532805f8f2d9564575f",
+            "prov:usedEntity": "niiri:f80c4f725486ccc8cbc7ca97e9202b10"
+        },
+        "_:wDF770": {
+            "prov:generatedEntity": "niiri:f5c396305d9d8b59e0f1de9b43bc1c04",
+            "prov:usedEntity": "niiri:4fc2bcbe1574c654541b41942566af13"
+        },
+        "_:wDF773": {
+            "prov:generatedEntity": "niiri:b17798d8da7350fcfdb2da256f317589",
+            "prov:usedEntity": "niiri:dff2d5252e6112d696cc75e19b35b055"
+        },
+        "_:wDF776": {
+            "prov:generatedEntity": "niiri:606ad57a2c441571f0c00836b6a11960",
+            "prov:usedEntity": "niiri:c1d3f6f0f50baea1174f7ada78444ce5"
+        },
+        "_:wDF779": {
+            "prov:generatedEntity": "niiri:44957024e6a6c3a8d350f2182ed7669b",
+            "prov:usedEntity": "niiri:ac01f2a6f9677b631c38f9d1203db903"
+        },
+        "_:wDF782": {
+            "prov:generatedEntity": "niiri:7a1f7b35bf5c2e76842344547587ee88",
+            "prov:usedEntity": "niiri:ac01f2a6f9677b631c38f9d1203db903"
+        },
+        "_:wDF785": {
+            "prov:generatedEntity": "niiri:52798f01ae0c76b1a815825b938124bf",
+            "prov:usedEntity": "niiri:6ac4331664607b2b0b57f58303204021"
+        },
+        "_:wDF788": {
+            "prov:generatedEntity": "niiri:ac84790ec5fc05c9de4754f79ac66e49",
+            "prov:usedEntity": "niiri:df3a63e829a4b0144a3bd3a075d00d6a"
+        },
+        "_:wDF791": {
+            "prov:generatedEntity": "niiri:e6936b16ba6c2d4218eb760cf497ca0c",
+            "prov:usedEntity": "niiri:df3a63e829a4b0144a3bd3a075d00d6a"
+        },
+        "_:wDF794": {
+            "prov:generatedEntity": "niiri:843790c8e8f506cec84c62b4bdaa4286",
+            "prov:usedEntity": "niiri:df3a63e829a4b0144a3bd3a075d00d6a"
+        },
+        "_:wDF797": {
+            "prov:generatedEntity": "niiri:0a719e8098002e353003ba2a27b073c0",
+            "prov:usedEntity": "niiri:de4cddb037f1620436ef1889e1446b84"
+        },
+        "_:wDF800": {
+            "prov:generatedEntity": "niiri:43e979b3f8840ac3905a6f8a4407fcd5",
+            "prov:usedEntity": "niiri:70eb10d3df67eb20319350b5182c2674"
+        },
+        "_:wDF803": {
+            "prov:generatedEntity": "niiri:eceeb78780be64894e966537ab3cb8b4",
+            "prov:usedEntity": "niiri:0c6701f42b3e926640123461fe2991bd"
+        },
+        "_:wDF806": {
+            "prov:generatedEntity": "niiri:ed981c1dca3ea9b8e6dca05eddddb42e",
+            "prov:usedEntity": "niiri:ff9cac1254b9e415d2191f7775b434dc"
+        },
+        "_:wDF809": {
+            "prov:generatedEntity": "niiri:f1d40c82f153f10f701e991dc46bf76c",
+            "prov:usedEntity": "niiri:42811518fc15bbd0a0761ed04fef9d90"
+        },
+        "_:wDF812": {
+            "prov:generatedEntity": "niiri:90a42fb8b7ab15a0fc7f9593788fd0d8",
+            "prov:usedEntity": "niiri:dd408b7babb59101191c5fa3158193a1"
+        },
+        "_:wDF815": {
+            "prov:generatedEntity": "niiri:977335353dc773fc7bbc24036d48d077",
+            "prov:usedEntity": "niiri:99548a2427d673d5bd15c691076864b1"
+        },
+        "_:wDF818": {
+            "prov:generatedEntity": "niiri:3c8fb8a88e5e0426d1a5f92207ba17b9",
+            "prov:usedEntity": "niiri:7a1eb6258840314d739698ecb8549782"
+        },
+        "_:wDF821": {
+            "prov:generatedEntity": "niiri:98867af87517f1e98b09c71216997a9b",
+            "prov:usedEntity": "niiri:7a1eb6258840314d739698ecb8549782"
+        },
+        "_:wDF824": {
+            "prov:generatedEntity": "niiri:33190d6d2e32f171dd46bc01760c790f",
+            "prov:usedEntity": "niiri:d766f0de412bd93d96229079d9de064c"
+        },
+        "_:wDF827": {
+            "prov:generatedEntity": "niiri:89a194ad515e6bc3d514f374a7c0b423",
+            "prov:usedEntity": "niiri:8661090d64b5d8ebc0a4bd8254976fb2"
+        },
+        "_:wDF830": {
+            "prov:generatedEntity": "niiri:8ae3f86dbfbb937f245ae840af8b5c49",
+            "prov:usedEntity": "niiri:52941f17d3d4d9019f15d6efbca27815"
+        },
+        "_:wDF833": {
+            "prov:generatedEntity": "niiri:3dd185a366e3d00acea89b72842526fa",
+            "prov:usedEntity": "niiri:65bb243af8ca1e554de57b71bb66bc25"
+        },
+        "_:wDF836": {
+            "prov:generatedEntity": "niiri:0071dedc5b10c2348b38dd7fd1f3af16",
+            "prov:usedEntity": "niiri:65bb243af8ca1e554de57b71bb66bc25"
+        },
+        "_:wDF839": {
+            "prov:generatedEntity": "niiri:73dbca8a980ae25e2ff56feb2e61e1f1",
+            "prov:usedEntity": "niiri:eb7b45334c4709abfab6a80cdaa2bc22"
+        },
+        "_:wDF842": {
+            "prov:generatedEntity": "niiri:85b1cb20bd5854a8141f9a51241094c0",
+            "prov:usedEntity": "niiri:afbff827e6265de5fc31843cacb634e6"
+        },
+        "_:wDF845": {
+            "prov:generatedEntity": "niiri:80c689d708c2928c17585d1c5c63574b",
+            "prov:usedEntity": "niiri:44d83170827403caee586f5f0c738aff"
+        },
+        "_:wDF848": {
+            "prov:generatedEntity": "niiri:68c2fcab274675b0f794f0f1b1cef55a",
+            "prov:usedEntity": "niiri:2d968184be68de22a2c6d1f79a1a3779"
+        },
+        "_:wDF851": {
+            "prov:generatedEntity": "niiri:543cc9adfb564a9668b2518ca40bcc25",
+            "prov:usedEntity": "niiri:8c5cc0e6fb31318c9adb3b82365f2ae6"
+        },
+        "_:wDF854": {
+            "prov:generatedEntity": "niiri:2db3c23fc333f8331cda3b16530368ad",
+            "prov:usedEntity": "niiri:db5e02d87132e15c42c39a266963eb55"
+        },
+        "_:wDF857": {
+            "prov:generatedEntity": "niiri:953c82968cbb8941046013eaafb134b0",
+            "prov:usedEntity": "niiri:6e1483cf3114e5bdc77f5e480decfc71"
+        },
+        "_:wDF860": {
+            "prov:generatedEntity": "niiri:3cabe98da9708d5c6d9ef929b06fe15d",
+            "prov:usedEntity": "niiri:1eb993430541f6c2dc79f73b3a96decc"
+        },
+        "_:wDF863": {
+            "prov:generatedEntity": "niiri:0483d1896bdb7110c7c114277f735ab9",
+            "prov:usedEntity": "niiri:e576b0cc1b6a471310c83c2e65672f5f"
+        },
+        "_:wDF866": {
+            "prov:generatedEntity": "niiri:e91d29fc9817e2a7b36fc978ba3fe7d8",
+            "prov:usedEntity": "niiri:01a6664df87623bed0fd193f07c04638"
+        },
+        "_:wDF869": {
+            "prov:generatedEntity": "niiri:c156e4600d2260f008778fbfcc998fb4",
+            "prov:usedEntity": "niiri:9fbbe8461310da88b0ce5b0b68e8e62c"
+        },
+        "_:wDF872": {
+            "prov:generatedEntity": "niiri:ec175136c213f64b6858d2d67479878d",
+            "prov:usedEntity": "niiri:9fbbe8461310da88b0ce5b0b68e8e62c"
+        },
+        "_:wDF875": {
+            "prov:generatedEntity": "niiri:1a52e7aaf9f3a5bd152c0ebd9fcef4fd",
+            "prov:usedEntity": "niiri:ae14e5d65d87b53bd2bbf000849a1635"
+        },
+        "_:wDF878": {
+            "prov:generatedEntity": "niiri:2c83e3b2c475480b66ada9ebc6da746b",
+            "prov:usedEntity": "niiri:40d7f1124d8e7cab0c81135fe2f535ad"
+        },
+        "_:wDF881": {
+            "prov:generatedEntity": "niiri:c0b01d212ef6b8d37eb57b24d78fab11",
+            "prov:usedEntity": "niiri:3383de798490342ce6540ea70b023ffa"
+        },
+        "_:wDF884": {
+            "prov:generatedEntity": "niiri:861c2c7575cf5f18aa4f01bea0b82135",
+            "prov:usedEntity": "niiri:4bcfe0e6f6bc971e3e914655ca98bf82"
+        },
+        "_:wDF887": {
+            "prov:generatedEntity": "niiri:a5987a6772c4cd944a2d21945bf8cc08",
+            "prov:usedEntity": "niiri:bbf13cce053679ff04cb1b23082b44ac"
+        },
+        "_:wDF890": {
+            "prov:generatedEntity": "niiri:9a723a9a2cf5ca36130eb2146162ff79",
+            "prov:usedEntity": "niiri:2151f348776220c1024fdc2f0b0bc92f"
+        },
+        "_:wDF893": {
+            "prov:generatedEntity": "niiri:419f74c7325474e8e1f981e499bf215a",
+            "prov:usedEntity": "niiri:8ccfe08eafd83c22c7082eb44f58a70f"
+        },
+        "_:wDF896": {
+            "prov:generatedEntity": "niiri:3877f612a4c9aaac9336d7f9e3e88d69",
+            "prov:usedEntity": "niiri:bad308d46fbeeacaf458653ab9b853d6"
+        },
+        "_:wDF899": {
+            "prov:generatedEntity": "niiri:8637dbbca99c6bf52067de598426c4d0",
+            "prov:usedEntity": "niiri:bad308d46fbeeacaf458653ab9b853d6"
+        },
+        "_:wDF902": {
+            "prov:generatedEntity": "niiri:2e6563d391260b35c952b660146494c2",
+            "prov:usedEntity": "niiri:687916ac6701ade9ca268dec72dc0c0d"
+        },
+        "_:wDF905": {
+            "prov:generatedEntity": "niiri:2d7a05b0881bcaf974a82728c80d267b",
+            "prov:usedEntity": "niiri:9071142b0c2683c96f4377cdddced1d0"
+        },
+        "_:wDF908": {
+            "prov:generatedEntity": "niiri:3daa0fd1f3c9c061fc41328ca9438a27",
+            "prov:usedEntity": "niiri:884f659ac62495dd158e264f576d0fc2"
+        },
+        "_:wDF911": {
+            "prov:generatedEntity": "niiri:2e8cafa261c265066c3b0c06f8f7546a",
+            "prov:usedEntity": "niiri:2088eea3a39320e89e2a625ec7e9f82e"
+        },
+        "_:wDF914": {
+            "prov:generatedEntity": "niiri:8139ce719a3bbb4c2ad3027af6da9b91",
+            "prov:usedEntity": "niiri:7fc88d60dca200d4c67a0a607a345633"
+        },
+        "_:wDF917": {
+            "prov:generatedEntity": "niiri:f80978e3da40bc3e863003eb710a4f97",
+            "prov:usedEntity": "niiri:ca1da2e7a46f823f402d9c62e070d0fc"
+        },
+        "_:wDF920": {
+            "prov:generatedEntity": "niiri:4e7e46ac0c58102be99f07a84d8b80ce",
+            "prov:usedEntity": "niiri:ea6ee099e3b8edbdd2bde04e8682a6ce"
+        },
+        "_:wDF923": {
+            "prov:generatedEntity": "niiri:a61c69f7358597f7aa5c12a588c1ce7c",
+            "prov:usedEntity": "niiri:1ef7113e2a59f273a63186ced0b0fc6b"
+        },
+        "_:wDF926": {
+            "prov:generatedEntity": "niiri:ab548589200676685973c248e76b07b4",
+            "prov:usedEntity": "niiri:02f0aee7ff558248fe49e5f3579c0585"
+        },
+        "_:wDF929": {
+            "prov:generatedEntity": "niiri:6d8e54d85422fdb3fc4d40dcb8a7528b",
+            "prov:usedEntity": "niiri:c2cda63a78bcde6ae7a69f7ab8eadb2c"
+        },
+        "_:wDF932": {
+            "prov:generatedEntity": "niiri:5deeb5d90a0af409b6cff616354e11a7",
+            "prov:usedEntity": "niiri:2c7f2ff6921dbb36e89f44a3a1dd839b"
+        },
+        "_:wDF935": {
+            "prov:generatedEntity": "niiri:b9a1b6a6a5bd0918b2da9d95b2f3281d",
+            "prov:usedEntity": "niiri:03e03b97c9ae144949ccd274ec79dd81"
+        },
+        "_:wDF938": {
+            "prov:generatedEntity": "niiri:77808b7180e73fc3945d40bbbd602a7c",
+            "prov:usedEntity": "niiri:036f2836a317a98100c1a6652ab21784"
+        },
+        "_:wDF941": {
+            "prov:generatedEntity": "niiri:07c12d4cbb23e86fca36208cc6a9eb4f",
+            "prov:usedEntity": "niiri:a029a63406d370c8869c59656bb90a54"
+        },
+        "_:wDF944": {
+            "prov:generatedEntity": "niiri:3a4c88d5e566a02cdf99eb0ce85232b0",
+            "prov:usedEntity": "niiri:c429131bcf59cefceae4a934fd1aa80a"
+        },
+        "_:wDF947": {
+            "prov:generatedEntity": "niiri:24b5fea160dd2add4c0826068ad6d59a",
+            "prov:usedEntity": "niiri:9ac7226087de1c45b555519c1250dc59"
+        },
+        "_:wDF950": {
+            "prov:generatedEntity": "niiri:1b0c82bff8134900d83ca4ab18a5f9a1",
+            "prov:usedEntity": "niiri:9c1fe61e0e5d7d3b62e90ebdfdb9d4d4"
+        },
+        "_:wDF953": {
+            "prov:generatedEntity": "niiri:52d92ac8e74231b2934c36f68802206e",
+            "prov:usedEntity": "niiri:7489f5e950ff72b41ea437f2c2026c6f"
+        },
+        "_:wDF956": {
+            "prov:generatedEntity": "niiri:d117036fe64a05a3b7c805f5ca53e73e",
+            "prov:usedEntity": "niiri:e83b9cd4cb9554eedc76bd43c766b08d"
+        },
+        "_:wDF959": {
+            "prov:generatedEntity": "niiri:c1fb5dac9debfbd27cdbf2c5644bd72c",
+            "prov:usedEntity": "niiri:6f3ca580fb0dafec12bb76f49a9e660f"
+        },
+        "_:wDF962": {
+            "prov:generatedEntity": "niiri:3b66a36836011aa9090bd0e7407688b5",
+            "prov:usedEntity": "niiri:37ee2d388f0d21999c13e5808ab4abaa"
+        },
+        "_:wDF965": {
+            "prov:generatedEntity": "niiri:8de26e655b38ebe0ae823a3c6315b489",
+            "prov:usedEntity": "niiri:17c3d65f0a2dd8b609c3139c41ebf930"
+        },
+        "_:wDF968": {
+            "prov:generatedEntity": "niiri:3a28b75034719222480546a8f248e93d",
+            "prov:usedEntity": "niiri:bbd0acc33408cc31d2590c5760c85985"
+        },
+        "_:wDF971": {
+            "prov:generatedEntity": "niiri:12ba61b8d3db496fc57a6862ebafea4f",
+            "prov:usedEntity": "niiri:04aa6294da937ca4a062fce158511fb6"
+        },
+        "_:wDF974": {
+            "prov:generatedEntity": "niiri:1ca1bec4b1e87f060081099329ba04c7",
+            "prov:usedEntity": "niiri:6e2a6189013a78c14191e7633ed21b0a"
+        },
+        "_:wDF977": {
+            "prov:generatedEntity": "niiri:5570619f587edcedc3276cafac9a60e6",
+            "prov:usedEntity": "niiri:81840f3ae0159e07fac81fc13e72fbf5"
+        },
+        "_:wDF980": {
+            "prov:generatedEntity": "niiri:191389c9f10b0de3fdc2d8f22b74563e",
+            "prov:usedEntity": "niiri:dd602a84f4dd916125d3c669097eec23"
+        },
+        "_:wDF983": {
+            "prov:generatedEntity": "niiri:aedad9f4ec6caede41f6dc10a706c84d",
+            "prov:usedEntity": "niiri:1c2363e827044fb757d9bf0cf8e052e5"
+        },
+        "_:wDF986": {
+            "prov:generatedEntity": "niiri:4c440fe68b006ba088752502fc89d323",
+            "prov:usedEntity": "niiri:45132e41bd386f5b430c16f7c2c90e0a"
+        },
+        "_:wDF989": {
+            "prov:generatedEntity": "niiri:293fb40452e1ad24570cc1435e986bc8",
+            "prov:usedEntity": "niiri:c4e5f3528c31047605f368909a0632ee"
+        },
+        "_:wDF992": {
+            "prov:generatedEntity": "niiri:29f6517310b6e9273df1d8b7f169679e",
+            "prov:usedEntity": "niiri:1355ee0795599ee6287d2b70ebc8d729"
+        },
+        "_:wDF995": {
+            "prov:generatedEntity": "niiri:542b8ad9afd2cc487bc118184a9d1898",
+            "prov:usedEntity": "niiri:370789fb0338d1e1885081e0362c340f"
+        },
+        "_:wDF998": {
+            "prov:generatedEntity": "niiri:6b45ddf4564bf60372a7295ba801c752",
+            "prov:usedEntity": "niiri:40392b1ab652b1fe41dac16581269fb2"
+        },
+        "_:wDF1001": {
+            "prov:generatedEntity": "niiri:31f0e1886831f0a1dbaaece14761126e",
+            "prov:usedEntity": "niiri:65ef2c95ae3f51b5861bb20b84514bd9"
+        },
+        "_:wDF1004": {
+            "prov:generatedEntity": "niiri:e272d51328812cf371cc587ac58a5526",
+            "prov:usedEntity": "niiri:5cc71319d109fdb0ef9f0f9c7bd41492"
+        },
+        "_:wDF1007": {
+            "prov:generatedEntity": "niiri:4e23f38355e282e3d94d0ca850cd592a",
+            "prov:usedEntity": "niiri:4bf75a353d782554be968730ac4840cd"
+        },
+        "_:wDF1010": {
+            "prov:generatedEntity": "niiri:a5d23eefb67d323e152120970fdbfb9b",
+            "prov:usedEntity": "niiri:332041ad6aeaf3a74891ecd53c374a96"
+        },
+        "_:wDF1013": {
+            "prov:generatedEntity": "niiri:b2d310b49e85f22bad1ac328ed239ef7",
+            "prov:usedEntity": "niiri:b47672c30d95e784941e629a0021b66b"
+        },
+        "_:wDF1016": {
+            "prov:generatedEntity": "niiri:ae8fdbe9961a1dc724d425e20affb4ad",
+            "prov:usedEntity": "niiri:4ade8b0865402c36f9bde1298af17ab4"
+        },
+        "_:wDF1019": {
+            "prov:generatedEntity": "niiri:02fa43a4dca1b09dd2c3be30a44755f8",
+            "prov:usedEntity": "niiri:8d46ffe6156e40b274554eb8fc558f49"
+        },
+        "_:wDF1022": {
+            "prov:generatedEntity": "niiri:1bb674b1760d589a90a0632e34f21e8a",
+            "prov:usedEntity": "niiri:4d3c4f523d2ecfeb9befc1c5babb099d"
+        },
+        "_:wDF1025": {
+            "prov:generatedEntity": "niiri:7af7dc9d762aed03c62f1ccb4dc9f1b1",
+            "prov:usedEntity": "niiri:24a29d9d6136d7a26f77ad7395967c47"
+        },
+        "_:wDF1028": {
+            "prov:generatedEntity": "niiri:75daec94f2d9f1cbc921b112d9ef9ce2",
+            "prov:usedEntity": "niiri:7289b1de1e9e889ff1fb5691142cd967"
+        },
+        "_:wDF1031": {
+            "prov:generatedEntity": "niiri:faf603f8089ae20ce68bd6964020283e",
+            "prov:usedEntity": "niiri:4465bf32a18439b39ae380aba9c3f3b0"
+        },
+        "_:wDF1034": {
+            "prov:generatedEntity": "niiri:d1bf63b81607321155f8338c282e59b2",
+            "prov:usedEntity": "niiri:1cd15156a67e7cd4faba9f06d50293c8"
+        },
+        "_:wDF1037": {
+            "prov:generatedEntity": "niiri:ad40b53c8dd4e2ab45b2ef401a4c24fc",
+            "prov:usedEntity": "niiri:ad7c299b4aa35cd98fdbd415f19783a7"
+        },
+        "_:wDF1040": {
+            "prov:generatedEntity": "niiri:d5a95ad6a90a7c4b7b4c65611bcfb3ee",
+            "prov:usedEntity": "niiri:fe8b635d8a705b40fb4ced016e9d726a"
+        },
+        "_:wDF1043": {
+            "prov:generatedEntity": "niiri:a4bd9f4aa32c821fe2cb97c3309c18de",
+            "prov:usedEntity": "niiri:71e15e602f95bdd78bc912bf527abf9d"
+        },
+        "_:wDF1046": {
+            "prov:generatedEntity": "niiri:60b2aa1e5a1e97e22c14f51ae12c8d5c",
+            "prov:usedEntity": "niiri:46e2492f096548abf33dea89e7a868bc"
+        },
+        "_:wDF1049": {
+            "prov:generatedEntity": "niiri:98e838a33321e9ba14f44d7f98af1258",
+            "prov:usedEntity": "niiri:f234bb306a90feca64756c5add571e95"
+        },
+        "_:wDF1052": {
+            "prov:generatedEntity": "niiri:b33c6c90358c64f445051a6f1ddaa146",
+            "prov:usedEntity": "niiri:9a23d6bdea30bc505d71bdea4b14cc81"
+        },
+        "_:wDF1055": {
+            "prov:generatedEntity": "niiri:6c21781a2f968dd6b89eb9acbab79c64",
+            "prov:usedEntity": "niiri:55a2e8a69b22f0385eb446ff36f57cd5"
+        },
+        "_:wDF1058": {
+            "prov:generatedEntity": "niiri:1b91a4eb434472d16421d0c377206835",
+            "prov:usedEntity": "niiri:c1b67e6fa1bc1b0441ef946f06fc7939"
+        },
+        "_:wDF1061": {
+            "prov:generatedEntity": "niiri:7d02ed7f20eb6fe558766caecf63c155",
+            "prov:usedEntity": "niiri:598d8f8cb448fe66f29b80c3e9c6b8c7"
+        },
+        "_:wDF1064": {
+            "prov:generatedEntity": "niiri:81902bcb64a59f174ed4a22dc2692239",
+            "prov:usedEntity": "niiri:9e74994c43b00fa8f3c04ed564b75259"
+        },
+        "_:wDF1067": {
+            "prov:generatedEntity": "niiri:4302df4d2f6614b3486ee45c6c620874",
+            "prov:usedEntity": "niiri:59f7c04e9a6910158fa3c13760b2a417"
+        },
+        "_:wDF1070": {
+            "prov:generatedEntity": "niiri:abd2f7443e3cc8dca0d22ff7fa5b1665",
+            "prov:usedEntity": "niiri:81a8b467cb1446f1ff5cdaa2c7d6e479"
+        },
+        "_:wDF1073": {
+            "prov:generatedEntity": "niiri:eb863adb5a212bbe0de0abe4fb289aad",
+            "prov:usedEntity": "niiri:b6cb8a909916808e62aec6d7aa7ee1b8"
+        },
+        "_:wDF1076": {
+            "prov:generatedEntity": "niiri:f5b6dec4e6c487fdf092083f6476a41e",
+            "prov:usedEntity": "niiri:50e1d73ec7323535a313db319aa8fda1"
+        },
+        "_:wDF1079": {
+            "prov:generatedEntity": "niiri:6d3f27e6e0aa864aa68bacd72871f8c3",
+            "prov:usedEntity": "niiri:7dcc4c8a94cbe8b1b1f9e1f46a8741d3"
+        },
+        "_:wDF1082": {
+            "prov:generatedEntity": "niiri:a5774a9de179c5a31a4170040a80ba30",
+            "prov:usedEntity": "niiri:b54fdacdf6871d0d178386e52e6bcf8e"
+        },
+        "_:wDF1085": {
+            "prov:generatedEntity": "niiri:abdd30b092a8fb58bf5083e43d76564b",
+            "prov:usedEntity": "niiri:22043ef18c61c537ac8a05e639b5f722"
+        },
+        "_:wDF1088": {
+            "prov:generatedEntity": "niiri:853d2a530b3a85eb977c69e3afe8644a",
+            "prov:usedEntity": "niiri:fd886d44827bbf7fd4cd36a6fa24a0dc"
+        },
+        "_:wDF1091": {
+            "prov:generatedEntity": "niiri:906ee563af4ace86c7988da22e67ae3f",
+            "prov:usedEntity": "niiri:e782c57868e4be48647d27ca19f3f3c2"
+        },
+        "_:wDF1094": {
+            "prov:generatedEntity": "niiri:0a50255f519e99d47205e1125596b9b6",
+            "prov:usedEntity": "niiri:f434c353ca0df61bb269a9c7f670117c"
+        },
+        "_:wDF1097": {
+            "prov:generatedEntity": "niiri:296160c26ce8de6d4816b73bc3fcbc6a",
+            "prov:usedEntity": "niiri:0ccff4009d26155a785837676412d40e"
+        },
+        "_:wDF1100": {
+            "prov:generatedEntity": "niiri:59f7ae9e78c57e6eb798ea767f4fd090",
+            "prov:usedEntity": "niiri:800c8b037dc30701b156bb7c32952fad"
+        },
+        "_:wDF1103": {
+            "prov:generatedEntity": "niiri:2c74c9e73a8754c200410a8ddc063874",
+            "prov:usedEntity": "niiri:783b5fc0e23ce088341f9b979cd6ab07"
+        },
+        "_:wDF1106": {
+            "prov:generatedEntity": "niiri:54ccde113afb801a2d42f17bcc407213",
+            "prov:usedEntity": "niiri:eeecebef37458a809e6ef90a22514949"
+        },
+        "_:wDF1109": {
+            "prov:generatedEntity": "niiri:443bd980ef1188caf910159d88fbb606",
+            "prov:usedEntity": "niiri:9e9084297f3aec6679c40f52af1c9c5c"
+        },
+        "_:wDF1112": {
+            "prov:generatedEntity": "niiri:fad207295de11587bdc4ed90e387142b",
+            "prov:usedEntity": "niiri:dc54137a08092762cc961c9285859566"
+        },
+        "_:wDF1115": {
+            "prov:generatedEntity": "niiri:63f4617c03904f8fe616125bfc5a9e72",
+            "prov:usedEntity": "niiri:9ff86139e0b5b4951d06b07e9a923ed4"
+        },
+        "_:wDF1118": {
+            "prov:generatedEntity": "niiri:a6f44d12d066b455d18d5cf9ff1bdaee",
+            "prov:usedEntity": "niiri:8a8ea66289482bc8790b162d4c9789ef"
+        },
+        "_:wDF1121": {
+            "prov:generatedEntity": "niiri:182ba929021f340ee67f2468e637cc44",
+            "prov:usedEntity": "niiri:05c885a40fe6550c25d2a55d7c3808dc"
+        },
+        "_:wDF1124": {
+            "prov:generatedEntity": "niiri:f240087ba6b26ab0e7705cb6916792eb",
+            "prov:usedEntity": "niiri:1285ada80442ae469e874ddbb7e341cc"
+        },
+        "_:wDF1127": {
+            "prov:generatedEntity": "niiri:01c2ba3dcb7343112c96e480784b9ad1",
+            "prov:usedEntity": "niiri:7fb9b0874581a71159fdd853f93751f2"
+        },
+        "_:wDF1130": {
+            "prov:generatedEntity": "niiri:cd8669b3a66c8ac45b3908124a6c355e",
+            "prov:usedEntity": "niiri:62b88250957696695608f4f9d5c33c94"
+        },
+        "_:wDF1133": {
+            "prov:generatedEntity": "niiri:71daf19003d4f9dfcddcf08cbdd35abd",
+            "prov:usedEntity": "niiri:11a529a736c285cc9a00cdcf5fb4962d"
+        },
+        "_:wDF1136": {
+            "prov:generatedEntity": "niiri:3057043901ea2a078a58803f5a56dec7",
+            "prov:usedEntity": "niiri:56c0d386be3b33d6180c1118121d2610"
+        },
+        "_:wDF1139": {
+            "prov:generatedEntity": "niiri:f5292c900080c8c0ef7cf8ec19aa3697",
+            "prov:usedEntity": "niiri:d285ba30108c36cd9e0a52ef7d0d4cec"
+        },
+        "_:wDF1142": {
+            "prov:generatedEntity": "niiri:30a84acd12436a2955bf4b443a3b850c",
+            "prov:usedEntity": "niiri:d38a6da35a3b35e251b575be2481d895"
+        },
+        "_:wDF1145": {
+            "prov:generatedEntity": "niiri:03b8a2fea9829914437905e68925e360",
+            "prov:usedEntity": "niiri:4f56e832e623fb38abb2d199755b3aa5"
+        },
+        "_:wDF1148": {
+            "prov:generatedEntity": "niiri:c88d9634fff92159e1df0499f5d4e04b",
+            "prov:usedEntity": "niiri:92f563ca517a60ccfbb3ef7b2af62dac"
+        },
+        "_:wDF1151": {
+            "prov:generatedEntity": "niiri:2a999512422d958e9dd451fe676d13a1",
+            "prov:usedEntity": "niiri:8600387b3b7cea249641e5cdebba0daa"
+        },
+        "_:wDF1154": {
+            "prov:generatedEntity": "niiri:f985f79075267f7e7ea06f7a3d3b4fd0",
+            "prov:usedEntity": "niiri:0f7371e43c32093550d9b7e335f29fdd"
+        },
+        "_:wDF1157": {
+            "prov:generatedEntity": "niiri:f181b589179ed8f92f3f7f4795974d3e",
+            "prov:usedEntity": "niiri:60ee0a470203bf71030d2277a3fde6c3"
+        },
+        "_:wDF1160": {
+            "prov:generatedEntity": "niiri:b24deafd5ea91430bd7b734255475770",
+            "prov:usedEntity": "niiri:7cded2bfb4aacaabc3212bf6e55636da"
+        },
+        "_:wDF1163": {
+            "prov:generatedEntity": "niiri:ed3e68d921eeb26ff4420aa1da45f707",
+            "prov:usedEntity": "niiri:56d77ed8a1025508e9f36442b2aa1001"
+        },
+        "_:wDF1166": {
+            "prov:generatedEntity": "niiri:5d28dbbc72458950d35719ada2f35c1d",
+            "prov:usedEntity": "niiri:5debe73d92bf3a2e632b239ed32da2c4"
+        },
+        "_:wDF1169": {
+            "prov:generatedEntity": "niiri:49fa6fc625869e411d951c76ea01f001",
+            "prov:usedEntity": "niiri:f3bc76ba4a3df529282c2ee84c68df86"
+        },
+        "_:wDF1172": {
+            "prov:generatedEntity": "niiri:7047971620448cda11f6eecfb2f451f4",
+            "prov:usedEntity": "niiri:28bbba0604724f0b5ea3c95637660afa"
+        },
+        "_:wDF1175": {
+            "prov:generatedEntity": "niiri:27fc8dfd0e287d18ed37abcd26235c8c",
+            "prov:usedEntity": "niiri:e2e08d4842a9d04eb18949c6410171c2"
+        },
+        "_:wDF1178": {
+            "prov:generatedEntity": "niiri:c78a4edd720ceef3e574dba70e0cc9fc",
+            "prov:usedEntity": "niiri:21fbadccdcf80825edc168ed54a646dd"
+        },
+        "_:wDF1181": {
+            "prov:generatedEntity": "niiri:a9c0e06b74f100f91729fb0b3f27bb2e",
+            "prov:usedEntity": "niiri:37a7db920a02cc0218b6f2862406e37a"
+        }
+    },
+    "wasAttributedTo": {
+        "_:wAT6": {
+            "prov:entity": "niiri:e2f4df9e4df57e86b857fd981bd770f4",
+            "prov:agent": "niiri:06a12d76cf24728b70559a82704e66d8"
+        },
+        "_:wAT7": {
+            "prov:entity": "niiri:e2f4df9e4df57e86b857fd981bd770f4",
+            "prov:agent": "niiri:78ef43d31af19b56191d7258da75b6e0"
+        }
+    },
+    "wasAssociatedWith": {
+        "_:wAW13": {
+            "prov:activity": "niiri:af398ef47bafd7ba0d7a56b68ea654a5",
+            "prov:agent": "niiri:108629946ef3459712b1ceefc5a31493"
+        },
+        "_:wAW45": {
+            "prov:activity": "niiri:d56c7f996ee59831f6e800e8e38c6886",
+            "prov:agent": "niiri:108629946ef3459712b1ceefc5a31493"
+        },
+        "_:wAW68": {
+            "prov:activity": "niiri:acd80690d12cb39b6a731ff1e4c00286",
+            "prov:agent": "niiri:108629946ef3459712b1ceefc5a31493"
+        }
+    }
+    }
+  }
+}

--- a/spmexport/ex_spm_con_f/nidm.jsonld
+++ b/spmexport/ex_spm_con_f/nidm.jsonld
@@ -7,7 +7,7 @@
       "niiri": "http://iri.nidash.org/",
       "spm": "http://purl.org/nidash/spm#",
       "neurolex": "http://neurolex.org/wiki/",
-      "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#",
+      "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/",
       "dct": "http://purl.org/dc/terms/",
       "nfo": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#",
       "dc": "http://purl.org/dc/elements/1.1/",
@@ -22,32 +22,32 @@
   ],
   "@graph": [
     {
-      "@id": "niiri:ce463eb8dde7dcf0cf14b6d33f1e2267",
-      "@type": ["prov:Entity","prov:Bundle","nidm_NIDMResults:"],
+      "@id": "niiri:a792e7640ea680e887ff5fb67a74d579",
+      "@type": ["prov:Entity","prov:Bundle","nidm_NIDMResults"],
       "rdfs:label": "NIDM-Results",
-      "nidm_version:": {"@type": "xsd:string", "@value": "1.3.0"}
+      "nidm_version": {"@type": "xsd:string", "@value": "1.3.0"}
     },
     {
-      "@id": "niiri:639a1bbc0d4b85d4e0192ccfc285b09e",
-      "@type": ["prov:Agent","nidm_spm_results_nidm:","prov:SoftwareAgent"],
+      "@id": "niiri:6899857b8c32ae5b43d240b4f06f2892",
+      "@type": ["prov:Agent","nidm_spm_results_nidm","prov:SoftwareAgent"],
       "rdfs:label": "spm_results_nidm",
-      "nidm_softwareVersion:": {"@type": "xsd:string", "@value": "12.6903"}
+      "nidm_softwareVersion": {"@type": "xsd:string", "@value": "12.7057"}
     },
     {
-      "@id": "niiri:b4759ceddf4e022a13785ece7a98a2c5",
-      "@type": ["prov:Activity","nidm_NIDMResultsExport:"],
+      "@id": "niiri:34e091da330b63901082b65ed57e7701",
+      "@type": ["prov:Activity","nidm_NIDMResultsExport"],
       "rdfs:label": "NIDM-Results export"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:b4759ceddf4e022a13785ece7a98a2c5",
-      "agent": "niiri:639a1bbc0d4b85d4e0192ccfc285b09e"
+      "activity_associated": "niiri:34e091da330b63901082b65ed57e7701",
+      "agent": "niiri:6899857b8c32ae5b43d240b4f06f2892"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:ce463eb8dde7dcf0cf14b6d33f1e2267",
-      "activity": "niiri:b4759ceddf4e022a13785ece7a98a2c5",
-      "atTime": "2016-12-07T16:07:38"
+      "entity_generated": "niiri:a792e7640ea680e887ff5fb67a74d579",
+      "activity": "niiri:34e091da330b63901082b65ed57e7701",
+      "atTime": "2017-04-19T12:17:33"
     }
   ]
 },
@@ -157,544 +157,544 @@
       "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
     }
   ],
-  "@id": "niiri:ce463eb8dde7dcf0cf14b6d33f1e2267",
+  "@id": "niiri:a792e7640ea680e887ff5fb67a74d579",
   "@graph": [
     {
-      "@id": "niiri:7b26c0d4242cba44b7aa7b136ad76c7c",
-      "@type": ["prov:Agent","src_SPM:","prov:SoftwareAgent"],
+      "@id": "niiri:108629946ef3459712b1ceefc5a31493",
+      "@type": ["prov:Agent","src_SPM","prov:SoftwareAgent"],
       "rdfs:label": "SPM",
-      "nidm_softwareVersion:": {"@type": "xsd:string", "@value": "12.12.2"}
+      "nidm_softwareVersion": {"@type": "xsd:string", "@value": "12.6906"}
     },
     {
-      "@id": "niiri:d41125507fc2262be74a5954df8b238e",
-      "@type": ["prov:Entity","nidm_CoordinateSpace:"],
+      "@id": "niiri:e85365bb21fa161b4325e2ba8cd4fd25",
+      "@type": ["prov:Entity","nidm_CoordinateSpace"],
       "rdfs:label": "Coordinate space 1",
-      "nidm_voxelToWorldMapping:": {"@type": "xsd:string", "@value": "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"},
-      "nidm_voxelUnits:": {"@type": "xsd:string", "@value": "[\"mm\", \"mm\", \"mm\"]"},
-      "nidm_voxelSize:": {"@type": "xsd:string", "@value": "[2, 2, 2]"},
-      "nidm_inWorldCoordinateSystem:": {"@id": "nidm_Ixi549CoordinateSystem:"},
-      "nidm_numberOfDimensions:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_dimensionsInVoxels:": {"@type": "xsd:string", "@value": "[79,95,79]"}
+      "nidm_voxelToWorldMapping": {"@type": "xsd:string", "@value": "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"},
+      "nidm_voxelUnits": {"@type": "xsd:string", "@value": "[\"mm\", \"mm\", \"mm\"]"},
+      "nidm_voxelSize": {"@type": "xsd:string", "@value": "[2, 2, 2]"},
+      "nidm_inWorldCoordinateSystem": {"@id": "nidm_Ixi549CoordinateSystem"},
+      "nidm_numberOfDimensions": {"@type": "xsd:int", "@value": "3"},
+      "nidm_dimensionsInVoxels": {"@type": "xsd:string", "@value": "[79,95,79]"}
     },
     {
-      "@id": "niiri:b7edf29b28f8114c800f627fdde4e8b4",
-      "@type": ["prov:Agent","nlx_Imaginginstrument:","nlx_Magneticresonanceimagingscanner:"],
+      "@id": "niiri:06a12d76cf24728b70559a82704e66d8",
+      "@type": ["prov:Agent","nlx_Imaginginstrument","nlx_Magneticresonanceimagingscanner"],
       "rdfs:label": "MRI Scanner"
     },
     {
-      "@id": "niiri:46eb5ac3b59bdcb7100eef68cc68b609",
+      "@id": "niiri:78ef43d31af19b56191d7258da75b6e0",
       "@type": ["prov:Agent","prov:Person"],
       "rdfs:label": "Person"
     },
     {
-      "@id": "niiri:ae0f01d8c139b1e36225276d4c0f0e9f",
-      "@type": ["prov:Entity","prov:Collection","nidm_Data:"],
+      "@id": "niiri:e2f4df9e4df57e86b857fd981bd770f4",
+      "@type": ["prov:Entity","prov:Collection","nidm_Data"],
       "rdfs:label": "Data",
-      "nidm_grandMeanScaling:": {"@type": "xsd:boolean", "@value": "true"},
-      "nidm_targetIntensity:": {"@type": "xsd:float", "@value": "100"},
-      "nidm_hasMRIProtocol:": {"@id": "nlx_FunctionalMRIprotocol:"}
+      "nidm_grandMeanScaling": {"@type": "xsd:boolean", "@value": "true"},
+      "nidm_targetIntensity": {"@type": "xsd:float", "@value": "100"},
+      "nidm_hasMRIProtocol": {"@id": "nlx_FunctionalMRIprotocol"}
     },
     {
       "@type": "prov:Attribution",
-      "entity_attributed": "niiri:ae0f01d8c139b1e36225276d4c0f0e9f",
-      "agent": "niiri:b7edf29b28f8114c800f627fdde4e8b4"
+      "entity_attributed": "niiri:e2f4df9e4df57e86b857fd981bd770f4",
+      "agent": "niiri:06a12d76cf24728b70559a82704e66d8"
     },
     {
       "@type": "prov:Attribution",
-      "entity_attributed": "niiri:ae0f01d8c139b1e36225276d4c0f0e9f",
-      "agent": "niiri:46eb5ac3b59bdcb7100eef68cc68b609"
+      "entity_attributed": "niiri:e2f4df9e4df57e86b857fd981bd770f4",
+      "agent": "niiri:78ef43d31af19b56191d7258da75b6e0"
     },
     {
-      "@id": "niiri:8214fea5d4998cc5b1a42c6002966b96",
-      "@type": ["prov:Entity","spm_DCTDriftModel:"],
+      "@id": "niiri:84c830ff207d2b79a733f2225b489cae",
+      "@type": ["prov:Entity","spm_DCTDriftModel"],
       "rdfs:label": "SPM's DCT Drift Model",
-      "spm_SPMsDriftCutoffPeriod:": {"@type": "xsd:float", "@value": "128"}
+      "spm_SPMsDriftCutoffPeriod": {"@type": "xsd:float", "@value": "128"}
     },
     {
-      "@id": "niiri:2bf00b7ff264eefba8a8b057940d9351",
-      "@type": ["prov:Entity","nidm_DesignMatrix:"],
+      "@id": "niiri:c48b8f1c4db4fafced12fe461ce9d3ba",
+      "@type": ["prov:Entity","nidm_DesignMatrix"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "DesignMatrix.csv"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "DesignMatrix.csv"},
       "dct:format": {"@type": "xsd:string", "@value": "text/csv"},
-      "dc:description": {"@id": "niiri:b66b5c7aa591a931bd3902540932c8b8"},
+      "dc:description": {"@id": "niiri:82527de1b9c5a981fb6b965a6f20adc2"},
       "rdfs:label": "Design Matrix",
-      "nidm_regressorNames:": {"@type": "xsd:string", "@value": "[\"Sn(1) to*bf(1)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) constant\"]"},
-      "nidm_hasDriftModel:": {"@id": "niiri:8214fea5d4998cc5b1a42c6002966b96"},
-      "nidm_hasHRFBasis:": {"@id": "spm_SPMsCanonicalHRF:"}
+      "nidm_regressorNames": {"@type": "xsd:string", "@value": "[\"Sn(1) to*bf(1)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) constant\"]"},
+      "nidm_hasDriftModel": {"@id": "niiri:84c830ff207d2b79a733f2225b489cae"},
+      "nidm_hasHRFBasis": {"@id": "spm_SPMsCanonicalHRF"}
     },
     {
-      "@id": "niiri:b66b5c7aa591a931bd3902540932c8b8",
+      "@id": "niiri:82527de1b9c5a981fb6b965a6f20adc2",
       "@type": ["prov:Entity","dctype:Image"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "DesignMatrix.png"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "DesignMatrix.png"},
       "dct:format": {"@type": "xsd:string", "@value": "image/png"}
     },
     {
-      "@id": "niiri:ac0b8ab44183500efaf7e4f075835e70",
-      "@type": ["prov:Entity","nidm_ErrorModel:"],
-      "nidm_hasErrorDistribution:": {"@id": "obo_normaldistribution:"},
-      "nidm_hasErrorDependence:": {"@id": "obo_Toeplitzcovariancestructure:"},
-      "nidm_dependenceMapWiseDependence:": {"@id": "nidm_ConstantParameter:"},
-      "nidm_errorVarianceHomogeneous:": {"@type": "xsd:boolean", "@value": "true"},
-      "nidm_varianceMapWiseDependence:": {"@id": "nidm_IndependentParameter:"}
+      "@id": "niiri:cc140a0d6189b0430c070bd23d6ca3d0",
+      "@type": ["prov:Entity","nidm_ErrorModel"],
+      "nidm_hasErrorDistribution": {"@id": "obo_normaldistribution"},
+      "nidm_hasErrorDependence": {"@id": "obo_Toeplitzcovariancestructure"},
+      "nidm_dependenceMapWiseDependence": {"@id": "nidm_ConstantParameter"},
+      "nidm_errorVarianceHomogeneous": {"@type": "xsd:boolean", "@value": "true"},
+      "nidm_varianceMapWiseDependence": {"@id": "nidm_IndependentParameter"}
     },
     {
-      "@id": "niiri:376877f6735dc4d6d5ddbc5e03ab4fc4",
-      "@type": ["prov:Activity","nidm_ModelParametersEstimation:"],
+      "@id": "niiri:af398ef47bafd7ba0d7a56b68ea654a5",
+      "@type": ["prov:Activity","nidm_ModelParametersEstimation"],
       "rdfs:label": "Model parameters estimation",
-      "nidm_withEstimationMethod:": {"@id": "obo_generalizedleastsquaresestimation:"}
+      "nidm_withEstimationMethod": {"@id": "obo_generalizedleastsquaresestimation"}
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:376877f6735dc4d6d5ddbc5e03ab4fc4",
-      "agent": "niiri:7b26c0d4242cba44b7aa7b136ad76c7c"
+      "activity_associated": "niiri:af398ef47bafd7ba0d7a56b68ea654a5",
+      "agent": "niiri:108629946ef3459712b1ceefc5a31493"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:376877f6735dc4d6d5ddbc5e03ab4fc4",
-      "entity": "niiri:2bf00b7ff264eefba8a8b057940d9351"
+      "activity_using": "niiri:af398ef47bafd7ba0d7a56b68ea654a5",
+      "entity": "niiri:c48b8f1c4db4fafced12fe461ce9d3ba"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:376877f6735dc4d6d5ddbc5e03ab4fc4",
-      "entity": "niiri:ae0f01d8c139b1e36225276d4c0f0e9f"
+      "activity_using": "niiri:af398ef47bafd7ba0d7a56b68ea654a5",
+      "entity": "niiri:e2f4df9e4df57e86b857fd981bd770f4"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:376877f6735dc4d6d5ddbc5e03ab4fc4",
-      "entity": "niiri:ac0b8ab44183500efaf7e4f075835e70"
+      "activity_using": "niiri:af398ef47bafd7ba0d7a56b68ea654a5",
+      "entity": "niiri:cc140a0d6189b0430c070bd23d6ca3d0"
     },
     {
-      "@id": "niiri:e53ae7ec054c49559f59b829bea5fb83",
-      "@type": ["prov:Entity","nidm_MaskMap:"],
+      "@id": "niiri:2966074b9e21383f6f55902411f9d3e2",
+      "@type": ["prov:Entity","nidm_MaskMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "Mask.nii.gz"},
-      "nidm_isUserDefined:": {"@type": "xsd:boolean", "@value": "false"},
+      "nidm_isUserDefined": {"@type": "xsd:boolean", "@value": "false"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "Mask.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Mask",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:d41125507fc2262be74a5954df8b238e"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:e85365bb21fa161b4325e2ba8cd4fd25"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876"}
     },
     {
-      "@id": "niiri:e524a54e73715457cf6e6d07b44bf6f9",
-      "@type": ["prov:Entity","nidm_MaskMap:"],
+      "@id": "niiri:c4fb2761d2a5b5a53b14dfb73eb55ec9",
+      "@type": ["prov:Entity","nidm_MaskMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "mask.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "36929e1f5f4143bd9cc818cd896a25f129961fab208c3a4438555f40444c08347b359142ee8c53ece6e8cca1627f49db0788a1fd3b9e2ecaef61999c6c6c67ac"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e53ae7ec054c49559f59b829bea5fb83",
-      "entity": "niiri:e524a54e73715457cf6e6d07b44bf6f9"
+      "entity_derived": "niiri:2966074b9e21383f6f55902411f9d3e2",
+      "entity": "niiri:c4fb2761d2a5b5a53b14dfb73eb55ec9"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:e53ae7ec054c49559f59b829bea5fb83",
-      "activity": "niiri:376877f6735dc4d6d5ddbc5e03ab4fc4"
+      "entity_generated": "niiri:2966074b9e21383f6f55902411f9d3e2",
+      "activity": "niiri:af398ef47bafd7ba0d7a56b68ea654a5"
     },
     {
-      "@id": "niiri:3cc5a83b37768cbe21579a6b718b9dc6",
-      "@type": ["prov:Entity","nidm_GrandMeanMap:"],
+      "@id": "niiri:41db56fb656683f93922ac7c8120201a",
+      "@type": ["prov:Entity","nidm_GrandMeanMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "GrandMean.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "GrandMean.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Grand Mean Map",
-      "nidm_maskedMedian:": {"@type": "xsd:float", "@value": "111.557487487793"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:d41125507fc2262be74a5954df8b238e"},
+      "nidm_maskedMedian": {"@type": "xsd:float", "@value": "111.557487487793"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:e85365bb21fa161b4325e2ba8cd4fd25"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "512157cc6bff89d9343a09b4068226eb3edd64a8cbcee861f06231767fae6f8d4819921182adebee083a9bf309afd65529ab04a92f0aa6b0038c8098550f6124"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:3cc5a83b37768cbe21579a6b718b9dc6",
-      "activity": "niiri:376877f6735dc4d6d5ddbc5e03ab4fc4"
+      "entity_generated": "niiri:41db56fb656683f93922ac7c8120201a",
+      "activity": "niiri:af398ef47bafd7ba0d7a56b68ea654a5"
     },
     {
-      "@id": "niiri:96a4fd17186177029abc0c2067061b7d",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:e53ec83adf28281a0da4fb79bd6f8d37",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0001.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0001.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 1",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:d41125507fc2262be74a5954df8b238e"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:e85365bb21fa161b4325e2ba8cd4fd25"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd"}
     },
     {
-      "@id": "niiri:663f8479afd302937d77248845bfabf8",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:a303f093674cfea3af31e31f0b993403",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0001.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:96a4fd17186177029abc0c2067061b7d",
-      "entity": "niiri:663f8479afd302937d77248845bfabf8"
+      "entity_derived": "niiri:e53ec83adf28281a0da4fb79bd6f8d37",
+      "entity": "niiri:a303f093674cfea3af31e31f0b993403"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:96a4fd17186177029abc0c2067061b7d",
-      "activity": "niiri:376877f6735dc4d6d5ddbc5e03ab4fc4"
+      "entity_generated": "niiri:e53ec83adf28281a0da4fb79bd6f8d37",
+      "activity": "niiri:af398ef47bafd7ba0d7a56b68ea654a5"
     },
     {
-      "@id": "niiri:be1472a97e74610721d9d264aea22df8",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:72b76763a43f712d064e7ff5a0abf2f4",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0002.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0002.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 2",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:d41125507fc2262be74a5954df8b238e"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:e85365bb21fa161b4325e2ba8cd4fd25"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c"}
     },
     {
-      "@id": "niiri:9189ed4708aed4d5e8eb2c7cbd82a49d",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:3832b1c295247b7ad30eeb6b6a356d9a",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0002.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:be1472a97e74610721d9d264aea22df8",
-      "entity": "niiri:9189ed4708aed4d5e8eb2c7cbd82a49d"
+      "entity_derived": "niiri:72b76763a43f712d064e7ff5a0abf2f4",
+      "entity": "niiri:3832b1c295247b7ad30eeb6b6a356d9a"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:be1472a97e74610721d9d264aea22df8",
-      "activity": "niiri:376877f6735dc4d6d5ddbc5e03ab4fc4"
+      "entity_generated": "niiri:72b76763a43f712d064e7ff5a0abf2f4",
+      "activity": "niiri:af398ef47bafd7ba0d7a56b68ea654a5"
     },
     {
-      "@id": "niiri:4434eac4cf5be61afe744f9dfc0ed890",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:4e1dd7422d51470871328ffe1585b00e",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0003.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0003.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 3",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:d41125507fc2262be74a5954df8b238e"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:e85365bb21fa161b4325e2ba8cd4fd25"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373"}
     },
     {
-      "@id": "niiri:a4e6149a14b95cc6c19e7e1b10e14d9c",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:132d0cc169a2090d70bcc3a2cf72ef78",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0003.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4434eac4cf5be61afe744f9dfc0ed890",
-      "entity": "niiri:a4e6149a14b95cc6c19e7e1b10e14d9c"
+      "entity_derived": "niiri:4e1dd7422d51470871328ffe1585b00e",
+      "entity": "niiri:132d0cc169a2090d70bcc3a2cf72ef78"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:4434eac4cf5be61afe744f9dfc0ed890",
-      "activity": "niiri:376877f6735dc4d6d5ddbc5e03ab4fc4"
+      "entity_generated": "niiri:4e1dd7422d51470871328ffe1585b00e",
+      "activity": "niiri:af398ef47bafd7ba0d7a56b68ea654a5"
     },
     {
-      "@id": "niiri:07e8d8f330905940fe3f59bdd08cb5da",
-      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap:"],
+      "@id": "niiri:5838dc3694e3780735e8138028cf3030",
+      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ResidualMeanSquares.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ResidualMeanSquares.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Residual Mean Squares Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:d41125507fc2262be74a5954df8b238e"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:e85365bb21fa161b4325e2ba8cd4fd25"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "991abf563d795a43b1e2eef8643e57023f2e0b090b2031f05f839321fc0643df6f71d423486a1021519b6dc82f6b0f563e19f3fbd50cb16063bed54a0e192d3e"}
     },
     {
-      "@id": "niiri:c10e53b422e02d9772ee9daea58b9a61",
-      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap:"],
+      "@id": "niiri:bc3cced01cc00b56e891f3591686d4d7",
+      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "ResMS.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "40b28d03fcf9a2f60b11f10d7fb83bf3618b234fb5aedf09df644cb7cbb6aab8c9f468897c1078166d455a3d04a83f4e3bf762cfca0b4ea982d7a4e406849f18"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:07e8d8f330905940fe3f59bdd08cb5da",
-      "entity": "niiri:c10e53b422e02d9772ee9daea58b9a61"
+      "entity_derived": "niiri:5838dc3694e3780735e8138028cf3030",
+      "entity": "niiri:bc3cced01cc00b56e891f3591686d4d7"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:07e8d8f330905940fe3f59bdd08cb5da",
-      "activity": "niiri:376877f6735dc4d6d5ddbc5e03ab4fc4"
+      "entity_generated": "niiri:5838dc3694e3780735e8138028cf3030",
+      "activity": "niiri:af398ef47bafd7ba0d7a56b68ea654a5"
     },
     {
-      "@id": "niiri:cbcaa8f3061021e485aface02a14bf8b",
-      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap:"],
+      "@id": "niiri:c7a291c12eb2c6c7e9ebcb9759d8ea7c",
+      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ReselsPerVoxel.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ReselsPerVoxel.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Resels per Voxel Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:d41125507fc2262be74a5954df8b238e"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:e85365bb21fa161b4325e2ba8cd4fd25"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "1a3f9216e145249ccc0b14b2bc337d6b38b81ad45e32768001fb22b35f0c2c0f3e2bce013b40c85f7dc0fc62723ac761ee7f7e1e6aff128a05f0ba7b8b8202a3"}
     },
     {
-      "@id": "niiri:591f8b6987f170ae9c1491013fbce184",
-      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap:"],
+      "@id": "niiri:37ab6fc51451696d75a2fb041b423fb9",
+      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "RPV.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "4f76663162857f6b38b2a45a63b15a23b2ca8b338c283b69c1e71f2ea2f43797d045a733cd14e845be9c12f8b8f84d3931c599a08e8f6d77e99fab46ad87ab8f"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cbcaa8f3061021e485aface02a14bf8b",
-      "entity": "niiri:591f8b6987f170ae9c1491013fbce184"
+      "entity_derived": "niiri:c7a291c12eb2c6c7e9ebcb9759d8ea7c",
+      "entity": "niiri:37ab6fc51451696d75a2fb041b423fb9"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:cbcaa8f3061021e485aface02a14bf8b",
-      "activity": "niiri:376877f6735dc4d6d5ddbc5e03ab4fc4"
+      "entity_generated": "niiri:c7a291c12eb2c6c7e9ebcb9759d8ea7c",
+      "activity": "niiri:af398ef47bafd7ba0d7a56b68ea654a5"
     },
     {
-      "@id": "niiri:e1b7e3b4519d803e0bd21bfc83f9ca68",
-      "@type": ["prov:Entity","obo_contrastweightmatrix:"],
-      "nidm_statisticType:": {"@id": "obo_Fstatistic:"},
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
+      "@id": "niiri:543c3abe649faffdd9de4655fb735982",
+      "@type": ["prov:Entity","obo_contrastweightmatrix"],
+      "nidm_statisticType": {"@id": "obo_Fstatistic"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
       "rdfs:label": "Contrast: tone counting vs baseline",
       "prov:value": {"@type": "xsd:string", "@value": "[1, 0, 0]"}
     },
     {
-      "@id": "niiri:1e48214fea2412f798a0804c4f07aa3f",
-      "@type": ["prov:Activity","nidm_ContrastEstimation:"],
+      "@id": "niiri:d56c7f996ee59831f6e800e8e38c6886",
+      "@type": ["prov:Activity","nidm_ContrastEstimation"],
       "rdfs:label": "Contrast estimation"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:1e48214fea2412f798a0804c4f07aa3f",
-      "agent": "niiri:7b26c0d4242cba44b7aa7b136ad76c7c"
+      "activity_associated": "niiri:d56c7f996ee59831f6e800e8e38c6886",
+      "agent": "niiri:108629946ef3459712b1ceefc5a31493"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:1e48214fea2412f798a0804c4f07aa3f",
-      "entity": "niiri:e53ae7ec054c49559f59b829bea5fb83"
+      "activity_using": "niiri:d56c7f996ee59831f6e800e8e38c6886",
+      "entity": "niiri:2966074b9e21383f6f55902411f9d3e2"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:1e48214fea2412f798a0804c4f07aa3f",
-      "entity": "niiri:07e8d8f330905940fe3f59bdd08cb5da"
+      "activity_using": "niiri:d56c7f996ee59831f6e800e8e38c6886",
+      "entity": "niiri:5838dc3694e3780735e8138028cf3030"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:1e48214fea2412f798a0804c4f07aa3f",
-      "entity": "niiri:2bf00b7ff264eefba8a8b057940d9351"
+      "activity_using": "niiri:d56c7f996ee59831f6e800e8e38c6886",
+      "entity": "niiri:c48b8f1c4db4fafced12fe461ce9d3ba"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:1e48214fea2412f798a0804c4f07aa3f",
-      "entity": "niiri:e1b7e3b4519d803e0bd21bfc83f9ca68"
+      "activity_using": "niiri:d56c7f996ee59831f6e800e8e38c6886",
+      "entity": "niiri:543c3abe649faffdd9de4655fb735982"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:1e48214fea2412f798a0804c4f07aa3f",
-      "entity": "niiri:96a4fd17186177029abc0c2067061b7d"
+      "activity_using": "niiri:d56c7f996ee59831f6e800e8e38c6886",
+      "entity": "niiri:e53ec83adf28281a0da4fb79bd6f8d37"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:1e48214fea2412f798a0804c4f07aa3f",
-      "entity": "niiri:be1472a97e74610721d9d264aea22df8"
+      "activity_using": "niiri:d56c7f996ee59831f6e800e8e38c6886",
+      "entity": "niiri:72b76763a43f712d064e7ff5a0abf2f4"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:1e48214fea2412f798a0804c4f07aa3f",
-      "entity": "niiri:4434eac4cf5be61afe744f9dfc0ed890"
+      "activity_using": "niiri:d56c7f996ee59831f6e800e8e38c6886",
+      "entity": "niiri:4e1dd7422d51470871328ffe1585b00e"
     },
     {
-      "@id": "niiri:eff9a5890d3882e89100ae2e0c85dc26",
-      "@type": ["prov:Entity","nidm_StatisticMap:"],
+      "@id": "niiri:22b2d246ca83f9742df6152441f4821f",
+      "@type": ["prov:Entity","nidm_StatisticMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "FStatistic.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "FStatistic.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "F-Statistic Map: tone counting vs baseline",
-      "nidm_statisticType:": {"@id": "obo_Fstatistic:"},
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
-      "nidm_errorDegreesOfFreedom:": {"@type": "xsd:float", "@value": "97.9999999998522"},
-      "nidm_effectDegreesOfFreedom:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:d41125507fc2262be74a5954df8b238e"},
+      "nidm_statisticType": {"@id": "obo_Fstatistic"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
+      "nidm_errorDegreesOfFreedom": {"@type": "xsd:float", "@value": "97.9999999998522"},
+      "nidm_effectDegreesOfFreedom": {"@type": "xsd:float", "@value": "1"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:e85365bb21fa161b4325e2ba8cd4fd25"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "04986199ffcd3f12e4ccd95adf79d83627b3cc230969d1c39bfbb2732235f2ce33e15a0bcbfc7b892ccc17b17b2563de2a83d05e06944ea0d017558021d3a502"}
     },
     {
-      "@id": "niiri:05ce456d5c40ef9ac164e8c40683aac4",
-      "@type": ["prov:Entity","nidm_StatisticMap:"],
+      "@id": "niiri:e3f29dfdfad324d9c4f41fb318e668b4",
+      "@type": ["prov:Entity","nidm_StatisticMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "spmF_0001.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "c8f88ccb9f7c33bd901d8af4b0078e409ac7f4b037ee840cfbb528f918f0c27d651e201bcc709cd7bfc442c8057b377aa6f3e36afee8d3ade5ce8de5f7d65166"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:eff9a5890d3882e89100ae2e0c85dc26",
-      "entity": "niiri:05ce456d5c40ef9ac164e8c40683aac4"
+      "entity_derived": "niiri:22b2d246ca83f9742df6152441f4821f",
+      "entity": "niiri:e3f29dfdfad324d9c4f41fb318e668b4"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:eff9a5890d3882e89100ae2e0c85dc26",
-      "activity": "niiri:1e48214fea2412f798a0804c4f07aa3f"
+      "entity_generated": "niiri:22b2d246ca83f9742df6152441f4821f",
+      "activity": "niiri:d56c7f996ee59831f6e800e8e38c6886"
     },
     {
-      "@id": "niiri:5c976011393498fb9c9deecbb8ae073b",
-      "@type": ["prov:Entity","nidm_ContrastExplainedMeanSquareMap:"],
+      "@id": "niiri:7f4cdffd78ae5971875e37f617e84f61",
+      "@type": ["prov:Entity","nidm_ContrastExplainedMeanSquareMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ContrastExplainedMeanSquare.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ContrastExplainedMeanSquare.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Contrast Explained Mean Square Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:d41125507fc2262be74a5954df8b238e"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:e85365bb21fa161b4325e2ba8cd4fd25"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "9c0fc116d1bdba4d13d20c49c9ab93b22d60636dd953d081d8e8cd5f488bd427bfb32339578346aad9a8f54a907cb00a74e8a0a0758786ffb6c633730ff94774"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:5c976011393498fb9c9deecbb8ae073b",
-      "activity": "niiri:1e48214fea2412f798a0804c4f07aa3f"
+      "entity_generated": "niiri:7f4cdffd78ae5971875e37f617e84f61",
+      "activity": "niiri:d56c7f996ee59831f6e800e8e38c6886"
     },
     {
-      "@id": "niiri:1cb202c358b5a2a2aa236342646b6c49",
-      "@type": ["prov:Entity","nidm_HeightThreshold:","nidm_PValueUncorrected:"],
-      "rdfs:label": "Height Threshold: p<0.001000 (unc.)",
+      "@id": "niiri:c90905a2f9fd05b279e167b48e9e991b",
+      "@type": ["prov:Entity","nidm_HeightThreshold","nidm_PValueUncorrected"],
+      "rdfs:label": "Height Threshold: p<0.001 (unc.)",
       "prov:value": {"@type": "xsd:float", "@value": "0.000999500134086118"},
-      "nidm_equivalentThreshold:": [{"@id": "niiri:b72ad3691601a8a5e155b68d80c49788"},{"@id": "niiri:55ef01e6730508dbaaa0649edf17937f"}]
+      "nidm_equivalentThreshold": [{"@id": "niiri:242e46f10e864dfba4d04608f5933a37"},{"@id": "niiri:ee1543686e6a6f4ecaabc7f8fed88df7"}]
     },
     {
-      "@id": "niiri:b72ad3691601a8a5e155b68d80c49788",
-      "@type": ["prov:Entity","nidm_HeightThreshold:","obo_statistic:"],
-      "rdfs:label": "Height Threshold",
+      "@id": "niiri:242e46f10e864dfba4d04608f5933a37",
+      "@type": ["prov:Entity","nidm_HeightThreshold","obo_statistic"],
+      "rdfs:label": "Height Threshold: F=11.509654)",
       "prov:value": {"@type": "xsd:float", "@value": "11.5096541798536"}
     },
     {
-      "@id": "niiri:55ef01e6730508dbaaa0649edf17937f",
-      "@type": ["prov:Entity","nidm_HeightThreshold:","obo_FWERadjustedpvalue:"],
-      "rdfs:label": "Height Threshold",
+      "@id": "niiri:ee1543686e6a6f4ecaabc7f8fed88df7",
+      "@type": ["prov:Entity","nidm_HeightThreshold","obo_FWERadjustedpvalue"],
+      "rdfs:label": "Height Threshold: p<1.000000 (FWE)",
       "prov:value": {"@type": "xsd:float", "@value": "1"}
     },
     {
-      "@id": "niiri:7d3c94b79cfb116e3522f460364a10ca",
-      "@type": ["prov:Entity","nidm_ExtentThreshold:","obo_statistic:"],
+      "@id": "niiri:3f89804bcbc35a20ed10f6065ed6f45f",
+      "@type": ["prov:Entity","nidm_ExtentThreshold","obo_statistic"],
       "rdfs:label": "Extent Threshold: k>=0",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "0"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0"},
-      "nidm_equivalentThreshold:": [{"@id": "niiri:e76f6444a057489092dcf438d0ba28d9"},{"@id": "niiri:b5bc6365c635348a4c6f7dd4c0162516"}]
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "0"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0"},
+      "nidm_equivalentThreshold": [{"@id": "niiri:dfd666502d3a5b4e831a683a161e814b"},{"@id": "niiri:ef06cbe71e52afe55ddec88cd1796f92"}]
     },
     {
-      "@id": "niiri:e76f6444a057489092dcf438d0ba28d9",
-      "@type": ["prov:Entity","nidm_ExtentThreshold:","obo_FWERadjustedpvalue:"],
+      "@id": "niiri:dfd666502d3a5b4e831a683a161e814b",
+      "@type": ["prov:Entity","nidm_ExtentThreshold","obo_FWERadjustedpvalue"],
       "rdfs:label": "Extent Threshold",
       "prov:value": {"@type": "xsd:float", "@value": "1"}
     },
     {
-      "@id": "niiri:b5bc6365c635348a4c6f7dd4c0162516",
-      "@type": ["prov:Entity","nidm_ExtentThreshold:","nidm_PValueUncorrected:"],
+      "@id": "niiri:ef06cbe71e52afe55ddec88cd1796f92",
+      "@type": ["prov:Entity","nidm_ExtentThreshold","nidm_PValueUncorrected"],
       "rdfs:label": "Extent Threshold",
       "prov:value": {"@type": "xsd:float", "@value": "1"}
     },
     {
-      "@id": "niiri:3d98e913b92115cd75804f26601428a0",
-      "@type": ["prov:Entity","nidm_PeakDefinitionCriteria:"],
+      "@id": "niiri:6e55046381e462ccd425414e6c6e55df",
+      "@type": ["prov:Entity","nidm_PeakDefinitionCriteria"],
       "rdfs:label": "Peak Definition Criteria",
-      "nidm_maxNumberOfPeaksPerCluster:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_minDistanceBetweenPeaks:": {"@type": "xsd:float", "@value": "8"}
+      "nidm_maxNumberOfPeaksPerCluster": {"@type": "xsd:int", "@value": "3"},
+      "nidm_minDistanceBetweenPeaks": {"@type": "xsd:float", "@value": "8"}
     },
     {
-      "@id": "niiri:110334b011c4dffd4cd084aaa8a23b50",
-      "@type": ["prov:Entity","nidm_ClusterDefinitionCriteria:"],
+      "@id": "niiri:1c65c77d484fdd55f58d632b3d659641",
+      "@type": ["prov:Entity","nidm_ClusterDefinitionCriteria"],
       "rdfs:label": "Cluster Connectivity Criterion: 18",
-      "nidm_hasConnectivityCriterion:": {"@id": "nidm_voxel18connected:"}
+      "nidm_hasConnectivityCriterion": {"@id": "nidm_voxel18connected"}
     },
     {
-      "@id": "niiri:165f4a3fe16dc2972f764b7e81300e66",
-      "@type": ["prov:Activity","nidm_Inference:"],
-      "nidm_hasAlternativeHypothesis:": {"@id": "nidm_OneTailedTest:"},
+      "@id": "niiri:acd80690d12cb39b6a731ff1e4c00286",
+      "@type": ["prov:Activity","nidm_Inference"],
+      "nidm_hasAlternativeHypothesis": {"@id": "nidm_OneTailedTest"},
       "rdfs:label": "Inference"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:165f4a3fe16dc2972f764b7e81300e66",
-      "agent": "niiri:7b26c0d4242cba44b7aa7b136ad76c7c"
+      "activity_associated": "niiri:acd80690d12cb39b6a731ff1e4c00286",
+      "agent": "niiri:108629946ef3459712b1ceefc5a31493"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:165f4a3fe16dc2972f764b7e81300e66",
-      "entity": "niiri:1cb202c358b5a2a2aa236342646b6c49"
+      "activity_using": "niiri:acd80690d12cb39b6a731ff1e4c00286",
+      "entity": "niiri:c90905a2f9fd05b279e167b48e9e991b"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:165f4a3fe16dc2972f764b7e81300e66",
-      "entity": "niiri:7d3c94b79cfb116e3522f460364a10ca"
+      "activity_using": "niiri:acd80690d12cb39b6a731ff1e4c00286",
+      "entity": "niiri:3f89804bcbc35a20ed10f6065ed6f45f"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:165f4a3fe16dc2972f764b7e81300e66",
-      "entity": "niiri:eff9a5890d3882e89100ae2e0c85dc26"
+      "activity_using": "niiri:acd80690d12cb39b6a731ff1e4c00286",
+      "entity": "niiri:22b2d246ca83f9742df6152441f4821f"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:165f4a3fe16dc2972f764b7e81300e66",
-      "entity": "niiri:cbcaa8f3061021e485aface02a14bf8b"
+      "activity_using": "niiri:acd80690d12cb39b6a731ff1e4c00286",
+      "entity": "niiri:c7a291c12eb2c6c7e9ebcb9759d8ea7c"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:165f4a3fe16dc2972f764b7e81300e66",
-      "entity": "niiri:e53ae7ec054c49559f59b829bea5fb83"
+      "activity_using": "niiri:acd80690d12cb39b6a731ff1e4c00286",
+      "entity": "niiri:2966074b9e21383f6f55902411f9d3e2"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:165f4a3fe16dc2972f764b7e81300e66",
-      "entity": "niiri:3d98e913b92115cd75804f26601428a0"
+      "activity_using": "niiri:acd80690d12cb39b6a731ff1e4c00286",
+      "entity": "niiri:6e55046381e462ccd425414e6c6e55df"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:165f4a3fe16dc2972f764b7e81300e66",
-      "entity": "niiri:110334b011c4dffd4cd084aaa8a23b50"
+      "activity_using": "niiri:acd80690d12cb39b6a731ff1e4c00286",
+      "entity": "niiri:1c65c77d484fdd55f58d632b3d659641"
     },
     {
-      "@id": "niiri:7c1a351894d826c482f0c4374916a68d",
-      "@type": ["prov:Entity","nidm_SearchSpaceMaskMap:"],
+      "@id": "niiri:78e99904e3bcdd85e6a94fdbda3413d3",
+      "@type": ["prov:Entity","nidm_SearchSpaceMaskMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "SearchSpaceMask.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "SearchSpaceMask.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Search Space Mask Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:d41125507fc2262be74a5954df8b238e"},
-      "nidm_searchVolumeInVoxels:": {"@type": "xsd:int", "@value": "223057"},
-      "nidm_searchVolumeInUnits:": {"@type": "xsd:float", "@value": "1784456"},
-      "nidm_reselSizeInVoxels:": {"@type": "xsd:float", "@value": "65.5786964036542"},
-      "nidm_searchVolumeInResels:": {"@type": "xsd:float", "@value": "3155.84193266257"},
-      "spm_searchVolumeReselsGeometry:": {"@type": "xsd:string", "@value": "[6, 97.8140592306853, 965.938819261507, 3155.84193266257]"},
-      "nidm_noiseFWHMInVoxels:": {"@type": "xsd:string", "@value": "[4.09118640605185, 4.0346308705955, 3.97291894351243]"},
-      "nidm_noiseFWHMInUnits:": {"@type": "xsd:string", "@value": "[8.18237281210369, 8.069261741191, 7.94583788702486]"},
-      "nidm_randomFieldStationarity:": {"@type": "xsd:boolean", "@value": "true"},
-      "nidm_expectedNumberOfVoxelsPerCluster:": {"@type": "xsd:float", "@value": "5.88889159437044"},
-      "nidm_expectedNumberOfClusters:": {"@type": "xsd:float", "@value": "40.6597852835614"},
-      "nidm_heightCriticalThresholdFWE05:": {"@type": "xsd:float", "@value": "30.1873792634448"},
-      "nidm_heightCriticalThresholdFDR05:": {"@type": "xsd:float", "@value": "22.5453071594238"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:e85365bb21fa161b4325e2ba8cd4fd25"},
+      "nidm_searchVolumeInVoxels": {"@type": "xsd:int", "@value": "223057"},
+      "nidm_searchVolumeInUnits": {"@type": "xsd:float", "@value": "1784456"},
+      "nidm_reselSizeInVoxels": {"@type": "xsd:float", "@value": "65.5786964036542"},
+      "nidm_searchVolumeInResels": {"@type": "xsd:float", "@value": "3155.84193266257"},
+      "spm_searchVolumeReselsGeometry": {"@type": "xsd:string", "@value": "[6, 97.8140592306853, 965.938819261507, 3155.84193266257]"},
+      "nidm_noiseFWHMInVoxels": {"@type": "xsd:string", "@value": "[4.09118640605185, 4.0346308705955, 3.97291894351243]"},
+      "nidm_noiseFWHMInUnits": {"@type": "xsd:string", "@value": "[8.18237281210369, 8.069261741191, 7.94583788702486]"},
+      "nidm_randomFieldStationarity": {"@type": "xsd:boolean", "@value": "true"},
+      "nidm_expectedNumberOfVoxelsPerCluster": {"@type": "xsd:float", "@value": "5.88889159437044"},
+      "nidm_expectedNumberOfClusters": {"@type": "xsd:float", "@value": "40.6597852835614"},
+      "nidm_heightCriticalThresholdFWE05": {"@type": "xsd:float", "@value": "30.1873792634448"},
+      "nidm_heightCriticalThresholdFDR05": {"@type": "xsd:float", "@value": "22.5453071594238"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876"},
-      "spm_smallestSignificantClusterSizeInVoxelsFWE05:": {"@type": "xsd:int", "@value": "86"},
-      "spm_smallestSignificantClusterSizeInVoxelsFDR05:": {"@type": "xsd:int", "@value": "51"}
+      "spm_smallestSignificantClusterSizeInVoxelsFWE05": {"@type": "xsd:int", "@value": "86"},
+      "spm_smallestSignificantClusterSizeInVoxelsFDR05": {"@type": "xsd:int", "@value": "51"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:7c1a351894d826c482f0c4374916a68d",
-      "activity": "niiri:165f4a3fe16dc2972f764b7e81300e66"
+      "entity_generated": "niiri:78e99904e3bcdd85e6a94fdbda3413d3",
+      "activity": "niiri:acd80690d12cb39b6a731ff1e4c00286"
     },
     {
-      "@id": "niiri:5c3a280abdc45cbf2db33ae481f80003",
-      "@type": ["prov:Entity","nidm_ExcursionSetMap:"],
+      "@id": "niiri:4391a2ef60f122937f69c2336ae7251d",
+      "@type": ["prov:Entity","nidm_ExcursionSetMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ExcursionSet.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ExcursionSet.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Excursion Set Map",
-      "nidm_numberOfSupraThresholdClusters:": {"@type": "xsd:int", "@value": "184"},
-      "nidm_pValue:": {"@type": "xsd:float", "@value": "0"},
-      "nidm_hasClusterLabelsMap:": {"@id": "niiri:dadf5c1767d521958b140228a7d36014"},
-      "nidm_hasMaximumIntensityProjection:": {"@id": "niiri:3574a16f01d4afb5e7cc20b434f843d1"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:d41125507fc2262be74a5954df8b238e"},
+      "nidm_numberOfSupraThresholdClusters": {"@type": "xsd:int", "@value": "184"},
+      "nidm_pValue": {"@type": "xsd:float", "@value": "0"},
+      "nidm_hasClusterLabelsMap": {"@id": "niiri:2b1331d80daab9b0cd80c884a151f411"},
+      "nidm_hasMaximumIntensityProjection": {"@id": "niiri:ffeb9e623c6efb2a5664eb58fcae60d1"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:e85365bb21fa161b4325e2ba8cd4fd25"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "059b760592f8180167aef22914cae89482e9a83c8b1a3d01ed8e313c99bf4e1dbbf1e70e4100dfc87789c5dc1571a71e7d7122be0a817ee2fba7c35c6638dd66"}
     },
     {
-      "@id": "niiri:dadf5c1767d521958b140228a7d36014",
-      "@type": ["prov:Entity","nidm_ClusterLabelsMap:"],
+      "@id": "niiri:2b1331d80daab9b0cd80c884a151f411",
+      "@type": ["prov:Entity","nidm_ClusterLabelsMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ClusterLabels.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ClusterLabels.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Cluster Labels Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:d41125507fc2262be74a5954df8b238e"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:e85365bb21fa161b4325e2ba8cd4fd25"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "b3175bc7185eccf2b55e86c7cb8166bc41c808e3a44971eabd71190fd50bdf8d6d8b820bb69a70ed7b8c5ec063a8523f3640529894dd0b1cdb1a8621ee1f30df"}
     },
     {
-      "@id": "niiri:3574a16f01d4afb5e7cc20b434f843d1",
+      "@id": "niiri:ffeb9e623c6efb2a5664eb58fcae60d1",
       "@type": ["prov:Entity","dctype:Image"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "MaximumIntensityProjection.png"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "MaximumIntensityProjection.png"},
@@ -702,8320 +702,8320 @@
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:5c3a280abdc45cbf2db33ae481f80003",
-      "activity": "niiri:165f4a3fe16dc2972f764b7e81300e66"
+      "entity_generated": "niiri:4391a2ef60f122937f69c2336ae7251d",
+      "activity": "niiri:acd80690d12cb39b6a731ff1e4c00286"
     },
     {
-      "@id": "niiri:651d36d872d7daabb7dba2117ccd0147",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:a02993e23816e346753a88b23cc8928d",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0001",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1212"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "18.4816116584541"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.97791594741181e-19"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "2.28984133580943e-17"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "1"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1212"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "18.4816116584541"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.97791594741181e-19"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "2.28984133580943e-17"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "1"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:651d36d872d7daabb7dba2117ccd0147",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:a02993e23816e346753a88b23cc8928d",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:7f4e9fb870f5c98792fa6bf0f88370fb",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:1fb6d1d0216b48739f26ab81c9d1d36e",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0002",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4556"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "69.4737811187434"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.62965270678044e-45"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1.0358560980476e-42"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "2"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4556"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "69.4737811187434"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.62965270678044e-45"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1.0358560980476e-42"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "2"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7f4e9fb870f5c98792fa6bf0f88370fb",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:1fb6d1d0216b48739f26ab81c9d1d36e",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:284d49d49a311520554c2b72c79155a5",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:513b4dd1fd53a8b3917570bbd44a1da7",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0003",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "725"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "11.0554195151644"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.01378007680423e-13"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "4.12203604582828e-12"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "3.10892556886631e-12"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "3"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "725"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "11.0554195151644"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.01378007680423e-13"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "4.12203604582828e-12"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "3.10892556886631e-12"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "3"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:284d49d49a311520554c2b72c79155a5",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:513b4dd1fd53a8b3917570bbd44a1da7",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:42c8820b665da5b8d98f4ce5fcb8de2d",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:0383eb2fc5ee76be5634bfee80f2ca3b",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0004",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "153"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "2.33307473906228"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.47804175343133e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00100705903153597"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000253310934795202"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "4"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "153"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "2.33307473906228"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.47804175343133e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00100705903153597"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000253310934795202"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "4"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:42c8820b665da5b8d98f4ce5fcb8de2d",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:0383eb2fc5ee76be5634bfee80f2ca3b",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:7e43e146a206ef37a717db06b7c719b8",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:e67cada24205233131c2bfe154669c61",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0005",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "313"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "4.77289145965028"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.78025631888379e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1.53704292116252e-06"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "5.54898403464322e-07"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "5"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "313"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "4.77289145965028"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.78025631888379e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1.53704292116252e-06"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "5.54898403464322e-07"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "5"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7e43e146a206ef37a717db06b7c719b8",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:e67cada24205233131c2bfe154669c61",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:4e4ee541dcb7596b480cb3aebb5ec524",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:a3635579e9882ee1f3c09824008b66b4",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0006",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1743"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "26.5787533999056"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.79274571779028e-24"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "2.93955070691137e-22"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "6"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1743"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "26.5787533999056"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.79274571779028e-24"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "2.93955070691137e-22"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "6"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4e4ee541dcb7596b480cb3aebb5ec524",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:a3635579e9882ee1f3c09824008b66b4",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:78e7ba6b5db9ff6ef88f595eef8c1789",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c50d34609678664d461509f54c79eea7",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0007",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "203"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "3.09551746424603"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.74542128986256e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.000111622009958512"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "2.97151480785124e-05"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "7"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "203"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "3.09551746424603"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.74542128986256e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.000111622009958512"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "2.97151480785124e-05"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "7"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:78e7ba6b5db9ff6ef88f595eef8c1789",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:c50d34609678664d461509f54c79eea7",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:8170af49aff81684fdb2d887f6db1095",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:86785a60d43172b11448d491c5ae96dc",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0008",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "415"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "6.32827461902514"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.10116908495443e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "4.47732975139559e-08"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "2.25127901812905e-08"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "8"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "415"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "6.32827461902514"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.10116908495443e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "4.47732975139559e-08"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "2.25127901812905e-08"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "8"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8170af49aff81684fdb2d887f6db1095",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:86785a60d43172b11448d491c5ae96dc",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:740bf59b1d25123628eef463c4259e34",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:dded355a673488279610ef537e861858",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0009",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "755"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "11.5128851502746"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.46595915881099e-14"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1.81588077907691e-12"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1.64347297044244e-12"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "9"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "755"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "11.5128851502746"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.46595915881099e-14"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1.81588077907691e-12"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1.64347297044244e-12"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "9"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:740bf59b1d25123628eef463c4259e34",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:dded355a673488279610ef537e861858",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:1b8c8488e08d0790c457517765f898e1",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c1b3c9780e84e1bcfb3c612aa647510e",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0010",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "101"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.54013430487118"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000322150104613025"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0130131413575594"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00246981746869986"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "10"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "101"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.54013430487118"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000322150104613025"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0130131413575594"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00246981746869986"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "10"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1b8c8488e08d0790c457517765f898e1",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:c1b3c9780e84e1bcfb3c612aa647510e",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:9ff5e136f972c43baf0362735367bbdb",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:86886012c734f3d338a1efb48a81145a",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0011",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4088"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "62.3373172110235"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.84129160432794e-42"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "6.2939882759817e-40"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "11"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4088"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "62.3373172110235"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.84129160432794e-42"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "6.2939882759817e-40"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "11"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9ff5e136f972c43baf0362735367bbdb",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:86886012c734f3d338a1efb48a81145a",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:d852b48a402ab69819373ede91d1c632",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:e25e46750ed6706bcfbfa5e14d55d777",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0012",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "649"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "9.89650657288509"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.52486281845645e-13"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "3.46619399849146e-11"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "2.24082108370855e-11"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "12"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "649"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "9.89650657288509"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.52486281845645e-13"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "3.46619399849146e-11"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "2.24082108370855e-11"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "12"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d852b48a402ab69819373ede91d1c632",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:e25e46750ed6706bcfbfa5e14d55d777",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:2f36545388d37f7477d8f0618c919f09",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:e2ac8194c797871c399100cc42929140",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0013",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "40"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.609954180147001"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0130862767797146"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.412621113012691"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0650777007423645"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "13"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "40"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.609954180147001"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0130862767797146"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.412621113012691"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0650777007423645"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "13"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2f36545388d37f7477d8f0618c919f09",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:e2ac8194c797871c399100cc42929140",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:6da57157038eade3ca7a4c29d0c28ad8",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:e480d8d12a9dc866e99b7a65d64c73b5",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0014",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "226"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "3.44624111783056"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.06192606997673e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "4.31767538493499e-05"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1.22121498047324e-05"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "14"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "226"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "3.44624111783056"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.06192606997673e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "4.31767538493499e-05"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1.22121498047324e-05"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "14"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6da57157038eade3ca7a4c29d0c28ad8",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:e480d8d12a9dc866e99b7a65d64c73b5",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:f36a9d2eb3726086574d1578e1d9f0f8",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:82f170400f1b69cc64c4688f03080756",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0015",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "113"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.72312055891528"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000172454772843055"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00698744750493652"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00137963818274444"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "15"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "113"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.72312055891528"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000172454772843055"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00698744750493652"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00137963818274444"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "15"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f36a9d2eb3726086574d1578e1d9f0f8",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:82f170400f1b69cc64c4688f03080756",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:3132927065aeeaa4a3a285e94ec260a6",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c7d451f7f453a0be61177b599ede33a5",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0016",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "312"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "4.75764260514661"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.92047785056314e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1.59405660560274e-06"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "5.54898403464322e-07"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "16"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "312"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "4.75764260514661"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.92047785056314e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1.59405660560274e-06"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "5.54898403464322e-07"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "16"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3132927065aeeaa4a3a285e94ec260a6",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:c7d451f7f453a0be61177b599ede33a5",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:1cad58fd2cece054821848126afc3007",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:37926699687cca9b9dd0b742b092ff48",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0017",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "341"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "5.19985938575318"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.38423708416377e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "5.6282766780491e-07"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "2.31545112260121e-07"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "17"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "341"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "5.19985938575318"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.38423708416377e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "5.6282766780491e-07"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "2.31545112260121e-07"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "17"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1cad58fd2cece054821848126afc3007",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:37926699687cca9b9dd0b742b092ff48",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:1fcfe58e890a992a0cbd392039bb176f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:e7fc074f64298360eb2c7ffbcb4e63aa",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0018",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "32"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.487963344117601"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0238298502170892"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.620506038183986"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0932913285094554"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "18"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "32"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.487963344117601"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0238298502170892"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.620506038183986"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0932913285094554"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "18"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1fcfe58e890a992a0cbd392039bb176f",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:e7fc074f64298360eb2c7ffbcb4e63aa",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:41b3f1fe29e41e8399e5532675d71afb",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:617a58ee9ff77a4075c0708ea690d16c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0019",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "119"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.81461368593733"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000127236609479189"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00516005416668353"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00111483505448432"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "19"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "119"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.81461368593733"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000127236609479189"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00516005416668353"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00111483505448432"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "19"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:41b3f1fe29e41e8399e5532675d71afb",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:617a58ee9ff77a4075c0708ea690d16c",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:9a54b48570d440ea6ac8f1f92e78425f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:fd34291df44a2d10645e6546a1593a1c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0020",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "86"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.31140148731605"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000729410759827573"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0292222114056673"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00516198383877974"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "20"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "86"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.31140148731605"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000729410759827573"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0292222114056673"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00516198383877974"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "20"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9a54b48570d440ea6ac8f1f92e78425f",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:fd34291df44a2d10645e6546a1593a1c",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:ffd74835caba617d42d83e59e6b5a54e",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:8677fb654966f35b2ba255c1e63d1cb1",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0021",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "500"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "7.62442725183751"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.19462568299287e-11"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "2.92531932011286e-09"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1.65476390708836e-09"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "21"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "500"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "7.62442725183751"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.19462568299287e-11"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "2.92531932011286e-09"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1.65476390708836e-09"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "21"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ffd74835caba617d42d83e59e6b5a54e",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:8677fb654966f35b2ba255c1e63d1cb1",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:56af8a072a247476eb5fd62c25fdf6e9",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:545f94f2d451c1c902303c221a0a1089",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0022",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "96"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.4638900323528"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000420994377301339"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0169718682525768"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00309851861693785"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "22"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "96"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.4638900323528"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000420994377301339"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0169718682525768"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00309851861693785"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "22"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:56af8a072a247476eb5fd62c25fdf6e9",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:545f94f2d451c1c902303c221a0a1089",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:097010bf7718d0ca7ca15cd545a5d22f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f9a9c037c3239038fee46308d6b9feba",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0023",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "17"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.259230526562475"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0861954671385755"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.969943886254665"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.233234793433793"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "23"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "17"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.259230526562475"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0861954671385755"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.969943886254665"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.233234793433793"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "23"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:097010bf7718d0ca7ca15cd545a5d22f",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:f9a9c037c3239038fee46308d6b9feba",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:9bd5784f7d92f66f0e060878415afdd2",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:6441c160dec1271f21351fe6ca31e10a",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0024",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "232"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "3.53773424485261"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.33343104779995e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "3.38829776668215e-05"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1.02223420853013e-05"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "24"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "232"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "3.53773424485261"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.33343104779995e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "3.38829776668215e-05"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1.02223420853013e-05"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "24"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9bd5784f7d92f66f0e060878415afdd2",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:6441c160dec1271f21351fe6ca31e10a",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:acdf8cd47c627692be1a25b68765ef7e",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:2872350aa13a26854db92f5a27149fe1",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0025",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "39"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.594705325643326"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0140713171349931"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.435681648303699"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0663877526368907"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "25"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "39"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.594705325643326"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0140713171349931"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.435681648303699"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0663877526368907"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "25"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:acdf8cd47c627692be1a25b68765ef7e",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:2872350aa13a26854db92f5a27149fe1",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:7a9e3b4c3767f5381b56e2fbeb688be4",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:e3742b34c6808b2398052ec8dae20d8c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0026",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "282"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "4.30017697003636"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.19145699221196e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "4.8444268134773e-06"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1.56591490405001e-06"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "26"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "282"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "4.30017697003636"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.19145699221196e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "4.8444268134773e-06"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1.56591490405001e-06"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "26"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7a9e3b4c3767f5381b56e2fbeb688be4",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:e3742b34c6808b2398052ec8dae20d8c",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:3e392a8fdf40615d1b9393f7900b1a84",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:002a4160ef17e67bfe8f93c22d701531",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0027",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "14"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.21348396305145"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.116072048788839"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.991080046819058"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.28101653917298"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "27"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "14"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.21348396305145"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.116072048788839"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.991080046819058"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.28101653917298"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "27"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3e392a8fdf40615d1b9393f7900b1a84",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:002a4160ef17e67bfe8f93c22d701531",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:5a380674b2894ae5398504bd4a8533f8",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:88b01b8106ca0618c3b109ef9140a77a",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0028",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "131"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.99759993998143"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.02994857850605e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00285428077037841"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00068079502023427"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "28"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "131"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.99759993998143"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.02994857850605e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00285428077037841"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00068079502023427"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "28"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5a380674b2894ae5398504bd4a8533f8",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:88b01b8106ca0618c3b109ef9140a77a",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:13af72d1f5f712ec17e2a4eb12791728",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:5b45e4eea89f71e19bb39684bf2f0eb7",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0029",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "19"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.289728235569826"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0713756287874445"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.945093181573621"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.215296978637538"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "29"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "19"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.289728235569826"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0713756287874445"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.945093181573621"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.215296978637538"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "29"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:13af72d1f5f712ec17e2a4eb12791728",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:5b45e4eea89f71e19bb39684bf2f0eb7",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:d959803f17fca1477b93bbeb0285f2c2",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c3da843e94fc98cca5669ae4eef8d2ed",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0030",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "12"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.1829862540441"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.143241570472552"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.997044748433009"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.325388258851229"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "30"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "12"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.1829862540441"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.143241570472552"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.997044748433009"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.325388258851229"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "30"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d959803f17fca1477b93bbeb0285f2c2",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:c3da843e94fc98cca5669ae4eef8d2ed",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:02b0f364d58bda58fce33ecdaf3e7191",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:5d3257a6906cc23f21f8344f8a202720",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0031",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "116"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.7688671224263"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00014803315627116"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00600091847870632"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00123809548881334"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "31"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "116"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.7688671224263"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00014803315627116"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00600091847870632"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00123809548881334"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "31"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:02b0f364d58bda58fce33ecdaf3e7191",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:5d3257a6906cc23f21f8344f8a202720",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:cd0210a509aed4af1fa29d3bf1351438",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f9cfce19a79a082c82d2f3a6386b09c9",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0032",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "128"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.9518533764704"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.13957933683974e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00330406500536851"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000748841298989256"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "32"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "128"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.9518533764704"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.13957933683974e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00330406500536851"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000748841298989256"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "32"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cd0210a509aed4af1fa29d3bf1351438",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:f9cfce19a79a082c82d2f3a6386b09c9",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:b9079ad818d03296fe8330a4f70c5c53",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:36f4c495e82ce16bc5e3538ec47db115",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0033",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "341"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "5.19985938575318"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.38423708416377e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "5.6282766780491e-07"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "2.31545112260121e-07"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "33"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "341"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "5.19985938575318"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.38423708416377e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "5.6282766780491e-07"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "2.31545112260121e-07"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "33"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b9079ad818d03296fe8330a4f70c5c53",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:36f4c495e82ce16bc5e3538ec47db115",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:6ed412630e5ab417bee547bf394670cd",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f3db818d25677c7c9807d3bc465f0dec",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0034",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "15"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.228732817555125"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.104882953664569"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.985941363519183"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.26079004694974"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "34"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "15"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.228732817555125"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.104882953664569"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.985941363519183"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.26079004694974"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "34"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6ed412630e5ab417bee547bf394670cd",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:f3db818d25677c7c9807d3bc465f0dec",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:a69405853461b6b0f7066443a438e1d5",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:16cd91852662e2b6fb06dce21defbb02",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0035",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "36"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.548958762132301"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0175611492050606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.510334393232324"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0751453826449104"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "35"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "36"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.548958762132301"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0175611492050606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.510334393232324"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0751453826449104"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "35"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a69405853461b6b0f7066443a438e1d5",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:16cd91852662e2b6fb06dce21defbb02",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:0747284a50ab24237772bdee19f8130e",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:d1f64d168706b2b7b1ea74aeb9acf76d",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0036",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "43"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.655700743658026"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0105632193593491"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.34916441811034"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0588979503672797"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "36"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "43"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.655700743658026"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0105632193593491"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.34916441811034"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0588979503672797"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "36"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0747284a50ab24237772bdee19f8130e",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:d1f64d168706b2b7b1ea74aeb9acf76d",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:a1f38c4aab7577b61865da78d168d6b4",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:81dc6b3cbc9f571d3c373afc2c155834",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0037",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "21"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.320225944577176"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0594903493216948"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.910977384061662"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.199022259548943"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "37"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "21"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.320225944577176"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0594903493216948"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.910977384061662"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.199022259548943"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "37"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a1f38c4aab7577b61865da78d168d6b4",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:81dc6b3cbc9f571d3c373afc2c155834",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:b2b2a00d477027244468267bb4cfdd7e",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:5c83c29ecdf61abf3b54b84749525008",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0038",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "42"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.640451889154351"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0113384872261853"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.369360223137178"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0613612249887678"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "38"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "42"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.640451889154351"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0113384872261853"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.369360223137178"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0613612249887678"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "38"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b2b2a00d477027244468267bb4cfdd7e",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:5c83c29ecdf61abf3b54b84749525008",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:1aefd578b3c1231848bc58379b5aa924",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:01690965efcb17bbde83102ddcb2faab",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0039",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "29"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.442216780606576"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0302138425428038"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.7072652442307"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.113456061793386"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "39"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "29"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.442216780606576"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0302138425428038"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.7072652442307"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.113456061793386"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "39"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1aefd578b3c1231848bc58379b5aa924",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:01690965efcb17bbde83102ddcb2faab",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:42e2f22eff9709257cf127b203589014",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:06b13cc33465cdc0e1390a27c23a9ac4",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0040",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "39"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.594705325643326"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0140713171349931"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.435681648303699"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0663877526368907"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "40"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "39"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.594705325643326"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0140713171349931"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.435681648303699"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0663877526368907"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "40"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:42e2f22eff9709257cf127b203589014",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:06b13cc33465cdc0e1390a27c23a9ac4",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:2974d7622a4eb3c979c41bc0bae55ebd",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:7f6f25f12f4270c6aaed0a3240d5a8a1",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0041",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "29"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.442216780606576"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0302138425428038"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.7072652442307"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.113456061793386"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "41"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "29"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.442216780606576"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0302138425428038"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.7072652442307"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.113456061793386"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "41"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2974d7622a4eb3c979c41bc0bae55ebd",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:7f6f25f12f4270c6aaed0a3240d5a8a1",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:dd84655271d1a93ad919193767608ec8",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:8f37ccae34c7cba6e277659e1d99e2a9",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0042",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "40"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.609954180147001"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0130862767797146"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.412621113012691"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0650777007423645"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "42"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "40"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.609954180147001"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0130862767797146"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.412621113012691"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0650777007423645"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "42"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:dd84655271d1a93ad919193767608ec8",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:8f37ccae34c7cba6e277659e1d99e2a9",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:0f340a0ff58ecb32a533ddd1cf07f45d",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:3acfc147a4a82a0c9064e4e844ecc743",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0043",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "37"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.564207616635976"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0163002147678929"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.484574874552217"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0731521833485923"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "43"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "37"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.564207616635976"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0163002147678929"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.484574874552217"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0731521833485923"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "43"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0f340a0ff58ecb32a533ddd1cf07f45d",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:3acfc147a4a82a0c9064e4e844ecc743",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:43c527932f85b9bc3ce5b3b60117f451",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:bb2efddb865295f983adb4172abe81b6",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0044",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "43"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.655700743658026"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0105632193593491"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.34916441811034"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0588979503672797"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "44"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "43"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.655700743658026"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0105632193593491"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.34916441811034"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0588979503672797"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "44"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:43c527932f85b9bc3ce5b3b60117f451",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:bb2efddb865295f983adb4172abe81b6",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:4c9c90b34337736af0c1709b3e2dce99",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:29b1a5a35e558ec0833c58691621c112",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0045",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "53"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.808189288694776"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00534811305849296"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.1954346848858"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0339328552676794"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "45"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "53"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.808189288694776"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00534811305849296"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.1954346848858"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0339328552676794"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "45"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4c9c90b34337736af0c1709b3e2dce99",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:29b1a5a35e558ec0833c58691621c112",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:645b34305a7adc863333ef8d055b94b6",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:16e2e680906eb7d77a0f37a900f566bb",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0046",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "43"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.655700743658026"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0105632193593491"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.34916441811034"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0588979503672797"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "46"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "43"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.655700743658026"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0105632193593491"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.34916441811034"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0588979503672797"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "46"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:645b34305a7adc863333ef8d055b94b6",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:16e2e680906eb7d77a0f37a900f566bb",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:147ce23197bb1c39e660c70911b5c483",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:160595535853afe9f10e3ba4462634ee",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0047",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "51"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.777691579687426"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00610545983579011"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.219832536837772"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0374468203261794"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "47"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "51"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.777691579687426"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00610545983579011"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.219832536837772"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0374468203261794"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "47"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:147ce23197bb1c39e660c70911b5c483",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:160595535853afe9f10e3ba4462634ee",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:4c767097d4f857da1a95ec39b9d9edc3",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:5bea9c455010164eafb48efd433d0b3b",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0048",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "64"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.975926688235202"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00265363180882805"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.102279134829792"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0180840093638652"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "48"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "64"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.975926688235202"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00265363180882805"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.102279134829792"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0180840093638652"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "48"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4c767097d4f857da1a95ec39b9d9edc3",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:5bea9c455010164eafb48efd433d0b3b",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:e039dc19484a5a0f4a9f1920c4f37802",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:54acd58c8408a4a54a5d29cdbcf77a2a",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0049",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "12"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.1829862540441"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.143241570472552"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.997044748433009"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.325388258851229"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "49"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "12"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.1829862540441"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.143241570472552"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.997044748433009"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.325388258851229"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "49"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e039dc19484a5a0f4a9f1920c4f37802",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:54acd58c8408a4a54a5d29cdbcf77a2a",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:90684205dbd5e3565c63d92ea2c2ba92",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:e0f95b0e95e26dd40bce67d69e9c88a7",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0050",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "20"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0651131165511113"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.929170899457028"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.2101897095685"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "50"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "20"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0651131165511113"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.929170899457028"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.2101897095685"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "50"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:90684205dbd5e3565c63d92ea2c2ba92",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:e0f95b0e95e26dd40bce67d69e9c88a7",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:43d72ad1d7d22b80f01808f8d966ccdd",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:e1915181e888f91227f9d80a2ceda361",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0051",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "12"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.1829862540441"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.143241570472552"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.997044748433009"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.325388258851229"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "51"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "12"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.1829862540441"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.143241570472552"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.997044748433009"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.325388258851229"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "51"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:43d72ad1d7d22b80f01808f8d966ccdd",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:e1915181e888f91227f9d80a2ceda361",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:fce6ba03f6215ffda4130a08998532e7",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:059524711a78d34f86f9ff7484d30c28",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0052",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "20"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0651131165511113"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.929170899457028"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.2101897095685"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "52"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "20"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0651131165511113"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.929170899457028"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.2101897095685"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "52"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:fce6ba03f6215ffda4130a08998532e7",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:059524711a78d34f86f9ff7484d30c28",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:90faaaeae176fe54bdbf1e2a7100afb2",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f80c4f725486ccc8cbc7ca97e9202b10",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0053",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "32"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.487963344117601"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0238298502170892"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.620506038183986"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0932913285094554"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "53"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "32"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.487963344117601"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0238298502170892"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.620506038183986"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0932913285094554"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "53"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:90faaaeae176fe54bdbf1e2a7100afb2",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:f80c4f725486ccc8cbc7ca97e9202b10",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:a56b7f6c2daf0ff5655692e9a3ba50e8",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:4fc2bcbe1574c654541b41942566af13",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0054",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "23"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.350723653584526"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0498676814730745"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.868350109038333"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.173125535680108"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "54"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "23"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.350723653584526"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0498676814730745"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.868350109038333"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.173125535680108"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "54"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a56b7f6c2daf0ff5655692e9a3ba50e8",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:4fc2bcbe1574c654541b41942566af13",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:94a06b9bd15a2d12f76ca646af0fa348",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:dff2d5252e6112d696cc75e19b35b055",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0055",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "10"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.15248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.178919623096924"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999307244516111"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.374104666475387"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "55"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "10"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.15248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.178919623096924"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999307244516111"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.374104666475387"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "55"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:94a06b9bd15a2d12f76ca646af0fa348",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:dff2d5252e6112d696cc75e19b35b055",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:e6bd6b781a9701be59c8d9453ba0f42d",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c1d3f6f0f50baea1174f7ada78444ce5",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0056",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "19"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.289728235569826"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0713756287874445"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.945093181573621"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.215296978637538"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "56"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "19"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.289728235569826"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0713756287874445"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.945093181573621"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.215296978637538"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "56"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e6bd6b781a9701be59c8d9453ba0f42d",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:c1d3f6f0f50baea1174f7ada78444ce5",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:24a7631619b05b254e46f418981f33fd",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:ac01f2a6f9677b631c38f9d1203db903",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0057",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "23"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.350723653584526"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0498676814730745"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.868350109038333"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.173125535680108"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "57"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "23"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.350723653584526"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0498676814730745"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.868350109038333"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.173125535680108"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "57"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:24a7631619b05b254e46f418981f33fd",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:ac01f2a6f9677b631c38f9d1203db903",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:26d38070320861a52f54239810eefb6d",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:6ac4331664607b2b0b57f58303204021",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0058",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "18"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.27447938106615"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0783677980047555"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.958680380360757"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.225307419263672"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "58"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "18"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.27447938106615"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0783677980047555"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.958680380360757"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.225307419263672"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "58"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:26d38070320861a52f54239810eefb6d",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:6ac4331664607b2b0b57f58303204021",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:a5c107a7aa03e749be4156dafe333465",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:df3a63e829a4b0144a3bd3a075d00d6a",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0059",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "56"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.853935852205802"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00439806211087432"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.16374715135319"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0289015510143169"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "59"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "56"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.853935852205802"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00439806211087432"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.16374715135319"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0289015510143169"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "59"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a5c107a7aa03e749be4156dafe333465",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:df3a63e829a4b0144a3bd3a075d00d6a",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:1e592c6195e8eed44af6ede26c558b5b",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:de4cddb037f1620436ef1889e1446b84",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0060",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "23"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.350723653584526"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0498676814730745"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.868350109038333"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.173125535680108"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "60"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "23"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.350723653584526"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0498676814730745"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.868350109038333"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.173125535680108"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "60"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1e592c6195e8eed44af6ede26c558b5b",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:de4cddb037f1620436ef1889e1446b84",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:561f8f2dc565936a85d74fd6e6439dd5",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:70eb10d3df67eb20319350b5182c2674",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0061",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "15"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.228732817555125"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.104882953664569"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.985941363519183"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.26079004694974"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "61"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "15"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.228732817555125"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.104882953664569"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.985941363519183"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.26079004694974"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "61"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:561f8f2dc565936a85d74fd6e6439dd5",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:70eb10d3df67eb20319350b5182c2674",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:74f3d914b0fa073ea25c95d2b38e58fb",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:0c6701f42b3e926640123461fe2991bd",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0062",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0609954180147001"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.392898461436365"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999884635261"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.60244430753576"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "62"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0609954180147001"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.392898461436365"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999884635261"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.60244430753576"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "62"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:74f3d914b0fa073ea25c95d2b38e58fb",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:0c6701f42b3e926640123461fe2991bd",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:3df28d3c24f5b16d0bd211139131d8c1",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:ff9cac1254b9e415d2191f7775b434dc",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0063",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "17"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.259230526562475"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0861954671385755"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.969943886254665"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.233234793433793"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "63"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "17"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.259230526562475"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0861954671385755"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.969943886254665"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.233234793433793"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "63"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3df28d3c24f5b16d0bd211139131d8c1",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:ff9cac1254b9e415d2191f7775b434dc",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:7f4b39cb147f1d9dd77391be1117b986",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:42811518fc15bbd0a0761ed04fef9d90",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0064",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "5"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0762442725183751"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.338223691582417"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999998934538669"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.576232956029303"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "64"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "5"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0762442725183751"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.338223691582417"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999998934538669"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.576232956029303"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "64"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7f4b39cb147f1d9dd77391be1117b986",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:42811518fc15bbd0a0761ed04fef9d90",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:e186e249fc14850bf873b0628a153098",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:dd408b7babb59101191c5fa3158193a1",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0065",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "11"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.167737399540425"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.159819830652318"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.998493912421707"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.35008153380984"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "65"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "11"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.167737399540425"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.159819830652318"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.998493912421707"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.35008153380984"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "65"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e186e249fc14850bf873b0628a153098",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:dd408b7babb59101191c5fa3158193a1",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:28c5ec87b0dddeb6b0b0fcaa674d02f8",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:99548a2427d673d5bd15c691076864b1",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0066",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "5"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0762442725183751"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.338223691582417"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999998934538669"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.576232956029303"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "66"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "5"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0762442725183751"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.338223691582417"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999998934538669"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.576232956029303"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "66"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:28c5ec87b0dddeb6b0b0fcaa674d02f8",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:99548a2427d673d5bd15c691076864b1",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:b9c11d17264a448b811fbb99435e6a29",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:7a1eb6258840314d739698ecb8549782",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0067",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "18"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.27447938106615"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0783677980047555"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.958680380360757"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.225307419263672"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "67"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "18"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.27447938106615"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0783677980047555"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.958680380360757"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.225307419263672"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "67"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b9c11d17264a448b811fbb99435e6a29",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:7a1eb6258840314d739698ecb8549782",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:4f417da08fec0d40b87c31dc3acdb804",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:d766f0de412bd93d96229079d9de064c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0068",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "6"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0914931270220502"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.294006431429813"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999993568085853"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.520165224837362"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "68"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "6"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0914931270220502"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.294006431429813"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999993568085853"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.520165224837362"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "68"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4f417da08fec0d40b87c31dc3acdb804",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:d766f0de412bd93d96229079d9de064c",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:595ec99dd41031dea87a56ab2ed11ae6",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:8661090d64b5d8ebc0a4bd8254976fb2",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0069",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "32"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.487963344117601"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0238298502170892"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.620506038183986"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0932913285094554"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "69"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "32"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.487963344117601"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0238298502170892"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.620506038183986"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0932913285094554"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "69"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:595ec99dd41031dea87a56ab2ed11ae6",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:8661090d64b5d8ebc0a4bd8254976fb2",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:2c7e261ed1ca11499bdd3aefccd19ad9",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:52941f17d3d4d9019f15d6efbca27815",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0070",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "34"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.518461053124951"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0204261661708045"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.564178939107314"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0854185130779095"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "70"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "34"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.518461053124951"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0204261661708045"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.564178939107314"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0854185130779095"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "70"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2c7e261ed1ca11499bdd3aefccd19ad9",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:52941f17d3d4d9019f15d6efbca27815",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:ad031ab3c998c491419cfcf8be1da45c",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:65bb243af8ca1e554de57b71bb66bc25",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0071",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "40"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.609954180147001"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0130862767797146"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.412621113012691"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0650777007423645"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "71"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "40"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.609954180147001"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0130862767797146"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.412621113012691"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0650777007423645"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "71"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ad031ab3c998c491419cfcf8be1da45c",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:65bb243af8ca1e554de57b71bb66bc25",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:5c2053c39d7e04181ae00f2c3455846a",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:eb7b45334c4709abfab6a80cdaa2bc22",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0072",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "16"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.2439816720588"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0949840077331822"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.978974711675474"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.24967224889865"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "72"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "16"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.2439816720588"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0949840077331822"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.978974711675474"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.24967224889865"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "72"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5c2053c39d7e04181ae00f2c3455846a",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:eb7b45334c4709abfab6a80cdaa2bc22",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:117133b74d26b0653d13dd1ed378d736",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:afbff827e6265de5fc31843cacb634e6",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0073",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "16"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.2439816720588"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0949840077331822"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.978974711675474"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.24967224889865"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "73"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "16"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.2439816720588"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0949840077331822"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.978974711675474"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.24967224889865"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "73"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:117133b74d26b0653d13dd1ed378d736",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:afbff827e6265de5fc31843cacb634e6",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:f826be788a1ac88ee83c24f89532c22c",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:44d83170827403caee586f5f0c738aff",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0074",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "7"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.106741981525725"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.257522594755246"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999971648012046"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.483511810560871"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "74"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "7"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.106741981525725"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.257522594755246"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999971648012046"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.483511810560871"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "74"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f826be788a1ac88ee83c24f89532c22c",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:44d83170827403caee586f5f0c738aff",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:069291996dee025660d592de3e37d709",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:2d968184be68de22a2c6d1f79a1a3779",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0075",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "19"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.289728235569826"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0713756287874445"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.945093181573621"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.215296978637538"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "75"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "19"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.289728235569826"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0713756287874445"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.945093181573621"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.215296978637538"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "75"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:069291996dee025660d592de3e37d709",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:2d968184be68de22a2c6d1f79a1a3779",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:83bc0d4252d6531714bcacd111e1cc46",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:8c5cc0e6fb31318c9adb3b82365f2ae6",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0076",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "6"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0914931270220502"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.294006431429813"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999993568085853"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.520165224837362"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "76"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "6"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0914931270220502"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.294006431429813"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999993568085853"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.520165224837362"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "76"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:83bc0d4252d6531714bcacd111e1cc46",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:8c5cc0e6fb31318c9adb3b82365f2ae6",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:5703312bcab5b7a9d45a9c8f5e2a301f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:db5e02d87132e15c42c39a266963eb55",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0077",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "19"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.289728235569826"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0713756287874445"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.945093181573621"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.215296978637538"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "77"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "19"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.289728235569826"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0713756287874445"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.945093181573621"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.215296978637538"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "77"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5703312bcab5b7a9d45a9c8f5e2a301f",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:db5e02d87132e15c42c39a266963eb55",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:39fa289e8e1804e6c510280f0e399486",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:6e1483cf3114e5bdc77f5e480decfc71",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0078",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0609954180147001"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.392898461436365"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999884635261"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.60244430753576"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "78"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0609954180147001"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.392898461436365"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999884635261"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.60244430753576"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "78"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:39fa289e8e1804e6c510280f0e399486",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:6e1483cf3114e5bdc77f5e480decfc71",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:aec4d890e92fb9730ea03f8d53fbe940",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:1eb993430541f6c2dc79f73b3a96decc",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0079",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "11"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.167737399540425"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.159819830652318"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.998493912421707"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.35008153380984"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "79"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "11"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.167737399540425"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.159819830652318"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.998493912421707"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.35008153380984"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "79"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:aec4d890e92fb9730ea03f8d53fbe940",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:1eb993430541f6c2dc79f73b3a96decc",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:6f32c27f31869cd578e8b60308359ec9",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:e576b0cc1b6a471310c83c2e65672f5f",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0080",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "10"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.15248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.178919623096924"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999307244516111"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.374104666475387"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "80"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "10"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.15248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.178919623096924"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999307244516111"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.374104666475387"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "80"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6f32c27f31869cd578e8b60308359ec9",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:e576b0cc1b6a471310c83c2e65672f5f",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:a2bcb1ae11c4d80d14c85b5637295099",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:01a6664df87623bed0fd193f07c04638",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0081",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "6"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0914931270220502"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.294006431429813"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999993568085853"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.520165224837362"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "81"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "6"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0914931270220502"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.294006431429813"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999993568085853"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.520165224837362"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "81"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a2bcb1ae11c4d80d14c85b5637295099",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:01a6664df87623bed0fd193f07c04638",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:6e5d34b600dd5cfbc70efee8ab867c9f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:9fbbe8461310da88b0ce5b0b68e8e62c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0082",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "38"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.579456471139651"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0151399339386457"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.459676077699012"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0696436961177701"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "82"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "38"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.579456471139651"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0151399339386457"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.459676077699012"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0696436961177701"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "82"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6e5d34b600dd5cfbc70efee8ab867c9f",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:9fbbe8461310da88b0ce5b0b68e8e62c",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:96be67b14048a7acaffdcf5d2d455f8b",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:ae14e5d65d87b53bd2bbf000849a1635",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0083",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0609954180147001"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.392898461436365"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999884635261"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.60244430753576"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "83"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0609954180147001"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.392898461436365"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999884635261"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.60244430753576"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "83"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:96be67b14048a7acaffdcf5d2d455f8b",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:ae14e5d65d87b53bd2bbf000849a1635",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:bbdf3a3cea68312933b0e0f7ac23c71f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:40d7f1124d8e7cab0c81135fe2f535ad",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0084",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "6"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0914931270220502"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.294006431429813"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999993568085853"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.520165224837362"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "84"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "6"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0914931270220502"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.294006431429813"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999993568085853"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.520165224837362"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "84"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:bbdf3a3cea68312933b0e0f7ac23c71f",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:40d7f1124d8e7cab0c81135fe2f535ad",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:3cf31cb78a4315d8e0bb0e1795c2b177",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:3383de798490342ce6540ea70b023ffa",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0085",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "24"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.365972508088201"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0457449503010114"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.844324233893837"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.168341417107722"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "85"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "24"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.365972508088201"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0457449503010114"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.844324233893837"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.168341417107722"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "85"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3cf31cb78a4315d8e0bb0e1795c2b177",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:3383de798490342ce6540ea70b023ffa",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:2de3fe021b32432646cff16795c27e84",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:4bcfe0e6f6bc971e3e914655ca98bf82",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0086",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "11"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.167737399540425"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.159819830652318"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.998493912421707"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.35008153380984"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "86"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "11"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.167737399540425"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.159819830652318"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.998493912421707"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.35008153380984"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "86"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2de3fe021b32432646cff16795c27e84",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:4bcfe0e6f6bc971e3e914655ca98bf82",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:4899fcf255f8d47f7118cf27e2fd1a7d",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:bbf13cce053679ff04cb1b23082b44ac",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0087",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "9"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.137239690533075"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.201071431446766"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999718540285087"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.411079370957833"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "87"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "9"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.137239690533075"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.201071431446766"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999718540285087"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.411079370957833"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "87"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4899fcf255f8d47f7118cf27e2fd1a7d",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:bbf13cce053679ff04cb1b23082b44ac",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:655cdd92103093b072ae23a6af82f68e",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:2151f348776220c1024fdc2f0b0bc92f",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0088",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0609954180147001"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.392898461436365"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999884635261"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.60244430753576"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "88"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0609954180147001"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.392898461436365"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999884635261"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.60244430753576"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "88"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:655cdd92103093b072ae23a6af82f68e",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:2151f348776220c1024fdc2f0b0bc92f",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:626eb7ded63e9b32e8502a0a107f553d",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:8ccfe08eafd83c22c7082eb44f58a70f",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0089",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "36"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.548958762132301"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0175611492050606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.510334393232324"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0751453826449104"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "89"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "36"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.548958762132301"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0175611492050606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.510334393232324"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0751453826449104"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "89"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:626eb7ded63e9b32e8502a0a107f553d",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:8ccfe08eafd83c22c7082eb44f58a70f",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:b4ad782774b491871a7992522f937437",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:bad308d46fbeeacaf458653ab9b853d6",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0090",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "17"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.259230526562475"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0861954671385755"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.969943886254665"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.233234793433793"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "90"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "17"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.259230526562475"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0861954671385755"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.969943886254665"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.233234793433793"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "90"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b4ad782774b491871a7992522f937437",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:bad308d46fbeeacaf458653ab9b853d6",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:677611b98bfd5eb8fbc23315abaa9320",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:687916ac6701ade9ca268dec72dc0c0d",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0091",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0609954180147001"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.392898461436365"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999884635261"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.60244430753576"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "91"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0609954180147001"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.392898461436365"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999884635261"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.60244430753576"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "91"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:677611b98bfd5eb8fbc23315abaa9320",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:687916ac6701ade9ca268dec72dc0c0d",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:0dbd53cf7610b049d137c94d182a0076",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:9071142b0c2683c96f4377cdddced1d0",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0092",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "22"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.335474799080851"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0544305197907388"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.89064253285737"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.185466956323999"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "92"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "22"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.335474799080851"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0544305197907388"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.89064253285737"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.185466956323999"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "92"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0dbd53cf7610b049d137c94d182a0076",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:9071142b0c2683c96f4377cdddced1d0",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:76019faf9ae4e38fc7ae7798a2f879f4",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:884f659ac62495dd158e264f576d0fc2",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0093",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "6"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0914931270220502"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.294006431429813"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999993568085853"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.520165224837362"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "93"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "6"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0914931270220502"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.294006431429813"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999993568085853"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.520165224837362"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "93"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:76019faf9ae4e38fc7ae7798a2f879f4",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:884f659ac62495dd158e264f576d0fc2",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:e6b0f9d536c2b1a1fd955a8eaff2a2df",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:2088eea3a39320e89e2a625ec7e9f82e",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0094",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "12"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.1829862540441"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.143241570472552"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.997044748433009"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.325388258851229"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "94"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "12"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.1829862540441"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.143241570472552"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.997044748433009"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.325388258851229"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "94"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e6b0f9d536c2b1a1fd955a8eaff2a2df",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:2088eea3a39320e89e2a625ec7e9f82e",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:7fee2fcd04048e290bf06db1c5562ffd",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:7fc88d60dca200d4c67a0a607a345633",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0095",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "18"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.27447938106615"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0783677980047555"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.958680380360757"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.225307419263672"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "95"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "18"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.27447938106615"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0783677980047555"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.958680380360757"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.225307419263672"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "95"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7fee2fcd04048e290bf06db1c5562ffd",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:7fc88d60dca200d4c67a0a607a345633",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:a544035a692226b8c28c019b1e283632",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:ca1da2e7a46f823f402d9c62e070d0fc",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0096",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "7"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.106741981525725"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.257522594755246"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999971648012046"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.483511810560871"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "96"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "7"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.106741981525725"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.257522594755246"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999971648012046"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.483511810560871"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "96"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a544035a692226b8c28c019b1e283632",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:ca1da2e7a46f823f402d9c62e070d0fc",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:9c40cb58c75073f4f983d06c6a655c74",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:ea6ee099e3b8edbdd2bde04e8682a6ce",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0097",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "9"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.137239690533075"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.201071431446766"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999718540285087"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.411079370957833"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "97"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "9"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.137239690533075"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.201071431446766"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999718540285087"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.411079370957833"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "97"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9c40cb58c75073f4f983d06c6a655c74",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:ea6ee099e3b8edbdd2bde04e8682a6ce",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:f8d5d9e3adb56590f1e9d795fa0fb5b7",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:1ef7113e2a59f273a63186ced0b0fc6b",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0098",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "15"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.228732817555125"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.104882953664569"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.985941363519183"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.26079004694974"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "98"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "15"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.228732817555125"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.104882953664569"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.985941363519183"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.26079004694974"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "98"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f8d5d9e3adb56590f1e9d795fa0fb5b7",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:1ef7113e2a59f273a63186ced0b0fc6b",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:d763c6c8de6f4537a51f15146880d851",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:02f0aee7ff558248fe49e5f3579c0585",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0099",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "8"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.1219908360294"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.22696566672688"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999901787324827"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.453931333453761"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "99"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "8"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.1219908360294"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.22696566672688"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999901787324827"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.453931333453761"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "99"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d763c6c8de6f4537a51f15146880d851",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:02f0aee7ff558248fe49e5f3579c0585",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:c81c855fadc265b4e1ccb72361a5ab5b",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c2cda63a78bcde6ae7a69f7ab8eadb2c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0100",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "10"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.15248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.178919623096924"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999307244516111"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.374104666475387"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "100"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "10"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.15248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.178919623096924"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999307244516111"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.374104666475387"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "100"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c81c855fadc265b4e1ccb72361a5ab5b",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:c2cda63a78bcde6ae7a69f7ab8eadb2c",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:adb14ea605c87220ed90422a86d00cf7",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:2c7f2ff6921dbb36e89f44a3a1dd839b",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0101",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0457465635110251"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.462472368627877"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999993184233"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.654795742860352"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "101"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0457465635110251"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.462472368627877"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999993184233"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.654795742860352"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "101"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:adb14ea605c87220ed90422a86d00cf7",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:2c7f2ff6921dbb36e89f44a3a1dd839b",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:d5aa67ffe10d81e16892509076504f14",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:03e03b97c9ae144949ccd274ec79dd81",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0102",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "7"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.106741981525725"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.257522594755246"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999971648012046"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.483511810560871"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "102"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "7"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.106741981525725"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.257522594755246"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999971648012046"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.483511810560871"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "102"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d5aa67ffe10d81e16892509076504f14",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:03e03b97c9ae144949ccd274ec79dd81",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:3fae830c70c9ca8cf8f3cbed4301161f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:036f2836a317a98100c1a6652ab21784",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0103",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "13"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.198235108547775"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.128769259078544"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.994677064942681"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.30770835935652"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "103"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "13"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.198235108547775"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.128769259078544"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.994677064942681"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.30770835935652"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "103"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3fae830c70c9ca8cf8f3cbed4301161f",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:036f2836a317a98100c1a6652ab21784",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:c35054132a92b4bf34b2e1b8acd96c91",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:a029a63406d370c8869c59656bb90a54",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0104",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0609954180147001"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.392898461436365"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999884635261"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.60244430753576"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "104"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0609954180147001"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.392898461436365"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999884635261"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.60244430753576"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "104"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c35054132a92b4bf34b2e1b8acd96c91",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:a029a63406d370c8869c59656bb90a54",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:21c649902d379fc9de7f1be15e128c6b",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c429131bcf59cefceae4a934fd1aa80a",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0105",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.555152912425081"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999842626"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.654795742860352"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "105"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.555152912425081"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999842626"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.654795742860352"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "105"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:21c649902d379fc9de7f1be15e128c6b",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:c429131bcf59cefceae4a934fd1aa80a",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:24ec764638d7b84cf388c10bdbf8e52e",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:9ac7226087de1c45b555519c1250dc59",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0106",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "17"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.259230526562475"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0861954671385755"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.969943886254665"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.233234793433793"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "106"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "17"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.259230526562475"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0861954671385755"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.969943886254665"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.233234793433793"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "106"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:24ec764638d7b84cf388c10bdbf8e52e",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:9ac7226087de1c45b555519c1250dc59",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:7e5ff536134bdc8ab5fcb743674e90c4",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:9c1fe61e0e5d7d3b62e90ebdfdb9d4d4",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0107",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "14"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.21348396305145"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.116072048788839"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.991080046819058"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.28101653917298"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "107"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "14"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.21348396305145"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.116072048788839"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.991080046819058"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.28101653917298"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "107"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7e5ff536134bdc8ab5fcb743674e90c4",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:9c1fe61e0e5d7d3b62e90ebdfdb9d4d4",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:ec6922a6284384102e3683f4f534bdd4",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:7489f5e950ff72b41ea437f2c2026c6f",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0108",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0609954180147001"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.392898461436365"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999884635261"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.60244430753576"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "108"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0609954180147001"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.392898461436365"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999884635261"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.60244430753576"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "108"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ec6922a6284384102e3683f4f534bdd4",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:7489f5e950ff72b41ea437f2c2026c6f",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:1587d965de8a227487a386f18a622f62",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:e83b9cd4cb9554eedc76bd43c766b08d",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0109",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.555152912425081"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999842626"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.654795742860352"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "109"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.555152912425081"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999842626"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.654795742860352"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "109"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1587d965de8a227487a386f18a622f62",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:e83b9cd4cb9554eedc76bd43c766b08d",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:cde75203fe8335e4da3e8277987b76e3",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:6f3ca580fb0dafec12bb76f49a9e660f",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0110",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "8"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.1219908360294"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.22696566672688"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999901787324827"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.453931333453761"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "110"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "8"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.1219908360294"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.22696566672688"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999901787324827"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.453931333453761"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "110"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cde75203fe8335e4da3e8277987b76e3",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:6f3ca580fb0dafec12bb76f49a9e660f",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:1963461ba0ecaf2bdd626d72af091d83",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:37ee2d388f0d21999c13e5808ab4abaa",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0111",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "7"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.106741981525725"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.257522594755246"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999971648012046"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.483511810560871"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "111"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "7"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.106741981525725"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.257522594755246"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999971648012046"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.483511810560871"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "111"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1963461ba0ecaf2bdd626d72af091d83",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:37ee2d388f0d21999c13e5808ab4abaa",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:031b2ebac9374480bd55f336b2f0698d",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:17c3d65f0a2dd8b609c3139c41ebf930",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0112",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "7"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.106741981525725"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.257522594755246"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999971648012046"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.483511810560871"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "112"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "7"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.106741981525725"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.257522594755246"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999971648012046"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.483511810560871"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "112"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:031b2ebac9374480bd55f336b2f0698d",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:17c3d65f0a2dd8b609c3139c41ebf930",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:8424ab2f8e8a8fcd5c99b549000e3d8a",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:bbd0acc33408cc31d2590c5760c85985",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0113",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0609954180147001"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.392898461436365"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999884635261"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.60244430753576"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "113"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0609954180147001"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.392898461436365"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999884635261"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.60244430753576"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "113"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8424ab2f8e8a8fcd5c99b549000e3d8a",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:bbd0acc33408cc31d2590c5760c85985",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:cb3496ce3deece902bd5c57224f82327",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:04aa6294da937ca4a062fce158511fb6",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0114",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999352"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "114"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999352"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "114"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cb3496ce3deece902bd5c57224f82327",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:04aa6294da937ca4a062fce158511fb6",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:a3a27b078e8a7d6edcf7ae4db82c3d7a",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:6e2a6189013a78c14191e7633ed21b0a",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0115",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0609954180147001"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.392898461436365"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999884635261"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.60244430753576"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "115"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0609954180147001"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.392898461436365"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999884635261"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.60244430753576"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "115"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a3a27b078e8a7d6edcf7ae4db82c3d7a",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:6e2a6189013a78c14191e7633ed21b0a",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:4f03ee575ea9164c216c53e2e6502c3f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:81840f3ae0159e07fac81fc13e72fbf5",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0116",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0609954180147001"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.392898461436365"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999884635261"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.60244430753576"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "116"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0609954180147001"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.392898461436365"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999884635261"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.60244430753576"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "116"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4f03ee575ea9164c216c53e2e6502c3f",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:81840f3ae0159e07fac81fc13e72fbf5",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:8ddc263efb94c47b4f51cbca78984739",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:dd602a84f4dd916125d3c669097eec23",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0117",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "10"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.15248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.178919623096924"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999307244516111"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.374104666475387"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "117"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "10"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.15248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.178919623096924"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999307244516111"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.374104666475387"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "117"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8ddc263efb94c47b4f51cbca78984739",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:dd602a84f4dd916125d3c669097eec23",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:b615db2c02106c19996d725a76dd5932",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:1c2363e827044fb757d9bf0cf8e052e5",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0118",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0457465635110251"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.462472368627877"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999993184233"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.654795742860352"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "118"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0457465635110251"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.462472368627877"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999993184233"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.654795742860352"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "118"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b615db2c02106c19996d725a76dd5932",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:1c2363e827044fb757d9bf0cf8e052e5",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:6e455b57979dad222384fa2bedf5c673",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:45132e41bd386f5b430c16f7c2c90e0a",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0119",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "5"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0762442725183751"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.338223691582417"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999998934538669"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.576232956029303"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "119"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "5"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0762442725183751"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.338223691582417"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999998934538669"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.576232956029303"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "119"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6e455b57979dad222384fa2bedf5c673",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:45132e41bd386f5b430c16f7c2c90e0a",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:59697598e154d20a6b71266d474312af",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c4e5f3528c31047605f368909a0632ee",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0120",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "15"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.228732817555125"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.104882953664569"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.985941363519183"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.26079004694974"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "120"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "15"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.228732817555125"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.104882953664569"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.985941363519183"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.26079004694974"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "120"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:59697598e154d20a6b71266d474312af",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:c4e5f3528c31047605f368909a0632ee",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:737e8596c1e48716edbdb5c9d774c8a2",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:1355ee0795599ee6287d2b70ebc8d729",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0121",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0609954180147001"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.392898461436365"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999884635261"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.60244430753576"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "121"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0609954180147001"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.392898461436365"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999884635261"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.60244430753576"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "121"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:737e8596c1e48716edbdb5c9d774c8a2",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:1355ee0795599ee6287d2b70ebc8d729",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:6e426d70bd3515ce04a9030b5a306cc1",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:370789fb0338d1e1885081e0362c340f",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0122",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0457465635110251"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.462472368627877"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999993184233"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.654795742860352"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "122"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0457465635110251"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.462472368627877"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999993184233"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.654795742860352"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "122"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6e426d70bd3515ce04a9030b5a306cc1",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:370789fb0338d1e1885081e0362c340f",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:8b57f16537b5d60872068ffb74ea46c2",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:40392b1ab652b1fe41dac16581269fb2",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0123",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.555152912425081"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999842626"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.654795742860352"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "123"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.555152912425081"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999842626"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.654795742860352"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "123"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8b57f16537b5d60872068ffb74ea46c2",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:40392b1ab652b1fe41dac16581269fb2",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:57fac0849992a04e841522c89a1e8fad",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:65ef2c95ae3f51b5861bb20b84514bd9",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0124",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999352"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "124"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999352"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "124"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:57fac0849992a04e841522c89a1e8fad",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:65ef2c95ae3f51b5861bb20b84514bd9",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:7d9186e6ae7abd1a3b75051676646bf7",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:5cc71319d109fdb0ef9f0f9c7bd41492",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0125",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999352"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "125"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999352"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "125"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7d9186e6ae7abd1a3b75051676646bf7",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:5cc71319d109fdb0ef9f0f9c7bd41492",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:05a6f19551a73fb9cdefb486a3b7d7c7",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:4bf75a353d782554be968730ac4840cd",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0126",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0457465635110251"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.462472368627877"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999993184233"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.654795742860352"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "126"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0457465635110251"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.462472368627877"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999993184233"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.654795742860352"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "126"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:05a6f19551a73fb9cdefb486a3b7d7c7",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:4bf75a353d782554be968730ac4840cd",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:f652c5b4f145cc8a8477c98b20d1e8e7",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:332041ad6aeaf3a74891ecd53c374a96",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0127",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.555152912425081"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999842626"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.654795742860352"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "127"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.555152912425081"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999842626"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.654795742860352"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "127"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f652c5b4f145cc8a8477c98b20d1e8e7",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:332041ad6aeaf3a74891ecd53c374a96",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:220f34dd841d349b45f448f4ed96568e",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:b47672c30d95e784941e629a0021b66b",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0128",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0457465635110251"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.462472368627877"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999993184233"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.654795742860352"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "128"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0457465635110251"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.462472368627877"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999993184233"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.654795742860352"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "128"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:220f34dd841d349b45f448f4ed96568e",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:b47672c30d95e784941e629a0021b66b",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:73421e1373e081b7d78772065fdc0ab7",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:4ade8b0865402c36f9bde1298af17ab4",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0129",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.555152912425081"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999842626"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.654795742860352"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "129"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.555152912425081"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999842626"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.654795742860352"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "129"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:73421e1373e081b7d78772065fdc0ab7",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:4ade8b0865402c36f9bde1298af17ab4",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:fd107443c1e505341538e35623ef13ad",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:8d46ffe6156e40b274554eb8fc558f49",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0130",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "7"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.106741981525725"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.257522594755246"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999971648012046"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.483511810560871"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "130"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "7"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.106741981525725"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.257522594755246"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999971648012046"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.483511810560871"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "130"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:fd107443c1e505341538e35623ef13ad",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:8d46ffe6156e40b274554eb8fc558f49",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:32a1c5504e28cf0e83bddf4c41d902c9",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:4d3c4f523d2ecfeb9befc1c5babb099d",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0131",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.555152912425081"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999842626"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.654795742860352"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "131"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.555152912425081"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999842626"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.654795742860352"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "131"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:32a1c5504e28cf0e83bddf4c41d902c9",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:4d3c4f523d2ecfeb9befc1c5babb099d",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:4c3e4e7060e2b7cf9ba40d556d3850b1",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:24a29d9d6136d7a26f77ad7395967c47",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0132",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999352"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "132"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999352"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "132"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4c3e4e7060e2b7cf9ba40d556d3850b1",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:24a29d9d6136d7a26f77ad7395967c47",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:908b3d895326bd3ac6957280d4de7d76",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:7289b1de1e9e889ff1fb5691142cd967",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0133",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999352"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "133"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999352"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "133"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:908b3d895326bd3ac6957280d4de7d76",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:7289b1de1e9e889ff1fb5691142cd967",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:000f81203c82e4c9e73a3c6aace6130e",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:4465bf32a18439b39ae380aba9c3f3b0",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0134",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.555152912425081"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999842626"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.654795742860352"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "134"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.555152912425081"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999842626"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.654795742860352"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "134"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:000f81203c82e4c9e73a3c6aace6130e",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:4465bf32a18439b39ae380aba9c3f3b0",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:1a6f934195839bd5aafde8865b102795",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:1cd15156a67e7cd4faba9f06d50293c8",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0135",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999352"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "135"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999352"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "135"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1a6f934195839bd5aafde8865b102795",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:1cd15156a67e7cd4faba9f06d50293c8",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:6179fefaf9c60c4a862df01568a93c88",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:ad7c299b4aa35cd98fdbd415f19783a7",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0136",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999352"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "136"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999352"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "136"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6179fefaf9c60c4a862df01568a93c88",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:ad7c299b4aa35cd98fdbd415f19783a7",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:a1eaf067aa20aea18c22e185e1ee2f97",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:fe8b635d8a705b40fb4ced016e9d726a",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0137",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.555152912425081"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999842626"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.654795742860352"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "137"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.555152912425081"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999842626"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.654795742860352"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "137"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a1eaf067aa20aea18c22e185e1ee2f97",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:fe8b635d8a705b40fb4ced016e9d726a",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:e3d6362d81a3c6aaee10e57f2d21a4b6",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:71e15e602f95bdd78bc912bf527abf9d",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0138",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999352"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "138"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999352"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "138"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e3d6362d81a3c6aaee10e57f2d21a4b6",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:71e15e602f95bdd78bc912bf527abf9d",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:d40597f499b8e4493f5c750b1bb49759",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:46e2492f096548abf33dea89e7a868bc",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0139",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999352"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "139"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999352"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "139"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d40597f499b8e4493f5c750b1bb49759",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:46e2492f096548abf33dea89e7a868bc",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:965898643a16b92a90cc3cfaafcd3c48",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f234bb306a90feca64756c5add571e95",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0140",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.555152912425081"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999842626"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.654795742860352"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "140"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.555152912425081"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999842626"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.654795742860352"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "140"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:965898643a16b92a90cc3cfaafcd3c48",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:f234bb306a90feca64756c5add571e95",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:d1ba7d5acbc118fa7879e7e4e6844b1d",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:9a23d6bdea30bc505d71bdea4b14cc81",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0141",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.555152912425081"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999842626"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.654795742860352"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "141"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.555152912425081"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999842626"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.654795742860352"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "141"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d1ba7d5acbc118fa7879e7e4e6844b1d",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:9a23d6bdea30bc505d71bdea4b14cc81",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:a9f3103d256c0dc28abb00c6f6a495ee",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:55a2e8a69b22f0385eb446ff36f57cd5",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0142",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999352"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "142"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999352"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "142"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a9f3103d256c0dc28abb00c6f6a495ee",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:55a2e8a69b22f0385eb446ff36f57cd5",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:a6963a6fd81257c75c10efb4a812813d",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c1b67e6fa1bc1b0441ef946f06fc7939",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0143",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999352"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "143"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999352"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "143"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a6963a6fd81257c75c10efb4a812813d",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:c1b67e6fa1bc1b0441ef946f06fc7939",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:60ac234a805ede443ca63c3de0f14e32",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:598d8f8cb448fe66f29b80c3e9c6b8c7",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0144",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0609954180147001"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.392898461436365"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999884635261"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.60244430753576"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "144"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0609954180147001"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.392898461436365"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999884635261"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.60244430753576"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "144"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:60ac234a805ede443ca63c3de0f14e32",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:598d8f8cb448fe66f29b80c3e9c6b8c7",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:c00dd1395bbc6f074ad431089be26084",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:9e74994c43b00fa8f3c04ed564b75259",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0145",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999352"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "145"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999352"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "145"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c00dd1395bbc6f074ad431089be26084",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:9e74994c43b00fa8f3c04ed564b75259",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:911801103dad8b9c7f55df419fdee788",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:59f7c04e9a6910158fa3c13760b2a417",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0146",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.555152912425081"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999842626"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.654795742860352"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "146"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.555152912425081"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999842626"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.654795742860352"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "146"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:911801103dad8b9c7f55df419fdee788",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:59f7c04e9a6910158fa3c13760b2a417",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:48d4b018c043db4e0876cc1418962d0a",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:81a8b467cb1446f1ff5cdaa2c7d6e479",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0147",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.555152912425081"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999842626"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.654795742860352"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "147"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.555152912425081"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999842626"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.654795742860352"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "147"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:48d4b018c043db4e0876cc1418962d0a",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:81a8b467cb1446f1ff5cdaa2c7d6e479",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:7c2265b55eb6b5357939defcb818c9dd",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:b6cb8a909916808e62aec6d7aa7ee1b8",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0148",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999352"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "148"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999352"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "148"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7c2265b55eb6b5357939defcb818c9dd",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:b6cb8a909916808e62aec6d7aa7ee1b8",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:1f5d5a2bac2575d7232fa251d172c68f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:50e1d73ec7323535a313db319aa8fda1",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0149",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "6"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0914931270220502"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.294006431429813"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999993568085853"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.520165224837362"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "149"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "6"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0914931270220502"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.294006431429813"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999993568085853"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.520165224837362"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "149"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1f5d5a2bac2575d7232fa251d172c68f",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:50e1d73ec7323535a313db319aa8fda1",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:12c379cdb678fa3f360c5174016779ac",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:7dcc4c8a94cbe8b1b1f9e1f46a8741d3",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0150",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.555152912425081"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999842626"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.654795742860352"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "150"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.555152912425081"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999842626"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.654795742860352"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "150"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:12c379cdb678fa3f360c5174016779ac",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:7dcc4c8a94cbe8b1b1f9e1f46a8741d3",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:7238de23a632331ed72cd39240a7d4d5",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:b54fdacdf6871d0d178386e52e6bcf8e",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0151",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0457465635110251"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.462472368627877"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999993184233"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.654795742860352"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "151"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0457465635110251"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.462472368627877"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999993184233"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.654795742860352"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "151"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7238de23a632331ed72cd39240a7d4d5",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:b54fdacdf6871d0d178386e52e6bcf8e",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:90c9af05cf8cff54600fa41f0a61a708",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:22043ef18c61c537ac8a05e639b5f722",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0152",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "5"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0762442725183751"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.338223691582417"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999998934538669"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.576232956029303"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "152"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "5"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0762442725183751"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.338223691582417"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999998934538669"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.576232956029303"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "152"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:90c9af05cf8cff54600fa41f0a61a708",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:22043ef18c61c537ac8a05e639b5f722",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:1aab52c0fe0f750adfdb1e30721e6758",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:fd886d44827bbf7fd4cd36a6fa24a0dc",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0153",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999352"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "153"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999352"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "153"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1aab52c0fe0f750adfdb1e30721e6758",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:fd886d44827bbf7fd4cd36a6fa24a0dc",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:08248410e312407cc447ee8d99d1d449",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:e782c57868e4be48647d27ca19f3f3c2",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0154",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0457465635110251"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.462472368627877"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999993184233"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.654795742860352"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "154"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0457465635110251"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.462472368627877"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999993184233"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.654795742860352"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "154"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:08248410e312407cc447ee8d99d1d449",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:e782c57868e4be48647d27ca19f3f3c2",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:837d994ade992773480832f35a3ea15b",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f434c353ca0df61bb269a9c7f670117c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0155",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.555152912425081"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999842626"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.654795742860352"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "155"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.555152912425081"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999842626"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.654795742860352"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "155"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:837d994ade992773480832f35a3ea15b",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:f434c353ca0df61bb269a9c7f670117c",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:ec417a43750788f61cf51df2e50808c5",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:0ccff4009d26155a785837676412d40e",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0156",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.555152912425081"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999842626"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.654795742860352"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "156"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.555152912425081"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999842626"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.654795742860352"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "156"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ec417a43750788f61cf51df2e50808c5",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:0ccff4009d26155a785837676412d40e",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:5f3c04257193f8ded9ef85828608888b",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:800c8b037dc30701b156bb7c32952fad",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0157",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.555152912425081"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999842626"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.654795742860352"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "157"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.555152912425081"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999842626"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.654795742860352"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "157"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5f3c04257193f8ded9ef85828608888b",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:800c8b037dc30701b156bb7c32952fad",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:d50af5499fc7c0898889af641bf5dae2",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:783b5fc0e23ce088341f9b979cd6ab07",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0158",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999352"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "158"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999352"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "158"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d50af5499fc7c0898889af641bf5dae2",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:783b5fc0e23ce088341f9b979cd6ab07",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:301ccd51f1c98193e0b8474c0344334b",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:eeecebef37458a809e6ef90a22514949",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0159",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.555152912425081"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999842626"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.654795742860352"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "159"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.555152912425081"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999842626"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.654795742860352"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "159"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:301ccd51f1c98193e0b8474c0344334b",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:eeecebef37458a809e6ef90a22514949",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:005ca6c90e1fc6c5ee2dad1ef8e090a4",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:9e9084297f3aec6679c40f52af1c9c5c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0160",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.555152912425081"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999842626"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.654795742860352"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "160"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.555152912425081"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999842626"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.654795742860352"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "160"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:005ca6c90e1fc6c5ee2dad1ef8e090a4",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:9e9084297f3aec6679c40f52af1c9c5c",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:fc3a8b55f288365aa4cfd22a7a666181",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:dc54137a08092762cc961c9285859566",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0161",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999352"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "161"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999352"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "161"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:fc3a8b55f288365aa4cfd22a7a666181",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:dc54137a08092762cc961c9285859566",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:e47c402c0100f7defbaf50bdcc093c1b",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:9ff86139e0b5b4951d06b07e9a923ed4",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0162",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999352"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "162"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999352"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "162"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e47c402c0100f7defbaf50bdcc093c1b",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:9ff86139e0b5b4951d06b07e9a923ed4",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:db2fdb0a656161d3af9766d9e89d922c",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:8a8ea66289482bc8790b162d4c9789ef",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0163",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.555152912425081"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999842626"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.654795742860352"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "163"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.555152912425081"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999842626"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.654795742860352"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "163"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:db2fdb0a656161d3af9766d9e89d922c",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:8a8ea66289482bc8790b162d4c9789ef",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:9999ed39d65e3e020fe7293a38d50b01",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:05c885a40fe6550c25d2a55d7c3808dc",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0164",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.555152912425081"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999842626"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.654795742860352"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "164"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.555152912425081"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999842626"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.654795742860352"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "164"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9999ed39d65e3e020fe7293a38d50b01",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:05c885a40fe6550c25d2a55d7c3808dc",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:ef7b89c154bf8954bad4e84699ecd010",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:1285ada80442ae469e874ddbb7e341cc",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0165",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.555152912425081"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999842626"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.654795742860352"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "165"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.555152912425081"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999842626"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.654795742860352"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "165"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ef7b89c154bf8954bad4e84699ecd010",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:1285ada80442ae469e874ddbb7e341cc",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:202b2ec8923685d33ff8474567fb097f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:7fb9b0874581a71159fdd853f93751f2",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0166",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999352"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "166"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999352"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "166"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:202b2ec8923685d33ff8474567fb097f",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:7fb9b0874581a71159fdd853f93751f2",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:5e31db36bebfe06aef3ad33a08c38510",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:62b88250957696695608f4f9d5c33c94",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0167",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.555152912425081"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999842626"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.654795742860352"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "167"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.555152912425081"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999842626"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.654795742860352"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "167"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5e31db36bebfe06aef3ad33a08c38510",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:62b88250957696695608f4f9d5c33c94",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:c57896abf584d2b1a83fb9ad3c827d15",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:11a529a736c285cc9a00cdcf5fb4962d",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0168",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.555152912425081"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999842626"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.654795742860352"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "168"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.555152912425081"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999842626"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.654795742860352"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "168"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c57896abf584d2b1a83fb9ad3c827d15",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:11a529a736c285cc9a00cdcf5fb4962d",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:ea8d2f5330ef8fd7ac99fb062748cba2",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:56c0d386be3b33d6180c1118121d2610",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0169",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999352"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "169"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999352"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "169"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ea8d2f5330ef8fd7ac99fb062748cba2",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:56c0d386be3b33d6180c1118121d2610",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:c638448ba82adee617884aeddb79eb28",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:d285ba30108c36cd9e0a52ef7d0d4cec",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0170",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0457465635110251"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.462472368627877"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999993184233"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.654795742860352"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "170"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0457465635110251"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.462472368627877"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999993184233"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.654795742860352"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "170"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c638448ba82adee617884aeddb79eb28",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:d285ba30108c36cd9e0a52ef7d0d4cec",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:4d95857f68b5b80d99c4947f63e88283",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:d38a6da35a3b35e251b575be2481d895",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0171",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.555152912425081"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999842626"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.654795742860352"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "171"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.555152912425081"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999842626"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.654795742860352"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "171"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4d95857f68b5b80d99c4947f63e88283",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:d38a6da35a3b35e251b575be2481d895",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:ef0d129d225ab1994fdabef30426f127",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:4f56e832e623fb38abb2d199755b3aa5",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0172",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999352"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "172"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999352"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "172"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ef0d129d225ab1994fdabef30426f127",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:4f56e832e623fb38abb2d199755b3aa5",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:48094119160b8ddede68780fbf27c3d9",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:92f563ca517a60ccfbb3ef7b2af62dac",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0173",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999352"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "173"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999352"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "173"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:48094119160b8ddede68780fbf27c3d9",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:92f563ca517a60ccfbb3ef7b2af62dac",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:494d564667be2308342989663d3f52ff",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:8600387b3b7cea249641e5cdebba0daa",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0174",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999352"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "174"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999352"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "174"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:494d564667be2308342989663d3f52ff",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:8600387b3b7cea249641e5cdebba0daa",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:ea21239ad949045b078440398a34a9c6",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:0f7371e43c32093550d9b7e335f29fdd",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0175",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0457465635110251"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.462472368627877"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999993184233"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.654795742860352"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "175"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0457465635110251"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.462472368627877"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999993184233"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.654795742860352"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "175"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ea21239ad949045b078440398a34a9c6",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:0f7371e43c32093550d9b7e335f29fdd",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:db760edea5f4f806e9afd9a12723ee09",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:60ee0a470203bf71030d2277a3fde6c3",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0176",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.555152912425081"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999842626"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.654795742860352"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "176"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.555152912425081"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999842626"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.654795742860352"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "176"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:db760edea5f4f806e9afd9a12723ee09",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:60ee0a470203bf71030d2277a3fde6c3",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:5bbac11b8bfa6c995310ee87183ab4d6",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:7cded2bfb4aacaabc3212bf6e55636da",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0177",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.555152912425081"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999842626"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.654795742860352"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "177"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.555152912425081"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999842626"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.654795742860352"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "177"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5bbac11b8bfa6c995310ee87183ab4d6",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:7cded2bfb4aacaabc3212bf6e55636da",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:3f3b062de3ba5acf073f1b59cfb5a6e6",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:56d77ed8a1025508e9f36442b2aa1001",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0178",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.555152912425081"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999842626"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.654795742860352"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "178"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.555152912425081"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999842626"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.654795742860352"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "178"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3f3b062de3ba5acf073f1b59cfb5a6e6",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:56d77ed8a1025508e9f36442b2aa1001",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:39a4606d938ba1ca81229a71c823e41d",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:5debe73d92bf3a2e632b239ed32da2c4",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0179",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999352"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "179"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999352"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "179"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:39a4606d938ba1ca81229a71c823e41d",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:5debe73d92bf3a2e632b239ed32da2c4",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:a49d384fb03c39001132a62f5ee742ce",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f3bc76ba4a3df529282c2ee84c68df86",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0180",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999352"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "180"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999352"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "180"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a49d384fb03c39001132a62f5ee742ce",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:f3bc76ba4a3df529282c2ee84c68df86",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:1df9ca7cc28a8741906406c23e450c49",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:28bbba0604724f0b5ea3c95637660afa",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0181",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999352"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "181"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999352"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "181"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1df9ca7cc28a8741906406c23e450c49",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:28bbba0604724f0b5ea3c95637660afa",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:b3a0d8de966bc74adb169669f1390504",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:e2e08d4842a9d04eb18949c6410171c2",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0182",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999352"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "182"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999352"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "182"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b3a0d8de966bc74adb169669f1390504",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:e2e08d4842a9d04eb18949c6410171c2",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:070e421862800af00c11e7304e4407bb",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:21fbadccdcf80825edc168ed54a646dd",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0183",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999352"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "183"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999352"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "183"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:070e421862800af00c11e7304e4407bb",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:21fbadccdcf80825edc168ed54a646dd",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:93297a88c8e657de407b42d03cd7f823",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:37a7db920a02cc0218b6f2862406e37a",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0184",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999352"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.690223976658915"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "184"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999352"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.690223976658915"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "184"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:93297a88c8e657de407b42d03cd7f823",
-      "entity": "niiri:5c3a280abdc45cbf2db33ae481f80003"
+      "entity_derived": "niiri:37a7db920a02cc0218b6f2862406e37a",
+      "entity": "niiri:4391a2ef60f122937f69c2336ae7251d"
     },
     {
-      "@id": "niiri:1ad729b1a9263ed5d09311c4d445786c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:15408ee32b85d99dd9469a376a205277",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0001",
-      "prov:atLocation": {"@id": "niiri:1cd3079cb752db2e6f39d53c29f0b9ea"},
+      "prov:atLocation": {"@id": "niiri:0641f44bc1cc38d2f46b260ac05dd0d0"},
       "prov:value": {"@type": "xsd:float", "@value": "63.4091377258301"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "6.87763687596762"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.0426772212877e-12"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "6.78640924345331e-07"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "7.69046642070356e-06"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "6.87763687596762"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.0426772212877e-12"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "6.78640924345331e-07"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "7.69046642070356e-06"}
     },
     {
-      "@id": "niiri:1cd3079cb752db2e6f39d53c29f0b9ea",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0641f44bc1cc38d2f46b260ac05dd0d0",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0001",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[30,-82,-32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[30,-82,-32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1ad729b1a9263ed5d09311c4d445786c",
-      "entity": "niiri:651d36d872d7daabb7dba2117ccd0147"
+      "entity_derived": "niiri:15408ee32b85d99dd9469a376a205277",
+      "entity": "niiri:a02993e23816e346753a88b23cc8928d"
     },
     {
-      "@id": "niiri:145d15104600c06d595e2959214660f0",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:6339834c453190a84e0be6fb23a08d7b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0002",
-      "prov:atLocation": {"@id": "niiri:e6eb5f01ff0031ff4c2360df47a2d7b9"},
+      "prov:atLocation": {"@id": "niiri:a391976265e9c457b429d33fcbc53448"},
       "prov:value": {"@type": "xsd:float", "@value": "34.330680847168"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.28627890808187"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.24147619143756e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0123751495969127"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00298745408887002"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.28627890808187"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.24147619143756e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0123751495969127"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00298745408887002"}
     },
     {
-      "@id": "niiri:e6eb5f01ff0031ff4c2360df47a2d7b9",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a391976265e9c457b429d33fcbc53448",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0002",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[30,-74,-20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[30,-74,-20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:145d15104600c06d595e2959214660f0",
-      "entity": "niiri:651d36d872d7daabb7dba2117ccd0147"
+      "entity_derived": "niiri:6339834c453190a84e0be6fb23a08d7b",
+      "entity": "niiri:a02993e23816e346753a88b23cc8928d"
     },
     {
-      "@id": "niiri:ab7381fb540a83aff37aa2e379fe46f0",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:fc608ab17d14b0216545bc760bc76351",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0003",
-      "prov:atLocation": {"@id": "niiri:90bbb6afadfd2bed6ba4ba8364ef6b0e"},
+      "prov:atLocation": {"@id": "niiri:458bef7562a6ed14ea6c60927fd8bf32"},
       "prov:value": {"@type": "xsd:float", "@value": "32.5551681518555"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.16035838696565"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.2323877274234e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0224930278720513"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00456113578807012"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.16035838696565"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.2323877274234e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0224930278720513"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00456113578807012"}
     },
     {
-      "@id": "niiri:90bbb6afadfd2bed6ba4ba8364ef6b0e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:458bef7562a6ed14ea6c60927fd8bf32",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0003",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[54,-56,-34]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[54,-56,-34]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ab7381fb540a83aff37aa2e379fe46f0",
-      "entity": "niiri:651d36d872d7daabb7dba2117ccd0147"
+      "entity_derived": "niiri:fc608ab17d14b0216545bc760bc76351",
+      "entity": "niiri:a02993e23816e346753a88b23cc8928d"
     },
     {
-      "@id": "niiri:c32cd83c477444569ca2477bf81b2a88",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:360c87bfdf28bfd144d5781923cd8ac1",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0004",
-      "prov:atLocation": {"@id": "niiri:a2f25c4463c4698eaaa3e399732c09ec"},
+      "prov:atLocation": {"@id": "niiri:4f45e9467d9e02d216ecae26355acbf6"},
       "prov:value": {"@type": "xsd:float", "@value": "63.223461151123"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "6.86947288292734"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.22197823976467e-12"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "7.18635271623747e-07"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "7.69046642070356e-06"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "6.86947288292734"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.22197823976467e-12"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "7.18635271623747e-07"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "7.69046642070356e-06"}
     },
     {
-      "@id": "niiri:a2f25c4463c4698eaaa3e399732c09ec",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4f45e9467d9e02d216ecae26355acbf6",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0004",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-4,-86,42]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-4,-86,42]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c32cd83c477444569ca2477bf81b2a88",
-      "entity": "niiri:7f4e9fb870f5c98792fa6bf0f88370fb"
+      "entity_derived": "niiri:360c87bfdf28bfd144d5781923cd8ac1",
+      "entity": "niiri:1fb6d1d0216b48739f26ab81c9d1d36e"
     },
     {
-      "@id": "niiri:c7402cd815b21a13269235eacad1f7f8",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a998ae1169d6a1bfd5bc42c534c9ce86",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0005",
-      "prov:atLocation": {"@id": "niiri:7978c6257d052d04738b9f1a9744d852"},
+      "prov:atLocation": {"@id": "niiri:1d2c00421e4eb30b21b92956b0d1a751"},
       "prov:value": {"@type": "xsd:float", "@value": "59.1932106018066"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "6.68743781613539"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.1355583140471e-11"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "2.5328927799606e-06"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1.2812091676231e-05"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "6.68743781613539"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.1355583140471e-11"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "2.5328927799606e-06"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1.2812091676231e-05"}
     },
     {
-      "@id": "niiri:7978c6257d052d04738b9f1a9744d852",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:1d2c00421e4eb30b21b92956b0d1a751",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0005",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-4,-64,62]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-4,-64,62]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c7402cd815b21a13269235eacad1f7f8",
-      "entity": "niiri:7f4e9fb870f5c98792fa6bf0f88370fb"
+      "entity_derived": "niiri:a998ae1169d6a1bfd5bc42c534c9ce86",
+      "entity": "niiri:1fb6d1d0216b48739f26ab81c9d1d36e"
     },
     {
-      "@id": "niiri:9e7ce398a2ef8b1fe239a4553ed8f749",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:8c4b10f0f0d23304c6889f254b8b1f11",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0006",
-      "prov:atLocation": {"@id": "niiri:4203a80796c8345b0e9bdc9b1aa3b2e7"},
+      "prov:atLocation": {"@id": "niiri:4513a5af88ce9b4dea2229e2abbdb320"},
       "prov:value": {"@type": "xsd:float", "@value": "54.7871932983398"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "6.47692789306752"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.680444920524e-11"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1.04400104977698e-05"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "3.92759435111279e-05"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "6.47692789306752"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.680444920524e-11"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1.04400104977698e-05"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "3.92759435111279e-05"}
     },
     {
-      "@id": "niiri:4203a80796c8345b0e9bdc9b1aa3b2e7",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4513a5af88ce9b4dea2229e2abbdb320",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0006",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-30,-80,46]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-30,-80,46]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9e7ce398a2ef8b1fe239a4553ed8f749",
-      "entity": "niiri:7f4e9fb870f5c98792fa6bf0f88370fb"
+      "entity_derived": "niiri:8c4b10f0f0d23304c6889f254b8b1f11",
+      "entity": "niiri:1fb6d1d0216b48739f26ab81c9d1d36e"
     },
     {
-      "@id": "niiri:5ee1f8d731e1ff5d356efe2b97a98c4b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:fd91d07679d40254e3422190a6146551",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0007",
-      "prov:atLocation": {"@id": "niiri:43cbf9c937f77f8f3111c53fea2726a2"},
+      "prov:atLocation": {"@id": "niiri:8163502ef4eb2bd47c0afd06aa34e260"},
       "prov:value": {"@type": "xsd:float", "@value": "62.7276649475098"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "6.84758591415851"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.75532938079459e-12"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "8.37602977088459e-07"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "7.69046642070356e-06"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "6.84758591415851"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.75532938079459e-12"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "8.37602977088459e-07"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "7.69046642070356e-06"}
     },
     {
-      "@id": "niiri:43cbf9c937f77f8f3111c53fea2726a2",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:8163502ef4eb2bd47c0afd06aa34e260",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0007",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[46,16,24]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[46,16,24]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5ee1f8d731e1ff5d356efe2b97a98c4b",
-      "entity": "niiri:284d49d49a311520554c2b72c79155a5"
+      "entity_derived": "niiri:fd91d07679d40254e3422190a6146551",
+      "entity": "niiri:513b4dd1fd53a8b3917570bbd44a1da7"
     },
     {
-      "@id": "niiri:3369f244119ffdeef13b1e360cf6619a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:78698a7744e2e52357780a5302642060",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0008",
-      "prov:atLocation": {"@id": "niiri:f0aae1de8a4ec1ad4e4ce4de228f83d6"},
+      "prov:atLocation": {"@id": "niiri:98338f9e531b28eb906487132e15e34f"},
       "prov:value": {"@type": "xsd:float", "@value": "24.248779296875"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.49788176431045"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.43169230909712e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.337713339570932"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0315627223093611"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.49788176431045"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.43169230909712e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.337713339570932"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0315627223093611"}
     },
     {
-      "@id": "niiri:f0aae1de8a4ec1ad4e4ce4de228f83d6",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:98338f9e531b28eb906487132e15e34f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0008",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[52,30,20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[52,30,20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3369f244119ffdeef13b1e360cf6619a",
-      "entity": "niiri:284d49d49a311520554c2b72c79155a5"
+      "entity_derived": "niiri:78698a7744e2e52357780a5302642060",
+      "entity": "niiri:513b4dd1fd53a8b3917570bbd44a1da7"
     },
     {
-      "@id": "niiri:6e25d0b91bf2ce19599d87d9efd5a15e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:7b293150101749bc3e0a5b062221e484",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0009",
-      "prov:atLocation": {"@id": "niiri:eb27e419063e80cd2385a42440d7284c"},
+      "prov:atLocation": {"@id": "niiri:a69afafa9366b5b57795632c3b4e962c"},
       "prov:value": {"@type": "xsd:float", "@value": "23.2752456665039"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.41058321872095"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.15462881078843e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.441809153541913"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0401580107168157"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.41058321872095"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.15462881078843e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.441809153541913"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0401580107168157"}
     },
     {
-      "@id": "niiri:eb27e419063e80cd2385a42440d7284c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a69afafa9366b5b57795632c3b4e962c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0009",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[56,18,8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[56,18,8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6e25d0b91bf2ce19599d87d9efd5a15e",
-      "entity": "niiri:284d49d49a311520554c2b72c79155a5"
+      "entity_derived": "niiri:7b293150101749bc3e0a5b062221e484",
+      "entity": "niiri:513b4dd1fd53a8b3917570bbd44a1da7"
     },
     {
-      "@id": "niiri:593485f29d2b0c951bdfac03fc11c663",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d13ff858d119b29455bfd66007ccda04",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0010",
-      "prov:atLocation": {"@id": "niiri:108eb5c0731eb38f8865c8df4f845eed"},
+      "prov:atLocation": {"@id": "niiri:4b5f03880a32d3c6ecb349f93624a7fa"},
       "prov:value": {"@type": "xsd:float", "@value": "53.7021408081055"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "6.4230764301046"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.67736976822653e-11"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1.48942911553096e-05"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "4.66369239309748e-05"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "6.4230764301046"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.67736976822653e-11"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1.48942911553096e-05"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "4.66369239309748e-05"}
     },
     {
-      "@id": "niiri:108eb5c0731eb38f8865c8df4f845eed",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4b5f03880a32d3c6ecb349f93624a7fa",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0010",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-46,-78,24]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-46,-78,24]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:593485f29d2b0c951bdfac03fc11c663",
-      "entity": "niiri:42c8820b665da5b8d98f4ce5fcb8de2d"
+      "entity_derived": "niiri:d13ff858d119b29455bfd66007ccda04",
+      "entity": "niiri:0383eb2fc5ee76be5634bfee80f2ca3b"
     },
     {
-      "@id": "niiri:8647615bdccf00383af5ede801d4cd56",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:fd5511cc6e2bfdffd9438532ea9e531a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0011",
-      "prov:atLocation": {"@id": "niiri:8d711debd43eb5904b0ca65c16d9940a"},
+      "prov:atLocation": {"@id": "niiri:0e6a1706845dc9fd273961896d6d0a14"},
       "prov:value": {"@type": "xsd:float", "@value": "50.6493988037109"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "6.26694330529563"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.84102066924652e-10"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "4.10652052134086e-05"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "9.17691949136767e-05"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "6.26694330529563"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.84102066924652e-10"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "4.10652052134086e-05"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "9.17691949136767e-05"}
     },
     {
-      "@id": "niiri:8d711debd43eb5904b0ca65c16d9940a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0e6a1706845dc9fd273961896d6d0a14",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0011",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[34,-88,-2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[34,-88,-2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8647615bdccf00383af5ede801d4cd56",
-      "entity": "niiri:7e43e146a206ef37a717db06b7c719b8"
+      "entity_derived": "niiri:fd5511cc6e2bfdffd9438532ea9e531a",
+      "entity": "niiri:e67cada24205233131c2bfe154669c61"
     },
     {
-      "@id": "niiri:35811f25295d140b23f0ba5c711fd12c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c5b79c6acbda7306e022436ba2ff08ea",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0012",
-      "prov:atLocation": {"@id": "niiri:a8420206394c401da4a17097322c3b08"},
+      "prov:atLocation": {"@id": "niiri:1c858f13a6a8dd1ed4f691dbb61441ff"},
       "prov:value": {"@type": "xsd:float", "@value": "42.0282821655273"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.78380990161557"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.65137320379461e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00081446430319021"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000655649142634339"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.78380990161557"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.65137320379461e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00081446430319021"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000655649142634339"}
     },
     {
-      "@id": "niiri:a8420206394c401da4a17097322c3b08",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:1c858f13a6a8dd1ed4f691dbb61441ff",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0012",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[42,-72,-10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[42,-72,-10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:35811f25295d140b23f0ba5c711fd12c",
-      "entity": "niiri:7e43e146a206ef37a717db06b7c719b8"
+      "entity_derived": "niiri:c5b79c6acbda7306e022436ba2ff08ea",
+      "entity": "niiri:e67cada24205233131c2bfe154669c61"
     },
     {
-      "@id": "niiri:1a8e8acc36a5b6c46aa24ba76ab69931",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:93f22f5d612344b81124870b08ecc87e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0013",
-      "prov:atLocation": {"@id": "niiri:00fdca4dac7efb2179e283d653684982"},
+      "prov:atLocation": {"@id": "niiri:8c19f2d54053cf0b01e427341923ddb7"},
       "prov:value": {"@type": "xsd:float", "@value": "27.3277149200439"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.75932547479613"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "9.71204984545615e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.129624789952327"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0155044826465378"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.75932547479613"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "9.71204984545615e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.129624789952327"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0155044826465378"}
     },
     {
-      "@id": "niiri:00fdca4dac7efb2179e283d653684982",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:8c19f2d54053cf0b01e427341923ddb7",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0013",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[34,-86,12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[34,-86,12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1a8e8acc36a5b6c46aa24ba76ab69931",
-      "entity": "niiri:7e43e146a206ef37a717db06b7c719b8"
+      "entity_derived": "niiri:93f22f5d612344b81124870b08ecc87e",
+      "entity": "niiri:e67cada24205233131c2bfe154669c61"
     },
     {
-      "@id": "niiri:cb47ae16504ee86bdbe1cea951f05d08",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:46fc5c23e8aa00759077219a8ff53cba",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0014",
-      "prov:atLocation": {"@id": "niiri:4617ba0c314a173227fbd8f2bf21e0c0"},
+      "prov:atLocation": {"@id": "niiri:e72913318bdae423d898d64f71c73ee3"},
       "prov:value": {"@type": "xsd:float", "@value": "49.6541976928711"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "6.21449041258159"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.574573887415e-10"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "5.74276232319093e-05"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000101984986721175"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "6.21449041258159"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.574573887415e-10"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "5.74276232319093e-05"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000101984986721175"}
     },
     {
-      "@id": "niiri:4617ba0c314a173227fbd8f2bf21e0c0",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e72913318bdae423d898d64f71c73ee3",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0014",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[20,-58,-50]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[20,-58,-50]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cb47ae16504ee86bdbe1cea951f05d08",
-      "entity": "niiri:4e4ee541dcb7596b480cb3aebb5ec524"
+      "entity_derived": "niiri:46fc5c23e8aa00759077219a8ff53cba",
+      "entity": "niiri:a3635579e9882ee1f3c09824008b66b4"
     },
     {
-      "@id": "niiri:7352ae583383da450074239b69227dbb",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:7908619b88ba244bd93c6dba0bbb87e6",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0015",
-      "prov:atLocation": {"@id": "niiri:b61c39fa67e052055981497233c2b7d2"},
+      "prov:atLocation": {"@id": "niiri:c1e24413c80edd5055adad6446606542"},
       "prov:value": {"@type": "xsd:float", "@value": "37.7286491394043"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.51490684020097"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.74482378545449e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00389195156635691"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00135850417567201"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.51490684020097"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.74482378545449e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00389195156635691"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00135850417567201"}
     },
     {
-      "@id": "niiri:b61c39fa67e052055981497233c2b7d2",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c1e24413c80edd5055adad6446606542",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0015",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-28,-46,-44]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-28,-46,-44]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7352ae583383da450074239b69227dbb",
-      "entity": "niiri:4e4ee541dcb7596b480cb3aebb5ec524"
+      "entity_derived": "niiri:7908619b88ba244bd93c6dba0bbb87e6",
+      "entity": "niiri:a3635579e9882ee1f3c09824008b66b4"
     },
     {
-      "@id": "niiri:a8f7ff25ee2eec409fd770cbee1a5a51",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c5f3e3a0fd6c3b436aae4cb7598c34c9",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0016",
-      "prov:atLocation": {"@id": "niiri:00219d6515673b5f9b9cdcf9e0ae68b3"},
+      "prov:atLocation": {"@id": "niiri:100f5aac01b00bba82ce7d02dad389fd"},
       "prov:value": {"@type": "xsd:float", "@value": "36.3174209594727"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.42181897111099"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.94978058645867e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0063697813576209"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00184664824144078"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.42181897111099"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.94978058645867e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0063697813576209"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00184664824144078"}
     },
     {
-      "@id": "niiri:00219d6515673b5f9b9cdcf9e0ae68b3",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:100f5aac01b00bba82ce7d02dad389fd",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0016",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[24,-48,-52]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[24,-48,-52]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a8f7ff25ee2eec409fd770cbee1a5a51",
-      "entity": "niiri:4e4ee541dcb7596b480cb3aebb5ec524"
+      "entity_derived": "niiri:c5f3e3a0fd6c3b436aae4cb7598c34c9",
+      "entity": "niiri:a3635579e9882ee1f3c09824008b66b4"
     },
     {
-      "@id": "niiri:f2577dcf463bf25350ef976435690d84",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a49cb1b476653b5bd0a7cc950718a0ff",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0017",
-      "prov:atLocation": {"@id": "niiri:ab378512d8e136af08169d05b2ec2611"},
+      "prov:atLocation": {"@id": "niiri:bbb63b81e8f877c8efc6acbf7b6623b9"},
       "prov:value": {"@type": "xsd:float", "@value": "46.5456809997559"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "6.04535479047381"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.45407846558521e-10"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.000166268388501201"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000246160584800799"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "6.04535479047381"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.45407846558521e-10"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.000166268388501201"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000246160584800799"}
     },
     {
-      "@id": "niiri:ab378512d8e136af08169d05b2ec2611",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:bbb63b81e8f877c8efc6acbf7b6623b9",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0017",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-32,-90,22]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-32,-90,22]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f2577dcf463bf25350ef976435690d84",
-      "entity": "niiri:78e7ba6b5db9ff6ef88f595eef8c1789"
+      "entity_derived": "niiri:a49cb1b476653b5bd0a7cc950718a0ff",
+      "entity": "niiri:c50d34609678664d461509f54c79eea7"
     },
     {
-      "@id": "niiri:370905ec9a39617e4bda707de93ec7ca",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3e717c804be08adc2679246149af5db7",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0018",
-      "prov:atLocation": {"@id": "niiri:13246d6248cd3d6c599d17e0db1435f9"},
+      "prov:atLocation": {"@id": "niiri:101ef180b33241930bb79e194dcbbed9"},
       "prov:value": {"@type": "xsd:float", "@value": "41.0003623962402"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.72141667593276"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.28197319216162e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00117818104479539"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000789910490520138"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.72141667593276"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.28197319216162e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00117818104479539"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000789910490520138"}
     },
     {
-      "@id": "niiri:13246d6248cd3d6c599d17e0db1435f9",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:101ef180b33241930bb79e194dcbbed9",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0018",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-18,-100,14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-18,-100,14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:370905ec9a39617e4bda707de93ec7ca",
-      "entity": "niiri:78e7ba6b5db9ff6ef88f595eef8c1789"
+      "entity_derived": "niiri:3e717c804be08adc2679246149af5db7",
+      "entity": "niiri:c50d34609678664d461509f54c79eea7"
     },
     {
-      "@id": "niiri:1985ca322dad916f2dc1a4980b292a8f",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:2d6ad9f56e2f5b6c94d89c1ef5625631",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0019",
-      "prov:atLocation": {"@id": "niiri:299aa0c3669c07f81bc6fb0ad3f0eaad"},
+      "prov:atLocation": {"@id": "niiri:d479bae72ae64f4cf25acf6fbff4867f"},
       "prov:value": {"@type": "xsd:float", "@value": "30.2211799621582"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.9872751544685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.06184112175423e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0494340056154295"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00803010760019555"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.9872751544685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.06184112175423e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0494340056154295"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00803010760019555"}
     },
     {
-      "@id": "niiri:299aa0c3669c07f81bc6fb0ad3f0eaad",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d479bae72ae64f4cf25acf6fbff4867f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0019",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-30,-92,12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-30,-92,12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1985ca322dad916f2dc1a4980b292a8f",
-      "entity": "niiri:78e7ba6b5db9ff6ef88f595eef8c1789"
+      "entity_derived": "niiri:2d6ad9f56e2f5b6c94d89c1ef5625631",
+      "entity": "niiri:c50d34609678664d461509f54c79eea7"
     },
     {
-      "@id": "niiri:51ceaf84580ed7b298048fda09805453",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e8ccf7a91909009975707eb5438a1c41",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0020",
-      "prov:atLocation": {"@id": "niiri:14f7786c455797486e51096d023a6749"},
+      "prov:atLocation": {"@id": "niiri:c8e15c365b5b224e2797ad45cf7f4de2"},
       "prov:value": {"@type": "xsd:float", "@value": "41.3373107910156"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.74199410170229"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.67840410856013e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00104355073571449"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000741810621169375"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.74199410170229"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.67840410856013e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00104355073571449"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000741810621169375"}
     },
     {
-      "@id": "niiri:14f7786c455797486e51096d023a6749",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c8e15c365b5b224e2797ad45cf7f4de2",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0020",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-40,-82,-8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-40,-82,-8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:51ceaf84580ed7b298048fda09805453",
-      "entity": "niiri:8170af49aff81684fdb2d887f6db1095"
+      "entity_derived": "niiri:e8ccf7a91909009975707eb5438a1c41",
+      "entity": "niiri:86785a60d43172b11448d491c5ae96dc"
     },
     {
-      "@id": "niiri:eb91d43cfeef4d99c757e6da6c881f5a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:7ebb22fd72bd0789f6bd1e8550c7084c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0021",
-      "prov:atLocation": {"@id": "niiri:b3989deb6f7b20fc2a7daac835687e74"},
+      "prov:atLocation": {"@id": "niiri:59238a22c085684ec58ad478012612fb"},
       "prov:value": {"@type": "xsd:float", "@value": "39.6630401611328"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.63850646223464"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.57656923258787e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00191306375378475"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0009870871843719"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.63850646223464"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.57656923258787e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00191306375378475"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0009870871843719"}
     },
     {
-      "@id": "niiri:b3989deb6f7b20fc2a7daac835687e74",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:59238a22c085684ec58ad478012612fb",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0021",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-34,-68,-10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-34,-68,-10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:eb91d43cfeef4d99c757e6da6c881f5a",
-      "entity": "niiri:8170af49aff81684fdb2d887f6db1095"
+      "entity_derived": "niiri:7ebb22fd72bd0789f6bd1e8550c7084c",
+      "entity": "niiri:86785a60d43172b11448d491c5ae96dc"
     },
     {
-      "@id": "niiri:2a0e74b47e33f43d9f083a3ebb12d695",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:92d02c82b7f90dbed092d3b95cad4470",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0022",
-      "prov:atLocation": {"@id": "niiri:596e679482f1d7fa8baa5f00c151a91a"},
+      "prov:atLocation": {"@id": "niiri:733e8754b4ff170374623f8b270dad17"},
       "prov:value": {"@type": "xsd:float", "@value": "34.0695152282715"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.26805007110655"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.89402515074988e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0135093653627159"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00308832183253126"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.26805007110655"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.89402515074988e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0135093653627159"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00308832183253126"}
     },
     {
-      "@id": "niiri:596e679482f1d7fa8baa5f00c151a91a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:733e8754b4ff170374623f8b270dad17",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0022",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-40,-76,-22]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-40,-76,-22]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2a0e74b47e33f43d9f083a3ebb12d695",
-      "entity": "niiri:8170af49aff81684fdb2d887f6db1095"
+      "entity_derived": "niiri:92d02c82b7f90dbed092d3b95cad4470",
+      "entity": "niiri:86785a60d43172b11448d491c5ae96dc"
     },
     {
-      "@id": "niiri:ff6f6a4c4bfdf0fe50725960fe944ca6",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ac1f6889a3b03207d78c9ad5528f9b90",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0023",
-      "prov:atLocation": {"@id": "niiri:254d2682d5a144ef20099e46bfdc1a27"},
+      "prov:atLocation": {"@id": "niiri:838ab3f78f4c999519706107ecaa6651"},
       "prov:value": {"@type": "xsd:float", "@value": "39.8922958374023"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.65286295967349"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.88985576871681e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00175988750867406"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0009870871843719"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.65286295967349"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.88985576871681e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00175988750867406"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0009870871843719"}
     },
     {
-      "@id": "niiri:254d2682d5a144ef20099e46bfdc1a27",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:838ab3f78f4c999519706107ecaa6651",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0023",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[32,24,-4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[32,24,-4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ff6f6a4c4bfdf0fe50725960fe944ca6",
-      "entity": "niiri:740bf59b1d25123628eef463c4259e34"
+      "entity_derived": "niiri:ac1f6889a3b03207d78c9ad5528f9b90",
+      "entity": "niiri:dded355a673488279610ef537e861858"
     },
     {
-      "@id": "niiri:8e4d07d3bc5930dc8217e347ca18629e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d9645c1bc51e20ae6eda890163cdd768",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0024",
-      "prov:atLocation": {"@id": "niiri:2e89e2c02ad28ca1a272e1073c5753e3"},
+      "prov:atLocation": {"@id": "niiri:9aa5edc1fd84dac2c53c7ba42b273db8"},
       "prov:value": {"@type": "xsd:float", "@value": "32.3555946350098"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.14590447978288"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.33117438405606e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0240593381842931"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00469183536701006"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.14590447978288"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.33117438405606e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0240593381842931"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00469183536701006"}
     },
     {
-      "@id": "niiri:2e89e2c02ad28ca1a272e1073c5753e3",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:9aa5edc1fd84dac2c53c7ba42b273db8",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0024",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[18,16,4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[18,16,4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8e4d07d3bc5930dc8217e347ca18629e",
-      "entity": "niiri:740bf59b1d25123628eef463c4259e34"
+      "entity_derived": "niiri:d9645c1bc51e20ae6eda890163cdd768",
+      "entity": "niiri:dded355a673488279610ef537e861858"
     },
     {
-      "@id": "niiri:3b28f2b6b85307e7c4db65226998e921",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:14dc5bbb6203781bf94b7883581e8d1b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0025",
-      "prov:atLocation": {"@id": "niiri:3c24385914da61858b61de5e8f8e8fef"},
+      "prov:atLocation": {"@id": "niiri:aff5a93c627ebd7f5b8c391f53c40006"},
       "prov:value": {"@type": "xsd:float", "@value": "26.9382591247559"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.72739751788369"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.13707888627079e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.147150618143017"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0165894956342347"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.72739751788369"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.13707888627079e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.147150618143017"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0165894956342347"}
     },
     {
-      "@id": "niiri:3c24385914da61858b61de5e8f8e8fef",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:aff5a93c627ebd7f5b8c391f53c40006",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0025",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[48,28,-14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[48,28,-14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3b28f2b6b85307e7c4db65226998e921",
-      "entity": "niiri:740bf59b1d25123628eef463c4259e34"
+      "entity_derived": "niiri:14dc5bbb6203781bf94b7883581e8d1b",
+      "entity": "niiri:dded355a673488279610ef537e861858"
     },
     {
-      "@id": "niiri:7bc9513b152a52efd9b6697970efbb6a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:4833f73495c82243b6bcc3fb9a23ef06",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0026",
-      "prov:atLocation": {"@id": "niiri:5136316bd9bb72240db547846785b492"},
+      "prov:atLocation": {"@id": "niiri:7b97acac961566aab143009298852de2"},
       "prov:value": {"@type": "xsd:float", "@value": "39.4447784423828"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.62478222171801"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "9.28710763847818e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00207155431898742"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0009870871843719"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.62478222171801"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "9.28710763847818e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00207155431898742"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0009870871843719"}
     },
     {
-      "@id": "niiri:5136316bd9bb72240db547846785b492",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7b97acac961566aab143009298852de2",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0026",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-26,54,-44]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-26,54,-44]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7bc9513b152a52efd9b6697970efbb6a",
-      "entity": "niiri:1b8c8488e08d0790c457517765f898e1"
+      "entity_derived": "niiri:4833f73495c82243b6bcc3fb9a23ef06",
+      "entity": "niiri:c1b3c9780e84e1bcfb3c612aa647510e"
     },
     {
-      "@id": "niiri:cac8b26581e206debe18a5a800fd5f0b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a037c89bf27b3fb47dd39ef32c69f1e8",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0027",
-      "prov:atLocation": {"@id": "niiri:3b6bf80b79156b68f986ef6607de4779"},
+      "prov:atLocation": {"@id": "niiri:e1f6f1196ac80f76a0456036af7a4b8b"},
       "prov:value": {"@type": "xsd:float", "@value": "23.9405002593994"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.47049572345504"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.90192522159438e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.368629337644182"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0337742742636344"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.47049572345504"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.90192522159438e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.368629337644182"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0337742742636344"}
     },
     {
-      "@id": "niiri:3b6bf80b79156b68f986ef6607de4779",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e1f6f1196ac80f76a0456036af7a4b8b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0027",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-32,50,-34]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-32,50,-34]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cac8b26581e206debe18a5a800fd5f0b",
-      "entity": "niiri:1b8c8488e08d0790c457517765f898e1"
+      "entity_derived": "niiri:a037c89bf27b3fb47dd39ef32c69f1e8",
+      "entity": "niiri:c1b3c9780e84e1bcfb3c612aa647510e"
     },
     {
-      "@id": "niiri:487bd84b76361e8216368b31ae09d694",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a30cccdb175a9992ba9c54a7f5f86040",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0028",
-      "prov:atLocation": {"@id": "niiri:99242ae3344afae9c9275a8a5b5fc9c7"},
+      "prov:atLocation": {"@id": "niiri:5b912d29fd13e7d63c52b495d006664f"},
       "prov:value": {"@type": "xsd:float", "@value": "39.4393730163574"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.62444163011351"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "9.30544841182268e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00207564535686733"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0009870871843719"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.62444163011351"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "9.30544841182268e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00207564535686733"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0009870871843719"}
     },
     {
-      "@id": "niiri:99242ae3344afae9c9275a8a5b5fc9c7",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:5b912d29fd13e7d63c52b495d006664f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0028",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[8,18,50]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[8,18,50]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:487bd84b76361e8216368b31ae09d694",
-      "entity": "niiri:9ff5e136f972c43baf0362735367bbdb"
+      "entity_derived": "niiri:a30cccdb175a9992ba9c54a7f5f86040",
+      "entity": "niiri:86886012c734f3d338a1efb48a81145a"
     },
     {
-      "@id": "niiri:4052527fe72d34186f9144bc7efd27ca",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f41be624e1053c51fdbdb702c880be11",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0029",
-      "prov:atLocation": {"@id": "niiri:2691f9d189ed38cd001d6a8184beaa7d"},
+      "prov:atLocation": {"@id": "niiri:e9b06bf73aae5f22582fa6e9a26ee0d0"},
       "prov:value": {"@type": "xsd:float", "@value": "37.8498382568359"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.52278322654796"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.66835655290853e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00372138605145689"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00135850417567201"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.52278322654796"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.66835655290853e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00372138605145689"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00135850417567201"}
     },
     {
-      "@id": "niiri:2691f9d189ed38cd001d6a8184beaa7d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e9b06bf73aae5f22582fa6e9a26ee0d0",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0029",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-6,12,52]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-6,12,52]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4052527fe72d34186f9144bc7efd27ca",
-      "entity": "niiri:9ff5e136f972c43baf0362735367bbdb"
+      "entity_derived": "niiri:f41be624e1053c51fdbdb702c880be11",
+      "entity": "niiri:86886012c734f3d338a1efb48a81145a"
     },
     {
-      "@id": "niiri:f9f053201880a1a84c25c8fbfee294c0",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:30a835006f53ac1656aa862dc46eefb1",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0030",
-      "prov:atLocation": {"@id": "niiri:3af5f8ccfc99ade65319ab76b8184d36"},
+      "prov:atLocation": {"@id": "niiri:668b668695b4f9c1225911b2e3aafc5f"},
       "prov:value": {"@type": "xsd:float", "@value": "35.8222694396973"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.38854316616903"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.55155518327877e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00751236362554308"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00208265173602203"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.38854316616903"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.55155518327877e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00751236362554308"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00208265173602203"}
     },
     {
-      "@id": "niiri:3af5f8ccfc99ade65319ab76b8184d36",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:668b668695b4f9c1225911b2e3aafc5f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0030",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[8,32,38]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[8,32,38]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f9f053201880a1a84c25c8fbfee294c0",
-      "entity": "niiri:9ff5e136f972c43baf0362735367bbdb"
+      "entity_derived": "niiri:30a835006f53ac1656aa862dc46eefb1",
+      "entity": "niiri:86886012c734f3d338a1efb48a81145a"
     },
     {
-      "@id": "niiri:9606f9d15f3bc939ca2851b756c73d5e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0f9e5faadc247bb0f606f8f2783c5dfc",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0031",
-      "prov:atLocation": {"@id": "niiri:33045b6b173ae3c19b060630f6bd98d4"},
+      "prov:atLocation": {"@id": "niiri:19ae5d9dd47ddd4d5cf6d132960e4df6"},
       "prov:value": {"@type": "xsd:float", "@value": "39.0784225463867"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.60162129933516"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.06178051906269e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00236837574764137"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00100197986852916"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.60162129933516"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.06178051906269e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00236837574764137"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00100197986852916"}
     },
     {
-      "@id": "niiri:33045b6b173ae3c19b060630f6bd98d4",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:19ae5d9dd47ddd4d5cf6d132960e4df6",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0031",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[52,-32,42]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[52,-32,42]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9606f9d15f3bc939ca2851b756c73d5e",
-      "entity": "niiri:d852b48a402ab69819373ede91d1c632"
+      "entity_derived": "niiri:0f9e5faadc247bb0f606f8f2783c5dfc",
+      "entity": "niiri:e25e46750ed6706bcfbfa5e14d55d777"
     },
     {
-      "@id": "niiri:1ba1d7a563060d427efe80daeb039ef3",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5833c7ef6fbc97e336c4176bdd68792a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0032",
-      "prov:atLocation": {"@id": "niiri:c05521563177347eedfa794ffc2cbb1d"},
+      "prov:atLocation": {"@id": "niiri:0e8cee08b4f95550d2575f9157d645ee"},
       "prov:value": {"@type": "xsd:float", "@value": "39.0315551757812"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.59864699876771"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.08015588695665e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00240936329200458"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00100197986852916"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.59864699876771"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.08015588695665e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00240936329200458"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00100197986852916"}
     },
     {
-      "@id": "niiri:c05521563177347eedfa794ffc2cbb1d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0e8cee08b4f95550d2575f9157d645ee",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0032",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[40,-62,50]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[40,-62,50]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1ba1d7a563060d427efe80daeb039ef3",
-      "entity": "niiri:d852b48a402ab69819373ede91d1c632"
+      "entity_derived": "niiri:5833c7ef6fbc97e336c4176bdd68792a",
+      "entity": "niiri:e25e46750ed6706bcfbfa5e14d55d777"
     },
     {
-      "@id": "niiri:c3e147319287620cf6f6682a13bb0c44",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e161d7cffaa802baa8842dbbc2ff600e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0033",
-      "prov:atLocation": {"@id": "niiri:bda2060e4fc205817c927e5c4cc0d265"},
+      "prov:atLocation": {"@id": "niiri:f26173f80e46fa5a537d30b91a145a04"},
       "prov:value": {"@type": "xsd:float", "@value": "32.5285148620605"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.15843165663784"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.24513486854383e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0226961325651858"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00456113578807012"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.15843165663784"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.24513486854383e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0226961325651858"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00456113578807012"}
     },
     {
-      "@id": "niiri:bda2060e4fc205817c927e5c4cc0d265",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f26173f80e46fa5a537d30b91a145a04",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0033",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[56,-44,52]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[56,-44,52]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c3e147319287620cf6f6682a13bb0c44",
-      "entity": "niiri:d852b48a402ab69819373ede91d1c632"
+      "entity_derived": "niiri:e161d7cffaa802baa8842dbbc2ff600e",
+      "entity": "niiri:e25e46750ed6706bcfbfa5e14d55d777"
     },
     {
-      "@id": "niiri:9cae9fe3c87539a4263e6b3cb80c5f42",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5922bca96de375a1c4dae7b56d92f626",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0034",
-      "prov:atLocation": {"@id": "niiri:c26f11a9c1966c5cc8d3a97ffd8acc2c"},
+      "prov:atLocation": {"@id": "niiri:b342d1a5b119cd356d082e704609a7af"},
       "prov:value": {"@type": "xsd:float", "@value": "37.8682479858398"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.52397812994418"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.65704366894559e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00369615187187566"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00135850417567201"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.52397812994418"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.65704366894559e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00369615187187566"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00135850417567201"}
     },
     {
-      "@id": "niiri:c26f11a9c1966c5cc8d3a97ffd8acc2c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b342d1a5b119cd356d082e704609a7af",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0034",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-28,-94,4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-28,-94,4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9cae9fe3c87539a4263e6b3cb80c5f42",
-      "entity": "niiri:2f36545388d37f7477d8f0618c919f09"
+      "entity_derived": "niiri:5922bca96de375a1c4dae7b56d92f626",
+      "entity": "niiri:e2ac8194c797871c399100cc42929140"
     },
     {
-      "@id": "niiri:370f06f8656e584e8bd7a15eb29b6f66",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a4cb37e2bdfafa8de612a84fcbdf3e3e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0035",
-      "prov:atLocation": {"@id": "niiri:5aa56f4b5bc0433444955a59931d33c6"},
+      "prov:atLocation": {"@id": "niiri:e6af297a793f37a7c50553e7b57ac4f4"},
       "prov:value": {"@type": "xsd:float", "@value": "13.7997980117798"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.39898111375179"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000338186933782514"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999983062369"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.517098903229732"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.39898111375179"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000338186933782514"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999983062369"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.517098903229732"}
     },
     {
-      "@id": "niiri:5aa56f4b5bc0433444955a59931d33c6",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e6af297a793f37a7c50553e7b57ac4f4",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0035",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-34,-84,-2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-34,-84,-2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:370f06f8656e584e8bd7a15eb29b6f66",
-      "entity": "niiri:2f36545388d37f7477d8f0618c919f09"
+      "entity_derived": "niiri:a4cb37e2bdfafa8de612a84fcbdf3e3e",
+      "entity": "niiri:e2ac8194c797871c399100cc42929140"
     },
     {
-      "@id": "niiri:6dafd1b7bbda5f996e96f933f65cf52b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5f5bff873009036bef971ae6521ab438",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0036",
-      "prov:atLocation": {"@id": "niiri:9f0d1dd25a994924631ac77e99c886e5"},
+      "prov:atLocation": {"@id": "niiri:7d85c1d7748a0e2b666ce05b7a08b3b3"},
       "prov:value": {"@type": "xsd:float", "@value": "37.2234077453613"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.48187213205114"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.1042418696382e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00469365878715888"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00150767324732148"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.48187213205114"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.1042418696382e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00469365878715888"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00150767324732148"}
     },
     {
-      "@id": "niiri:9f0d1dd25a994924631ac77e99c886e5",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7d85c1d7748a0e2b666ce05b7a08b3b3",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0036",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[32,2,46]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[32,2,46]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6dafd1b7bbda5f996e96f933f65cf52b",
-      "entity": "niiri:6da57157038eade3ca7a4c29d0c28ad8"
+      "entity_derived": "niiri:5f5bff873009036bef971ae6521ab438",
+      "entity": "niiri:e480d8d12a9dc866e99b7a65d64c73b5"
     },
     {
-      "@id": "niiri:6c54477095f54c7a3b23f4f4f13e9a11",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:8981157e9a4e6b5b093e68b901438bad",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0037",
-      "prov:atLocation": {"@id": "niiri:4b59168815bd120e5fd696c03ce5c99b"},
+      "prov:atLocation": {"@id": "niiri:1f9e20630d2591abc7429d5b071cfdfd"},
       "prov:value": {"@type": "xsd:float", "@value": "21.2399845123291"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.21989878746824"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.22206011216042e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.701750105433623"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0674703024550716"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.21989878746824"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.22206011216042e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.701750105433623"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0674703024550716"}
     },
     {
-      "@id": "niiri:4b59168815bd120e5fd696c03ce5c99b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:1f9e20630d2591abc7429d5b071cfdfd",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0037",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[28,4,58]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[28,4,58]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6c54477095f54c7a3b23f4f4f13e9a11",
-      "entity": "niiri:6da57157038eade3ca7a4c29d0c28ad8"
+      "entity_derived": "niiri:8981157e9a4e6b5b093e68b901438bad",
+      "entity": "niiri:e480d8d12a9dc866e99b7a65d64c73b5"
     },
     {
-      "@id": "niiri:e5ef6fd0bdd08411180840b8529fe6f9",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:2c14d6250d370f445e78b4505c0ef514",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0038",
-      "prov:atLocation": {"@id": "niiri:16d7b76654f595d9da06fb0f430cee2d"},
+      "prov:atLocation": {"@id": "niiri:a105d9481745a29ec63afc10e1ef6b75"},
       "prov:value": {"@type": "xsd:float", "@value": "15.9035987854004"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.65519960348906"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000128490978751894"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999764209794947"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.29501424528785"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.65519960348906"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000128490978751894"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999764209794947"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.29501424528785"}
     },
     {
-      "@id": "niiri:16d7b76654f595d9da06fb0f430cee2d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a105d9481745a29ec63afc10e1ef6b75",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0038",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[42,4,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[42,4,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e5ef6fd0bdd08411180840b8529fe6f9",
-      "entity": "niiri:6da57157038eade3ca7a4c29d0c28ad8"
+      "entity_derived": "niiri:2c14d6250d370f445e78b4505c0ef514",
+      "entity": "niiri:e480d8d12a9dc866e99b7a65d64c73b5"
     },
     {
-      "@id": "niiri:04086fe279a8d0368c806231baab87c4",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c76586b39c4dce8e30ab4aec2bd0cfe3",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0039",
-      "prov:atLocation": {"@id": "niiri:6530c3b3e69718001b26adc51b4d89cc"},
+      "prov:atLocation": {"@id": "niiri:6710a695671f6faba8360e71e27233bc"},
       "prov:value": {"@type": "xsd:float", "@value": "37.0886573791504"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.47300715255656"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.21231123420651e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00493011007616861"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00153274880779606"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.47300715255656"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.21231123420651e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00493011007616861"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00153274880779606"}
     },
     {
-      "@id": "niiri:6530c3b3e69718001b26adc51b4d89cc",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6710a695671f6faba8360e71e27233bc",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0039",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[36,-86,24]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[36,-86,24]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:04086fe279a8d0368c806231baab87c4",
-      "entity": "niiri:f36a9d2eb3726086574d1578e1d9f0f8"
+      "entity_derived": "niiri:c76586b39c4dce8e30ab4aec2bd0cfe3",
+      "entity": "niiri:82f170400f1b69cc64c4688f03080756"
     },
     {
-      "@id": "niiri:834a6b2114c1b74621532f33080c5672",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:cbb5e181055a603b555fe4e31c70e6db",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0040",
-      "prov:atLocation": {"@id": "niiri:015e2301960ea3c0dde2b17317fb271b"},
+      "prov:atLocation": {"@id": "niiri:78e5b9b06ac93d423a8111be3ef702c4"},
       "prov:value": {"@type": "xsd:float", "@value": "22.2462520599365"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.31562212585875"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.95770158346087e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.569468011037952"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0515172252256118"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.31562212585875"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.95770158346087e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.569468011037952"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0515172252256118"}
     },
     {
-      "@id": "niiri:015e2301960ea3c0dde2b17317fb271b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:78e5b9b06ac93d423a8111be3ef702c4",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0040",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[40,-82,32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[40,-82,32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:834a6b2114c1b74621532f33080c5672",
-      "entity": "niiri:f36a9d2eb3726086574d1578e1d9f0f8"
+      "entity_derived": "niiri:cbb5e181055a603b555fe4e31c70e6db",
+      "entity": "niiri:82f170400f1b69cc64c4688f03080756"
     },
     {
-      "@id": "niiri:dac11f21422e5b84e6225de84bed6cf1",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:66ffbe934050578ca7c698d14aa85d25",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0041",
-      "prov:atLocation": {"@id": "niiri:0f33cb1812dd5fbe10201b85a4c8325b"},
+      "prov:atLocation": {"@id": "niiri:b75d0a763814255b3c3a4c299253e49e"},
       "prov:value": {"@type": "xsd:float", "@value": "21.6013984680176"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.25461718208726"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.04703485692692e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.654350531154308"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0608459925765272"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.25461718208726"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.04703485692692e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.654350531154308"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0608459925765272"}
     },
     {
-      "@id": "niiri:0f33cb1812dd5fbe10201b85a4c8325b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b75d0a763814255b3c3a4c299253e49e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0041",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[28,-92,26]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[28,-92,26]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:dac11f21422e5b84e6225de84bed6cf1",
-      "entity": "niiri:f36a9d2eb3726086574d1578e1d9f0f8"
+      "entity_derived": "niiri:66ffbe934050578ca7c698d14aa85d25",
+      "entity": "niiri:82f170400f1b69cc64c4688f03080756"
     },
     {
-      "@id": "niiri:f1ee71a44f0186b27050b8b75b15486a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c141baff99ff608f6fd42bbe6f81dd32",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0042",
-      "prov:atLocation": {"@id": "niiri:4d41596e92e5ee6ff6d1600c6fb69e7e"},
+      "prov:atLocation": {"@id": "niiri:e06c4859c1235e6e7a24c07d2a8f9420"},
       "prov:value": {"@type": "xsd:float", "@value": "35.8021011352539"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.38718083940908"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.57857066202172e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00756307748953688"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00208265173602203"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.38718083940908"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.57857066202172e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00756307748953688"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00208265173602203"}
     },
     {
-      "@id": "niiri:4d41596e92e5ee6ff6d1600c6fb69e7e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e06c4859c1235e6e7a24c07d2a8f9420",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0042",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-52,0,38]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-52,0,38]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f1ee71a44f0186b27050b8b75b15486a",
-      "entity": "niiri:3132927065aeeaa4a3a285e94ec260a6"
+      "entity_derived": "niiri:c141baff99ff608f6fd42bbe6f81dd32",
+      "entity": "niiri:c7d451f7f453a0be61177b599ede33a5"
     },
     {
-      "@id": "niiri:03f60451ad894853f8cedd47338360c8",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b7060223bff407a13eb216f455300b91",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0043",
-      "prov:atLocation": {"@id": "niiri:cc2d7d3584bd585cc58b66129262580a"},
+      "prov:atLocation": {"@id": "niiri:d91a8f2dc685df25dd670f56364b8b27"},
       "prov:value": {"@type": "xsd:float", "@value": "27.304349899292"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.75741877507894"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "9.80420573615248e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.130618606044682"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0155044826465378"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.75741877507894"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "9.80420573615248e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.130618606044682"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0155044826465378"}
     },
     {
-      "@id": "niiri:cc2d7d3584bd585cc58b66129262580a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d91a8f2dc685df25dd670f56364b8b27",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0043",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-60,8,20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-60,8,20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:03f60451ad894853f8cedd47338360c8",
-      "entity": "niiri:3132927065aeeaa4a3a285e94ec260a6"
+      "entity_derived": "niiri:b7060223bff407a13eb216f455300b91",
+      "entity": "niiri:c7d451f7f453a0be61177b599ede33a5"
     },
     {
-      "@id": "niiri:f1de543adf152a9d036d0d9bd6d6db38",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:25383c240e64533096acb91f30ed5f79",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0044",
-      "prov:atLocation": {"@id": "niiri:a4826a5ff1dd5dc82f90da238a9c2e0e"},
+      "prov:atLocation": {"@id": "niiri:2312acaca8091779181ea64815241be7"},
       "prov:value": {"@type": "xsd:float", "@value": "24.8951110839844"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.55454903196731"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.62490395575021e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.279280704231587"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0268577436307079"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.55454903196731"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.62490395575021e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.279280704231587"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0268577436307079"}
     },
     {
-      "@id": "niiri:a4826a5ff1dd5dc82f90da238a9c2e0e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:2312acaca8091779181ea64815241be7",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0044",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-44,6,28]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-44,6,28]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f1de543adf152a9d036d0d9bd6d6db38",
-      "entity": "niiri:3132927065aeeaa4a3a285e94ec260a6"
+      "entity_derived": "niiri:25383c240e64533096acb91f30ed5f79",
+      "entity": "niiri:c7d451f7f453a0be61177b599ede33a5"
     },
     {
-      "@id": "niiri:2ac655095d5518c19a2bc9820490a0d4",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:68ea392bb49f24d944e1b260af098020",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0045",
-      "prov:atLocation": {"@id": "niiri:f2e579f7fb1529bf37359eefe7d6ec57"},
+      "prov:atLocation": {"@id": "niiri:e4d53353bebc01fea518333458b6e995"},
       "prov:value": {"@type": "xsd:float", "@value": "35.5708847045898"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.37152336467669"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.90371248659704e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00816987841831085"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00217310121107197"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.37152336467669"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.90371248659704e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00816987841831085"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00217310121107197"}
     },
     {
-      "@id": "niiri:f2e579f7fb1529bf37359eefe7d6ec57",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e4d53353bebc01fea518333458b6e995",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0045",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[30,-66,-6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[30,-66,-6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2ac655095d5518c19a2bc9820490a0d4",
-      "entity": "niiri:1cad58fd2cece054821848126afc3007"
+      "entity_derived": "niiri:68ea392bb49f24d944e1b260af098020",
+      "entity": "niiri:37926699687cca9b9dd0b742b092ff48"
     },
     {
-      "@id": "niiri:5134eb6ddb2e676dd190459560925dac",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:1735ae6e0d994f082ddd12a7f2621f0a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0046",
-      "prov:atLocation": {"@id": "niiri:a83fac439dbaeb921eefe4b4fcb01c40"},
+      "prov:atLocation": {"@id": "niiri:e9dbabf41ff4b3cbd53c7a1462ebfaab"},
       "prov:value": {"@type": "xsd:float", "@value": "35.2681846618652"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.350915057242"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.3755296941228e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00903953548239023"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00235638277703814"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.350915057242"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.3755296941228e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00903953548239023"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00235638277703814"}
     },
     {
-      "@id": "niiri:a83fac439dbaeb921eefe4b4fcb01c40",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e9dbabf41ff4b3cbd53c7a1462ebfaab",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0046",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[24,-54,-16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[24,-54,-16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5134eb6ddb2e676dd190459560925dac",
-      "entity": "niiri:1cad58fd2cece054821848126afc3007"
+      "entity_derived": "niiri:1735ae6e0d994f082ddd12a7f2621f0a",
+      "entity": "niiri:37926699687cca9b9dd0b742b092ff48"
     },
     {
-      "@id": "niiri:c0ac049f4c5298835d536c905ec83fae",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:93b54ac55b78a51e2a8346189557574f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0047",
-      "prov:atLocation": {"@id": "niiri:d6dbdc051fbcd9ea6e3f628a108cb411"},
+      "prov:atLocation": {"@id": "niiri:f253c7c3034017bc1e14b769c4a9f665"},
       "prov:value": {"@type": "xsd:float", "@value": "33.5431251525879"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.23100638995574"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.42948405521682e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.016124846685693"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00349953417360534"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.23100638995574"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.42948405521682e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.016124846685693"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00349953417360534"}
     },
     {
-      "@id": "niiri:d6dbdc051fbcd9ea6e3f628a108cb411",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f253c7c3034017bc1e14b769c4a9f665",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0047",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[18,-54,-6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[18,-54,-6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c0ac049f4c5298835d536c905ec83fae",
-      "entity": "niiri:1cad58fd2cece054821848126afc3007"
+      "entity_derived": "niiri:93b54ac55b78a51e2a8346189557574f",
+      "entity": "niiri:37926699687cca9b9dd0b742b092ff48"
     },
     {
-      "@id": "niiri:86babbe08a5271f8f862022cb9c85a37",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5766230ffa1accb71218f9a65385d08e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0048",
-      "prov:atLocation": {"@id": "niiri:8decd82989c21ea201824f4fd23c5371"},
+      "prov:atLocation": {"@id": "niiri:ceca5eb2386bd4c4e47d2c0c586a097d"},
       "prov:value": {"@type": "xsd:float", "@value": "34.9530181884766"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.32932369363006"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.92895819714789e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0100448972767031"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00246864149540014"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.32932369363006"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.92895819714789e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0100448972767031"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00246864149540014"}
     },
     {
-      "@id": "niiri:8decd82989c21ea201824f4fd23c5371",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ceca5eb2386bd4c4e47d2c0c586a097d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0048",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[16,-84,44]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[16,-84,44]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:86babbe08a5271f8f862022cb9c85a37",
-      "entity": "niiri:1fcfe58e890a992a0cbd392039bb176f"
+      "entity_derived": "niiri:5766230ffa1accb71218f9a65385d08e",
+      "entity": "niiri:e7fc074f64298360eb2c7ffbcb4e63aa"
     },
     {
-      "@id": "niiri:85e9e5a479a64fe96308e993a393382e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b7d8fb60227ddc169d23c315114e2e40",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0049",
-      "prov:atLocation": {"@id": "niiri:a4aa70ad14969702e648abc2981b2229"},
+      "prov:atLocation": {"@id": "niiri:20089fd71414202501ea181905ceda27"},
       "prov:value": {"@type": "xsd:float", "@value": "34.2299766540527"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.27926163486319"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.48527449520486e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0128006355440512"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00299523511468489"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.27926163486319"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.48527449520486e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0128006355440512"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00299523511468489"}
     },
     {
-      "@id": "niiri:a4aa70ad14969702e648abc2981b2229",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:20089fd71414202501ea181905ceda27",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0049",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-48,-52,-26]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-48,-52,-26]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:85e9e5a479a64fe96308e993a393382e",
-      "entity": "niiri:41b3f1fe29e41e8399e5532675d71afb"
+      "entity_derived": "niiri:b7d8fb60227ddc169d23c315114e2e40",
+      "entity": "niiri:617a58ee9ff77a4075c0708ea690d16c"
     },
     {
-      "@id": "niiri:419a6b6979a7c4e08ae0860340857632",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:be6ef07847d5a11377cd20e3bf142605",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0050",
-      "prov:atLocation": {"@id": "niiri:cfc6ec4dd43c2525d3f5c8b60349f2ba"},
+      "prov:atLocation": {"@id": "niiri:7a0a448d7f559d689b8d444542976a30"},
       "prov:value": {"@type": "xsd:float", "@value": "25.4968433380127"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.60642227215859"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.04828043492977e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.232501903028901"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0230459220332407"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.60642227215859"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.04828043492977e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.232501903028901"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0230459220332407"}
     },
     {
-      "@id": "niiri:cfc6ec4dd43c2525d3f5c8b60349f2ba",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7a0a448d7f559d689b8d444542976a30",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0050",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-34,-42,-28]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-34,-42,-28]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:419a6b6979a7c4e08ae0860340857632",
-      "entity": "niiri:41b3f1fe29e41e8399e5532675d71afb"
+      "entity_derived": "niiri:be6ef07847d5a11377cd20e3bf142605",
+      "entity": "niiri:617a58ee9ff77a4075c0708ea690d16c"
     },
     {
-      "@id": "niiri:541c2830bbdf066f7986aa03a275db5b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:270434b20e00025409cc3402d4134104",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0051",
-      "prov:atLocation": {"@id": "niiri:e699bc65a7aa87c6ed1347272f96036c"},
+      "prov:atLocation": {"@id": "niiri:dde4c1281c1e7730093e357f4c333b57"},
       "prov:value": {"@type": "xsd:float", "@value": "33.9315414428711"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.2583798008004"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.26650642990379e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0141503991863343"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00317914466289153"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.2583798008004"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.26650642990379e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0141503991863343"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00317914466289153"}
     },
     {
-      "@id": "niiri:e699bc65a7aa87c6ed1347272f96036c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:dde4c1281c1e7730093e357f4c333b57",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0051",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[58,12,-20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[58,12,-20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:541c2830bbdf066f7986aa03a275db5b",
-      "entity": "niiri:9a54b48570d440ea6ac8f1f92e78425f"
+      "entity_derived": "niiri:270434b20e00025409cc3402d4134104",
+      "entity": "niiri:fd34291df44a2d10645e6546a1593a1c"
     },
     {
-      "@id": "niiri:8db13aa1400987668a666204b86a9a65",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:dd6a5e6b2dd23e0f9e80ac6bfc81c96b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0052",
-      "prov:atLocation": {"@id": "niiri:d7b874652c2c7ed615f7cedfdc28589e"},
+      "prov:atLocation": {"@id": "niiri:cbc78a2103930efca8b6cba5d06325aa"},
       "prov:value": {"@type": "xsd:float", "@value": "19.0596389770508"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.00175558310566"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.14371148909531e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.929942403817741"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.124351274352918"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.00175558310566"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.14371148909531e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.929942403817741"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.124351274352918"}
     },
     {
-      "@id": "niiri:d7b874652c2c7ed615f7cedfdc28589e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:cbc78a2103930efca8b6cba5d06325aa",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0052",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[60,-2,-16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[60,-2,-16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8db13aa1400987668a666204b86a9a65",
-      "entity": "niiri:9a54b48570d440ea6ac8f1f92e78425f"
+      "entity_derived": "niiri:dd6a5e6b2dd23e0f9e80ac6bfc81c96b",
+      "entity": "niiri:fd34291df44a2d10645e6546a1593a1c"
     },
     {
-      "@id": "niiri:d097a1148dac67761e4e100e3073a34c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:39553cd2909fb4f309850bc50283f969",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0053",
-      "prov:atLocation": {"@id": "niiri:5e4f204c6ed90a1362ea319673a1a1b3"},
+      "prov:atLocation": {"@id": "niiri:a51d05f416df644328a6cb3628a53340"},
       "prov:value": {"@type": "xsd:float", "@value": "16.95458984375"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.77515624884835"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.99536997647676e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.996665924683688"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.218440612600676"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.77515624884835"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.99536997647676e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.996665924683688"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.218440612600676"}
     },
     {
-      "@id": "niiri:5e4f204c6ed90a1362ea319673a1a1b3",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a51d05f416df644328a6cb3628a53340",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0053",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[60,4,-22]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[60,4,-22]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d097a1148dac67761e4e100e3073a34c",
-      "entity": "niiri:9a54b48570d440ea6ac8f1f92e78425f"
+      "entity_derived": "niiri:39553cd2909fb4f309850bc50283f969",
+      "entity": "niiri:fd34291df44a2d10645e6546a1593a1c"
     },
     {
-      "@id": "niiri:e1dc3fa319bf52239f49913d17a1f776",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:829cbe8430fd88bbc00d346769721904",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0054",
-      "prov:atLocation": {"@id": "niiri:83c602bcf84c9c5ab8d1ed41e44765a8"},
+      "prov:atLocation": {"@id": "niiri:004948ca236c52cf9756f94713a6c2af"},
       "prov:value": {"@type": "xsd:float", "@value": "33.4968719482422"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.22773182499393"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.58010831272793e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0163777835136855"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00349953417360534"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.22773182499393"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.58010831272793e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0163777835136855"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00349953417360534"}
     },
     {
-      "@id": "niiri:83c602bcf84c9c5ab8d1ed41e44765a8",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:004948ca236c52cf9756f94713a6c2af",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0054",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-8,50,14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-8,50,14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e1dc3fa319bf52239f49913d17a1f776",
-      "entity": "niiri:ffd74835caba617d42d83e59e6b5a54e"
+      "entity_derived": "niiri:829cbe8430fd88bbc00d346769721904",
+      "entity": "niiri:8677fb654966f35b2ba255c1e63d1cb1"
     },
     {
-      "@id": "niiri:f034e055ebe1a33dc31858900fb098d6",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:779dd8335e4fd65858941476e998673b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0055",
-      "prov:atLocation": {"@id": "niiri:0dff3b10c950662524b9f222c1981f13"},
+      "prov:atLocation": {"@id": "niiri:54043a6e802dade52c783cf91d848c19"},
       "prov:value": {"@type": "xsd:float", "@value": "29.9832496643066"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.96911405212995"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.36297509062611e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0535569381204491"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00813843087070338"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.96911405212995"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.36297509062611e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0535569381204491"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00813843087070338"}
     },
     {
-      "@id": "niiri:0dff3b10c950662524b9f222c1981f13",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:54043a6e802dade52c783cf91d848c19",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0055",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[0,64,14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[0,64,14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f034e055ebe1a33dc31858900fb098d6",
-      "entity": "niiri:ffd74835caba617d42d83e59e6b5a54e"
+      "entity_derived": "niiri:779dd8335e4fd65858941476e998673b",
+      "entity": "niiri:8677fb654966f35b2ba255c1e63d1cb1"
     },
     {
-      "@id": "niiri:a98a41f7e6b66a8f640f080fe37400a8",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:03c31dd1111118a4d4e27639746be972",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0056",
-      "prov:atLocation": {"@id": "niiri:d4bc3d5b7f9c56de6a3f56e7080d05a2"},
+      "prov:atLocation": {"@id": "niiri:abb708694b565836e1566ffb6107e47f"},
       "prov:value": {"@type": "xsd:float", "@value": "22.9387531280518"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.37984280105142"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.93824767269879e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.481901129565415"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0438469723479488"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.37984280105142"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.93824767269879e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.481901129565415"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0438469723479488"}
     },
     {
-      "@id": "niiri:d4bc3d5b7f9c56de6a3f56e7080d05a2",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:abb708694b565836e1566ffb6107e47f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0056",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-20,44,-16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-20,44,-16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a98a41f7e6b66a8f640f080fe37400a8",
-      "entity": "niiri:ffd74835caba617d42d83e59e6b5a54e"
+      "entity_derived": "niiri:03c31dd1111118a4d4e27639746be972",
+      "entity": "niiri:8677fb654966f35b2ba255c1e63d1cb1"
     },
     {
-      "@id": "niiri:88ad3cc3781d8b88b017dd39a403ba13",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f29776971e9edeb3024d30c38070b4fe",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0057",
-      "prov:atLocation": {"@id": "niiri:d69eb16669b789396003dd1e55f55d19"},
+      "prov:atLocation": {"@id": "niiri:4caf6e61318e78b90d840ebd45b97e54"},
       "prov:value": {"@type": "xsd:float", "@value": "33.4191627502441"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.22222309196889"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.83939008655688e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.016811779659474"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00353415653584831"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.22222309196889"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.83939008655688e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.016811779659474"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00353415653584831"}
     },
     {
-      "@id": "niiri:d69eb16669b789396003dd1e55f55d19",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4caf6e61318e78b90d840ebd45b97e54",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0057",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-34,-2,52]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-34,-2,52]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:88ad3cc3781d8b88b017dd39a403ba13",
-      "entity": "niiri:56af8a072a247476eb5fd62c25fdf6e9"
+      "entity_derived": "niiri:f29776971e9edeb3024d30c38070b4fe",
+      "entity": "niiri:545f94f2d451c1c902303c221a0a1089"
     },
     {
-      "@id": "niiri:1ebe37481bd2402d0c4496e789620aaf",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:4f203f7fbd8966e70a518b7a5098265c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0058",
-      "prov:atLocation": {"@id": "niiri:036d01b30c63f19c9c51d74c4ae9441e"},
+      "prov:atLocation": {"@id": "niiri:840423c9f78860e1bbacbdb8430b4cb1"},
       "prov:value": {"@type": "xsd:float", "@value": "29.2642135620117"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.91361665883884"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.47057450281285e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0681879801861663"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00986818968821408"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.91361665883884"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.47057450281285e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0681879801861663"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00986818968821408"}
     },
     {
-      "@id": "niiri:036d01b30c63f19c9c51d74c4ae9441e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:840423c9f78860e1bbacbdb8430b4cb1",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0058",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-54,-46,58]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-54,-46,58]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1ebe37481bd2402d0c4496e789620aaf",
-      "entity": "niiri:097010bf7718d0ca7ca15cd545a5d22f"
+      "entity_derived": "niiri:4f203f7fbd8966e70a518b7a5098265c",
+      "entity": "niiri:f9a9c037c3239038fee46308d6b9feba"
     },
     {
-      "@id": "niiri:bb174da829ac30b4114254d72cff3fe9",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:7ab50e444de918ebf5bcfdebceaf9ad0",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0059",
-      "prov:atLocation": {"@id": "niiri:91f5a4a193bd5413aaca5507a5b695b1"},
+      "prov:atLocation": {"@id": "niiri:73c5ac956eca1bb030453396f1ae3059"},
       "prov:value": {"@type": "xsd:float", "@value": "28.8472003936768"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.88099763110222"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.2775255054982e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0783986768366318"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0110008671467558"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.88099763110222"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.2775255054982e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0783986768366318"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0110008671467558"}
     },
     {
-      "@id": "niiri:91f5a4a193bd5413aaca5507a5b695b1",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:73c5ac956eca1bb030453396f1ae3059",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0059",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[34,-42,70]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[34,-42,70]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:bb174da829ac30b4114254d72cff3fe9",
-      "entity": "niiri:9bd5784f7d92f66f0e060878415afdd2"
+      "entity_derived": "niiri:7ab50e444de918ebf5bcfdebceaf9ad0",
+      "entity": "niiri:6441c160dec1271f21351fe6ca31e10a"
     },
     {
-      "@id": "niiri:b31569768eb0ecaf798b885c052d70bc",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:48472e5c0e95db5f72001e9bbdb54075",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0060",
-      "prov:atLocation": {"@id": "niiri:c0e88496f1b24da7d9c729666ca6e6b9"},
+      "prov:atLocation": {"@id": "niiri:c39236425bbf9b6441d6709219569da0"},
       "prov:value": {"@type": "xsd:float", "@value": "27.9873161315918"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.81269831822163"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.44529926488546e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.104344146902035"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0136039810527477"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.81269831822163"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.44529926488546e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.104344146902035"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0136039810527477"}
     },
     {
-      "@id": "niiri:c0e88496f1b24da7d9c729666ca6e6b9",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c39236425bbf9b6441d6709219569da0",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0060",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[22,-52,72]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[22,-52,72]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b31569768eb0ecaf798b885c052d70bc",
-      "entity": "niiri:9bd5784f7d92f66f0e060878415afdd2"
+      "entity_derived": "niiri:48472e5c0e95db5f72001e9bbdb54075",
+      "entity": "niiri:6441c160dec1271f21351fe6ca31e10a"
     },
     {
-      "@id": "niiri:7181bc8829a207383619341fb4ea356b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5ddd28f08b4c942fd117d28ee9faac64",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0061",
-      "prov:atLocation": {"@id": "niiri:d81296739d1d52ad4d973c73a6fbbe33"},
+      "prov:atLocation": {"@id": "niiri:42db9c9a0d0502948e4fee8df9e3124e"},
       "prov:value": {"@type": "xsd:float", "@value": "27.299201965332"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.75699852876781"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "9.82463004728373e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.130838529326203"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0155044826465378"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.75699852876781"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "9.82463004728373e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.130838529326203"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0155044826465378"}
     },
     {
-      "@id": "niiri:d81296739d1d52ad4d973c73a6fbbe33",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:42db9c9a0d0502948e4fee8df9e3124e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0061",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[40,-44,62]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[40,-44,62]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7181bc8829a207383619341fb4ea356b",
-      "entity": "niiri:9bd5784f7d92f66f0e060878415afdd2"
+      "entity_derived": "niiri:5ddd28f08b4c942fd117d28ee9faac64",
+      "entity": "niiri:6441c160dec1271f21351fe6ca31e10a"
     },
     {
-      "@id": "niiri:ed2995aa862047bd5161a8a6730d0afa",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:2b3ce71bfa91fff55105d339fbbdbe2b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0062",
-      "prov:atLocation": {"@id": "niiri:034855fb3b812c879b54f99448454eef"},
+      "prov:atLocation": {"@id": "niiri:91623ffcf878c645ac2db15bb89ab96c"},
       "prov:value": {"@type": "xsd:float", "@value": "28.2855854034424"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.83655063572385"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.60558149623292e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0945247092312007"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0127733737382444"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.83655063572385"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.60558149623292e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0945247092312007"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0127733737382444"}
     },
     {
-      "@id": "niiri:034855fb3b812c879b54f99448454eef",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:91623ffcf878c645ac2db15bb89ab96c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0062",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-62,-38,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-62,-38,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ed2995aa862047bd5161a8a6730d0afa",
-      "entity": "niiri:acdf8cd47c627692be1a25b68765ef7e"
+      "entity_derived": "niiri:2b3ce71bfa91fff55105d339fbbdbe2b",
+      "entity": "niiri:2872350aa13a26854db92f5a27149fe1"
     },
     {
-      "@id": "niiri:8a1082010857a17aaa32971414fa6ba6",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f2be8929a3710e3a368deadf13c7b07c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0063",
-      "prov:atLocation": {"@id": "niiri:98d06df7fa85f28faf41d867cabd92b4"},
+      "prov:atLocation": {"@id": "niiri:ae22616a0f065e3a7f82a19748390b4d"},
       "prov:value": {"@type": "xsd:float", "@value": "20.8939819335938"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.18629418105686"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.41772903717863e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.745987987161102"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0747839778627127"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.18629418105686"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.41772903717863e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.745987987161102"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0747839778627127"}
     },
     {
-      "@id": "niiri:98d06df7fa85f28faf41d867cabd92b4",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ae22616a0f065e3a7f82a19748390b4d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0063",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-60,-50,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-60,-50,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8a1082010857a17aaa32971414fa6ba6",
-      "entity": "niiri:acdf8cd47c627692be1a25b68765ef7e"
+      "entity_derived": "niiri:f2be8929a3710e3a368deadf13c7b07c",
+      "entity": "niiri:2872350aa13a26854db92f5a27149fe1"
     },
     {
-      "@id": "niiri:fb0d45cf20c643da2fd4b62ec24218a2",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:6beebfb6b83f4e4fbc1d0fabd13b2921",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0064",
-      "prov:atLocation": {"@id": "niiri:d264808c9c2957a199dd50cedd176208"},
+      "prov:atLocation": {"@id": "niiri:3de11b76086fc65df36803e9e359450b"},
       "prov:value": {"@type": "xsd:float", "@value": "28.164192199707"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.82686385572958"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.93499344617265e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0984091095914084"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0131723064509997"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.82686385572958"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.93499344617265e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0984091095914084"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0131723064509997"}
     },
     {
-      "@id": "niiri:d264808c9c2957a199dd50cedd176208",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:3de11b76086fc65df36803e9e359450b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0064",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[32,40,16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[32,40,16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:fb0d45cf20c643da2fd4b62ec24218a2",
-      "entity": "niiri:7a9e3b4c3767f5381b56e2fbeb688be4"
+      "entity_derived": "niiri:6beebfb6b83f4e4fbc1d0fabd13b2921",
+      "entity": "niiri:e3742b34c6808b2398052ec8dae20d8c"
     },
     {
-      "@id": "niiri:cc3f0dcda760e37ccf1f076ac386c0b1",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:514baf9fb6cc825d6a8ed488bfd99826",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0065",
-      "prov:atLocation": {"@id": "niiri:e475a296c558cc8055b307c5eb9227bd"},
+      "prov:atLocation": {"@id": "niiri:265726ad7fe9d9c8c3951257f3edcbe3"},
       "prov:value": {"@type": "xsd:float", "@value": "20.7001953125"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.16731300977185"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.54105576545271e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.769962873085872"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0785095339135121"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.16731300977185"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.54105576545271e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.769962873085872"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0785095339135121"}
     },
     {
-      "@id": "niiri:e475a296c558cc8055b307c5eb9227bd",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:265726ad7fe9d9c8c3951257f3edcbe3",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0065",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[40,46,12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[40,46,12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cc3f0dcda760e37ccf1f076ac386c0b1",
-      "entity": "niiri:7a9e3b4c3767f5381b56e2fbeb688be4"
+      "entity_derived": "niiri:514baf9fb6cc825d6a8ed488bfd99826",
+      "entity": "niiri:e3742b34c6808b2398052ec8dae20d8c"
     },
     {
-      "@id": "niiri:64a414ffbcbf234a397cc934a39c33de",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c2a20f1f60d0404677a01e0473330666",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0066",
-      "prov:atLocation": {"@id": "niiri:c367485fb36a5056f4f61efc7f41695d"},
+      "prov:atLocation": {"@id": "niiri:61822c3ab944ea0faa2fcde49bf6928c"},
       "prov:value": {"@type": "xsd:float", "@value": "18.6263465881348"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.9564888351335"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.80297206890035e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.955406749953662"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.140236437115493"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.9564888351335"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.80297206890035e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.955406749953662"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.140236437115493"}
     },
     {
-      "@id": "niiri:c367485fb36a5056f4f61efc7f41695d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:61822c3ab944ea0faa2fcde49bf6928c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0066",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[36,54,6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[36,54,6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:64a414ffbcbf234a397cc934a39c33de",
-      "entity": "niiri:7a9e3b4c3767f5381b56e2fbeb688be4"
+      "entity_derived": "niiri:c2a20f1f60d0404677a01e0473330666",
+      "entity": "niiri:e3742b34c6808b2398052ec8dae20d8c"
     },
     {
-      "@id": "niiri:76d12aad81066e83e9a226b4c3cd850f",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a7269318ead6ea41a838413495ff7e57",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0067",
-      "prov:atLocation": {"@id": "niiri:e6019c791343b2ba7fc4a50937b90f30"},
+      "prov:atLocation": {"@id": "niiri:b998be76596a69687ddc0d63f339c66f"},
       "prov:value": {"@type": "xsd:float", "@value": "27.7903442382812"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.79685095721308"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.05897185318649e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.111355921927938"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0142325796838019"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.79685095721308"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.05897185318649e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.111355921927938"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0142325796838019"}
     },
     {
-      "@id": "niiri:e6019c791343b2ba7fc4a50937b90f30",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b998be76596a69687ddc0d63f339c66f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0067",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-4,-50,74]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-4,-50,74]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:76d12aad81066e83e9a226b4c3cd850f",
-      "entity": "niiri:3e392a8fdf40615d1b9393f7900b1a84"
+      "entity_derived": "niiri:a7269318ead6ea41a838413495ff7e57",
+      "entity": "niiri:002a4160ef17e67bfe8f93c22d701531"
     },
     {
-      "@id": "niiri:4db9685a551cd3d8b1a929c0c750acf3",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:357040efdf37bc34eb1815732a22e3e1",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0068",
-      "prov:atLocation": {"@id": "niiri:fad8f32fdd1a8a4f17d7cc784e5f7d16"},
+      "prov:atLocation": {"@id": "niiri:7ec9e9fcf91f20c5fd87870401d2533a"},
       "prov:value": {"@type": "xsd:float", "@value": "27.776086807251"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.79570089443694"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.10535070061569e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.111880510607324"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0142325796838019"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.79570089443694"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.10535070061569e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.111880510607324"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0142325796838019"}
     },
     {
-      "@id": "niiri:fad8f32fdd1a8a4f17d7cc784e5f7d16",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7ec9e9fcf91f20c5fd87870401d2533a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0068",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[40,26,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[40,26,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4db9685a551cd3d8b1a929c0c750acf3",
-      "entity": "niiri:5a380674b2894ae5398504bd4a8533f8"
+      "entity_derived": "niiri:357040efdf37bc34eb1815732a22e3e1",
+      "entity": "niiri:88b01b8106ca0618c3b109ef9140a77a"
     },
     {
-      "@id": "niiri:2226ec97c21a62742a885c0b1f69c1ac",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:4a825f1cb4eb89df074bde02c951cda0",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0069",
-      "prov:atLocation": {"@id": "niiri:1d76842a826598672a5c8a96f7df6647"},
+      "prov:atLocation": {"@id": "niiri:36f52911aa619b4ef4106054a1fc54dd"},
       "prov:value": {"@type": "xsd:float", "@value": "27.7102565765381"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.79038551132749"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.32305908970987e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.114333288035698"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0142910518357785"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.79038551132749"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.32305908970987e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.114333288035698"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0142910518357785"}
     },
     {
-      "@id": "niiri:1d76842a826598672a5c8a96f7df6647",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:36f52911aa619b4ef4106054a1fc54dd",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0069",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-12,-26,84]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-12,-26,84]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2226ec97c21a62742a885c0b1f69c1ac",
-      "entity": "niiri:13af72d1f5f712ec17e2a4eb12791728"
+      "entity_derived": "niiri:4a825f1cb4eb89df074bde02c951cda0",
+      "entity": "niiri:5b45e4eea89f71e19bb39684bf2f0eb7"
     },
     {
-      "@id": "niiri:b7a274756bfe57533a707f92d131756e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:2f6549876aed12baa3dab8de8273d38a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0070",
-      "prov:atLocation": {"@id": "niiri:888ee5317a79bcb7ad00f180aeab2e56"},
+      "prov:atLocation": {"@id": "niiri:44b1830cba35547169ca826553dd909c"},
       "prov:value": {"@type": "xsd:float", "@value": "27.1838035583496"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.74756386643394"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.02940694712839e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.13586045231926"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0157421086869962"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.74756386643394"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.02940694712839e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.13586045231926"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0157421086869962"}
     },
     {
-      "@id": "niiri:888ee5317a79bcb7ad00f180aeab2e56",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:44b1830cba35547169ca826553dd909c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0070",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[22,-16,80]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[22,-16,80]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b7a274756bfe57533a707f92d131756e",
-      "entity": "niiri:d959803f17fca1477b93bbeb0285f2c2"
+      "entity_derived": "niiri:2f6549876aed12baa3dab8de8273d38a",
+      "entity": "niiri:c3da843e94fc98cca5669ae4eef8d2ed"
     },
     {
-      "@id": "niiri:3ab9a4e9eec326914bcb611614bd4168",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f1895be0d1633922d7667327f8d09e70",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0071",
-      "prov:atLocation": {"@id": "niiri:192a09ec58406e66d604edb406fd5c8d"},
+      "prov:atLocation": {"@id": "niiri:b006146ea3a6c5cef54d99ae22492584"},
       "prov:value": {"@type": "xsd:float", "@value": "26.9941082000732"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.73199532964814"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.11161764859702e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.144508578107306"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.016538239689936"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.73199532964814"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.11161764859702e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.144508578107306"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.016538239689936"}
     },
     {
-      "@id": "niiri:192a09ec58406e66d604edb406fd5c8d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b006146ea3a6c5cef54d99ae22492584",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0071",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-20,22,-10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-20,22,-10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3ab9a4e9eec326914bcb611614bd4168",
-      "entity": "niiri:02b0f364d58bda58fce33ecdaf3e7191"
+      "entity_derived": "niiri:f1895be0d1633922d7667327f8d09e70",
+      "entity": "niiri:5d3257a6906cc23f21f8344f8a202720"
     },
     {
-      "@id": "niiri:6fae1cb761159cb1828c7e100c9f9860",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:adea458f35a2dd3e503f5b76a33ccca9",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0072",
-      "prov:atLocation": {"@id": "niiri:480b12cbc91811e27eccdd1d15933704"},
+      "prov:atLocation": {"@id": "niiri:8498f671244493e5dccddbfdee69de45"},
       "prov:value": {"@type": "xsd:float", "@value": "22.6613578796387"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.35427468283891"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.67541091325941e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.516272526829242"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0461712684947748"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.35427468283891"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.67541091325941e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.516272526829242"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0461712684947748"}
     },
     {
-      "@id": "niiri:480b12cbc91811e27eccdd1d15933704",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:8498f671244493e5dccddbfdee69de45",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0072",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-20,22,-20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-20,22,-20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6fae1cb761159cb1828c7e100c9f9860",
-      "entity": "niiri:02b0f364d58bda58fce33ecdaf3e7191"
+      "entity_derived": "niiri:adea458f35a2dd3e503f5b76a33ccca9",
+      "entity": "niiri:5d3257a6906cc23f21f8344f8a202720"
     },
     {
-      "@id": "niiri:476676425794194c27a827a9f0c6b148",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b2abdbde6951cc3df4267da78e9eab09",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0073",
-      "prov:atLocation": {"@id": "niiri:807410e5abbbfc2c759a743341ef3252"},
+      "prov:atLocation": {"@id": "niiri:2c46ac4fa1bcf476c140cdc40fa6d0cf"},
       "prov:value": {"@type": "xsd:float", "@value": "16.1252555847168"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.68091120119901"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00011620096893894"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999550326152138"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.274499735322593"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.68091120119901"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00011620096893894"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999550326152138"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.274499735322593"}
     },
     {
-      "@id": "niiri:807410e5abbbfc2c759a743341ef3252",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:2c46ac4fa1bcf476c140cdc40fa6d0cf",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0073",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-28,36,-14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-28,36,-14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:476676425794194c27a827a9f0c6b148",
-      "entity": "niiri:02b0f364d58bda58fce33ecdaf3e7191"
+      "entity_derived": "niiri:b2abdbde6951cc3df4267da78e9eab09",
+      "entity": "niiri:5d3257a6906cc23f21f8344f8a202720"
     },
     {
-      "@id": "niiri:67414756bbde1bde08546a2688a1d56c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ce8e5b9eaf298dd260287509743e52a9",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0074",
-      "prov:atLocation": {"@id": "niiri:e38c23447f1976e7966b4523abca5ae9"},
+      "prov:atLocation": {"@id": "niiri:fa7acea05fec3c868da9178c655ffd07"},
       "prov:value": {"@type": "xsd:float", "@value": "26.7744998931885"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.71387838295499"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.21522879270586e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.155157441670289"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0172891722870727"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.71387838295499"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.21522879270586e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.155157441670289"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0172891722870727"}
     },
     {
-      "@id": "niiri:e38c23447f1976e7966b4523abca5ae9",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:fa7acea05fec3c868da9178c655ffd07",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0074",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-60,-52,18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-60,-52,18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:67414756bbde1bde08546a2688a1d56c",
-      "entity": "niiri:cd0210a509aed4af1fa29d3bf1351438"
+      "entity_derived": "niiri:ce8e5b9eaf298dd260287509743e52a9",
+      "entity": "niiri:f9cfce19a79a082c82d2f3a6386b09c9"
     },
     {
-      "@id": "niiri:035f24946566726f6667f33756436ce2",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3b07b1d9d18e5301a1eddd1ed55de100",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0075",
-      "prov:atLocation": {"@id": "niiri:29a61d3c8818b64ad94e245a81e5eee6"},
+      "prov:atLocation": {"@id": "niiri:4935504f2ca9890d702d363dd7b1d03f"},
       "prov:value": {"@type": "xsd:float", "@value": "24.3260192871094"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.50470678054082"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.3232325669097e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.330274885793216"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0310816877190926"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.50470678054082"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.3232325669097e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.330274885793216"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0310816877190926"}
     },
     {
-      "@id": "niiri:29a61d3c8818b64ad94e245a81e5eee6",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4935504f2ca9890d702d363dd7b1d03f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0075",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-58,-64,12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-58,-64,12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:035f24946566726f6667f33756436ce2",
-      "entity": "niiri:cd0210a509aed4af1fa29d3bf1351438"
+      "entity_derived": "niiri:3b07b1d9d18e5301a1eddd1ed55de100",
+      "entity": "niiri:f9cfce19a79a082c82d2f3a6386b09c9"
     },
     {
-      "@id": "niiri:cd9ceab8b72471e4a4629ed95a3798f7",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:68ccf59f802d72bf9d431b3b294d2c32",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0076",
-      "prov:atLocation": {"@id": "niiri:b986ba1201da6c46992b1bcee44033c1"},
+      "prov:atLocation": {"@id": "niiri:1e60d9d582eaec821f0d35b91631e387"},
       "prov:value": {"@type": "xsd:float", "@value": "14.2642917633057"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.45757108528077"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000272534210682851"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999731150238"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.453704488417404"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.45757108528077"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000272534210682851"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999731150238"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.453704488417404"}
     },
     {
-      "@id": "niiri:b986ba1201da6c46992b1bcee44033c1",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:1e60d9d582eaec821f0d35b91631e387",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0076",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-66,-44,16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-66,-44,16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cd9ceab8b72471e4a4629ed95a3798f7",
-      "entity": "niiri:cd0210a509aed4af1fa29d3bf1351438"
+      "entity_derived": "niiri:68ccf59f802d72bf9d431b3b294d2c32",
+      "entity": "niiri:f9cfce19a79a082c82d2f3a6386b09c9"
     },
     {
-      "@id": "niiri:7adcc5b8a365d50984373dc4e9d4745c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:90812b753072fe6baba25b8214327983",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0077",
-      "prov:atLocation": {"@id": "niiri:144b48dc9980d0f12dcf73dad17db8d9"},
+      "prov:atLocation": {"@id": "niiri:2e7dbc2e92942cb373a386b48d8ab2ae"},
       "prov:value": {"@type": "xsd:float", "@value": "26.5194854736328"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.69271316665315"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.34802686679869e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.168426938943843"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0184657823782908"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.69271316665315"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.34802686679869e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.168426938943843"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0184657823782908"}
     },
     {
-      "@id": "niiri:144b48dc9980d0f12dcf73dad17db8d9",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:2e7dbc2e92942cb373a386b48d8ab2ae",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0077",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-48,28,2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-48,28,2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7adcc5b8a365d50984373dc4e9d4745c",
-      "entity": "niiri:b9079ad818d03296fe8330a4f70c5c53"
+      "entity_derived": "niiri:90812b753072fe6baba25b8214327983",
+      "entity": "niiri:36f4c495e82ce16bc5e3538ec47db115"
     },
     {
-      "@id": "niiri:79d36c0ec9a324401fc0e2eb636b12e4",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:19c2eb940423bd075119228e3100f958",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0078",
-      "prov:atLocation": {"@id": "niiri:b47a9596c2644d5468cf006ab33ca079"},
+      "prov:atLocation": {"@id": "niiri:cbe4d401b56f46238b61ab011826b9de"},
       "prov:value": {"@type": "xsd:float", "@value": "25.691427230835"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.62301960855807"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.89096978542302e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.218875206501387"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0221192226146001"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.62301960855807"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.89096978542302e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.218875206501387"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0221192226146001"}
     },
     {
-      "@id": "niiri:b47a9596c2644d5468cf006ab33ca079",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:cbe4d401b56f46238b61ab011826b9de",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0078",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-26,30,36]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-26,30,36]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:79d36c0ec9a324401fc0e2eb636b12e4",
-      "entity": "niiri:b9079ad818d03296fe8330a4f70c5c53"
+      "entity_derived": "niiri:19c2eb940423bd075119228e3100f958",
+      "entity": "niiri:36f4c495e82ce16bc5e3538ec47db115"
     },
     {
-      "@id": "niiri:b4e1727e487e8b71ba67d88addf8b5dd",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:45fb7b2544c4802833f71463702fb573",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0079",
-      "prov:atLocation": {"@id": "niiri:13eed93b488bc2f8ea02ff9e1be0807e"},
+      "prov:atLocation": {"@id": "niiri:826ac32082a51738929fdbd7249ac832"},
       "prov:value": {"@type": "xsd:float", "@value": "19.5458869934082"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.05176480514799"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.54163753627967e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.892419390862991"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.108193496757792"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.05176480514799"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.54163753627967e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.892419390862991"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.108193496757792"}
     },
     {
-      "@id": "niiri:13eed93b488bc2f8ea02ff9e1be0807e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:826ac32082a51738929fdbd7249ac832",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0079",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-12,18,18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-12,18,18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b4e1727e487e8b71ba67d88addf8b5dd",
-      "entity": "niiri:b9079ad818d03296fe8330a4f70c5c53"
+      "entity_derived": "niiri:45fb7b2544c4802833f71463702fb573",
+      "entity": "niiri:36f4c495e82ce16bc5e3538ec47db115"
     },
     {
-      "@id": "niiri:1e8afe377d891571110d3fb4b1a28861",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ae25400879fdbbd71ea06f98f2949c87",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0080",
-      "prov:atLocation": {"@id": "niiri:9f0dfc6b98b181edb1625a402d1f1170"},
+      "prov:atLocation": {"@id": "niiri:d6cf34caaee1bde6a1304bf6965b1515"},
       "prov:value": {"@type": "xsd:float", "@value": "25.5991687774658"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.61516091591235"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.96395429286067e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.225247536188687"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0225353109118294"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.61516091591235"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.96395429286067e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.225247536188687"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0225353109118294"}
     },
     {
-      "@id": "niiri:9f0dfc6b98b181edb1625a402d1f1170",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d6cf34caaee1bde6a1304bf6965b1515",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0080",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-16,-94,-10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-16,-94,-10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1e8afe377d891571110d3fb4b1a28861",
-      "entity": "niiri:6ed412630e5ab417bee547bf394670cd"
+      "entity_derived": "niiri:ae25400879fdbbd71ea06f98f2949c87",
+      "entity": "niiri:f3db818d25677c7c9807d3bc465f0dec"
     },
     {
-      "@id": "niiri:087f9d74d18da0bfcfc9d0dea8ab2a56",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:dbfa2e37fc9b5cbbd31da892e2cc2e8a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0081",
-      "prov:atLocation": {"@id": "niiri:1258eebdfcb9560033aeba6b2948a8e8"},
+      "prov:atLocation": {"@id": "niiri:81d3490604ccd120799925539af20ef2"},
       "prov:value": {"@type": "xsd:float", "@value": "25.4056377410889"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.59861326841205"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.12656228593122e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.239135795532846"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0234803184814089"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.59861326841205"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.12656228593122e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.239135795532846"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0234803184814089"}
     },
     {
-      "@id": "niiri:1258eebdfcb9560033aeba6b2948a8e8",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:81d3490604ccd120799925539af20ef2",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0081",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[30,48,-36]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[30,48,-36]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:087f9d74d18da0bfcfc9d0dea8ab2a56",
-      "entity": "niiri:a69405853461b6b0f7066443a438e1d5"
+      "entity_derived": "niiri:dbfa2e37fc9b5cbbd31da892e2cc2e8a",
+      "entity": "niiri:16cd91852662e2b6fb06dce21defbb02"
     },
     {
-      "@id": "niiri:8a7f0dd59332e520147aa43d3301426b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c98e1abf15afafba77dc2a1b5bccdb07",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0082",
-      "prov:atLocation": {"@id": "niiri:7c1abf19d0206f7e77a0710fe94d3393"},
+      "prov:atLocation": {"@id": "niiri:191de3f73a536af56269b0d980e647bf"},
       "prov:value": {"@type": "xsd:float", "@value": "25.2654209136963"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.58657091932872"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.25292694944201e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.249647931424908"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0240262284056265"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.58657091932872"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.25292694944201e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.249647931424908"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0240262284056265"}
     },
     {
-      "@id": "niiri:7c1abf19d0206f7e77a0710fe94d3393",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:191de3f73a536af56269b0d980e647bf",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0082",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[2,38,-14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[2,38,-14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8a7f0dd59332e520147aa43d3301426b",
-      "entity": "niiri:0747284a50ab24237772bdee19f8130e"
+      "entity_derived": "niiri:c98e1abf15afafba77dc2a1b5bccdb07",
+      "entity": "niiri:d1f64d168706b2b7b1ea74aeb9acf76d"
     },
     {
-      "@id": "niiri:e25945315446edcba8cd31ac9a2e3ec7",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:11bc9e8dccdea4c6f0576729732a26b1",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0083",
-      "prov:atLocation": {"@id": "niiri:81e9f46ae1541e8684d30680194d1ff9"},
+      "prov:atLocation": {"@id": "niiri:fee409d8fb1182c19595120e80d6f171"},
       "prov:value": {"@type": "xsd:float", "@value": "18.0576820373535"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.89603144574785"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.88908495202001e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.97812034582109"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.163088144322206"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.89603144574785"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.88908495202001e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.97812034582109"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.163088144322206"}
     },
     {
-      "@id": "niiri:81e9f46ae1541e8684d30680194d1ff9",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:fee409d8fb1182c19595120e80d6f171",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0083",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[8,46,-18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[8,46,-18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e25945315446edcba8cd31ac9a2e3ec7",
-      "entity": "niiri:0747284a50ab24237772bdee19f8130e"
+      "entity_derived": "niiri:11bc9e8dccdea4c6f0576729732a26b1",
+      "entity": "niiri:d1f64d168706b2b7b1ea74aeb9acf76d"
     },
     {
-      "@id": "niiri:b2713b8071a14adab90b4fdd4762d876",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:9eaf1659f6e51a24c9b5249d9eca8663",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0084",
-      "prov:atLocation": {"@id": "niiri:b366280a87ab07a8afd5a92437f93a85"},
+      "prov:atLocation": {"@id": "niiri:3e306b247465821a8416bea1f0792417"},
       "prov:value": {"@type": "xsd:float", "@value": "24.3388156890869"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.50583608073911"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.30560549555159e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.32905451036308"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0310816877190926"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.50583608073911"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.30560549555159e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.32905451036308"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0310816877190926"}
     },
     {
-      "@id": "niiri:b366280a87ab07a8afd5a92437f93a85",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:3e306b247465821a8416bea1f0792417",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0084",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-58,-30,-18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-58,-30,-18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b2713b8071a14adab90b4fdd4762d876",
-      "entity": "niiri:a1f38c4aab7577b61865da78d168d6b4"
+      "entity_derived": "niiri:9eaf1659f6e51a24c9b5249d9eca8663",
+      "entity": "niiri:81dc6b3cbc9f571d3c373afc2c155834"
     },
     {
-      "@id": "niiri:43d157fbe61ac3ac584d21aa31a2fac6",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:df657fae07b6aff0d6f00ce65dfc1a80",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0085",
-      "prov:atLocation": {"@id": "niiri:65c986b576a1eac65333099d7fd3dd9f"},
+      "prov:atLocation": {"@id": "niiri:00f8a5c75c390f4c4a77aa0c74938e09"},
       "prov:value": {"@type": "xsd:float", "@value": "24.2647590637207"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.4992949508152"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.40896034356497e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.336164282110146"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0315627223093611"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.4992949508152"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.40896034356497e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.336164282110146"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0315627223093611"}
     },
     {
-      "@id": "niiri:65c986b576a1eac65333099d7fd3dd9f",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:00f8a5c75c390f4c4a77aa0c74938e09",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0085",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[28,10,-48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[28,10,-48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:43d157fbe61ac3ac584d21aa31a2fac6",
-      "entity": "niiri:b2b2a00d477027244468267bb4cfdd7e"
+      "entity_derived": "niiri:df657fae07b6aff0d6f00ce65dfc1a80",
+      "entity": "niiri:5c83c29ecdf61abf3b54b84749525008"
     },
     {
-      "@id": "niiri:691e769de224d51eb649045f8ef83491",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:cd2b04f2aeb928b0be2c2b49a81c72cc",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0086",
-      "prov:atLocation": {"@id": "niiri:2ea822d88aca06fe087b463e86eb36f4"},
+      "prov:atLocation": {"@id": "niiri:7945a1875a4816413138667329ef1f28"},
       "prov:value": {"@type": "xsd:float", "@value": "23.435432434082"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.42511309261812"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.8195886048763e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.423415338028086"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0388969248253009"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.42511309261812"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.8195886048763e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.423415338028086"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0388969248253009"}
     },
     {
-      "@id": "niiri:2ea822d88aca06fe087b463e86eb36f4",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7945a1875a4816413138667329ef1f28",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0086",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-48,18,-36]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-48,18,-36]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:691e769de224d51eb649045f8ef83491",
-      "entity": "niiri:1aefd578b3c1231848bc58379b5aa924"
+      "entity_derived": "niiri:cd2b04f2aeb928b0be2c2b49a81c72cc",
+      "entity": "niiri:01690965efcb17bbde83102ddcb2faab"
     },
     {
-      "@id": "niiri:157998c9ea79fd46b084d5da98dc8213",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:176829804e5fc15b1d1a6c6d59815463",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0087",
-      "prov:atLocation": {"@id": "niiri:b91c82676dd2a428ca424a279f265584"},
+      "prov:atLocation": {"@id": "niiri:0bd53d1e4f2f294994607ed9b19f0de8"},
       "prov:value": {"@type": "xsd:float", "@value": "22.7630805969238"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.36367473144233"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.39478488917433e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.503542709649183"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0453548437799061"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.36367473144233"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.39478488917433e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.503542709649183"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0453548437799061"}
     },
     {
-      "@id": "niiri:b91c82676dd2a428ca424a279f265584",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0bd53d1e4f2f294994607ed9b19f0de8",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0087",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-32,-22,-20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-32,-22,-20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:157998c9ea79fd46b084d5da98dc8213",
-      "entity": "niiri:42e2f22eff9709257cf127b203589014"
+      "entity_derived": "niiri:176829804e5fc15b1d1a6c6d59815463",
+      "entity": "niiri:06b13cc33465cdc0e1390a27c23a9ac4"
     },
     {
-      "@id": "niiri:c0fe090dd271ccdc48c93392dfa499f6",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0b19217ec62c40e969523b448d183a81",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0088",
-      "prov:atLocation": {"@id": "niiri:8c5b8cefbe231ebb2a9ced63082569db"},
+      "prov:atLocation": {"@id": "niiri:8902a12641b236a6f0e57e20ffe1b3d9"},
       "prov:value": {"@type": "xsd:float", "@value": "22.6970634460449"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.35757737148877"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.57550076188507e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.511788595032734"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0458137283186348"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.35757737148877"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.57550076188507e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.511788595032734"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0458137283186348"}
     },
     {
-      "@id": "niiri:8c5b8cefbe231ebb2a9ced63082569db",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:8902a12641b236a6f0e57e20ffe1b3d9",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0088",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-46,-66,-6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-46,-66,-6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c0fe090dd271ccdc48c93392dfa499f6",
-      "entity": "niiri:2974d7622a4eb3c979c41bc0bae55ebd"
+      "entity_derived": "niiri:0b19217ec62c40e969523b448d183a81",
+      "entity": "niiri:7f6f25f12f4270c6aaed0a3240d5a8a1"
     },
     {
-      "@id": "niiri:25a3c5d53b1149a69c2cad7fabc33df1",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:fb41e19cf49308d445b6143dd6530c16",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0089",
-      "prov:atLocation": {"@id": "niiri:5be22bea07a58070e46f9221c8e4cade"},
+      "prov:atLocation": {"@id": "niiri:a75a3a79996c194090886fd73b647151"},
       "prov:value": {"@type": "xsd:float", "@value": "14.1656980514526"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.44523640108096"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000285280079043382"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999844740898"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.467962708438717"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.44523640108096"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000285280079043382"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999844740898"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.467962708438717"}
     },
     {
-      "@id": "niiri:5be22bea07a58070e46f9221c8e4cade",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a75a3a79996c194090886fd73b647151",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0089",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-54,-64,-8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-54,-64,-8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:25a3c5d53b1149a69c2cad7fabc33df1",
-      "entity": "niiri:2974d7622a4eb3c979c41bc0bae55ebd"
+      "entity_derived": "niiri:fb41e19cf49308d445b6143dd6530c16",
+      "entity": "niiri:7f6f25f12f4270c6aaed0a3240d5a8a1"
     },
     {
-      "@id": "niiri:5ecc1af9e6559873e638586b57b43bf9",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e444cfdfe2f6cbaf0481b63d2834fda6",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0090",
-      "prov:atLocation": {"@id": "niiri:26b915d76f24959b015d5a13200e6fde"},
+      "prov:atLocation": {"@id": "niiri:4353faa47737a9ce68ee616b1f970063"},
       "prov:value": {"@type": "xsd:float", "@value": "22.5773677825928"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.34649211997001"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.91660093510293e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.526883623410185"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0471103061870597"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.34649211997001"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.91660093510293e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.526883623410185"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0471103061870597"}
     },
     {
-      "@id": "niiri:26b915d76f24959b015d5a13200e6fde",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4353faa47737a9ce68ee616b1f970063",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0090",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-48,-58,26]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-48,-58,26]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5ecc1af9e6559873e638586b57b43bf9",
-      "entity": "niiri:dd84655271d1a93ad919193767608ec8"
+      "entity_derived": "niiri:e444cfdfe2f6cbaf0481b63d2834fda6",
+      "entity": "niiri:8f37ccae34c7cba6e277659e1d99e2a9"
     },
     {
-      "@id": "niiri:1102890296e43a27581e19edef3f6ea2",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5cdb4e3e9ed6941e49fa8b89c908661b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0091",
-      "prov:atLocation": {"@id": "niiri:1fb1dd4e0ecff1691a8fc8830f7c89fa"},
+      "prov:atLocation": {"@id": "niiri:8a6f228a2d58da780f109d6dee18edb2"},
       "prov:value": {"@type": "xsd:float", "@value": "18.1794853210449"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.909083502135"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.6323469247822e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.974191386889975"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.158566450522772"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.909083502135"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.6323469247822e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.974191386889975"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.158566450522772"}
     },
     {
-      "@id": "niiri:1fb1dd4e0ecff1691a8fc8830f7c89fa",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:8a6f228a2d58da780f109d6dee18edb2",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0091",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-40,-54,24]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-40,-54,24]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1102890296e43a27581e19edef3f6ea2",
-      "entity": "niiri:dd84655271d1a93ad919193767608ec8"
+      "entity_derived": "niiri:5cdb4e3e9ed6941e49fa8b89c908661b",
+      "entity": "niiri:8f37ccae34c7cba6e277659e1d99e2a9"
     },
     {
-      "@id": "niiri:3e8512b99a74d1e7cb6f4d079a060195",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:dd4fd70f165a7929f76cd0a4dfbf5059",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0092",
-      "prov:atLocation": {"@id": "niiri:1b555de9730f3d550d48d41abeba3f1d"},
+      "prov:atLocation": {"@id": "niiri:21f3959c2cd89d63592ed6a03bacfca5"},
       "prov:value": {"@type": "xsd:float", "@value": "22.300386428833"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.3206898346505"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.77710889177108e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.562434726478465"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0510171908662791"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.3206898346505"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.77710889177108e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.562434726478465"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0510171908662791"}
     },
     {
-      "@id": "niiri:1b555de9730f3d550d48d41abeba3f1d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:21f3959c2cd89d63592ed6a03bacfca5",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0092",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[58,-38,6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[58,-38,6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3e8512b99a74d1e7cb6f4d079a060195",
-      "entity": "niiri:0f340a0ff58ecb32a533ddd1cf07f45d"
+      "entity_derived": "niiri:dd4fd70f165a7929f76cd0a4dfbf5059",
+      "entity": "niiri:3acfc147a4a82a0c9064e4e844ecc743"
     },
     {
-      "@id": "niiri:d47a9fea626980e6b1ef2924dabe6a81",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:6263d0bf0edefd0d5b70b55319094a47",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0093",
-      "prov:atLocation": {"@id": "niiri:29aa36a62824fcd63d780ed55757920a"},
+      "prov:atLocation": {"@id": "niiri:e989bd9b9d36dcbd27f6bb25eecabde9"},
       "prov:value": {"@type": "xsd:float", "@value": "22.2661895751953"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.31748949702426"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.89069578244206e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.566874895647931"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.051397236162478"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.31748949702426"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.89069578244206e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.566874895647931"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.051397236162478"}
     },
     {
-      "@id": "niiri:29aa36a62824fcd63d780ed55757920a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e989bd9b9d36dcbd27f6bb25eecabde9",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0093",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[42,-66,6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[42,-66,6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d47a9fea626980e6b1ef2924dabe6a81",
-      "entity": "niiri:43c527932f85b9bc3ce5b3b60117f451"
+      "entity_derived": "niiri:6263d0bf0edefd0d5b70b55319094a47",
+      "entity": "niiri:bb2efddb865295f983adb4172abe81b6"
     },
     {
-      "@id": "niiri:dc87dcb5ff0422da1d35c47b664eb074",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a05276936cf0d417dc5ca6d7a0d6a3f9",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0094",
-      "prov:atLocation": {"@id": "niiri:841ad5ad32d7c372ada388e673e16793"},
+      "prov:atLocation": {"@id": "niiri:cc95f61fed018b19add13d2f5b0ea062"},
       "prov:value": {"@type": "xsd:float", "@value": "22.1354484558105"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.30522386387639"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.34084780676481e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.583932942615046"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0533499015486859"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.30522386387639"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.34084780676481e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.583932942615046"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0533499015486859"}
     },
     {
-      "@id": "niiri:841ad5ad32d7c372ada388e673e16793",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:cc95f61fed018b19add13d2f5b0ea062",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0094",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-36,-74,-14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-36,-74,-14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:dc87dcb5ff0422da1d35c47b664eb074",
-      "entity": "niiri:4c9c90b34337736af0c1709b3e2dce99"
+      "entity_derived": "niiri:a05276936cf0d417dc5ca6d7a0d6a3f9",
+      "entity": "niiri:29b1a5a35e558ec0833c58691621c112"
     },
     {
-      "@id": "niiri:e888c65f8d4b187785526e34e54596eb",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3ccae7f904d1cb2d10acffdcfadc8f10",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0095",
-      "prov:atLocation": {"@id": "niiri:936c0177160c4e527ad489766a349270"},
+      "prov:atLocation": {"@id": "niiri:c9b5f5d788c682c3f5ede975be932a63"},
       "prov:value": {"@type": "xsd:float", "@value": "16.7093238830566"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.7475977576799"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.92681312850696e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99803966762084"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.231798608212325"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.7475977576799"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.92681312850696e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99803966762084"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.231798608212325"}
     },
     {
-      "@id": "niiri:936c0177160c4e527ad489766a349270",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c9b5f5d788c682c3f5ede975be932a63",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0095",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-36,-68,-20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-36,-68,-20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e888c65f8d4b187785526e34e54596eb",
-      "entity": "niiri:4c9c90b34337736af0c1709b3e2dce99"
+      "entity_derived": "niiri:3ccae7f904d1cb2d10acffdcfadc8f10",
+      "entity": "niiri:29b1a5a35e558ec0833c58691621c112"
     },
     {
-      "@id": "niiri:eeca61f4cebf9669d662fcaeb1fe04bb",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:8e4ca43f93486def424cfb00d341a82e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0096",
-      "prov:atLocation": {"@id": "niiri:067e2de875421b92ea5ef14a4beec1b7"},
+      "prov:atLocation": {"@id": "niiri:9362a39a8676e78d5f782844a37c400b"},
       "prov:value": {"@type": "xsd:float", "@value": "22.009162902832"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.29333057860161"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.80063176944557e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.600511384577349"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0552945360022594"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.29333057860161"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.80063176944557e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.600511384577349"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0552945360022594"}
     },
     {
-      "@id": "niiri:067e2de875421b92ea5ef14a4beec1b7",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:9362a39a8676e78d5f782844a37c400b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0096",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[20,52,-8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[20,52,-8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:eeca61f4cebf9669d662fcaeb1fe04bb",
-      "entity": "niiri:645b34305a7adc863333ef8d055b94b6"
+      "entity_derived": "niiri:8e4ca43f93486def424cfb00d341a82e",
+      "entity": "niiri:16e2e680906eb7d77a0f37a900f566bb"
     },
     {
-      "@id": "niiri:02c32317a2587c4e20987e49068cdfdd",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e5b709733a7a64fd4daeb683bb3734c7",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0097",
-      "prov:atLocation": {"@id": "niiri:fdfd8d1cbb4a9bfd41738fc28889cdd1"},
+      "prov:atLocation": {"@id": "niiri:93c38f3e63878c9d511e15582b642126"},
       "prov:value": {"@type": "xsd:float", "@value": "19.9573459625244"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.09345225838168"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.12498807569128e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.853596609416469"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0969483313559081"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.09345225838168"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.12498807569128e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.853596609416469"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0969483313559081"}
     },
     {
-      "@id": "niiri:fdfd8d1cbb4a9bfd41738fc28889cdd1",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:93c38f3e63878c9d511e15582b642126",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0097",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[8,66,-12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[8,66,-12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:02c32317a2587c4e20987e49068cdfdd",
-      "entity": "niiri:645b34305a7adc863333ef8d055b94b6"
+      "entity_derived": "niiri:e5b709733a7a64fd4daeb683bb3734c7",
+      "entity": "niiri:16e2e680906eb7d77a0f37a900f566bb"
     },
     {
-      "@id": "niiri:fda61110b4be429734ac1fee6209dea7",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c9aaa481cdfc446e54553d8f78ce6094",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0098",
-      "prov:atLocation": {"@id": "niiri:35d6be2cd0bfbb4370fcbe2dc07d7110"},
+      "prov:atLocation": {"@id": "niiri:66687a1556cf944ab251cc50c5a1afec"},
       "prov:value": {"@type": "xsd:float", "@value": "21.6827297210693"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.26237714614837"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.01131850654967e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.643607390332145"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0595012953349514"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.26237714614837"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.01131850654967e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.643607390332145"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0595012953349514"}
     },
     {
-      "@id": "niiri:35d6be2cd0bfbb4370fcbe2dc07d7110",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:66687a1556cf944ab251cc50c5a1afec",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0098",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-50,-56,-46]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-50,-56,-46]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:fda61110b4be429734ac1fee6209dea7",
-      "entity": "niiri:147ce23197bb1c39e660c70911b5c483"
+      "entity_derived": "niiri:c9aaa481cdfc446e54553d8f78ce6094",
+      "entity": "niiri:160595535853afe9f10e3ba4462634ee"
     },
     {
-      "@id": "niiri:2550be23d66e4dc7fc4b7dcf374e5c8d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:6197fba6e2664d7308395423fa054a5a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0099",
-      "prov:atLocation": {"@id": "niiri:e3dbec50daf97eaf5ef864b0210a0ed9"},
+      "prov:atLocation": {"@id": "niiri:59ccd11f545a7e2d5564defe74cdf344"},
       "prov:value": {"@type": "xsd:float", "@value": "20.8459243774414"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.18159782528346"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.44733828864041e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.751996552599621"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0757651987419718"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.18159782528346"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.44733828864041e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.751996552599621"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0757651987419718"}
     },
     {
-      "@id": "niiri:e3dbec50daf97eaf5ef864b0210a0ed9",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:59ccd11f545a7e2d5564defe74cdf344",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0099",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-54,-60,-34]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-54,-60,-34]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2550be23d66e4dc7fc4b7dcf374e5c8d",
-      "entity": "niiri:147ce23197bb1c39e660c70911b5c483"
+      "entity_derived": "niiri:6197fba6e2664d7308395423fa054a5a",
+      "entity": "niiri:160595535853afe9f10e3ba4462634ee"
     },
     {
-      "@id": "niiri:e2b712aa23b785bf2512d75cc71c1f60",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:665564fcd3b0c01a2d413f93a062d71e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0100",
-      "prov:atLocation": {"@id": "niiri:7e6c51e7d9c351d654b1574131f29158"},
+      "prov:atLocation": {"@id": "niiri:13a8380ee841694a3439ded70c91247f"},
       "prov:value": {"@type": "xsd:float", "@value": "21.6761283874512"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.26174801852479"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.01417038346208e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.644479756447942"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0595012953349514"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.26174801852479"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.01417038346208e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.644479756447942"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0595012953349514"}
     },
     {
-      "@id": "niiri:7e6c51e7d9c351d654b1574131f29158",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:13a8380ee841694a3439ded70c91247f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0100",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-6,22,-4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-6,22,-4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e2b712aa23b785bf2512d75cc71c1f60",
-      "entity": "niiri:4c767097d4f857da1a95ec39b9d9edc3"
+      "entity_derived": "niiri:665564fcd3b0c01a2d413f93a062d71e",
+      "entity": "niiri:5bea9c455010164eafb48efd433d0b3b"
     },
     {
-      "@id": "niiri:75f647b6e41d8fc22a0e0977805c1613",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d510f031f5c43274a32cc49cf1f3f001",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0101",
-      "prov:atLocation": {"@id": "niiri:1cecb0735e82a478ba9325b76b765942"},
+      "prov:atLocation": {"@id": "niiri:891a5976572946a7b565dcbdfa45714d"},
       "prov:value": {"@type": "xsd:float", "@value": "16.2054805755615"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.69016146811634"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000112055876962391"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999439014335705"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.269643439858175"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.69016146811634"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000112055876962391"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999439014335705"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.269643439858175"}
     },
     {
-      "@id": "niiri:1cecb0735e82a478ba9325b76b765942",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:891a5976572946a7b565dcbdfa45714d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0101",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[2,24,-10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[2,24,-10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:75f647b6e41d8fc22a0e0977805c1613",
-      "entity": "niiri:4c767097d4f857da1a95ec39b9d9edc3"
+      "entity_derived": "niiri:d510f031f5c43274a32cc49cf1f3f001",
+      "entity": "niiri:5bea9c455010164eafb48efd433d0b3b"
     },
     {
-      "@id": "niiri:1ea89db36385d43e680df4cf1937c752",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:31b0c9c2327a4d798a48c9c2cca5ac27",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0102",
-      "prov:atLocation": {"@id": "niiri:05c9a525e9ad3c3bb3e23ba283598628"},
+      "prov:atLocation": {"@id": "niiri:f74543d456ae0968251bded2c0a3475d"},
       "prov:value": {"@type": "xsd:float", "@value": "21.5253620147705"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.24734493361237"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.08159392907536e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.664379439585423"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0622520078187919"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.24734493361237"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.08159392907536e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.664379439585423"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0622520078187919"}
     },
     {
-      "@id": "niiri:05c9a525e9ad3c3bb3e23ba283598628",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f74543d456ae0968251bded2c0a3475d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0102",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-4,58,40]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-4,58,40]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1ea89db36385d43e680df4cf1937c752",
-      "entity": "niiri:e039dc19484a5a0f4a9f1920c4f37802"
+      "entity_derived": "niiri:31b0c9c2327a4d798a48c9c2cca5ac27",
+      "entity": "niiri:54acd58c8408a4a54a5d29cdbcf77a2a"
     },
     {
-      "@id": "niiri:ea634ac3460003e29d29d4a7f5c1a646",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d3aa0d69a7eaa43c7b928709eff2bf3c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0103",
-      "prov:atLocation": {"@id": "niiri:6957a245193d2f46f8c65e90228e4fb3"},
+      "prov:atLocation": {"@id": "niiri:e26583fef812bde0be11d99cc55cdd5b"},
       "prov:value": {"@type": "xsd:float", "@value": "21.3095722198486"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.22661368779567"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.18617218586303e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.692690637306793"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.066091397071435"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.22661368779567"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.18617218586303e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.692690637306793"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.066091397071435"}
     },
     {
-      "@id": "niiri:6957a245193d2f46f8c65e90228e4fb3",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e26583fef812bde0be11d99cc55cdd5b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0103",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[56,-66,28]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[56,-66,28]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ea634ac3460003e29d29d4a7f5c1a646",
-      "entity": "niiri:90684205dbd5e3565c63d92ea2c2ba92"
+      "entity_derived": "niiri:d3aa0d69a7eaa43c7b928709eff2bf3c",
+      "entity": "niiri:e0f95b0e95e26dd40bce67d69e9c88a7"
     },
     {
-      "@id": "niiri:6aa24132bd020294cf997d47bec08962",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d97a5111c9a07f3911f9566bb4f817b7",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0104",
-      "prov:atLocation": {"@id": "niiri:4bb3470ea7fab10c6e4a2cb7e24167a4"},
+      "prov:atLocation": {"@id": "niiri:0baf1fce706fc700d3c2c6983653cd7c"},
       "prov:value": {"@type": "xsd:float", "@value": "21.1252059936523"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.20879143363758"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.28370116740939e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.716590361946796"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0697051976348589"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.20879143363758"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.28370116740939e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.716590361946796"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0697051976348589"}
     },
     {
-      "@id": "niiri:4bb3470ea7fab10c6e4a2cb7e24167a4",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0baf1fce706fc700d3c2c6983653cd7c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0104",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[16,-98,6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[16,-98,6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6aa24132bd020294cf997d47bec08962",
-      "entity": "niiri:43d72ad1d7d22b80f01808f8d966ccdd"
+      "entity_derived": "niiri:d97a5111c9a07f3911f9566bb4f817b7",
+      "entity": "niiri:e1915181e888f91227f9d80a2ceda361"
     },
     {
-      "@id": "niiri:5916a805521346eef56b006e4de1d886",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:142389ac0cc7b6ad0aefee61aaa19f01",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0105",
-      "prov:atLocation": {"@id": "niiri:f226b8e795a08bc9e83e1c9723241f54"},
+      "prov:atLocation": {"@id": "niiri:96c31dac1b644e65f3fac10a4bcdf913"},
       "prov:value": {"@type": "xsd:float", "@value": "20.9664764404297"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.19336518197686"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.3742322497845e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.736853371757955"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0731699937068361"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.19336518197686"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.3742322497845e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.736853371757955"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0731699937068361"}
     },
     {
-      "@id": "niiri:f226b8e795a08bc9e83e1c9723241f54",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:96c31dac1b644e65f3fac10a4bcdf913",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0105",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-60,-16,28]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-60,-16,28]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5916a805521346eef56b006e4de1d886",
-      "entity": "niiri:fce6ba03f6215ffda4130a08998532e7"
+      "entity_derived": "niiri:142389ac0cc7b6ad0aefee61aaa19f01",
+      "entity": "niiri:059524711a78d34f86f9ff7484d30c28"
     },
     {
-      "@id": "niiri:ffa5ca5b56650798f24d66c1ed26b018",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:55baaf76e4730532805f8f2d9564575f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0106",
-      "prov:atLocation": {"@id": "niiri:f1b33b4cf1deec88ae98054d4bcd3ee8"},
+      "prov:atLocation": {"@id": "niiri:326c1f2b49a399f5d14885efa0367044"},
       "prov:value": {"@type": "xsd:float", "@value": "20.4901485443115"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.14660690773876"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.68719329129985e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.795085603917253"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0839823722931768"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.14660690773876"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.68719329129985e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.795085603917253"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0839823722931768"}
     },
     {
-      "@id": "niiri:f1b33b4cf1deec88ae98054d4bcd3ee8",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:326c1f2b49a399f5d14885efa0367044",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0106",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[16,14,62]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[16,14,62]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ffa5ca5b56650798f24d66c1ed26b018",
-      "entity": "niiri:90faaaeae176fe54bdbf1e2a7100afb2"
+      "entity_derived": "niiri:55baaf76e4730532805f8f2d9564575f",
+      "entity": "niiri:f80c4f725486ccc8cbc7ca97e9202b10"
     },
     {
-      "@id": "niiri:9ab30b882bdce7ae8c8f9df0e9da4732",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f5c396305d9d8b59e0f1de9b43bc1c04",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0107",
-      "prov:atLocation": {"@id": "niiri:37e02f565a077430db77e2e77ba591c5"},
+      "prov:atLocation": {"@id": "niiri:251fea1831ca94c94c0699f4dbebb262"},
       "prov:value": {"@type": "xsd:float", "@value": "20.1859455108643"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.11637075760553"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.92442496569356e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.829516805025193"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0918155656683619"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.11637075760553"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.92442496569356e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.829516805025193"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0918155656683619"}
     },
     {
-      "@id": "niiri:37e02f565a077430db77e2e77ba591c5",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:251fea1831ca94c94c0699f4dbebb262",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0107",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-46,-32,58]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-46,-32,58]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9ab30b882bdce7ae8c8f9df0e9da4732",
-      "entity": "niiri:a56b7f6c2daf0ff5655692e9a3ba50e8"
+      "entity_derived": "niiri:f5c396305d9d8b59e0f1de9b43bc1c04",
+      "entity": "niiri:4fc2bcbe1574c654541b41942566af13"
     },
     {
-      "@id": "niiri:22d9a01396c2e063eef7b45fef2c0f15",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b17798d8da7350fcfdb2da256f317589",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0108",
-      "prov:atLocation": {"@id": "niiri:6ec8c82b1d1de3c00711b7fd7869cad2"},
+      "prov:atLocation": {"@id": "niiri:78af07cd6758279fa7f56ce54921d1cb"},
       "prov:value": {"@type": "xsd:float", "@value": "19.9081478118896"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.08849741803632"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.17088189312653e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.858555794271687"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0982970474931675"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.08849741803632"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.17088189312653e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.858555794271687"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0982970474931675"}
     },
     {
-      "@id": "niiri:6ec8c82b1d1de3c00711b7fd7869cad2",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:78af07cd6758279fa7f56ce54921d1cb",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0108",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[38,-82,10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[38,-82,10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:22d9a01396c2e063eef7b45fef2c0f15",
-      "entity": "niiri:94a06b9bd15a2d12f76ca646af0fa348"
+      "entity_derived": "niiri:b17798d8da7350fcfdb2da256f317589",
+      "entity": "niiri:dff2d5252e6112d696cc75e19b35b055"
     },
     {
-      "@id": "niiri:e7be33d40089bfba3b2033cdca6e66df",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:606ad57a2c441571f0c00836b6a11960",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0109",
-      "prov:atLocation": {"@id": "niiri:7d784374f98004829297818ba5e6c57d"},
+      "prov:atLocation": {"@id": "niiri:ecb1b99ed2d95e871037822a0cde1bff"},
       "prov:value": {"@type": "xsd:float", "@value": "19.88161277771"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.08582170061298"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.19605490655583e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.861196205689319"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0988533813000291"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.08582170061298"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.19605490655583e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.861196205689319"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0988533813000291"}
     },
     {
-      "@id": "niiri:7d784374f98004829297818ba5e6c57d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ecb1b99ed2d95e871037822a0cde1bff",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0109",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[38,-78,44]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[38,-78,44]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e7be33d40089bfba3b2033cdca6e66df",
-      "entity": "niiri:e6bd6b781a9701be59c8d9453ba0f42d"
+      "entity_derived": "niiri:606ad57a2c441571f0c00836b6a11960",
+      "entity": "niiri:c1d3f6f0f50baea1174f7ada78444ce5"
     },
     {
-      "@id": "niiri:4defe0c7577a8a72b50638c086e04293",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:44957024e6a6c3a8d350f2182ed7669b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0110",
-      "prov:atLocation": {"@id": "niiri:0f56b877b6b3d4e2793a888b59c3ae04"},
+      "prov:atLocation": {"@id": "niiri:db64ae2b2c4d3bcd61012d22f3845781"},
       "prov:value": {"@type": "xsd:float", "@value": "19.6855850219727"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.0659821671938"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.39152966687861e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.879930855992272"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.104063286439229"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.0659821671938"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.39152966687861e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.879930855992272"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.104063286439229"}
     },
     {
-      "@id": "niiri:0f56b877b6b3d4e2793a888b59c3ae04",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:db64ae2b2c4d3bcd61012d22f3845781",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0110",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-14,68,12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-14,68,12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4defe0c7577a8a72b50638c086e04293",
-      "entity": "niiri:24a7631619b05b254e46f418981f33fd"
+      "entity_derived": "niiri:44957024e6a6c3a8d350f2182ed7669b",
+      "entity": "niiri:ac01f2a6f9677b631c38f9d1203db903"
     },
     {
-      "@id": "niiri:d98b611de8d7e1482ae41f7a7530e8dc",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:7a1f7b35bf5c2e76842344547587ee88",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0111",
-      "prov:atLocation": {"@id": "niiri:f8b1837e055a5a75c502336b4d3fec6d"},
+      "prov:atLocation": {"@id": "niiri:1726de2b89d7e8b3dd5c75339c03089a"},
       "prov:value": {"@type": "xsd:float", "@value": "15.3516979217529"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.59017266008559"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000165229496364216"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999962977415156"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.336130452148725"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.59017266008559"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000165229496364216"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999962977415156"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.336130452148725"}
     },
     {
-      "@id": "niiri:f8b1837e055a5a75c502336b4d3fec6d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:1726de2b89d7e8b3dd5c75339c03089a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0111",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-18,66,26]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-18,66,26]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d98b611de8d7e1482ae41f7a7530e8dc",
-      "entity": "niiri:24a7631619b05b254e46f418981f33fd"
+      "entity_derived": "niiri:7a1f7b35bf5c2e76842344547587ee88",
+      "entity": "niiri:ac01f2a6f9677b631c38f9d1203db903"
     },
     {
-      "@id": "niiri:c0af81189f9a5aace7d1dbfc2f31f56c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:52798f01ae0c76b1a815825b938124bf",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0112",
-      "prov:atLocation": {"@id": "niiri:f515e14d6e41c47d4558f27b59d822b2"},
+      "prov:atLocation": {"@id": "niiri:ddba1731b4fb95f8dc592e2e1dff8512"},
       "prov:value": {"@type": "xsd:float", "@value": "19.3617496490479"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.0329231622068"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.75436479366675e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.907734095795052"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.114345300686635"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.0329231622068"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.75436479366675e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.907734095795052"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.114345300686635"}
     },
     {
-      "@id": "niiri:f515e14d6e41c47d4558f27b59d822b2",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ddba1731b4fb95f8dc592e2e1dff8512",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0112",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[14,-66,-12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[14,-66,-12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c0af81189f9a5aace7d1dbfc2f31f56c",
-      "entity": "niiri:26d38070320861a52f54239810eefb6d"
+      "entity_derived": "niiri:52798f01ae0c76b1a815825b938124bf",
+      "entity": "niiri:6ac4331664607b2b0b57f58303204021"
     },
     {
-      "@id": "niiri:519b3586ed16092208050d4ee00a0452",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ac84790ec5fc05c9de4754f79ac66e49",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0113",
-      "prov:atLocation": {"@id": "niiri:fffb2bca0e0a1be9b8744f849dea122e"},
+      "prov:atLocation": {"@id": "niiri:08c5e7ad57bb2c8bbad532efbb58aec7"},
       "prov:value": {"@type": "xsd:float", "@value": "19.3172149658203"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.0283486821653"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.80849975954345e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.911237684671062"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.115154016069316"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.0283486821653"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.80849975954345e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.911237684671062"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.115154016069316"}
     },
     {
-      "@id": "niiri:fffb2bca0e0a1be9b8744f849dea122e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:08c5e7ad57bb2c8bbad532efbb58aec7",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0113",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[44,26,-30]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[44,26,-30]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:519b3586ed16092208050d4ee00a0452",
-      "entity": "niiri:a5c107a7aa03e749be4156dafe333465"
+      "entity_derived": "niiri:ac84790ec5fc05c9de4754f79ac66e49",
+      "entity": "niiri:df3a63e829a4b0144a3bd3a075d00d6a"
     },
     {
-      "@id": "niiri:baca4373834d30fe008b9865ab711552",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e6936b16ba6c2d4218eb760cf497ca0c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0114",
-      "prov:atLocation": {"@id": "niiri:34c57cb11965b6d093c5d8909cd2fc0e"},
+      "prov:atLocation": {"@id": "niiri:6f85ca7632c41f1bfb8b8f02fb275c74"},
       "prov:value": {"@type": "xsd:float", "@value": "18.8370418548584"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.9785849448618"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.46633215003722e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.943955324716031"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.133237780105225"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.9785849448618"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.46633215003722e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.943955324716031"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.133237780105225"}
     },
     {
-      "@id": "niiri:34c57cb11965b6d093c5d8909cd2fc0e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6f85ca7632c41f1bfb8b8f02fb275c74",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0114",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[36,24,-28]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[36,24,-28]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:baca4373834d30fe008b9865ab711552",
-      "entity": "niiri:a5c107a7aa03e749be4156dafe333465"
+      "entity_derived": "niiri:e6936b16ba6c2d4218eb760cf497ca0c",
+      "entity": "niiri:df3a63e829a4b0144a3bd3a075d00d6a"
     },
     {
-      "@id": "niiri:8420d782c03b4101b20be6b34c135201",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:843790c8e8f506cec84c62b4bdaa4286",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0115",
-      "prov:atLocation": {"@id": "niiri:a8c3e95440667fef2aef500030081e3c"},
+      "prov:atLocation": {"@id": "niiri:1a20382ea26ff7dfc455a550e14bb2cb"},
       "prov:value": {"@type": "xsd:float", "@value": "18.5280513763428"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.94612490561611"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.97130955323011e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.960162786431476"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.143791985595671"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.94612490561611"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.97130955323011e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.960162786431476"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.143791985595671"}
     },
     {
-      "@id": "niiri:a8c3e95440667fef2aef500030081e3c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:1a20382ea26ff7dfc455a550e14bb2cb",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0115",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[38,18,-34]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[38,18,-34]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8420d782c03b4101b20be6b34c135201",
-      "entity": "niiri:a5c107a7aa03e749be4156dafe333465"
+      "entity_derived": "niiri:843790c8e8f506cec84c62b4bdaa4286",
+      "entity": "niiri:df3a63e829a4b0144a3bd3a075d00d6a"
     },
     {
-      "@id": "niiri:76222a078033ae4ec966dfcdd2343400",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0a719e8098002e353003ba2a27b073c0",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0116",
-      "prov:atLocation": {"@id": "niiri:b428928e15b6c558aaf9cd5d4b43d4fa"},
+      "prov:atLocation": {"@id": "niiri:3f13732ea3fe61d9c16166a94afce717"},
       "prov:value": {"@type": "xsd:float", "@value": "19.0981063842773"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.00574189150977"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.09115647554314e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.927318703179416"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.123657042203662"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.00574189150977"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.09115647554314e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.927318703179416"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.123657042203662"}
     },
     {
-      "@id": "niiri:b428928e15b6c558aaf9cd5d4b43d4fa",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:3f13732ea3fe61d9c16166a94afce717",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0116",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-52,-62,52]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-52,-62,52]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:76222a078033ae4ec966dfcdd2343400",
-      "entity": "niiri:1e592c6195e8eed44af6ede26c558b5b"
+      "entity_derived": "niiri:0a719e8098002e353003ba2a27b073c0",
+      "entity": "niiri:de4cddb037f1620436ef1889e1446b84"
     },
     {
-      "@id": "niiri:7c29318db9338de16c9df0f656c59d09",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:43e979b3f8840ac3905a6f8a4407fcd5",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0117",
-      "prov:atLocation": {"@id": "niiri:44c320e08d656c9bf218305a167749b5"},
+      "prov:atLocation": {"@id": "niiri:72836d9af30b43e0ac21adb81f3ce707"},
       "prov:value": {"@type": "xsd:float", "@value": "18.9605255126953"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.99146047420243"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.28338171369236e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.936427564303669"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.128343860654482"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.99146047420243"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.28338171369236e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.936427564303669"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.128343860654482"}
     },
     {
-      "@id": "niiri:44c320e08d656c9bf218305a167749b5",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:72836d9af30b43e0ac21adb81f3ce707",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0117",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-30,-50,2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-30,-50,2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7c29318db9338de16c9df0f656c59d09",
-      "entity": "niiri:561f8f2dc565936a85d74fd6e6439dd5"
+      "entity_derived": "niiri:43e979b3f8840ac3905a6f8a4407fcd5",
+      "entity": "niiri:70eb10d3df67eb20319350b5182c2674"
     },
     {
-      "@id": "niiri:52258c37479b367e53c8b38802a12867",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:eceeb78780be64894e966537ab3cb8b4",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0118",
-      "prov:atLocation": {"@id": "niiri:c3a94a5300718750a6bd78e846528ddd"},
+      "prov:atLocation": {"@id": "niiri:8c4301dda467a2d0ec1f85c4f2963cca"},
       "prov:value": {"@type": "xsd:float", "@value": "18.5464344024658"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.9480658572893"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.93925668565887e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.95930107827696"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.143340168336726"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.9480658572893"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.93925668565887e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.95930107827696"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.143340168336726"}
     },
     {
-      "@id": "niiri:c3a94a5300718750a6bd78e846528ddd",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:8c4301dda467a2d0ec1f85c4f2963cca",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0118",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-26,-92,32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-26,-92,32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:52258c37479b367e53c8b38802a12867",
-      "entity": "niiri:74f3d914b0fa073ea25c95d2b38e58fb"
+      "entity_derived": "niiri:eceeb78780be64894e966537ab3cb8b4",
+      "entity": "niiri:0c6701f42b3e926640123461fe2991bd"
     },
     {
-      "@id": "niiri:b9162ca6a49a3e216d418c1d65f981af",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ed981c1dca3ea9b8e6dca05eddddb42e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0119",
-      "prov:atLocation": {"@id": "niiri:5a8a239114f81e75d7fc1e5c695c1878"},
+      "prov:atLocation": {"@id": "niiri:b842305f64b7dc7dc554a449bebc0d75"},
       "prov:value": {"@type": "xsd:float", "@value": "18.5085258483887"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.94406195686995"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.00564728540997e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.961064206627909"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.144306772236207"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.94406195686995"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.00564728540997e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.961064206627909"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.144306772236207"}
     },
     {
-      "@id": "niiri:5a8a239114f81e75d7fc1e5c695c1878",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b842305f64b7dc7dc554a449bebc0d75",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0119",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-64,-24,18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-64,-24,18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b9162ca6a49a3e216d418c1d65f981af",
-      "entity": "niiri:3df28d3c24f5b16d0bd211139131d8c1"
+      "entity_derived": "niiri:ed981c1dca3ea9b8e6dca05eddddb42e",
+      "entity": "niiri:ff9cac1254b9e415d2191f7775b434dc"
     },
     {
-      "@id": "niiri:c8358d5d022c77b4884b6072e1454afc",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f1d40c82f153f10f701e991dc46bf76c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0120",
-      "prov:atLocation": {"@id": "niiri:e414591911281c3dc6505239152cf96f"},
+      "prov:atLocation": {"@id": "niiri:1bac7263c1c3b607ba8edd87055ad184"},
       "prov:value": {"@type": "xsd:float", "@value": "18.1724834442139"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.90833473727659"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.64672426668811e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.97443020941977"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.158566450522772"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.90833473727659"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.64672426668811e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.97443020941977"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.158566450522772"}
     },
     {
-      "@id": "niiri:e414591911281c3dc6505239152cf96f",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:1bac7263c1c3b607ba8edd87055ad184",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0120",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-48,-80,6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-48,-80,6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c8358d5d022c77b4884b6072e1454afc",
-      "entity": "niiri:7f4b39cb147f1d9dd77391be1117b986"
+      "entity_derived": "niiri:f1d40c82f153f10f701e991dc46bf76c",
+      "entity": "niiri:42811518fc15bbd0a0761ed04fef9d90"
     },
     {
-      "@id": "niiri:d41d46d391de81a26321b642a363d6a2",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:90a42fb8b7ab15a0fc7f9593788fd0d8",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0121",
-      "prov:atLocation": {"@id": "niiri:b71ab1408fd1af806b03d8156b375b1e"},
+      "prov:atLocation": {"@id": "niiri:d1e7b6efc3415e116d507bcdb32379a9"},
       "prov:value": {"@type": "xsd:float", "@value": "18.1425399780273"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.90513054435556"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.70872668005828e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.975433443618306"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.159647764898926"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.90513054435556"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.70872668005828e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.975433443618306"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.159647764898926"}
     },
     {
-      "@id": "niiri:b71ab1408fd1af806b03d8156b375b1e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d1e7b6efc3415e116d507bcdb32379a9",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0121",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-52,22,-20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-52,22,-20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d41d46d391de81a26321b642a363d6a2",
-      "entity": "niiri:e186e249fc14850bf873b0628a153098"
+      "entity_derived": "niiri:90a42fb8b7ab15a0fc7f9593788fd0d8",
+      "entity": "niiri:dd408b7babb59101191c5fa3158193a1"
     },
     {
-      "@id": "niiri:060885fee6768915bf388d99f5e98afc",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:977335353dc773fc7bbc24036d48d077",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0122",
-      "prov:atLocation": {"@id": "niiri:04b6a7eb58bc007d8c3cb674f2fa7bfd"},
+      "prov:atLocation": {"@id": "niiri:e0be6cf70dbd9397b6107de3bded3c2c"},
       "prov:value": {"@type": "xsd:float", "@value": "18.022855758667"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.89228911595248"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.96514030533524e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.979157897585619"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.164060003510711"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.89228911595248"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.96514030533524e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.979157897585619"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.164060003510711"}
     },
     {
-      "@id": "niiri:04b6a7eb58bc007d8c3cb674f2fa7bfd",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e0be6cf70dbd9397b6107de3bded3c2c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0122",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-18,-60,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-18,-60,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:060885fee6768915bf388d99f5e98afc",
-      "entity": "niiri:28c5ec87b0dddeb6b0b0fcaa674d02f8"
+      "entity_derived": "niiri:977335353dc773fc7bbc24036d48d077",
+      "entity": "niiri:99548a2427d673d5bd15c691076864b1"
     },
     {
-      "@id": "niiri:bb716ddfde071cd1533efc20b8df8c51",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3c8fb8a88e5e0426d1a5f92207ba17b9",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0123",
-      "prov:atLocation": {"@id": "niiri:83fdcb3696a2e7236bd63c40266a9864"},
+      "prov:atLocation": {"@id": "niiri:01f90b37285ec72c334de342360ab244"},
       "prov:value": {"@type": "xsd:float", "@value": "17.9444541931152"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.88384718470911"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.14082712614883e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.981359691584305"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.167674319621895"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.88384718470911"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.14082712614883e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.981359691584305"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.167674319621895"}
     },
     {
-      "@id": "niiri:83fdcb3696a2e7236bd63c40266a9864",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:01f90b37285ec72c334de342360ab244",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0123",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-48,-60,-12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-48,-60,-12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:bb716ddfde071cd1533efc20b8df8c51",
-      "entity": "niiri:b9c11d17264a448b811fbb99435e6a29"
+      "entity_derived": "niiri:3c8fb8a88e5e0426d1a5f92207ba17b9",
+      "entity": "niiri:7a1eb6258840314d739698ecb8549782"
     },
     {
-      "@id": "niiri:0ab0eae007c10352dafb61bb561c13f2",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:98867af87517f1e98b09c71216997a9b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0124",
-      "prov:atLocation": {"@id": "niiri:9985fa5371e8690277b3ef48a3f99ff3"},
+      "prov:atLocation": {"@id": "niiri:a625149c64d12d1f3e068260e53f8b7c"},
       "prov:value": {"@type": "xsd:float", "@value": "12.8559341430664"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.27598947955534"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000526462414867646"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999987892"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.682960649498925"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.27598947955534"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000526462414867646"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999987892"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.682960649498925"}
     },
     {
-      "@id": "niiri:9985fa5371e8690277b3ef48a3f99ff3",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a625149c64d12d1f3e068260e53f8b7c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0124",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-56,-58,-14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-56,-58,-14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0ab0eae007c10352dafb61bb561c13f2",
-      "entity": "niiri:b9c11d17264a448b811fbb99435e6a29"
+      "entity_derived": "niiri:98867af87517f1e98b09c71216997a9b",
+      "entity": "niiri:7a1eb6258840314d739698ecb8549782"
     },
     {
-      "@id": "niiri:65deeeda13fede5f3d5d94a8e680fbb2",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:33190d6d2e32f171dd46bc01760c790f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0125",
-      "prov:atLocation": {"@id": "niiri:33ae88e566df91eb8d94e7dc1db559a6"},
+      "prov:atLocation": {"@id": "niiri:eb5117c3c1e358890a16b2a446aebe1c"},
       "prov:value": {"@type": "xsd:float", "@value": "17.8700103759766"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.87580933368031"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.31354385788774e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.983284702748605"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.170688289174118"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.87580933368031"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.31354385788774e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.983284702748605"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.170688289174118"}
     },
     {
-      "@id": "niiri:33ae88e566df91eb8d94e7dc1db559a6",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:eb5117c3c1e358890a16b2a446aebe1c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0125",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-20,-98,22]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-20,-98,22]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:65deeeda13fede5f3d5d94a8e680fbb2",
-      "entity": "niiri:4f417da08fec0d40b87c31dc3acdb804"
+      "entity_derived": "niiri:33190d6d2e32f171dd46bc01760c790f",
+      "entity": "niiri:d766f0de412bd93d96229079d9de064c"
     },
     {
-      "@id": "niiri:1b0082413964ff5ea4cf9dd0977c356c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:89a194ad515e6bc3d514f374a7c0b423",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0126",
-      "prov:atLocation": {"@id": "niiri:c5d2b0b72e1fe61b041c9d27481def2b"},
+      "prov:atLocation": {"@id": "niiri:55087ecc6cef2182a564f80c0e849e24"},
       "prov:value": {"@type": "xsd:float", "@value": "17.8590641021729"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.87462562045091"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.33943727588637e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.983554595306202"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.170688289174118"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.87462562045091"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.33943727588637e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.983554595306202"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.170688289174118"}
     },
     {
-      "@id": "niiri:c5d2b0b72e1fe61b041c9d27481def2b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:55087ecc6cef2182a564f80c0e849e24",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0126",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-36,-74,-34]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-36,-74,-34]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1b0082413964ff5ea4cf9dd0977c356c",
-      "entity": "niiri:595ec99dd41031dea87a56ab2ed11ae6"
+      "entity_derived": "niiri:89a194ad515e6bc3d514f374a7c0b423",
+      "entity": "niiri:8661090d64b5d8ebc0a4bd8254976fb2"
     },
     {
-      "@id": "niiri:eabdd8b43fb4440db555c5c4b1c7eec8",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:8ae3f86dbfbb937f245ae840af8b5c49",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0127",
-      "prov:atLocation": {"@id": "niiri:8b119d251b89faba60107a27003daf9d"},
+      "prov:atLocation": {"@id": "niiri:61c92221d1b627be5d2a89643880952c"},
       "prov:value": {"@type": "xsd:float", "@value": "17.8335304260254"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.87186262680309"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.40034110888543e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.98417134410357"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.171220146803025"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.87186262680309"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.40034110888543e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.98417134410357"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.171220146803025"}
     },
     {
-      "@id": "niiri:8b119d251b89faba60107a27003daf9d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:61c92221d1b627be5d2a89643880952c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0127",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[38,42,30]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[38,42,30]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:eabdd8b43fb4440db555c5c4b1c7eec8",
-      "entity": "niiri:2c7e261ed1ca11499bdd3aefccd19ad9"
+      "entity_derived": "niiri:8ae3f86dbfbb937f245ae840af8b5c49",
+      "entity": "niiri:52941f17d3d4d9019f15d6efbca27815"
     },
     {
-      "@id": "niiri:f89d8f5f4b280e4c5911e7d950245fa4",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3dd185a366e3d00acea89b72842526fa",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0128",
-      "prov:atLocation": {"@id": "niiri:f9d80438169dda4b0015945385e60ddb"},
+      "prov:atLocation": {"@id": "niiri:d9d89e136ea97b0a6bb9498f7668246d"},
       "prov:value": {"@type": "xsd:float", "@value": "17.8262977600098"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.87107951763206"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.41772180187028e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.984342815309589"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.171220146803025"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.87107951763206"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.41772180187028e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.984342815309589"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.171220146803025"}
     },
     {
-      "@id": "niiri:f9d80438169dda4b0015945385e60ddb",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d9d89e136ea97b0a6bb9498f7668246d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0128",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-6,8,-14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-6,8,-14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f89d8f5f4b280e4c5911e7d950245fa4",
-      "entity": "niiri:ad031ab3c998c491419cfcf8be1da45c"
+      "entity_derived": "niiri:3dd185a366e3d00acea89b72842526fa",
+      "entity": "niiri:65bb243af8ca1e554de57b71bb66bc25"
     },
     {
-      "@id": "niiri:dab38586d985bb164cbf08a6d51acddb",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0071dedc5b10c2348b38dd7fd1f3af16",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0129",
-      "prov:atLocation": {"@id": "niiri:0476946b128ab3679c9823fabfadcee7"},
+      "prov:atLocation": {"@id": "niiri:c3d13d62a8ef6f9f67c2b84365de7ab2"},
       "prov:value": {"@type": "xsd:float", "@value": "12.8113403320312"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.27004069778544"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000537660061517675"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999999193"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.68956410159948"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.27004069778544"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000537660061517675"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999999193"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.68956410159948"}
     },
     {
-      "@id": "niiri:0476946b128ab3679c9823fabfadcee7",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c3d13d62a8ef6f9f67c2b84365de7ab2",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0129",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-14,10,-20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-14,10,-20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:dab38586d985bb164cbf08a6d51acddb",
-      "entity": "niiri:ad031ab3c998c491419cfcf8be1da45c"
+      "entity_derived": "niiri:0071dedc5b10c2348b38dd7fd1f3af16",
+      "entity": "niiri:65bb243af8ca1e554de57b71bb66bc25"
     },
     {
-      "@id": "niiri:fe062c4e63d26572e38462cc54d25914",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:73dbca8a980ae25e2ff56feb2e61e1f1",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0130",
-      "prov:atLocation": {"@id": "niiri:d16b94cd6aacbd472908f60c7f6ff9b3"},
+      "prov:atLocation": {"@id": "niiri:187769859be171e252e8f9d09cb2f452"},
       "prov:value": {"@type": "xsd:float", "@value": "17.6728630065918"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.85441801648814"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.80026235302844e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.987658348187978"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.17739917442045"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.85441801648814"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.80026235302844e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.987658348187978"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.17739917442045"}
     },
     {
-      "@id": "niiri:d16b94cd6aacbd472908f60c7f6ff9b3",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:187769859be171e252e8f9d09cb2f452",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0130",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[34,-54,-16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[34,-54,-16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:fe062c4e63d26572e38462cc54d25914",
-      "entity": "niiri:5c2053c39d7e04181ae00f2c3455846a"
+      "entity_derived": "niiri:73dbca8a980ae25e2ff56feb2e61e1f1",
+      "entity": "niiri:eb7b45334c4709abfab6a80cdaa2bc22"
     },
     {
-      "@id": "niiri:c35104447675ceff9f6199c1b53bbd2b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:85b1cb20bd5854a8141f9a51241094c0",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0131",
-      "prov:atLocation": {"@id": "niiri:36df87de402f185918c03e0a531385b2"},
+      "prov:atLocation": {"@id": "niiri:f239b5bb600b66b26ae2b541d5f0205c"},
       "prov:value": {"@type": "xsd:float", "@value": "17.5372142791748"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.83961006214911"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.16149383911857e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.990112599467216"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.183733780945217"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.83961006214911"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.16149383911857e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.990112599467216"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.183733780945217"}
     },
     {
-      "@id": "niiri:36df87de402f185918c03e0a531385b2",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f239b5bb600b66b26ae2b541d5f0205c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0131",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[2,56,-20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[2,56,-20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c35104447675ceff9f6199c1b53bbd2b",
-      "entity": "niiri:117133b74d26b0653d13dd1ed378d736"
+      "entity_derived": "niiri:85b1cb20bd5854a8141f9a51241094c0",
+      "entity": "niiri:afbff827e6265de5fc31843cacb634e6"
     },
     {
-      "@id": "niiri:3df03444dcd947a772bbda2d14dbc765",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:80c689d708c2928c17585d1c5c63574b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0132",
-      "prov:atLocation": {"@id": "niiri:ebe90014cbe702b1339781b49a1ec1b3"},
+      "prov:atLocation": {"@id": "niiri:873406fbc3b5a81d2e3a4e71e24d489e"},
       "prov:value": {"@type": "xsd:float", "@value": "17.5327644348145"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.83912305138784"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.17372699829311e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.990186087413737"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.183733780945217"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.83912305138784"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.17372699829311e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.990186087413737"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.183733780945217"}
     },
     {
-      "@id": "niiri:ebe90014cbe702b1339781b49a1ec1b3",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:873406fbc3b5a81d2e3a4e71e24d489e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0132",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[12,-100,20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[12,-100,20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3df03444dcd947a772bbda2d14dbc765",
-      "entity": "niiri:f826be788a1ac88ee83c24f89532c22c"
+      "entity_derived": "niiri:80c689d708c2928c17585d1c5c63574b",
+      "entity": "niiri:44d83170827403caee586f5f0c738aff"
     },
     {
-      "@id": "niiri:51e69c5e1f14aa998ff20b3c0eec6e70",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:68c2fcab274675b0f794f0f1b1cef55a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0133",
-      "prov:atLocation": {"@id": "niiri:38f634005017e3191b375d479957b876"},
+      "prov:atLocation": {"@id": "niiri:81c9356383fb408177b2b19cfcec8486"},
       "prov:value": {"@type": "xsd:float", "@value": "17.4226627349854"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.82704759724244"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.48447222785231e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.991871994244491"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.190627577478618"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.82704759724244"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.48447222785231e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.991871994244491"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.190627577478618"}
     },
     {
-      "@id": "niiri:38f634005017e3191b375d479957b876",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:81c9356383fb408177b2b19cfcec8486",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0133",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-40,-38,44]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-40,-38,44]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:51e69c5e1f14aa998ff20b3c0eec6e70",
-      "entity": "niiri:069291996dee025660d592de3e37d709"
+      "entity_derived": "niiri:68c2fcab274675b0f794f0f1b1cef55a",
+      "entity": "niiri:2d968184be68de22a2c6d1f79a1a3779"
     },
     {
-      "@id": "niiri:004788f80a9206c42efb90bf22999294",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:543cc9adfb564a9668b2518ca40bcc25",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0134",
-      "prov:atLocation": {"@id": "niiri:4805cfcf9581f17b78a3eac1ebb74dc6"},
+      "prov:atLocation": {"@id": "niiri:12d35d58ccbb85001b356a289c171fb3"},
       "prov:value": {"@type": "xsd:float", "@value": "17.1287994384766"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.79457571367347"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.39480733209508e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.995271127156069"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.20629819959706"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.79457571367347"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.39480733209508e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.995271127156069"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.20629819959706"}
     },
     {
-      "@id": "niiri:4805cfcf9581f17b78a3eac1ebb74dc6",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:12d35d58ccbb85001b356a289c171fb3",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0134",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-4,-60,-60]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-4,-60,-60]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:004788f80a9206c42efb90bf22999294",
-      "entity": "niiri:83bc0d4252d6531714bcacd111e1cc46"
+      "entity_derived": "niiri:543cc9adfb564a9668b2518ca40bcc25",
+      "entity": "niiri:8c5cc0e6fb31318c9adb3b82365f2ae6"
     },
     {
-      "@id": "niiri:d47322a1af3764fd46416538f71aa57e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:2db3c23fc333f8331cda3b16530368ad",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0135",
-      "prov:atLocation": {"@id": "niiri:a3d0967c7aea0e6f185195200b593d4e"},
+      "prov:atLocation": {"@id": "niiri:4d8f35cbbd84a090f57d6ed9ea09084e"},
       "prov:value": {"@type": "xsd:float", "@value": "16.9863605499268"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.7787073073582"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.88222920551362e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.996440597738596"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.216588338073415"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.7787073073582"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.88222920551362e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.996440597738596"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.216588338073415"}
     },
     {
-      "@id": "niiri:a3d0967c7aea0e6f185195200b593d4e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4d8f35cbbd84a090f57d6ed9ea09084e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0135",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-48,-72,2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-48,-72,2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d47322a1af3764fd46416538f71aa57e",
-      "entity": "niiri:5703312bcab5b7a9d45a9c8f5e2a301f"
+      "entity_derived": "niiri:2db3c23fc333f8331cda3b16530368ad",
+      "entity": "niiri:db5e02d87132e15c42c39a266963eb55"
     },
     {
-      "@id": "niiri:565bbb90c34b5483f94ac309e1cf4c10",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:953c82968cbb8941046013eaafb134b0",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0136",
-      "prov:atLocation": {"@id": "niiri:dadc8cfac50065609852eee449902fbb"},
+      "prov:atLocation": {"@id": "niiri:afa42bca2bc4c889ad1a2eea4afff83b"},
       "prov:value": {"@type": "xsd:float", "@value": "16.8094520568848"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.75887945181758"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.53380207227472e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.997551066032961"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.228878695263587"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.75887945181758"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.53380207227472e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.997551066032961"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.228878695263587"}
     },
     {
-      "@id": "niiri:dadc8cfac50065609852eee449902fbb",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:afa42bca2bc4c889ad1a2eea4afff83b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0136",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-26,-66,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-26,-66,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:565bbb90c34b5483f94ac309e1cf4c10",
-      "entity": "niiri:39fa289e8e1804e6c510280f0e399486"
+      "entity_derived": "niiri:953c82968cbb8941046013eaafb134b0",
+      "entity": "niiri:6e1483cf3114e5bdc77f5e480decfc71"
     },
     {
-      "@id": "niiri:f7dd5bd8e78dace0e7256ee8e480a754",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3cabe98da9708d5c6d9ef929b06fe15d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0137",
-      "prov:atLocation": {"@id": "niiri:72bc54b51439d57273d4fc5feb6c0d07"},
+      "prov:atLocation": {"@id": "niiri:eff0511f81e80158699d68bd98fa9405"},
       "prov:value": {"@type": "xsd:float", "@value": "16.7728652954102"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.75476213591481"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.67530868189359e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.997740205701951"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.230558109866913"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.75476213591481"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.67530868189359e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.997740205701951"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.230558109866913"}
     },
     {
-      "@id": "niiri:72bc54b51439d57273d4fc5feb6c0d07",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:eff0511f81e80158699d68bd98fa9405",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0137",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[28,-78,-4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[28,-78,-4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f7dd5bd8e78dace0e7256ee8e480a754",
-      "entity": "niiri:aec4d890e92fb9730ea03f8d53fbe940"
+      "entity_derived": "niiri:3cabe98da9708d5c6d9ef929b06fe15d",
+      "entity": "niiri:1eb993430541f6c2dc79f73b3a96decc"
     },
     {
-      "@id": "niiri:0195d4add9d5b6928a841f3d28f415c7",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0483d1896bdb7110c7c114277f735ab9",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0138",
-      "prov:atLocation": {"@id": "niiri:e2e952472cf7f089347a5890633c05b7"},
+      "prov:atLocation": {"@id": "niiri:5a911e435abed8cd7a26c34c1d6c107f"},
       "prov:value": {"@type": "xsd:float", "@value": "16.7388191223145"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.75092555231661"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.809150518585e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.997905089099941"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.231105699024221"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.75092555231661"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.809150518585e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.997905089099941"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.231105699024221"}
     },
     {
-      "@id": "niiri:e2e952472cf7f089347a5890633c05b7",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:5a911e435abed8cd7a26c34c1d6c107f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0138",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-32,16,-46]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-32,16,-46]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0195d4add9d5b6928a841f3d28f415c7",
-      "entity": "niiri:6f32c27f31869cd578e8b60308359ec9"
+      "entity_derived": "niiri:0483d1896bdb7110c7c114277f735ab9",
+      "entity": "niiri:e576b0cc1b6a471310c83c2e65672f5f"
     },
     {
-      "@id": "niiri:550faac6b8dd2504485e40c3bbfb3073",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e91d29fc9817e2a7b36fc978ba3fe7d8",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0139",
-      "prov:atLocation": {"@id": "niiri:43b0118cb5db387213a156a4e1f1aff0"},
+      "prov:atLocation": {"@id": "niiri:33167c8e22920a525f3568a883d101c6"},
       "prov:value": {"@type": "xsd:float", "@value": "16.59206199646"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.7343303583498"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "9.41076528112594e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.998505188879306"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.241173215874839"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.7343303583498"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "9.41076528112594e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.998505188879306"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.241173215874839"}
     },
     {
-      "@id": "niiri:43b0118cb5db387213a156a4e1f1aff0",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:33167c8e22920a525f3568a883d101c6",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0139",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[20,-66,34]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[20,-66,34]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:550faac6b8dd2504485e40c3bbfb3073",
-      "entity": "niiri:a2bcb1ae11c4d80d14c85b5637295099"
+      "entity_derived": "niiri:e91d29fc9817e2a7b36fc978ba3fe7d8",
+      "entity": "niiri:01a6664df87623bed0fd193f07c04638"
     },
     {
-      "@id": "niiri:78da07a0233d16819aa1e9e13de77ecd",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c156e4600d2260f008778fbfcc998fb4",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0140",
-      "prov:atLocation": {"@id": "niiri:08d403b38dc368dcdb9b2fbeb03cce3f"},
+      "prov:atLocation": {"@id": "niiri:005224864c46a4f96af3799c87601109"},
       "prov:value": {"@type": "xsd:float", "@value": "16.4643402099609"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.71981100422245"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "9.96859555968399e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.998902236749178"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.250667985672322"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.71981100422245"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "9.96859555968399e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.998902236749178"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.250667985672322"}
     },
     {
-      "@id": "niiri:08d403b38dc368dcdb9b2fbeb03cce3f",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:005224864c46a4f96af3799c87601109",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0140",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-46,-56,14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-46,-56,14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:78da07a0233d16819aa1e9e13de77ecd",
-      "entity": "niiri:6e5d34b600dd5cfbc70efee8ab867c9f"
+      "entity_derived": "niiri:c156e4600d2260f008778fbfcc998fb4",
+      "entity": "niiri:9fbbe8461310da88b0ce5b0b68e8e62c"
     },
     {
-      "@id": "niiri:88aebeaace0915b1e2b8cd25561c98d6",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ec175136c213f64b6858d2d67479878d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0141",
-      "prov:atLocation": {"@id": "niiri:e2c5c3a0379ef78f67437674a3bb1b63"},
+      "prov:atLocation": {"@id": "niiri:b19e011215edc6c32c1ec6d92455e9ed"},
       "prov:value": {"@type": "xsd:float", "@value": "15.7879962921143"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.64169928081447"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000135422173195066"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999835135686248"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.302609017771479"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.64169928081447"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000135422173195066"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999835135686248"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.302609017771479"}
     },
     {
-      "@id": "niiri:e2c5c3a0379ef78f67437674a3bb1b63",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b19e011215edc6c32c1ec6d92455e9ed",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0141",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-50,-50,20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-50,-50,20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:88aebeaace0915b1e2b8cd25561c98d6",
-      "entity": "niiri:6e5d34b600dd5cfbc70efee8ab867c9f"
+      "entity_derived": "niiri:ec175136c213f64b6858d2d67479878d",
+      "entity": "niiri:9fbbe8461310da88b0ce5b0b68e8e62c"
     },
     {
-      "@id": "niiri:2c1b864f7498eb14c461a262d2e4159c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:1a52e7aaf9f3a5bd152c0ebd9fcef4fd",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0142",
-      "prov:atLocation": {"@id": "niiri:5332b1080529e4f4115a33dc6f3d5e06"},
+      "prov:atLocation": {"@id": "niiri:87d81140c3614e8c44dfad60899c3eba"},
       "prov:value": {"@type": "xsd:float", "@value": "16.4616966247559"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.71950972254369"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "9.98049320762862e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.998909395230241"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.250667985672322"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.71950972254369"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "9.98049320762862e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.998909395230241"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.250667985672322"}
     },
     {
-      "@id": "niiri:5332b1080529e4f4115a33dc6f3d5e06",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:87d81140c3614e8c44dfad60899c3eba",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0142",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[54,-70,10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[54,-70,10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2c1b864f7498eb14c461a262d2e4159c",
-      "entity": "niiri:96be67b14048a7acaffdcf5d2d455f8b"
+      "entity_derived": "niiri:1a52e7aaf9f3a5bd152c0ebd9fcef4fd",
+      "entity": "niiri:ae14e5d65d87b53bd2bbf000849a1635"
     },
     {
-      "@id": "niiri:1929176f6523cd3eb0f67a70edb58f7a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:2c83e3b2c475480b66ada9ebc6da746b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0143",
-      "prov:atLocation": {"@id": "niiri:3990057aa9042769b27afb3c4b8d8ef6"},
+      "prov:atLocation": {"@id": "niiri:1b509c10d0feceee9f9e723c8315cfc9"},
       "prov:value": {"@type": "xsd:float", "@value": "16.4018669128418"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.71268281226793"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000102536916068097"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999061078942832"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.255433180603606"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.71268281226793"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000102536916068097"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999061078942832"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.255433180603606"}
     },
     {
-      "@id": "niiri:3990057aa9042769b27afb3c4b8d8ef6",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:1b509c10d0feceee9f9e723c8315cfc9",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0143",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-30,-10,66]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-30,-10,66]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1929176f6523cd3eb0f67a70edb58f7a",
-      "entity": "niiri:bbdf3a3cea68312933b0e0f7ac23c71f"
+      "entity_derived": "niiri:2c83e3b2c475480b66ada9ebc6da746b",
+      "entity": "niiri:40d7f1124d8e7cab0c81135fe2f535ad"
     },
     {
-      "@id": "niiri:c9ed57a259ba6e39c80121a7b2fde6e1",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c0b01d212ef6b8d37eb57b24d78fab11",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0144",
-      "prov:atLocation": {"@id": "niiri:df2c041128c92286725f3bba2c095857"},
+      "prov:atLocation": {"@id": "niiri:7ac3c69eacd73432ce5a57cff71ee461"},
       "prov:value": {"@type": "xsd:float", "@value": "16.3890476226807"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.71121798724803"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000103132189635535"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999091114381714"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.255887110131141"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.71121798724803"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000103132189635535"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999091114381714"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.255887110131141"}
     },
     {
-      "@id": "niiri:df2c041128c92286725f3bba2c095857",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7ac3c69eacd73432ce5a57cff71ee461",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0144",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-10,42,4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-10,42,4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c9ed57a259ba6e39c80121a7b2fde6e1",
-      "entity": "niiri:3cf31cb78a4315d8e0bb0e1795c2b177"
+      "entity_derived": "niiri:c0b01d212ef6b8d37eb57b24d78fab11",
+      "entity": "niiri:3383de798490342ce6540ea70b023ffa"
     },
     {
-      "@id": "niiri:3e9981701d6165795315b3c65c4e1a88",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:861c2c7575cf5f18aa4f01bea0b82135",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0145",
-      "prov:atLocation": {"@id": "niiri:405640b932db22c888695538a714a09e"},
+      "prov:atLocation": {"@id": "niiri:3817f54a70e50af79f9a6b8831c78d7a"},
       "prov:value": {"@type": "xsd:float", "@value": "16.298921585083"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.70089879419966"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000107418577610985"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999279946312565"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.26288576268692"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.70089879419966"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000107418577610985"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999279946312565"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.26288576268692"}
     },
     {
-      "@id": "niiri:405640b932db22c888695538a714a09e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:3817f54a70e50af79f9a6b8831c78d7a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0145",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-48,2,50]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-48,2,50]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3e9981701d6165795315b3c65c4e1a88",
-      "entity": "niiri:2de3fe021b32432646cff16795c27e84"
+      "entity_derived": "niiri:861c2c7575cf5f18aa4f01bea0b82135",
+      "entity": "niiri:4bcfe0e6f6bc971e3e914655ca98bf82"
     },
     {
-      "@id": "niiri:68a4ad5f46f51ac375b9a7e75f4a279b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a5987a6772c4cd944a2d21945bf8cc08",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0146",
-      "prov:atLocation": {"@id": "niiri:c76e9f1de64e9896c08504a86ebd44a2"},
+      "prov:atLocation": {"@id": "niiri:c934c3e1b26d7a3234b6656c39cdea38"},
       "prov:value": {"@type": "xsd:float", "@value": "16.1748123168945"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.68662875371095"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000113622246557199"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999484104559633"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.271891418707172"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.68662875371095"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000113622246557199"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999484104559633"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.271891418707172"}
     },
     {
-      "@id": "niiri:c76e9f1de64e9896c08504a86ebd44a2",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c934c3e1b26d7a3234b6656c39cdea38",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0146",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-36,-40,-36]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-36,-40,-36]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:68a4ad5f46f51ac375b9a7e75f4a279b",
-      "entity": "niiri:4899fcf255f8d47f7118cf27e2fd1a7d"
+      "entity_derived": "niiri:a5987a6772c4cd944a2d21945bf8cc08",
+      "entity": "niiri:bbf13cce053679ff04cb1b23082b44ac"
     },
     {
-      "@id": "niiri:492da5cf15cca67420b9c9fad372f24d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:9a723a9a2cf5ca36130eb2146162ff79",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0147",
-      "prov:atLocation": {"@id": "niiri:5822e1bf84fdeaba21887a2231df37f7"},
+      "prov:atLocation": {"@id": "niiri:5375c6e20f2ad76e7323a119f4565a0a"},
       "prov:value": {"@type": "xsd:float", "@value": "16.1662578582764"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.68564259218778"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00011406315591389"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999496106370773"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.271968636129453"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.68564259218778"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00011406315591389"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999496106370773"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.271968636129453"}
     },
     {
-      "@id": "niiri:5822e1bf84fdeaba21887a2231df37f7",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:5375c6e20f2ad76e7323a119f4565a0a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0147",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[8,-16,80]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[8,-16,80]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:492da5cf15cca67420b9c9fad372f24d",
-      "entity": "niiri:655cdd92103093b072ae23a6af82f68e"
+      "entity_derived": "niiri:9a723a9a2cf5ca36130eb2146162ff79",
+      "entity": "niiri:2151f348776220c1024fdc2f0b0bc92f"
     },
     {
-      "@id": "niiri:25e89f9bb1a13d578dc3f9f6e0161d05",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:419f74c7325474e8e1f981e499bf215a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0148",
-      "prov:atLocation": {"@id": "niiri:3fe76f4decfea080047eb66eea50ae5f"},
+      "prov:atLocation": {"@id": "niiri:4a3926792d8bd2558570215cd1dfc6df"},
       "prov:value": {"@type": "xsd:float", "@value": "15.8700971603394"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.65129366161918"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000130461342294219"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999787108603416"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.297253203818069"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.65129366161918"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000130461342294219"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999787108603416"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.297253203818069"}
     },
     {
-      "@id": "niiri:3fe76f4decfea080047eb66eea50ae5f",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4a3926792d8bd2558570215cd1dfc6df",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0148",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[64,-30,-4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[64,-30,-4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:25e89f9bb1a13d578dc3f9f6e0161d05",
-      "entity": "niiri:626eb7ded63e9b32e8502a0a107f553d"
+      "entity_derived": "niiri:419f74c7325474e8e1f981e499bf215a",
+      "entity": "niiri:8ccfe08eafd83c22c7082eb44f58a70f"
     },
     {
-      "@id": "niiri:17e85dcb08c223124c8919b3ec748120",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3877f612a4c9aaac9336d7f9e3e88d69",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0149",
-      "prov:atLocation": {"@id": "niiri:1ab01aec73bb6b808a1130aa3526d7e3"},
+      "prov:atLocation": {"@id": "niiri:e4fc36d8eddefb2f351cae894068f752"},
       "prov:value": {"@type": "xsd:float", "@value": "15.8040924072266"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.64358278828341"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000134434558439089"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999826557542014"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.302499842954719"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.64358278828341"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000134434558439089"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999826557542014"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.302499842954719"}
     },
     {
-      "@id": "niiri:1ab01aec73bb6b808a1130aa3526d7e3",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e4fc36d8eddefb2f351cae894068f752",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0149",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-24,58,2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-24,58,2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:17e85dcb08c223124c8919b3ec748120",
-      "entity": "niiri:b4ad782774b491871a7992522f937437"
+      "entity_derived": "niiri:3877f612a4c9aaac9336d7f9e3e88d69",
+      "entity": "niiri:bad308d46fbeeacaf458653ab9b853d6"
     },
     {
-      "@id": "niiri:4fe611bb9a85fe47c515763d486540dc",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:8637dbbca99c6bf52067de598426c4d0",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0150",
-      "prov:atLocation": {"@id": "niiri:705d8ec8ed9460150b6144ddb1c06f86"},
+      "prov:atLocation": {"@id": "niiri:07a3802a0d3e86c0622c2132242acb1c"},
       "prov:value": {"@type": "xsd:float", "@value": "14.5666723251343"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.49506845160221"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000236970094563582"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999998710493543"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.419549680505734"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.49506845160221"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000236970094563582"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999998710493543"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.419549680505734"}
     },
     {
-      "@id": "niiri:705d8ec8ed9460150b6144ddb1c06f86",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:07a3802a0d3e86c0622c2132242acb1c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0150",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-22,64,8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-22,64,8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4fe611bb9a85fe47c515763d486540dc",
-      "entity": "niiri:b4ad782774b491871a7992522f937437"
+      "entity_derived": "niiri:8637dbbca99c6bf52067de598426c4d0",
+      "entity": "niiri:bad308d46fbeeacaf458653ab9b853d6"
     },
     {
-      "@id": "niiri:52e81872af24f6613bcd6c058744f5f7",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:2e6563d391260b35c952b660146494c2",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0151",
-      "prov:atLocation": {"@id": "niiri:9e3b439f91eeabe30e6cb5a6ff583901"},
+      "prov:atLocation": {"@id": "niiri:817ffa699ebce4b3995e88c66ffdd822"},
       "prov:value": {"@type": "xsd:float", "@value": "15.7909498214722"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.64204498343963"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000135240396418101"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999833590389148"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.302609017771479"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.64204498343963"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000135240396418101"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999833590389148"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.302609017771479"}
     },
     {
-      "@id": "niiri:9e3b439f91eeabe30e6cb5a6ff583901",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:817ffa699ebce4b3995e88c66ffdd822",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0151",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-64,-46,40]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-64,-46,40]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:52e81872af24f6613bcd6c058744f5f7",
-      "entity": "niiri:677611b98bfd5eb8fbc23315abaa9320"
+      "entity_derived": "niiri:2e6563d391260b35c952b660146494c2",
+      "entity": "niiri:687916ac6701ade9ca268dec72dc0c0d"
     },
     {
-      "@id": "niiri:283577c39a6db96ba450852ad3cd7244",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:2d7a05b0881bcaf974a82728c80d267b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0152",
-      "prov:atLocation": {"@id": "niiri:9cd7919fecb35ce5ba9c556c717efe29"},
+      "prov:atLocation": {"@id": "niiri:f16a8477087128670c6728a97eaa864d"},
       "prov:value": {"@type": "xsd:float", "@value": "15.7291193008423"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.63479927525788"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000139098574372776"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999863401028703"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.306447101172765"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.63479927525788"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000139098574372776"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999863401028703"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.306447101172765"}
     },
     {
-      "@id": "niiri:9cd7919fecb35ce5ba9c556c717efe29",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f16a8477087128670c6728a97eaa864d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0152",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[2,-44,56]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[2,-44,56]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:283577c39a6db96ba450852ad3cd7244",
-      "entity": "niiri:0dbd53cf7610b049d137c94d182a0076"
+      "entity_derived": "niiri:2d7a05b0881bcaf974a82728c80d267b",
+      "entity": "niiri:9071142b0c2683c96f4377cdddced1d0"
     },
     {
-      "@id": "niiri:655bfb4890539809eb32aa2fb6f639ac",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3daa0fd1f3c9c061fc41328ca9438a27",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0153",
-      "prov:atLocation": {"@id": "niiri:e3590f8bf2d1313c81d4c84f99bad3c7"},
+      "prov:atLocation": {"@id": "niiri:8611ef160b9557309f5e6ad3264be190"},
       "prov:value": {"@type": "xsd:float", "@value": "15.7138509750366"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.6330072403139"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000140068577241359"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999869988931104"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.306447101172765"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.6330072403139"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000140068577241359"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999869988931104"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.306447101172765"}
     },
     {
-      "@id": "niiri:e3590f8bf2d1313c81d4c84f99bad3c7",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:8611ef160b9557309f5e6ad3264be190",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0153",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[18,12,-20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[18,12,-20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:655bfb4890539809eb32aa2fb6f639ac",
-      "entity": "niiri:76019faf9ae4e38fc7ae7798a2f879f4"
+      "entity_derived": "niiri:3daa0fd1f3c9c061fc41328ca9438a27",
+      "entity": "niiri:884f659ac62495dd158e264f576d0fc2"
     },
     {
-      "@id": "niiri:49ab401e77e69625fa593378e409ab43",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:2e8cafa261c265066c3b0c06f8f7546a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0154",
-      "prov:atLocation": {"@id": "niiri:76f623d7e81f533aa77b3a07690095cd"},
+      "prov:atLocation": {"@id": "niiri:59510129aa2ba33613be10e00d44383a"},
       "prov:value": {"@type": "xsd:float", "@value": "15.708869934082"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.6324223784443"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000140386524073888"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999872076198509"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.306447101172765"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.6324223784443"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000140386524073888"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999872076198509"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.306447101172765"}
     },
     {
-      "@id": "niiri:76f623d7e81f533aa77b3a07690095cd",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:59510129aa2ba33613be10e00d44383a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0154",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[4,6,32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[4,6,32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:49ab401e77e69625fa593378e409ab43",
-      "entity": "niiri:e6b0f9d536c2b1a1fd955a8eaff2a2df"
+      "entity_derived": "niiri:2e8cafa261c265066c3b0c06f8f7546a",
+      "entity": "niiri:2088eea3a39320e89e2a625ec7e9f82e"
     },
     {
-      "@id": "niiri:417fb0d435cedfc9a69bdf8dad69ba5a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:8139ce719a3bbb4c2ad3027af6da9b91",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0155",
-      "prov:atLocation": {"@id": "niiri:41c7b9983f9fc691d94a24b38527dfae"},
+      "prov:atLocation": {"@id": "niiri:6159441b4ec9659addc0939d61b94795"},
       "prov:value": {"@type": "xsd:float", "@value": "15.701042175293"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.6315030231558"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000140887678002244"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999875296214591"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.306447101172765"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.6315030231558"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000140887678002244"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999875296214591"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.306447101172765"}
     },
     {
-      "@id": "niiri:41c7b9983f9fc691d94a24b38527dfae",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6159441b4ec9659addc0939d61b94795",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0155",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-50,-48,-16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-50,-48,-16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:417fb0d435cedfc9a69bdf8dad69ba5a",
-      "entity": "niiri:7fee2fcd04048e290bf06db1c5562ffd"
+      "entity_derived": "niiri:8139ce719a3bbb4c2ad3027af6da9b91",
+      "entity": "niiri:7fc88d60dca200d4c67a0a607a345633"
     },
     {
-      "@id": "niiri:9ea32e8e16dc172a558d5e2a91244ec2",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f80978e3da40bc3e863003eb710a4f97",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0156",
-      "prov:atLocation": {"@id": "niiri:3a67eb95091016b19b62925ff1530b09"},
+      "prov:atLocation": {"@id": "niiri:eeb84644b683af6ceb08368cba83a580"},
       "prov:value": {"@type": "xsd:float", "@value": "15.676775932312"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.62865114343584"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000142452965301465"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999884825274485"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.308330257911763"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.62865114343584"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000142452965301465"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999884825274485"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.308330257911763"}
     },
     {
-      "@id": "niiri:3a67eb95091016b19b62925ff1530b09",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:eeb84644b683af6ceb08368cba83a580",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0156",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[4,-96,8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[4,-96,8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9ea32e8e16dc172a558d5e2a91244ec2",
-      "entity": "niiri:a544035a692226b8c28c019b1e283632"
+      "entity_derived": "niiri:f80978e3da40bc3e863003eb710a4f97",
+      "entity": "niiri:ca1da2e7a46f823f402d9c62e070d0fc"
     },
     {
-      "@id": "niiri:4dd77395a8f425a329cea7d63ef36eb2",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:4e7e46ac0c58102be99f07a84d8b80ce",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0157",
-      "prov:atLocation": {"@id": "niiri:430c1e1ce3c3b410797123ab1f1ba51a"},
+      "prov:atLocation": {"@id": "niiri:9b468a9909484a871d5fb8ff8e97d872"},
       "prov:value": {"@type": "xsd:float", "@value": "15.6319704055786"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.62337799963497"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00014539019458093"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999900731149395"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.312547307242678"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.62337799963497"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00014539019458093"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999900731149395"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.312547307242678"}
     },
     {
-      "@id": "niiri:430c1e1ce3c3b410797123ab1f1ba51a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:9b468a9909484a871d5fb8ff8e97d872",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0157",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-68,-28,0]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-68,-28,0]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4dd77395a8f425a329cea7d63ef36eb2",
-      "entity": "niiri:9c40cb58c75073f4f983d06c6a655c74"
+      "entity_derived": "niiri:4e7e46ac0c58102be99f07a84d8b80ce",
+      "entity": "niiri:ea6ee099e3b8edbdd2bde04e8682a6ce"
     },
     {
-      "@id": "niiri:c56cb3d4548edcef09396283f6a3311d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a61c69f7358597f7aa5c12a588c1ce7c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0158",
-      "prov:atLocation": {"@id": "niiri:bcc4aedc3bba097da5f1e38542555e69"},
+      "prov:atLocation": {"@id": "niiri:2fda99f58ae75a6c5ac429d5b6053dc7"},
       "prov:value": {"@type": "xsd:float", "@value": "15.4950304031372"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.60720172487664"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000154758512821873"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999937921710337"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.325857771765735"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.60720172487664"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000154758512821873"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999937921710337"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.325857771765735"}
     },
     {
-      "@id": "niiri:bcc4aedc3bba097da5f1e38542555e69",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:2fda99f58ae75a6c5ac429d5b6053dc7",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0158",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-48,-50,-38]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-48,-50,-38]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c56cb3d4548edcef09396283f6a3311d",
-      "entity": "niiri:f8d5d9e3adb56590f1e9d795fa0fb5b7"
+      "entity_derived": "niiri:a61c69f7358597f7aa5c12a588c1ce7c",
+      "entity": "niiri:1ef7113e2a59f273a63186ced0b0fc6b"
     },
     {
-      "@id": "niiri:6492005ac86d44d9eafa0aafd7adcac0",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ab548589200676685973c248e76b07b4",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0159",
-      "prov:atLocation": {"@id": "niiri:0d0b6563d75959c51f007b78e8e0c2cf"},
+      "prov:atLocation": {"@id": "niiri:de558f593a64c3e86a629fa5e4ec3f3b"},
       "prov:value": {"@type": "xsd:float", "@value": "15.4388980865479"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.60054472544061"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000158775598232741"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99994913578297"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.329941167587052"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.60054472544061"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000158775598232741"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99994913578297"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.329941167587052"}
     },
     {
-      "@id": "niiri:0d0b6563d75959c51f007b78e8e0c2cf",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:de558f593a64c3e86a629fa5e4ec3f3b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0159",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[28,-62,52]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[28,-62,52]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6492005ac86d44d9eafa0aafd7adcac0",
-      "entity": "niiri:d763c6c8de6f4537a51f15146880d851"
+      "entity_derived": "niiri:ab548589200676685973c248e76b07b4",
+      "entity": "niiri:02f0aee7ff558248fe49e5f3579c0585"
     },
     {
-      "@id": "niiri:d305fbf9673e2985f5e39c80181a26df",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:6d8e54d85422fdb3fc4d40dcb8a7528b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0160",
-      "prov:atLocation": {"@id": "niiri:53e250cec29016a1a4a68e30b11d7b72"},
+      "prov:atLocation": {"@id": "niiri:e79376ec4a6c43b7e658f206276a73d8"},
       "prov:value": {"@type": "xsd:float", "@value": "15.4314498901367"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.59966025263468"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000159316609409377"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999950477945125"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.329967567413556"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.59966025263468"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000159316609409377"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999950477945125"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.329967567413556"}
     },
     {
-      "@id": "niiri:53e250cec29016a1a4a68e30b11d7b72",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e79376ec4a6c43b7e658f206276a73d8",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0160",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-26,-50,-26]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-26,-50,-26]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d305fbf9673e2985f5e39c80181a26df",
-      "entity": "niiri:c81c855fadc265b4e1ccb72361a5ab5b"
+      "entity_derived": "niiri:6d8e54d85422fdb3fc4d40dcb8a7528b",
+      "entity": "niiri:c2cda63a78bcde6ae7a69f7ab8eadb2c"
     },
     {
-      "@id": "niiri:5afe30a0f271b9c39b5c17d5754616e6",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5deeb5d90a0af409b6cff616354e11a7",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0161",
-      "prov:atLocation": {"@id": "niiri:90a3142db91f5d8edde9e74e68dd388e"},
+      "prov:atLocation": {"@id": "niiri:2bde547f7aec22d7518accdce026c12c"},
       "prov:value": {"@type": "xsd:float", "@value": "15.3998956680298"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.59591017819407"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000161629666827423"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999955817597174"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.332893773024534"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.59591017819407"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000161629666827423"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999955817597174"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.332893773024534"}
     },
     {
-      "@id": "niiri:90a3142db91f5d8edde9e74e68dd388e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:2bde547f7aec22d7518accdce026c12c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0161",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[34,12,64]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[34,12,64]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5afe30a0f271b9c39b5c17d5754616e6",
-      "entity": "niiri:adb14ea605c87220ed90422a86d00cf7"
+      "entity_derived": "niiri:5deeb5d90a0af409b6cff616354e11a7",
+      "entity": "niiri:2c7f2ff6921dbb36e89f44a3a1dd839b"
     },
     {
-      "@id": "niiri:385afdce90c603da6856fb145be9e564",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b9a1b6a6a5bd0918b2da9d95b2f3281d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0162",
-      "prov:atLocation": {"@id": "niiri:52ef5ab931812ea9d3c9597c3b43115d"},
+      "prov:atLocation": {"@id": "niiri:7c7a24b9cb1d730e5e18aacc805d3ce2"},
       "prov:value": {"@type": "xsd:float", "@value": "15.3762083053589"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.59309183388917"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000163388677505649"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999959478963553"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.334848055204527"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.59309183388917"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000163388677505649"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999959478963553"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.334848055204527"}
     },
     {
-      "@id": "niiri:52ef5ab931812ea9d3c9597c3b43115d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7c7a24b9cb1d730e5e18aacc805d3ce2",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0162",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[12,-60,2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[12,-60,2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:385afdce90c603da6856fb145be9e564",
-      "entity": "niiri:d5aa67ffe10d81e16892509076504f14"
+      "entity_derived": "niiri:b9a1b6a6a5bd0918b2da9d95b2f3281d",
+      "entity": "niiri:03e03b97c9ae144949ccd274ec79dd81"
     },
     {
-      "@id": "niiri:bdd46b6b87a63614e7cab12c58787ae2",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:77808b7180e73fc3945d40bbbd602a7c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0163",
-      "prov:atLocation": {"@id": "niiri:a8b1b2a07e1a026125e80b724c2110cf"},
+      "prov:atLocation": {"@id": "niiri:4e4841b781aab4f23390e4712c5dd517"},
       "prov:value": {"@type": "xsd:float", "@value": "15.2871723175049"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.58247351023423"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000170178069703208"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999970922373423"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.343198560123146"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.58247351023423"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000170178069703208"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999970922373423"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.343198560123146"}
     },
     {
-      "@id": "niiri:a8b1b2a07e1a026125e80b724c2110cf",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4e4841b781aab4f23390e4712c5dd517",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0163",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[54,-24,-2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[54,-24,-2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:bdd46b6b87a63614e7cab12c58787ae2",
-      "entity": "niiri:3fae830c70c9ca8cf8f3cbed4301161f"
+      "entity_derived": "niiri:77808b7180e73fc3945d40bbbd602a7c",
+      "entity": "niiri:036f2836a317a98100c1a6652ab21784"
     },
     {
-      "@id": "niiri:562c93862da14a62c182e923b5b74ebc",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:07c12d4cbb23e86fca36208cc6a9eb4f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0164",
-      "prov:atLocation": {"@id": "niiri:0eae67a04ae2f5080393c631873ca725"},
+      "prov:atLocation": {"@id": "niiri:93e589f292425b950a446aa909654e13"},
       "prov:value": {"@type": "xsd:float", "@value": "15.2692956924438"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.58033683390377"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00017157578503435"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999972831864908"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.344539994060292"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.58033683390377"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00017157578503435"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999972831864908"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.344539994060292"}
     },
     {
-      "@id": "niiri:0eae67a04ae2f5080393c631873ca725",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:93e589f292425b950a446aa909654e13",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0164",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-14,-98,-4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-14,-98,-4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:562c93862da14a62c182e923b5b74ebc",
-      "entity": "niiri:c35054132a92b4bf34b2e1b8acd96c91"
+      "entity_derived": "niiri:07c12d4cbb23e86fca36208cc6a9eb4f",
+      "entity": "niiri:a029a63406d370c8869c59656bb90a54"
     },
     {
-      "@id": "niiri:2a64383bd3d13df477c4aa76215a3ba3",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3a4c88d5e566a02cdf99eb0ce85232b0",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0165",
-      "prov:atLocation": {"@id": "niiri:17d218a14f543ed5edb2bef5516204b1"},
+      "prov:atLocation": {"@id": "niiri:33e9c66b8f9fafa079d5d5d649b33e95"},
       "prov:value": {"@type": "xsd:float", "@value": "15.2561340332031"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.57876269120649"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000172612379221393"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999974164363014"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.34525482719666"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.57876269120649"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000172612379221393"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999974164363014"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.34525482719666"}
     },
     {
-      "@id": "niiri:17d218a14f543ed5edb2bef5516204b1",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:33e9c66b8f9fafa079d5d5d649b33e95",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0165",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[52,40,-32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[52,40,-32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2a64383bd3d13df477c4aa76215a3ba3",
-      "entity": "niiri:21c649902d379fc9de7f1be15e128c6b"
+      "entity_derived": "niiri:3a4c88d5e566a02cdf99eb0ce85232b0",
+      "entity": "niiri:c429131bcf59cefceae4a934fd1aa80a"
     },
     {
-      "@id": "niiri:e124404cc77a7b89f79d5806315a547c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:24b5fea160dd2add4c0826068ad6d59a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0166",
-      "prov:atLocation": {"@id": "niiri:10f4332a5dea5374b9422b40d8100936"},
+      "prov:atLocation": {"@id": "niiri:c1c6a7167e5e88a6a1b5357f8dc99d2c"},
       "prov:value": {"@type": "xsd:float", "@value": "15.2322616577148"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.57590533845626"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000174508968234677"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999976431095502"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.345634100571722"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.57590533845626"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000174508968234677"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999976431095502"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.345634100571722"}
     },
     {
-      "@id": "niiri:10f4332a5dea5374b9422b40d8100936",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c1c6a7167e5e88a6a1b5357f8dc99d2c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0166",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-36,-46,-18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-36,-46,-18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e124404cc77a7b89f79d5806315a547c",
-      "entity": "niiri:24ec764638d7b84cf388c10bdbf8e52e"
+      "entity_derived": "niiri:24b5fea160dd2add4c0826068ad6d59a",
+      "entity": "niiri:9ac7226087de1c45b555519c1250dc59"
     },
     {
-      "@id": "niiri:8ba891c9418f9a9dc0a017aa2e16c3be",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:1b0c82bff8134900d83ca4ab18a5f9a1",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0167",
-      "prov:atLocation": {"@id": "niiri:44dddcfc5edd6bf1d9d603c1b073db3f"},
+      "prov:atLocation": {"@id": "niiri:41ce647be65b12c740f9a69ac2bc2072"},
       "prov:value": {"@type": "xsd:float", "@value": "15.106840133667"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.56084639153832"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000184830650378665"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999985642365922"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.357155778315693"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.56084639153832"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000184830650378665"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999985642365922"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.357155778315693"}
     },
     {
-      "@id": "niiri:44dddcfc5edd6bf1d9d603c1b073db3f",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:41ce647be65b12c740f9a69ac2bc2072",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0167",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-50,-46,-32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-50,-46,-32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8ba891c9418f9a9dc0a017aa2e16c3be",
-      "entity": "niiri:7e5ff536134bdc8ab5fcb743674e90c4"
+      "entity_derived": "niiri:1b0c82bff8134900d83ca4ab18a5f9a1",
+      "entity": "niiri:9c1fe61e0e5d7d3b62e90ebdfdb9d4d4"
     },
     {
-      "@id": "niiri:8379520857b8af55cf1805934d42de76",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:52d92ac8e74231b2934c36f68802206e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0168",
-      "prov:atLocation": {"@id": "niiri:1e28949330f556a725bfe8973acf49b1"},
+      "prov:atLocation": {"@id": "niiri:7cb75652d69e9abf19d2ee2c4fa1e4fb"},
       "prov:value": {"@type": "xsd:float", "@value": "15.0247755050659"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.55095019170042"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000191921525476424"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999989746346377"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.366093757282605"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.55095019170042"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000191921525476424"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999989746346377"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.366093757282605"}
     },
     {
-      "@id": "niiri:1e28949330f556a725bfe8973acf49b1",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7cb75652d69e9abf19d2ee2c4fa1e4fb",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0168",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[16,-80,34]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[16,-80,34]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8379520857b8af55cf1805934d42de76",
-      "entity": "niiri:ec6922a6284384102e3683f4f534bdd4"
+      "entity_derived": "niiri:52d92ac8e74231b2934c36f68802206e",
+      "entity": "niiri:7489f5e950ff72b41ea437f2c2026c6f"
     },
     {
-      "@id": "niiri:d5fb13475ead04b97a6bc0c5cf77a7b6",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d117036fe64a05a3b7c805f5ca53e73e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0169",
-      "prov:atLocation": {"@id": "niiri:cd4fb279af14a2919459e77c2d68532d"},
+      "prov:atLocation": {"@id": "niiri:9a1e586581e6bddb054aee681f832543"},
       "prov:value": {"@type": "xsd:float", "@value": "14.9055671691895"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.53651359109015"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00020272281950362"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999993824799586"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.380347203516888"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.53651359109015"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00020272281950362"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999993824799586"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.380347203516888"}
     },
     {
-      "@id": "niiri:cd4fb279af14a2919459e77c2d68532d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:9a1e586581e6bddb054aee681f832543",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0169",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[64,-30,-22]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[64,-30,-22]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d5fb13475ead04b97a6bc0c5cf77a7b6",
-      "entity": "niiri:1587d965de8a227487a386f18a622f62"
+      "entity_derived": "niiri:d117036fe64a05a3b7c805f5ca53e73e",
+      "entity": "niiri:e83b9cd4cb9554eedc76bd43c766b08d"
     },
     {
-      "@id": "niiri:8386fab97aa78085b846ca72be1375c2",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c1fb5dac9debfbd27cdbf2c5644bd72c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0170",
-      "prov:atLocation": {"@id": "niiri:90135c09df01dc00b9ae6433652e1957"},
+      "prov:atLocation": {"@id": "niiri:d8e46fdef899ea7ef1ae4932eb2a23ab"},
       "prov:value": {"@type": "xsd:float", "@value": "14.8710918426514"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.53232486243101"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000205961489586182"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999468897041"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.384169468988064"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.53232486243101"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000205961489586182"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999468897041"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.384169468988064"}
     },
     {
-      "@id": "niiri:90135c09df01dc00b9ae6433652e1957",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d8e46fdef899ea7ef1ae4932eb2a23ab",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0170",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-10,0,-26]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-10,0,-26]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8386fab97aa78085b846ca72be1375c2",
-      "entity": "niiri:cde75203fe8335e4da3e8277987b76e3"
+      "entity_derived": "niiri:c1fb5dac9debfbd27cdbf2c5644bd72c",
+      "entity": "niiri:6f3ca580fb0dafec12bb76f49a9e660f"
     },
     {
-      "@id": "niiri:f76d49b1ed43e2533464668a6954e3f7",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3b66a36836011aa9090bd0e7407688b5",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0171",
-      "prov:atLocation": {"@id": "niiri:737c5b254d8053c6781fe72ecfab960e"},
+      "prov:atLocation": {"@id": "niiri:0709e326475b1e5b4645c9564c8fc035"},
       "prov:value": {"@type": "xsd:float", "@value": "14.7261476516724"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.51464664736948"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000220169736176778"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999997240347399"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.402613109615176"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.51464664736948"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000220169736176778"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999997240347399"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.402613109615176"}
     },
     {
-      "@id": "niiri:737c5b254d8053c6781fe72ecfab960e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0709e326475b1e5b4645c9564c8fc035",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0171",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[6,-86,-14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[6,-86,-14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f76d49b1ed43e2533464668a6954e3f7",
-      "entity": "niiri:1963461ba0ecaf2bdd626d72af091d83"
+      "entity_derived": "niiri:3b66a36836011aa9090bd0e7407688b5",
+      "entity": "niiri:37ee2d388f0d21999c13e5808ab4abaa"
     },
     {
-      "@id": "niiri:7d086b408d223ad920f53d221022020e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:8de26e655b38ebe0ae823a3c6315b489",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0172",
-      "prov:atLocation": {"@id": "niiri:f5eb75a18c012485610d81fd8d0f64e9"},
+      "prov:atLocation": {"@id": "niiri:8e522834b8f477e782bc23a55b9554cb"},
       "prov:value": {"@type": "xsd:float", "@value": "14.6060304641724"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.49991285381712"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000232705141600564"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999998437784089"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.414927735129735"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.49991285381712"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000232705141600564"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999998437784089"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.414927735129735"}
     },
     {
-      "@id": "niiri:f5eb75a18c012485610d81fd8d0f64e9",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:8e522834b8f477e782bc23a55b9554cb",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0172",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[12,52,-12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[12,52,-12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7d086b408d223ad920f53d221022020e",
-      "entity": "niiri:031b2ebac9374480bd55f336b2f0698d"
+      "entity_derived": "niiri:8de26e655b38ebe0ae823a3c6315b489",
+      "entity": "niiri:17c3d65f0a2dd8b609c3139c41ebf930"
     },
     {
-      "@id": "niiri:21e6f173b43fe0229a78d435762354fa",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3a28b75034719222480546a8f248e93d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0173",
-      "prov:atLocation": {"@id": "niiri:389cde518a3428b0670d3ca8db8ab089"},
+      "prov:atLocation": {"@id": "niiri:54cd1db3599f092f7c78fff2e8d1615a"},
       "prov:value": {"@type": "xsd:float", "@value": "14.5363855361938"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.49133496134193"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000240306645747146"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999998889540591"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.422120265651345"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.49133496134193"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000240306645747146"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999998889540591"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.422120265651345"}
     },
     {
-      "@id": "niiri:389cde518a3428b0670d3ca8db8ab089",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:54cd1db3599f092f7c78fff2e8d1615a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0173",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[36,54,20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[36,54,20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:21e6f173b43fe0229a78d435762354fa",
-      "entity": "niiri:8424ab2f8e8a8fcd5c99b549000e3d8a"
+      "entity_derived": "niiri:3a28b75034719222480546a8f248e93d",
+      "entity": "niiri:bbd0acc33408cc31d2590c5760c85985"
     },
     {
-      "@id": "niiri:cfd29d6b862a9f5b8c4f5c8768652d51",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:12ba61b8d3db496fc57a6862ebafea4f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0174",
-      "prov:atLocation": {"@id": "niiri:723b57795cebfe51b9f7ac8f922a3406"},
+      "prov:atLocation": {"@id": "niiri:9fd3a79c0e2a551ded703808f3d2e025"},
       "prov:value": {"@type": "xsd:float", "@value": "14.4983959197998"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.48664497650161"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0002445600975165"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999081527317"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.425901789152019"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.48664497650161"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0002445600975165"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999081527317"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.425901789152019"}
     },
     {
-      "@id": "niiri:723b57795cebfe51b9f7ac8f922a3406",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:9fd3a79c0e2a551ded703808f3d2e025",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0174",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[22,-80,54]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[22,-80,54]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cfd29d6b862a9f5b8c4f5c8768652d51",
-      "entity": "niiri:cb3496ce3deece902bd5c57224f82327"
+      "entity_derived": "niiri:12ba61b8d3db496fc57a6862ebafea4f",
+      "entity": "niiri:04aa6294da937ca4a062fce158511fb6"
     },
     {
-      "@id": "niiri:b0097d657d563c0ed526a53ad4d35cc0",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:1ca1bec4b1e87f060081099329ba04c7",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0175",
-      "prov:atLocation": {"@id": "niiri:f5cd7c9e0765c96da29c86c47396cb30"},
+      "prov:atLocation": {"@id": "niiri:039763d5557fd6b882a82f1f2fa88193"},
       "prov:value": {"@type": "xsd:float", "@value": "14.4410257339478"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.4795476354157"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00025113053481729"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999313840959"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.433055163923937"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.4795476354157"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00025113053481729"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999313840959"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.433055163923937"}
     },
     {
-      "@id": "niiri:f5cd7c9e0765c96da29c86c47396cb30",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:039763d5557fd6b882a82f1f2fa88193",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0175",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-22,-36,76]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-22,-36,76]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b0097d657d563c0ed526a53ad4d35cc0",
-      "entity": "niiri:a3a27b078e8a7d6edcf7ae4db82c3d7a"
+      "entity_derived": "niiri:1ca1bec4b1e87f060081099329ba04c7",
+      "entity": "niiri:6e2a6189013a78c14191e7633ed21b0a"
     },
     {
-      "@id": "niiri:59fa50d957e29dd591c676c8c178c87d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5570619f587edcedc3276cafac9a60e6",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0176",
-      "prov:atLocation": {"@id": "niiri:ebdfb13c9a07087afe2c7242faee2044"},
+      "prov:atLocation": {"@id": "niiri:f0ea17a233eefa7eab37721460a7244a"},
       "prov:value": {"@type": "xsd:float", "@value": "14.4293870925903"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.47810563161417"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000252485443433037"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999353730622"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.43353733164354"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.47810563161417"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000252485443433037"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999353730622"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.43353733164354"}
     },
     {
-      "@id": "niiri:ebdfb13c9a07087afe2c7242faee2044",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f0ea17a233eefa7eab37721460a7244a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0176",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[26,62,6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[26,62,6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:59fa50d957e29dd591c676c8c178c87d",
-      "entity": "niiri:4f03ee575ea9164c216c53e2e6502c3f"
+      "entity_derived": "niiri:5570619f587edcedc3276cafac9a60e6",
+      "entity": "niiri:81840f3ae0159e07fac81fc13e72fbf5"
     },
     {
-      "@id": "niiri:04db5f1da5e9e02a8e3ae06f6921e16e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:191389c9f10b0de3fdc2d8f22b74563e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0177",
-      "prov:atLocation": {"@id": "niiri:8fb297386f41d2110208c30bb125fac6"},
+      "prov:atLocation": {"@id": "niiri:1ebed5337c4efa7db3bac190a73c4a66"},
       "prov:value": {"@type": "xsd:float", "@value": "14.3534603118896"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.46868038509791"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000261510638276841"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999565455566"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.443489346067816"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.46868038509791"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000261510638276841"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999565455566"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.443489346067816"}
     },
     {
-      "@id": "niiri:8fb297386f41d2110208c30bb125fac6",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:1ebed5337c4efa7db3bac190a73c4a66",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0177",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[22,40,26]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[22,40,26]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:04db5f1da5e9e02a8e3ae06f6921e16e",
-      "entity": "niiri:8ddc263efb94c47b4f51cbca78984739"
+      "entity_derived": "niiri:191389c9f10b0de3fdc2d8f22b74563e",
+      "entity": "niiri:dd602a84f4dd916125d3c669097eec23"
     },
     {
-      "@id": "niiri:0da7da691d434ca45f64b54f97f14934",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:aedad9f4ec6caede41f6dc10a706c84d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0178",
-      "prov:atLocation": {"@id": "niiri:7bc09c4d8cdb5f33e5e1defbb37268e8"},
+      "prov:atLocation": {"@id": "niiri:ac86a4452eca6d7e0a7b5e876240c351"},
       "prov:value": {"@type": "xsd:float", "@value": "14.3390064239502"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.46688257307826"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000263265928860834"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999959757588"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.443939228312532"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.46688257307826"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000263265928860834"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999959757588"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.443939228312532"}
     },
     {
-      "@id": "niiri:7bc09c4d8cdb5f33e5e1defbb37268e8",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ac86a4452eca6d7e0a7b5e876240c351",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0178",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-22,-74,60]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-22,-74,60]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0da7da691d434ca45f64b54f97f14934",
-      "entity": "niiri:b615db2c02106c19996d725a76dd5932"
+      "entity_derived": "niiri:aedad9f4ec6caede41f6dc10a706c84d",
+      "entity": "niiri:1c2363e827044fb757d9bf0cf8e052e5"
     },
     {
-      "@id": "niiri:afa775723febe159c089c9dec314c31e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:4c440fe68b006ba088752502fc89d323",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0179",
-      "prov:atLocation": {"@id": "niiri:efcaa7aeb871102569f97676f9904ed5"},
+      "prov:atLocation": {"@id": "niiri:22107ce4b501a53fc85295e23a1ea347"},
       "prov:value": {"@type": "xsd:float", "@value": "14.3375244140625"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.46669817220102"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000263446587826399"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999600741004"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.443939228312532"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.46669817220102"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000263446587826399"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999600741004"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.443939228312532"}
     },
     {
-      "@id": "niiri:efcaa7aeb871102569f97676f9904ed5",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:22107ce4b501a53fc85295e23a1ea347",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0179",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[60,-58,-2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[60,-58,-2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:afa775723febe159c089c9dec314c31e",
-      "entity": "niiri:6e455b57979dad222384fa2bedf5c673"
+      "entity_derived": "niiri:4c440fe68b006ba088752502fc89d323",
+      "entity": "niiri:45132e41bd386f5b430c16f7c2c90e0a"
     },
     {
-      "@id": "niiri:17efd927653dbab6e1c8226ff36b3c4e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:293fb40452e1ad24570cc1435e986bc8",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0180",
-      "prov:atLocation": {"@id": "niiri:80cb4552c31fb99deaba6189e8eec2b7"},
+      "prov:atLocation": {"@id": "niiri:ecdd542cc1f75543496cd4ccdffb2154"},
       "prov:value": {"@type": "xsd:float", "@value": "14.3194494247437"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.46444820092492"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000265660226814735"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999637520677"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.445794785853199"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.46444820092492"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000265660226814735"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999637520677"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.445794785853199"}
     },
     {
-      "@id": "niiri:80cb4552c31fb99deaba6189e8eec2b7",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ecdd542cc1f75543496cd4ccdffb2154",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0180",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[20,-72,10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[20,-72,10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:17efd927653dbab6e1c8226ff36b3c4e",
-      "entity": "niiri:59697598e154d20a6b71266d474312af"
+      "entity_derived": "niiri:293fb40452e1ad24570cc1435e986bc8",
+      "entity": "niiri:c4e5f3528c31047605f368909a0632ee"
     },
     {
-      "@id": "niiri:b89534fb37186d46db9526e5c2fd2352",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:29f6517310b6e9273df1d8b7f169679e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0181",
-      "prov:atLocation": {"@id": "niiri:63bc4acd1ddad561a66d67e914cbcdda"},
+      "prov:atLocation": {"@id": "niiri:30293dec841bdf9cee0f1f324755eb67"},
       "prov:value": {"@type": "xsd:float", "@value": "13.9198055267334"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.41423607996236"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000319805638077209"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999996382628"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.505510989298795"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.41423607996236"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000319805638077209"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999996382628"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.505510989298795"}
     },
     {
-      "@id": "niiri:63bc4acd1ddad561a66d67e914cbcdda",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:30293dec841bdf9cee0f1f324755eb67",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0181",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[20,18,-16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[20,18,-16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b89534fb37186d46db9526e5c2fd2352",
-      "entity": "niiri:737e8596c1e48716edbdb5c9d774c8a2"
+      "entity_derived": "niiri:29f6517310b6e9273df1d8b7f169679e",
+      "entity": "niiri:1355ee0795599ee6287d2b70ebc8d729"
     },
     {
-      "@id": "niiri:14f61e442b87c6a980a9b55ce85697bc",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:542b8ad9afd2cc487bc118184a9d1898",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0182",
-      "prov:atLocation": {"@id": "niiri:67c7b3bc1eb9e002863654c3fc2db48b"},
+      "prov:atLocation": {"@id": "niiri:2ca2e43070b78c6b911a95ec58c54372"},
       "prov:value": {"@type": "xsd:float", "@value": "13.8895444869995"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.41039722335618"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000324341637228609"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999970034447"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.508910387235141"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.41039722335618"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000324341637228609"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999970034447"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.508910387235141"}
     },
     {
-      "@id": "niiri:67c7b3bc1eb9e002863654c3fc2db48b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:2ca2e43070b78c6b911a95ec58c54372",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0182",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[30,-94,14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[30,-94,14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:14f61e442b87c6a980a9b55ce85697bc",
-      "entity": "niiri:6e426d70bd3515ce04a9030b5a306cc1"
+      "entity_derived": "niiri:542b8ad9afd2cc487bc118184a9d1898",
+      "entity": "niiri:370789fb0338d1e1885081e0362c340f"
     },
     {
-      "@id": "niiri:ce19e677cb4b3410c8b4155cc304c1f6",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:6b45ddf4564bf60372a7295ba801c752",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0183",
-      "prov:atLocation": {"@id": "niiri:98e229d5de0a4985c8feaa5df5a1844b"},
+      "prov:atLocation": {"@id": "niiri:c6f990446c1cd96198a4848a9a3e7916"},
       "prov:value": {"@type": "xsd:float", "@value": "13.8777379989624"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.40889804768482"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000326129256370655"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999972172211"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.508910387235141"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.40889804768482"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000326129256370655"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999972172211"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.508910387235141"}
     },
     {
-      "@id": "niiri:98e229d5de0a4985c8feaa5df5a1844b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c6f990446c1cd96198a4848a9a3e7916",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0183",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[52,40,-8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[52,40,-8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ce19e677cb4b3410c8b4155cc304c1f6",
-      "entity": "niiri:8b57f16537b5d60872068ffb74ea46c2"
+      "entity_derived": "niiri:6b45ddf4564bf60372a7295ba801c752",
+      "entity": "niiri:40392b1ab652b1fe41dac16581269fb2"
     },
     {
-      "@id": "niiri:5003d318e510a88af44a500d4013e290",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:31f0e1886831f0a1dbaaece14761126e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0184",
-      "prov:atLocation": {"@id": "niiri:4908b528270e759195bfb04b4a40f8fe"},
+      "prov:atLocation": {"@id": "niiri:acfb6cd2464d523732fc5c4f75550cbe"},
       "prov:value": {"@type": "xsd:float", "@value": "13.8520250320435"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.4056302617749"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000330057567596631"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999976340597"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.510923995091643"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.4056302617749"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000330057567596631"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999976340597"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.510923995091643"}
     },
     {
-      "@id": "niiri:4908b528270e759195bfb04b4a40f8fe",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:acfb6cd2464d523732fc5c4f75550cbe",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0184",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[46,-76,-16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[46,-76,-16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5003d318e510a88af44a500d4013e290",
-      "entity": "niiri:57fac0849992a04e841522c89a1e8fad"
+      "entity_derived": "niiri:31f0e1886831f0a1dbaaece14761126e",
+      "entity": "niiri:65ef2c95ae3f51b5861bb20b84514bd9"
     },
     {
-      "@id": "niiri:04b94afa4c0c689ec22edc0617cb5c0e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e272d51328812cf371cc587ac58a5526",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0185",
-      "prov:atLocation": {"@id": "niiri:0e6554b673a6bda5e0e3c96188f27df5"},
+      "prov:atLocation": {"@id": "niiri:fc79049bf5c6c73ad72ccc47fa125036"},
       "prov:value": {"@type": "xsd:float", "@value": "13.8400564193726"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.4041079037944"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00033190262699101"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999978073029"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.511965057359758"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.4041079037944"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00033190262699101"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999978073029"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.511965057359758"}
     },
     {
-      "@id": "niiri:0e6554b673a6bda5e0e3c96188f27df5",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:fc79049bf5c6c73ad72ccc47fa125036",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0185",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-40,-38,66]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-40,-38,66]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:04b94afa4c0c689ec22edc0617cb5c0e",
-      "entity": "niiri:7d9186e6ae7abd1a3b75051676646bf7"
+      "entity_derived": "niiri:e272d51328812cf371cc587ac58a5526",
+      "entity": "niiri:5cc71319d109fdb0ef9f0f9c7bd41492"
     },
     {
-      "@id": "niiri:05dd7bc31b69126a43533248a520aec6",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:4e23f38355e282e3d94d0ca850cd592a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0186",
-      "prov:atLocation": {"@id": "niiri:bae05943598e7894c560ea6634f0065a"},
+      "prov:atLocation": {"@id": "niiri:bc1ed1b5f884be34190d17a6a34ea467"},
       "prov:value": {"@type": "xsd:float", "@value": "13.7650365829468"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.39454677341543"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000343711482697406"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999998648758"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.521258506668093"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.39454677341543"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000343711482697406"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999998648758"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.521258506668093"}
     },
     {
-      "@id": "niiri:bae05943598e7894c560ea6634f0065a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:bc1ed1b5f884be34190d17a6a34ea467",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0186",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-30,-58,-16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-30,-58,-16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:05dd7bc31b69126a43533248a520aec6",
-      "entity": "niiri:05a6f19551a73fb9cdefb486a3b7d7c7"
+      "entity_derived": "niiri:4e23f38355e282e3d94d0ca850cd592a",
+      "entity": "niiri:4bf75a353d782554be968730ac4840cd"
     },
     {
-      "@id": "niiri:02f5beedec6151839411b6af10ce9b1d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a5d23eefb67d323e152120970fdbfb9b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0187",
-      "prov:atLocation": {"@id": "niiri:afe6bb918bf7641b8c1609c51fcc2d66"},
+      "prov:atLocation": {"@id": "niiri:f40ad9017c1996f81d9a6de18883ece2"},
       "prov:value": {"@type": "xsd:float", "@value": "13.6462821960449"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.37934453884673"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000363294438112227"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999993887608"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.54285139155384"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.37934453884673"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000363294438112227"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999993887608"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.54285139155384"}
     },
     {
-      "@id": "niiri:afe6bb918bf7641b8c1609c51fcc2d66",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f40ad9017c1996f81d9a6de18883ece2",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0187",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[50,46,-12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[50,46,-12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:02f5beedec6151839411b6af10ce9b1d",
-      "entity": "niiri:f652c5b4f145cc8a8477c98b20d1e8e7"
+      "entity_derived": "niiri:a5d23eefb67d323e152120970fdbfb9b",
+      "entity": "niiri:332041ad6aeaf3a74891ecd53c374a96"
     },
     {
-      "@id": "niiri:38dea93aeffa24df7e703750f22f6007",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b2d310b49e85f22bad1ac328ed239ef7",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0188",
-      "prov:atLocation": {"@id": "niiri:6d2a5164869e6cd73b4ff41bf65f99ab"},
+      "prov:atLocation": {"@id": "niiri:3188ca18da93c376e8b714dde85b69f9"},
       "prov:value": {"@type": "xsd:float", "@value": "13.6285772323608"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.37707094032846"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00036631076264837"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999458514"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.545098853746109"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.37707094032846"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00036631076264837"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999458514"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.545098853746109"}
     },
     {
-      "@id": "niiri:6d2a5164869e6cd73b4ff41bf65f99ab",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:3188ca18da93c376e8b714dde85b69f9",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0188",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-20,-14,70]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-20,-14,70]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:38dea93aeffa24df7e703750f22f6007",
-      "entity": "niiri:220f34dd841d349b45f448f4ed96568e"
+      "entity_derived": "niiri:b2d310b49e85f22bad1ac328ed239ef7",
+      "entity": "niiri:b47672c30d95e784941e629a0021b66b"
     },
     {
-      "@id": "niiri:38711773b6e76b61aaa202f0bf111aac",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ae8fdbe9961a1dc724d425e20affb4ad",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0189",
-      "prov:atLocation": {"@id": "niiri:042fe332fb2a7fb78203524667da891e"},
+      "prov:atLocation": {"@id": "niiri:8d02755a1dc43a17d77f1edd70edbda3"},
       "prov:value": {"@type": "xsd:float", "@value": "13.5882997512817"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.37189174994258"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000373268921653791"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999995901462"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.550594852089412"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.37189174994258"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000373268921653791"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999995901462"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.550594852089412"}
     },
     {
-      "@id": "niiri:042fe332fb2a7fb78203524667da891e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:8d02755a1dc43a17d77f1edd70edbda3",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0189",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-24,-28,80]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-24,-28,80]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:38711773b6e76b61aaa202f0bf111aac",
-      "entity": "niiri:73421e1373e081b7d78772065fdc0ab7"
+      "entity_derived": "niiri:ae8fdbe9961a1dc724d425e20affb4ad",
+      "entity": "niiri:4ade8b0865402c36f9bde1298af17ab4"
     },
     {
-      "@id": "niiri:f88984a4e5c67384154f76c2008adbc2",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:02fa43a4dca1b09dd2c3be30a44755f8",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0190",
-      "prov:atLocation": {"@id": "niiri:1a200c9df626205b9289babc571b3f08"},
+      "prov:atLocation": {"@id": "niiri:4d13638d382a0721c68d1709aab16557"},
       "prov:value": {"@type": "xsd:float", "@value": "13.3802738189697"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.34498751004771"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000411431379332639"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999088907"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.589500594790403"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.34498751004771"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000411431379332639"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999088907"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.589500594790403"}
     },
     {
-      "@id": "niiri:1a200c9df626205b9289babc571b3f08",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4d13638d382a0721c68d1709aab16557",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0190",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[52,-46,-12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[52,-46,-12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f88984a4e5c67384154f76c2008adbc2",
-      "entity": "niiri:fd107443c1e505341538e35623ef13ad"
+      "entity_derived": "niiri:02fa43a4dca1b09dd2c3be30a44755f8",
+      "entity": "niiri:8d46ffe6156e40b274554eb8fc558f49"
     },
     {
-      "@id": "niiri:731d674cf48ac57dc021de1c57121d00",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:1bb674b1760d589a90a0632e34f21e8a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0191",
-      "prov:atLocation": {"@id": "niiri:768cc18f7bb8b84d08d5ac651841ba42"},
+      "prov:atLocation": {"@id": "niiri:f167259377277e0b37c958e0f7afe5bc"},
       "prov:value": {"@type": "xsd:float", "@value": "13.3560466766357"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.34183716228186"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000416129350639172"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999240863"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.59334627957149"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.34183716228186"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000416129350639172"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999240863"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.59334627957149"}
     },
     {
-      "@id": "niiri:768cc18f7bb8b84d08d5ac651841ba42",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f167259377277e0b37c958e0f7afe5bc",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0191",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[54,8,-36]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[54,8,-36]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:731d674cf48ac57dc021de1c57121d00",
-      "entity": "niiri:32a1c5504e28cf0e83bddf4c41d902c9"
+      "entity_derived": "niiri:1bb674b1760d589a90a0632e34f21e8a",
+      "entity": "niiri:4d3c4f523d2ecfeb9befc1c5babb099d"
     },
     {
-      "@id": "niiri:da3ef04b6df57b2c7e61b9f81e61edd9",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:7af7dc9d762aed03c62f1ccb4dc9f1b1",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0192",
-      "prov:atLocation": {"@id": "niiri:7e19e95d18dfe15f3b337d360ceacae9"},
+      "prov:atLocation": {"@id": "niiri:ddcb77e03b58b0ecad10fb686502cb55"},
       "prov:value": {"@type": "xsd:float", "@value": "13.2219953536987"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.324340860909"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000443138995409265"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999731254"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.61993269765931"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.324340860909"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000443138995409265"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999731254"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.61993269765931"}
     },
     {
-      "@id": "niiri:7e19e95d18dfe15f3b337d360ceacae9",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ddcb77e03b58b0ecad10fb686502cb55",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0192",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[2,-78,-20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[2,-78,-20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:da3ef04b6df57b2c7e61b9f81e61edd9",
-      "entity": "niiri:4c3e4e7060e2b7cf9ba40d556d3850b1"
+      "entity_derived": "niiri:7af7dc9d762aed03c62f1ccb4dc9f1b1",
+      "entity": "niiri:24a29d9d6136d7a26f77ad7395967c47"
     },
     {
-      "@id": "niiri:2551cde3a4a21ee9a2c5655d953b1893",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:75daec94f2d9f1cbc921b112d9ef9ce2",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0193",
-      "prov:atLocation": {"@id": "niiri:fa604978205651a01310d7f693105ef4"},
+      "prov:atLocation": {"@id": "niiri:89d682f2aee216c11881fb170e685723"},
       "prov:value": {"@type": "xsd:float", "@value": "13.1609621047974"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.3163379950432"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000456027248061708"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999835257"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.629521256290025"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.3163379950432"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000456027248061708"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999835257"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.629521256290025"}
     },
     {
-      "@id": "niiri:fa604978205651a01310d7f693105ef4",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:89d682f2aee216c11881fb170e685723",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0193",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-30,-44,54]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-30,-44,54]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2551cde3a4a21ee9a2c5655d953b1893",
-      "entity": "niiri:908b3d895326bd3ac6957280d4de7d76"
+      "entity_derived": "niiri:75daec94f2d9f1cbc921b112d9ef9ce2",
+      "entity": "niiri:7289b1de1e9e889ff1fb5691142cd967"
     },
     {
-      "@id": "niiri:9572b8f88bd3f41aeee3af027e62eeca",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:faf603f8089ae20ce68bd6964020283e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0194",
-      "prov:atLocation": {"@id": "niiri:bec52b58537a3d8c000e3fb1b732b22f"},
+      "prov:atLocation": {"@id": "niiri:a73940ea69cb3b5a0586787884ed744a"},
       "prov:value": {"@type": "xsd:float", "@value": "13.1470022201538"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.31450426670224"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000459028893888824"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999852923"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.6313035812178"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.31450426670224"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000459028893888824"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999852923"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.6313035812178"}
     },
     {
-      "@id": "niiri:bec52b58537a3d8c000e3fb1b732b22f",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a73940ea69cb3b5a0586787884ed744a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0194",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-34,-32,-10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-34,-32,-10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9572b8f88bd3f41aeee3af027e62eeca",
-      "entity": "niiri:000f81203c82e4c9e73a3c6aace6130e"
+      "entity_derived": "niiri:faf603f8089ae20ce68bd6964020283e",
+      "entity": "niiri:4465bf32a18439b39ae380aba9c3f3b0"
     },
     {
-      "@id": "niiri:2589d8f03f59ff750fd037748b135654",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d1bf63b81607321155f8338c282e59b2",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0195",
-      "prov:atLocation": {"@id": "niiri:ef7a18775b39641a52fcc7adcd0fa1fb"},
+      "prov:atLocation": {"@id": "niiri:2828b9a85d8b30329115bf86cdec2f09"},
       "prov:value": {"@type": "xsd:float", "@value": "13.1295585632324"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.31221120560286"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000462808186444841"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999872459"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.63388766436911"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.31221120560286"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000462808186444841"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999872459"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.63388766436911"}
     },
     {
-      "@id": "niiri:ef7a18775b39641a52fcc7adcd0fa1fb",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:2828b9a85d8b30329115bf86cdec2f09",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0195",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[52,-74,-4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[52,-74,-4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2589d8f03f59ff750fd037748b135654",
-      "entity": "niiri:1a6f934195839bd5aafde8865b102795"
+      "entity_derived": "niiri:d1bf63b81607321155f8338c282e59b2",
+      "entity": "niiri:1cd15156a67e7cd4faba9f06d50293c8"
     },
     {
-      "@id": "niiri:4a039d31d48a4d855d37672e1fddb518",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ad40b53c8dd4e2ab45b2ef401a4c24fc",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0196",
-      "prov:atLocation": {"@id": "niiri:37847488c895ec745c1ceedec0a4f95d"},
+      "prov:atLocation": {"@id": "niiri:0e0b46edbad1d5cc68e5d1a4a943c4e2"},
       "prov:value": {"@type": "xsd:float", "@value": "13.1201601028442"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.31097493716214"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000464857675592345"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999988193"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.634645676204038"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.31097493716214"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000464857675592345"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999988193"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.634645676204038"}
     },
     {
-      "@id": "niiri:37847488c895ec745c1ceedec0a4f95d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0e0b46edbad1d5cc68e5d1a4a943c4e2",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0196",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[24,-76,6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[24,-76,6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4a039d31d48a4d855d37672e1fddb518",
-      "entity": "niiri:6179fefaf9c60c4a862df01568a93c88"
+      "entity_derived": "niiri:ad40b53c8dd4e2ab45b2ef401a4c24fc",
+      "entity": "niiri:ad7c299b4aa35cd98fdbd415f19783a7"
     },
     {
-      "@id": "niiri:abaee743c73f41b308287d222feefa29",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d5a95ad6a90a7c4b7b4c65611bcfb3ee",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0197",
-      "prov:atLocation": {"@id": "niiri:a477dc5da8ee5797441bd8aa5669b41b"},
+      "prov:atLocation": {"@id": "niiri:e87409f2102a691e85a72e6831af93bd"},
       "prov:value": {"@type": "xsd:float", "@value": "13.046257019043"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.30123438509586"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000481302154360597"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999936213"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.650319788160183"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.30123438509586"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000481302154360597"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999936213"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.650319788160183"}
     },
     {
-      "@id": "niiri:a477dc5da8ee5797441bd8aa5669b41b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e87409f2102a691e85a72e6831af93bd",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0197",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-60,-4,-10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-60,-4,-10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:abaee743c73f41b308287d222feefa29",
-      "entity": "niiri:a1eaf067aa20aea18c22e185e1ee2f97"
+      "entity_derived": "niiri:d5a95ad6a90a7c4b7b4c65611bcfb3ee",
+      "entity": "niiri:fe8b635d8a705b40fb4ced016e9d726a"
     },
     {
-      "@id": "niiri:a0a956b6ce2985e809d8b37dcb8d629a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a4bd9f4aa32c821fe2cb97c3309c18de",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0198",
-      "prov:atLocation": {"@id": "niiri:0c3866cec09aa3ddb5dd402fd5547a98"},
+      "prov:atLocation": {"@id": "niiri:963a82208403e301602399f8ef788246"},
       "prov:value": {"@type": "xsd:float", "@value": "13.0227518081665"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.29812912032221"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000486656828599608"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999947735"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.654413109208221"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.29812912032221"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000486656828599608"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999947735"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.654413109208221"}
     },
     {
-      "@id": "niiri:0c3866cec09aa3ddb5dd402fd5547a98",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:963a82208403e301602399f8ef788246",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0198",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[40,-52,68]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[40,-52,68]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a0a956b6ce2985e809d8b37dcb8d629a",
-      "entity": "niiri:e3d6362d81a3c6aaee10e57f2d21a4b6"
+      "entity_derived": "niiri:a4bd9f4aa32c821fe2cb97c3309c18de",
+      "entity": "niiri:71e15e602f95bdd78bc912bf527abf9d"
     },
     {
-      "@id": "niiri:4c980131dc417cb9367514a5f5ad0574",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:60b2aa1e5a1e97e22c14f51ae12c8d5c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0199",
-      "prov:atLocation": {"@id": "niiri:b38f693094d7eb8aa13160ebce41e820"},
+      "prov:atLocation": {"@id": "niiri:121190025dfe1a383743f7fbe9664dc2"},
       "prov:value": {"@type": "xsd:float", "@value": "12.9725027084351"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.29147894602831"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000498310382184619"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999966052"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.66402192610552"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.29147894602831"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000498310382184619"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999966052"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.66402192610552"}
     },
     {
-      "@id": "niiri:b38f693094d7eb8aa13160ebce41e820",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:121190025dfe1a383743f7fbe9664dc2",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0199",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-14,58,10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-14,58,10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4c980131dc417cb9367514a5f5ad0574",
-      "entity": "niiri:d40597f499b8e4493f5c750b1bb49759"
+      "entity_derived": "niiri:60b2aa1e5a1e97e22c14f51ae12c8d5c",
+      "entity": "niiri:46e2492f096548abf33dea89e7a868bc"
     },
     {
-      "@id": "niiri:2a29c30b083a91b29b72a9b04b478c5b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:98e838a33321e9ba14f44d7f98af1258",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0200",
-      "prov:atLocation": {"@id": "niiri:871743f71e41218b7f125aa57ee5f92d"},
+      "prov:atLocation": {"@id": "niiri:d06b3cad307d15a0de08951bdf20ae6a"},
       "prov:value": {"@type": "xsd:float", "@value": "12.9253482818604"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.28522365934433"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000509507233156237"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999977514"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.670440081569804"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.28522365934433"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000509507233156237"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999977514"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.670440081569804"}
     },
     {
-      "@id": "niiri:871743f71e41218b7f125aa57ee5f92d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d06b3cad307d15a0de08951bdf20ae6a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0200",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-28,-42,-20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-28,-42,-20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2a29c30b083a91b29b72a9b04b478c5b",
-      "entity": "niiri:965898643a16b92a90cc3cfaafcd3c48"
+      "entity_derived": "niiri:98e838a33321e9ba14f44d7f98af1258",
+      "entity": "niiri:f234bb306a90feca64756c5add571e95"
     },
     {
-      "@id": "niiri:20680cc9cdc4fc6c7f8c266812915f50",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b33c6c90358c64f445051a6f1ddaa146",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0201",
-      "prov:atLocation": {"@id": "niiri:4e254ab19b7087b758b58b01547e88b2"},
+      "prov:atLocation": {"@id": "niiri:804b433957f0b0751f8e56a78e15792f"},
       "prov:value": {"@type": "xsd:float", "@value": "12.9120073318481"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.28345132118853"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000512721763674673"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999980013"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.672215583608969"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.28345132118853"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000512721763674673"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999980013"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.672215583608969"}
     },
     {
-      "@id": "niiri:4e254ab19b7087b758b58b01547e88b2",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:804b433957f0b0751f8e56a78e15792f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0201",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-30,64,10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-30,64,10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:20680cc9cdc4fc6c7f8c266812915f50",
-      "entity": "niiri:d1ba7d5acbc118fa7879e7e4e6844b1d"
+      "entity_derived": "niiri:b33c6c90358c64f445051a6f1ddaa146",
+      "entity": "niiri:9a23d6bdea30bc505d71bdea4b14cc81"
     },
     {
-      "@id": "niiri:e963925f531d9bf94edaa4d6565a0b3c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:6c21781a2f968dd6b89eb9acbab79c64",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0202",
-      "prov:atLocation": {"@id": "niiri:c29057c71e81e51a9cadb8ce30147e8d"},
+      "prov:atLocation": {"@id": "niiri:e72f5cd5280ab8a81cdb28854ee6c88b"},
       "prov:value": {"@type": "xsd:float", "@value": "12.8873691558838"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.28017513962894"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000518713316777997"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999983944"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.676739301292717"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.28017513962894"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000518713316777997"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999983944"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.676739301292717"}
     },
     {
-      "@id": "niiri:c29057c71e81e51a9cadb8ce30147e8d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e72f5cd5280ab8a81cdb28854ee6c88b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0202",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-66,-36,22]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-66,-36,22]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e963925f531d9bf94edaa4d6565a0b3c",
-      "entity": "niiri:a9f3103d256c0dc28abb00c6f6a495ee"
+      "entity_derived": "niiri:6c21781a2f968dd6b89eb9acbab79c64",
+      "entity": "niiri:55a2e8a69b22f0385eb446ff36f57cd5"
     },
     {
-      "@id": "niiri:7f37d1f9c144579425ce0f3358580e57",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:1b91a4eb434472d16421d0c377206835",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0203",
-      "prov:atLocation": {"@id": "niiri:9038335116cb7c698ffe37e21bc86573"},
+      "prov:atLocation": {"@id": "niiri:3c19d9ef241dff3575137612c854cd2f"},
       "prov:value": {"@type": "xsd:float", "@value": "12.8246231079102"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.271813961984"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00053429933476512"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999990888"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.687743631356335"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.271813961984"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00053429933476512"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999990888"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.687743631356335"}
     },
     {
-      "@id": "niiri:9038335116cb7c698ffe37e21bc86573",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:3c19d9ef241dff3575137612c854cd2f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0203",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[44,-60,-52]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[44,-60,-52]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7f37d1f9c144579425ce0f3358580e57",
-      "entity": "niiri:a6963a6fd81257c75c10efb4a812813d"
+      "entity_derived": "niiri:1b91a4eb434472d16421d0c377206835",
+      "entity": "niiri:c1b67e6fa1bc1b0441ef946f06fc7939"
     },
     {
-      "@id": "niiri:76a919e4a9c7d1fa9bfa1930d9c7f803",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:7d02ed7f20eb6fe558766caecf63c155",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0204",
-      "prov:atLocation": {"@id": "niiri:b0731a2e5846f8d41f36e48cbf02d4f7"},
+      "prov:atLocation": {"@id": "niiri:28f4e80afae132d68d4b5232d5c0653c"},
       "prov:value": {"@type": "xsd:float", "@value": "12.7540121078491"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.26237411173788"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000552416159637859"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999995255"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.700439054447179"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.26237411173788"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000552416159637859"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999995255"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.700439054447179"}
     },
     {
-      "@id": "niiri:b0731a2e5846f8d41f36e48cbf02d4f7",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:28f4e80afae132d68d4b5232d5c0653c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0204",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[48,-36,62]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[48,-36,62]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:76a919e4a9c7d1fa9bfa1930d9c7f803",
-      "entity": "niiri:60ac234a805ede443ca63c3de0f14e32"
+      "entity_derived": "niiri:7d02ed7f20eb6fe558766caecf63c155",
+      "entity": "niiri:598d8f8cb448fe66f29b80c3e9c6b8c7"
     },
     {
-      "@id": "niiri:a49714e6df954b1973a24cabca2c16f0",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:81902bcb64a59f174ed4a22dc2692239",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0205",
-      "prov:atLocation": {"@id": "niiri:d4b233039ca491074ca976cbdb4f7d79"},
+      "prov:atLocation": {"@id": "niiri:0d290b8bc5ddb3996222710a9c2aa917"},
       "prov:value": {"@type": "xsd:float", "@value": "12.7177801132202"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.25751764552706"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000561956352459259"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999996627"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.707106764798581"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.25751764552706"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000561956352459259"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999996627"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.707106764798581"}
     },
     {
-      "@id": "niiri:d4b233039ca491074ca976cbdb4f7d79",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0d290b8bc5ddb3996222710a9c2aa917",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0205",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[46,-74,-34]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[46,-74,-34]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a49714e6df954b1973a24cabca2c16f0",
-      "entity": "niiri:c00dd1395bbc6f074ad431089be26084"
+      "entity_derived": "niiri:81902bcb64a59f174ed4a22dc2692239",
+      "entity": "niiri:9e74994c43b00fa8f3c04ed564b75259"
     },
     {
-      "@id": "niiri:8ee156f72ef039a467a995e472713f73",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:4302df4d2f6614b3486ee45c6c620874",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0206",
-      "prov:atLocation": {"@id": "niiri:0a9f19f4287a24fa3a34431b5c450bf9"},
+      "prov:atLocation": {"@id": "niiri:2607c517e39ded7c56c566e9062d1286"},
       "prov:value": {"@type": "xsd:float", "@value": "12.7100811004639"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.25648457184145"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000564005302693849"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999996865"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.707573008885887"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.25648457184145"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000564005302693849"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999996865"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.707573008885887"}
     },
     {
-      "@id": "niiri:0a9f19f4287a24fa3a34431b5c450bf9",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:2607c517e39ded7c56c566e9062d1286",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0206",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-56,-60,0]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-56,-60,0]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8ee156f72ef039a467a995e472713f73",
-      "entity": "niiri:911801103dad8b9c7f55df419fdee788"
+      "entity_derived": "niiri:4302df4d2f6614b3486ee45c6c620874",
+      "entity": "niiri:59f7c04e9a6910158fa3c13760b2a417"
     },
     {
-      "@id": "niiri:888772eaabf2dccfc423c3ad90e71cc0",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:abd2f7443e3cc8dca0d22ff7fa5b1665",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0207",
-      "prov:atLocation": {"@id": "niiri:864659c15bfaa9afecbbe524a7ea18a9"},
+      "prov:atLocation": {"@id": "niiri:455db5fb74827a39d068ce266c9b9900"},
       "prov:value": {"@type": "xsd:float", "@value": "12.6978673934937"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.25484490255242"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000567271531173308"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999997209"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.709190250795189"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.25484490255242"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000567271531173308"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999997209"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.709190250795189"}
     },
     {
-      "@id": "niiri:864659c15bfaa9afecbbe524a7ea18a9",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:455db5fb74827a39d068ce266c9b9900",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0207",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[18,60,12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[18,60,12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:888772eaabf2dccfc423c3ad90e71cc0",
-      "entity": "niiri:48d4b018c043db4e0876cc1418962d0a"
+      "entity_derived": "niiri:abd2f7443e3cc8dca0d22ff7fa5b1665",
+      "entity": "niiri:81a8b467cb1446f1ff5cdaa2c7d6e479"
     },
     {
-      "@id": "niiri:31f56b1eb2c1ff406b1c9021481a96b6",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:eb863adb5a212bbe0de0abe4fb289aad",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0208",
-      "prov:atLocation": {"@id": "niiri:6b1b60e50a54fbb4c598ff1ccf4ac6bb"},
+      "prov:atLocation": {"@id": "niiri:2c125691782263a2065a16349878da2b"},
       "prov:value": {"@type": "xsd:float", "@value": "12.640664100647"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.24715232109298"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000582829932485596"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999998392"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.722376235864621"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.24715232109298"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000582829932485596"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999998392"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.722376235864621"}
     },
     {
-      "@id": "niiri:6b1b60e50a54fbb4c598ff1ccf4ac6bb",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:2c125691782263a2065a16349878da2b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0208",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-64,-34,8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-64,-34,8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:31f56b1eb2c1ff406b1c9021481a96b6",
-      "entity": "niiri:7c2265b55eb6b5357939defcb818c9dd"
+      "entity_derived": "niiri:eb863adb5a212bbe0de0abe4fb289aad",
+      "entity": "niiri:b6cb8a909916808e62aec6d7aa7ee1b8"
     },
     {
-      "@id": "niiri:64ee191eca48627a7c9516d49d6fa858",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f5b6dec4e6c487fdf092083f6476a41e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0209",
-      "prov:atLocation": {"@id": "niiri:1c879164aeca46febe791915b478ad82"},
+      "prov:atLocation": {"@id": "niiri:73c80915e2c2b11251a84ba8336fa798"},
       "prov:value": {"@type": "xsd:float", "@value": "12.6130704879761"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.24343381706964"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000590491220582523"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999998772"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.726684303777293"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.24343381706964"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000590491220582523"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999998772"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.726684303777293"}
     },
     {
-      "@id": "niiri:1c879164aeca46febe791915b478ad82",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:73c80915e2c2b11251a84ba8336fa798",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0209",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[64,-34,16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[64,-34,16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:64ee191eca48627a7c9516d49d6fa858",
-      "entity": "niiri:1f5d5a2bac2575d7232fa251d172c68f"
+      "entity_derived": "niiri:f5b6dec4e6c487fdf092083f6476a41e",
+      "entity": "niiri:50e1d73ec7323535a313db319aa8fda1"
     },
     {
-      "@id": "niiri:543c0e14b5959b80c6e5e8e58a9c6300",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:6d3f27e6e0aa864aa68bacd72871f8c3",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0210",
-      "prov:atLocation": {"@id": "niiri:a4bde52a87132486564dd06fe64e7b45"},
+      "prov:atLocation": {"@id": "niiri:231abd23ef63978da267e6cf949efc2d"},
       "prov:value": {"@type": "xsd:float", "@value": "12.6124353408813"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.2433481651477"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000590668781873749"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999999878"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.726684303777293"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.2433481651477"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000590668781873749"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999999878"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.726684303777293"}
     },
     {
-      "@id": "niiri:a4bde52a87132486564dd06fe64e7b45",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:231abd23ef63978da267e6cf949efc2d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0210",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-28,-72,62]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-28,-72,62]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:543c0e14b5959b80c6e5e8e58a9c6300",
-      "entity": "niiri:12c379cdb678fa3f360c5174016779ac"
+      "entity_derived": "niiri:6d3f27e6e0aa864aa68bacd72871f8c3",
+      "entity": "niiri:7dcc4c8a94cbe8b1b1f9e1f46a8741d3"
     },
     {
-      "@id": "niiri:a763bfe0f1145f2891603f2fb90de9a0",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a5774a9de179c5a31a4170040a80ba30",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0211",
-      "prov:atLocation": {"@id": "niiri:817b70b1a3821ff617c7a2c57d37b389"},
+      "prov:atLocation": {"@id": "niiri:57002557123aec38be66fd4d6c272034"},
       "prov:value": {"@type": "xsd:float", "@value": "12.5952806472778"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.24103377259091"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00059548536599352"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999999897"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.728854295079526"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.24103377259091"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00059548536599352"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999999897"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.728854295079526"}
     },
     {
-      "@id": "niiri:817b70b1a3821ff617c7a2c57d37b389",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:57002557123aec38be66fd4d6c272034",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0211",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-68,-2,-12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-68,-2,-12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a763bfe0f1145f2891603f2fb90de9a0",
-      "entity": "niiri:7238de23a632331ed72cd39240a7d4d5"
+      "entity_derived": "niiri:a5774a9de179c5a31a4170040a80ba30",
+      "entity": "niiri:b54fdacdf6871d0d178386e52e6bcf8e"
     },
     {
-      "@id": "niiri:a8060e9cb4cdb11e181b7f963ca0a64d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:abdd30b092a8fb58bf5083e43d76564b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0212",
-      "prov:atLocation": {"@id": "niiri:06785a8aa664ba9db55579fd59eb53e8"},
+      "prov:atLocation": {"@id": "niiri:46d5e8ac330814012d725b0adff81c3c"},
       "prov:value": {"@type": "xsd:float", "@value": "12.5901155471802"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.24033654772109"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000596943488260782"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999021"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.728854295079526"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.24033654772109"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000596943488260782"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999021"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.728854295079526"}
     },
     {
-      "@id": "niiri:06785a8aa664ba9db55579fd59eb53e8",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:46d5e8ac330814012d725b0adff81c3c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0212",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[4,6,-12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[4,6,-12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a8060e9cb4cdb11e181b7f963ca0a64d",
-      "entity": "niiri:90c9af05cf8cff54600fa41f0a61a708"
+      "entity_derived": "niiri:abdd30b092a8fb58bf5083e43d76564b",
+      "entity": "niiri:22043ef18c61c537ac8a05e639b5f722"
     },
     {
-      "@id": "niiri:2ebe5ed2e266f3d20b2727456a7fbf7d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:853d2a530b3a85eb977c69e3afe8644a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0213",
-      "prov:atLocation": {"@id": "niiri:f71aee131a7fe7780ab7721213184a28"},
+      "prov:atLocation": {"@id": "niiri:79927a4241953f4159a3cdc9b5130fc5"},
       "prov:value": {"@type": "xsd:float", "@value": "12.583477973938"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.23944029497736"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000598822687494338"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999084"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.728854295079526"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.23944029497736"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000598822687494338"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999084"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.728854295079526"}
     },
     {
-      "@id": "niiri:f71aee131a7fe7780ab7721213184a28",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:79927a4241953f4159a3cdc9b5130fc5",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0213",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[2,64,32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[2,64,32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2ebe5ed2e266f3d20b2727456a7fbf7d",
-      "entity": "niiri:1aab52c0fe0f750adfdb1e30721e6758"
+      "entity_derived": "niiri:853d2a530b3a85eb977c69e3afe8644a",
+      "entity": "niiri:fd886d44827bbf7fd4cd36a6fa24a0dc"
     },
     {
-      "@id": "niiri:c7024af881fb2ecac3f2c0f10ef02da4",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:906ee563af4ace86c7988da22e67ae3f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0214",
-      "prov:atLocation": {"@id": "niiri:b2b0a721a76b1f2b8bf35b0a1505e8b6"},
+      "prov:atLocation": {"@id": "niiri:e0df519bf861a9890d949691d5d8d5dd"},
       "prov:value": {"@type": "xsd:float", "@value": "12.5809669494629"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.23910116152933"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000599535182603472"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999106"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.728854295079526"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.23910116152933"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000599535182603472"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999106"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.728854295079526"}
     },
     {
-      "@id": "niiri:b2b0a721a76b1f2b8bf35b0a1505e8b6",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e0df519bf861a9890d949691d5d8d5dd",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0214",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-4,32,62]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-4,32,62]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c7024af881fb2ecac3f2c0f10ef02da4",
-      "entity": "niiri:08248410e312407cc447ee8d99d1d449"
+      "entity_derived": "niiri:906ee563af4ace86c7988da22e67ae3f",
+      "entity": "niiri:e782c57868e4be48647d27ca19f3f3c2"
     },
     {
-      "@id": "niiri:df777ee0a227dd45031c77084105b850",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0a50255f519e99d47205e1125596b9b6",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0215",
-      "prov:atLocation": {"@id": "niiri:2e0cb4fd63c4b84e4b5cf834e4b7bf9d"},
+      "prov:atLocation": {"@id": "niiri:daef6d48a716dbb207fa790aef629485"},
       "prov:value": {"@type": "xsd:float", "@value": "12.5469427108765"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.2345017532799"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000609275862458403"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999364"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.736274936039545"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.2345017532799"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000609275862458403"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999364"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.736274936039545"}
     },
     {
-      "@id": "niiri:2e0cb4fd63c4b84e4b5cf834e4b7bf9d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:daef6d48a716dbb207fa790aef629485",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0215",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-58,-32,22]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-58,-32,22]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:df777ee0a227dd45031c77084105b850",
-      "entity": "niiri:837d994ade992773480832f35a3ea15b"
+      "entity_derived": "niiri:0a50255f519e99d47205e1125596b9b6",
+      "entity": "niiri:f434c353ca0df61bb269a9c7f670117c"
     },
     {
-      "@id": "niiri:c96eb997f2b14f31707c32f47b1135da",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:296160c26ce8de6d4816b73bc3fcbc6a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0216",
-      "prov:atLocation": {"@id": "niiri:f88728d130bd777fbd452fc7db29a753"},
+      "prov:atLocation": {"@id": "niiri:660279d86c93ff3310e9a91bc4f125db"},
       "prov:value": {"@type": "xsd:float", "@value": "12.524956703186"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.23152553702292"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000615656604518122"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999491"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.740571104544667"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.23152553702292"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000615656604518122"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999491"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.740571104544667"}
     },
     {
-      "@id": "niiri:f88728d130bd777fbd452fc7db29a753",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:660279d86c93ff3310e9a91bc4f125db",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0216",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[10,-28,82]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[10,-28,82]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c96eb997f2b14f31707c32f47b1135da",
-      "entity": "niiri:ec417a43750788f61cf51df2e50808c5"
+      "entity_derived": "niiri:296160c26ce8de6d4816b73bc3fcbc6a",
+      "entity": "niiri:0ccff4009d26155a785837676412d40e"
     },
     {
-      "@id": "niiri:eca2e3c331a843d4ad0aa7710090bf1a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:59f7ae9e78c57e6eb798ea767f4fd090",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0217",
-      "prov:atLocation": {"@id": "niiri:9c43af0b3f337dfbdac94c1d4bd64bc0"},
+      "prov:atLocation": {"@id": "niiri:9e4bdcd20187d0bbf232df192ad15318"},
       "prov:value": {"@type": "xsd:float", "@value": "12.4362440109253"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.21948340596333"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000642108966113164"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999796"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.762909381039546"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.21948340596333"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000642108966113164"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999796"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.762909381039546"}
     },
     {
-      "@id": "niiri:9c43af0b3f337dfbdac94c1d4bd64bc0",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:9e4bdcd20187d0bbf232df192ad15318",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0217",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-56,-6,42]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-56,-6,42]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:eca2e3c331a843d4ad0aa7710090bf1a",
-      "entity": "niiri:5f3c04257193f8ded9ef85828608888b"
+      "entity_derived": "niiri:59f7ae9e78c57e6eb798ea767f4fd090",
+      "entity": "niiri:800c8b037dc30701b156bb7c32952fad"
     },
     {
-      "@id": "niiri:96199b266f206e1e0c82db9d24c5592c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:2c74c9e73a8754c200410a8ddc063874",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0218",
-      "prov:atLocation": {"@id": "niiri:14f355cf6fb1f9a87e97c08f4b05608e"},
+      "prov:atLocation": {"@id": "niiri:ab6fb86002fd943cb7cf666f118a55db"},
       "prov:value": {"@type": "xsd:float", "@value": "12.3832416534424"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.21226312911464"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000658468484597718"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999883"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.775928724251441"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.21226312911464"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000658468484597718"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999883"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.775928724251441"}
     },
     {
-      "@id": "niiri:14f355cf6fb1f9a87e97c08f4b05608e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ab6fb86002fd943cb7cf666f118a55db",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0218",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-18,-74,-2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-18,-74,-2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:96199b266f206e1e0c82db9d24c5592c",
-      "entity": "niiri:d50af5499fc7c0898889af641bf5dae2"
+      "entity_derived": "niiri:2c74c9e73a8754c200410a8ddc063874",
+      "entity": "niiri:783b5fc0e23ce088341f9b979cd6ab07"
     },
     {
-      "@id": "niiri:6553656394b274cdce05521f32bac312",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:54ccde113afb801a2d42f17bcc407213",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0219",
-      "prov:atLocation": {"@id": "niiri:215589654fb76738a1a31c228687ea17"},
+      "prov:atLocation": {"@id": "niiri:a3ceb25dee9ea36b3e29d0facc7e028f"},
       "prov:value": {"@type": "xsd:float", "@value": "12.3691940307617"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.21034625579366"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000662875839162802"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.9999999999999"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.778244481400815"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.21034625579366"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000662875839162802"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.9999999999999"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.778244481400815"}
     },
     {
-      "@id": "niiri:215589654fb76738a1a31c228687ea17",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a3ceb25dee9ea36b3e29d0facc7e028f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0219",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[30,48,-14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[30,48,-14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6553656394b274cdce05521f32bac312",
-      "entity": "niiri:301ccd51f1c98193e0b8474c0344334b"
+      "entity_derived": "niiri:54ccde113afb801a2d42f17bcc407213",
+      "entity": "niiri:eeecebef37458a809e6ef90a22514949"
     },
     {
-      "@id": "niiri:cd0fd5013a5d6bed8167b8d5d9ef8703",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:443bd980ef1188caf910159d88fbb606",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0220",
-      "prov:atLocation": {"@id": "niiri:604772cbf2031eb4ef0aabe8f8404186"},
+      "prov:atLocation": {"@id": "niiri:e363d467ac24834cdb9d83f9fcca7984"},
       "prov:value": {"@type": "xsd:float", "@value": "12.3557033538818"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.20850410332099"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00066713702624499"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999913"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.780414436307547"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.20850410332099"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00066713702624499"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999913"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.780414436307547"}
     },
     {
-      "@id": "niiri:604772cbf2031eb4ef0aabe8f8404186",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e363d467ac24834cdb9d83f9fcca7984",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0220",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-50,-28,50]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-50,-28,50]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cd0fd5013a5d6bed8167b8d5d9ef8703",
-      "entity": "niiri:005ca6c90e1fc6c5ee2dad1ef8e090a4"
+      "entity_derived": "niiri:443bd980ef1188caf910159d88fbb606",
+      "entity": "niiri:9e9084297f3aec6679c40f52af1c9c5c"
     },
     {
-      "@id": "niiri:12ba3b1b76b5eba595aa1c21916733d9",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:fad207295de11587bdc4ed90e387142b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0221",
-      "prov:atLocation": {"@id": "niiri:ec5b44fdbb38ff726d45997ba350ba77"},
+      "prov:atLocation": {"@id": "niiri:04e3ef7c6e8524c62cde0d3294ee3869"},
       "prov:value": {"@type": "xsd:float", "@value": "12.3468074798584"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.20728868558414"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000669962300702265"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999921"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.781198266304304"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.20728868558414"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000669962300702265"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999921"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.781198266304304"}
     },
     {
-      "@id": "niiri:ec5b44fdbb38ff726d45997ba350ba77",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:04e3ef7c6e8524c62cde0d3294ee3869",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0221",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[48,12,50]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[48,12,50]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:12ba3b1b76b5eba595aa1c21916733d9",
-      "entity": "niiri:fc3a8b55f288365aa4cfd22a7a666181"
+      "entity_derived": "niiri:fad207295de11587bdc4ed90e387142b",
+      "entity": "niiri:dc54137a08092762cc961c9285859566"
     },
     {
-      "@id": "niiri:004670278ac8becc4c58380e118049fe",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:63f4617c03904f8fe616125bfc5a9e72",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0222",
-      "prov:atLocation": {"@id": "niiri:ad8bfe1b803de4cf393a23ea48a00d50"},
+      "prov:atLocation": {"@id": "niiri:52831440b618015383f7181f6b5b4b26"},
       "prov:value": {"@type": "xsd:float", "@value": "12.3028221130371"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.20127105926381"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000684113775728967"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999951"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.789536719399159"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.20127105926381"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000684113775728967"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999951"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.789536719399159"}
     },
     {
-      "@id": "niiri:ad8bfe1b803de4cf393a23ea48a00d50",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:52831440b618015383f7181f6b5b4b26",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0222",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[60,-40,-12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[60,-40,-12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:004670278ac8becc4c58380e118049fe",
-      "entity": "niiri:e47c402c0100f7defbaf50bdcc093c1b"
+      "entity_derived": "niiri:63f4617c03904f8fe616125bfc5a9e72",
+      "entity": "niiri:9ff86139e0b5b4951d06b07e9a923ed4"
     },
     {
-      "@id": "niiri:f96073a5a47b6b6d8383e8d0fb38a6d9",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a6f44d12d066b455d18d5cf9ff1bdaee",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0223",
-      "prov:atLocation": {"@id": "niiri:4a9ef22179fc6e85734ab54ea4375285"},
+      "prov:atLocation": {"@id": "niiri:a8e775408cf4088e2ab46f7c20423ab9"},
       "prov:value": {"@type": "xsd:float", "@value": "12.3004894256592"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.20095155097531"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000684872807174552"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999952"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.789536719399159"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.20095155097531"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000684872807174552"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999952"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.789536719399159"}
     },
     {
-      "@id": "niiri:4a9ef22179fc6e85734ab54ea4375285",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a8e775408cf4088e2ab46f7c20423ab9",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0223",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-62,-50,-10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-62,-50,-10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f96073a5a47b6b6d8383e8d0fb38a6d9",
-      "entity": "niiri:db2fdb0a656161d3af9766d9e89d922c"
+      "entity_derived": "niiri:a6f44d12d066b455d18d5cf9ff1bdaee",
+      "entity": "niiri:8a8ea66289482bc8790b162d4c9789ef"
     },
     {
-      "@id": "niiri:154502b6963e5a2eda6daf2855d7b3f1",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:182ba929021f340ee67f2468e637cc44",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0224",
-      "prov:atLocation": {"@id": "niiri:5b705031e65c1c2b3956a95bdea4378a"},
+      "prov:atLocation": {"@id": "niiri:b4e52186e6b0a6847c84cc50c415fc7e"},
       "prov:value": {"@type": "xsd:float", "@value": "12.2552633285522"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.19474945772007"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000699761387021658"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999971"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.80078769815287"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.19474945772007"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000699761387021658"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999971"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.80078769815287"}
     },
     {
-      "@id": "niiri:5b705031e65c1c2b3956a95bdea4378a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b4e52186e6b0a6847c84cc50c415fc7e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0224",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-2,58,32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-2,58,32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:154502b6963e5a2eda6daf2855d7b3f1",
-      "entity": "niiri:9999ed39d65e3e020fe7293a38d50b01"
+      "entity_derived": "niiri:182ba929021f340ee67f2468e637cc44",
+      "entity": "niiri:05c885a40fe6550c25d2a55d7c3808dc"
     },
     {
-      "@id": "niiri:8119b9ec415f8238dcbf0e29213d4bf5",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f240087ba6b26ab0e7705cb6916792eb",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0225",
-      "prov:atLocation": {"@id": "niiri:764e2320a20fbeb430d6020256838224"},
+      "prov:atLocation": {"@id": "niiri:51d8d61148f300b8db3cd50807339c24"},
       "prov:value": {"@type": "xsd:float", "@value": "12.0593566894531"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.16771793453572"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000768202532788531"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999997"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.853659787459179"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.16771793453572"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000768202532788531"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999997"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.853659787459179"}
     },
     {
-      "@id": "niiri:764e2320a20fbeb430d6020256838224",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:51d8d61148f300b8db3cd50807339c24",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0225",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[20,16,50]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[20,16,50]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8119b9ec415f8238dcbf0e29213d4bf5",
-      "entity": "niiri:ef7b89c154bf8954bad4e84699ecd010"
+      "entity_derived": "niiri:f240087ba6b26ab0e7705cb6916792eb",
+      "entity": "niiri:1285ada80442ae469e874ddbb7e341cc"
     },
     {
-      "@id": "niiri:e7c0b1cc303d37f487e7e91c92f3214f",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:01c2ba3dcb7343112c96e480784b9ad1",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0226",
-      "prov:atLocation": {"@id": "niiri:f86ef5ee9240bdaeddb5196e0c46df36"},
+      "prov:atLocation": {"@id": "niiri:ccf7f33772892b6927718a745ad9c44b"},
       "prov:value": {"@type": "xsd:float", "@value": "12.0245819091797"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.16289116572021"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000781053593003622"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999998"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.861413078419457"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.16289116572021"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000781053593003622"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999998"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.861413078419457"}
     },
     {
-      "@id": "niiri:f86ef5ee9240bdaeddb5196e0c46df36",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ccf7f33772892b6927718a745ad9c44b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0226",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-12,-78,56]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-12,-78,56]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e7c0b1cc303d37f487e7e91c92f3214f",
-      "entity": "niiri:202b2ec8923685d33ff8474567fb097f"
+      "entity_derived": "niiri:01c2ba3dcb7343112c96e480784b9ad1",
+      "entity": "niiri:7fb9b0874581a71159fdd853f93751f2"
     },
     {
-      "@id": "niiri:e2229c1fec8b3b1a15ff653868ab4986",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:cd8669b3a66c8ac45b3908124a6c355e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0227",
-      "prov:atLocation": {"@id": "niiri:2a66b0c329bac60596635d117a870372"},
+      "prov:atLocation": {"@id": "niiri:c1e93dd2175b8f1a8aacb7c865e765d0"},
       "prov:value": {"@type": "xsd:float", "@value": "12.0227870941162"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.16264180848804"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000781722842800425"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999998"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.861413078419457"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.16264180848804"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000781722842800425"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999998"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.861413078419457"}
     },
     {
-      "@id": "niiri:2a66b0c329bac60596635d117a870372",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c1e93dd2175b8f1a8aacb7c865e765d0",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0227",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[14,-14,72]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[14,-14,72]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e2229c1fec8b3b1a15ff653868ab4986",
-      "entity": "niiri:5e31db36bebfe06aef3ad33a08c38510"
+      "entity_derived": "niiri:cd8669b3a66c8ac45b3908124a6c355e",
+      "entity": "niiri:62b88250957696695608f4f9d5c33c94"
     },
     {
-      "@id": "niiri:72727159e9811517f5b36fd2c43678d0",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:71daf19003d4f9dfcddcf08cbdd35abd",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0228",
-      "prov:atLocation": {"@id": "niiri:f2f5cba9f1a0043aec7f2b059b817ab2"},
+      "prov:atLocation": {"@id": "niiri:a3c7efc0ca1f4ef769468595f11497ea"},
       "prov:value": {"@type": "xsd:float", "@value": "12.0113868713379"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.16105741225029"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000785987554661749"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999998"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.862288646172828"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.16105741225029"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000785987554661749"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999998"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.862288646172828"}
     },
     {
-      "@id": "niiri:f2f5cba9f1a0043aec7f2b059b817ab2",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a3c7efc0ca1f4ef769468595f11497ea",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0228",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[8,-54,-34]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[8,-54,-34]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:72727159e9811517f5b36fd2c43678d0",
-      "entity": "niiri:c57896abf584d2b1a83fb9ad3c827d15"
+      "entity_derived": "niiri:71daf19003d4f9dfcddcf08cbdd35abd",
+      "entity": "niiri:11a529a736c285cc9a00cdcf5fb4962d"
     },
     {
-      "@id": "niiri:2cf80c9d2ce23618d80c776c78776914",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3057043901ea2a078a58803f5a56dec7",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0229",
-      "prov:atLocation": {"@id": "niiri:3a4812b6b94aece02ec415596e337c47"},
+      "prov:atLocation": {"@id": "niiri:c9498ecd645e8ee7c1b2854ae6ad27b0"},
       "prov:value": {"@type": "xsd:float", "@value": "12.00501537323"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.16017149794514"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000788381493643353"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999998"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.862288646172828"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.16017149794514"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000788381493643353"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999998"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.862288646172828"}
     },
     {
-      "@id": "niiri:3a4812b6b94aece02ec415596e337c47",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c9498ecd645e8ee7c1b2854ae6ad27b0",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0229",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-8,-40,78]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-8,-40,78]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2cf80c9d2ce23618d80c776c78776914",
-      "entity": "niiri:ea8d2f5330ef8fd7ac99fb062748cba2"
+      "entity_derived": "niiri:3057043901ea2a078a58803f5a56dec7",
+      "entity": "niiri:56c0d386be3b33d6180c1118121d2610"
     },
     {
-      "@id": "niiri:2c9c8d1c090be7f9d4995486b65b0310",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f5292c900080c8c0ef7cf8ec19aa3697",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0230",
-      "prov:atLocation": {"@id": "niiri:091f59ed4f068443320c1b3f82fab5bf"},
+      "prov:atLocation": {"@id": "niiri:4de46218eaea869bbf89aff4b4ac9b02"},
       "prov:value": {"@type": "xsd:float", "@value": "12.0031709671021"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.15991499103056"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000789075885015644"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999998"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.862288646172828"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.15991499103056"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000789075885015644"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999998"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.862288646172828"}
     },
     {
-      "@id": "niiri:091f59ed4f068443320c1b3f82fab5bf",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4de46218eaea869bbf89aff4b4ac9b02",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0230",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-60,-60,26]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-60,-60,26]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2c9c8d1c090be7f9d4995486b65b0310",
-      "entity": "niiri:c638448ba82adee617884aeddb79eb28"
+      "entity_derived": "niiri:f5292c900080c8c0ef7cf8ec19aa3697",
+      "entity": "niiri:d285ba30108c36cd9e0a52ef7d0d4cec"
     },
     {
-      "@id": "niiri:f1ed81ce13078f158c03a0d5e7471588",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:30a84acd12436a2955bf4b443a3b850c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0231",
-      "prov:atLocation": {"@id": "niiri:1c3507b31075438b0af48c0f54f24140"},
+      "prov:atLocation": {"@id": "niiri:3581a3e4b5344f48549574e9392dca58"},
       "prov:value": {"@type": "xsd:float", "@value": "11.9899396896362"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.15807416017948"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000794075753797419"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999999"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.864648849849365"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.15807416017948"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000794075753797419"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999999"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.864648849849365"}
     },
     {
-      "@id": "niiri:1c3507b31075438b0af48c0f54f24140",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:3581a3e4b5344f48549574e9392dca58",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0231",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[48,-80,10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[48,-80,10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f1ed81ce13078f158c03a0d5e7471588",
-      "entity": "niiri:4d95857f68b5b80d99c4947f63e88283"
+      "entity_derived": "niiri:30a84acd12436a2955bf4b443a3b850c",
+      "entity": "niiri:d38a6da35a3b35e251b575be2481d895"
     },
     {
-      "@id": "niiri:5507595d5883d29964389d0188c6b157",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:03b8a2fea9829914437905e68925e360",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0232",
-      "prov:atLocation": {"@id": "niiri:6203db38b560aaef834eeb8f540b491f"},
+      "prov:atLocation": {"@id": "niiri:f028b4f21a1973e22582d89d86a59e4c"},
       "prov:value": {"@type": "xsd:float", "@value": "11.9840250015259"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.1572508576916"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000796321345690965"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999999"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.864758992605231"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.1572508576916"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000796321345690965"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999999"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.864758992605231"}
     },
     {
-      "@id": "niiri:6203db38b560aaef834eeb8f540b491f",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f028b4f21a1973e22582d89d86a59e4c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0232",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[62,-54,-8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[62,-54,-8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5507595d5883d29964389d0188c6b157",
-      "entity": "niiri:ef0d129d225ab1994fdabef30426f127"
+      "entity_derived": "niiri:03b8a2fea9829914437905e68925e360",
+      "entity": "niiri:4f56e832e623fb38abb2d199755b3aa5"
     },
     {
-      "@id": "niiri:87a5ed15fe49eea54b04710a3752ed1e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c88d9634fff92159e1df0499f5d4e04b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0233",
-      "prov:atLocation": {"@id": "niiri:ff666065a5b6658dc645513bf36c7121"},
+      "prov:atLocation": {"@id": "niiri:1851842618253ccc503cfb02e8736641"},
       "prov:value": {"@type": "xsd:float", "@value": "11.93297290802"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.15013407761285"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000815977744435759"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999999"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.878904312044662"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.15013407761285"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000815977744435759"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999999"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.878904312044662"}
     },
     {
-      "@id": "niiri:ff666065a5b6658dc645513bf36c7121",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:1851842618253ccc503cfb02e8736641",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0233",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-38,-54,-42]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-38,-54,-42]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:87a5ed15fe49eea54b04710a3752ed1e",
-      "entity": "niiri:48094119160b8ddede68780fbf27c3d9"
+      "entity_derived": "niiri:c88d9634fff92159e1df0499f5d4e04b",
+      "entity": "niiri:92f563ca517a60ccfbb3ef7b2af62dac"
     },
     {
-      "@id": "niiri:188e7ed2867f60504ca92b5508398d6d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:2a999512422d958e9dd451fe676d13a1",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0234",
-      "prov:atLocation": {"@id": "niiri:16bf1c0055fb25a7afd2e00a1e33b0f7"},
+      "prov:atLocation": {"@id": "niiri:691ae2c0b1d9726dd204612040f5685f"},
       "prov:value": {"@type": "xsd:float", "@value": "11.8026752471924"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.13188412058022"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000868442069883013"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.916815339863787"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.13188412058022"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000868442069883013"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.916815339863787"}
     },
     {
-      "@id": "niiri:16bf1c0055fb25a7afd2e00a1e33b0f7",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:691ae2c0b1d9726dd204612040f5685f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0234",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[22,44,-16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[22,44,-16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:188e7ed2867f60504ca92b5508398d6d",
-      "entity": "niiri:494d564667be2308342989663d3f52ff"
+      "entity_derived": "niiri:2a999512422d958e9dd451fe676d13a1",
+      "entity": "niiri:8600387b3b7cea249641e5cdebba0daa"
     },
     {
-      "@id": "niiri:af993a46a0375f6a5f8320017c4f1674",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f985f79075267f7e7ea06f7a3d3b4fd0",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0235",
-      "prov:atLocation": {"@id": "niiri:3de565782250cc9687888876a06bb48a"},
+      "prov:atLocation": {"@id": "niiri:7cda6698f70c94692a960278e4b33bf9"},
       "prov:value": {"@type": "xsd:float", "@value": "11.7988748550415"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.13134995085887"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000870023394025643"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.916815339863787"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.13134995085887"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000870023394025643"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.916815339863787"}
     },
     {
-      "@id": "niiri:3de565782250cc9687888876a06bb48a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7cda6698f70c94692a960278e4b33bf9",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0235",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[24,68,20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[24,68,20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:af993a46a0375f6a5f8320017c4f1674",
-      "entity": "niiri:ea21239ad949045b078440398a34a9c6"
+      "entity_derived": "niiri:f985f79075267f7e7ea06f7a3d3b4fd0",
+      "entity": "niiri:0f7371e43c32093550d9b7e335f29fdd"
     },
     {
-      "@id": "niiri:5373ecb9c5fa5f62bd4b9686506c5254",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f181b589179ed8f92f3f7f4795974d3e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0236",
-      "prov:atLocation": {"@id": "niiri:c88286fcf0c0dc2b44fbd7b90606f375"},
+      "prov:atLocation": {"@id": "niiri:429847480689f42655b6238b01c24ecf"},
       "prov:value": {"@type": "xsd:float", "@value": "11.7978382110596"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.13120422529702"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000870455250713387"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.916815339863787"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.13120422529702"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000870455250713387"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.916815339863787"}
     },
     {
-      "@id": "niiri:c88286fcf0c0dc2b44fbd7b90606f375",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:429847480689f42655b6238b01c24ecf",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0236",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-36,-32,-22]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-36,-32,-22]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5373ecb9c5fa5f62bd4b9686506c5254",
-      "entity": "niiri:db760edea5f4f806e9afd9a12723ee09"
+      "entity_derived": "niiri:f181b589179ed8f92f3f7f4795974d3e",
+      "entity": "niiri:60ee0a470203bf71030d2277a3fde6c3"
     },
     {
-      "@id": "niiri:4242b471ef1c97b21528586c67ca68bc",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b24deafd5ea91430bd7b734255475770",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0237",
-      "prov:atLocation": {"@id": "niiri:09297421cb82b28e580bc19e6204f397"},
+      "prov:atLocation": {"@id": "niiri:060b7e14bd3b6dc2f252c0b0afc1d7a1"},
       "prov:value": {"@type": "xsd:float", "@value": "11.7785091400146"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.12848559662294"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000878548112890121"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.921335336720806"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.12848559662294"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000878548112890121"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.921335336720806"}
     },
     {
-      "@id": "niiri:09297421cb82b28e580bc19e6204f397",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:060b7e14bd3b6dc2f252c0b0afc1d7a1",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0237",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[42,-42,14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[42,-42,14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4242b471ef1c97b21528586c67ca68bc",
-      "entity": "niiri:5bbac11b8bfa6c995310ee87183ab4d6"
+      "entity_derived": "niiri:b24deafd5ea91430bd7b734255475770",
+      "entity": "niiri:7cded2bfb4aacaabc3212bf6e55636da"
     },
     {
-      "@id": "niiri:1f7ae5732a778aa683c4a171dbae0b98",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ed3e68d921eeb26ff4420aa1da45f707",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0238",
-      "prov:atLocation": {"@id": "niiri:baf7677535e711ccecef9410ee445b28"},
+      "prov:atLocation": {"@id": "niiri:729a7087b921fe5cd9363facfa24c6f0"},
       "prov:value": {"@type": "xsd:float", "@value": "11.7414026260376"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.12325880540281"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000894301978610734"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.931755566916896"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.12325880540281"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000894301978610734"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.931755566916896"}
     },
     {
-      "@id": "niiri:baf7677535e711ccecef9410ee445b28",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:729a7087b921fe5cd9363facfa24c6f0",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0238",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[42,46,-12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[42,46,-12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1f7ae5732a778aa683c4a171dbae0b98",
-      "entity": "niiri:3f3b062de3ba5acf073f1b59cfb5a6e6"
+      "entity_derived": "niiri:ed3e68d921eeb26ff4420aa1da45f707",
+      "entity": "niiri:56d77ed8a1025508e9f36442b2aa1001"
     },
     {
-      "@id": "niiri:8fb8b517ce468d8dcfbcedc05b4dfca5",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5d28dbbc72458950d35719ada2f35c1d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0239",
-      "prov:atLocation": {"@id": "niiri:bdd766aab7694eb3e5475178fd6d34c4"},
+      "prov:atLocation": {"@id": "niiri:24cc5c274366ef4b77b9970877943695"},
       "prov:value": {"@type": "xsd:float", "@value": "11.6729784011841"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.1135936902341"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000924119094904752"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.952845585496322"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.1135936902341"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000924119094904752"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.952845585496322"}
     },
     {
-      "@id": "niiri:bdd766aab7694eb3e5475178fd6d34c4",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:24cc5c274366ef4b77b9970877943695",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0239",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[32,28,-24]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[32,28,-24]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8fb8b517ce468d8dcfbcedc05b4dfca5",
-      "entity": "niiri:39a4606d938ba1ca81229a71c823e41d"
+      "entity_derived": "niiri:5d28dbbc72458950d35719ada2f35c1d",
+      "entity": "niiri:5debe73d92bf3a2e632b239ed32da2c4"
     },
     {
-      "@id": "niiri:abea7107eba4f962756ca01a29b2c6c1",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:49fa6fc625869e411d951c76ea01f001",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0240",
-      "prov:atLocation": {"@id": "niiri:7bb00425f1dcab057b4ffa37303f3f07"},
+      "prov:atLocation": {"@id": "niiri:7341e654c7650694fa4a633b7d57e71c"},
       "prov:value": {"@type": "xsd:float", "@value": "11.648645401001"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.11014811684365"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000934967749947835"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.959250568995591"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.11014811684365"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000934967749947835"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.959250568995591"}
     },
     {
-      "@id": "niiri:7bb00425f1dcab057b4ffa37303f3f07",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7341e654c7650694fa4a633b7d57e71c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0240",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[42,20,-14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[42,20,-14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:abea7107eba4f962756ca01a29b2c6c1",
-      "entity": "niiri:a49d384fb03c39001132a62f5ee742ce"
+      "entity_derived": "niiri:49fa6fc625869e411d951c76ea01f001",
+      "entity": "niiri:f3bc76ba4a3df529282c2ee84c68df86"
     },
     {
-      "@id": "niiri:f6c3aef4b5a32a913944e0b618bb9d22",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:7047971620448cda11f6eecfb2f451f4",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0241",
-      "prov:atLocation": {"@id": "niiri:d203afcd357f0bbdba0a75f6f32c82cf"},
+      "prov:atLocation": {"@id": "niiri:4b469a270ee563c51daff07a0ec32f1e"},
       "prov:value": {"@type": "xsd:float", "@value": "11.6256742477417"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.1068912843889"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000945329574052578"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.963708379847036"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.1068912843889"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000945329574052578"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.963708379847036"}
     },
     {
-      "@id": "niiri:d203afcd357f0bbdba0a75f6f32c82cf",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4b469a270ee563c51daff07a0ec32f1e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0241",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-22,-82,0]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-22,-82,0]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f6c3aef4b5a32a913944e0b618bb9d22",
-      "entity": "niiri:1df9ca7cc28a8741906406c23e450c49"
+      "entity_derived": "niiri:7047971620448cda11f6eecfb2f451f4",
+      "entity": "niiri:28bbba0604724f0b5ea3c95637660afa"
     },
     {
-      "@id": "niiri:2622cd3d464cf135af4aac90969d14c4",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:27fc8dfd0e287d18ed37abcd26235c8c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0242",
-      "prov:atLocation": {"@id": "niiri:1f4e92cddcda2154118f1b7337fcf3b0"},
+      "prov:atLocation": {"@id": "niiri:1477eff6e204f38ed59b87445071b9ed"},
       "prov:value": {"@type": "xsd:float", "@value": "11.6246528625488"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.10674638057242"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000945793036476794"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.963708379847036"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.10674638057242"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000945793036476794"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.963708379847036"}
     },
     {
-      "@id": "niiri:1f4e92cddcda2154118f1b7337fcf3b0",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:1477eff6e204f38ed59b87445071b9ed",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0242",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[2,-42,-62]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[2,-42,-62]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2622cd3d464cf135af4aac90969d14c4",
-      "entity": "niiri:b3a0d8de966bc74adb169669f1390504"
+      "entity_derived": "niiri:27fc8dfd0e287d18ed37abcd26235c8c",
+      "entity": "niiri:e2e08d4842a9d04eb18949c6410171c2"
     },
     {
-      "@id": "niiri:f38bca5aa6c461d6da7f28fd6a2a042e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c78a4edd720ceef3e574dba70e0cc9fc",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0243",
-      "prov:atLocation": {"@id": "niiri:34094eeb46510e11bb2665dd446bca80"},
+      "prov:atLocation": {"@id": "niiri:0b8fbe19681a8a8318549ff8c0485803"},
       "prov:value": {"@type": "xsd:float", "@value": "11.586296081543"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.10129898410053"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000963368201000958"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.975038721030712"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.10129898410053"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000963368201000958"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.975038721030712"}
     },
     {
-      "@id": "niiri:34094eeb46510e11bb2665dd446bca80",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0b8fbe19681a8a8318549ff8c0485803",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0243",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[52,-42,18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[52,-42,18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f38bca5aa6c461d6da7f28fd6a2a042e",
-      "entity": "niiri:070e421862800af00c11e7304e4407bb"
+      "entity_derived": "niiri:c78a4edd720ceef3e574dba70e0cc9fc",
+      "entity": "niiri:21fbadccdcf80825edc168ed54a646dd"
     },
     {
-      "@id": "niiri:9ff10ca343cba033a822e58949624a59",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a9c0e06b74f100f91729fb0b3f27bb2e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0244",
-      "prov:atLocation": {"@id": "niiri:62ff6f37d3c90639a888eadbf051dd28"},
+      "prov:atLocation": {"@id": "niiri:0885c3bb08b39c786df94baf46e2a0c6"},
       "prov:value": {"@type": "xsd:float", "@value": "11.5521640777588"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.09644218031477"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000979290273004696"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.985021600249525"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.09644218031477"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000979290273004696"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.985021600249525"}
     },
     {
-      "@id": "niiri:62ff6f37d3c90639a888eadbf051dd28",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0885c3bb08b39c786df94baf46e2a0c6",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0244",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[54,44,14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[54,44,14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9ff10ca343cba033a822e58949624a59",
-      "entity": "niiri:93297a88c8e657de407b42d03cd7f823"
+      "entity_derived": "niiri:a9c0e06b74f100f91729fb0b3f27bb2e",
+      "entity": "niiri:37a7db920a02cc0218b6f2862406e37a"
     }
   ]
 }

--- a/spmexport/ex_spm_con_f/nidm.ttl
+++ b/spmexport/ex_spm_con_f/nidm.ttl
@@ -4,7 +4,7 @@
 @prefix niiri: <http://iri.nidash.org/> .
 @prefix spm: <http://purl.org/nidash/spm#> .
 @prefix neurolex: <http://neurolex.org/wiki/> .
-@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#> .
+@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
@@ -17,27 +17,27 @@
 @prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-niiri:ce463eb8dde7dcf0cf14b6d33f1e2267
+niiri:a792e7640ea680e887ff5fb67a74d579
   a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
   rdfs:label "NIDM-Results" ;
   nidm_version: "1.3.0"^^xsd:string .
 
-niiri:639a1bbc0d4b85d4e0192ccfc285b09e
+niiri:6899857b8c32ae5b43d240b4f06f2892
   a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
   rdfs:label "spm_results_nidm" ;
-  nidm_softwareVersion: "12.6903"^^xsd:string .
+  nidm_softwareVersion: "12.7057"^^xsd:string .
 
-niiri:b4759ceddf4e022a13785ece7a98a2c5
+niiri:34e091da330b63901082b65ed57e7701
   a prov:Activity, nidm_NIDMResultsExport: ; 
   rdfs:label "NIDM-Results export" .
 
-niiri:b4759ceddf4e022a13785ece7a98a2c5 prov:wasAssociatedWith niiri:639a1bbc0d4b85d4e0192ccfc285b09e .
+niiri:34e091da330b63901082b65ed57e7701 prov:wasAssociatedWith niiri:6899857b8c32ae5b43d240b4f06f2892 .
 
 _:blank5 a prov:Generation .
 
-niiri:ce463eb8dde7dcf0cf14b6d33f1e2267 prov:qualifiedGeneration _:blank5 .
+niiri:a792e7640ea680e887ff5fb67a74d579 prov:qualifiedGeneration _:blank5 .
 
-_:blank5 prov:atTime "2016-12-07T16:07:38"^^xsd:dateTime .
+_:blank5 prov:atTime "2017-04-19T12:17:33"^^xsd:dateTime .
 
 @prefix nidm_Ixi549CoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000050> .
 @prefix src_SPM: <http://scicrunch.org/resolver/SCR_007037> .
@@ -141,12 +141,12 @@ _:blank5 prov:atTime "2016-12-07T16:07:38"^^xsd:dateTime .
 @prefix nidm_Coordinate: <http://purl.org/nidash/nidm#NIDM_0000015> .
 @prefix nidm_coordinateVector: <http://purl.org/nidash/nidm#NIDM_0000086> .
 
-niiri:7b26c0d4242cba44b7aa7b136ad76c7c
+niiri:108629946ef3459712b1ceefc5a31493
     a prov:Agent, src_SPM:, prov:SoftwareAgent ; 
     rdfs:label "SPM" ;
-    nidm_softwareVersion: "12.12.2"^^xsd:string .
+    nidm_softwareVersion: "12.6906"^^xsd:string .
 
-niiri:d41125507fc2262be74a5954df8b238e
+niiri:e85365bb21fa161b4325e2ba8cd4fd25
     a prov:Entity, nidm_CoordinateSpace: ; 
     rdfs:label "Coordinate space 1" ;
     nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
@@ -156,48 +156,48 @@ niiri:d41125507fc2262be74a5954df8b238e
     nidm_numberOfDimensions: "3"^^xsd:int ;
     nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
 
-niiri:b7edf29b28f8114c800f627fdde4e8b4
+niiri:06a12d76cf24728b70559a82704e66d8
     a prov:Agent, nlx_Imaginginstrument:, nlx_Magneticresonanceimagingscanner: ; 
     rdfs:label "MRI Scanner" .
 
-niiri:46eb5ac3b59bdcb7100eef68cc68b609
+niiri:78ef43d31af19b56191d7258da75b6e0
     a prov:Agent, prov:Person ; 
     rdfs:label "Person" .
 
-niiri:ae0f01d8c139b1e36225276d4c0f0e9f
+niiri:e2f4df9e4df57e86b857fd981bd770f4
     a prov:Entity, prov:Collection, nidm_Data: ; 
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "true"^^xsd:boolean ;
     nidm_targetIntensity: "100"^^xsd:float ;
     nidm_hasMRIProtocol: nlx_FunctionalMRIprotocol: .
 
-niiri:ae0f01d8c139b1e36225276d4c0f0e9f prov:wasAttributedTo niiri:b7edf29b28f8114c800f627fdde4e8b4 .
+niiri:e2f4df9e4df57e86b857fd981bd770f4 prov:wasAttributedTo niiri:06a12d76cf24728b70559a82704e66d8 .
 
-niiri:ae0f01d8c139b1e36225276d4c0f0e9f prov:wasAttributedTo niiri:46eb5ac3b59bdcb7100eef68cc68b609 .
+niiri:e2f4df9e4df57e86b857fd981bd770f4 prov:wasAttributedTo niiri:78ef43d31af19b56191d7258da75b6e0 .
 
-niiri:8214fea5d4998cc5b1a42c6002966b96
+niiri:84c830ff207d2b79a733f2225b489cae
     a prov:Entity, spm_DCTDriftModel: ; 
     rdfs:label "SPM's DCT Drift Model" ;
     spm_SPMsDriftCutoffPeriod: "128"^^xsd:float .
 
-niiri:2bf00b7ff264eefba8a8b057940d9351
+niiri:c48b8f1c4db4fafced12fe461ce9d3ba
     a prov:Entity, nidm_DesignMatrix: ; 
     prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.csv"^^xsd:string ;
     dct:format "text/csv"^^xsd:string ;
-    dc:description niiri:b66b5c7aa591a931bd3902540932c8b8 ;
+    dc:description niiri:82527de1b9c5a981fb6b965a6f20adc2 ;
     rdfs:label "Design Matrix" ;
     nidm_regressorNames: "[\"Sn(1) to*bf(1)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) constant\"]"^^xsd:string ;
-    nidm_hasDriftModel: niiri:8214fea5d4998cc5b1a42c6002966b96 ;
+    nidm_hasDriftModel: niiri:84c830ff207d2b79a733f2225b489cae ;
     nidm_hasHRFBasis: spm_SPMsCanonicalHRF: .
 
-niiri:b66b5c7aa591a931bd3902540932c8b8
+niiri:82527de1b9c5a981fb6b965a6f20adc2
     a prov:Entity, dctype:Image ; 
     prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:ac0b8ab44183500efaf7e4f075835e70
+niiri:cc140a0d6189b0430c070bd23d6ca3d0
     a prov:Entity, nidm_ErrorModel: ; 
     nidm_hasErrorDistribution: obo_normaldistribution: ;
     nidm_hasErrorDependence: obo_Toeplitzcovariancestructure: ;
@@ -205,174 +205,174 @@ niiri:ac0b8ab44183500efaf7e4f075835e70
     nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
     nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
 
-niiri:376877f6735dc4d6d5ddbc5e03ab4fc4
+niiri:af398ef47bafd7ba0d7a56b68ea654a5
     a prov:Activity, nidm_ModelParametersEstimation: ; 
     rdfs:label "Model parameters estimation" ;
     nidm_withEstimationMethod: obo_generalizedleastsquaresestimation: .
 
-niiri:376877f6735dc4d6d5ddbc5e03ab4fc4 prov:wasAssociatedWith niiri:7b26c0d4242cba44b7aa7b136ad76c7c .
+niiri:af398ef47bafd7ba0d7a56b68ea654a5 prov:wasAssociatedWith niiri:108629946ef3459712b1ceefc5a31493 .
 
-niiri:376877f6735dc4d6d5ddbc5e03ab4fc4 prov:used niiri:2bf00b7ff264eefba8a8b057940d9351 .
+niiri:af398ef47bafd7ba0d7a56b68ea654a5 prov:used niiri:c48b8f1c4db4fafced12fe461ce9d3ba .
 
-niiri:376877f6735dc4d6d5ddbc5e03ab4fc4 prov:used niiri:ae0f01d8c139b1e36225276d4c0f0e9f .
+niiri:af398ef47bafd7ba0d7a56b68ea654a5 prov:used niiri:e2f4df9e4df57e86b857fd981bd770f4 .
 
-niiri:376877f6735dc4d6d5ddbc5e03ab4fc4 prov:used niiri:ac0b8ab44183500efaf7e4f075835e70 .
+niiri:af398ef47bafd7ba0d7a56b68ea654a5 prov:used niiri:cc140a0d6189b0430c070bd23d6ca3d0 .
 
-niiri:e53ae7ec054c49559f59b829bea5fb83
+niiri:2966074b9e21383f6f55902411f9d3e2
     a prov:Entity, nidm_MaskMap: ; 
     prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
     nidm_isUserDefined: "false"^^xsd:boolean ;
     nfo:fileName "Mask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Mask" ;
-    nidm_inCoordinateSpace: niiri:d41125507fc2262be74a5954df8b238e ;
+    nidm_inCoordinateSpace: niiri:e85365bb21fa161b4325e2ba8cd4fd25 ;
     crypto:sha512 "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876"^^xsd:string .
 
-niiri:e524a54e73715457cf6e6d07b44bf6f9
+niiri:c4fb2761d2a5b5a53b14dfb73eb55ec9
     a prov:Entity, nidm_MaskMap: ; 
     nfo:fileName "mask.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "36929e1f5f4143bd9cc818cd896a25f129961fab208c3a4438555f40444c08347b359142ee8c53ece6e8cca1627f49db0788a1fd3b9e2ecaef61999c6c6c67ac"^^xsd:string .
 
-niiri:e53ae7ec054c49559f59b829bea5fb83 prov:wasDerivedFrom niiri:e524a54e73715457cf6e6d07b44bf6f9 .
+niiri:2966074b9e21383f6f55902411f9d3e2 prov:wasDerivedFrom niiri:c4fb2761d2a5b5a53b14dfb73eb55ec9 .
 
-niiri:e53ae7ec054c49559f59b829bea5fb83 prov:wasGeneratedBy niiri:376877f6735dc4d6d5ddbc5e03ab4fc4 .
+niiri:2966074b9e21383f6f55902411f9d3e2 prov:wasGeneratedBy niiri:af398ef47bafd7ba0d7a56b68ea654a5 .
 
-niiri:3cc5a83b37768cbe21579a6b718b9dc6
+niiri:41db56fb656683f93922ac7c8120201a
     a prov:Entity, nidm_GrandMeanMap: ; 
     prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
     nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Grand Mean Map" ;
     nidm_maskedMedian: "111.557487487793"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:d41125507fc2262be74a5954df8b238e ;
+    nidm_inCoordinateSpace: niiri:e85365bb21fa161b4325e2ba8cd4fd25 ;
     crypto:sha512 "512157cc6bff89d9343a09b4068226eb3edd64a8cbcee861f06231767fae6f8d4819921182adebee083a9bf309afd65529ab04a92f0aa6b0038c8098550f6124"^^xsd:string .
 
-niiri:3cc5a83b37768cbe21579a6b718b9dc6 prov:wasGeneratedBy niiri:376877f6735dc4d6d5ddbc5e03ab4fc4 .
+niiri:41db56fb656683f93922ac7c8120201a prov:wasGeneratedBy niiri:af398ef47bafd7ba0d7a56b68ea654a5 .
 
-niiri:96a4fd17186177029abc0c2067061b7d
+niiri:e53ec83adf28281a0da4fb79bd6f8d37
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0001.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0001.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 1" ;
-    nidm_inCoordinateSpace: niiri:d41125507fc2262be74a5954df8b238e ;
+    nidm_inCoordinateSpace: niiri:e85365bb21fa161b4325e2ba8cd4fd25 ;
     crypto:sha512 "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd"^^xsd:string .
 
-niiri:663f8479afd302937d77248845bfabf8
+niiri:a303f093674cfea3af31e31f0b993403
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd"^^xsd:string .
 
-niiri:96a4fd17186177029abc0c2067061b7d prov:wasDerivedFrom niiri:663f8479afd302937d77248845bfabf8 .
+niiri:e53ec83adf28281a0da4fb79bd6f8d37 prov:wasDerivedFrom niiri:a303f093674cfea3af31e31f0b993403 .
 
-niiri:96a4fd17186177029abc0c2067061b7d prov:wasGeneratedBy niiri:376877f6735dc4d6d5ddbc5e03ab4fc4 .
+niiri:e53ec83adf28281a0da4fb79bd6f8d37 prov:wasGeneratedBy niiri:af398ef47bafd7ba0d7a56b68ea654a5 .
 
-niiri:be1472a97e74610721d9d264aea22df8
+niiri:72b76763a43f712d064e7ff5a0abf2f4
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0002.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0002.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 2" ;
-    nidm_inCoordinateSpace: niiri:d41125507fc2262be74a5954df8b238e ;
+    nidm_inCoordinateSpace: niiri:e85365bb21fa161b4325e2ba8cd4fd25 ;
     crypto:sha512 "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c"^^xsd:string .
 
-niiri:9189ed4708aed4d5e8eb2c7cbd82a49d
+niiri:3832b1c295247b7ad30eeb6b6a356d9a
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0002.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c"^^xsd:string .
 
-niiri:be1472a97e74610721d9d264aea22df8 prov:wasDerivedFrom niiri:9189ed4708aed4d5e8eb2c7cbd82a49d .
+niiri:72b76763a43f712d064e7ff5a0abf2f4 prov:wasDerivedFrom niiri:3832b1c295247b7ad30eeb6b6a356d9a .
 
-niiri:be1472a97e74610721d9d264aea22df8 prov:wasGeneratedBy niiri:376877f6735dc4d6d5ddbc5e03ab4fc4 .
+niiri:72b76763a43f712d064e7ff5a0abf2f4 prov:wasGeneratedBy niiri:af398ef47bafd7ba0d7a56b68ea654a5 .
 
-niiri:4434eac4cf5be61afe744f9dfc0ed890
+niiri:4e1dd7422d51470871328ffe1585b00e
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0003.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0003.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 3" ;
-    nidm_inCoordinateSpace: niiri:d41125507fc2262be74a5954df8b238e ;
+    nidm_inCoordinateSpace: niiri:e85365bb21fa161b4325e2ba8cd4fd25 ;
     crypto:sha512 "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373"^^xsd:string .
 
-niiri:a4e6149a14b95cc6c19e7e1b10e14d9c
+niiri:132d0cc169a2090d70bcc3a2cf72ef78
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0003.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373"^^xsd:string .
 
-niiri:4434eac4cf5be61afe744f9dfc0ed890 prov:wasDerivedFrom niiri:a4e6149a14b95cc6c19e7e1b10e14d9c .
+niiri:4e1dd7422d51470871328ffe1585b00e prov:wasDerivedFrom niiri:132d0cc169a2090d70bcc3a2cf72ef78 .
 
-niiri:4434eac4cf5be61afe744f9dfc0ed890 prov:wasGeneratedBy niiri:376877f6735dc4d6d5ddbc5e03ab4fc4 .
+niiri:4e1dd7422d51470871328ffe1585b00e prov:wasGeneratedBy niiri:af398ef47bafd7ba0d7a56b68ea654a5 .
 
-niiri:07e8d8f330905940fe3f59bdd08cb5da
+niiri:5838dc3694e3780735e8138028cf3030
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Residual Mean Squares Map" ;
-    nidm_inCoordinateSpace: niiri:d41125507fc2262be74a5954df8b238e ;
+    nidm_inCoordinateSpace: niiri:e85365bb21fa161b4325e2ba8cd4fd25 ;
     crypto:sha512 "991abf563d795a43b1e2eef8643e57023f2e0b090b2031f05f839321fc0643df6f71d423486a1021519b6dc82f6b0f563e19f3fbd50cb16063bed54a0e192d3e"^^xsd:string .
 
-niiri:c10e53b422e02d9772ee9daea58b9a61
+niiri:bc3cced01cc00b56e891f3591686d4d7
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     nfo:fileName "ResMS.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "40b28d03fcf9a2f60b11f10d7fb83bf3618b234fb5aedf09df644cb7cbb6aab8c9f468897c1078166d455a3d04a83f4e3bf762cfca0b4ea982d7a4e406849f18"^^xsd:string .
 
-niiri:07e8d8f330905940fe3f59bdd08cb5da prov:wasDerivedFrom niiri:c10e53b422e02d9772ee9daea58b9a61 .
+niiri:5838dc3694e3780735e8138028cf3030 prov:wasDerivedFrom niiri:bc3cced01cc00b56e891f3591686d4d7 .
 
-niiri:07e8d8f330905940fe3f59bdd08cb5da prov:wasGeneratedBy niiri:376877f6735dc4d6d5ddbc5e03ab4fc4 .
+niiri:5838dc3694e3780735e8138028cf3030 prov:wasGeneratedBy niiri:af398ef47bafd7ba0d7a56b68ea654a5 .
 
-niiri:cbcaa8f3061021e485aface02a14bf8b
+niiri:c7a291c12eb2c6c7e9ebcb9759d8ea7c
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Resels per Voxel Map" ;
-    nidm_inCoordinateSpace: niiri:d41125507fc2262be74a5954df8b238e ;
+    nidm_inCoordinateSpace: niiri:e85365bb21fa161b4325e2ba8cd4fd25 ;
     crypto:sha512 "1a3f9216e145249ccc0b14b2bc337d6b38b81ad45e32768001fb22b35f0c2c0f3e2bce013b40c85f7dc0fc62723ac761ee7f7e1e6aff128a05f0ba7b8b8202a3"^^xsd:string .
 
-niiri:591f8b6987f170ae9c1491013fbce184
+niiri:37ab6fc51451696d75a2fb041b423fb9
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     nfo:fileName "RPV.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "4f76663162857f6b38b2a45a63b15a23b2ca8b338c283b69c1e71f2ea2f43797d045a733cd14e845be9c12f8b8f84d3931c599a08e8f6d77e99fab46ad87ab8f"^^xsd:string .
 
-niiri:cbcaa8f3061021e485aface02a14bf8b prov:wasDerivedFrom niiri:591f8b6987f170ae9c1491013fbce184 .
+niiri:c7a291c12eb2c6c7e9ebcb9759d8ea7c prov:wasDerivedFrom niiri:37ab6fc51451696d75a2fb041b423fb9 .
 
-niiri:cbcaa8f3061021e485aface02a14bf8b prov:wasGeneratedBy niiri:376877f6735dc4d6d5ddbc5e03ab4fc4 .
+niiri:c7a291c12eb2c6c7e9ebcb9759d8ea7c prov:wasGeneratedBy niiri:af398ef47bafd7ba0d7a56b68ea654a5 .
 
-niiri:e1b7e3b4519d803e0bd21bfc83f9ca68
+niiri:543c3abe649faffdd9de4655fb735982
     a prov:Entity, obo_contrastweightmatrix: ; 
     nidm_statisticType: obo_Fstatistic: ;
     nidm_contrastName: "tone counting vs baseline"^^xsd:string ;
     rdfs:label "Contrast: tone counting vs baseline" ;
     prov:value "[1, 0, 0]"^^xsd:string .
 
-niiri:1e48214fea2412f798a0804c4f07aa3f
+niiri:d56c7f996ee59831f6e800e8e38c6886
     a prov:Activity, nidm_ContrastEstimation: ; 
     rdfs:label "Contrast estimation" .
 
-niiri:1e48214fea2412f798a0804c4f07aa3f prov:wasAssociatedWith niiri:7b26c0d4242cba44b7aa7b136ad76c7c .
+niiri:d56c7f996ee59831f6e800e8e38c6886 prov:wasAssociatedWith niiri:108629946ef3459712b1ceefc5a31493 .
 
-niiri:1e48214fea2412f798a0804c4f07aa3f prov:used niiri:e53ae7ec054c49559f59b829bea5fb83 .
+niiri:d56c7f996ee59831f6e800e8e38c6886 prov:used niiri:2966074b9e21383f6f55902411f9d3e2 .
 
-niiri:1e48214fea2412f798a0804c4f07aa3f prov:used niiri:07e8d8f330905940fe3f59bdd08cb5da .
+niiri:d56c7f996ee59831f6e800e8e38c6886 prov:used niiri:5838dc3694e3780735e8138028cf3030 .
 
-niiri:1e48214fea2412f798a0804c4f07aa3f prov:used niiri:2bf00b7ff264eefba8a8b057940d9351 .
+niiri:d56c7f996ee59831f6e800e8e38c6886 prov:used niiri:c48b8f1c4db4fafced12fe461ce9d3ba .
 
-niiri:1e48214fea2412f798a0804c4f07aa3f prov:used niiri:e1b7e3b4519d803e0bd21bfc83f9ca68 .
+niiri:d56c7f996ee59831f6e800e8e38c6886 prov:used niiri:543c3abe649faffdd9de4655fb735982 .
 
-niiri:1e48214fea2412f798a0804c4f07aa3f prov:used niiri:96a4fd17186177029abc0c2067061b7d .
+niiri:d56c7f996ee59831f6e800e8e38c6886 prov:used niiri:e53ec83adf28281a0da4fb79bd6f8d37 .
 
-niiri:1e48214fea2412f798a0804c4f07aa3f prov:used niiri:be1472a97e74610721d9d264aea22df8 .
+niiri:d56c7f996ee59831f6e800e8e38c6886 prov:used niiri:72b76763a43f712d064e7ff5a0abf2f4 .
 
-niiri:1e48214fea2412f798a0804c4f07aa3f prov:used niiri:4434eac4cf5be61afe744f9dfc0ed890 .
+niiri:d56c7f996ee59831f6e800e8e38c6886 prov:used niiri:4e1dd7422d51470871328ffe1585b00e .
 
-niiri:eff9a5890d3882e89100ae2e0c85dc26
+niiri:22b2d246ca83f9742df6152441f4821f
     a prov:Entity, nidm_StatisticMap: ; 
     prov:atLocation "FStatistic.nii.gz"^^xsd:anyURI ;
     nfo:fileName "FStatistic.nii.gz"^^xsd:string ;
@@ -382,104 +382,104 @@ niiri:eff9a5890d3882e89100ae2e0c85dc26
     nidm_contrastName: "tone counting vs baseline"^^xsd:string ;
     nidm_errorDegreesOfFreedom: "97.9999999998522"^^xsd:float ;
     nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:d41125507fc2262be74a5954df8b238e ;
+    nidm_inCoordinateSpace: niiri:e85365bb21fa161b4325e2ba8cd4fd25 ;
     crypto:sha512 "04986199ffcd3f12e4ccd95adf79d83627b3cc230969d1c39bfbb2732235f2ce33e15a0bcbfc7b892ccc17b17b2563de2a83d05e06944ea0d017558021d3a502"^^xsd:string .
 
-niiri:05ce456d5c40ef9ac164e8c40683aac4
+niiri:e3f29dfdfad324d9c4f41fb318e668b4
     a prov:Entity, nidm_StatisticMap: ; 
     nfo:fileName "spmF_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "c8f88ccb9f7c33bd901d8af4b0078e409ac7f4b037ee840cfbb528f918f0c27d651e201bcc709cd7bfc442c8057b377aa6f3e36afee8d3ade5ce8de5f7d65166"^^xsd:string .
 
-niiri:eff9a5890d3882e89100ae2e0c85dc26 prov:wasDerivedFrom niiri:05ce456d5c40ef9ac164e8c40683aac4 .
+niiri:22b2d246ca83f9742df6152441f4821f prov:wasDerivedFrom niiri:e3f29dfdfad324d9c4f41fb318e668b4 .
 
-niiri:eff9a5890d3882e89100ae2e0c85dc26 prov:wasGeneratedBy niiri:1e48214fea2412f798a0804c4f07aa3f .
+niiri:22b2d246ca83f9742df6152441f4821f prov:wasGeneratedBy niiri:d56c7f996ee59831f6e800e8e38c6886 .
 
-niiri:5c976011393498fb9c9deecbb8ae073b
+niiri:7f4cdffd78ae5971875e37f617e84f61
     a prov:Entity, nidm_ContrastExplainedMeanSquareMap: ; 
     prov:atLocation "ContrastExplainedMeanSquare.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ContrastExplainedMeanSquare.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Explained Mean Square Map" ;
-    nidm_inCoordinateSpace: niiri:d41125507fc2262be74a5954df8b238e ;
+    nidm_inCoordinateSpace: niiri:e85365bb21fa161b4325e2ba8cd4fd25 ;
     crypto:sha512 "9c0fc116d1bdba4d13d20c49c9ab93b22d60636dd953d081d8e8cd5f488bd427bfb32339578346aad9a8f54a907cb00a74e8a0a0758786ffb6c633730ff94774"^^xsd:string .
 
-niiri:5c976011393498fb9c9deecbb8ae073b prov:wasGeneratedBy niiri:1e48214fea2412f798a0804c4f07aa3f .
+niiri:7f4cdffd78ae5971875e37f617e84f61 prov:wasGeneratedBy niiri:d56c7f996ee59831f6e800e8e38c6886 .
 
-niiri:1cb202c358b5a2a2aa236342646b6c49
+niiri:c90905a2f9fd05b279e167b48e9e991b
     a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
-    rdfs:label "Height Threshold: p<0.001000 (unc.)" ;
+    rdfs:label "Height Threshold: p<0.001 (unc.)" ;
     prov:value "0.000999500134086118"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:b72ad3691601a8a5e155b68d80c49788 ;
-    nidm_equivalentThreshold: niiri:55ef01e6730508dbaaa0649edf17937f .
+    nidm_equivalentThreshold: niiri:242e46f10e864dfba4d04608f5933a37 ;
+    nidm_equivalentThreshold: niiri:ee1543686e6a6f4ecaabc7f8fed88df7 .
 
-niiri:b72ad3691601a8a5e155b68d80c49788
+niiri:242e46f10e864dfba4d04608f5933a37
     a prov:Entity, nidm_HeightThreshold:, obo_statistic: ; 
-    rdfs:label "Height Threshold" ;
+    rdfs:label "Height Threshold: F=11.509654)" ;
     prov:value "11.5096541798536"^^xsd:float .
 
-niiri:55ef01e6730508dbaaa0649edf17937f
+niiri:ee1543686e6a6f4ecaabc7f8fed88df7
     a prov:Entity, nidm_HeightThreshold:, obo_FWERadjustedpvalue: ; 
-    rdfs:label "Height Threshold" ;
+    rdfs:label "Height Threshold: p<1.000000 (FWE)" ;
     prov:value "1"^^xsd:float .
 
-niiri:7d3c94b79cfb116e3522f460364a10ca
+niiri:3f89804bcbc35a20ed10f6065ed6f45f
     a prov:Entity, nidm_ExtentThreshold:, obo_statistic: ; 
     rdfs:label "Extent Threshold: k>=0" ;
     nidm_clusterSizeInVoxels: "0"^^xsd:int ;
     nidm_clusterSizeInResels: "0"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:e76f6444a057489092dcf438d0ba28d9 ;
-    nidm_equivalentThreshold: niiri:b5bc6365c635348a4c6f7dd4c0162516 .
+    nidm_equivalentThreshold: niiri:dfd666502d3a5b4e831a683a161e814b ;
+    nidm_equivalentThreshold: niiri:ef06cbe71e52afe55ddec88cd1796f92 .
 
-niiri:e76f6444a057489092dcf438d0ba28d9
+niiri:dfd666502d3a5b4e831a683a161e814b
     a prov:Entity, nidm_ExtentThreshold:, obo_FWERadjustedpvalue: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:b5bc6365c635348a4c6f7dd4c0162516
+niiri:ef06cbe71e52afe55ddec88cd1796f92
     a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:3d98e913b92115cd75804f26601428a0
+niiri:6e55046381e462ccd425414e6c6e55df
     a prov:Entity, nidm_PeakDefinitionCriteria: ; 
     rdfs:label "Peak Definition Criteria" ;
     nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
     nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
 
-niiri:110334b011c4dffd4cd084aaa8a23b50
+niiri:1c65c77d484fdd55f58d632b3d659641
     a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
     rdfs:label "Cluster Connectivity Criterion: 18" ;
     nidm_hasConnectivityCriterion: nidm_voxel18connected: .
 
-niiri:165f4a3fe16dc2972f764b7e81300e66
+niiri:acd80690d12cb39b6a731ff1e4c00286
     a prov:Activity, nidm_Inference: ; 
     nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
     rdfs:label "Inference" .
 
-niiri:165f4a3fe16dc2972f764b7e81300e66 prov:wasAssociatedWith niiri:7b26c0d4242cba44b7aa7b136ad76c7c .
+niiri:acd80690d12cb39b6a731ff1e4c00286 prov:wasAssociatedWith niiri:108629946ef3459712b1ceefc5a31493 .
 
-niiri:165f4a3fe16dc2972f764b7e81300e66 prov:used niiri:1cb202c358b5a2a2aa236342646b6c49 .
+niiri:acd80690d12cb39b6a731ff1e4c00286 prov:used niiri:c90905a2f9fd05b279e167b48e9e991b .
 
-niiri:165f4a3fe16dc2972f764b7e81300e66 prov:used niiri:7d3c94b79cfb116e3522f460364a10ca .
+niiri:acd80690d12cb39b6a731ff1e4c00286 prov:used niiri:3f89804bcbc35a20ed10f6065ed6f45f .
 
-niiri:165f4a3fe16dc2972f764b7e81300e66 prov:used niiri:eff9a5890d3882e89100ae2e0c85dc26 .
+niiri:acd80690d12cb39b6a731ff1e4c00286 prov:used niiri:22b2d246ca83f9742df6152441f4821f .
 
-niiri:165f4a3fe16dc2972f764b7e81300e66 prov:used niiri:cbcaa8f3061021e485aface02a14bf8b .
+niiri:acd80690d12cb39b6a731ff1e4c00286 prov:used niiri:c7a291c12eb2c6c7e9ebcb9759d8ea7c .
 
-niiri:165f4a3fe16dc2972f764b7e81300e66 prov:used niiri:e53ae7ec054c49559f59b829bea5fb83 .
+niiri:acd80690d12cb39b6a731ff1e4c00286 prov:used niiri:2966074b9e21383f6f55902411f9d3e2 .
 
-niiri:165f4a3fe16dc2972f764b7e81300e66 prov:used niiri:3d98e913b92115cd75804f26601428a0 .
+niiri:acd80690d12cb39b6a731ff1e4c00286 prov:used niiri:6e55046381e462ccd425414e6c6e55df .
 
-niiri:165f4a3fe16dc2972f764b7e81300e66 prov:used niiri:110334b011c4dffd4cd084aaa8a23b50 .
+niiri:acd80690d12cb39b6a731ff1e4c00286 prov:used niiri:1c65c77d484fdd55f58d632b3d659641 .
 
-niiri:7c1a351894d826c482f0c4374916a68d
+niiri:78e99904e3bcdd85e6a94fdbda3413d3
     a prov:Entity, nidm_SearchSpaceMaskMap: ; 
     prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
     nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Search Space Mask Map" ;
-    nidm_inCoordinateSpace: niiri:d41125507fc2262be74a5954df8b238e ;
+    nidm_inCoordinateSpace: niiri:e85365bb21fa161b4325e2ba8cd4fd25 ;
     nidm_searchVolumeInVoxels: "223057"^^xsd:int ;
     nidm_searchVolumeInUnits: "1784456"^^xsd:float ;
     nidm_reselSizeInVoxels: "65.5786964036542"^^xsd:float ;
@@ -496,9 +496,9 @@ niiri:7c1a351894d826c482f0c4374916a68d
     spm_smallestSignificantClusterSizeInVoxelsFWE05: "86"^^xsd:int ;
     spm_smallestSignificantClusterSizeInVoxelsFDR05: "51"^^xsd:int .
 
-niiri:7c1a351894d826c482f0c4374916a68d prov:wasGeneratedBy niiri:165f4a3fe16dc2972f764b7e81300e66 .
+niiri:78e99904e3bcdd85e6a94fdbda3413d3 prov:wasGeneratedBy niiri:acd80690d12cb39b6a731ff1e4c00286 .
 
-niiri:5c3a280abdc45cbf2db33ae481f80003
+niiri:4391a2ef60f122937f69c2336ae7251d
     a prov:Entity, nidm_ExcursionSetMap: ; 
     prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
@@ -506,29 +506,29 @@ niiri:5c3a280abdc45cbf2db33ae481f80003
     rdfs:label "Excursion Set Map" ;
     nidm_numberOfSupraThresholdClusters: "184"^^xsd:int ;
     nidm_pValue: "0"^^xsd:float ;
-    nidm_hasClusterLabelsMap: niiri:dadf5c1767d521958b140228a7d36014 ;
-    nidm_hasMaximumIntensityProjection: niiri:3574a16f01d4afb5e7cc20b434f843d1 ;
-    nidm_inCoordinateSpace: niiri:d41125507fc2262be74a5954df8b238e ;
+    nidm_hasClusterLabelsMap: niiri:2b1331d80daab9b0cd80c884a151f411 ;
+    nidm_hasMaximumIntensityProjection: niiri:ffeb9e623c6efb2a5664eb58fcae60d1 ;
+    nidm_inCoordinateSpace: niiri:e85365bb21fa161b4325e2ba8cd4fd25 ;
     crypto:sha512 "059b760592f8180167aef22914cae89482e9a83c8b1a3d01ed8e313c99bf4e1dbbf1e70e4100dfc87789c5dc1571a71e7d7122be0a817ee2fba7c35c6638dd66"^^xsd:string .
 
-niiri:dadf5c1767d521958b140228a7d36014
+niiri:2b1331d80daab9b0cd80c884a151f411
     a prov:Entity, nidm_ClusterLabelsMap: ; 
     prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Cluster Labels Map" ;
-    nidm_inCoordinateSpace: niiri:d41125507fc2262be74a5954df8b238e ;
+    nidm_inCoordinateSpace: niiri:e85365bb21fa161b4325e2ba8cd4fd25 ;
     crypto:sha512 "b3175bc7185eccf2b55e86c7cb8166bc41c808e3a44971eabd71190fd50bdf8d6d8b820bb69a70ed7b8c5ec063a8523f3640529894dd0b1cdb1a8621ee1f30df"^^xsd:string .
 
-niiri:3574a16f01d4afb5e7cc20b434f843d1
+niiri:ffeb9e623c6efb2a5664eb58fcae60d1
     a prov:Entity, dctype:Image ; 
     prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
     nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:5c3a280abdc45cbf2db33ae481f80003 prov:wasGeneratedBy niiri:165f4a3fe16dc2972f764b7e81300e66 .
+niiri:4391a2ef60f122937f69c2336ae7251d prov:wasGeneratedBy niiri:acd80690d12cb39b6a731ff1e4c00286 .
 
-niiri:651d36d872d7daabb7dba2117ccd0147
+niiri:a02993e23816e346753a88b23cc8928d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0001" ;
     nidm_clusterSizeInVoxels: "1212"^^xsd:int ;
@@ -538,9 +538,9 @@ niiri:651d36d872d7daabb7dba2117ccd0147
     nidm_qValueFDR: "2.28984133580943e-17"^^xsd:float ;
     nidm_clusterLabelId: "1"^^xsd:int .
 
-niiri:651d36d872d7daabb7dba2117ccd0147 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:a02993e23816e346753a88b23cc8928d prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:7f4e9fb870f5c98792fa6bf0f88370fb
+niiri:1fb6d1d0216b48739f26ab81c9d1d36e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0002" ;
     nidm_clusterSizeInVoxels: "4556"^^xsd:int ;
@@ -550,9 +550,9 @@ niiri:7f4e9fb870f5c98792fa6bf0f88370fb
     nidm_qValueFDR: "1.0358560980476e-42"^^xsd:float ;
     nidm_clusterLabelId: "2"^^xsd:int .
 
-niiri:7f4e9fb870f5c98792fa6bf0f88370fb prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:1fb6d1d0216b48739f26ab81c9d1d36e prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:284d49d49a311520554c2b72c79155a5
+niiri:513b4dd1fd53a8b3917570bbd44a1da7
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0003" ;
     nidm_clusterSizeInVoxels: "725"^^xsd:int ;
@@ -562,9 +562,9 @@ niiri:284d49d49a311520554c2b72c79155a5
     nidm_qValueFDR: "3.10892556886631e-12"^^xsd:float ;
     nidm_clusterLabelId: "3"^^xsd:int .
 
-niiri:284d49d49a311520554c2b72c79155a5 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:513b4dd1fd53a8b3917570bbd44a1da7 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:42c8820b665da5b8d98f4ce5fcb8de2d
+niiri:0383eb2fc5ee76be5634bfee80f2ca3b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0004" ;
     nidm_clusterSizeInVoxels: "153"^^xsd:int ;
@@ -574,9 +574,9 @@ niiri:42c8820b665da5b8d98f4ce5fcb8de2d
     nidm_qValueFDR: "0.000253310934795202"^^xsd:float ;
     nidm_clusterLabelId: "4"^^xsd:int .
 
-niiri:42c8820b665da5b8d98f4ce5fcb8de2d prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:0383eb2fc5ee76be5634bfee80f2ca3b prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:7e43e146a206ef37a717db06b7c719b8
+niiri:e67cada24205233131c2bfe154669c61
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0005" ;
     nidm_clusterSizeInVoxels: "313"^^xsd:int ;
@@ -586,9 +586,9 @@ niiri:7e43e146a206ef37a717db06b7c719b8
     nidm_qValueFDR: "5.54898403464322e-07"^^xsd:float ;
     nidm_clusterLabelId: "5"^^xsd:int .
 
-niiri:7e43e146a206ef37a717db06b7c719b8 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:e67cada24205233131c2bfe154669c61 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:4e4ee541dcb7596b480cb3aebb5ec524
+niiri:a3635579e9882ee1f3c09824008b66b4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0006" ;
     nidm_clusterSizeInVoxels: "1743"^^xsd:int ;
@@ -598,9 +598,9 @@ niiri:4e4ee541dcb7596b480cb3aebb5ec524
     nidm_qValueFDR: "2.93955070691137e-22"^^xsd:float ;
     nidm_clusterLabelId: "6"^^xsd:int .
 
-niiri:4e4ee541dcb7596b480cb3aebb5ec524 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:a3635579e9882ee1f3c09824008b66b4 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:78e7ba6b5db9ff6ef88f595eef8c1789
+niiri:c50d34609678664d461509f54c79eea7
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0007" ;
     nidm_clusterSizeInVoxels: "203"^^xsd:int ;
@@ -610,9 +610,9 @@ niiri:78e7ba6b5db9ff6ef88f595eef8c1789
     nidm_qValueFDR: "2.97151480785124e-05"^^xsd:float ;
     nidm_clusterLabelId: "7"^^xsd:int .
 
-niiri:78e7ba6b5db9ff6ef88f595eef8c1789 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:c50d34609678664d461509f54c79eea7 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:8170af49aff81684fdb2d887f6db1095
+niiri:86785a60d43172b11448d491c5ae96dc
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0008" ;
     nidm_clusterSizeInVoxels: "415"^^xsd:int ;
@@ -622,9 +622,9 @@ niiri:8170af49aff81684fdb2d887f6db1095
     nidm_qValueFDR: "2.25127901812905e-08"^^xsd:float ;
     nidm_clusterLabelId: "8"^^xsd:int .
 
-niiri:8170af49aff81684fdb2d887f6db1095 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:86785a60d43172b11448d491c5ae96dc prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:740bf59b1d25123628eef463c4259e34
+niiri:dded355a673488279610ef537e861858
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0009" ;
     nidm_clusterSizeInVoxels: "755"^^xsd:int ;
@@ -634,9 +634,9 @@ niiri:740bf59b1d25123628eef463c4259e34
     nidm_qValueFDR: "1.64347297044244e-12"^^xsd:float ;
     nidm_clusterLabelId: "9"^^xsd:int .
 
-niiri:740bf59b1d25123628eef463c4259e34 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:dded355a673488279610ef537e861858 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:1b8c8488e08d0790c457517765f898e1
+niiri:c1b3c9780e84e1bcfb3c612aa647510e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0010" ;
     nidm_clusterSizeInVoxels: "101"^^xsd:int ;
@@ -646,9 +646,9 @@ niiri:1b8c8488e08d0790c457517765f898e1
     nidm_qValueFDR: "0.00246981746869986"^^xsd:float ;
     nidm_clusterLabelId: "10"^^xsd:int .
 
-niiri:1b8c8488e08d0790c457517765f898e1 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:c1b3c9780e84e1bcfb3c612aa647510e prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:9ff5e136f972c43baf0362735367bbdb
+niiri:86886012c734f3d338a1efb48a81145a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0011" ;
     nidm_clusterSizeInVoxels: "4088"^^xsd:int ;
@@ -658,9 +658,9 @@ niiri:9ff5e136f972c43baf0362735367bbdb
     nidm_qValueFDR: "6.2939882759817e-40"^^xsd:float ;
     nidm_clusterLabelId: "11"^^xsd:int .
 
-niiri:9ff5e136f972c43baf0362735367bbdb prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:86886012c734f3d338a1efb48a81145a prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:d852b48a402ab69819373ede91d1c632
+niiri:e25e46750ed6706bcfbfa5e14d55d777
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0012" ;
     nidm_clusterSizeInVoxels: "649"^^xsd:int ;
@@ -670,9 +670,9 @@ niiri:d852b48a402ab69819373ede91d1c632
     nidm_qValueFDR: "2.24082108370855e-11"^^xsd:float ;
     nidm_clusterLabelId: "12"^^xsd:int .
 
-niiri:d852b48a402ab69819373ede91d1c632 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:e25e46750ed6706bcfbfa5e14d55d777 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:2f36545388d37f7477d8f0618c919f09
+niiri:e2ac8194c797871c399100cc42929140
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0013" ;
     nidm_clusterSizeInVoxels: "40"^^xsd:int ;
@@ -682,9 +682,9 @@ niiri:2f36545388d37f7477d8f0618c919f09
     nidm_qValueFDR: "0.0650777007423645"^^xsd:float ;
     nidm_clusterLabelId: "13"^^xsd:int .
 
-niiri:2f36545388d37f7477d8f0618c919f09 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:e2ac8194c797871c399100cc42929140 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:6da57157038eade3ca7a4c29d0c28ad8
+niiri:e480d8d12a9dc866e99b7a65d64c73b5
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0014" ;
     nidm_clusterSizeInVoxels: "226"^^xsd:int ;
@@ -694,9 +694,9 @@ niiri:6da57157038eade3ca7a4c29d0c28ad8
     nidm_qValueFDR: "1.22121498047324e-05"^^xsd:float ;
     nidm_clusterLabelId: "14"^^xsd:int .
 
-niiri:6da57157038eade3ca7a4c29d0c28ad8 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:e480d8d12a9dc866e99b7a65d64c73b5 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:f36a9d2eb3726086574d1578e1d9f0f8
+niiri:82f170400f1b69cc64c4688f03080756
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0015" ;
     nidm_clusterSizeInVoxels: "113"^^xsd:int ;
@@ -706,9 +706,9 @@ niiri:f36a9d2eb3726086574d1578e1d9f0f8
     nidm_qValueFDR: "0.00137963818274444"^^xsd:float ;
     nidm_clusterLabelId: "15"^^xsd:int .
 
-niiri:f36a9d2eb3726086574d1578e1d9f0f8 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:82f170400f1b69cc64c4688f03080756 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:3132927065aeeaa4a3a285e94ec260a6
+niiri:c7d451f7f453a0be61177b599ede33a5
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0016" ;
     nidm_clusterSizeInVoxels: "312"^^xsd:int ;
@@ -718,9 +718,9 @@ niiri:3132927065aeeaa4a3a285e94ec260a6
     nidm_qValueFDR: "5.54898403464322e-07"^^xsd:float ;
     nidm_clusterLabelId: "16"^^xsd:int .
 
-niiri:3132927065aeeaa4a3a285e94ec260a6 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:c7d451f7f453a0be61177b599ede33a5 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:1cad58fd2cece054821848126afc3007
+niiri:37926699687cca9b9dd0b742b092ff48
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0017" ;
     nidm_clusterSizeInVoxels: "341"^^xsd:int ;
@@ -730,9 +730,9 @@ niiri:1cad58fd2cece054821848126afc3007
     nidm_qValueFDR: "2.31545112260121e-07"^^xsd:float ;
     nidm_clusterLabelId: "17"^^xsd:int .
 
-niiri:1cad58fd2cece054821848126afc3007 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:37926699687cca9b9dd0b742b092ff48 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:1fcfe58e890a992a0cbd392039bb176f
+niiri:e7fc074f64298360eb2c7ffbcb4e63aa
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0018" ;
     nidm_clusterSizeInVoxels: "32"^^xsd:int ;
@@ -742,9 +742,9 @@ niiri:1fcfe58e890a992a0cbd392039bb176f
     nidm_qValueFDR: "0.0932913285094554"^^xsd:float ;
     nidm_clusterLabelId: "18"^^xsd:int .
 
-niiri:1fcfe58e890a992a0cbd392039bb176f prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:e7fc074f64298360eb2c7ffbcb4e63aa prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:41b3f1fe29e41e8399e5532675d71afb
+niiri:617a58ee9ff77a4075c0708ea690d16c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0019" ;
     nidm_clusterSizeInVoxels: "119"^^xsd:int ;
@@ -754,9 +754,9 @@ niiri:41b3f1fe29e41e8399e5532675d71afb
     nidm_qValueFDR: "0.00111483505448432"^^xsd:float ;
     nidm_clusterLabelId: "19"^^xsd:int .
 
-niiri:41b3f1fe29e41e8399e5532675d71afb prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:617a58ee9ff77a4075c0708ea690d16c prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:9a54b48570d440ea6ac8f1f92e78425f
+niiri:fd34291df44a2d10645e6546a1593a1c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0020" ;
     nidm_clusterSizeInVoxels: "86"^^xsd:int ;
@@ -766,9 +766,9 @@ niiri:9a54b48570d440ea6ac8f1f92e78425f
     nidm_qValueFDR: "0.00516198383877974"^^xsd:float ;
     nidm_clusterLabelId: "20"^^xsd:int .
 
-niiri:9a54b48570d440ea6ac8f1f92e78425f prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:fd34291df44a2d10645e6546a1593a1c prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:ffd74835caba617d42d83e59e6b5a54e
+niiri:8677fb654966f35b2ba255c1e63d1cb1
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0021" ;
     nidm_clusterSizeInVoxels: "500"^^xsd:int ;
@@ -778,9 +778,9 @@ niiri:ffd74835caba617d42d83e59e6b5a54e
     nidm_qValueFDR: "1.65476390708836e-09"^^xsd:float ;
     nidm_clusterLabelId: "21"^^xsd:int .
 
-niiri:ffd74835caba617d42d83e59e6b5a54e prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:8677fb654966f35b2ba255c1e63d1cb1 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:56af8a072a247476eb5fd62c25fdf6e9
+niiri:545f94f2d451c1c902303c221a0a1089
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0022" ;
     nidm_clusterSizeInVoxels: "96"^^xsd:int ;
@@ -790,9 +790,9 @@ niiri:56af8a072a247476eb5fd62c25fdf6e9
     nidm_qValueFDR: "0.00309851861693785"^^xsd:float ;
     nidm_clusterLabelId: "22"^^xsd:int .
 
-niiri:56af8a072a247476eb5fd62c25fdf6e9 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:545f94f2d451c1c902303c221a0a1089 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:097010bf7718d0ca7ca15cd545a5d22f
+niiri:f9a9c037c3239038fee46308d6b9feba
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0023" ;
     nidm_clusterSizeInVoxels: "17"^^xsd:int ;
@@ -802,9 +802,9 @@ niiri:097010bf7718d0ca7ca15cd545a5d22f
     nidm_qValueFDR: "0.233234793433793"^^xsd:float ;
     nidm_clusterLabelId: "23"^^xsd:int .
 
-niiri:097010bf7718d0ca7ca15cd545a5d22f prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:f9a9c037c3239038fee46308d6b9feba prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:9bd5784f7d92f66f0e060878415afdd2
+niiri:6441c160dec1271f21351fe6ca31e10a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0024" ;
     nidm_clusterSizeInVoxels: "232"^^xsd:int ;
@@ -814,9 +814,9 @@ niiri:9bd5784f7d92f66f0e060878415afdd2
     nidm_qValueFDR: "1.02223420853013e-05"^^xsd:float ;
     nidm_clusterLabelId: "24"^^xsd:int .
 
-niiri:9bd5784f7d92f66f0e060878415afdd2 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:6441c160dec1271f21351fe6ca31e10a prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:acdf8cd47c627692be1a25b68765ef7e
+niiri:2872350aa13a26854db92f5a27149fe1
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0025" ;
     nidm_clusterSizeInVoxels: "39"^^xsd:int ;
@@ -826,9 +826,9 @@ niiri:acdf8cd47c627692be1a25b68765ef7e
     nidm_qValueFDR: "0.0663877526368907"^^xsd:float ;
     nidm_clusterLabelId: "25"^^xsd:int .
 
-niiri:acdf8cd47c627692be1a25b68765ef7e prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:2872350aa13a26854db92f5a27149fe1 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:7a9e3b4c3767f5381b56e2fbeb688be4
+niiri:e3742b34c6808b2398052ec8dae20d8c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0026" ;
     nidm_clusterSizeInVoxels: "282"^^xsd:int ;
@@ -838,9 +838,9 @@ niiri:7a9e3b4c3767f5381b56e2fbeb688be4
     nidm_qValueFDR: "1.56591490405001e-06"^^xsd:float ;
     nidm_clusterLabelId: "26"^^xsd:int .
 
-niiri:7a9e3b4c3767f5381b56e2fbeb688be4 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:e3742b34c6808b2398052ec8dae20d8c prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:3e392a8fdf40615d1b9393f7900b1a84
+niiri:002a4160ef17e67bfe8f93c22d701531
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0027" ;
     nidm_clusterSizeInVoxels: "14"^^xsd:int ;
@@ -850,9 +850,9 @@ niiri:3e392a8fdf40615d1b9393f7900b1a84
     nidm_qValueFDR: "0.28101653917298"^^xsd:float ;
     nidm_clusterLabelId: "27"^^xsd:int .
 
-niiri:3e392a8fdf40615d1b9393f7900b1a84 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:002a4160ef17e67bfe8f93c22d701531 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:5a380674b2894ae5398504bd4a8533f8
+niiri:88b01b8106ca0618c3b109ef9140a77a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0028" ;
     nidm_clusterSizeInVoxels: "131"^^xsd:int ;
@@ -862,9 +862,9 @@ niiri:5a380674b2894ae5398504bd4a8533f8
     nidm_qValueFDR: "0.00068079502023427"^^xsd:float ;
     nidm_clusterLabelId: "28"^^xsd:int .
 
-niiri:5a380674b2894ae5398504bd4a8533f8 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:88b01b8106ca0618c3b109ef9140a77a prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:13af72d1f5f712ec17e2a4eb12791728
+niiri:5b45e4eea89f71e19bb39684bf2f0eb7
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0029" ;
     nidm_clusterSizeInVoxels: "19"^^xsd:int ;
@@ -874,9 +874,9 @@ niiri:13af72d1f5f712ec17e2a4eb12791728
     nidm_qValueFDR: "0.215296978637538"^^xsd:float ;
     nidm_clusterLabelId: "29"^^xsd:int .
 
-niiri:13af72d1f5f712ec17e2a4eb12791728 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:5b45e4eea89f71e19bb39684bf2f0eb7 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:d959803f17fca1477b93bbeb0285f2c2
+niiri:c3da843e94fc98cca5669ae4eef8d2ed
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0030" ;
     nidm_clusterSizeInVoxels: "12"^^xsd:int ;
@@ -886,9 +886,9 @@ niiri:d959803f17fca1477b93bbeb0285f2c2
     nidm_qValueFDR: "0.325388258851229"^^xsd:float ;
     nidm_clusterLabelId: "30"^^xsd:int .
 
-niiri:d959803f17fca1477b93bbeb0285f2c2 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:c3da843e94fc98cca5669ae4eef8d2ed prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:02b0f364d58bda58fce33ecdaf3e7191
+niiri:5d3257a6906cc23f21f8344f8a202720
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0031" ;
     nidm_clusterSizeInVoxels: "116"^^xsd:int ;
@@ -898,9 +898,9 @@ niiri:02b0f364d58bda58fce33ecdaf3e7191
     nidm_qValueFDR: "0.00123809548881334"^^xsd:float ;
     nidm_clusterLabelId: "31"^^xsd:int .
 
-niiri:02b0f364d58bda58fce33ecdaf3e7191 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:5d3257a6906cc23f21f8344f8a202720 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:cd0210a509aed4af1fa29d3bf1351438
+niiri:f9cfce19a79a082c82d2f3a6386b09c9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0032" ;
     nidm_clusterSizeInVoxels: "128"^^xsd:int ;
@@ -910,9 +910,9 @@ niiri:cd0210a509aed4af1fa29d3bf1351438
     nidm_qValueFDR: "0.000748841298989256"^^xsd:float ;
     nidm_clusterLabelId: "32"^^xsd:int .
 
-niiri:cd0210a509aed4af1fa29d3bf1351438 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:f9cfce19a79a082c82d2f3a6386b09c9 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:b9079ad818d03296fe8330a4f70c5c53
+niiri:36f4c495e82ce16bc5e3538ec47db115
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0033" ;
     nidm_clusterSizeInVoxels: "341"^^xsd:int ;
@@ -922,9 +922,9 @@ niiri:b9079ad818d03296fe8330a4f70c5c53
     nidm_qValueFDR: "2.31545112260121e-07"^^xsd:float ;
     nidm_clusterLabelId: "33"^^xsd:int .
 
-niiri:b9079ad818d03296fe8330a4f70c5c53 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:36f4c495e82ce16bc5e3538ec47db115 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:6ed412630e5ab417bee547bf394670cd
+niiri:f3db818d25677c7c9807d3bc465f0dec
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0034" ;
     nidm_clusterSizeInVoxels: "15"^^xsd:int ;
@@ -934,9 +934,9 @@ niiri:6ed412630e5ab417bee547bf394670cd
     nidm_qValueFDR: "0.26079004694974"^^xsd:float ;
     nidm_clusterLabelId: "34"^^xsd:int .
 
-niiri:6ed412630e5ab417bee547bf394670cd prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:f3db818d25677c7c9807d3bc465f0dec prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:a69405853461b6b0f7066443a438e1d5
+niiri:16cd91852662e2b6fb06dce21defbb02
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0035" ;
     nidm_clusterSizeInVoxels: "36"^^xsd:int ;
@@ -946,9 +946,9 @@ niiri:a69405853461b6b0f7066443a438e1d5
     nidm_qValueFDR: "0.0751453826449104"^^xsd:float ;
     nidm_clusterLabelId: "35"^^xsd:int .
 
-niiri:a69405853461b6b0f7066443a438e1d5 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:16cd91852662e2b6fb06dce21defbb02 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:0747284a50ab24237772bdee19f8130e
+niiri:d1f64d168706b2b7b1ea74aeb9acf76d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0036" ;
     nidm_clusterSizeInVoxels: "43"^^xsd:int ;
@@ -958,9 +958,9 @@ niiri:0747284a50ab24237772bdee19f8130e
     nidm_qValueFDR: "0.0588979503672797"^^xsd:float ;
     nidm_clusterLabelId: "36"^^xsd:int .
 
-niiri:0747284a50ab24237772bdee19f8130e prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:d1f64d168706b2b7b1ea74aeb9acf76d prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:a1f38c4aab7577b61865da78d168d6b4
+niiri:81dc6b3cbc9f571d3c373afc2c155834
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0037" ;
     nidm_clusterSizeInVoxels: "21"^^xsd:int ;
@@ -970,9 +970,9 @@ niiri:a1f38c4aab7577b61865da78d168d6b4
     nidm_qValueFDR: "0.199022259548943"^^xsd:float ;
     nidm_clusterLabelId: "37"^^xsd:int .
 
-niiri:a1f38c4aab7577b61865da78d168d6b4 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:81dc6b3cbc9f571d3c373afc2c155834 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:b2b2a00d477027244468267bb4cfdd7e
+niiri:5c83c29ecdf61abf3b54b84749525008
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0038" ;
     nidm_clusterSizeInVoxels: "42"^^xsd:int ;
@@ -982,9 +982,9 @@ niiri:b2b2a00d477027244468267bb4cfdd7e
     nidm_qValueFDR: "0.0613612249887678"^^xsd:float ;
     nidm_clusterLabelId: "38"^^xsd:int .
 
-niiri:b2b2a00d477027244468267bb4cfdd7e prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:5c83c29ecdf61abf3b54b84749525008 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:1aefd578b3c1231848bc58379b5aa924
+niiri:01690965efcb17bbde83102ddcb2faab
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0039" ;
     nidm_clusterSizeInVoxels: "29"^^xsd:int ;
@@ -994,9 +994,9 @@ niiri:1aefd578b3c1231848bc58379b5aa924
     nidm_qValueFDR: "0.113456061793386"^^xsd:float ;
     nidm_clusterLabelId: "39"^^xsd:int .
 
-niiri:1aefd578b3c1231848bc58379b5aa924 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:01690965efcb17bbde83102ddcb2faab prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:42e2f22eff9709257cf127b203589014
+niiri:06b13cc33465cdc0e1390a27c23a9ac4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0040" ;
     nidm_clusterSizeInVoxels: "39"^^xsd:int ;
@@ -1006,9 +1006,9 @@ niiri:42e2f22eff9709257cf127b203589014
     nidm_qValueFDR: "0.0663877526368907"^^xsd:float ;
     nidm_clusterLabelId: "40"^^xsd:int .
 
-niiri:42e2f22eff9709257cf127b203589014 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:06b13cc33465cdc0e1390a27c23a9ac4 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:2974d7622a4eb3c979c41bc0bae55ebd
+niiri:7f6f25f12f4270c6aaed0a3240d5a8a1
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0041" ;
     nidm_clusterSizeInVoxels: "29"^^xsd:int ;
@@ -1018,9 +1018,9 @@ niiri:2974d7622a4eb3c979c41bc0bae55ebd
     nidm_qValueFDR: "0.113456061793386"^^xsd:float ;
     nidm_clusterLabelId: "41"^^xsd:int .
 
-niiri:2974d7622a4eb3c979c41bc0bae55ebd prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:7f6f25f12f4270c6aaed0a3240d5a8a1 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:dd84655271d1a93ad919193767608ec8
+niiri:8f37ccae34c7cba6e277659e1d99e2a9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0042" ;
     nidm_clusterSizeInVoxels: "40"^^xsd:int ;
@@ -1030,9 +1030,9 @@ niiri:dd84655271d1a93ad919193767608ec8
     nidm_qValueFDR: "0.0650777007423645"^^xsd:float ;
     nidm_clusterLabelId: "42"^^xsd:int .
 
-niiri:dd84655271d1a93ad919193767608ec8 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:8f37ccae34c7cba6e277659e1d99e2a9 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:0f340a0ff58ecb32a533ddd1cf07f45d
+niiri:3acfc147a4a82a0c9064e4e844ecc743
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0043" ;
     nidm_clusterSizeInVoxels: "37"^^xsd:int ;
@@ -1042,9 +1042,9 @@ niiri:0f340a0ff58ecb32a533ddd1cf07f45d
     nidm_qValueFDR: "0.0731521833485923"^^xsd:float ;
     nidm_clusterLabelId: "43"^^xsd:int .
 
-niiri:0f340a0ff58ecb32a533ddd1cf07f45d prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:3acfc147a4a82a0c9064e4e844ecc743 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:43c527932f85b9bc3ce5b3b60117f451
+niiri:bb2efddb865295f983adb4172abe81b6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0044" ;
     nidm_clusterSizeInVoxels: "43"^^xsd:int ;
@@ -1054,9 +1054,9 @@ niiri:43c527932f85b9bc3ce5b3b60117f451
     nidm_qValueFDR: "0.0588979503672797"^^xsd:float ;
     nidm_clusterLabelId: "44"^^xsd:int .
 
-niiri:43c527932f85b9bc3ce5b3b60117f451 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:bb2efddb865295f983adb4172abe81b6 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:4c9c90b34337736af0c1709b3e2dce99
+niiri:29b1a5a35e558ec0833c58691621c112
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0045" ;
     nidm_clusterSizeInVoxels: "53"^^xsd:int ;
@@ -1066,9 +1066,9 @@ niiri:4c9c90b34337736af0c1709b3e2dce99
     nidm_qValueFDR: "0.0339328552676794"^^xsd:float ;
     nidm_clusterLabelId: "45"^^xsd:int .
 
-niiri:4c9c90b34337736af0c1709b3e2dce99 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:29b1a5a35e558ec0833c58691621c112 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:645b34305a7adc863333ef8d055b94b6
+niiri:16e2e680906eb7d77a0f37a900f566bb
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0046" ;
     nidm_clusterSizeInVoxels: "43"^^xsd:int ;
@@ -1078,9 +1078,9 @@ niiri:645b34305a7adc863333ef8d055b94b6
     nidm_qValueFDR: "0.0588979503672797"^^xsd:float ;
     nidm_clusterLabelId: "46"^^xsd:int .
 
-niiri:645b34305a7adc863333ef8d055b94b6 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:16e2e680906eb7d77a0f37a900f566bb prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:147ce23197bb1c39e660c70911b5c483
+niiri:160595535853afe9f10e3ba4462634ee
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0047" ;
     nidm_clusterSizeInVoxels: "51"^^xsd:int ;
@@ -1090,9 +1090,9 @@ niiri:147ce23197bb1c39e660c70911b5c483
     nidm_qValueFDR: "0.0374468203261794"^^xsd:float ;
     nidm_clusterLabelId: "47"^^xsd:int .
 
-niiri:147ce23197bb1c39e660c70911b5c483 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:160595535853afe9f10e3ba4462634ee prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:4c767097d4f857da1a95ec39b9d9edc3
+niiri:5bea9c455010164eafb48efd433d0b3b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0048" ;
     nidm_clusterSizeInVoxels: "64"^^xsd:int ;
@@ -1102,9 +1102,9 @@ niiri:4c767097d4f857da1a95ec39b9d9edc3
     nidm_qValueFDR: "0.0180840093638652"^^xsd:float ;
     nidm_clusterLabelId: "48"^^xsd:int .
 
-niiri:4c767097d4f857da1a95ec39b9d9edc3 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:5bea9c455010164eafb48efd433d0b3b prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:e039dc19484a5a0f4a9f1920c4f37802
+niiri:54acd58c8408a4a54a5d29cdbcf77a2a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0049" ;
     nidm_clusterSizeInVoxels: "12"^^xsd:int ;
@@ -1114,9 +1114,9 @@ niiri:e039dc19484a5a0f4a9f1920c4f37802
     nidm_qValueFDR: "0.325388258851229"^^xsd:float ;
     nidm_clusterLabelId: "49"^^xsd:int .
 
-niiri:e039dc19484a5a0f4a9f1920c4f37802 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:54acd58c8408a4a54a5d29cdbcf77a2a prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:90684205dbd5e3565c63d92ea2c2ba92
+niiri:e0f95b0e95e26dd40bce67d69e9c88a7
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0050" ;
     nidm_clusterSizeInVoxels: "20"^^xsd:int ;
@@ -1126,9 +1126,9 @@ niiri:90684205dbd5e3565c63d92ea2c2ba92
     nidm_qValueFDR: "0.2101897095685"^^xsd:float ;
     nidm_clusterLabelId: "50"^^xsd:int .
 
-niiri:90684205dbd5e3565c63d92ea2c2ba92 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:e0f95b0e95e26dd40bce67d69e9c88a7 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:43d72ad1d7d22b80f01808f8d966ccdd
+niiri:e1915181e888f91227f9d80a2ceda361
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0051" ;
     nidm_clusterSizeInVoxels: "12"^^xsd:int ;
@@ -1138,9 +1138,9 @@ niiri:43d72ad1d7d22b80f01808f8d966ccdd
     nidm_qValueFDR: "0.325388258851229"^^xsd:float ;
     nidm_clusterLabelId: "51"^^xsd:int .
 
-niiri:43d72ad1d7d22b80f01808f8d966ccdd prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:e1915181e888f91227f9d80a2ceda361 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:fce6ba03f6215ffda4130a08998532e7
+niiri:059524711a78d34f86f9ff7484d30c28
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0052" ;
     nidm_clusterSizeInVoxels: "20"^^xsd:int ;
@@ -1150,9 +1150,9 @@ niiri:fce6ba03f6215ffda4130a08998532e7
     nidm_qValueFDR: "0.2101897095685"^^xsd:float ;
     nidm_clusterLabelId: "52"^^xsd:int .
 
-niiri:fce6ba03f6215ffda4130a08998532e7 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:059524711a78d34f86f9ff7484d30c28 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:90faaaeae176fe54bdbf1e2a7100afb2
+niiri:f80c4f725486ccc8cbc7ca97e9202b10
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0053" ;
     nidm_clusterSizeInVoxels: "32"^^xsd:int ;
@@ -1162,9 +1162,9 @@ niiri:90faaaeae176fe54bdbf1e2a7100afb2
     nidm_qValueFDR: "0.0932913285094554"^^xsd:float ;
     nidm_clusterLabelId: "53"^^xsd:int .
 
-niiri:90faaaeae176fe54bdbf1e2a7100afb2 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:f80c4f725486ccc8cbc7ca97e9202b10 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:a56b7f6c2daf0ff5655692e9a3ba50e8
+niiri:4fc2bcbe1574c654541b41942566af13
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0054" ;
     nidm_clusterSizeInVoxels: "23"^^xsd:int ;
@@ -1174,9 +1174,9 @@ niiri:a56b7f6c2daf0ff5655692e9a3ba50e8
     nidm_qValueFDR: "0.173125535680108"^^xsd:float ;
     nidm_clusterLabelId: "54"^^xsd:int .
 
-niiri:a56b7f6c2daf0ff5655692e9a3ba50e8 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:4fc2bcbe1574c654541b41942566af13 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:94a06b9bd15a2d12f76ca646af0fa348
+niiri:dff2d5252e6112d696cc75e19b35b055
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0055" ;
     nidm_clusterSizeInVoxels: "10"^^xsd:int ;
@@ -1186,9 +1186,9 @@ niiri:94a06b9bd15a2d12f76ca646af0fa348
     nidm_qValueFDR: "0.374104666475387"^^xsd:float ;
     nidm_clusterLabelId: "55"^^xsd:int .
 
-niiri:94a06b9bd15a2d12f76ca646af0fa348 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:dff2d5252e6112d696cc75e19b35b055 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:e6bd6b781a9701be59c8d9453ba0f42d
+niiri:c1d3f6f0f50baea1174f7ada78444ce5
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0056" ;
     nidm_clusterSizeInVoxels: "19"^^xsd:int ;
@@ -1198,9 +1198,9 @@ niiri:e6bd6b781a9701be59c8d9453ba0f42d
     nidm_qValueFDR: "0.215296978637538"^^xsd:float ;
     nidm_clusterLabelId: "56"^^xsd:int .
 
-niiri:e6bd6b781a9701be59c8d9453ba0f42d prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:c1d3f6f0f50baea1174f7ada78444ce5 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:24a7631619b05b254e46f418981f33fd
+niiri:ac01f2a6f9677b631c38f9d1203db903
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0057" ;
     nidm_clusterSizeInVoxels: "23"^^xsd:int ;
@@ -1210,9 +1210,9 @@ niiri:24a7631619b05b254e46f418981f33fd
     nidm_qValueFDR: "0.173125535680108"^^xsd:float ;
     nidm_clusterLabelId: "57"^^xsd:int .
 
-niiri:24a7631619b05b254e46f418981f33fd prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:ac01f2a6f9677b631c38f9d1203db903 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:26d38070320861a52f54239810eefb6d
+niiri:6ac4331664607b2b0b57f58303204021
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0058" ;
     nidm_clusterSizeInVoxels: "18"^^xsd:int ;
@@ -1222,9 +1222,9 @@ niiri:26d38070320861a52f54239810eefb6d
     nidm_qValueFDR: "0.225307419263672"^^xsd:float ;
     nidm_clusterLabelId: "58"^^xsd:int .
 
-niiri:26d38070320861a52f54239810eefb6d prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:6ac4331664607b2b0b57f58303204021 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:a5c107a7aa03e749be4156dafe333465
+niiri:df3a63e829a4b0144a3bd3a075d00d6a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0059" ;
     nidm_clusterSizeInVoxels: "56"^^xsd:int ;
@@ -1234,9 +1234,9 @@ niiri:a5c107a7aa03e749be4156dafe333465
     nidm_qValueFDR: "0.0289015510143169"^^xsd:float ;
     nidm_clusterLabelId: "59"^^xsd:int .
 
-niiri:a5c107a7aa03e749be4156dafe333465 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:df3a63e829a4b0144a3bd3a075d00d6a prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:1e592c6195e8eed44af6ede26c558b5b
+niiri:de4cddb037f1620436ef1889e1446b84
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0060" ;
     nidm_clusterSizeInVoxels: "23"^^xsd:int ;
@@ -1246,9 +1246,9 @@ niiri:1e592c6195e8eed44af6ede26c558b5b
     nidm_qValueFDR: "0.173125535680108"^^xsd:float ;
     nidm_clusterLabelId: "60"^^xsd:int .
 
-niiri:1e592c6195e8eed44af6ede26c558b5b prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:de4cddb037f1620436ef1889e1446b84 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:561f8f2dc565936a85d74fd6e6439dd5
+niiri:70eb10d3df67eb20319350b5182c2674
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0061" ;
     nidm_clusterSizeInVoxels: "15"^^xsd:int ;
@@ -1258,9 +1258,9 @@ niiri:561f8f2dc565936a85d74fd6e6439dd5
     nidm_qValueFDR: "0.26079004694974"^^xsd:float ;
     nidm_clusterLabelId: "61"^^xsd:int .
 
-niiri:561f8f2dc565936a85d74fd6e6439dd5 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:70eb10d3df67eb20319350b5182c2674 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:74f3d914b0fa073ea25c95d2b38e58fb
+niiri:0c6701f42b3e926640123461fe2991bd
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0062" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1270,9 +1270,9 @@ niiri:74f3d914b0fa073ea25c95d2b38e58fb
     nidm_qValueFDR: "0.60244430753576"^^xsd:float ;
     nidm_clusterLabelId: "62"^^xsd:int .
 
-niiri:74f3d914b0fa073ea25c95d2b38e58fb prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:0c6701f42b3e926640123461fe2991bd prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:3df28d3c24f5b16d0bd211139131d8c1
+niiri:ff9cac1254b9e415d2191f7775b434dc
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0063" ;
     nidm_clusterSizeInVoxels: "17"^^xsd:int ;
@@ -1282,9 +1282,9 @@ niiri:3df28d3c24f5b16d0bd211139131d8c1
     nidm_qValueFDR: "0.233234793433793"^^xsd:float ;
     nidm_clusterLabelId: "63"^^xsd:int .
 
-niiri:3df28d3c24f5b16d0bd211139131d8c1 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:ff9cac1254b9e415d2191f7775b434dc prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:7f4b39cb147f1d9dd77391be1117b986
+niiri:42811518fc15bbd0a0761ed04fef9d90
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0064" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -1294,9 +1294,9 @@ niiri:7f4b39cb147f1d9dd77391be1117b986
     nidm_qValueFDR: "0.576232956029303"^^xsd:float ;
     nidm_clusterLabelId: "64"^^xsd:int .
 
-niiri:7f4b39cb147f1d9dd77391be1117b986 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:42811518fc15bbd0a0761ed04fef9d90 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:e186e249fc14850bf873b0628a153098
+niiri:dd408b7babb59101191c5fa3158193a1
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0065" ;
     nidm_clusterSizeInVoxels: "11"^^xsd:int ;
@@ -1306,9 +1306,9 @@ niiri:e186e249fc14850bf873b0628a153098
     nidm_qValueFDR: "0.35008153380984"^^xsd:float ;
     nidm_clusterLabelId: "65"^^xsd:int .
 
-niiri:e186e249fc14850bf873b0628a153098 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:dd408b7babb59101191c5fa3158193a1 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:28c5ec87b0dddeb6b0b0fcaa674d02f8
+niiri:99548a2427d673d5bd15c691076864b1
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0066" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -1318,9 +1318,9 @@ niiri:28c5ec87b0dddeb6b0b0fcaa674d02f8
     nidm_qValueFDR: "0.576232956029303"^^xsd:float ;
     nidm_clusterLabelId: "66"^^xsd:int .
 
-niiri:28c5ec87b0dddeb6b0b0fcaa674d02f8 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:99548a2427d673d5bd15c691076864b1 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:b9c11d17264a448b811fbb99435e6a29
+niiri:7a1eb6258840314d739698ecb8549782
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0067" ;
     nidm_clusterSizeInVoxels: "18"^^xsd:int ;
@@ -1330,9 +1330,9 @@ niiri:b9c11d17264a448b811fbb99435e6a29
     nidm_qValueFDR: "0.225307419263672"^^xsd:float ;
     nidm_clusterLabelId: "67"^^xsd:int .
 
-niiri:b9c11d17264a448b811fbb99435e6a29 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:7a1eb6258840314d739698ecb8549782 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:4f417da08fec0d40b87c31dc3acdb804
+niiri:d766f0de412bd93d96229079d9de064c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0068" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -1342,9 +1342,9 @@ niiri:4f417da08fec0d40b87c31dc3acdb804
     nidm_qValueFDR: "0.520165224837362"^^xsd:float ;
     nidm_clusterLabelId: "68"^^xsd:int .
 
-niiri:4f417da08fec0d40b87c31dc3acdb804 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:d766f0de412bd93d96229079d9de064c prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:595ec99dd41031dea87a56ab2ed11ae6
+niiri:8661090d64b5d8ebc0a4bd8254976fb2
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0069" ;
     nidm_clusterSizeInVoxels: "32"^^xsd:int ;
@@ -1354,9 +1354,9 @@ niiri:595ec99dd41031dea87a56ab2ed11ae6
     nidm_qValueFDR: "0.0932913285094554"^^xsd:float ;
     nidm_clusterLabelId: "69"^^xsd:int .
 
-niiri:595ec99dd41031dea87a56ab2ed11ae6 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:8661090d64b5d8ebc0a4bd8254976fb2 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:2c7e261ed1ca11499bdd3aefccd19ad9
+niiri:52941f17d3d4d9019f15d6efbca27815
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0070" ;
     nidm_clusterSizeInVoxels: "34"^^xsd:int ;
@@ -1366,9 +1366,9 @@ niiri:2c7e261ed1ca11499bdd3aefccd19ad9
     nidm_qValueFDR: "0.0854185130779095"^^xsd:float ;
     nidm_clusterLabelId: "70"^^xsd:int .
 
-niiri:2c7e261ed1ca11499bdd3aefccd19ad9 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:52941f17d3d4d9019f15d6efbca27815 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:ad031ab3c998c491419cfcf8be1da45c
+niiri:65bb243af8ca1e554de57b71bb66bc25
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0071" ;
     nidm_clusterSizeInVoxels: "40"^^xsd:int ;
@@ -1378,9 +1378,9 @@ niiri:ad031ab3c998c491419cfcf8be1da45c
     nidm_qValueFDR: "0.0650777007423645"^^xsd:float ;
     nidm_clusterLabelId: "71"^^xsd:int .
 
-niiri:ad031ab3c998c491419cfcf8be1da45c prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:65bb243af8ca1e554de57b71bb66bc25 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:5c2053c39d7e04181ae00f2c3455846a
+niiri:eb7b45334c4709abfab6a80cdaa2bc22
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0072" ;
     nidm_clusterSizeInVoxels: "16"^^xsd:int ;
@@ -1390,9 +1390,9 @@ niiri:5c2053c39d7e04181ae00f2c3455846a
     nidm_qValueFDR: "0.24967224889865"^^xsd:float ;
     nidm_clusterLabelId: "72"^^xsd:int .
 
-niiri:5c2053c39d7e04181ae00f2c3455846a prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:eb7b45334c4709abfab6a80cdaa2bc22 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:117133b74d26b0653d13dd1ed378d736
+niiri:afbff827e6265de5fc31843cacb634e6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0073" ;
     nidm_clusterSizeInVoxels: "16"^^xsd:int ;
@@ -1402,9 +1402,9 @@ niiri:117133b74d26b0653d13dd1ed378d736
     nidm_qValueFDR: "0.24967224889865"^^xsd:float ;
     nidm_clusterLabelId: "73"^^xsd:int .
 
-niiri:117133b74d26b0653d13dd1ed378d736 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:afbff827e6265de5fc31843cacb634e6 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:f826be788a1ac88ee83c24f89532c22c
+niiri:44d83170827403caee586f5f0c738aff
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0074" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -1414,9 +1414,9 @@ niiri:f826be788a1ac88ee83c24f89532c22c
     nidm_qValueFDR: "0.483511810560871"^^xsd:float ;
     nidm_clusterLabelId: "74"^^xsd:int .
 
-niiri:f826be788a1ac88ee83c24f89532c22c prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:44d83170827403caee586f5f0c738aff prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:069291996dee025660d592de3e37d709
+niiri:2d968184be68de22a2c6d1f79a1a3779
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0075" ;
     nidm_clusterSizeInVoxels: "19"^^xsd:int ;
@@ -1426,9 +1426,9 @@ niiri:069291996dee025660d592de3e37d709
     nidm_qValueFDR: "0.215296978637538"^^xsd:float ;
     nidm_clusterLabelId: "75"^^xsd:int .
 
-niiri:069291996dee025660d592de3e37d709 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:2d968184be68de22a2c6d1f79a1a3779 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:83bc0d4252d6531714bcacd111e1cc46
+niiri:8c5cc0e6fb31318c9adb3b82365f2ae6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0076" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -1438,9 +1438,9 @@ niiri:83bc0d4252d6531714bcacd111e1cc46
     nidm_qValueFDR: "0.520165224837362"^^xsd:float ;
     nidm_clusterLabelId: "76"^^xsd:int .
 
-niiri:83bc0d4252d6531714bcacd111e1cc46 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:8c5cc0e6fb31318c9adb3b82365f2ae6 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:5703312bcab5b7a9d45a9c8f5e2a301f
+niiri:db5e02d87132e15c42c39a266963eb55
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0077" ;
     nidm_clusterSizeInVoxels: "19"^^xsd:int ;
@@ -1450,9 +1450,9 @@ niiri:5703312bcab5b7a9d45a9c8f5e2a301f
     nidm_qValueFDR: "0.215296978637538"^^xsd:float ;
     nidm_clusterLabelId: "77"^^xsd:int .
 
-niiri:5703312bcab5b7a9d45a9c8f5e2a301f prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:db5e02d87132e15c42c39a266963eb55 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:39fa289e8e1804e6c510280f0e399486
+niiri:6e1483cf3114e5bdc77f5e480decfc71
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0078" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1462,9 +1462,9 @@ niiri:39fa289e8e1804e6c510280f0e399486
     nidm_qValueFDR: "0.60244430753576"^^xsd:float ;
     nidm_clusterLabelId: "78"^^xsd:int .
 
-niiri:39fa289e8e1804e6c510280f0e399486 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:6e1483cf3114e5bdc77f5e480decfc71 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:aec4d890e92fb9730ea03f8d53fbe940
+niiri:1eb993430541f6c2dc79f73b3a96decc
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0079" ;
     nidm_clusterSizeInVoxels: "11"^^xsd:int ;
@@ -1474,9 +1474,9 @@ niiri:aec4d890e92fb9730ea03f8d53fbe940
     nidm_qValueFDR: "0.35008153380984"^^xsd:float ;
     nidm_clusterLabelId: "79"^^xsd:int .
 
-niiri:aec4d890e92fb9730ea03f8d53fbe940 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:1eb993430541f6c2dc79f73b3a96decc prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:6f32c27f31869cd578e8b60308359ec9
+niiri:e576b0cc1b6a471310c83c2e65672f5f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0080" ;
     nidm_clusterSizeInVoxels: "10"^^xsd:int ;
@@ -1486,9 +1486,9 @@ niiri:6f32c27f31869cd578e8b60308359ec9
     nidm_qValueFDR: "0.374104666475387"^^xsd:float ;
     nidm_clusterLabelId: "80"^^xsd:int .
 
-niiri:6f32c27f31869cd578e8b60308359ec9 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:e576b0cc1b6a471310c83c2e65672f5f prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:a2bcb1ae11c4d80d14c85b5637295099
+niiri:01a6664df87623bed0fd193f07c04638
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0081" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -1498,9 +1498,9 @@ niiri:a2bcb1ae11c4d80d14c85b5637295099
     nidm_qValueFDR: "0.520165224837362"^^xsd:float ;
     nidm_clusterLabelId: "81"^^xsd:int .
 
-niiri:a2bcb1ae11c4d80d14c85b5637295099 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:01a6664df87623bed0fd193f07c04638 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:6e5d34b600dd5cfbc70efee8ab867c9f
+niiri:9fbbe8461310da88b0ce5b0b68e8e62c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0082" ;
     nidm_clusterSizeInVoxels: "38"^^xsd:int ;
@@ -1510,9 +1510,9 @@ niiri:6e5d34b600dd5cfbc70efee8ab867c9f
     nidm_qValueFDR: "0.0696436961177701"^^xsd:float ;
     nidm_clusterLabelId: "82"^^xsd:int .
 
-niiri:6e5d34b600dd5cfbc70efee8ab867c9f prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:9fbbe8461310da88b0ce5b0b68e8e62c prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:96be67b14048a7acaffdcf5d2d455f8b
+niiri:ae14e5d65d87b53bd2bbf000849a1635
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0083" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1522,9 +1522,9 @@ niiri:96be67b14048a7acaffdcf5d2d455f8b
     nidm_qValueFDR: "0.60244430753576"^^xsd:float ;
     nidm_clusterLabelId: "83"^^xsd:int .
 
-niiri:96be67b14048a7acaffdcf5d2d455f8b prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:ae14e5d65d87b53bd2bbf000849a1635 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:bbdf3a3cea68312933b0e0f7ac23c71f
+niiri:40d7f1124d8e7cab0c81135fe2f535ad
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0084" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -1534,9 +1534,9 @@ niiri:bbdf3a3cea68312933b0e0f7ac23c71f
     nidm_qValueFDR: "0.520165224837362"^^xsd:float ;
     nidm_clusterLabelId: "84"^^xsd:int .
 
-niiri:bbdf3a3cea68312933b0e0f7ac23c71f prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:40d7f1124d8e7cab0c81135fe2f535ad prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:3cf31cb78a4315d8e0bb0e1795c2b177
+niiri:3383de798490342ce6540ea70b023ffa
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0085" ;
     nidm_clusterSizeInVoxels: "24"^^xsd:int ;
@@ -1546,9 +1546,9 @@ niiri:3cf31cb78a4315d8e0bb0e1795c2b177
     nidm_qValueFDR: "0.168341417107722"^^xsd:float ;
     nidm_clusterLabelId: "85"^^xsd:int .
 
-niiri:3cf31cb78a4315d8e0bb0e1795c2b177 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:3383de798490342ce6540ea70b023ffa prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:2de3fe021b32432646cff16795c27e84
+niiri:4bcfe0e6f6bc971e3e914655ca98bf82
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0086" ;
     nidm_clusterSizeInVoxels: "11"^^xsd:int ;
@@ -1558,9 +1558,9 @@ niiri:2de3fe021b32432646cff16795c27e84
     nidm_qValueFDR: "0.35008153380984"^^xsd:float ;
     nidm_clusterLabelId: "86"^^xsd:int .
 
-niiri:2de3fe021b32432646cff16795c27e84 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:4bcfe0e6f6bc971e3e914655ca98bf82 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:4899fcf255f8d47f7118cf27e2fd1a7d
+niiri:bbf13cce053679ff04cb1b23082b44ac
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0087" ;
     nidm_clusterSizeInVoxels: "9"^^xsd:int ;
@@ -1570,9 +1570,9 @@ niiri:4899fcf255f8d47f7118cf27e2fd1a7d
     nidm_qValueFDR: "0.411079370957833"^^xsd:float ;
     nidm_clusterLabelId: "87"^^xsd:int .
 
-niiri:4899fcf255f8d47f7118cf27e2fd1a7d prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:bbf13cce053679ff04cb1b23082b44ac prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:655cdd92103093b072ae23a6af82f68e
+niiri:2151f348776220c1024fdc2f0b0bc92f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0088" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1582,9 +1582,9 @@ niiri:655cdd92103093b072ae23a6af82f68e
     nidm_qValueFDR: "0.60244430753576"^^xsd:float ;
     nidm_clusterLabelId: "88"^^xsd:int .
 
-niiri:655cdd92103093b072ae23a6af82f68e prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:2151f348776220c1024fdc2f0b0bc92f prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:626eb7ded63e9b32e8502a0a107f553d
+niiri:8ccfe08eafd83c22c7082eb44f58a70f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0089" ;
     nidm_clusterSizeInVoxels: "36"^^xsd:int ;
@@ -1594,9 +1594,9 @@ niiri:626eb7ded63e9b32e8502a0a107f553d
     nidm_qValueFDR: "0.0751453826449104"^^xsd:float ;
     nidm_clusterLabelId: "89"^^xsd:int .
 
-niiri:626eb7ded63e9b32e8502a0a107f553d prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:8ccfe08eafd83c22c7082eb44f58a70f prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:b4ad782774b491871a7992522f937437
+niiri:bad308d46fbeeacaf458653ab9b853d6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0090" ;
     nidm_clusterSizeInVoxels: "17"^^xsd:int ;
@@ -1606,9 +1606,9 @@ niiri:b4ad782774b491871a7992522f937437
     nidm_qValueFDR: "0.233234793433793"^^xsd:float ;
     nidm_clusterLabelId: "90"^^xsd:int .
 
-niiri:b4ad782774b491871a7992522f937437 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:bad308d46fbeeacaf458653ab9b853d6 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:677611b98bfd5eb8fbc23315abaa9320
+niiri:687916ac6701ade9ca268dec72dc0c0d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0091" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1618,9 +1618,9 @@ niiri:677611b98bfd5eb8fbc23315abaa9320
     nidm_qValueFDR: "0.60244430753576"^^xsd:float ;
     nidm_clusterLabelId: "91"^^xsd:int .
 
-niiri:677611b98bfd5eb8fbc23315abaa9320 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:687916ac6701ade9ca268dec72dc0c0d prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:0dbd53cf7610b049d137c94d182a0076
+niiri:9071142b0c2683c96f4377cdddced1d0
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0092" ;
     nidm_clusterSizeInVoxels: "22"^^xsd:int ;
@@ -1630,9 +1630,9 @@ niiri:0dbd53cf7610b049d137c94d182a0076
     nidm_qValueFDR: "0.185466956323999"^^xsd:float ;
     nidm_clusterLabelId: "92"^^xsd:int .
 
-niiri:0dbd53cf7610b049d137c94d182a0076 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:9071142b0c2683c96f4377cdddced1d0 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:76019faf9ae4e38fc7ae7798a2f879f4
+niiri:884f659ac62495dd158e264f576d0fc2
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0093" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -1642,9 +1642,9 @@ niiri:76019faf9ae4e38fc7ae7798a2f879f4
     nidm_qValueFDR: "0.520165224837362"^^xsd:float ;
     nidm_clusterLabelId: "93"^^xsd:int .
 
-niiri:76019faf9ae4e38fc7ae7798a2f879f4 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:884f659ac62495dd158e264f576d0fc2 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:e6b0f9d536c2b1a1fd955a8eaff2a2df
+niiri:2088eea3a39320e89e2a625ec7e9f82e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0094" ;
     nidm_clusterSizeInVoxels: "12"^^xsd:int ;
@@ -1654,9 +1654,9 @@ niiri:e6b0f9d536c2b1a1fd955a8eaff2a2df
     nidm_qValueFDR: "0.325388258851229"^^xsd:float ;
     nidm_clusterLabelId: "94"^^xsd:int .
 
-niiri:e6b0f9d536c2b1a1fd955a8eaff2a2df prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:2088eea3a39320e89e2a625ec7e9f82e prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:7fee2fcd04048e290bf06db1c5562ffd
+niiri:7fc88d60dca200d4c67a0a607a345633
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0095" ;
     nidm_clusterSizeInVoxels: "18"^^xsd:int ;
@@ -1666,9 +1666,9 @@ niiri:7fee2fcd04048e290bf06db1c5562ffd
     nidm_qValueFDR: "0.225307419263672"^^xsd:float ;
     nidm_clusterLabelId: "95"^^xsd:int .
 
-niiri:7fee2fcd04048e290bf06db1c5562ffd prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:7fc88d60dca200d4c67a0a607a345633 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:a544035a692226b8c28c019b1e283632
+niiri:ca1da2e7a46f823f402d9c62e070d0fc
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0096" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -1678,9 +1678,9 @@ niiri:a544035a692226b8c28c019b1e283632
     nidm_qValueFDR: "0.483511810560871"^^xsd:float ;
     nidm_clusterLabelId: "96"^^xsd:int .
 
-niiri:a544035a692226b8c28c019b1e283632 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:ca1da2e7a46f823f402d9c62e070d0fc prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:9c40cb58c75073f4f983d06c6a655c74
+niiri:ea6ee099e3b8edbdd2bde04e8682a6ce
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0097" ;
     nidm_clusterSizeInVoxels: "9"^^xsd:int ;
@@ -1690,9 +1690,9 @@ niiri:9c40cb58c75073f4f983d06c6a655c74
     nidm_qValueFDR: "0.411079370957833"^^xsd:float ;
     nidm_clusterLabelId: "97"^^xsd:int .
 
-niiri:9c40cb58c75073f4f983d06c6a655c74 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:ea6ee099e3b8edbdd2bde04e8682a6ce prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:f8d5d9e3adb56590f1e9d795fa0fb5b7
+niiri:1ef7113e2a59f273a63186ced0b0fc6b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0098" ;
     nidm_clusterSizeInVoxels: "15"^^xsd:int ;
@@ -1702,9 +1702,9 @@ niiri:f8d5d9e3adb56590f1e9d795fa0fb5b7
     nidm_qValueFDR: "0.26079004694974"^^xsd:float ;
     nidm_clusterLabelId: "98"^^xsd:int .
 
-niiri:f8d5d9e3adb56590f1e9d795fa0fb5b7 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:1ef7113e2a59f273a63186ced0b0fc6b prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:d763c6c8de6f4537a51f15146880d851
+niiri:02f0aee7ff558248fe49e5f3579c0585
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0099" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -1714,9 +1714,9 @@ niiri:d763c6c8de6f4537a51f15146880d851
     nidm_qValueFDR: "0.453931333453761"^^xsd:float ;
     nidm_clusterLabelId: "99"^^xsd:int .
 
-niiri:d763c6c8de6f4537a51f15146880d851 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:02f0aee7ff558248fe49e5f3579c0585 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:c81c855fadc265b4e1ccb72361a5ab5b
+niiri:c2cda63a78bcde6ae7a69f7ab8eadb2c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0100" ;
     nidm_clusterSizeInVoxels: "10"^^xsd:int ;
@@ -1726,9 +1726,9 @@ niiri:c81c855fadc265b4e1ccb72361a5ab5b
     nidm_qValueFDR: "0.374104666475387"^^xsd:float ;
     nidm_clusterLabelId: "100"^^xsd:int .
 
-niiri:c81c855fadc265b4e1ccb72361a5ab5b prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:c2cda63a78bcde6ae7a69f7ab8eadb2c prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:adb14ea605c87220ed90422a86d00cf7
+niiri:2c7f2ff6921dbb36e89f44a3a1dd839b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0101" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1738,9 +1738,9 @@ niiri:adb14ea605c87220ed90422a86d00cf7
     nidm_qValueFDR: "0.654795742860352"^^xsd:float ;
     nidm_clusterLabelId: "101"^^xsd:int .
 
-niiri:adb14ea605c87220ed90422a86d00cf7 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:2c7f2ff6921dbb36e89f44a3a1dd839b prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:d5aa67ffe10d81e16892509076504f14
+niiri:03e03b97c9ae144949ccd274ec79dd81
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0102" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -1750,9 +1750,9 @@ niiri:d5aa67ffe10d81e16892509076504f14
     nidm_qValueFDR: "0.483511810560871"^^xsd:float ;
     nidm_clusterLabelId: "102"^^xsd:int .
 
-niiri:d5aa67ffe10d81e16892509076504f14 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:03e03b97c9ae144949ccd274ec79dd81 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:3fae830c70c9ca8cf8f3cbed4301161f
+niiri:036f2836a317a98100c1a6652ab21784
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0103" ;
     nidm_clusterSizeInVoxels: "13"^^xsd:int ;
@@ -1762,9 +1762,9 @@ niiri:3fae830c70c9ca8cf8f3cbed4301161f
     nidm_qValueFDR: "0.30770835935652"^^xsd:float ;
     nidm_clusterLabelId: "103"^^xsd:int .
 
-niiri:3fae830c70c9ca8cf8f3cbed4301161f prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:036f2836a317a98100c1a6652ab21784 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:c35054132a92b4bf34b2e1b8acd96c91
+niiri:a029a63406d370c8869c59656bb90a54
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0104" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1774,9 +1774,9 @@ niiri:c35054132a92b4bf34b2e1b8acd96c91
     nidm_qValueFDR: "0.60244430753576"^^xsd:float ;
     nidm_clusterLabelId: "104"^^xsd:int .
 
-niiri:c35054132a92b4bf34b2e1b8acd96c91 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:a029a63406d370c8869c59656bb90a54 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:21c649902d379fc9de7f1be15e128c6b
+niiri:c429131bcf59cefceae4a934fd1aa80a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0105" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1786,9 +1786,9 @@ niiri:21c649902d379fc9de7f1be15e128c6b
     nidm_qValueFDR: "0.654795742860352"^^xsd:float ;
     nidm_clusterLabelId: "105"^^xsd:int .
 
-niiri:21c649902d379fc9de7f1be15e128c6b prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:c429131bcf59cefceae4a934fd1aa80a prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:24ec764638d7b84cf388c10bdbf8e52e
+niiri:9ac7226087de1c45b555519c1250dc59
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0106" ;
     nidm_clusterSizeInVoxels: "17"^^xsd:int ;
@@ -1798,9 +1798,9 @@ niiri:24ec764638d7b84cf388c10bdbf8e52e
     nidm_qValueFDR: "0.233234793433793"^^xsd:float ;
     nidm_clusterLabelId: "106"^^xsd:int .
 
-niiri:24ec764638d7b84cf388c10bdbf8e52e prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:9ac7226087de1c45b555519c1250dc59 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:7e5ff536134bdc8ab5fcb743674e90c4
+niiri:9c1fe61e0e5d7d3b62e90ebdfdb9d4d4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0107" ;
     nidm_clusterSizeInVoxels: "14"^^xsd:int ;
@@ -1810,9 +1810,9 @@ niiri:7e5ff536134bdc8ab5fcb743674e90c4
     nidm_qValueFDR: "0.28101653917298"^^xsd:float ;
     nidm_clusterLabelId: "107"^^xsd:int .
 
-niiri:7e5ff536134bdc8ab5fcb743674e90c4 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:9c1fe61e0e5d7d3b62e90ebdfdb9d4d4 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:ec6922a6284384102e3683f4f534bdd4
+niiri:7489f5e950ff72b41ea437f2c2026c6f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0108" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1822,9 +1822,9 @@ niiri:ec6922a6284384102e3683f4f534bdd4
     nidm_qValueFDR: "0.60244430753576"^^xsd:float ;
     nidm_clusterLabelId: "108"^^xsd:int .
 
-niiri:ec6922a6284384102e3683f4f534bdd4 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:7489f5e950ff72b41ea437f2c2026c6f prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:1587d965de8a227487a386f18a622f62
+niiri:e83b9cd4cb9554eedc76bd43c766b08d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0109" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1834,9 +1834,9 @@ niiri:1587d965de8a227487a386f18a622f62
     nidm_qValueFDR: "0.654795742860352"^^xsd:float ;
     nidm_clusterLabelId: "109"^^xsd:int .
 
-niiri:1587d965de8a227487a386f18a622f62 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:e83b9cd4cb9554eedc76bd43c766b08d prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:cde75203fe8335e4da3e8277987b76e3
+niiri:6f3ca580fb0dafec12bb76f49a9e660f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0110" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -1846,9 +1846,9 @@ niiri:cde75203fe8335e4da3e8277987b76e3
     nidm_qValueFDR: "0.453931333453761"^^xsd:float ;
     nidm_clusterLabelId: "110"^^xsd:int .
 
-niiri:cde75203fe8335e4da3e8277987b76e3 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:6f3ca580fb0dafec12bb76f49a9e660f prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:1963461ba0ecaf2bdd626d72af091d83
+niiri:37ee2d388f0d21999c13e5808ab4abaa
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0111" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -1858,9 +1858,9 @@ niiri:1963461ba0ecaf2bdd626d72af091d83
     nidm_qValueFDR: "0.483511810560871"^^xsd:float ;
     nidm_clusterLabelId: "111"^^xsd:int .
 
-niiri:1963461ba0ecaf2bdd626d72af091d83 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:37ee2d388f0d21999c13e5808ab4abaa prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:031b2ebac9374480bd55f336b2f0698d
+niiri:17c3d65f0a2dd8b609c3139c41ebf930
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0112" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -1870,9 +1870,9 @@ niiri:031b2ebac9374480bd55f336b2f0698d
     nidm_qValueFDR: "0.483511810560871"^^xsd:float ;
     nidm_clusterLabelId: "112"^^xsd:int .
 
-niiri:031b2ebac9374480bd55f336b2f0698d prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:17c3d65f0a2dd8b609c3139c41ebf930 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:8424ab2f8e8a8fcd5c99b549000e3d8a
+niiri:bbd0acc33408cc31d2590c5760c85985
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0113" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1882,9 +1882,9 @@ niiri:8424ab2f8e8a8fcd5c99b549000e3d8a
     nidm_qValueFDR: "0.60244430753576"^^xsd:float ;
     nidm_clusterLabelId: "113"^^xsd:int .
 
-niiri:8424ab2f8e8a8fcd5c99b549000e3d8a prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:bbd0acc33408cc31d2590c5760c85985 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:cb3496ce3deece902bd5c57224f82327
+niiri:04aa6294da937ca4a062fce158511fb6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0114" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1894,9 +1894,9 @@ niiri:cb3496ce3deece902bd5c57224f82327
     nidm_qValueFDR: "0.690223976658915"^^xsd:float ;
     nidm_clusterLabelId: "114"^^xsd:int .
 
-niiri:cb3496ce3deece902bd5c57224f82327 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:04aa6294da937ca4a062fce158511fb6 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:a3a27b078e8a7d6edcf7ae4db82c3d7a
+niiri:6e2a6189013a78c14191e7633ed21b0a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0115" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1906,9 +1906,9 @@ niiri:a3a27b078e8a7d6edcf7ae4db82c3d7a
     nidm_qValueFDR: "0.60244430753576"^^xsd:float ;
     nidm_clusterLabelId: "115"^^xsd:int .
 
-niiri:a3a27b078e8a7d6edcf7ae4db82c3d7a prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:6e2a6189013a78c14191e7633ed21b0a prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:4f03ee575ea9164c216c53e2e6502c3f
+niiri:81840f3ae0159e07fac81fc13e72fbf5
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0116" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1918,9 +1918,9 @@ niiri:4f03ee575ea9164c216c53e2e6502c3f
     nidm_qValueFDR: "0.60244430753576"^^xsd:float ;
     nidm_clusterLabelId: "116"^^xsd:int .
 
-niiri:4f03ee575ea9164c216c53e2e6502c3f prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:81840f3ae0159e07fac81fc13e72fbf5 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:8ddc263efb94c47b4f51cbca78984739
+niiri:dd602a84f4dd916125d3c669097eec23
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0117" ;
     nidm_clusterSizeInVoxels: "10"^^xsd:int ;
@@ -1930,9 +1930,9 @@ niiri:8ddc263efb94c47b4f51cbca78984739
     nidm_qValueFDR: "0.374104666475387"^^xsd:float ;
     nidm_clusterLabelId: "117"^^xsd:int .
 
-niiri:8ddc263efb94c47b4f51cbca78984739 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:dd602a84f4dd916125d3c669097eec23 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:b615db2c02106c19996d725a76dd5932
+niiri:1c2363e827044fb757d9bf0cf8e052e5
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0118" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1942,9 +1942,9 @@ niiri:b615db2c02106c19996d725a76dd5932
     nidm_qValueFDR: "0.654795742860352"^^xsd:float ;
     nidm_clusterLabelId: "118"^^xsd:int .
 
-niiri:b615db2c02106c19996d725a76dd5932 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:1c2363e827044fb757d9bf0cf8e052e5 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:6e455b57979dad222384fa2bedf5c673
+niiri:45132e41bd386f5b430c16f7c2c90e0a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0119" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -1954,9 +1954,9 @@ niiri:6e455b57979dad222384fa2bedf5c673
     nidm_qValueFDR: "0.576232956029303"^^xsd:float ;
     nidm_clusterLabelId: "119"^^xsd:int .
 
-niiri:6e455b57979dad222384fa2bedf5c673 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:45132e41bd386f5b430c16f7c2c90e0a prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:59697598e154d20a6b71266d474312af
+niiri:c4e5f3528c31047605f368909a0632ee
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0120" ;
     nidm_clusterSizeInVoxels: "15"^^xsd:int ;
@@ -1966,9 +1966,9 @@ niiri:59697598e154d20a6b71266d474312af
     nidm_qValueFDR: "0.26079004694974"^^xsd:float ;
     nidm_clusterLabelId: "120"^^xsd:int .
 
-niiri:59697598e154d20a6b71266d474312af prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:c4e5f3528c31047605f368909a0632ee prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:737e8596c1e48716edbdb5c9d774c8a2
+niiri:1355ee0795599ee6287d2b70ebc8d729
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0121" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1978,9 +1978,9 @@ niiri:737e8596c1e48716edbdb5c9d774c8a2
     nidm_qValueFDR: "0.60244430753576"^^xsd:float ;
     nidm_clusterLabelId: "121"^^xsd:int .
 
-niiri:737e8596c1e48716edbdb5c9d774c8a2 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:1355ee0795599ee6287d2b70ebc8d729 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:6e426d70bd3515ce04a9030b5a306cc1
+niiri:370789fb0338d1e1885081e0362c340f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0122" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1990,9 +1990,9 @@ niiri:6e426d70bd3515ce04a9030b5a306cc1
     nidm_qValueFDR: "0.654795742860352"^^xsd:float ;
     nidm_clusterLabelId: "122"^^xsd:int .
 
-niiri:6e426d70bd3515ce04a9030b5a306cc1 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:370789fb0338d1e1885081e0362c340f prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:8b57f16537b5d60872068ffb74ea46c2
+niiri:40392b1ab652b1fe41dac16581269fb2
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0123" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2002,9 +2002,9 @@ niiri:8b57f16537b5d60872068ffb74ea46c2
     nidm_qValueFDR: "0.654795742860352"^^xsd:float ;
     nidm_clusterLabelId: "123"^^xsd:int .
 
-niiri:8b57f16537b5d60872068ffb74ea46c2 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:40392b1ab652b1fe41dac16581269fb2 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:57fac0849992a04e841522c89a1e8fad
+niiri:65ef2c95ae3f51b5861bb20b84514bd9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0124" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2014,9 +2014,9 @@ niiri:57fac0849992a04e841522c89a1e8fad
     nidm_qValueFDR: "0.690223976658915"^^xsd:float ;
     nidm_clusterLabelId: "124"^^xsd:int .
 
-niiri:57fac0849992a04e841522c89a1e8fad prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:65ef2c95ae3f51b5861bb20b84514bd9 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:7d9186e6ae7abd1a3b75051676646bf7
+niiri:5cc71319d109fdb0ef9f0f9c7bd41492
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0125" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2026,9 +2026,9 @@ niiri:7d9186e6ae7abd1a3b75051676646bf7
     nidm_qValueFDR: "0.690223976658915"^^xsd:float ;
     nidm_clusterLabelId: "125"^^xsd:int .
 
-niiri:7d9186e6ae7abd1a3b75051676646bf7 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:5cc71319d109fdb0ef9f0f9c7bd41492 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:05a6f19551a73fb9cdefb486a3b7d7c7
+niiri:4bf75a353d782554be968730ac4840cd
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0126" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -2038,9 +2038,9 @@ niiri:05a6f19551a73fb9cdefb486a3b7d7c7
     nidm_qValueFDR: "0.654795742860352"^^xsd:float ;
     nidm_clusterLabelId: "126"^^xsd:int .
 
-niiri:05a6f19551a73fb9cdefb486a3b7d7c7 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:4bf75a353d782554be968730ac4840cd prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:f652c5b4f145cc8a8477c98b20d1e8e7
+niiri:332041ad6aeaf3a74891ecd53c374a96
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0127" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2050,9 +2050,9 @@ niiri:f652c5b4f145cc8a8477c98b20d1e8e7
     nidm_qValueFDR: "0.654795742860352"^^xsd:float ;
     nidm_clusterLabelId: "127"^^xsd:int .
 
-niiri:f652c5b4f145cc8a8477c98b20d1e8e7 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:332041ad6aeaf3a74891ecd53c374a96 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:220f34dd841d349b45f448f4ed96568e
+niiri:b47672c30d95e784941e629a0021b66b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0128" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -2062,9 +2062,9 @@ niiri:220f34dd841d349b45f448f4ed96568e
     nidm_qValueFDR: "0.654795742860352"^^xsd:float ;
     nidm_clusterLabelId: "128"^^xsd:int .
 
-niiri:220f34dd841d349b45f448f4ed96568e prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:b47672c30d95e784941e629a0021b66b prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:73421e1373e081b7d78772065fdc0ab7
+niiri:4ade8b0865402c36f9bde1298af17ab4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0129" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2074,9 +2074,9 @@ niiri:73421e1373e081b7d78772065fdc0ab7
     nidm_qValueFDR: "0.654795742860352"^^xsd:float ;
     nidm_clusterLabelId: "129"^^xsd:int .
 
-niiri:73421e1373e081b7d78772065fdc0ab7 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:4ade8b0865402c36f9bde1298af17ab4 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:fd107443c1e505341538e35623ef13ad
+niiri:8d46ffe6156e40b274554eb8fc558f49
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0130" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -2086,9 +2086,9 @@ niiri:fd107443c1e505341538e35623ef13ad
     nidm_qValueFDR: "0.483511810560871"^^xsd:float ;
     nidm_clusterLabelId: "130"^^xsd:int .
 
-niiri:fd107443c1e505341538e35623ef13ad prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:8d46ffe6156e40b274554eb8fc558f49 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:32a1c5504e28cf0e83bddf4c41d902c9
+niiri:4d3c4f523d2ecfeb9befc1c5babb099d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0131" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2098,9 +2098,9 @@ niiri:32a1c5504e28cf0e83bddf4c41d902c9
     nidm_qValueFDR: "0.654795742860352"^^xsd:float ;
     nidm_clusterLabelId: "131"^^xsd:int .
 
-niiri:32a1c5504e28cf0e83bddf4c41d902c9 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:4d3c4f523d2ecfeb9befc1c5babb099d prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:4c3e4e7060e2b7cf9ba40d556d3850b1
+niiri:24a29d9d6136d7a26f77ad7395967c47
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0132" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2110,9 +2110,9 @@ niiri:4c3e4e7060e2b7cf9ba40d556d3850b1
     nidm_qValueFDR: "0.690223976658915"^^xsd:float ;
     nidm_clusterLabelId: "132"^^xsd:int .
 
-niiri:4c3e4e7060e2b7cf9ba40d556d3850b1 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:24a29d9d6136d7a26f77ad7395967c47 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:908b3d895326bd3ac6957280d4de7d76
+niiri:7289b1de1e9e889ff1fb5691142cd967
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0133" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2122,9 +2122,9 @@ niiri:908b3d895326bd3ac6957280d4de7d76
     nidm_qValueFDR: "0.690223976658915"^^xsd:float ;
     nidm_clusterLabelId: "133"^^xsd:int .
 
-niiri:908b3d895326bd3ac6957280d4de7d76 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:7289b1de1e9e889ff1fb5691142cd967 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:000f81203c82e4c9e73a3c6aace6130e
+niiri:4465bf32a18439b39ae380aba9c3f3b0
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0134" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2134,9 +2134,9 @@ niiri:000f81203c82e4c9e73a3c6aace6130e
     nidm_qValueFDR: "0.654795742860352"^^xsd:float ;
     nidm_clusterLabelId: "134"^^xsd:int .
 
-niiri:000f81203c82e4c9e73a3c6aace6130e prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:4465bf32a18439b39ae380aba9c3f3b0 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:1a6f934195839bd5aafde8865b102795
+niiri:1cd15156a67e7cd4faba9f06d50293c8
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0135" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2146,9 +2146,9 @@ niiri:1a6f934195839bd5aafde8865b102795
     nidm_qValueFDR: "0.690223976658915"^^xsd:float ;
     nidm_clusterLabelId: "135"^^xsd:int .
 
-niiri:1a6f934195839bd5aafde8865b102795 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:1cd15156a67e7cd4faba9f06d50293c8 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:6179fefaf9c60c4a862df01568a93c88
+niiri:ad7c299b4aa35cd98fdbd415f19783a7
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0136" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2158,9 +2158,9 @@ niiri:6179fefaf9c60c4a862df01568a93c88
     nidm_qValueFDR: "0.690223976658915"^^xsd:float ;
     nidm_clusterLabelId: "136"^^xsd:int .
 
-niiri:6179fefaf9c60c4a862df01568a93c88 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:ad7c299b4aa35cd98fdbd415f19783a7 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:a1eaf067aa20aea18c22e185e1ee2f97
+niiri:fe8b635d8a705b40fb4ced016e9d726a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0137" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2170,9 +2170,9 @@ niiri:a1eaf067aa20aea18c22e185e1ee2f97
     nidm_qValueFDR: "0.654795742860352"^^xsd:float ;
     nidm_clusterLabelId: "137"^^xsd:int .
 
-niiri:a1eaf067aa20aea18c22e185e1ee2f97 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:fe8b635d8a705b40fb4ced016e9d726a prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:e3d6362d81a3c6aaee10e57f2d21a4b6
+niiri:71e15e602f95bdd78bc912bf527abf9d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0138" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2182,9 +2182,9 @@ niiri:e3d6362d81a3c6aaee10e57f2d21a4b6
     nidm_qValueFDR: "0.690223976658915"^^xsd:float ;
     nidm_clusterLabelId: "138"^^xsd:int .
 
-niiri:e3d6362d81a3c6aaee10e57f2d21a4b6 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:71e15e602f95bdd78bc912bf527abf9d prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:d40597f499b8e4493f5c750b1bb49759
+niiri:46e2492f096548abf33dea89e7a868bc
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0139" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2194,9 +2194,9 @@ niiri:d40597f499b8e4493f5c750b1bb49759
     nidm_qValueFDR: "0.690223976658915"^^xsd:float ;
     nidm_clusterLabelId: "139"^^xsd:int .
 
-niiri:d40597f499b8e4493f5c750b1bb49759 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:46e2492f096548abf33dea89e7a868bc prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:965898643a16b92a90cc3cfaafcd3c48
+niiri:f234bb306a90feca64756c5add571e95
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0140" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2206,9 +2206,9 @@ niiri:965898643a16b92a90cc3cfaafcd3c48
     nidm_qValueFDR: "0.654795742860352"^^xsd:float ;
     nidm_clusterLabelId: "140"^^xsd:int .
 
-niiri:965898643a16b92a90cc3cfaafcd3c48 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:f234bb306a90feca64756c5add571e95 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:d1ba7d5acbc118fa7879e7e4e6844b1d
+niiri:9a23d6bdea30bc505d71bdea4b14cc81
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0141" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2218,9 +2218,9 @@ niiri:d1ba7d5acbc118fa7879e7e4e6844b1d
     nidm_qValueFDR: "0.654795742860352"^^xsd:float ;
     nidm_clusterLabelId: "141"^^xsd:int .
 
-niiri:d1ba7d5acbc118fa7879e7e4e6844b1d prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:9a23d6bdea30bc505d71bdea4b14cc81 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:a9f3103d256c0dc28abb00c6f6a495ee
+niiri:55a2e8a69b22f0385eb446ff36f57cd5
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0142" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2230,9 +2230,9 @@ niiri:a9f3103d256c0dc28abb00c6f6a495ee
     nidm_qValueFDR: "0.690223976658915"^^xsd:float ;
     nidm_clusterLabelId: "142"^^xsd:int .
 
-niiri:a9f3103d256c0dc28abb00c6f6a495ee prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:55a2e8a69b22f0385eb446ff36f57cd5 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:a6963a6fd81257c75c10efb4a812813d
+niiri:c1b67e6fa1bc1b0441ef946f06fc7939
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0143" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2242,9 +2242,9 @@ niiri:a6963a6fd81257c75c10efb4a812813d
     nidm_qValueFDR: "0.690223976658915"^^xsd:float ;
     nidm_clusterLabelId: "143"^^xsd:int .
 
-niiri:a6963a6fd81257c75c10efb4a812813d prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:c1b67e6fa1bc1b0441ef946f06fc7939 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:60ac234a805ede443ca63c3de0f14e32
+niiri:598d8f8cb448fe66f29b80c3e9c6b8c7
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0144" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -2254,9 +2254,9 @@ niiri:60ac234a805ede443ca63c3de0f14e32
     nidm_qValueFDR: "0.60244430753576"^^xsd:float ;
     nidm_clusterLabelId: "144"^^xsd:int .
 
-niiri:60ac234a805ede443ca63c3de0f14e32 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:598d8f8cb448fe66f29b80c3e9c6b8c7 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:c00dd1395bbc6f074ad431089be26084
+niiri:9e74994c43b00fa8f3c04ed564b75259
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0145" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2266,9 +2266,9 @@ niiri:c00dd1395bbc6f074ad431089be26084
     nidm_qValueFDR: "0.690223976658915"^^xsd:float ;
     nidm_clusterLabelId: "145"^^xsd:int .
 
-niiri:c00dd1395bbc6f074ad431089be26084 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:9e74994c43b00fa8f3c04ed564b75259 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:911801103dad8b9c7f55df419fdee788
+niiri:59f7c04e9a6910158fa3c13760b2a417
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0146" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2278,9 +2278,9 @@ niiri:911801103dad8b9c7f55df419fdee788
     nidm_qValueFDR: "0.654795742860352"^^xsd:float ;
     nidm_clusterLabelId: "146"^^xsd:int .
 
-niiri:911801103dad8b9c7f55df419fdee788 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:59f7c04e9a6910158fa3c13760b2a417 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:48d4b018c043db4e0876cc1418962d0a
+niiri:81a8b467cb1446f1ff5cdaa2c7d6e479
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0147" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2290,9 +2290,9 @@ niiri:48d4b018c043db4e0876cc1418962d0a
     nidm_qValueFDR: "0.654795742860352"^^xsd:float ;
     nidm_clusterLabelId: "147"^^xsd:int .
 
-niiri:48d4b018c043db4e0876cc1418962d0a prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:81a8b467cb1446f1ff5cdaa2c7d6e479 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:7c2265b55eb6b5357939defcb818c9dd
+niiri:b6cb8a909916808e62aec6d7aa7ee1b8
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0148" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2302,9 +2302,9 @@ niiri:7c2265b55eb6b5357939defcb818c9dd
     nidm_qValueFDR: "0.690223976658915"^^xsd:float ;
     nidm_clusterLabelId: "148"^^xsd:int .
 
-niiri:7c2265b55eb6b5357939defcb818c9dd prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:b6cb8a909916808e62aec6d7aa7ee1b8 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:1f5d5a2bac2575d7232fa251d172c68f
+niiri:50e1d73ec7323535a313db319aa8fda1
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0149" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -2314,9 +2314,9 @@ niiri:1f5d5a2bac2575d7232fa251d172c68f
     nidm_qValueFDR: "0.520165224837362"^^xsd:float ;
     nidm_clusterLabelId: "149"^^xsd:int .
 
-niiri:1f5d5a2bac2575d7232fa251d172c68f prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:50e1d73ec7323535a313db319aa8fda1 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:12c379cdb678fa3f360c5174016779ac
+niiri:7dcc4c8a94cbe8b1b1f9e1f46a8741d3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0150" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2326,9 +2326,9 @@ niiri:12c379cdb678fa3f360c5174016779ac
     nidm_qValueFDR: "0.654795742860352"^^xsd:float ;
     nidm_clusterLabelId: "150"^^xsd:int .
 
-niiri:12c379cdb678fa3f360c5174016779ac prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:7dcc4c8a94cbe8b1b1f9e1f46a8741d3 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:7238de23a632331ed72cd39240a7d4d5
+niiri:b54fdacdf6871d0d178386e52e6bcf8e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0151" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -2338,9 +2338,9 @@ niiri:7238de23a632331ed72cd39240a7d4d5
     nidm_qValueFDR: "0.654795742860352"^^xsd:float ;
     nidm_clusterLabelId: "151"^^xsd:int .
 
-niiri:7238de23a632331ed72cd39240a7d4d5 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:b54fdacdf6871d0d178386e52e6bcf8e prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:90c9af05cf8cff54600fa41f0a61a708
+niiri:22043ef18c61c537ac8a05e639b5f722
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0152" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -2350,9 +2350,9 @@ niiri:90c9af05cf8cff54600fa41f0a61a708
     nidm_qValueFDR: "0.576232956029303"^^xsd:float ;
     nidm_clusterLabelId: "152"^^xsd:int .
 
-niiri:90c9af05cf8cff54600fa41f0a61a708 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:22043ef18c61c537ac8a05e639b5f722 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:1aab52c0fe0f750adfdb1e30721e6758
+niiri:fd886d44827bbf7fd4cd36a6fa24a0dc
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0153" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2362,9 +2362,9 @@ niiri:1aab52c0fe0f750adfdb1e30721e6758
     nidm_qValueFDR: "0.690223976658915"^^xsd:float ;
     nidm_clusterLabelId: "153"^^xsd:int .
 
-niiri:1aab52c0fe0f750adfdb1e30721e6758 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:fd886d44827bbf7fd4cd36a6fa24a0dc prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:08248410e312407cc447ee8d99d1d449
+niiri:e782c57868e4be48647d27ca19f3f3c2
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0154" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -2374,9 +2374,9 @@ niiri:08248410e312407cc447ee8d99d1d449
     nidm_qValueFDR: "0.654795742860352"^^xsd:float ;
     nidm_clusterLabelId: "154"^^xsd:int .
 
-niiri:08248410e312407cc447ee8d99d1d449 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:e782c57868e4be48647d27ca19f3f3c2 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:837d994ade992773480832f35a3ea15b
+niiri:f434c353ca0df61bb269a9c7f670117c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0155" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2386,9 +2386,9 @@ niiri:837d994ade992773480832f35a3ea15b
     nidm_qValueFDR: "0.654795742860352"^^xsd:float ;
     nidm_clusterLabelId: "155"^^xsd:int .
 
-niiri:837d994ade992773480832f35a3ea15b prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:f434c353ca0df61bb269a9c7f670117c prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:ec417a43750788f61cf51df2e50808c5
+niiri:0ccff4009d26155a785837676412d40e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0156" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2398,9 +2398,9 @@ niiri:ec417a43750788f61cf51df2e50808c5
     nidm_qValueFDR: "0.654795742860352"^^xsd:float ;
     nidm_clusterLabelId: "156"^^xsd:int .
 
-niiri:ec417a43750788f61cf51df2e50808c5 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:0ccff4009d26155a785837676412d40e prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:5f3c04257193f8ded9ef85828608888b
+niiri:800c8b037dc30701b156bb7c32952fad
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0157" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2410,9 +2410,9 @@ niiri:5f3c04257193f8ded9ef85828608888b
     nidm_qValueFDR: "0.654795742860352"^^xsd:float ;
     nidm_clusterLabelId: "157"^^xsd:int .
 
-niiri:5f3c04257193f8ded9ef85828608888b prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:800c8b037dc30701b156bb7c32952fad prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:d50af5499fc7c0898889af641bf5dae2
+niiri:783b5fc0e23ce088341f9b979cd6ab07
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0158" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2422,9 +2422,9 @@ niiri:d50af5499fc7c0898889af641bf5dae2
     nidm_qValueFDR: "0.690223976658915"^^xsd:float ;
     nidm_clusterLabelId: "158"^^xsd:int .
 
-niiri:d50af5499fc7c0898889af641bf5dae2 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:783b5fc0e23ce088341f9b979cd6ab07 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:301ccd51f1c98193e0b8474c0344334b
+niiri:eeecebef37458a809e6ef90a22514949
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0159" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2434,9 +2434,9 @@ niiri:301ccd51f1c98193e0b8474c0344334b
     nidm_qValueFDR: "0.654795742860352"^^xsd:float ;
     nidm_clusterLabelId: "159"^^xsd:int .
 
-niiri:301ccd51f1c98193e0b8474c0344334b prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:eeecebef37458a809e6ef90a22514949 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:005ca6c90e1fc6c5ee2dad1ef8e090a4
+niiri:9e9084297f3aec6679c40f52af1c9c5c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0160" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2446,9 +2446,9 @@ niiri:005ca6c90e1fc6c5ee2dad1ef8e090a4
     nidm_qValueFDR: "0.654795742860352"^^xsd:float ;
     nidm_clusterLabelId: "160"^^xsd:int .
 
-niiri:005ca6c90e1fc6c5ee2dad1ef8e090a4 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:9e9084297f3aec6679c40f52af1c9c5c prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:fc3a8b55f288365aa4cfd22a7a666181
+niiri:dc54137a08092762cc961c9285859566
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0161" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2458,9 +2458,9 @@ niiri:fc3a8b55f288365aa4cfd22a7a666181
     nidm_qValueFDR: "0.690223976658915"^^xsd:float ;
     nidm_clusterLabelId: "161"^^xsd:int .
 
-niiri:fc3a8b55f288365aa4cfd22a7a666181 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:dc54137a08092762cc961c9285859566 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:e47c402c0100f7defbaf50bdcc093c1b
+niiri:9ff86139e0b5b4951d06b07e9a923ed4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0162" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2470,9 +2470,9 @@ niiri:e47c402c0100f7defbaf50bdcc093c1b
     nidm_qValueFDR: "0.690223976658915"^^xsd:float ;
     nidm_clusterLabelId: "162"^^xsd:int .
 
-niiri:e47c402c0100f7defbaf50bdcc093c1b prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:9ff86139e0b5b4951d06b07e9a923ed4 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:db2fdb0a656161d3af9766d9e89d922c
+niiri:8a8ea66289482bc8790b162d4c9789ef
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0163" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2482,9 +2482,9 @@ niiri:db2fdb0a656161d3af9766d9e89d922c
     nidm_qValueFDR: "0.654795742860352"^^xsd:float ;
     nidm_clusterLabelId: "163"^^xsd:int .
 
-niiri:db2fdb0a656161d3af9766d9e89d922c prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:8a8ea66289482bc8790b162d4c9789ef prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:9999ed39d65e3e020fe7293a38d50b01
+niiri:05c885a40fe6550c25d2a55d7c3808dc
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0164" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2494,9 +2494,9 @@ niiri:9999ed39d65e3e020fe7293a38d50b01
     nidm_qValueFDR: "0.654795742860352"^^xsd:float ;
     nidm_clusterLabelId: "164"^^xsd:int .
 
-niiri:9999ed39d65e3e020fe7293a38d50b01 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:05c885a40fe6550c25d2a55d7c3808dc prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:ef7b89c154bf8954bad4e84699ecd010
+niiri:1285ada80442ae469e874ddbb7e341cc
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0165" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2506,9 +2506,9 @@ niiri:ef7b89c154bf8954bad4e84699ecd010
     nidm_qValueFDR: "0.654795742860352"^^xsd:float ;
     nidm_clusterLabelId: "165"^^xsd:int .
 
-niiri:ef7b89c154bf8954bad4e84699ecd010 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:1285ada80442ae469e874ddbb7e341cc prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:202b2ec8923685d33ff8474567fb097f
+niiri:7fb9b0874581a71159fdd853f93751f2
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0166" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2518,9 +2518,9 @@ niiri:202b2ec8923685d33ff8474567fb097f
     nidm_qValueFDR: "0.690223976658915"^^xsd:float ;
     nidm_clusterLabelId: "166"^^xsd:int .
 
-niiri:202b2ec8923685d33ff8474567fb097f prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:7fb9b0874581a71159fdd853f93751f2 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:5e31db36bebfe06aef3ad33a08c38510
+niiri:62b88250957696695608f4f9d5c33c94
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0167" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2530,9 +2530,9 @@ niiri:5e31db36bebfe06aef3ad33a08c38510
     nidm_qValueFDR: "0.654795742860352"^^xsd:float ;
     nidm_clusterLabelId: "167"^^xsd:int .
 
-niiri:5e31db36bebfe06aef3ad33a08c38510 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:62b88250957696695608f4f9d5c33c94 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:c57896abf584d2b1a83fb9ad3c827d15
+niiri:11a529a736c285cc9a00cdcf5fb4962d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0168" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2542,9 +2542,9 @@ niiri:c57896abf584d2b1a83fb9ad3c827d15
     nidm_qValueFDR: "0.654795742860352"^^xsd:float ;
     nidm_clusterLabelId: "168"^^xsd:int .
 
-niiri:c57896abf584d2b1a83fb9ad3c827d15 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:11a529a736c285cc9a00cdcf5fb4962d prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:ea8d2f5330ef8fd7ac99fb062748cba2
+niiri:56c0d386be3b33d6180c1118121d2610
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0169" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2554,9 +2554,9 @@ niiri:ea8d2f5330ef8fd7ac99fb062748cba2
     nidm_qValueFDR: "0.690223976658915"^^xsd:float ;
     nidm_clusterLabelId: "169"^^xsd:int .
 
-niiri:ea8d2f5330ef8fd7ac99fb062748cba2 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:56c0d386be3b33d6180c1118121d2610 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:c638448ba82adee617884aeddb79eb28
+niiri:d285ba30108c36cd9e0a52ef7d0d4cec
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0170" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -2566,9 +2566,9 @@ niiri:c638448ba82adee617884aeddb79eb28
     nidm_qValueFDR: "0.654795742860352"^^xsd:float ;
     nidm_clusterLabelId: "170"^^xsd:int .
 
-niiri:c638448ba82adee617884aeddb79eb28 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:d285ba30108c36cd9e0a52ef7d0d4cec prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:4d95857f68b5b80d99c4947f63e88283
+niiri:d38a6da35a3b35e251b575be2481d895
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0171" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2578,9 +2578,9 @@ niiri:4d95857f68b5b80d99c4947f63e88283
     nidm_qValueFDR: "0.654795742860352"^^xsd:float ;
     nidm_clusterLabelId: "171"^^xsd:int .
 
-niiri:4d95857f68b5b80d99c4947f63e88283 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:d38a6da35a3b35e251b575be2481d895 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:ef0d129d225ab1994fdabef30426f127
+niiri:4f56e832e623fb38abb2d199755b3aa5
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0172" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2590,9 +2590,9 @@ niiri:ef0d129d225ab1994fdabef30426f127
     nidm_qValueFDR: "0.690223976658915"^^xsd:float ;
     nidm_clusterLabelId: "172"^^xsd:int .
 
-niiri:ef0d129d225ab1994fdabef30426f127 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:4f56e832e623fb38abb2d199755b3aa5 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:48094119160b8ddede68780fbf27c3d9
+niiri:92f563ca517a60ccfbb3ef7b2af62dac
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0173" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2602,9 +2602,9 @@ niiri:48094119160b8ddede68780fbf27c3d9
     nidm_qValueFDR: "0.690223976658915"^^xsd:float ;
     nidm_clusterLabelId: "173"^^xsd:int .
 
-niiri:48094119160b8ddede68780fbf27c3d9 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:92f563ca517a60ccfbb3ef7b2af62dac prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:494d564667be2308342989663d3f52ff
+niiri:8600387b3b7cea249641e5cdebba0daa
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0174" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2614,9 +2614,9 @@ niiri:494d564667be2308342989663d3f52ff
     nidm_qValueFDR: "0.690223976658915"^^xsd:float ;
     nidm_clusterLabelId: "174"^^xsd:int .
 
-niiri:494d564667be2308342989663d3f52ff prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:8600387b3b7cea249641e5cdebba0daa prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:ea21239ad949045b078440398a34a9c6
+niiri:0f7371e43c32093550d9b7e335f29fdd
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0175" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -2626,9 +2626,9 @@ niiri:ea21239ad949045b078440398a34a9c6
     nidm_qValueFDR: "0.654795742860352"^^xsd:float ;
     nidm_clusterLabelId: "175"^^xsd:int .
 
-niiri:ea21239ad949045b078440398a34a9c6 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:0f7371e43c32093550d9b7e335f29fdd prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:db760edea5f4f806e9afd9a12723ee09
+niiri:60ee0a470203bf71030d2277a3fde6c3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0176" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2638,9 +2638,9 @@ niiri:db760edea5f4f806e9afd9a12723ee09
     nidm_qValueFDR: "0.654795742860352"^^xsd:float ;
     nidm_clusterLabelId: "176"^^xsd:int .
 
-niiri:db760edea5f4f806e9afd9a12723ee09 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:60ee0a470203bf71030d2277a3fde6c3 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:5bbac11b8bfa6c995310ee87183ab4d6
+niiri:7cded2bfb4aacaabc3212bf6e55636da
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0177" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2650,9 +2650,9 @@ niiri:5bbac11b8bfa6c995310ee87183ab4d6
     nidm_qValueFDR: "0.654795742860352"^^xsd:float ;
     nidm_clusterLabelId: "177"^^xsd:int .
 
-niiri:5bbac11b8bfa6c995310ee87183ab4d6 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:7cded2bfb4aacaabc3212bf6e55636da prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:3f3b062de3ba5acf073f1b59cfb5a6e6
+niiri:56d77ed8a1025508e9f36442b2aa1001
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0178" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2662,9 +2662,9 @@ niiri:3f3b062de3ba5acf073f1b59cfb5a6e6
     nidm_qValueFDR: "0.654795742860352"^^xsd:float ;
     nidm_clusterLabelId: "178"^^xsd:int .
 
-niiri:3f3b062de3ba5acf073f1b59cfb5a6e6 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:56d77ed8a1025508e9f36442b2aa1001 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:39a4606d938ba1ca81229a71c823e41d
+niiri:5debe73d92bf3a2e632b239ed32da2c4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0179" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2674,9 +2674,9 @@ niiri:39a4606d938ba1ca81229a71c823e41d
     nidm_qValueFDR: "0.690223976658915"^^xsd:float ;
     nidm_clusterLabelId: "179"^^xsd:int .
 
-niiri:39a4606d938ba1ca81229a71c823e41d prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:5debe73d92bf3a2e632b239ed32da2c4 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:a49d384fb03c39001132a62f5ee742ce
+niiri:f3bc76ba4a3df529282c2ee84c68df86
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0180" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2686,9 +2686,9 @@ niiri:a49d384fb03c39001132a62f5ee742ce
     nidm_qValueFDR: "0.690223976658915"^^xsd:float ;
     nidm_clusterLabelId: "180"^^xsd:int .
 
-niiri:a49d384fb03c39001132a62f5ee742ce prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:f3bc76ba4a3df529282c2ee84c68df86 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:1df9ca7cc28a8741906406c23e450c49
+niiri:28bbba0604724f0b5ea3c95637660afa
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0181" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2698,9 +2698,9 @@ niiri:1df9ca7cc28a8741906406c23e450c49
     nidm_qValueFDR: "0.690223976658915"^^xsd:float ;
     nidm_clusterLabelId: "181"^^xsd:int .
 
-niiri:1df9ca7cc28a8741906406c23e450c49 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:28bbba0604724f0b5ea3c95637660afa prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:b3a0d8de966bc74adb169669f1390504
+niiri:e2e08d4842a9d04eb18949c6410171c2
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0182" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2710,9 +2710,9 @@ niiri:b3a0d8de966bc74adb169669f1390504
     nidm_qValueFDR: "0.690223976658915"^^xsd:float ;
     nidm_clusterLabelId: "182"^^xsd:int .
 
-niiri:b3a0d8de966bc74adb169669f1390504 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:e2e08d4842a9d04eb18949c6410171c2 prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:070e421862800af00c11e7304e4407bb
+niiri:21fbadccdcf80825edc168ed54a646dd
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0183" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2722,9 +2722,9 @@ niiri:070e421862800af00c11e7304e4407bb
     nidm_qValueFDR: "0.690223976658915"^^xsd:float ;
     nidm_clusterLabelId: "183"^^xsd:int .
 
-niiri:070e421862800af00c11e7304e4407bb prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:21fbadccdcf80825edc168ed54a646dd prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:93297a88c8e657de407b42d03cd7f823
+niiri:37a7db920a02cc0218b6f2862406e37a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0184" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2734,4153 +2734,4153 @@ niiri:93297a88c8e657de407b42d03cd7f823
     nidm_qValueFDR: "0.690223976658915"^^xsd:float ;
     nidm_clusterLabelId: "184"^^xsd:int .
 
-niiri:93297a88c8e657de407b42d03cd7f823 prov:wasDerivedFrom niiri:5c3a280abdc45cbf2db33ae481f80003 .
+niiri:37a7db920a02cc0218b6f2862406e37a prov:wasDerivedFrom niiri:4391a2ef60f122937f69c2336ae7251d .
 
-niiri:1ad729b1a9263ed5d09311c4d445786c
+niiri:15408ee32b85d99dd9469a376a205277
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0001" ;
-    prov:atLocation niiri:1cd3079cb752db2e6f39d53c29f0b9ea ;
+    prov:atLocation niiri:0641f44bc1cc38d2f46b260ac05dd0d0 ;
     prov:value "63.4091377258301"^^xsd:float ;
     nidm_equivalentZStatistic: "6.87763687596762"^^xsd:float ;
     nidm_pValueUncorrected: "3.0426772212877e-12"^^xsd:float ;
     nidm_pValueFWER: "6.78640924345331e-07"^^xsd:float ;
     nidm_qValueFDR: "7.69046642070356e-06"^^xsd:float .
 
-niiri:1cd3079cb752db2e6f39d53c29f0b9ea
+niiri:0641f44bc1cc38d2f46b260ac05dd0d0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0001" ;
     nidm_coordinateVector: "[30,-82,-32]"^^xsd:string .
 
-niiri:1ad729b1a9263ed5d09311c4d445786c prov:wasDerivedFrom niiri:651d36d872d7daabb7dba2117ccd0147 .
+niiri:15408ee32b85d99dd9469a376a205277 prov:wasDerivedFrom niiri:a02993e23816e346753a88b23cc8928d .
 
-niiri:145d15104600c06d595e2959214660f0
+niiri:6339834c453190a84e0be6fb23a08d7b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0002" ;
-    prov:atLocation niiri:e6eb5f01ff0031ff4c2360df47a2d7b9 ;
+    prov:atLocation niiri:a391976265e9c457b429d33fcbc53448 ;
     prov:value "34.330680847168"^^xsd:float ;
     nidm_equivalentZStatistic: "5.28627890808187"^^xsd:float ;
     nidm_pValueUncorrected: "6.24147619143756e-08"^^xsd:float ;
     nidm_pValueFWER: "0.0123751495969127"^^xsd:float ;
     nidm_qValueFDR: "0.00298745408887002"^^xsd:float .
 
-niiri:e6eb5f01ff0031ff4c2360df47a2d7b9
+niiri:a391976265e9c457b429d33fcbc53448
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0002" ;
     nidm_coordinateVector: "[30,-74,-20]"^^xsd:string .
 
-niiri:145d15104600c06d595e2959214660f0 prov:wasDerivedFrom niiri:651d36d872d7daabb7dba2117ccd0147 .
+niiri:6339834c453190a84e0be6fb23a08d7b prov:wasDerivedFrom niiri:a02993e23816e346753a88b23cc8928d .
 
-niiri:ab7381fb540a83aff37aa2e379fe46f0
+niiri:fc608ab17d14b0216545bc760bc76351
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0003" ;
-    prov:atLocation niiri:90bbb6afadfd2bed6ba4ba8364ef6b0e ;
+    prov:atLocation niiri:458bef7562a6ed14ea6c60927fd8bf32 ;
     prov:value "32.5551681518555"^^xsd:float ;
     nidm_equivalentZStatistic: "5.16035838696565"^^xsd:float ;
     nidm_pValueUncorrected: "1.2323877274234e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0224930278720513"^^xsd:float ;
     nidm_qValueFDR: "0.00456113578807012"^^xsd:float .
 
-niiri:90bbb6afadfd2bed6ba4ba8364ef6b0e
+niiri:458bef7562a6ed14ea6c60927fd8bf32
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0003" ;
     nidm_coordinateVector: "[54,-56,-34]"^^xsd:string .
 
-niiri:ab7381fb540a83aff37aa2e379fe46f0 prov:wasDerivedFrom niiri:651d36d872d7daabb7dba2117ccd0147 .
+niiri:fc608ab17d14b0216545bc760bc76351 prov:wasDerivedFrom niiri:a02993e23816e346753a88b23cc8928d .
 
-niiri:c32cd83c477444569ca2477bf81b2a88
+niiri:360c87bfdf28bfd144d5781923cd8ac1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0004" ;
-    prov:atLocation niiri:a2f25c4463c4698eaaa3e399732c09ec ;
+    prov:atLocation niiri:4f45e9467d9e02d216ecae26355acbf6 ;
     prov:value "63.223461151123"^^xsd:float ;
     nidm_equivalentZStatistic: "6.86947288292734"^^xsd:float ;
     nidm_pValueUncorrected: "3.22197823976467e-12"^^xsd:float ;
     nidm_pValueFWER: "7.18635271623747e-07"^^xsd:float ;
     nidm_qValueFDR: "7.69046642070356e-06"^^xsd:float .
 
-niiri:a2f25c4463c4698eaaa3e399732c09ec
+niiri:4f45e9467d9e02d216ecae26355acbf6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0004" ;
     nidm_coordinateVector: "[-4,-86,42]"^^xsd:string .
 
-niiri:c32cd83c477444569ca2477bf81b2a88 prov:wasDerivedFrom niiri:7f4e9fb870f5c98792fa6bf0f88370fb .
+niiri:360c87bfdf28bfd144d5781923cd8ac1 prov:wasDerivedFrom niiri:1fb6d1d0216b48739f26ab81c9d1d36e .
 
-niiri:c7402cd815b21a13269235eacad1f7f8
+niiri:a998ae1169d6a1bfd5bc42c534c9ce86
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0005" ;
-    prov:atLocation niiri:7978c6257d052d04738b9f1a9744d852 ;
+    prov:atLocation niiri:1d2c00421e4eb30b21b92956b0d1a751 ;
     prov:value "59.1932106018066"^^xsd:float ;
     nidm_equivalentZStatistic: "6.68743781613539"^^xsd:float ;
     nidm_pValueUncorrected: "1.1355583140471e-11"^^xsd:float ;
     nidm_pValueFWER: "2.5328927799606e-06"^^xsd:float ;
     nidm_qValueFDR: "1.2812091676231e-05"^^xsd:float .
 
-niiri:7978c6257d052d04738b9f1a9744d852
+niiri:1d2c00421e4eb30b21b92956b0d1a751
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0005" ;
     nidm_coordinateVector: "[-4,-64,62]"^^xsd:string .
 
-niiri:c7402cd815b21a13269235eacad1f7f8 prov:wasDerivedFrom niiri:7f4e9fb870f5c98792fa6bf0f88370fb .
+niiri:a998ae1169d6a1bfd5bc42c534c9ce86 prov:wasDerivedFrom niiri:1fb6d1d0216b48739f26ab81c9d1d36e .
 
-niiri:9e7ce398a2ef8b1fe239a4553ed8f749
+niiri:8c4b10f0f0d23304c6889f254b8b1f11
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0006" ;
-    prov:atLocation niiri:4203a80796c8345b0e9bdc9b1aa3b2e7 ;
+    prov:atLocation niiri:4513a5af88ce9b4dea2229e2abbdb320 ;
     prov:value "54.7871932983398"^^xsd:float ;
     nidm_equivalentZStatistic: "6.47692789306752"^^xsd:float ;
     nidm_pValueUncorrected: "4.680444920524e-11"^^xsd:float ;
     nidm_pValueFWER: "1.04400104977698e-05"^^xsd:float ;
     nidm_qValueFDR: "3.92759435111279e-05"^^xsd:float .
 
-niiri:4203a80796c8345b0e9bdc9b1aa3b2e7
+niiri:4513a5af88ce9b4dea2229e2abbdb320
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0006" ;
     nidm_coordinateVector: "[-30,-80,46]"^^xsd:string .
 
-niiri:9e7ce398a2ef8b1fe239a4553ed8f749 prov:wasDerivedFrom niiri:7f4e9fb870f5c98792fa6bf0f88370fb .
+niiri:8c4b10f0f0d23304c6889f254b8b1f11 prov:wasDerivedFrom niiri:1fb6d1d0216b48739f26ab81c9d1d36e .
 
-niiri:5ee1f8d731e1ff5d356efe2b97a98c4b
+niiri:fd91d07679d40254e3422190a6146551
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0007" ;
-    prov:atLocation niiri:43cbf9c937f77f8f3111c53fea2726a2 ;
+    prov:atLocation niiri:8163502ef4eb2bd47c0afd06aa34e260 ;
     prov:value "62.7276649475098"^^xsd:float ;
     nidm_equivalentZStatistic: "6.84758591415851"^^xsd:float ;
     nidm_pValueUncorrected: "3.75532938079459e-12"^^xsd:float ;
     nidm_pValueFWER: "8.37602977088459e-07"^^xsd:float ;
     nidm_qValueFDR: "7.69046642070356e-06"^^xsd:float .
 
-niiri:43cbf9c937f77f8f3111c53fea2726a2
+niiri:8163502ef4eb2bd47c0afd06aa34e260
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0007" ;
     nidm_coordinateVector: "[46,16,24]"^^xsd:string .
 
-niiri:5ee1f8d731e1ff5d356efe2b97a98c4b prov:wasDerivedFrom niiri:284d49d49a311520554c2b72c79155a5 .
+niiri:fd91d07679d40254e3422190a6146551 prov:wasDerivedFrom niiri:513b4dd1fd53a8b3917570bbd44a1da7 .
 
-niiri:3369f244119ffdeef13b1e360cf6619a
+niiri:78698a7744e2e52357780a5302642060
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0008" ;
-    prov:atLocation niiri:f0aae1de8a4ec1ad4e4ce4de228f83d6 ;
+    prov:atLocation niiri:98338f9e531b28eb906487132e15e34f ;
     prov:value "24.248779296875"^^xsd:float ;
     nidm_equivalentZStatistic: "4.49788176431045"^^xsd:float ;
     nidm_pValueUncorrected: "3.43169230909712e-06"^^xsd:float ;
     nidm_pValueFWER: "0.337713339570932"^^xsd:float ;
     nidm_qValueFDR: "0.0315627223093611"^^xsd:float .
 
-niiri:f0aae1de8a4ec1ad4e4ce4de228f83d6
+niiri:98338f9e531b28eb906487132e15e34f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0008" ;
     nidm_coordinateVector: "[52,30,20]"^^xsd:string .
 
-niiri:3369f244119ffdeef13b1e360cf6619a prov:wasDerivedFrom niiri:284d49d49a311520554c2b72c79155a5 .
+niiri:78698a7744e2e52357780a5302642060 prov:wasDerivedFrom niiri:513b4dd1fd53a8b3917570bbd44a1da7 .
 
-niiri:6e25d0b91bf2ce19599d87d9efd5a15e
+niiri:7b293150101749bc3e0a5b062221e484
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0009" ;
-    prov:atLocation niiri:eb27e419063e80cd2385a42440d7284c ;
+    prov:atLocation niiri:a69afafa9366b5b57795632c3b4e962c ;
     prov:value "23.2752456665039"^^xsd:float ;
     nidm_equivalentZStatistic: "4.41058321872095"^^xsd:float ;
     nidm_pValueUncorrected: "5.15462881078843e-06"^^xsd:float ;
     nidm_pValueFWER: "0.441809153541913"^^xsd:float ;
     nidm_qValueFDR: "0.0401580107168157"^^xsd:float .
 
-niiri:eb27e419063e80cd2385a42440d7284c
+niiri:a69afafa9366b5b57795632c3b4e962c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0009" ;
     nidm_coordinateVector: "[56,18,8]"^^xsd:string .
 
-niiri:6e25d0b91bf2ce19599d87d9efd5a15e prov:wasDerivedFrom niiri:284d49d49a311520554c2b72c79155a5 .
+niiri:7b293150101749bc3e0a5b062221e484 prov:wasDerivedFrom niiri:513b4dd1fd53a8b3917570bbd44a1da7 .
 
-niiri:593485f29d2b0c951bdfac03fc11c663
+niiri:d13ff858d119b29455bfd66007ccda04
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0010" ;
-    prov:atLocation niiri:108eb5c0731eb38f8865c8df4f845eed ;
+    prov:atLocation niiri:4b5f03880a32d3c6ecb349f93624a7fa ;
     prov:value "53.7021408081055"^^xsd:float ;
     nidm_equivalentZStatistic: "6.4230764301046"^^xsd:float ;
     nidm_pValueUncorrected: "6.67736976822653e-11"^^xsd:float ;
     nidm_pValueFWER: "1.48942911553096e-05"^^xsd:float ;
     nidm_qValueFDR: "4.66369239309748e-05"^^xsd:float .
 
-niiri:108eb5c0731eb38f8865c8df4f845eed
+niiri:4b5f03880a32d3c6ecb349f93624a7fa
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0010" ;
     nidm_coordinateVector: "[-46,-78,24]"^^xsd:string .
 
-niiri:593485f29d2b0c951bdfac03fc11c663 prov:wasDerivedFrom niiri:42c8820b665da5b8d98f4ce5fcb8de2d .
+niiri:d13ff858d119b29455bfd66007ccda04 prov:wasDerivedFrom niiri:0383eb2fc5ee76be5634bfee80f2ca3b .
 
-niiri:8647615bdccf00383af5ede801d4cd56
+niiri:fd5511cc6e2bfdffd9438532ea9e531a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0011" ;
-    prov:atLocation niiri:8d711debd43eb5904b0ca65c16d9940a ;
+    prov:atLocation niiri:0e6a1706845dc9fd273961896d6d0a14 ;
     prov:value "50.6493988037109"^^xsd:float ;
     nidm_equivalentZStatistic: "6.26694330529563"^^xsd:float ;
     nidm_pValueUncorrected: "1.84102066924652e-10"^^xsd:float ;
     nidm_pValueFWER: "4.10652052134086e-05"^^xsd:float ;
     nidm_qValueFDR: "9.17691949136767e-05"^^xsd:float .
 
-niiri:8d711debd43eb5904b0ca65c16d9940a
+niiri:0e6a1706845dc9fd273961896d6d0a14
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0011" ;
     nidm_coordinateVector: "[34,-88,-2]"^^xsd:string .
 
-niiri:8647615bdccf00383af5ede801d4cd56 prov:wasDerivedFrom niiri:7e43e146a206ef37a717db06b7c719b8 .
+niiri:fd5511cc6e2bfdffd9438532ea9e531a prov:wasDerivedFrom niiri:e67cada24205233131c2bfe154669c61 .
 
-niiri:35811f25295d140b23f0ba5c711fd12c
+niiri:c5b79c6acbda7306e022436ba2ff08ea
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0012" ;
-    prov:atLocation niiri:a8420206394c401da4a17097322c3b08 ;
+    prov:atLocation niiri:1c858f13a6a8dd1ed4f691dbb61441ff ;
     prov:value "42.0282821655273"^^xsd:float ;
     nidm_equivalentZStatistic: "5.78380990161557"^^xsd:float ;
     nidm_pValueUncorrected: "3.65137320379461e-09"^^xsd:float ;
     nidm_pValueFWER: "0.00081446430319021"^^xsd:float ;
     nidm_qValueFDR: "0.000655649142634339"^^xsd:float .
 
-niiri:a8420206394c401da4a17097322c3b08
+niiri:1c858f13a6a8dd1ed4f691dbb61441ff
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0012" ;
     nidm_coordinateVector: "[42,-72,-10]"^^xsd:string .
 
-niiri:35811f25295d140b23f0ba5c711fd12c prov:wasDerivedFrom niiri:7e43e146a206ef37a717db06b7c719b8 .
+niiri:c5b79c6acbda7306e022436ba2ff08ea prov:wasDerivedFrom niiri:e67cada24205233131c2bfe154669c61 .
 
-niiri:1a8e8acc36a5b6c46aa24ba76ab69931
+niiri:93f22f5d612344b81124870b08ecc87e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0013" ;
-    prov:atLocation niiri:00fdca4dac7efb2179e283d653684982 ;
+    prov:atLocation niiri:8c19f2d54053cf0b01e427341923ddb7 ;
     prov:value "27.3277149200439"^^xsd:float ;
     nidm_equivalentZStatistic: "4.75932547479613"^^xsd:float ;
     nidm_pValueUncorrected: "9.71204984545615e-07"^^xsd:float ;
     nidm_pValueFWER: "0.129624789952327"^^xsd:float ;
     nidm_qValueFDR: "0.0155044826465378"^^xsd:float .
 
-niiri:00fdca4dac7efb2179e283d653684982
+niiri:8c19f2d54053cf0b01e427341923ddb7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0013" ;
     nidm_coordinateVector: "[34,-86,12]"^^xsd:string .
 
-niiri:1a8e8acc36a5b6c46aa24ba76ab69931 prov:wasDerivedFrom niiri:7e43e146a206ef37a717db06b7c719b8 .
+niiri:93f22f5d612344b81124870b08ecc87e prov:wasDerivedFrom niiri:e67cada24205233131c2bfe154669c61 .
 
-niiri:cb47ae16504ee86bdbe1cea951f05d08
+niiri:46fc5c23e8aa00759077219a8ff53cba
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0014" ;
-    prov:atLocation niiri:4617ba0c314a173227fbd8f2bf21e0c0 ;
+    prov:atLocation niiri:e72913318bdae423d898d64f71c73ee3 ;
     prov:value "49.6541976928711"^^xsd:float ;
     nidm_equivalentZStatistic: "6.21449041258159"^^xsd:float ;
     nidm_pValueUncorrected: "2.574573887415e-10"^^xsd:float ;
     nidm_pValueFWER: "5.74276232319093e-05"^^xsd:float ;
     nidm_qValueFDR: "0.000101984986721175"^^xsd:float .
 
-niiri:4617ba0c314a173227fbd8f2bf21e0c0
+niiri:e72913318bdae423d898d64f71c73ee3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0014" ;
     nidm_coordinateVector: "[20,-58,-50]"^^xsd:string .
 
-niiri:cb47ae16504ee86bdbe1cea951f05d08 prov:wasDerivedFrom niiri:4e4ee541dcb7596b480cb3aebb5ec524 .
+niiri:46fc5c23e8aa00759077219a8ff53cba prov:wasDerivedFrom niiri:a3635579e9882ee1f3c09824008b66b4 .
 
-niiri:7352ae583383da450074239b69227dbb
+niiri:7908619b88ba244bd93c6dba0bbb87e6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0015" ;
-    prov:atLocation niiri:b61c39fa67e052055981497233c2b7d2 ;
+    prov:atLocation niiri:c1e24413c80edd5055adad6446606542 ;
     prov:value "37.7286491394043"^^xsd:float ;
     nidm_equivalentZStatistic: "5.51490684020097"^^xsd:float ;
     nidm_pValueUncorrected: "1.74482378545449e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00389195156635691"^^xsd:float ;
     nidm_qValueFDR: "0.00135850417567201"^^xsd:float .
 
-niiri:b61c39fa67e052055981497233c2b7d2
+niiri:c1e24413c80edd5055adad6446606542
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0015" ;
     nidm_coordinateVector: "[-28,-46,-44]"^^xsd:string .
 
-niiri:7352ae583383da450074239b69227dbb prov:wasDerivedFrom niiri:4e4ee541dcb7596b480cb3aebb5ec524 .
+niiri:7908619b88ba244bd93c6dba0bbb87e6 prov:wasDerivedFrom niiri:a3635579e9882ee1f3c09824008b66b4 .
 
-niiri:a8f7ff25ee2eec409fd770cbee1a5a51
+niiri:c5f3e3a0fd6c3b436aae4cb7598c34c9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0016" ;
-    prov:atLocation niiri:00219d6515673b5f9b9cdcf9e0ae68b3 ;
+    prov:atLocation niiri:100f5aac01b00bba82ce7d02dad389fd ;
     prov:value "36.3174209594727"^^xsd:float ;
     nidm_equivalentZStatistic: "5.42181897111099"^^xsd:float ;
     nidm_pValueUncorrected: "2.94978058645867e-08"^^xsd:float ;
     nidm_pValueFWER: "0.0063697813576209"^^xsd:float ;
     nidm_qValueFDR: "0.00184664824144078"^^xsd:float .
 
-niiri:00219d6515673b5f9b9cdcf9e0ae68b3
+niiri:100f5aac01b00bba82ce7d02dad389fd
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0016" ;
     nidm_coordinateVector: "[24,-48,-52]"^^xsd:string .
 
-niiri:a8f7ff25ee2eec409fd770cbee1a5a51 prov:wasDerivedFrom niiri:4e4ee541dcb7596b480cb3aebb5ec524 .
+niiri:c5f3e3a0fd6c3b436aae4cb7598c34c9 prov:wasDerivedFrom niiri:a3635579e9882ee1f3c09824008b66b4 .
 
-niiri:f2577dcf463bf25350ef976435690d84
+niiri:a49cb1b476653b5bd0a7cc950718a0ff
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0017" ;
-    prov:atLocation niiri:ab378512d8e136af08169d05b2ec2611 ;
+    prov:atLocation niiri:bbb63b81e8f877c8efc6acbf7b6623b9 ;
     prov:value "46.5456809997559"^^xsd:float ;
     nidm_equivalentZStatistic: "6.04535479047381"^^xsd:float ;
     nidm_pValueUncorrected: "7.45407846558521e-10"^^xsd:float ;
     nidm_pValueFWER: "0.000166268388501201"^^xsd:float ;
     nidm_qValueFDR: "0.000246160584800799"^^xsd:float .
 
-niiri:ab378512d8e136af08169d05b2ec2611
+niiri:bbb63b81e8f877c8efc6acbf7b6623b9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0017" ;
     nidm_coordinateVector: "[-32,-90,22]"^^xsd:string .
 
-niiri:f2577dcf463bf25350ef976435690d84 prov:wasDerivedFrom niiri:78e7ba6b5db9ff6ef88f595eef8c1789 .
+niiri:a49cb1b476653b5bd0a7cc950718a0ff prov:wasDerivedFrom niiri:c50d34609678664d461509f54c79eea7 .
 
-niiri:370905ec9a39617e4bda707de93ec7ca
+niiri:3e717c804be08adc2679246149af5db7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0018" ;
-    prov:atLocation niiri:13246d6248cd3d6c599d17e0db1435f9 ;
+    prov:atLocation niiri:101ef180b33241930bb79e194dcbbed9 ;
     prov:value "41.0003623962402"^^xsd:float ;
     nidm_equivalentZStatistic: "5.72141667593276"^^xsd:float ;
     nidm_pValueUncorrected: "5.28197319216162e-09"^^xsd:float ;
     nidm_pValueFWER: "0.00117818104479539"^^xsd:float ;
     nidm_qValueFDR: "0.000789910490520138"^^xsd:float .
 
-niiri:13246d6248cd3d6c599d17e0db1435f9
+niiri:101ef180b33241930bb79e194dcbbed9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0018" ;
     nidm_coordinateVector: "[-18,-100,14]"^^xsd:string .
 
-niiri:370905ec9a39617e4bda707de93ec7ca prov:wasDerivedFrom niiri:78e7ba6b5db9ff6ef88f595eef8c1789 .
+niiri:3e717c804be08adc2679246149af5db7 prov:wasDerivedFrom niiri:c50d34609678664d461509f54c79eea7 .
 
-niiri:1985ca322dad916f2dc1a4980b292a8f
+niiri:2d6ad9f56e2f5b6c94d89c1ef5625631
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0019" ;
-    prov:atLocation niiri:299aa0c3669c07f81bc6fb0ad3f0eaad ;
+    prov:atLocation niiri:d479bae72ae64f4cf25acf6fbff4867f ;
     prov:value "30.2211799621582"^^xsd:float ;
     nidm_equivalentZStatistic: "4.9872751544685"^^xsd:float ;
     nidm_pValueUncorrected: "3.06184112175423e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0494340056154295"^^xsd:float ;
     nidm_qValueFDR: "0.00803010760019555"^^xsd:float .
 
-niiri:299aa0c3669c07f81bc6fb0ad3f0eaad
+niiri:d479bae72ae64f4cf25acf6fbff4867f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0019" ;
     nidm_coordinateVector: "[-30,-92,12]"^^xsd:string .
 
-niiri:1985ca322dad916f2dc1a4980b292a8f prov:wasDerivedFrom niiri:78e7ba6b5db9ff6ef88f595eef8c1789 .
+niiri:2d6ad9f56e2f5b6c94d89c1ef5625631 prov:wasDerivedFrom niiri:c50d34609678664d461509f54c79eea7 .
 
-niiri:51ceaf84580ed7b298048fda09805453
+niiri:e8ccf7a91909009975707eb5438a1c41
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0020" ;
-    prov:atLocation niiri:14f7786c455797486e51096d023a6749 ;
+    prov:atLocation niiri:c8e15c365b5b224e2797ad45cf7f4de2 ;
     prov:value "41.3373107910156"^^xsd:float ;
     nidm_equivalentZStatistic: "5.74199410170229"^^xsd:float ;
     nidm_pValueUncorrected: "4.67840410856013e-09"^^xsd:float ;
     nidm_pValueFWER: "0.00104355073571449"^^xsd:float ;
     nidm_qValueFDR: "0.000741810621169375"^^xsd:float .
 
-niiri:14f7786c455797486e51096d023a6749
+niiri:c8e15c365b5b224e2797ad45cf7f4de2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0020" ;
     nidm_coordinateVector: "[-40,-82,-8]"^^xsd:string .
 
-niiri:51ceaf84580ed7b298048fda09805453 prov:wasDerivedFrom niiri:8170af49aff81684fdb2d887f6db1095 .
+niiri:e8ccf7a91909009975707eb5438a1c41 prov:wasDerivedFrom niiri:86785a60d43172b11448d491c5ae96dc .
 
-niiri:eb91d43cfeef4d99c757e6da6c881f5a
+niiri:7ebb22fd72bd0789f6bd1e8550c7084c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0021" ;
-    prov:atLocation niiri:b3989deb6f7b20fc2a7daac835687e74 ;
+    prov:atLocation niiri:59238a22c085684ec58ad478012612fb ;
     prov:value "39.6630401611328"^^xsd:float ;
     nidm_equivalentZStatistic: "5.63850646223464"^^xsd:float ;
     nidm_pValueUncorrected: "8.57656923258787e-09"^^xsd:float ;
     nidm_pValueFWER: "0.00191306375378475"^^xsd:float ;
     nidm_qValueFDR: "0.0009870871843719"^^xsd:float .
 
-niiri:b3989deb6f7b20fc2a7daac835687e74
+niiri:59238a22c085684ec58ad478012612fb
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0021" ;
     nidm_coordinateVector: "[-34,-68,-10]"^^xsd:string .
 
-niiri:eb91d43cfeef4d99c757e6da6c881f5a prov:wasDerivedFrom niiri:8170af49aff81684fdb2d887f6db1095 .
+niiri:7ebb22fd72bd0789f6bd1e8550c7084c prov:wasDerivedFrom niiri:86785a60d43172b11448d491c5ae96dc .
 
-niiri:2a0e74b47e33f43d9f083a3ebb12d695
+niiri:92d02c82b7f90dbed092d3b95cad4470
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0022" ;
-    prov:atLocation niiri:596e679482f1d7fa8baa5f00c151a91a ;
+    prov:atLocation niiri:733e8754b4ff170374623f8b270dad17 ;
     prov:value "34.0695152282715"^^xsd:float ;
     nidm_equivalentZStatistic: "5.26805007110655"^^xsd:float ;
     nidm_pValueUncorrected: "6.89402515074988e-08"^^xsd:float ;
     nidm_pValueFWER: "0.0135093653627159"^^xsd:float ;
     nidm_qValueFDR: "0.00308832183253126"^^xsd:float .
 
-niiri:596e679482f1d7fa8baa5f00c151a91a
+niiri:733e8754b4ff170374623f8b270dad17
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0022" ;
     nidm_coordinateVector: "[-40,-76,-22]"^^xsd:string .
 
-niiri:2a0e74b47e33f43d9f083a3ebb12d695 prov:wasDerivedFrom niiri:8170af49aff81684fdb2d887f6db1095 .
+niiri:92d02c82b7f90dbed092d3b95cad4470 prov:wasDerivedFrom niiri:86785a60d43172b11448d491c5ae96dc .
 
-niiri:ff6f6a4c4bfdf0fe50725960fe944ca6
+niiri:ac1f6889a3b03207d78c9ad5528f9b90
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0023" ;
-    prov:atLocation niiri:254d2682d5a144ef20099e46bfdc1a27 ;
+    prov:atLocation niiri:838ab3f78f4c999519706107ecaa6651 ;
     prov:value "39.8922958374023"^^xsd:float ;
     nidm_equivalentZStatistic: "5.65286295967349"^^xsd:float ;
     nidm_pValueUncorrected: "7.88985576871681e-09"^^xsd:float ;
     nidm_pValueFWER: "0.00175988750867406"^^xsd:float ;
     nidm_qValueFDR: "0.0009870871843719"^^xsd:float .
 
-niiri:254d2682d5a144ef20099e46bfdc1a27
+niiri:838ab3f78f4c999519706107ecaa6651
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0023" ;
     nidm_coordinateVector: "[32,24,-4]"^^xsd:string .
 
-niiri:ff6f6a4c4bfdf0fe50725960fe944ca6 prov:wasDerivedFrom niiri:740bf59b1d25123628eef463c4259e34 .
+niiri:ac1f6889a3b03207d78c9ad5528f9b90 prov:wasDerivedFrom niiri:dded355a673488279610ef537e861858 .
 
-niiri:8e4d07d3bc5930dc8217e347ca18629e
+niiri:d9645c1bc51e20ae6eda890163cdd768
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0024" ;
-    prov:atLocation niiri:2e89e2c02ad28ca1a272e1073c5753e3 ;
+    prov:atLocation niiri:9aa5edc1fd84dac2c53c7ba42b273db8 ;
     prov:value "32.3555946350098"^^xsd:float ;
     nidm_equivalentZStatistic: "5.14590447978288"^^xsd:float ;
     nidm_pValueUncorrected: "1.33117438405606e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0240593381842931"^^xsd:float ;
     nidm_qValueFDR: "0.00469183536701006"^^xsd:float .
 
-niiri:2e89e2c02ad28ca1a272e1073c5753e3
+niiri:9aa5edc1fd84dac2c53c7ba42b273db8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0024" ;
     nidm_coordinateVector: "[18,16,4]"^^xsd:string .
 
-niiri:8e4d07d3bc5930dc8217e347ca18629e prov:wasDerivedFrom niiri:740bf59b1d25123628eef463c4259e34 .
+niiri:d9645c1bc51e20ae6eda890163cdd768 prov:wasDerivedFrom niiri:dded355a673488279610ef537e861858 .
 
-niiri:3b28f2b6b85307e7c4db65226998e921
+niiri:14dc5bbb6203781bf94b7883581e8d1b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0025" ;
-    prov:atLocation niiri:3c24385914da61858b61de5e8f8e8fef ;
+    prov:atLocation niiri:aff5a93c627ebd7f5b8c391f53c40006 ;
     prov:value "26.9382591247559"^^xsd:float ;
     nidm_equivalentZStatistic: "4.72739751788369"^^xsd:float ;
     nidm_pValueUncorrected: "1.13707888627079e-06"^^xsd:float ;
     nidm_pValueFWER: "0.147150618143017"^^xsd:float ;
     nidm_qValueFDR: "0.0165894956342347"^^xsd:float .
 
-niiri:3c24385914da61858b61de5e8f8e8fef
+niiri:aff5a93c627ebd7f5b8c391f53c40006
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0025" ;
     nidm_coordinateVector: "[48,28,-14]"^^xsd:string .
 
-niiri:3b28f2b6b85307e7c4db65226998e921 prov:wasDerivedFrom niiri:740bf59b1d25123628eef463c4259e34 .
+niiri:14dc5bbb6203781bf94b7883581e8d1b prov:wasDerivedFrom niiri:dded355a673488279610ef537e861858 .
 
-niiri:7bc9513b152a52efd9b6697970efbb6a
+niiri:4833f73495c82243b6bcc3fb9a23ef06
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0026" ;
-    prov:atLocation niiri:5136316bd9bb72240db547846785b492 ;
+    prov:atLocation niiri:7b97acac961566aab143009298852de2 ;
     prov:value "39.4447784423828"^^xsd:float ;
     nidm_equivalentZStatistic: "5.62478222171801"^^xsd:float ;
     nidm_pValueUncorrected: "9.28710763847818e-09"^^xsd:float ;
     nidm_pValueFWER: "0.00207155431898742"^^xsd:float ;
     nidm_qValueFDR: "0.0009870871843719"^^xsd:float .
 
-niiri:5136316bd9bb72240db547846785b492
+niiri:7b97acac961566aab143009298852de2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0026" ;
     nidm_coordinateVector: "[-26,54,-44]"^^xsd:string .
 
-niiri:7bc9513b152a52efd9b6697970efbb6a prov:wasDerivedFrom niiri:1b8c8488e08d0790c457517765f898e1 .
+niiri:4833f73495c82243b6bcc3fb9a23ef06 prov:wasDerivedFrom niiri:c1b3c9780e84e1bcfb3c612aa647510e .
 
-niiri:cac8b26581e206debe18a5a800fd5f0b
+niiri:a037c89bf27b3fb47dd39ef32c69f1e8
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0027" ;
-    prov:atLocation niiri:3b6bf80b79156b68f986ef6607de4779 ;
+    prov:atLocation niiri:e1f6f1196ac80f76a0456036af7a4b8b ;
     prov:value "23.9405002593994"^^xsd:float ;
     nidm_equivalentZStatistic: "4.47049572345504"^^xsd:float ;
     nidm_pValueUncorrected: "3.90192522159438e-06"^^xsd:float ;
     nidm_pValueFWER: "0.368629337644182"^^xsd:float ;
     nidm_qValueFDR: "0.0337742742636344"^^xsd:float .
 
-niiri:3b6bf80b79156b68f986ef6607de4779
+niiri:e1f6f1196ac80f76a0456036af7a4b8b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0027" ;
     nidm_coordinateVector: "[-32,50,-34]"^^xsd:string .
 
-niiri:cac8b26581e206debe18a5a800fd5f0b prov:wasDerivedFrom niiri:1b8c8488e08d0790c457517765f898e1 .
+niiri:a037c89bf27b3fb47dd39ef32c69f1e8 prov:wasDerivedFrom niiri:c1b3c9780e84e1bcfb3c612aa647510e .
 
-niiri:487bd84b76361e8216368b31ae09d694
+niiri:a30cccdb175a9992ba9c54a7f5f86040
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0028" ;
-    prov:atLocation niiri:99242ae3344afae9c9275a8a5b5fc9c7 ;
+    prov:atLocation niiri:5b912d29fd13e7d63c52b495d006664f ;
     prov:value "39.4393730163574"^^xsd:float ;
     nidm_equivalentZStatistic: "5.62444163011351"^^xsd:float ;
     nidm_pValueUncorrected: "9.30544841182268e-09"^^xsd:float ;
     nidm_pValueFWER: "0.00207564535686733"^^xsd:float ;
     nidm_qValueFDR: "0.0009870871843719"^^xsd:float .
 
-niiri:99242ae3344afae9c9275a8a5b5fc9c7
+niiri:5b912d29fd13e7d63c52b495d006664f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0028" ;
     nidm_coordinateVector: "[8,18,50]"^^xsd:string .
 
-niiri:487bd84b76361e8216368b31ae09d694 prov:wasDerivedFrom niiri:9ff5e136f972c43baf0362735367bbdb .
+niiri:a30cccdb175a9992ba9c54a7f5f86040 prov:wasDerivedFrom niiri:86886012c734f3d338a1efb48a81145a .
 
-niiri:4052527fe72d34186f9144bc7efd27ca
+niiri:f41be624e1053c51fdbdb702c880be11
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0029" ;
-    prov:atLocation niiri:2691f9d189ed38cd001d6a8184beaa7d ;
+    prov:atLocation niiri:e9b06bf73aae5f22582fa6e9a26ee0d0 ;
     prov:value "37.8498382568359"^^xsd:float ;
     nidm_equivalentZStatistic: "5.52278322654796"^^xsd:float ;
     nidm_pValueUncorrected: "1.66835655290853e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00372138605145689"^^xsd:float ;
     nidm_qValueFDR: "0.00135850417567201"^^xsd:float .
 
-niiri:2691f9d189ed38cd001d6a8184beaa7d
+niiri:e9b06bf73aae5f22582fa6e9a26ee0d0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0029" ;
     nidm_coordinateVector: "[-6,12,52]"^^xsd:string .
 
-niiri:4052527fe72d34186f9144bc7efd27ca prov:wasDerivedFrom niiri:9ff5e136f972c43baf0362735367bbdb .
+niiri:f41be624e1053c51fdbdb702c880be11 prov:wasDerivedFrom niiri:86886012c734f3d338a1efb48a81145a .
 
-niiri:f9f053201880a1a84c25c8fbfee294c0
+niiri:30a835006f53ac1656aa862dc46eefb1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0030" ;
-    prov:atLocation niiri:3af5f8ccfc99ade65319ab76b8184d36 ;
+    prov:atLocation niiri:668b668695b4f9c1225911b2e3aafc5f ;
     prov:value "35.8222694396973"^^xsd:float ;
     nidm_equivalentZStatistic: "5.38854316616903"^^xsd:float ;
     nidm_pValueUncorrected: "3.55155518327877e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00751236362554308"^^xsd:float ;
     nidm_qValueFDR: "0.00208265173602203"^^xsd:float .
 
-niiri:3af5f8ccfc99ade65319ab76b8184d36
+niiri:668b668695b4f9c1225911b2e3aafc5f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0030" ;
     nidm_coordinateVector: "[8,32,38]"^^xsd:string .
 
-niiri:f9f053201880a1a84c25c8fbfee294c0 prov:wasDerivedFrom niiri:9ff5e136f972c43baf0362735367bbdb .
+niiri:30a835006f53ac1656aa862dc46eefb1 prov:wasDerivedFrom niiri:86886012c734f3d338a1efb48a81145a .
 
-niiri:9606f9d15f3bc939ca2851b756c73d5e
+niiri:0f9e5faadc247bb0f606f8f2783c5dfc
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0031" ;
-    prov:atLocation niiri:33045b6b173ae3c19b060630f6bd98d4 ;
+    prov:atLocation niiri:19ae5d9dd47ddd4d5cf6d132960e4df6 ;
     prov:value "39.0784225463867"^^xsd:float ;
     nidm_equivalentZStatistic: "5.60162129933516"^^xsd:float ;
     nidm_pValueUncorrected: "1.06178051906269e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00236837574764137"^^xsd:float ;
     nidm_qValueFDR: "0.00100197986852916"^^xsd:float .
 
-niiri:33045b6b173ae3c19b060630f6bd98d4
+niiri:19ae5d9dd47ddd4d5cf6d132960e4df6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0031" ;
     nidm_coordinateVector: "[52,-32,42]"^^xsd:string .
 
-niiri:9606f9d15f3bc939ca2851b756c73d5e prov:wasDerivedFrom niiri:d852b48a402ab69819373ede91d1c632 .
+niiri:0f9e5faadc247bb0f606f8f2783c5dfc prov:wasDerivedFrom niiri:e25e46750ed6706bcfbfa5e14d55d777 .
 
-niiri:1ba1d7a563060d427efe80daeb039ef3
+niiri:5833c7ef6fbc97e336c4176bdd68792a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0032" ;
-    prov:atLocation niiri:c05521563177347eedfa794ffc2cbb1d ;
+    prov:atLocation niiri:0e8cee08b4f95550d2575f9157d645ee ;
     prov:value "39.0315551757812"^^xsd:float ;
     nidm_equivalentZStatistic: "5.59864699876771"^^xsd:float ;
     nidm_pValueUncorrected: "1.08015588695665e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00240936329200458"^^xsd:float ;
     nidm_qValueFDR: "0.00100197986852916"^^xsd:float .
 
-niiri:c05521563177347eedfa794ffc2cbb1d
+niiri:0e8cee08b4f95550d2575f9157d645ee
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0032" ;
     nidm_coordinateVector: "[40,-62,50]"^^xsd:string .
 
-niiri:1ba1d7a563060d427efe80daeb039ef3 prov:wasDerivedFrom niiri:d852b48a402ab69819373ede91d1c632 .
+niiri:5833c7ef6fbc97e336c4176bdd68792a prov:wasDerivedFrom niiri:e25e46750ed6706bcfbfa5e14d55d777 .
 
-niiri:c3e147319287620cf6f6682a13bb0c44
+niiri:e161d7cffaa802baa8842dbbc2ff600e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0033" ;
-    prov:atLocation niiri:bda2060e4fc205817c927e5c4cc0d265 ;
+    prov:atLocation niiri:f26173f80e46fa5a537d30b91a145a04 ;
     prov:value "32.5285148620605"^^xsd:float ;
     nidm_equivalentZStatistic: "5.15843165663784"^^xsd:float ;
     nidm_pValueUncorrected: "1.24513486854383e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0226961325651858"^^xsd:float ;
     nidm_qValueFDR: "0.00456113578807012"^^xsd:float .
 
-niiri:bda2060e4fc205817c927e5c4cc0d265
+niiri:f26173f80e46fa5a537d30b91a145a04
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0033" ;
     nidm_coordinateVector: "[56,-44,52]"^^xsd:string .
 
-niiri:c3e147319287620cf6f6682a13bb0c44 prov:wasDerivedFrom niiri:d852b48a402ab69819373ede91d1c632 .
+niiri:e161d7cffaa802baa8842dbbc2ff600e prov:wasDerivedFrom niiri:e25e46750ed6706bcfbfa5e14d55d777 .
 
-niiri:9cae9fe3c87539a4263e6b3cb80c5f42
+niiri:5922bca96de375a1c4dae7b56d92f626
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0034" ;
-    prov:atLocation niiri:c26f11a9c1966c5cc8d3a97ffd8acc2c ;
+    prov:atLocation niiri:b342d1a5b119cd356d082e704609a7af ;
     prov:value "37.8682479858398"^^xsd:float ;
     nidm_equivalentZStatistic: "5.52397812994418"^^xsd:float ;
     nidm_pValueUncorrected: "1.65704366894559e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00369615187187566"^^xsd:float ;
     nidm_qValueFDR: "0.00135850417567201"^^xsd:float .
 
-niiri:c26f11a9c1966c5cc8d3a97ffd8acc2c
+niiri:b342d1a5b119cd356d082e704609a7af
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0034" ;
     nidm_coordinateVector: "[-28,-94,4]"^^xsd:string .
 
-niiri:9cae9fe3c87539a4263e6b3cb80c5f42 prov:wasDerivedFrom niiri:2f36545388d37f7477d8f0618c919f09 .
+niiri:5922bca96de375a1c4dae7b56d92f626 prov:wasDerivedFrom niiri:e2ac8194c797871c399100cc42929140 .
 
-niiri:370f06f8656e584e8bd7a15eb29b6f66
+niiri:a4cb37e2bdfafa8de612a84fcbdf3e3e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0035" ;
-    prov:atLocation niiri:5aa56f4b5bc0433444955a59931d33c6 ;
+    prov:atLocation niiri:e6af297a793f37a7c50553e7b57ac4f4 ;
     prov:value "13.7997980117798"^^xsd:float ;
     nidm_equivalentZStatistic: "3.39898111375179"^^xsd:float ;
     nidm_pValueUncorrected: "0.000338186933782514"^^xsd:float ;
     nidm_pValueFWER: "0.999999983062369"^^xsd:float ;
     nidm_qValueFDR: "0.517098903229732"^^xsd:float .
 
-niiri:5aa56f4b5bc0433444955a59931d33c6
+niiri:e6af297a793f37a7c50553e7b57ac4f4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0035" ;
     nidm_coordinateVector: "[-34,-84,-2]"^^xsd:string .
 
-niiri:370f06f8656e584e8bd7a15eb29b6f66 prov:wasDerivedFrom niiri:2f36545388d37f7477d8f0618c919f09 .
+niiri:a4cb37e2bdfafa8de612a84fcbdf3e3e prov:wasDerivedFrom niiri:e2ac8194c797871c399100cc42929140 .
 
-niiri:6dafd1b7bbda5f996e96f933f65cf52b
+niiri:5f5bff873009036bef971ae6521ab438
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0036" ;
-    prov:atLocation niiri:9f0d1dd25a994924631ac77e99c886e5 ;
+    prov:atLocation niiri:7d85c1d7748a0e2b666ce05b7a08b3b3 ;
     prov:value "37.2234077453613"^^xsd:float ;
     nidm_equivalentZStatistic: "5.48187213205114"^^xsd:float ;
     nidm_pValueUncorrected: "2.1042418696382e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00469365878715888"^^xsd:float ;
     nidm_qValueFDR: "0.00150767324732148"^^xsd:float .
 
-niiri:9f0d1dd25a994924631ac77e99c886e5
+niiri:7d85c1d7748a0e2b666ce05b7a08b3b3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0036" ;
     nidm_coordinateVector: "[32,2,46]"^^xsd:string .
 
-niiri:6dafd1b7bbda5f996e96f933f65cf52b prov:wasDerivedFrom niiri:6da57157038eade3ca7a4c29d0c28ad8 .
+niiri:5f5bff873009036bef971ae6521ab438 prov:wasDerivedFrom niiri:e480d8d12a9dc866e99b7a65d64c73b5 .
 
-niiri:6c54477095f54c7a3b23f4f4f13e9a11
+niiri:8981157e9a4e6b5b093e68b901438bad
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0037" ;
-    prov:atLocation niiri:4b59168815bd120e5fd696c03ce5c99b ;
+    prov:atLocation niiri:1f9e20630d2591abc7429d5b071cfdfd ;
     prov:value "21.2399845123291"^^xsd:float ;
     nidm_equivalentZStatistic: "4.21989878746824"^^xsd:float ;
     nidm_pValueUncorrected: "1.22206011216042e-05"^^xsd:float ;
     nidm_pValueFWER: "0.701750105433623"^^xsd:float ;
     nidm_qValueFDR: "0.0674703024550716"^^xsd:float .
 
-niiri:4b59168815bd120e5fd696c03ce5c99b
+niiri:1f9e20630d2591abc7429d5b071cfdfd
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0037" ;
     nidm_coordinateVector: "[28,4,58]"^^xsd:string .
 
-niiri:6c54477095f54c7a3b23f4f4f13e9a11 prov:wasDerivedFrom niiri:6da57157038eade3ca7a4c29d0c28ad8 .
+niiri:8981157e9a4e6b5b093e68b901438bad prov:wasDerivedFrom niiri:e480d8d12a9dc866e99b7a65d64c73b5 .
 
-niiri:e5ef6fd0bdd08411180840b8529fe6f9
+niiri:2c14d6250d370f445e78b4505c0ef514
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0038" ;
-    prov:atLocation niiri:16d7b76654f595d9da06fb0f430cee2d ;
+    prov:atLocation niiri:a105d9481745a29ec63afc10e1ef6b75 ;
     prov:value "15.9035987854004"^^xsd:float ;
     nidm_equivalentZStatistic: "3.65519960348906"^^xsd:float ;
     nidm_pValueUncorrected: "0.000128490978751894"^^xsd:float ;
     nidm_pValueFWER: "0.999764209794947"^^xsd:float ;
     nidm_qValueFDR: "0.29501424528785"^^xsd:float .
 
-niiri:16d7b76654f595d9da06fb0f430cee2d
+niiri:a105d9481745a29ec63afc10e1ef6b75
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0038" ;
     nidm_coordinateVector: "[42,4,48]"^^xsd:string .
 
-niiri:e5ef6fd0bdd08411180840b8529fe6f9 prov:wasDerivedFrom niiri:6da57157038eade3ca7a4c29d0c28ad8 .
+niiri:2c14d6250d370f445e78b4505c0ef514 prov:wasDerivedFrom niiri:e480d8d12a9dc866e99b7a65d64c73b5 .
 
-niiri:04086fe279a8d0368c806231baab87c4
+niiri:c76586b39c4dce8e30ab4aec2bd0cfe3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0039" ;
-    prov:atLocation niiri:6530c3b3e69718001b26adc51b4d89cc ;
+    prov:atLocation niiri:6710a695671f6faba8360e71e27233bc ;
     prov:value "37.0886573791504"^^xsd:float ;
     nidm_equivalentZStatistic: "5.47300715255656"^^xsd:float ;
     nidm_pValueUncorrected: "2.21231123420651e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00493011007616861"^^xsd:float ;
     nidm_qValueFDR: "0.00153274880779606"^^xsd:float .
 
-niiri:6530c3b3e69718001b26adc51b4d89cc
+niiri:6710a695671f6faba8360e71e27233bc
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0039" ;
     nidm_coordinateVector: "[36,-86,24]"^^xsd:string .
 
-niiri:04086fe279a8d0368c806231baab87c4 prov:wasDerivedFrom niiri:f36a9d2eb3726086574d1578e1d9f0f8 .
+niiri:c76586b39c4dce8e30ab4aec2bd0cfe3 prov:wasDerivedFrom niiri:82f170400f1b69cc64c4688f03080756 .
 
-niiri:834a6b2114c1b74621532f33080c5672
+niiri:cbb5e181055a603b555fe4e31c70e6db
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0040" ;
-    prov:atLocation niiri:015e2301960ea3c0dde2b17317fb271b ;
+    prov:atLocation niiri:78e5b9b06ac93d423a8111be3ef702c4 ;
     prov:value "22.2462520599365"^^xsd:float ;
     nidm_equivalentZStatistic: "4.31562212585875"^^xsd:float ;
     nidm_pValueUncorrected: "7.95770158346087e-06"^^xsd:float ;
     nidm_pValueFWER: "0.569468011037952"^^xsd:float ;
     nidm_qValueFDR: "0.0515172252256118"^^xsd:float .
 
-niiri:015e2301960ea3c0dde2b17317fb271b
+niiri:78e5b9b06ac93d423a8111be3ef702c4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0040" ;
     nidm_coordinateVector: "[40,-82,32]"^^xsd:string .
 
-niiri:834a6b2114c1b74621532f33080c5672 prov:wasDerivedFrom niiri:f36a9d2eb3726086574d1578e1d9f0f8 .
+niiri:cbb5e181055a603b555fe4e31c70e6db prov:wasDerivedFrom niiri:82f170400f1b69cc64c4688f03080756 .
 
-niiri:dac11f21422e5b84e6225de84bed6cf1
+niiri:66ffbe934050578ca7c698d14aa85d25
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0041" ;
-    prov:atLocation niiri:0f33cb1812dd5fbe10201b85a4c8325b ;
+    prov:atLocation niiri:b75d0a763814255b3c3a4c299253e49e ;
     prov:value "21.6013984680176"^^xsd:float ;
     nidm_equivalentZStatistic: "4.25461718208726"^^xsd:float ;
     nidm_pValueUncorrected: "1.04703485692692e-05"^^xsd:float ;
     nidm_pValueFWER: "0.654350531154308"^^xsd:float ;
     nidm_qValueFDR: "0.0608459925765272"^^xsd:float .
 
-niiri:0f33cb1812dd5fbe10201b85a4c8325b
+niiri:b75d0a763814255b3c3a4c299253e49e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0041" ;
     nidm_coordinateVector: "[28,-92,26]"^^xsd:string .
 
-niiri:dac11f21422e5b84e6225de84bed6cf1 prov:wasDerivedFrom niiri:f36a9d2eb3726086574d1578e1d9f0f8 .
+niiri:66ffbe934050578ca7c698d14aa85d25 prov:wasDerivedFrom niiri:82f170400f1b69cc64c4688f03080756 .
 
-niiri:f1ee71a44f0186b27050b8b75b15486a
+niiri:c141baff99ff608f6fd42bbe6f81dd32
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0042" ;
-    prov:atLocation niiri:4d41596e92e5ee6ff6d1600c6fb69e7e ;
+    prov:atLocation niiri:e06c4859c1235e6e7a24c07d2a8f9420 ;
     prov:value "35.8021011352539"^^xsd:float ;
     nidm_equivalentZStatistic: "5.38718083940908"^^xsd:float ;
     nidm_pValueUncorrected: "3.57857066202172e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00756307748953688"^^xsd:float ;
     nidm_qValueFDR: "0.00208265173602203"^^xsd:float .
 
-niiri:4d41596e92e5ee6ff6d1600c6fb69e7e
+niiri:e06c4859c1235e6e7a24c07d2a8f9420
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0042" ;
     nidm_coordinateVector: "[-52,0,38]"^^xsd:string .
 
-niiri:f1ee71a44f0186b27050b8b75b15486a prov:wasDerivedFrom niiri:3132927065aeeaa4a3a285e94ec260a6 .
+niiri:c141baff99ff608f6fd42bbe6f81dd32 prov:wasDerivedFrom niiri:c7d451f7f453a0be61177b599ede33a5 .
 
-niiri:03f60451ad894853f8cedd47338360c8
+niiri:b7060223bff407a13eb216f455300b91
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0043" ;
-    prov:atLocation niiri:cc2d7d3584bd585cc58b66129262580a ;
+    prov:atLocation niiri:d91a8f2dc685df25dd670f56364b8b27 ;
     prov:value "27.304349899292"^^xsd:float ;
     nidm_equivalentZStatistic: "4.75741877507894"^^xsd:float ;
     nidm_pValueUncorrected: "9.80420573615248e-07"^^xsd:float ;
     nidm_pValueFWER: "0.130618606044682"^^xsd:float ;
     nidm_qValueFDR: "0.0155044826465378"^^xsd:float .
 
-niiri:cc2d7d3584bd585cc58b66129262580a
+niiri:d91a8f2dc685df25dd670f56364b8b27
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0043" ;
     nidm_coordinateVector: "[-60,8,20]"^^xsd:string .
 
-niiri:03f60451ad894853f8cedd47338360c8 prov:wasDerivedFrom niiri:3132927065aeeaa4a3a285e94ec260a6 .
+niiri:b7060223bff407a13eb216f455300b91 prov:wasDerivedFrom niiri:c7d451f7f453a0be61177b599ede33a5 .
 
-niiri:f1de543adf152a9d036d0d9bd6d6db38
+niiri:25383c240e64533096acb91f30ed5f79
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0044" ;
-    prov:atLocation niiri:a4826a5ff1dd5dc82f90da238a9c2e0e ;
+    prov:atLocation niiri:2312acaca8091779181ea64815241be7 ;
     prov:value "24.8951110839844"^^xsd:float ;
     nidm_equivalentZStatistic: "4.55454903196731"^^xsd:float ;
     nidm_pValueUncorrected: "2.62490395575021e-06"^^xsd:float ;
     nidm_pValueFWER: "0.279280704231587"^^xsd:float ;
     nidm_qValueFDR: "0.0268577436307079"^^xsd:float .
 
-niiri:a4826a5ff1dd5dc82f90da238a9c2e0e
+niiri:2312acaca8091779181ea64815241be7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0044" ;
     nidm_coordinateVector: "[-44,6,28]"^^xsd:string .
 
-niiri:f1de543adf152a9d036d0d9bd6d6db38 prov:wasDerivedFrom niiri:3132927065aeeaa4a3a285e94ec260a6 .
+niiri:25383c240e64533096acb91f30ed5f79 prov:wasDerivedFrom niiri:c7d451f7f453a0be61177b599ede33a5 .
 
-niiri:2ac655095d5518c19a2bc9820490a0d4
+niiri:68ea392bb49f24d944e1b260af098020
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0045" ;
-    prov:atLocation niiri:f2e579f7fb1529bf37359eefe7d6ec57 ;
+    prov:atLocation niiri:e4d53353bebc01fea518333458b6e995 ;
     prov:value "35.5708847045898"^^xsd:float ;
     nidm_equivalentZStatistic: "5.37152336467669"^^xsd:float ;
     nidm_pValueUncorrected: "3.90371248659704e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00816987841831085"^^xsd:float ;
     nidm_qValueFDR: "0.00217310121107197"^^xsd:float .
 
-niiri:f2e579f7fb1529bf37359eefe7d6ec57
+niiri:e4d53353bebc01fea518333458b6e995
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0045" ;
     nidm_coordinateVector: "[30,-66,-6]"^^xsd:string .
 
-niiri:2ac655095d5518c19a2bc9820490a0d4 prov:wasDerivedFrom niiri:1cad58fd2cece054821848126afc3007 .
+niiri:68ea392bb49f24d944e1b260af098020 prov:wasDerivedFrom niiri:37926699687cca9b9dd0b742b092ff48 .
 
-niiri:5134eb6ddb2e676dd190459560925dac
+niiri:1735ae6e0d994f082ddd12a7f2621f0a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0046" ;
-    prov:atLocation niiri:a83fac439dbaeb921eefe4b4fcb01c40 ;
+    prov:atLocation niiri:e9dbabf41ff4b3cbd53c7a1462ebfaab ;
     prov:value "35.2681846618652"^^xsd:float ;
     nidm_equivalentZStatistic: "5.350915057242"^^xsd:float ;
     nidm_pValueUncorrected: "4.3755296941228e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00903953548239023"^^xsd:float ;
     nidm_qValueFDR: "0.00235638277703814"^^xsd:float .
 
-niiri:a83fac439dbaeb921eefe4b4fcb01c40
+niiri:e9dbabf41ff4b3cbd53c7a1462ebfaab
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0046" ;
     nidm_coordinateVector: "[24,-54,-16]"^^xsd:string .
 
-niiri:5134eb6ddb2e676dd190459560925dac prov:wasDerivedFrom niiri:1cad58fd2cece054821848126afc3007 .
+niiri:1735ae6e0d994f082ddd12a7f2621f0a prov:wasDerivedFrom niiri:37926699687cca9b9dd0b742b092ff48 .
 
-niiri:c0ac049f4c5298835d536c905ec83fae
+niiri:93b54ac55b78a51e2a8346189557574f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0047" ;
-    prov:atLocation niiri:d6dbdc051fbcd9ea6e3f628a108cb411 ;
+    prov:atLocation niiri:f253c7c3034017bc1e14b769c4a9f665 ;
     prov:value "33.5431251525879"^^xsd:float ;
     nidm_equivalentZStatistic: "5.23100638995574"^^xsd:float ;
     nidm_pValueUncorrected: "8.42948405521682e-08"^^xsd:float ;
     nidm_pValueFWER: "0.016124846685693"^^xsd:float ;
     nidm_qValueFDR: "0.00349953417360534"^^xsd:float .
 
-niiri:d6dbdc051fbcd9ea6e3f628a108cb411
+niiri:f253c7c3034017bc1e14b769c4a9f665
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0047" ;
     nidm_coordinateVector: "[18,-54,-6]"^^xsd:string .
 
-niiri:c0ac049f4c5298835d536c905ec83fae prov:wasDerivedFrom niiri:1cad58fd2cece054821848126afc3007 .
+niiri:93b54ac55b78a51e2a8346189557574f prov:wasDerivedFrom niiri:37926699687cca9b9dd0b742b092ff48 .
 
-niiri:86babbe08a5271f8f862022cb9c85a37
+niiri:5766230ffa1accb71218f9a65385d08e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0048" ;
-    prov:atLocation niiri:8decd82989c21ea201824f4fd23c5371 ;
+    prov:atLocation niiri:ceca5eb2386bd4c4e47d2c0c586a097d ;
     prov:value "34.9530181884766"^^xsd:float ;
     nidm_equivalentZStatistic: "5.32932369363006"^^xsd:float ;
     nidm_pValueUncorrected: "4.92895819714789e-08"^^xsd:float ;
     nidm_pValueFWER: "0.0100448972767031"^^xsd:float ;
     nidm_qValueFDR: "0.00246864149540014"^^xsd:float .
 
-niiri:8decd82989c21ea201824f4fd23c5371
+niiri:ceca5eb2386bd4c4e47d2c0c586a097d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0048" ;
     nidm_coordinateVector: "[16,-84,44]"^^xsd:string .
 
-niiri:86babbe08a5271f8f862022cb9c85a37 prov:wasDerivedFrom niiri:1fcfe58e890a992a0cbd392039bb176f .
+niiri:5766230ffa1accb71218f9a65385d08e prov:wasDerivedFrom niiri:e7fc074f64298360eb2c7ffbcb4e63aa .
 
-niiri:85e9e5a479a64fe96308e993a393382e
+niiri:b7d8fb60227ddc169d23c315114e2e40
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0049" ;
-    prov:atLocation niiri:a4aa70ad14969702e648abc2981b2229 ;
+    prov:atLocation niiri:20089fd71414202501ea181905ceda27 ;
     prov:value "34.2299766540527"^^xsd:float ;
     nidm_equivalentZStatistic: "5.27926163486319"^^xsd:float ;
     nidm_pValueUncorrected: "6.48527449520486e-08"^^xsd:float ;
     nidm_pValueFWER: "0.0128006355440512"^^xsd:float ;
     nidm_qValueFDR: "0.00299523511468489"^^xsd:float .
 
-niiri:a4aa70ad14969702e648abc2981b2229
+niiri:20089fd71414202501ea181905ceda27
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0049" ;
     nidm_coordinateVector: "[-48,-52,-26]"^^xsd:string .
 
-niiri:85e9e5a479a64fe96308e993a393382e prov:wasDerivedFrom niiri:41b3f1fe29e41e8399e5532675d71afb .
+niiri:b7d8fb60227ddc169d23c315114e2e40 prov:wasDerivedFrom niiri:617a58ee9ff77a4075c0708ea690d16c .
 
-niiri:419a6b6979a7c4e08ae0860340857632
+niiri:be6ef07847d5a11377cd20e3bf142605
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0050" ;
-    prov:atLocation niiri:cfc6ec4dd43c2525d3f5c8b60349f2ba ;
+    prov:atLocation niiri:7a0a448d7f559d689b8d444542976a30 ;
     prov:value "25.4968433380127"^^xsd:float ;
     nidm_equivalentZStatistic: "4.60642227215859"^^xsd:float ;
     nidm_pValueUncorrected: "2.04828043492977e-06"^^xsd:float ;
     nidm_pValueFWER: "0.232501903028901"^^xsd:float ;
     nidm_qValueFDR: "0.0230459220332407"^^xsd:float .
 
-niiri:cfc6ec4dd43c2525d3f5c8b60349f2ba
+niiri:7a0a448d7f559d689b8d444542976a30
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0050" ;
     nidm_coordinateVector: "[-34,-42,-28]"^^xsd:string .
 
-niiri:419a6b6979a7c4e08ae0860340857632 prov:wasDerivedFrom niiri:41b3f1fe29e41e8399e5532675d71afb .
+niiri:be6ef07847d5a11377cd20e3bf142605 prov:wasDerivedFrom niiri:617a58ee9ff77a4075c0708ea690d16c .
 
-niiri:541c2830bbdf066f7986aa03a275db5b
+niiri:270434b20e00025409cc3402d4134104
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0051" ;
-    prov:atLocation niiri:e699bc65a7aa87c6ed1347272f96036c ;
+    prov:atLocation niiri:dde4c1281c1e7730093e357f4c333b57 ;
     prov:value "33.9315414428711"^^xsd:float ;
     nidm_equivalentZStatistic: "5.2583798008004"^^xsd:float ;
     nidm_pValueUncorrected: "7.26650642990379e-08"^^xsd:float ;
     nidm_pValueFWER: "0.0141503991863343"^^xsd:float ;
     nidm_qValueFDR: "0.00317914466289153"^^xsd:float .
 
-niiri:e699bc65a7aa87c6ed1347272f96036c
+niiri:dde4c1281c1e7730093e357f4c333b57
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0051" ;
     nidm_coordinateVector: "[58,12,-20]"^^xsd:string .
 
-niiri:541c2830bbdf066f7986aa03a275db5b prov:wasDerivedFrom niiri:9a54b48570d440ea6ac8f1f92e78425f .
+niiri:270434b20e00025409cc3402d4134104 prov:wasDerivedFrom niiri:fd34291df44a2d10645e6546a1593a1c .
 
-niiri:8db13aa1400987668a666204b86a9a65
+niiri:dd6a5e6b2dd23e0f9e80ac6bfc81c96b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0052" ;
-    prov:atLocation niiri:d7b874652c2c7ed615f7cedfdc28589e ;
+    prov:atLocation niiri:cbc78a2103930efca8b6cba5d06325aa ;
     prov:value "19.0596389770508"^^xsd:float ;
     nidm_equivalentZStatistic: "4.00175558310566"^^xsd:float ;
     nidm_pValueUncorrected: "3.14371148909531e-05"^^xsd:float ;
     nidm_pValueFWER: "0.929942403817741"^^xsd:float ;
     nidm_qValueFDR: "0.124351274352918"^^xsd:float .
 
-niiri:d7b874652c2c7ed615f7cedfdc28589e
+niiri:cbc78a2103930efca8b6cba5d06325aa
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0052" ;
     nidm_coordinateVector: "[60,-2,-16]"^^xsd:string .
 
-niiri:8db13aa1400987668a666204b86a9a65 prov:wasDerivedFrom niiri:9a54b48570d440ea6ac8f1f92e78425f .
+niiri:dd6a5e6b2dd23e0f9e80ac6bfc81c96b prov:wasDerivedFrom niiri:fd34291df44a2d10645e6546a1593a1c .
 
-niiri:d097a1148dac67761e4e100e3073a34c
+niiri:39553cd2909fb4f309850bc50283f969
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0053" ;
-    prov:atLocation niiri:5e4f204c6ed90a1362ea319673a1a1b3 ;
+    prov:atLocation niiri:a51d05f416df644328a6cb3628a53340 ;
     prov:value "16.95458984375"^^xsd:float ;
     nidm_equivalentZStatistic: "3.77515624884835"^^xsd:float ;
     nidm_pValueUncorrected: "7.99536997647676e-05"^^xsd:float ;
     nidm_pValueFWER: "0.996665924683688"^^xsd:float ;
     nidm_qValueFDR: "0.218440612600676"^^xsd:float .
 
-niiri:5e4f204c6ed90a1362ea319673a1a1b3
+niiri:a51d05f416df644328a6cb3628a53340
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0053" ;
     nidm_coordinateVector: "[60,4,-22]"^^xsd:string .
 
-niiri:d097a1148dac67761e4e100e3073a34c prov:wasDerivedFrom niiri:9a54b48570d440ea6ac8f1f92e78425f .
+niiri:39553cd2909fb4f309850bc50283f969 prov:wasDerivedFrom niiri:fd34291df44a2d10645e6546a1593a1c .
 
-niiri:e1dc3fa319bf52239f49913d17a1f776
+niiri:829cbe8430fd88bbc00d346769721904
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0054" ;
-    prov:atLocation niiri:83c602bcf84c9c5ab8d1ed41e44765a8 ;
+    prov:atLocation niiri:004948ca236c52cf9756f94713a6c2af ;
     prov:value "33.4968719482422"^^xsd:float ;
     nidm_equivalentZStatistic: "5.22773182499393"^^xsd:float ;
     nidm_pValueUncorrected: "8.58010831272793e-08"^^xsd:float ;
     nidm_pValueFWER: "0.0163777835136855"^^xsd:float ;
     nidm_qValueFDR: "0.00349953417360534"^^xsd:float .
 
-niiri:83c602bcf84c9c5ab8d1ed41e44765a8
+niiri:004948ca236c52cf9756f94713a6c2af
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0054" ;
     nidm_coordinateVector: "[-8,50,14]"^^xsd:string .
 
-niiri:e1dc3fa319bf52239f49913d17a1f776 prov:wasDerivedFrom niiri:ffd74835caba617d42d83e59e6b5a54e .
+niiri:829cbe8430fd88bbc00d346769721904 prov:wasDerivedFrom niiri:8677fb654966f35b2ba255c1e63d1cb1 .
 
-niiri:f034e055ebe1a33dc31858900fb098d6
+niiri:779dd8335e4fd65858941476e998673b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0055" ;
-    prov:atLocation niiri:0dff3b10c950662524b9f222c1981f13 ;
+    prov:atLocation niiri:54043a6e802dade52c783cf91d848c19 ;
     prov:value "29.9832496643066"^^xsd:float ;
     nidm_equivalentZStatistic: "4.96911405212995"^^xsd:float ;
     nidm_pValueUncorrected: "3.36297509062611e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0535569381204491"^^xsd:float ;
     nidm_qValueFDR: "0.00813843087070338"^^xsd:float .
 
-niiri:0dff3b10c950662524b9f222c1981f13
+niiri:54043a6e802dade52c783cf91d848c19
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0055" ;
     nidm_coordinateVector: "[0,64,14]"^^xsd:string .
 
-niiri:f034e055ebe1a33dc31858900fb098d6 prov:wasDerivedFrom niiri:ffd74835caba617d42d83e59e6b5a54e .
+niiri:779dd8335e4fd65858941476e998673b prov:wasDerivedFrom niiri:8677fb654966f35b2ba255c1e63d1cb1 .
 
-niiri:a98a41f7e6b66a8f640f080fe37400a8
+niiri:03c31dd1111118a4d4e27639746be972
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0056" ;
-    prov:atLocation niiri:d4bc3d5b7f9c56de6a3f56e7080d05a2 ;
+    prov:atLocation niiri:abb708694b565836e1566ffb6107e47f ;
     prov:value "22.9387531280518"^^xsd:float ;
     nidm_equivalentZStatistic: "4.37984280105142"^^xsd:float ;
     nidm_pValueUncorrected: "5.93824767269879e-06"^^xsd:float ;
     nidm_pValueFWER: "0.481901129565415"^^xsd:float ;
     nidm_qValueFDR: "0.0438469723479488"^^xsd:float .
 
-niiri:d4bc3d5b7f9c56de6a3f56e7080d05a2
+niiri:abb708694b565836e1566ffb6107e47f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0056" ;
     nidm_coordinateVector: "[-20,44,-16]"^^xsd:string .
 
-niiri:a98a41f7e6b66a8f640f080fe37400a8 prov:wasDerivedFrom niiri:ffd74835caba617d42d83e59e6b5a54e .
+niiri:03c31dd1111118a4d4e27639746be972 prov:wasDerivedFrom niiri:8677fb654966f35b2ba255c1e63d1cb1 .
 
-niiri:88ad3cc3781d8b88b017dd39a403ba13
+niiri:f29776971e9edeb3024d30c38070b4fe
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0057" ;
-    prov:atLocation niiri:d69eb16669b789396003dd1e55f55d19 ;
+    prov:atLocation niiri:4caf6e61318e78b90d840ebd45b97e54 ;
     prov:value "33.4191627502441"^^xsd:float ;
     nidm_equivalentZStatistic: "5.22222309196889"^^xsd:float ;
     nidm_pValueUncorrected: "8.83939008655688e-08"^^xsd:float ;
     nidm_pValueFWER: "0.016811779659474"^^xsd:float ;
     nidm_qValueFDR: "0.00353415653584831"^^xsd:float .
 
-niiri:d69eb16669b789396003dd1e55f55d19
+niiri:4caf6e61318e78b90d840ebd45b97e54
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0057" ;
     nidm_coordinateVector: "[-34,-2,52]"^^xsd:string .
 
-niiri:88ad3cc3781d8b88b017dd39a403ba13 prov:wasDerivedFrom niiri:56af8a072a247476eb5fd62c25fdf6e9 .
+niiri:f29776971e9edeb3024d30c38070b4fe prov:wasDerivedFrom niiri:545f94f2d451c1c902303c221a0a1089 .
 
-niiri:1ebe37481bd2402d0c4496e789620aaf
+niiri:4f203f7fbd8966e70a518b7a5098265c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0058" ;
-    prov:atLocation niiri:036d01b30c63f19c9c51d74c4ae9441e ;
+    prov:atLocation niiri:840423c9f78860e1bbacbdb8430b4cb1 ;
     prov:value "29.2642135620117"^^xsd:float ;
     nidm_equivalentZStatistic: "4.91361665883884"^^xsd:float ;
     nidm_pValueUncorrected: "4.47057450281285e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0681879801861663"^^xsd:float ;
     nidm_qValueFDR: "0.00986818968821408"^^xsd:float .
 
-niiri:036d01b30c63f19c9c51d74c4ae9441e
+niiri:840423c9f78860e1bbacbdb8430b4cb1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0058" ;
     nidm_coordinateVector: "[-54,-46,58]"^^xsd:string .
 
-niiri:1ebe37481bd2402d0c4496e789620aaf prov:wasDerivedFrom niiri:097010bf7718d0ca7ca15cd545a5d22f .
+niiri:4f203f7fbd8966e70a518b7a5098265c prov:wasDerivedFrom niiri:f9a9c037c3239038fee46308d6b9feba .
 
-niiri:bb174da829ac30b4114254d72cff3fe9
+niiri:7ab50e444de918ebf5bcfdebceaf9ad0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0059" ;
-    prov:atLocation niiri:91f5a4a193bd5413aaca5507a5b695b1 ;
+    prov:atLocation niiri:73c5ac956eca1bb030453396f1ae3059 ;
     prov:value "28.8472003936768"^^xsd:float ;
     nidm_equivalentZStatistic: "4.88099763110222"^^xsd:float ;
     nidm_pValueUncorrected: "5.2775255054982e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0783986768366318"^^xsd:float ;
     nidm_qValueFDR: "0.0110008671467558"^^xsd:float .
 
-niiri:91f5a4a193bd5413aaca5507a5b695b1
+niiri:73c5ac956eca1bb030453396f1ae3059
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0059" ;
     nidm_coordinateVector: "[34,-42,70]"^^xsd:string .
 
-niiri:bb174da829ac30b4114254d72cff3fe9 prov:wasDerivedFrom niiri:9bd5784f7d92f66f0e060878415afdd2 .
+niiri:7ab50e444de918ebf5bcfdebceaf9ad0 prov:wasDerivedFrom niiri:6441c160dec1271f21351fe6ca31e10a .
 
-niiri:b31569768eb0ecaf798b885c052d70bc
+niiri:48472e5c0e95db5f72001e9bbdb54075
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0060" ;
-    prov:atLocation niiri:c0e88496f1b24da7d9c729666ca6e6b9 ;
+    prov:atLocation niiri:c39236425bbf9b6441d6709219569da0 ;
     prov:value "27.9873161315918"^^xsd:float ;
     nidm_equivalentZStatistic: "4.81269831822163"^^xsd:float ;
     nidm_pValueUncorrected: "7.44529926488546e-07"^^xsd:float ;
     nidm_pValueFWER: "0.104344146902035"^^xsd:float ;
     nidm_qValueFDR: "0.0136039810527477"^^xsd:float .
 
-niiri:c0e88496f1b24da7d9c729666ca6e6b9
+niiri:c39236425bbf9b6441d6709219569da0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0060" ;
     nidm_coordinateVector: "[22,-52,72]"^^xsd:string .
 
-niiri:b31569768eb0ecaf798b885c052d70bc prov:wasDerivedFrom niiri:9bd5784f7d92f66f0e060878415afdd2 .
+niiri:48472e5c0e95db5f72001e9bbdb54075 prov:wasDerivedFrom niiri:6441c160dec1271f21351fe6ca31e10a .
 
-niiri:7181bc8829a207383619341fb4ea356b
+niiri:5ddd28f08b4c942fd117d28ee9faac64
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0061" ;
-    prov:atLocation niiri:d81296739d1d52ad4d973c73a6fbbe33 ;
+    prov:atLocation niiri:42db9c9a0d0502948e4fee8df9e3124e ;
     prov:value "27.299201965332"^^xsd:float ;
     nidm_equivalentZStatistic: "4.75699852876781"^^xsd:float ;
     nidm_pValueUncorrected: "9.82463004728373e-07"^^xsd:float ;
     nidm_pValueFWER: "0.130838529326203"^^xsd:float ;
     nidm_qValueFDR: "0.0155044826465378"^^xsd:float .
 
-niiri:d81296739d1d52ad4d973c73a6fbbe33
+niiri:42db9c9a0d0502948e4fee8df9e3124e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0061" ;
     nidm_coordinateVector: "[40,-44,62]"^^xsd:string .
 
-niiri:7181bc8829a207383619341fb4ea356b prov:wasDerivedFrom niiri:9bd5784f7d92f66f0e060878415afdd2 .
+niiri:5ddd28f08b4c942fd117d28ee9faac64 prov:wasDerivedFrom niiri:6441c160dec1271f21351fe6ca31e10a .
 
-niiri:ed2995aa862047bd5161a8a6730d0afa
+niiri:2b3ce71bfa91fff55105d339fbbdbe2b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0062" ;
-    prov:atLocation niiri:034855fb3b812c879b54f99448454eef ;
+    prov:atLocation niiri:91623ffcf878c645ac2db15bb89ab96c ;
     prov:value "28.2855854034424"^^xsd:float ;
     nidm_equivalentZStatistic: "4.83655063572385"^^xsd:float ;
     nidm_pValueUncorrected: "6.60558149623292e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0945247092312007"^^xsd:float ;
     nidm_qValueFDR: "0.0127733737382444"^^xsd:float .
 
-niiri:034855fb3b812c879b54f99448454eef
+niiri:91623ffcf878c645ac2db15bb89ab96c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0062" ;
     nidm_coordinateVector: "[-62,-38,48]"^^xsd:string .
 
-niiri:ed2995aa862047bd5161a8a6730d0afa prov:wasDerivedFrom niiri:acdf8cd47c627692be1a25b68765ef7e .
+niiri:2b3ce71bfa91fff55105d339fbbdbe2b prov:wasDerivedFrom niiri:2872350aa13a26854db92f5a27149fe1 .
 
-niiri:8a1082010857a17aaa32971414fa6ba6
+niiri:f2be8929a3710e3a368deadf13c7b07c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0063" ;
-    prov:atLocation niiri:98d06df7fa85f28faf41d867cabd92b4 ;
+    prov:atLocation niiri:ae22616a0f065e3a7f82a19748390b4d ;
     prov:value "20.8939819335938"^^xsd:float ;
     nidm_equivalentZStatistic: "4.18629418105686"^^xsd:float ;
     nidm_pValueUncorrected: "1.41772903717863e-05"^^xsd:float ;
     nidm_pValueFWER: "0.745987987161102"^^xsd:float ;
     nidm_qValueFDR: "0.0747839778627127"^^xsd:float .
 
-niiri:98d06df7fa85f28faf41d867cabd92b4
+niiri:ae22616a0f065e3a7f82a19748390b4d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0063" ;
     nidm_coordinateVector: "[-60,-50,48]"^^xsd:string .
 
-niiri:8a1082010857a17aaa32971414fa6ba6 prov:wasDerivedFrom niiri:acdf8cd47c627692be1a25b68765ef7e .
+niiri:f2be8929a3710e3a368deadf13c7b07c prov:wasDerivedFrom niiri:2872350aa13a26854db92f5a27149fe1 .
 
-niiri:fb0d45cf20c643da2fd4b62ec24218a2
+niiri:6beebfb6b83f4e4fbc1d0fabd13b2921
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0064" ;
-    prov:atLocation niiri:d264808c9c2957a199dd50cedd176208 ;
+    prov:atLocation niiri:3de11b76086fc65df36803e9e359450b ;
     prov:value "28.164192199707"^^xsd:float ;
     nidm_equivalentZStatistic: "4.82686385572958"^^xsd:float ;
     nidm_pValueUncorrected: "6.93499344617265e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0984091095914084"^^xsd:float ;
     nidm_qValueFDR: "0.0131723064509997"^^xsd:float .
 
-niiri:d264808c9c2957a199dd50cedd176208
+niiri:3de11b76086fc65df36803e9e359450b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0064" ;
     nidm_coordinateVector: "[32,40,16]"^^xsd:string .
 
-niiri:fb0d45cf20c643da2fd4b62ec24218a2 prov:wasDerivedFrom niiri:7a9e3b4c3767f5381b56e2fbeb688be4 .
+niiri:6beebfb6b83f4e4fbc1d0fabd13b2921 prov:wasDerivedFrom niiri:e3742b34c6808b2398052ec8dae20d8c .
 
-niiri:cc3f0dcda760e37ccf1f076ac386c0b1
+niiri:514baf9fb6cc825d6a8ed488bfd99826
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0065" ;
-    prov:atLocation niiri:e475a296c558cc8055b307c5eb9227bd ;
+    prov:atLocation niiri:265726ad7fe9d9c8c3951257f3edcbe3 ;
     prov:value "20.7001953125"^^xsd:float ;
     nidm_equivalentZStatistic: "4.16731300977185"^^xsd:float ;
     nidm_pValueUncorrected: "1.54105576545271e-05"^^xsd:float ;
     nidm_pValueFWER: "0.769962873085872"^^xsd:float ;
     nidm_qValueFDR: "0.0785095339135121"^^xsd:float .
 
-niiri:e475a296c558cc8055b307c5eb9227bd
+niiri:265726ad7fe9d9c8c3951257f3edcbe3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0065" ;
     nidm_coordinateVector: "[40,46,12]"^^xsd:string .
 
-niiri:cc3f0dcda760e37ccf1f076ac386c0b1 prov:wasDerivedFrom niiri:7a9e3b4c3767f5381b56e2fbeb688be4 .
+niiri:514baf9fb6cc825d6a8ed488bfd99826 prov:wasDerivedFrom niiri:e3742b34c6808b2398052ec8dae20d8c .
 
-niiri:64a414ffbcbf234a397cc934a39c33de
+niiri:c2a20f1f60d0404677a01e0473330666
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0066" ;
-    prov:atLocation niiri:c367485fb36a5056f4f61efc7f41695d ;
+    prov:atLocation niiri:61822c3ab944ea0faa2fcde49bf6928c ;
     prov:value "18.6263465881348"^^xsd:float ;
     nidm_equivalentZStatistic: "3.9564888351335"^^xsd:float ;
     nidm_pValueUncorrected: "3.80297206890035e-05"^^xsd:float ;
     nidm_pValueFWER: "0.955406749953662"^^xsd:float ;
     nidm_qValueFDR: "0.140236437115493"^^xsd:float .
 
-niiri:c367485fb36a5056f4f61efc7f41695d
+niiri:61822c3ab944ea0faa2fcde49bf6928c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0066" ;
     nidm_coordinateVector: "[36,54,6]"^^xsd:string .
 
-niiri:64a414ffbcbf234a397cc934a39c33de prov:wasDerivedFrom niiri:7a9e3b4c3767f5381b56e2fbeb688be4 .
+niiri:c2a20f1f60d0404677a01e0473330666 prov:wasDerivedFrom niiri:e3742b34c6808b2398052ec8dae20d8c .
 
-niiri:76d12aad81066e83e9a226b4c3cd850f
+niiri:a7269318ead6ea41a838413495ff7e57
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0067" ;
-    prov:atLocation niiri:e6019c791343b2ba7fc4a50937b90f30 ;
+    prov:atLocation niiri:b998be76596a69687ddc0d63f339c66f ;
     prov:value "27.7903442382812"^^xsd:float ;
     nidm_equivalentZStatistic: "4.79685095721308"^^xsd:float ;
     nidm_pValueUncorrected: "8.05897185318649e-07"^^xsd:float ;
     nidm_pValueFWER: "0.111355921927938"^^xsd:float ;
     nidm_qValueFDR: "0.0142325796838019"^^xsd:float .
 
-niiri:e6019c791343b2ba7fc4a50937b90f30
+niiri:b998be76596a69687ddc0d63f339c66f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0067" ;
     nidm_coordinateVector: "[-4,-50,74]"^^xsd:string .
 
-niiri:76d12aad81066e83e9a226b4c3cd850f prov:wasDerivedFrom niiri:3e392a8fdf40615d1b9393f7900b1a84 .
+niiri:a7269318ead6ea41a838413495ff7e57 prov:wasDerivedFrom niiri:002a4160ef17e67bfe8f93c22d701531 .
 
-niiri:4db9685a551cd3d8b1a929c0c750acf3
+niiri:357040efdf37bc34eb1815732a22e3e1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0068" ;
-    prov:atLocation niiri:fad8f32fdd1a8a4f17d7cc784e5f7d16 ;
+    prov:atLocation niiri:7ec9e9fcf91f20c5fd87870401d2533a ;
     prov:value "27.776086807251"^^xsd:float ;
     nidm_equivalentZStatistic: "4.79570089443694"^^xsd:float ;
     nidm_pValueUncorrected: "8.10535070061569e-07"^^xsd:float ;
     nidm_pValueFWER: "0.111880510607324"^^xsd:float ;
     nidm_qValueFDR: "0.0142325796838019"^^xsd:float .
 
-niiri:fad8f32fdd1a8a4f17d7cc784e5f7d16
+niiri:7ec9e9fcf91f20c5fd87870401d2533a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0068" ;
     nidm_coordinateVector: "[40,26,48]"^^xsd:string .
 
-niiri:4db9685a551cd3d8b1a929c0c750acf3 prov:wasDerivedFrom niiri:5a380674b2894ae5398504bd4a8533f8 .
+niiri:357040efdf37bc34eb1815732a22e3e1 prov:wasDerivedFrom niiri:88b01b8106ca0618c3b109ef9140a77a .
 
-niiri:2226ec97c21a62742a885c0b1f69c1ac
+niiri:4a825f1cb4eb89df074bde02c951cda0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0069" ;
-    prov:atLocation niiri:1d76842a826598672a5c8a96f7df6647 ;
+    prov:atLocation niiri:36f52911aa619b4ef4106054a1fc54dd ;
     prov:value "27.7102565765381"^^xsd:float ;
     nidm_equivalentZStatistic: "4.79038551132749"^^xsd:float ;
     nidm_pValueUncorrected: "8.32305908970987e-07"^^xsd:float ;
     nidm_pValueFWER: "0.114333288035698"^^xsd:float ;
     nidm_qValueFDR: "0.0142910518357785"^^xsd:float .
 
-niiri:1d76842a826598672a5c8a96f7df6647
+niiri:36f52911aa619b4ef4106054a1fc54dd
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0069" ;
     nidm_coordinateVector: "[-12,-26,84]"^^xsd:string .
 
-niiri:2226ec97c21a62742a885c0b1f69c1ac prov:wasDerivedFrom niiri:13af72d1f5f712ec17e2a4eb12791728 .
+niiri:4a825f1cb4eb89df074bde02c951cda0 prov:wasDerivedFrom niiri:5b45e4eea89f71e19bb39684bf2f0eb7 .
 
-niiri:b7a274756bfe57533a707f92d131756e
+niiri:2f6549876aed12baa3dab8de8273d38a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0070" ;
-    prov:atLocation niiri:888ee5317a79bcb7ad00f180aeab2e56 ;
+    prov:atLocation niiri:44b1830cba35547169ca826553dd909c ;
     prov:value "27.1838035583496"^^xsd:float ;
     nidm_equivalentZStatistic: "4.74756386643394"^^xsd:float ;
     nidm_pValueUncorrected: "1.02940694712839e-06"^^xsd:float ;
     nidm_pValueFWER: "0.13586045231926"^^xsd:float ;
     nidm_qValueFDR: "0.0157421086869962"^^xsd:float .
 
-niiri:888ee5317a79bcb7ad00f180aeab2e56
+niiri:44b1830cba35547169ca826553dd909c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0070" ;
     nidm_coordinateVector: "[22,-16,80]"^^xsd:string .
 
-niiri:b7a274756bfe57533a707f92d131756e prov:wasDerivedFrom niiri:d959803f17fca1477b93bbeb0285f2c2 .
+niiri:2f6549876aed12baa3dab8de8273d38a prov:wasDerivedFrom niiri:c3da843e94fc98cca5669ae4eef8d2ed .
 
-niiri:3ab9a4e9eec326914bcb611614bd4168
+niiri:f1895be0d1633922d7667327f8d09e70
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0071" ;
-    prov:atLocation niiri:192a09ec58406e66d604edb406fd5c8d ;
+    prov:atLocation niiri:b006146ea3a6c5cef54d99ae22492584 ;
     prov:value "26.9941082000732"^^xsd:float ;
     nidm_equivalentZStatistic: "4.73199532964814"^^xsd:float ;
     nidm_pValueUncorrected: "1.11161764859702e-06"^^xsd:float ;
     nidm_pValueFWER: "0.144508578107306"^^xsd:float ;
     nidm_qValueFDR: "0.016538239689936"^^xsd:float .
 
-niiri:192a09ec58406e66d604edb406fd5c8d
+niiri:b006146ea3a6c5cef54d99ae22492584
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0071" ;
     nidm_coordinateVector: "[-20,22,-10]"^^xsd:string .
 
-niiri:3ab9a4e9eec326914bcb611614bd4168 prov:wasDerivedFrom niiri:02b0f364d58bda58fce33ecdaf3e7191 .
+niiri:f1895be0d1633922d7667327f8d09e70 prov:wasDerivedFrom niiri:5d3257a6906cc23f21f8344f8a202720 .
 
-niiri:6fae1cb761159cb1828c7e100c9f9860
+niiri:adea458f35a2dd3e503f5b76a33ccca9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0072" ;
-    prov:atLocation niiri:480b12cbc91811e27eccdd1d15933704 ;
+    prov:atLocation niiri:8498f671244493e5dccddbfdee69de45 ;
     prov:value "22.6613578796387"^^xsd:float ;
     nidm_equivalentZStatistic: "4.35427468283891"^^xsd:float ;
     nidm_pValueUncorrected: "6.67541091325941e-06"^^xsd:float ;
     nidm_pValueFWER: "0.516272526829242"^^xsd:float ;
     nidm_qValueFDR: "0.0461712684947748"^^xsd:float .
 
-niiri:480b12cbc91811e27eccdd1d15933704
+niiri:8498f671244493e5dccddbfdee69de45
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0072" ;
     nidm_coordinateVector: "[-20,22,-20]"^^xsd:string .
 
-niiri:6fae1cb761159cb1828c7e100c9f9860 prov:wasDerivedFrom niiri:02b0f364d58bda58fce33ecdaf3e7191 .
+niiri:adea458f35a2dd3e503f5b76a33ccca9 prov:wasDerivedFrom niiri:5d3257a6906cc23f21f8344f8a202720 .
 
-niiri:476676425794194c27a827a9f0c6b148
+niiri:b2abdbde6951cc3df4267da78e9eab09
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0073" ;
-    prov:atLocation niiri:807410e5abbbfc2c759a743341ef3252 ;
+    prov:atLocation niiri:2c46ac4fa1bcf476c140cdc40fa6d0cf ;
     prov:value "16.1252555847168"^^xsd:float ;
     nidm_equivalentZStatistic: "3.68091120119901"^^xsd:float ;
     nidm_pValueUncorrected: "0.00011620096893894"^^xsd:float ;
     nidm_pValueFWER: "0.999550326152138"^^xsd:float ;
     nidm_qValueFDR: "0.274499735322593"^^xsd:float .
 
-niiri:807410e5abbbfc2c759a743341ef3252
+niiri:2c46ac4fa1bcf476c140cdc40fa6d0cf
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0073" ;
     nidm_coordinateVector: "[-28,36,-14]"^^xsd:string .
 
-niiri:476676425794194c27a827a9f0c6b148 prov:wasDerivedFrom niiri:02b0f364d58bda58fce33ecdaf3e7191 .
+niiri:b2abdbde6951cc3df4267da78e9eab09 prov:wasDerivedFrom niiri:5d3257a6906cc23f21f8344f8a202720 .
 
-niiri:67414756bbde1bde08546a2688a1d56c
+niiri:ce8e5b9eaf298dd260287509743e52a9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0074" ;
-    prov:atLocation niiri:e38c23447f1976e7966b4523abca5ae9 ;
+    prov:atLocation niiri:fa7acea05fec3c868da9178c655ffd07 ;
     prov:value "26.7744998931885"^^xsd:float ;
     nidm_equivalentZStatistic: "4.71387838295499"^^xsd:float ;
     nidm_pValueUncorrected: "1.21522879270586e-06"^^xsd:float ;
     nidm_pValueFWER: "0.155157441670289"^^xsd:float ;
     nidm_qValueFDR: "0.0172891722870727"^^xsd:float .
 
-niiri:e38c23447f1976e7966b4523abca5ae9
+niiri:fa7acea05fec3c868da9178c655ffd07
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0074" ;
     nidm_coordinateVector: "[-60,-52,18]"^^xsd:string .
 
-niiri:67414756bbde1bde08546a2688a1d56c prov:wasDerivedFrom niiri:cd0210a509aed4af1fa29d3bf1351438 .
+niiri:ce8e5b9eaf298dd260287509743e52a9 prov:wasDerivedFrom niiri:f9cfce19a79a082c82d2f3a6386b09c9 .
 
-niiri:035f24946566726f6667f33756436ce2
+niiri:3b07b1d9d18e5301a1eddd1ed55de100
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0075" ;
-    prov:atLocation niiri:29a61d3c8818b64ad94e245a81e5eee6 ;
+    prov:atLocation niiri:4935504f2ca9890d702d363dd7b1d03f ;
     prov:value "24.3260192871094"^^xsd:float ;
     nidm_equivalentZStatistic: "4.50470678054082"^^xsd:float ;
     nidm_pValueUncorrected: "3.3232325669097e-06"^^xsd:float ;
     nidm_pValueFWER: "0.330274885793216"^^xsd:float ;
     nidm_qValueFDR: "0.0310816877190926"^^xsd:float .
 
-niiri:29a61d3c8818b64ad94e245a81e5eee6
+niiri:4935504f2ca9890d702d363dd7b1d03f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0075" ;
     nidm_coordinateVector: "[-58,-64,12]"^^xsd:string .
 
-niiri:035f24946566726f6667f33756436ce2 prov:wasDerivedFrom niiri:cd0210a509aed4af1fa29d3bf1351438 .
+niiri:3b07b1d9d18e5301a1eddd1ed55de100 prov:wasDerivedFrom niiri:f9cfce19a79a082c82d2f3a6386b09c9 .
 
-niiri:cd9ceab8b72471e4a4629ed95a3798f7
+niiri:68ccf59f802d72bf9d431b3b294d2c32
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0076" ;
-    prov:atLocation niiri:b986ba1201da6c46992b1bcee44033c1 ;
+    prov:atLocation niiri:1e60d9d582eaec821f0d35b91631e387 ;
     prov:value "14.2642917633057"^^xsd:float ;
     nidm_equivalentZStatistic: "3.45757108528077"^^xsd:float ;
     nidm_pValueUncorrected: "0.000272534210682851"^^xsd:float ;
     nidm_pValueFWER: "0.999999731150238"^^xsd:float ;
     nidm_qValueFDR: "0.453704488417404"^^xsd:float .
 
-niiri:b986ba1201da6c46992b1bcee44033c1
+niiri:1e60d9d582eaec821f0d35b91631e387
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0076" ;
     nidm_coordinateVector: "[-66,-44,16]"^^xsd:string .
 
-niiri:cd9ceab8b72471e4a4629ed95a3798f7 prov:wasDerivedFrom niiri:cd0210a509aed4af1fa29d3bf1351438 .
+niiri:68ccf59f802d72bf9d431b3b294d2c32 prov:wasDerivedFrom niiri:f9cfce19a79a082c82d2f3a6386b09c9 .
 
-niiri:7adcc5b8a365d50984373dc4e9d4745c
+niiri:90812b753072fe6baba25b8214327983
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0077" ;
-    prov:atLocation niiri:144b48dc9980d0f12dcf73dad17db8d9 ;
+    prov:atLocation niiri:2e7dbc2e92942cb373a386b48d8ab2ae ;
     prov:value "26.5194854736328"^^xsd:float ;
     nidm_equivalentZStatistic: "4.69271316665315"^^xsd:float ;
     nidm_pValueUncorrected: "1.34802686679869e-06"^^xsd:float ;
     nidm_pValueFWER: "0.168426938943843"^^xsd:float ;
     nidm_qValueFDR: "0.0184657823782908"^^xsd:float .
 
-niiri:144b48dc9980d0f12dcf73dad17db8d9
+niiri:2e7dbc2e92942cb373a386b48d8ab2ae
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0077" ;
     nidm_coordinateVector: "[-48,28,2]"^^xsd:string .
 
-niiri:7adcc5b8a365d50984373dc4e9d4745c prov:wasDerivedFrom niiri:b9079ad818d03296fe8330a4f70c5c53 .
+niiri:90812b753072fe6baba25b8214327983 prov:wasDerivedFrom niiri:36f4c495e82ce16bc5e3538ec47db115 .
 
-niiri:79d36c0ec9a324401fc0e2eb636b12e4
+niiri:19c2eb940423bd075119228e3100f958
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0078" ;
-    prov:atLocation niiri:b47a9596c2644d5468cf006ab33ca079 ;
+    prov:atLocation niiri:cbe4d401b56f46238b61ab011826b9de ;
     prov:value "25.691427230835"^^xsd:float ;
     nidm_equivalentZStatistic: "4.62301960855807"^^xsd:float ;
     nidm_pValueUncorrected: "1.89096978542302e-06"^^xsd:float ;
     nidm_pValueFWER: "0.218875206501387"^^xsd:float ;
     nidm_qValueFDR: "0.0221192226146001"^^xsd:float .
 
-niiri:b47a9596c2644d5468cf006ab33ca079
+niiri:cbe4d401b56f46238b61ab011826b9de
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0078" ;
     nidm_coordinateVector: "[-26,30,36]"^^xsd:string .
 
-niiri:79d36c0ec9a324401fc0e2eb636b12e4 prov:wasDerivedFrom niiri:b9079ad818d03296fe8330a4f70c5c53 .
+niiri:19c2eb940423bd075119228e3100f958 prov:wasDerivedFrom niiri:36f4c495e82ce16bc5e3538ec47db115 .
 
-niiri:b4e1727e487e8b71ba67d88addf8b5dd
+niiri:45fb7b2544c4802833f71463702fb573
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0079" ;
-    prov:atLocation niiri:13eed93b488bc2f8ea02ff9e1be0807e ;
+    prov:atLocation niiri:826ac32082a51738929fdbd7249ac832 ;
     prov:value "19.5458869934082"^^xsd:float ;
     nidm_equivalentZStatistic: "4.05176480514799"^^xsd:float ;
     nidm_pValueUncorrected: "2.54163753627967e-05"^^xsd:float ;
     nidm_pValueFWER: "0.892419390862991"^^xsd:float ;
     nidm_qValueFDR: "0.108193496757792"^^xsd:float .
 
-niiri:13eed93b488bc2f8ea02ff9e1be0807e
+niiri:826ac32082a51738929fdbd7249ac832
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0079" ;
     nidm_coordinateVector: "[-12,18,18]"^^xsd:string .
 
-niiri:b4e1727e487e8b71ba67d88addf8b5dd prov:wasDerivedFrom niiri:b9079ad818d03296fe8330a4f70c5c53 .
+niiri:45fb7b2544c4802833f71463702fb573 prov:wasDerivedFrom niiri:36f4c495e82ce16bc5e3538ec47db115 .
 
-niiri:1e8afe377d891571110d3fb4b1a28861
+niiri:ae25400879fdbbd71ea06f98f2949c87
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0080" ;
-    prov:atLocation niiri:9f0dfc6b98b181edb1625a402d1f1170 ;
+    prov:atLocation niiri:d6cf34caaee1bde6a1304bf6965b1515 ;
     prov:value "25.5991687774658"^^xsd:float ;
     nidm_equivalentZStatistic: "4.61516091591235"^^xsd:float ;
     nidm_pValueUncorrected: "1.96395429286067e-06"^^xsd:float ;
     nidm_pValueFWER: "0.225247536188687"^^xsd:float ;
     nidm_qValueFDR: "0.0225353109118294"^^xsd:float .
 
-niiri:9f0dfc6b98b181edb1625a402d1f1170
+niiri:d6cf34caaee1bde6a1304bf6965b1515
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0080" ;
     nidm_coordinateVector: "[-16,-94,-10]"^^xsd:string .
 
-niiri:1e8afe377d891571110d3fb4b1a28861 prov:wasDerivedFrom niiri:6ed412630e5ab417bee547bf394670cd .
+niiri:ae25400879fdbbd71ea06f98f2949c87 prov:wasDerivedFrom niiri:f3db818d25677c7c9807d3bc465f0dec .
 
-niiri:087f9d74d18da0bfcfc9d0dea8ab2a56
+niiri:dbfa2e37fc9b5cbbd31da892e2cc2e8a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0081" ;
-    prov:atLocation niiri:1258eebdfcb9560033aeba6b2948a8e8 ;
+    prov:atLocation niiri:81d3490604ccd120799925539af20ef2 ;
     prov:value "25.4056377410889"^^xsd:float ;
     nidm_equivalentZStatistic: "4.59861326841205"^^xsd:float ;
     nidm_pValueUncorrected: "2.12656228593122e-06"^^xsd:float ;
     nidm_pValueFWER: "0.239135795532846"^^xsd:float ;
     nidm_qValueFDR: "0.0234803184814089"^^xsd:float .
 
-niiri:1258eebdfcb9560033aeba6b2948a8e8
+niiri:81d3490604ccd120799925539af20ef2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0081" ;
     nidm_coordinateVector: "[30,48,-36]"^^xsd:string .
 
-niiri:087f9d74d18da0bfcfc9d0dea8ab2a56 prov:wasDerivedFrom niiri:a69405853461b6b0f7066443a438e1d5 .
+niiri:dbfa2e37fc9b5cbbd31da892e2cc2e8a prov:wasDerivedFrom niiri:16cd91852662e2b6fb06dce21defbb02 .
 
-niiri:8a7f0dd59332e520147aa43d3301426b
+niiri:c98e1abf15afafba77dc2a1b5bccdb07
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0082" ;
-    prov:atLocation niiri:7c1abf19d0206f7e77a0710fe94d3393 ;
+    prov:atLocation niiri:191de3f73a536af56269b0d980e647bf ;
     prov:value "25.2654209136963"^^xsd:float ;
     nidm_equivalentZStatistic: "4.58657091932872"^^xsd:float ;
     nidm_pValueUncorrected: "2.25292694944201e-06"^^xsd:float ;
     nidm_pValueFWER: "0.249647931424908"^^xsd:float ;
     nidm_qValueFDR: "0.0240262284056265"^^xsd:float .
 
-niiri:7c1abf19d0206f7e77a0710fe94d3393
+niiri:191de3f73a536af56269b0d980e647bf
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0082" ;
     nidm_coordinateVector: "[2,38,-14]"^^xsd:string .
 
-niiri:8a7f0dd59332e520147aa43d3301426b prov:wasDerivedFrom niiri:0747284a50ab24237772bdee19f8130e .
+niiri:c98e1abf15afafba77dc2a1b5bccdb07 prov:wasDerivedFrom niiri:d1f64d168706b2b7b1ea74aeb9acf76d .
 
-niiri:e25945315446edcba8cd31ac9a2e3ec7
+niiri:11bc9e8dccdea4c6f0576729732a26b1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0083" ;
-    prov:atLocation niiri:81e9f46ae1541e8684d30680194d1ff9 ;
+    prov:atLocation niiri:fee409d8fb1182c19595120e80d6f171 ;
     prov:value "18.0576820373535"^^xsd:float ;
     nidm_equivalentZStatistic: "3.89603144574785"^^xsd:float ;
     nidm_pValueUncorrected: "4.88908495202001e-05"^^xsd:float ;
     nidm_pValueFWER: "0.97812034582109"^^xsd:float ;
     nidm_qValueFDR: "0.163088144322206"^^xsd:float .
 
-niiri:81e9f46ae1541e8684d30680194d1ff9
+niiri:fee409d8fb1182c19595120e80d6f171
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0083" ;
     nidm_coordinateVector: "[8,46,-18]"^^xsd:string .
 
-niiri:e25945315446edcba8cd31ac9a2e3ec7 prov:wasDerivedFrom niiri:0747284a50ab24237772bdee19f8130e .
+niiri:11bc9e8dccdea4c6f0576729732a26b1 prov:wasDerivedFrom niiri:d1f64d168706b2b7b1ea74aeb9acf76d .
 
-niiri:b2713b8071a14adab90b4fdd4762d876
+niiri:9eaf1659f6e51a24c9b5249d9eca8663
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0084" ;
-    prov:atLocation niiri:b366280a87ab07a8afd5a92437f93a85 ;
+    prov:atLocation niiri:3e306b247465821a8416bea1f0792417 ;
     prov:value "24.3388156890869"^^xsd:float ;
     nidm_equivalentZStatistic: "4.50583608073911"^^xsd:float ;
     nidm_pValueUncorrected: "3.30560549555159e-06"^^xsd:float ;
     nidm_pValueFWER: "0.32905451036308"^^xsd:float ;
     nidm_qValueFDR: "0.0310816877190926"^^xsd:float .
 
-niiri:b366280a87ab07a8afd5a92437f93a85
+niiri:3e306b247465821a8416bea1f0792417
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0084" ;
     nidm_coordinateVector: "[-58,-30,-18]"^^xsd:string .
 
-niiri:b2713b8071a14adab90b4fdd4762d876 prov:wasDerivedFrom niiri:a1f38c4aab7577b61865da78d168d6b4 .
+niiri:9eaf1659f6e51a24c9b5249d9eca8663 prov:wasDerivedFrom niiri:81dc6b3cbc9f571d3c373afc2c155834 .
 
-niiri:43d157fbe61ac3ac584d21aa31a2fac6
+niiri:df657fae07b6aff0d6f00ce65dfc1a80
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0085" ;
-    prov:atLocation niiri:65c986b576a1eac65333099d7fd3dd9f ;
+    prov:atLocation niiri:00f8a5c75c390f4c4a77aa0c74938e09 ;
     prov:value "24.2647590637207"^^xsd:float ;
     nidm_equivalentZStatistic: "4.4992949508152"^^xsd:float ;
     nidm_pValueUncorrected: "3.40896034356497e-06"^^xsd:float ;
     nidm_pValueFWER: "0.336164282110146"^^xsd:float ;
     nidm_qValueFDR: "0.0315627223093611"^^xsd:float .
 
-niiri:65c986b576a1eac65333099d7fd3dd9f
+niiri:00f8a5c75c390f4c4a77aa0c74938e09
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0085" ;
     nidm_coordinateVector: "[28,10,-48]"^^xsd:string .
 
-niiri:43d157fbe61ac3ac584d21aa31a2fac6 prov:wasDerivedFrom niiri:b2b2a00d477027244468267bb4cfdd7e .
+niiri:df657fae07b6aff0d6f00ce65dfc1a80 prov:wasDerivedFrom niiri:5c83c29ecdf61abf3b54b84749525008 .
 
-niiri:691e769de224d51eb649045f8ef83491
+niiri:cd2b04f2aeb928b0be2c2b49a81c72cc
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0086" ;
-    prov:atLocation niiri:2ea822d88aca06fe087b463e86eb36f4 ;
+    prov:atLocation niiri:7945a1875a4816413138667329ef1f28 ;
     prov:value "23.435432434082"^^xsd:float ;
     nidm_equivalentZStatistic: "4.42511309261812"^^xsd:float ;
     nidm_pValueUncorrected: "4.8195886048763e-06"^^xsd:float ;
     nidm_pValueFWER: "0.423415338028086"^^xsd:float ;
     nidm_qValueFDR: "0.0388969248253009"^^xsd:float .
 
-niiri:2ea822d88aca06fe087b463e86eb36f4
+niiri:7945a1875a4816413138667329ef1f28
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0086" ;
     nidm_coordinateVector: "[-48,18,-36]"^^xsd:string .
 
-niiri:691e769de224d51eb649045f8ef83491 prov:wasDerivedFrom niiri:1aefd578b3c1231848bc58379b5aa924 .
+niiri:cd2b04f2aeb928b0be2c2b49a81c72cc prov:wasDerivedFrom niiri:01690965efcb17bbde83102ddcb2faab .
 
-niiri:157998c9ea79fd46b084d5da98dc8213
+niiri:176829804e5fc15b1d1a6c6d59815463
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0087" ;
-    prov:atLocation niiri:b91c82676dd2a428ca424a279f265584 ;
+    prov:atLocation niiri:0bd53d1e4f2f294994607ed9b19f0de8 ;
     prov:value "22.7630805969238"^^xsd:float ;
     nidm_equivalentZStatistic: "4.36367473144233"^^xsd:float ;
     nidm_pValueUncorrected: "6.39478488917433e-06"^^xsd:float ;
     nidm_pValueFWER: "0.503542709649183"^^xsd:float ;
     nidm_qValueFDR: "0.0453548437799061"^^xsd:float .
 
-niiri:b91c82676dd2a428ca424a279f265584
+niiri:0bd53d1e4f2f294994607ed9b19f0de8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0087" ;
     nidm_coordinateVector: "[-32,-22,-20]"^^xsd:string .
 
-niiri:157998c9ea79fd46b084d5da98dc8213 prov:wasDerivedFrom niiri:42e2f22eff9709257cf127b203589014 .
+niiri:176829804e5fc15b1d1a6c6d59815463 prov:wasDerivedFrom niiri:06b13cc33465cdc0e1390a27c23a9ac4 .
 
-niiri:c0fe090dd271ccdc48c93392dfa499f6
+niiri:0b19217ec62c40e969523b448d183a81
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0088" ;
-    prov:atLocation niiri:8c5b8cefbe231ebb2a9ced63082569db ;
+    prov:atLocation niiri:8902a12641b236a6f0e57e20ffe1b3d9 ;
     prov:value "22.6970634460449"^^xsd:float ;
     nidm_equivalentZStatistic: "4.35757737148877"^^xsd:float ;
     nidm_pValueUncorrected: "6.57550076188507e-06"^^xsd:float ;
     nidm_pValueFWER: "0.511788595032734"^^xsd:float ;
     nidm_qValueFDR: "0.0458137283186348"^^xsd:float .
 
-niiri:8c5b8cefbe231ebb2a9ced63082569db
+niiri:8902a12641b236a6f0e57e20ffe1b3d9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0088" ;
     nidm_coordinateVector: "[-46,-66,-6]"^^xsd:string .
 
-niiri:c0fe090dd271ccdc48c93392dfa499f6 prov:wasDerivedFrom niiri:2974d7622a4eb3c979c41bc0bae55ebd .
+niiri:0b19217ec62c40e969523b448d183a81 prov:wasDerivedFrom niiri:7f6f25f12f4270c6aaed0a3240d5a8a1 .
 
-niiri:25a3c5d53b1149a69c2cad7fabc33df1
+niiri:fb41e19cf49308d445b6143dd6530c16
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0089" ;
-    prov:atLocation niiri:5be22bea07a58070e46f9221c8e4cade ;
+    prov:atLocation niiri:a75a3a79996c194090886fd73b647151 ;
     prov:value "14.1656980514526"^^xsd:float ;
     nidm_equivalentZStatistic: "3.44523640108096"^^xsd:float ;
     nidm_pValueUncorrected: "0.000285280079043382"^^xsd:float ;
     nidm_pValueFWER: "0.999999844740898"^^xsd:float ;
     nidm_qValueFDR: "0.467962708438717"^^xsd:float .
 
-niiri:5be22bea07a58070e46f9221c8e4cade
+niiri:a75a3a79996c194090886fd73b647151
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0089" ;
     nidm_coordinateVector: "[-54,-64,-8]"^^xsd:string .
 
-niiri:25a3c5d53b1149a69c2cad7fabc33df1 prov:wasDerivedFrom niiri:2974d7622a4eb3c979c41bc0bae55ebd .
+niiri:fb41e19cf49308d445b6143dd6530c16 prov:wasDerivedFrom niiri:7f6f25f12f4270c6aaed0a3240d5a8a1 .
 
-niiri:5ecc1af9e6559873e638586b57b43bf9
+niiri:e444cfdfe2f6cbaf0481b63d2834fda6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0090" ;
-    prov:atLocation niiri:26b915d76f24959b015d5a13200e6fde ;
+    prov:atLocation niiri:4353faa47737a9ce68ee616b1f970063 ;
     prov:value "22.5773677825928"^^xsd:float ;
     nidm_equivalentZStatistic: "4.34649211997001"^^xsd:float ;
     nidm_pValueUncorrected: "6.91660093510293e-06"^^xsd:float ;
     nidm_pValueFWER: "0.526883623410185"^^xsd:float ;
     nidm_qValueFDR: "0.0471103061870597"^^xsd:float .
 
-niiri:26b915d76f24959b015d5a13200e6fde
+niiri:4353faa47737a9ce68ee616b1f970063
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0090" ;
     nidm_coordinateVector: "[-48,-58,26]"^^xsd:string .
 
-niiri:5ecc1af9e6559873e638586b57b43bf9 prov:wasDerivedFrom niiri:dd84655271d1a93ad919193767608ec8 .
+niiri:e444cfdfe2f6cbaf0481b63d2834fda6 prov:wasDerivedFrom niiri:8f37ccae34c7cba6e277659e1d99e2a9 .
 
-niiri:1102890296e43a27581e19edef3f6ea2
+niiri:5cdb4e3e9ed6941e49fa8b89c908661b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0091" ;
-    prov:atLocation niiri:1fb1dd4e0ecff1691a8fc8830f7c89fa ;
+    prov:atLocation niiri:8a6f228a2d58da780f109d6dee18edb2 ;
     prov:value "18.1794853210449"^^xsd:float ;
     nidm_equivalentZStatistic: "3.909083502135"^^xsd:float ;
     nidm_pValueUncorrected: "4.6323469247822e-05"^^xsd:float ;
     nidm_pValueFWER: "0.974191386889975"^^xsd:float ;
     nidm_qValueFDR: "0.158566450522772"^^xsd:float .
 
-niiri:1fb1dd4e0ecff1691a8fc8830f7c89fa
+niiri:8a6f228a2d58da780f109d6dee18edb2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0091" ;
     nidm_coordinateVector: "[-40,-54,24]"^^xsd:string .
 
-niiri:1102890296e43a27581e19edef3f6ea2 prov:wasDerivedFrom niiri:dd84655271d1a93ad919193767608ec8 .
+niiri:5cdb4e3e9ed6941e49fa8b89c908661b prov:wasDerivedFrom niiri:8f37ccae34c7cba6e277659e1d99e2a9 .
 
-niiri:3e8512b99a74d1e7cb6f4d079a060195
+niiri:dd4fd70f165a7929f76cd0a4dfbf5059
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0092" ;
-    prov:atLocation niiri:1b555de9730f3d550d48d41abeba3f1d ;
+    prov:atLocation niiri:21f3959c2cd89d63592ed6a03bacfca5 ;
     prov:value "22.300386428833"^^xsd:float ;
     nidm_equivalentZStatistic: "4.3206898346505"^^xsd:float ;
     nidm_pValueUncorrected: "7.77710889177108e-06"^^xsd:float ;
     nidm_pValueFWER: "0.562434726478465"^^xsd:float ;
     nidm_qValueFDR: "0.0510171908662791"^^xsd:float .
 
-niiri:1b555de9730f3d550d48d41abeba3f1d
+niiri:21f3959c2cd89d63592ed6a03bacfca5
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0092" ;
     nidm_coordinateVector: "[58,-38,6]"^^xsd:string .
 
-niiri:3e8512b99a74d1e7cb6f4d079a060195 prov:wasDerivedFrom niiri:0f340a0ff58ecb32a533ddd1cf07f45d .
+niiri:dd4fd70f165a7929f76cd0a4dfbf5059 prov:wasDerivedFrom niiri:3acfc147a4a82a0c9064e4e844ecc743 .
 
-niiri:d47a9fea626980e6b1ef2924dabe6a81
+niiri:6263d0bf0edefd0d5b70b55319094a47
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0093" ;
-    prov:atLocation niiri:29aa36a62824fcd63d780ed55757920a ;
+    prov:atLocation niiri:e989bd9b9d36dcbd27f6bb25eecabde9 ;
     prov:value "22.2661895751953"^^xsd:float ;
     nidm_equivalentZStatistic: "4.31748949702426"^^xsd:float ;
     nidm_pValueUncorrected: "7.89069578244206e-06"^^xsd:float ;
     nidm_pValueFWER: "0.566874895647931"^^xsd:float ;
     nidm_qValueFDR: "0.051397236162478"^^xsd:float .
 
-niiri:29aa36a62824fcd63d780ed55757920a
+niiri:e989bd9b9d36dcbd27f6bb25eecabde9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0093" ;
     nidm_coordinateVector: "[42,-66,6]"^^xsd:string .
 
-niiri:d47a9fea626980e6b1ef2924dabe6a81 prov:wasDerivedFrom niiri:43c527932f85b9bc3ce5b3b60117f451 .
+niiri:6263d0bf0edefd0d5b70b55319094a47 prov:wasDerivedFrom niiri:bb2efddb865295f983adb4172abe81b6 .
 
-niiri:dc87dcb5ff0422da1d35c47b664eb074
+niiri:a05276936cf0d417dc5ca6d7a0d6a3f9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0094" ;
-    prov:atLocation niiri:841ad5ad32d7c372ada388e673e16793 ;
+    prov:atLocation niiri:cc95f61fed018b19add13d2f5b0ea062 ;
     prov:value "22.1354484558105"^^xsd:float ;
     nidm_equivalentZStatistic: "4.30522386387639"^^xsd:float ;
     nidm_pValueUncorrected: "8.34084780676481e-06"^^xsd:float ;
     nidm_pValueFWER: "0.583932942615046"^^xsd:float ;
     nidm_qValueFDR: "0.0533499015486859"^^xsd:float .
 
-niiri:841ad5ad32d7c372ada388e673e16793
+niiri:cc95f61fed018b19add13d2f5b0ea062
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0094" ;
     nidm_coordinateVector: "[-36,-74,-14]"^^xsd:string .
 
-niiri:dc87dcb5ff0422da1d35c47b664eb074 prov:wasDerivedFrom niiri:4c9c90b34337736af0c1709b3e2dce99 .
+niiri:a05276936cf0d417dc5ca6d7a0d6a3f9 prov:wasDerivedFrom niiri:29b1a5a35e558ec0833c58691621c112 .
 
-niiri:e888c65f8d4b187785526e34e54596eb
+niiri:3ccae7f904d1cb2d10acffdcfadc8f10
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0095" ;
-    prov:atLocation niiri:936c0177160c4e527ad489766a349270 ;
+    prov:atLocation niiri:c9b5f5d788c682c3f5ede975be932a63 ;
     prov:value "16.7093238830566"^^xsd:float ;
     nidm_equivalentZStatistic: "3.7475977576799"^^xsd:float ;
     nidm_pValueUncorrected: "8.92681312850696e-05"^^xsd:float ;
     nidm_pValueFWER: "0.99803966762084"^^xsd:float ;
     nidm_qValueFDR: "0.231798608212325"^^xsd:float .
 
-niiri:936c0177160c4e527ad489766a349270
+niiri:c9b5f5d788c682c3f5ede975be932a63
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0095" ;
     nidm_coordinateVector: "[-36,-68,-20]"^^xsd:string .
 
-niiri:e888c65f8d4b187785526e34e54596eb prov:wasDerivedFrom niiri:4c9c90b34337736af0c1709b3e2dce99 .
+niiri:3ccae7f904d1cb2d10acffdcfadc8f10 prov:wasDerivedFrom niiri:29b1a5a35e558ec0833c58691621c112 .
 
-niiri:eeca61f4cebf9669d662fcaeb1fe04bb
+niiri:8e4ca43f93486def424cfb00d341a82e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0096" ;
-    prov:atLocation niiri:067e2de875421b92ea5ef14a4beec1b7 ;
+    prov:atLocation niiri:9362a39a8676e78d5f782844a37c400b ;
     prov:value "22.009162902832"^^xsd:float ;
     nidm_equivalentZStatistic: "4.29333057860161"^^xsd:float ;
     nidm_pValueUncorrected: "8.80063176944557e-06"^^xsd:float ;
     nidm_pValueFWER: "0.600511384577349"^^xsd:float ;
     nidm_qValueFDR: "0.0552945360022594"^^xsd:float .
 
-niiri:067e2de875421b92ea5ef14a4beec1b7
+niiri:9362a39a8676e78d5f782844a37c400b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0096" ;
     nidm_coordinateVector: "[20,52,-8]"^^xsd:string .
 
-niiri:eeca61f4cebf9669d662fcaeb1fe04bb prov:wasDerivedFrom niiri:645b34305a7adc863333ef8d055b94b6 .
+niiri:8e4ca43f93486def424cfb00d341a82e prov:wasDerivedFrom niiri:16e2e680906eb7d77a0f37a900f566bb .
 
-niiri:02c32317a2587c4e20987e49068cdfdd
+niiri:e5b709733a7a64fd4daeb683bb3734c7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0097" ;
-    prov:atLocation niiri:fdfd8d1cbb4a9bfd41738fc28889cdd1 ;
+    prov:atLocation niiri:93c38f3e63878c9d511e15582b642126 ;
     prov:value "19.9573459625244"^^xsd:float ;
     nidm_equivalentZStatistic: "4.09345225838168"^^xsd:float ;
     nidm_pValueUncorrected: "2.12498807569128e-05"^^xsd:float ;
     nidm_pValueFWER: "0.853596609416469"^^xsd:float ;
     nidm_qValueFDR: "0.0969483313559081"^^xsd:float .
 
-niiri:fdfd8d1cbb4a9bfd41738fc28889cdd1
+niiri:93c38f3e63878c9d511e15582b642126
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0097" ;
     nidm_coordinateVector: "[8,66,-12]"^^xsd:string .
 
-niiri:02c32317a2587c4e20987e49068cdfdd prov:wasDerivedFrom niiri:645b34305a7adc863333ef8d055b94b6 .
+niiri:e5b709733a7a64fd4daeb683bb3734c7 prov:wasDerivedFrom niiri:16e2e680906eb7d77a0f37a900f566bb .
 
-niiri:fda61110b4be429734ac1fee6209dea7
+niiri:c9aaa481cdfc446e54553d8f78ce6094
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0098" ;
-    prov:atLocation niiri:35d6be2cd0bfbb4370fcbe2dc07d7110 ;
+    prov:atLocation niiri:66687a1556cf944ab251cc50c5a1afec ;
     prov:value "21.6827297210693"^^xsd:float ;
     nidm_equivalentZStatistic: "4.26237714614837"^^xsd:float ;
     nidm_pValueUncorrected: "1.01131850654967e-05"^^xsd:float ;
     nidm_pValueFWER: "0.643607390332145"^^xsd:float ;
     nidm_qValueFDR: "0.0595012953349514"^^xsd:float .
 
-niiri:35d6be2cd0bfbb4370fcbe2dc07d7110
+niiri:66687a1556cf944ab251cc50c5a1afec
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0098" ;
     nidm_coordinateVector: "[-50,-56,-46]"^^xsd:string .
 
-niiri:fda61110b4be429734ac1fee6209dea7 prov:wasDerivedFrom niiri:147ce23197bb1c39e660c70911b5c483 .
+niiri:c9aaa481cdfc446e54553d8f78ce6094 prov:wasDerivedFrom niiri:160595535853afe9f10e3ba4462634ee .
 
-niiri:2550be23d66e4dc7fc4b7dcf374e5c8d
+niiri:6197fba6e2664d7308395423fa054a5a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0099" ;
-    prov:atLocation niiri:e3dbec50daf97eaf5ef864b0210a0ed9 ;
+    prov:atLocation niiri:59ccd11f545a7e2d5564defe74cdf344 ;
     prov:value "20.8459243774414"^^xsd:float ;
     nidm_equivalentZStatistic: "4.18159782528346"^^xsd:float ;
     nidm_pValueUncorrected: "1.44733828864041e-05"^^xsd:float ;
     nidm_pValueFWER: "0.751996552599621"^^xsd:float ;
     nidm_qValueFDR: "0.0757651987419718"^^xsd:float .
 
-niiri:e3dbec50daf97eaf5ef864b0210a0ed9
+niiri:59ccd11f545a7e2d5564defe74cdf344
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0099" ;
     nidm_coordinateVector: "[-54,-60,-34]"^^xsd:string .
 
-niiri:2550be23d66e4dc7fc4b7dcf374e5c8d prov:wasDerivedFrom niiri:147ce23197bb1c39e660c70911b5c483 .
+niiri:6197fba6e2664d7308395423fa054a5a prov:wasDerivedFrom niiri:160595535853afe9f10e3ba4462634ee .
 
-niiri:e2b712aa23b785bf2512d75cc71c1f60
+niiri:665564fcd3b0c01a2d413f93a062d71e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0100" ;
-    prov:atLocation niiri:7e6c51e7d9c351d654b1574131f29158 ;
+    prov:atLocation niiri:13a8380ee841694a3439ded70c91247f ;
     prov:value "21.6761283874512"^^xsd:float ;
     nidm_equivalentZStatistic: "4.26174801852479"^^xsd:float ;
     nidm_pValueUncorrected: "1.01417038346208e-05"^^xsd:float ;
     nidm_pValueFWER: "0.644479756447942"^^xsd:float ;
     nidm_qValueFDR: "0.0595012953349514"^^xsd:float .
 
-niiri:7e6c51e7d9c351d654b1574131f29158
+niiri:13a8380ee841694a3439ded70c91247f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0100" ;
     nidm_coordinateVector: "[-6,22,-4]"^^xsd:string .
 
-niiri:e2b712aa23b785bf2512d75cc71c1f60 prov:wasDerivedFrom niiri:4c767097d4f857da1a95ec39b9d9edc3 .
+niiri:665564fcd3b0c01a2d413f93a062d71e prov:wasDerivedFrom niiri:5bea9c455010164eafb48efd433d0b3b .
 
-niiri:75f647b6e41d8fc22a0e0977805c1613
+niiri:d510f031f5c43274a32cc49cf1f3f001
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0101" ;
-    prov:atLocation niiri:1cecb0735e82a478ba9325b76b765942 ;
+    prov:atLocation niiri:891a5976572946a7b565dcbdfa45714d ;
     prov:value "16.2054805755615"^^xsd:float ;
     nidm_equivalentZStatistic: "3.69016146811634"^^xsd:float ;
     nidm_pValueUncorrected: "0.000112055876962391"^^xsd:float ;
     nidm_pValueFWER: "0.999439014335705"^^xsd:float ;
     nidm_qValueFDR: "0.269643439858175"^^xsd:float .
 
-niiri:1cecb0735e82a478ba9325b76b765942
+niiri:891a5976572946a7b565dcbdfa45714d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0101" ;
     nidm_coordinateVector: "[2,24,-10]"^^xsd:string .
 
-niiri:75f647b6e41d8fc22a0e0977805c1613 prov:wasDerivedFrom niiri:4c767097d4f857da1a95ec39b9d9edc3 .
+niiri:d510f031f5c43274a32cc49cf1f3f001 prov:wasDerivedFrom niiri:5bea9c455010164eafb48efd433d0b3b .
 
-niiri:1ea89db36385d43e680df4cf1937c752
+niiri:31b0c9c2327a4d798a48c9c2cca5ac27
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0102" ;
-    prov:atLocation niiri:05c9a525e9ad3c3bb3e23ba283598628 ;
+    prov:atLocation niiri:f74543d456ae0968251bded2c0a3475d ;
     prov:value "21.5253620147705"^^xsd:float ;
     nidm_equivalentZStatistic: "4.24734493361237"^^xsd:float ;
     nidm_pValueUncorrected: "1.08159392907536e-05"^^xsd:float ;
     nidm_pValueFWER: "0.664379439585423"^^xsd:float ;
     nidm_qValueFDR: "0.0622520078187919"^^xsd:float .
 
-niiri:05c9a525e9ad3c3bb3e23ba283598628
+niiri:f74543d456ae0968251bded2c0a3475d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0102" ;
     nidm_coordinateVector: "[-4,58,40]"^^xsd:string .
 
-niiri:1ea89db36385d43e680df4cf1937c752 prov:wasDerivedFrom niiri:e039dc19484a5a0f4a9f1920c4f37802 .
+niiri:31b0c9c2327a4d798a48c9c2cca5ac27 prov:wasDerivedFrom niiri:54acd58c8408a4a54a5d29cdbcf77a2a .
 
-niiri:ea634ac3460003e29d29d4a7f5c1a646
+niiri:d3aa0d69a7eaa43c7b928709eff2bf3c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0103" ;
-    prov:atLocation niiri:6957a245193d2f46f8c65e90228e4fb3 ;
+    prov:atLocation niiri:e26583fef812bde0be11d99cc55cdd5b ;
     prov:value "21.3095722198486"^^xsd:float ;
     nidm_equivalentZStatistic: "4.22661368779567"^^xsd:float ;
     nidm_pValueUncorrected: "1.18617218586303e-05"^^xsd:float ;
     nidm_pValueFWER: "0.692690637306793"^^xsd:float ;
     nidm_qValueFDR: "0.066091397071435"^^xsd:float .
 
-niiri:6957a245193d2f46f8c65e90228e4fb3
+niiri:e26583fef812bde0be11d99cc55cdd5b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0103" ;
     nidm_coordinateVector: "[56,-66,28]"^^xsd:string .
 
-niiri:ea634ac3460003e29d29d4a7f5c1a646 prov:wasDerivedFrom niiri:90684205dbd5e3565c63d92ea2c2ba92 .
+niiri:d3aa0d69a7eaa43c7b928709eff2bf3c prov:wasDerivedFrom niiri:e0f95b0e95e26dd40bce67d69e9c88a7 .
 
-niiri:6aa24132bd020294cf997d47bec08962
+niiri:d97a5111c9a07f3911f9566bb4f817b7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0104" ;
-    prov:atLocation niiri:4bb3470ea7fab10c6e4a2cb7e24167a4 ;
+    prov:atLocation niiri:0baf1fce706fc700d3c2c6983653cd7c ;
     prov:value "21.1252059936523"^^xsd:float ;
     nidm_equivalentZStatistic: "4.20879143363758"^^xsd:float ;
     nidm_pValueUncorrected: "1.28370116740939e-05"^^xsd:float ;
     nidm_pValueFWER: "0.716590361946796"^^xsd:float ;
     nidm_qValueFDR: "0.0697051976348589"^^xsd:float .
 
-niiri:4bb3470ea7fab10c6e4a2cb7e24167a4
+niiri:0baf1fce706fc700d3c2c6983653cd7c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0104" ;
     nidm_coordinateVector: "[16,-98,6]"^^xsd:string .
 
-niiri:6aa24132bd020294cf997d47bec08962 prov:wasDerivedFrom niiri:43d72ad1d7d22b80f01808f8d966ccdd .
+niiri:d97a5111c9a07f3911f9566bb4f817b7 prov:wasDerivedFrom niiri:e1915181e888f91227f9d80a2ceda361 .
 
-niiri:5916a805521346eef56b006e4de1d886
+niiri:142389ac0cc7b6ad0aefee61aaa19f01
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0105" ;
-    prov:atLocation niiri:f226b8e795a08bc9e83e1c9723241f54 ;
+    prov:atLocation niiri:96c31dac1b644e65f3fac10a4bcdf913 ;
     prov:value "20.9664764404297"^^xsd:float ;
     nidm_equivalentZStatistic: "4.19336518197686"^^xsd:float ;
     nidm_pValueUncorrected: "1.3742322497845e-05"^^xsd:float ;
     nidm_pValueFWER: "0.736853371757955"^^xsd:float ;
     nidm_qValueFDR: "0.0731699937068361"^^xsd:float .
 
-niiri:f226b8e795a08bc9e83e1c9723241f54
+niiri:96c31dac1b644e65f3fac10a4bcdf913
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0105" ;
     nidm_coordinateVector: "[-60,-16,28]"^^xsd:string .
 
-niiri:5916a805521346eef56b006e4de1d886 prov:wasDerivedFrom niiri:fce6ba03f6215ffda4130a08998532e7 .
+niiri:142389ac0cc7b6ad0aefee61aaa19f01 prov:wasDerivedFrom niiri:059524711a78d34f86f9ff7484d30c28 .
 
-niiri:ffa5ca5b56650798f24d66c1ed26b018
+niiri:55baaf76e4730532805f8f2d9564575f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0106" ;
-    prov:atLocation niiri:f1b33b4cf1deec88ae98054d4bcd3ee8 ;
+    prov:atLocation niiri:326c1f2b49a399f5d14885efa0367044 ;
     prov:value "20.4901485443115"^^xsd:float ;
     nidm_equivalentZStatistic: "4.14660690773876"^^xsd:float ;
     nidm_pValueUncorrected: "1.68719329129985e-05"^^xsd:float ;
     nidm_pValueFWER: "0.795085603917253"^^xsd:float ;
     nidm_qValueFDR: "0.0839823722931768"^^xsd:float .
 
-niiri:f1b33b4cf1deec88ae98054d4bcd3ee8
+niiri:326c1f2b49a399f5d14885efa0367044
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0106" ;
     nidm_coordinateVector: "[16,14,62]"^^xsd:string .
 
-niiri:ffa5ca5b56650798f24d66c1ed26b018 prov:wasDerivedFrom niiri:90faaaeae176fe54bdbf1e2a7100afb2 .
+niiri:55baaf76e4730532805f8f2d9564575f prov:wasDerivedFrom niiri:f80c4f725486ccc8cbc7ca97e9202b10 .
 
-niiri:9ab30b882bdce7ae8c8f9df0e9da4732
+niiri:f5c396305d9d8b59e0f1de9b43bc1c04
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0107" ;
-    prov:atLocation niiri:37e02f565a077430db77e2e77ba591c5 ;
+    prov:atLocation niiri:251fea1831ca94c94c0699f4dbebb262 ;
     prov:value "20.1859455108643"^^xsd:float ;
     nidm_equivalentZStatistic: "4.11637075760553"^^xsd:float ;
     nidm_pValueUncorrected: "1.92442496569356e-05"^^xsd:float ;
     nidm_pValueFWER: "0.829516805025193"^^xsd:float ;
     nidm_qValueFDR: "0.0918155656683619"^^xsd:float .
 
-niiri:37e02f565a077430db77e2e77ba591c5
+niiri:251fea1831ca94c94c0699f4dbebb262
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0107" ;
     nidm_coordinateVector: "[-46,-32,58]"^^xsd:string .
 
-niiri:9ab30b882bdce7ae8c8f9df0e9da4732 prov:wasDerivedFrom niiri:a56b7f6c2daf0ff5655692e9a3ba50e8 .
+niiri:f5c396305d9d8b59e0f1de9b43bc1c04 prov:wasDerivedFrom niiri:4fc2bcbe1574c654541b41942566af13 .
 
-niiri:22d9a01396c2e063eef7b45fef2c0f15
+niiri:b17798d8da7350fcfdb2da256f317589
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0108" ;
-    prov:atLocation niiri:6ec8c82b1d1de3c00711b7fd7869cad2 ;
+    prov:atLocation niiri:78af07cd6758279fa7f56ce54921d1cb ;
     prov:value "19.9081478118896"^^xsd:float ;
     nidm_equivalentZStatistic: "4.08849741803632"^^xsd:float ;
     nidm_pValueUncorrected: "2.17088189312653e-05"^^xsd:float ;
     nidm_pValueFWER: "0.858555794271687"^^xsd:float ;
     nidm_qValueFDR: "0.0982970474931675"^^xsd:float .
 
-niiri:6ec8c82b1d1de3c00711b7fd7869cad2
+niiri:78af07cd6758279fa7f56ce54921d1cb
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0108" ;
     nidm_coordinateVector: "[38,-82,10]"^^xsd:string .
 
-niiri:22d9a01396c2e063eef7b45fef2c0f15 prov:wasDerivedFrom niiri:94a06b9bd15a2d12f76ca646af0fa348 .
+niiri:b17798d8da7350fcfdb2da256f317589 prov:wasDerivedFrom niiri:dff2d5252e6112d696cc75e19b35b055 .
 
-niiri:e7be33d40089bfba3b2033cdca6e66df
+niiri:606ad57a2c441571f0c00836b6a11960
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0109" ;
-    prov:atLocation niiri:7d784374f98004829297818ba5e6c57d ;
+    prov:atLocation niiri:ecb1b99ed2d95e871037822a0cde1bff ;
     prov:value "19.88161277771"^^xsd:float ;
     nidm_equivalentZStatistic: "4.08582170061298"^^xsd:float ;
     nidm_pValueUncorrected: "2.19605490655583e-05"^^xsd:float ;
     nidm_pValueFWER: "0.861196205689319"^^xsd:float ;
     nidm_qValueFDR: "0.0988533813000291"^^xsd:float .
 
-niiri:7d784374f98004829297818ba5e6c57d
+niiri:ecb1b99ed2d95e871037822a0cde1bff
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0109" ;
     nidm_coordinateVector: "[38,-78,44]"^^xsd:string .
 
-niiri:e7be33d40089bfba3b2033cdca6e66df prov:wasDerivedFrom niiri:e6bd6b781a9701be59c8d9453ba0f42d .
+niiri:606ad57a2c441571f0c00836b6a11960 prov:wasDerivedFrom niiri:c1d3f6f0f50baea1174f7ada78444ce5 .
 
-niiri:4defe0c7577a8a72b50638c086e04293
+niiri:44957024e6a6c3a8d350f2182ed7669b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0110" ;
-    prov:atLocation niiri:0f56b877b6b3d4e2793a888b59c3ae04 ;
+    prov:atLocation niiri:db64ae2b2c4d3bcd61012d22f3845781 ;
     prov:value "19.6855850219727"^^xsd:float ;
     nidm_equivalentZStatistic: "4.0659821671938"^^xsd:float ;
     nidm_pValueUncorrected: "2.39152966687861e-05"^^xsd:float ;
     nidm_pValueFWER: "0.879930855992272"^^xsd:float ;
     nidm_qValueFDR: "0.104063286439229"^^xsd:float .
 
-niiri:0f56b877b6b3d4e2793a888b59c3ae04
+niiri:db64ae2b2c4d3bcd61012d22f3845781
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0110" ;
     nidm_coordinateVector: "[-14,68,12]"^^xsd:string .
 
-niiri:4defe0c7577a8a72b50638c086e04293 prov:wasDerivedFrom niiri:24a7631619b05b254e46f418981f33fd .
+niiri:44957024e6a6c3a8d350f2182ed7669b prov:wasDerivedFrom niiri:ac01f2a6f9677b631c38f9d1203db903 .
 
-niiri:d98b611de8d7e1482ae41f7a7530e8dc
+niiri:7a1f7b35bf5c2e76842344547587ee88
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0111" ;
-    prov:atLocation niiri:f8b1837e055a5a75c502336b4d3fec6d ;
+    prov:atLocation niiri:1726de2b89d7e8b3dd5c75339c03089a ;
     prov:value "15.3516979217529"^^xsd:float ;
     nidm_equivalentZStatistic: "3.59017266008559"^^xsd:float ;
     nidm_pValueUncorrected: "0.000165229496364216"^^xsd:float ;
     nidm_pValueFWER: "0.999962977415156"^^xsd:float ;
     nidm_qValueFDR: "0.336130452148725"^^xsd:float .
 
-niiri:f8b1837e055a5a75c502336b4d3fec6d
+niiri:1726de2b89d7e8b3dd5c75339c03089a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0111" ;
     nidm_coordinateVector: "[-18,66,26]"^^xsd:string .
 
-niiri:d98b611de8d7e1482ae41f7a7530e8dc prov:wasDerivedFrom niiri:24a7631619b05b254e46f418981f33fd .
+niiri:7a1f7b35bf5c2e76842344547587ee88 prov:wasDerivedFrom niiri:ac01f2a6f9677b631c38f9d1203db903 .
 
-niiri:c0af81189f9a5aace7d1dbfc2f31f56c
+niiri:52798f01ae0c76b1a815825b938124bf
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0112" ;
-    prov:atLocation niiri:f515e14d6e41c47d4558f27b59d822b2 ;
+    prov:atLocation niiri:ddba1731b4fb95f8dc592e2e1dff8512 ;
     prov:value "19.3617496490479"^^xsd:float ;
     nidm_equivalentZStatistic: "4.0329231622068"^^xsd:float ;
     nidm_pValueUncorrected: "2.75436479366675e-05"^^xsd:float ;
     nidm_pValueFWER: "0.907734095795052"^^xsd:float ;
     nidm_qValueFDR: "0.114345300686635"^^xsd:float .
 
-niiri:f515e14d6e41c47d4558f27b59d822b2
+niiri:ddba1731b4fb95f8dc592e2e1dff8512
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0112" ;
     nidm_coordinateVector: "[14,-66,-12]"^^xsd:string .
 
-niiri:c0af81189f9a5aace7d1dbfc2f31f56c prov:wasDerivedFrom niiri:26d38070320861a52f54239810eefb6d .
+niiri:52798f01ae0c76b1a815825b938124bf prov:wasDerivedFrom niiri:6ac4331664607b2b0b57f58303204021 .
 
-niiri:519b3586ed16092208050d4ee00a0452
+niiri:ac84790ec5fc05c9de4754f79ac66e49
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0113" ;
-    prov:atLocation niiri:fffb2bca0e0a1be9b8744f849dea122e ;
+    prov:atLocation niiri:08c5e7ad57bb2c8bbad532efbb58aec7 ;
     prov:value "19.3172149658203"^^xsd:float ;
     nidm_equivalentZStatistic: "4.0283486821653"^^xsd:float ;
     nidm_pValueUncorrected: "2.80849975954345e-05"^^xsd:float ;
     nidm_pValueFWER: "0.911237684671062"^^xsd:float ;
     nidm_qValueFDR: "0.115154016069316"^^xsd:float .
 
-niiri:fffb2bca0e0a1be9b8744f849dea122e
+niiri:08c5e7ad57bb2c8bbad532efbb58aec7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0113" ;
     nidm_coordinateVector: "[44,26,-30]"^^xsd:string .
 
-niiri:519b3586ed16092208050d4ee00a0452 prov:wasDerivedFrom niiri:a5c107a7aa03e749be4156dafe333465 .
+niiri:ac84790ec5fc05c9de4754f79ac66e49 prov:wasDerivedFrom niiri:df3a63e829a4b0144a3bd3a075d00d6a .
 
-niiri:baca4373834d30fe008b9865ab711552
+niiri:e6936b16ba6c2d4218eb760cf497ca0c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0114" ;
-    prov:atLocation niiri:34c57cb11965b6d093c5d8909cd2fc0e ;
+    prov:atLocation niiri:6f85ca7632c41f1bfb8b8f02fb275c74 ;
     prov:value "18.8370418548584"^^xsd:float ;
     nidm_equivalentZStatistic: "3.9785849448618"^^xsd:float ;
     nidm_pValueUncorrected: "3.46633215003722e-05"^^xsd:float ;
     nidm_pValueFWER: "0.943955324716031"^^xsd:float ;
     nidm_qValueFDR: "0.133237780105225"^^xsd:float .
 
-niiri:34c57cb11965b6d093c5d8909cd2fc0e
+niiri:6f85ca7632c41f1bfb8b8f02fb275c74
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0114" ;
     nidm_coordinateVector: "[36,24,-28]"^^xsd:string .
 
-niiri:baca4373834d30fe008b9865ab711552 prov:wasDerivedFrom niiri:a5c107a7aa03e749be4156dafe333465 .
+niiri:e6936b16ba6c2d4218eb760cf497ca0c prov:wasDerivedFrom niiri:df3a63e829a4b0144a3bd3a075d00d6a .
 
-niiri:8420d782c03b4101b20be6b34c135201
+niiri:843790c8e8f506cec84c62b4bdaa4286
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0115" ;
-    prov:atLocation niiri:a8c3e95440667fef2aef500030081e3c ;
+    prov:atLocation niiri:1a20382ea26ff7dfc455a550e14bb2cb ;
     prov:value "18.5280513763428"^^xsd:float ;
     nidm_equivalentZStatistic: "3.94612490561611"^^xsd:float ;
     nidm_pValueUncorrected: "3.97130955323011e-05"^^xsd:float ;
     nidm_pValueFWER: "0.960162786431476"^^xsd:float ;
     nidm_qValueFDR: "0.143791985595671"^^xsd:float .
 
-niiri:a8c3e95440667fef2aef500030081e3c
+niiri:1a20382ea26ff7dfc455a550e14bb2cb
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0115" ;
     nidm_coordinateVector: "[38,18,-34]"^^xsd:string .
 
-niiri:8420d782c03b4101b20be6b34c135201 prov:wasDerivedFrom niiri:a5c107a7aa03e749be4156dafe333465 .
+niiri:843790c8e8f506cec84c62b4bdaa4286 prov:wasDerivedFrom niiri:df3a63e829a4b0144a3bd3a075d00d6a .
 
-niiri:76222a078033ae4ec966dfcdd2343400
+niiri:0a719e8098002e353003ba2a27b073c0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0116" ;
-    prov:atLocation niiri:b428928e15b6c558aaf9cd5d4b43d4fa ;
+    prov:atLocation niiri:3f13732ea3fe61d9c16166a94afce717 ;
     prov:value "19.0981063842773"^^xsd:float ;
     nidm_equivalentZStatistic: "4.00574189150977"^^xsd:float ;
     nidm_pValueUncorrected: "3.09115647554314e-05"^^xsd:float ;
     nidm_pValueFWER: "0.927318703179416"^^xsd:float ;
     nidm_qValueFDR: "0.123657042203662"^^xsd:float .
 
-niiri:b428928e15b6c558aaf9cd5d4b43d4fa
+niiri:3f13732ea3fe61d9c16166a94afce717
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0116" ;
     nidm_coordinateVector: "[-52,-62,52]"^^xsd:string .
 
-niiri:76222a078033ae4ec966dfcdd2343400 prov:wasDerivedFrom niiri:1e592c6195e8eed44af6ede26c558b5b .
+niiri:0a719e8098002e353003ba2a27b073c0 prov:wasDerivedFrom niiri:de4cddb037f1620436ef1889e1446b84 .
 
-niiri:7c29318db9338de16c9df0f656c59d09
+niiri:43e979b3f8840ac3905a6f8a4407fcd5
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0117" ;
-    prov:atLocation niiri:44c320e08d656c9bf218305a167749b5 ;
+    prov:atLocation niiri:72836d9af30b43e0ac21adb81f3ce707 ;
     prov:value "18.9605255126953"^^xsd:float ;
     nidm_equivalentZStatistic: "3.99146047420243"^^xsd:float ;
     nidm_pValueUncorrected: "3.28338171369236e-05"^^xsd:float ;
     nidm_pValueFWER: "0.936427564303669"^^xsd:float ;
     nidm_qValueFDR: "0.128343860654482"^^xsd:float .
 
-niiri:44c320e08d656c9bf218305a167749b5
+niiri:72836d9af30b43e0ac21adb81f3ce707
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0117" ;
     nidm_coordinateVector: "[-30,-50,2]"^^xsd:string .
 
-niiri:7c29318db9338de16c9df0f656c59d09 prov:wasDerivedFrom niiri:561f8f2dc565936a85d74fd6e6439dd5 .
+niiri:43e979b3f8840ac3905a6f8a4407fcd5 prov:wasDerivedFrom niiri:70eb10d3df67eb20319350b5182c2674 .
 
-niiri:52258c37479b367e53c8b38802a12867
+niiri:eceeb78780be64894e966537ab3cb8b4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0118" ;
-    prov:atLocation niiri:c3a94a5300718750a6bd78e846528ddd ;
+    prov:atLocation niiri:8c4301dda467a2d0ec1f85c4f2963cca ;
     prov:value "18.5464344024658"^^xsd:float ;
     nidm_equivalentZStatistic: "3.9480658572893"^^xsd:float ;
     nidm_pValueUncorrected: "3.93925668565887e-05"^^xsd:float ;
     nidm_pValueFWER: "0.95930107827696"^^xsd:float ;
     nidm_qValueFDR: "0.143340168336726"^^xsd:float .
 
-niiri:c3a94a5300718750a6bd78e846528ddd
+niiri:8c4301dda467a2d0ec1f85c4f2963cca
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0118" ;
     nidm_coordinateVector: "[-26,-92,32]"^^xsd:string .
 
-niiri:52258c37479b367e53c8b38802a12867 prov:wasDerivedFrom niiri:74f3d914b0fa073ea25c95d2b38e58fb .
+niiri:eceeb78780be64894e966537ab3cb8b4 prov:wasDerivedFrom niiri:0c6701f42b3e926640123461fe2991bd .
 
-niiri:b9162ca6a49a3e216d418c1d65f981af
+niiri:ed981c1dca3ea9b8e6dca05eddddb42e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0119" ;
-    prov:atLocation niiri:5a8a239114f81e75d7fc1e5c695c1878 ;
+    prov:atLocation niiri:b842305f64b7dc7dc554a449bebc0d75 ;
     prov:value "18.5085258483887"^^xsd:float ;
     nidm_equivalentZStatistic: "3.94406195686995"^^xsd:float ;
     nidm_pValueUncorrected: "4.00564728540997e-05"^^xsd:float ;
     nidm_pValueFWER: "0.961064206627909"^^xsd:float ;
     nidm_qValueFDR: "0.144306772236207"^^xsd:float .
 
-niiri:5a8a239114f81e75d7fc1e5c695c1878
+niiri:b842305f64b7dc7dc554a449bebc0d75
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0119" ;
     nidm_coordinateVector: "[-64,-24,18]"^^xsd:string .
 
-niiri:b9162ca6a49a3e216d418c1d65f981af prov:wasDerivedFrom niiri:3df28d3c24f5b16d0bd211139131d8c1 .
+niiri:ed981c1dca3ea9b8e6dca05eddddb42e prov:wasDerivedFrom niiri:ff9cac1254b9e415d2191f7775b434dc .
 
-niiri:c8358d5d022c77b4884b6072e1454afc
+niiri:f1d40c82f153f10f701e991dc46bf76c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0120" ;
-    prov:atLocation niiri:e414591911281c3dc6505239152cf96f ;
+    prov:atLocation niiri:1bac7263c1c3b607ba8edd87055ad184 ;
     prov:value "18.1724834442139"^^xsd:float ;
     nidm_equivalentZStatistic: "3.90833473727659"^^xsd:float ;
     nidm_pValueUncorrected: "4.64672426668811e-05"^^xsd:float ;
     nidm_pValueFWER: "0.97443020941977"^^xsd:float ;
     nidm_qValueFDR: "0.158566450522772"^^xsd:float .
 
-niiri:e414591911281c3dc6505239152cf96f
+niiri:1bac7263c1c3b607ba8edd87055ad184
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0120" ;
     nidm_coordinateVector: "[-48,-80,6]"^^xsd:string .
 
-niiri:c8358d5d022c77b4884b6072e1454afc prov:wasDerivedFrom niiri:7f4b39cb147f1d9dd77391be1117b986 .
+niiri:f1d40c82f153f10f701e991dc46bf76c prov:wasDerivedFrom niiri:42811518fc15bbd0a0761ed04fef9d90 .
 
-niiri:d41d46d391de81a26321b642a363d6a2
+niiri:90a42fb8b7ab15a0fc7f9593788fd0d8
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0121" ;
-    prov:atLocation niiri:b71ab1408fd1af806b03d8156b375b1e ;
+    prov:atLocation niiri:d1e7b6efc3415e116d507bcdb32379a9 ;
     prov:value "18.1425399780273"^^xsd:float ;
     nidm_equivalentZStatistic: "3.90513054435556"^^xsd:float ;
     nidm_pValueUncorrected: "4.70872668005828e-05"^^xsd:float ;
     nidm_pValueFWER: "0.975433443618306"^^xsd:float ;
     nidm_qValueFDR: "0.159647764898926"^^xsd:float .
 
-niiri:b71ab1408fd1af806b03d8156b375b1e
+niiri:d1e7b6efc3415e116d507bcdb32379a9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0121" ;
     nidm_coordinateVector: "[-52,22,-20]"^^xsd:string .
 
-niiri:d41d46d391de81a26321b642a363d6a2 prov:wasDerivedFrom niiri:e186e249fc14850bf873b0628a153098 .
+niiri:90a42fb8b7ab15a0fc7f9593788fd0d8 prov:wasDerivedFrom niiri:dd408b7babb59101191c5fa3158193a1 .
 
-niiri:060885fee6768915bf388d99f5e98afc
+niiri:977335353dc773fc7bbc24036d48d077
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0122" ;
-    prov:atLocation niiri:04b6a7eb58bc007d8c3cb674f2fa7bfd ;
+    prov:atLocation niiri:e0be6cf70dbd9397b6107de3bded3c2c ;
     prov:value "18.022855758667"^^xsd:float ;
     nidm_equivalentZStatistic: "3.89228911595248"^^xsd:float ;
     nidm_pValueUncorrected: "4.96514030533524e-05"^^xsd:float ;
     nidm_pValueFWER: "0.979157897585619"^^xsd:float ;
     nidm_qValueFDR: "0.164060003510711"^^xsd:float .
 
-niiri:04b6a7eb58bc007d8c3cb674f2fa7bfd
+niiri:e0be6cf70dbd9397b6107de3bded3c2c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0122" ;
     nidm_coordinateVector: "[-18,-60,48]"^^xsd:string .
 
-niiri:060885fee6768915bf388d99f5e98afc prov:wasDerivedFrom niiri:28c5ec87b0dddeb6b0b0fcaa674d02f8 .
+niiri:977335353dc773fc7bbc24036d48d077 prov:wasDerivedFrom niiri:99548a2427d673d5bd15c691076864b1 .
 
-niiri:bb716ddfde071cd1533efc20b8df8c51
+niiri:3c8fb8a88e5e0426d1a5f92207ba17b9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0123" ;
-    prov:atLocation niiri:83fdcb3696a2e7236bd63c40266a9864 ;
+    prov:atLocation niiri:01f90b37285ec72c334de342360ab244 ;
     prov:value "17.9444541931152"^^xsd:float ;
     nidm_equivalentZStatistic: "3.88384718470911"^^xsd:float ;
     nidm_pValueUncorrected: "5.14082712614883e-05"^^xsd:float ;
     nidm_pValueFWER: "0.981359691584305"^^xsd:float ;
     nidm_qValueFDR: "0.167674319621895"^^xsd:float .
 
-niiri:83fdcb3696a2e7236bd63c40266a9864
+niiri:01f90b37285ec72c334de342360ab244
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0123" ;
     nidm_coordinateVector: "[-48,-60,-12]"^^xsd:string .
 
-niiri:bb716ddfde071cd1533efc20b8df8c51 prov:wasDerivedFrom niiri:b9c11d17264a448b811fbb99435e6a29 .
+niiri:3c8fb8a88e5e0426d1a5f92207ba17b9 prov:wasDerivedFrom niiri:7a1eb6258840314d739698ecb8549782 .
 
-niiri:0ab0eae007c10352dafb61bb561c13f2
+niiri:98867af87517f1e98b09c71216997a9b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0124" ;
-    prov:atLocation niiri:9985fa5371e8690277b3ef48a3f99ff3 ;
+    prov:atLocation niiri:a625149c64d12d1f3e068260e53f8b7c ;
     prov:value "12.8559341430664"^^xsd:float ;
     nidm_equivalentZStatistic: "3.27598947955534"^^xsd:float ;
     nidm_pValueUncorrected: "0.000526462414867646"^^xsd:float ;
     nidm_pValueFWER: "0.999999999987892"^^xsd:float ;
     nidm_qValueFDR: "0.682960649498925"^^xsd:float .
 
-niiri:9985fa5371e8690277b3ef48a3f99ff3
+niiri:a625149c64d12d1f3e068260e53f8b7c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0124" ;
     nidm_coordinateVector: "[-56,-58,-14]"^^xsd:string .
 
-niiri:0ab0eae007c10352dafb61bb561c13f2 prov:wasDerivedFrom niiri:b9c11d17264a448b811fbb99435e6a29 .
+niiri:98867af87517f1e98b09c71216997a9b prov:wasDerivedFrom niiri:7a1eb6258840314d739698ecb8549782 .
 
-niiri:65deeeda13fede5f3d5d94a8e680fbb2
+niiri:33190d6d2e32f171dd46bc01760c790f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0125" ;
-    prov:atLocation niiri:33ae88e566df91eb8d94e7dc1db559a6 ;
+    prov:atLocation niiri:eb5117c3c1e358890a16b2a446aebe1c ;
     prov:value "17.8700103759766"^^xsd:float ;
     nidm_equivalentZStatistic: "3.87580933368031"^^xsd:float ;
     nidm_pValueUncorrected: "5.31354385788774e-05"^^xsd:float ;
     nidm_pValueFWER: "0.983284702748605"^^xsd:float ;
     nidm_qValueFDR: "0.170688289174118"^^xsd:float .
 
-niiri:33ae88e566df91eb8d94e7dc1db559a6
+niiri:eb5117c3c1e358890a16b2a446aebe1c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0125" ;
     nidm_coordinateVector: "[-20,-98,22]"^^xsd:string .
 
-niiri:65deeeda13fede5f3d5d94a8e680fbb2 prov:wasDerivedFrom niiri:4f417da08fec0d40b87c31dc3acdb804 .
+niiri:33190d6d2e32f171dd46bc01760c790f prov:wasDerivedFrom niiri:d766f0de412bd93d96229079d9de064c .
 
-niiri:1b0082413964ff5ea4cf9dd0977c356c
+niiri:89a194ad515e6bc3d514f374a7c0b423
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0126" ;
-    prov:atLocation niiri:c5d2b0b72e1fe61b041c9d27481def2b ;
+    prov:atLocation niiri:55087ecc6cef2182a564f80c0e849e24 ;
     prov:value "17.8590641021729"^^xsd:float ;
     nidm_equivalentZStatistic: "3.87462562045091"^^xsd:float ;
     nidm_pValueUncorrected: "5.33943727588637e-05"^^xsd:float ;
     nidm_pValueFWER: "0.983554595306202"^^xsd:float ;
     nidm_qValueFDR: "0.170688289174118"^^xsd:float .
 
-niiri:c5d2b0b72e1fe61b041c9d27481def2b
+niiri:55087ecc6cef2182a564f80c0e849e24
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0126" ;
     nidm_coordinateVector: "[-36,-74,-34]"^^xsd:string .
 
-niiri:1b0082413964ff5ea4cf9dd0977c356c prov:wasDerivedFrom niiri:595ec99dd41031dea87a56ab2ed11ae6 .
+niiri:89a194ad515e6bc3d514f374a7c0b423 prov:wasDerivedFrom niiri:8661090d64b5d8ebc0a4bd8254976fb2 .
 
-niiri:eabdd8b43fb4440db555c5c4b1c7eec8
+niiri:8ae3f86dbfbb937f245ae840af8b5c49
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0127" ;
-    prov:atLocation niiri:8b119d251b89faba60107a27003daf9d ;
+    prov:atLocation niiri:61c92221d1b627be5d2a89643880952c ;
     prov:value "17.8335304260254"^^xsd:float ;
     nidm_equivalentZStatistic: "3.87186262680309"^^xsd:float ;
     nidm_pValueUncorrected: "5.40034110888543e-05"^^xsd:float ;
     nidm_pValueFWER: "0.98417134410357"^^xsd:float ;
     nidm_qValueFDR: "0.171220146803025"^^xsd:float .
 
-niiri:8b119d251b89faba60107a27003daf9d
+niiri:61c92221d1b627be5d2a89643880952c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0127" ;
     nidm_coordinateVector: "[38,42,30]"^^xsd:string .
 
-niiri:eabdd8b43fb4440db555c5c4b1c7eec8 prov:wasDerivedFrom niiri:2c7e261ed1ca11499bdd3aefccd19ad9 .
+niiri:8ae3f86dbfbb937f245ae840af8b5c49 prov:wasDerivedFrom niiri:52941f17d3d4d9019f15d6efbca27815 .
 
-niiri:f89d8f5f4b280e4c5911e7d950245fa4
+niiri:3dd185a366e3d00acea89b72842526fa
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0128" ;
-    prov:atLocation niiri:f9d80438169dda4b0015945385e60ddb ;
+    prov:atLocation niiri:d9d89e136ea97b0a6bb9498f7668246d ;
     prov:value "17.8262977600098"^^xsd:float ;
     nidm_equivalentZStatistic: "3.87107951763206"^^xsd:float ;
     nidm_pValueUncorrected: "5.41772180187028e-05"^^xsd:float ;
     nidm_pValueFWER: "0.984342815309589"^^xsd:float ;
     nidm_qValueFDR: "0.171220146803025"^^xsd:float .
 
-niiri:f9d80438169dda4b0015945385e60ddb
+niiri:d9d89e136ea97b0a6bb9498f7668246d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0128" ;
     nidm_coordinateVector: "[-6,8,-14]"^^xsd:string .
 
-niiri:f89d8f5f4b280e4c5911e7d950245fa4 prov:wasDerivedFrom niiri:ad031ab3c998c491419cfcf8be1da45c .
+niiri:3dd185a366e3d00acea89b72842526fa prov:wasDerivedFrom niiri:65bb243af8ca1e554de57b71bb66bc25 .
 
-niiri:dab38586d985bb164cbf08a6d51acddb
+niiri:0071dedc5b10c2348b38dd7fd1f3af16
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0129" ;
-    prov:atLocation niiri:0476946b128ab3679c9823fabfadcee7 ;
+    prov:atLocation niiri:c3d13d62a8ef6f9f67c2b84365de7ab2 ;
     prov:value "12.8113403320312"^^xsd:float ;
     nidm_equivalentZStatistic: "3.27004069778544"^^xsd:float ;
     nidm_pValueUncorrected: "0.000537660061517675"^^xsd:float ;
     nidm_pValueFWER: "0.99999999999193"^^xsd:float ;
     nidm_qValueFDR: "0.68956410159948"^^xsd:float .
 
-niiri:0476946b128ab3679c9823fabfadcee7
+niiri:c3d13d62a8ef6f9f67c2b84365de7ab2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0129" ;
     nidm_coordinateVector: "[-14,10,-20]"^^xsd:string .
 
-niiri:dab38586d985bb164cbf08a6d51acddb prov:wasDerivedFrom niiri:ad031ab3c998c491419cfcf8be1da45c .
+niiri:0071dedc5b10c2348b38dd7fd1f3af16 prov:wasDerivedFrom niiri:65bb243af8ca1e554de57b71bb66bc25 .
 
-niiri:fe062c4e63d26572e38462cc54d25914
+niiri:73dbca8a980ae25e2ff56feb2e61e1f1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0130" ;
-    prov:atLocation niiri:d16b94cd6aacbd472908f60c7f6ff9b3 ;
+    prov:atLocation niiri:187769859be171e252e8f9d09cb2f452 ;
     prov:value "17.6728630065918"^^xsd:float ;
     nidm_equivalentZStatistic: "3.85441801648814"^^xsd:float ;
     nidm_pValueUncorrected: "5.80026235302844e-05"^^xsd:float ;
     nidm_pValueFWER: "0.987658348187978"^^xsd:float ;
     nidm_qValueFDR: "0.17739917442045"^^xsd:float .
 
-niiri:d16b94cd6aacbd472908f60c7f6ff9b3
+niiri:187769859be171e252e8f9d09cb2f452
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0130" ;
     nidm_coordinateVector: "[34,-54,-16]"^^xsd:string .
 
-niiri:fe062c4e63d26572e38462cc54d25914 prov:wasDerivedFrom niiri:5c2053c39d7e04181ae00f2c3455846a .
+niiri:73dbca8a980ae25e2ff56feb2e61e1f1 prov:wasDerivedFrom niiri:eb7b45334c4709abfab6a80cdaa2bc22 .
 
-niiri:c35104447675ceff9f6199c1b53bbd2b
+niiri:85b1cb20bd5854a8141f9a51241094c0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0131" ;
-    prov:atLocation niiri:36df87de402f185918c03e0a531385b2 ;
+    prov:atLocation niiri:f239b5bb600b66b26ae2b541d5f0205c ;
     prov:value "17.5372142791748"^^xsd:float ;
     nidm_equivalentZStatistic: "3.83961006214911"^^xsd:float ;
     nidm_pValueUncorrected: "6.16149383911857e-05"^^xsd:float ;
     nidm_pValueFWER: "0.990112599467216"^^xsd:float ;
     nidm_qValueFDR: "0.183733780945217"^^xsd:float .
 
-niiri:36df87de402f185918c03e0a531385b2
+niiri:f239b5bb600b66b26ae2b541d5f0205c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0131" ;
     nidm_coordinateVector: "[2,56,-20]"^^xsd:string .
 
-niiri:c35104447675ceff9f6199c1b53bbd2b prov:wasDerivedFrom niiri:117133b74d26b0653d13dd1ed378d736 .
+niiri:85b1cb20bd5854a8141f9a51241094c0 prov:wasDerivedFrom niiri:afbff827e6265de5fc31843cacb634e6 .
 
-niiri:3df03444dcd947a772bbda2d14dbc765
+niiri:80c689d708c2928c17585d1c5c63574b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0132" ;
-    prov:atLocation niiri:ebe90014cbe702b1339781b49a1ec1b3 ;
+    prov:atLocation niiri:873406fbc3b5a81d2e3a4e71e24d489e ;
     prov:value "17.5327644348145"^^xsd:float ;
     nidm_equivalentZStatistic: "3.83912305138784"^^xsd:float ;
     nidm_pValueUncorrected: "6.17372699829311e-05"^^xsd:float ;
     nidm_pValueFWER: "0.990186087413737"^^xsd:float ;
     nidm_qValueFDR: "0.183733780945217"^^xsd:float .
 
-niiri:ebe90014cbe702b1339781b49a1ec1b3
+niiri:873406fbc3b5a81d2e3a4e71e24d489e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0132" ;
     nidm_coordinateVector: "[12,-100,20]"^^xsd:string .
 
-niiri:3df03444dcd947a772bbda2d14dbc765 prov:wasDerivedFrom niiri:f826be788a1ac88ee83c24f89532c22c .
+niiri:80c689d708c2928c17585d1c5c63574b prov:wasDerivedFrom niiri:44d83170827403caee586f5f0c738aff .
 
-niiri:51e69c5e1f14aa998ff20b3c0eec6e70
+niiri:68c2fcab274675b0f794f0f1b1cef55a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0133" ;
-    prov:atLocation niiri:38f634005017e3191b375d479957b876 ;
+    prov:atLocation niiri:81c9356383fb408177b2b19cfcec8486 ;
     prov:value "17.4226627349854"^^xsd:float ;
     nidm_equivalentZStatistic: "3.82704759724244"^^xsd:float ;
     nidm_pValueUncorrected: "6.48447222785231e-05"^^xsd:float ;
     nidm_pValueFWER: "0.991871994244491"^^xsd:float ;
     nidm_qValueFDR: "0.190627577478618"^^xsd:float .
 
-niiri:38f634005017e3191b375d479957b876
+niiri:81c9356383fb408177b2b19cfcec8486
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0133" ;
     nidm_coordinateVector: "[-40,-38,44]"^^xsd:string .
 
-niiri:51e69c5e1f14aa998ff20b3c0eec6e70 prov:wasDerivedFrom niiri:069291996dee025660d592de3e37d709 .
+niiri:68c2fcab274675b0f794f0f1b1cef55a prov:wasDerivedFrom niiri:2d968184be68de22a2c6d1f79a1a3779 .
 
-niiri:004788f80a9206c42efb90bf22999294
+niiri:543cc9adfb564a9668b2518ca40bcc25
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0134" ;
-    prov:atLocation niiri:4805cfcf9581f17b78a3eac1ebb74dc6 ;
+    prov:atLocation niiri:12d35d58ccbb85001b356a289c171fb3 ;
     prov:value "17.1287994384766"^^xsd:float ;
     nidm_equivalentZStatistic: "3.79457571367347"^^xsd:float ;
     nidm_pValueUncorrected: "7.39480733209508e-05"^^xsd:float ;
     nidm_pValueFWER: "0.995271127156069"^^xsd:float ;
     nidm_qValueFDR: "0.20629819959706"^^xsd:float .
 
-niiri:4805cfcf9581f17b78a3eac1ebb74dc6
+niiri:12d35d58ccbb85001b356a289c171fb3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0134" ;
     nidm_coordinateVector: "[-4,-60,-60]"^^xsd:string .
 
-niiri:004788f80a9206c42efb90bf22999294 prov:wasDerivedFrom niiri:83bc0d4252d6531714bcacd111e1cc46 .
+niiri:543cc9adfb564a9668b2518ca40bcc25 prov:wasDerivedFrom niiri:8c5cc0e6fb31318c9adb3b82365f2ae6 .
 
-niiri:d47322a1af3764fd46416538f71aa57e
+niiri:2db3c23fc333f8331cda3b16530368ad
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0135" ;
-    prov:atLocation niiri:a3d0967c7aea0e6f185195200b593d4e ;
+    prov:atLocation niiri:4d8f35cbbd84a090f57d6ed9ea09084e ;
     prov:value "16.9863605499268"^^xsd:float ;
     nidm_equivalentZStatistic: "3.7787073073582"^^xsd:float ;
     nidm_pValueUncorrected: "7.88222920551362e-05"^^xsd:float ;
     nidm_pValueFWER: "0.996440597738596"^^xsd:float ;
     nidm_qValueFDR: "0.216588338073415"^^xsd:float .
 
-niiri:a3d0967c7aea0e6f185195200b593d4e
+niiri:4d8f35cbbd84a090f57d6ed9ea09084e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0135" ;
     nidm_coordinateVector: "[-48,-72,2]"^^xsd:string .
 
-niiri:d47322a1af3764fd46416538f71aa57e prov:wasDerivedFrom niiri:5703312bcab5b7a9d45a9c8f5e2a301f .
+niiri:2db3c23fc333f8331cda3b16530368ad prov:wasDerivedFrom niiri:db5e02d87132e15c42c39a266963eb55 .
 
-niiri:565bbb90c34b5483f94ac309e1cf4c10
+niiri:953c82968cbb8941046013eaafb134b0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0136" ;
-    prov:atLocation niiri:dadc8cfac50065609852eee449902fbb ;
+    prov:atLocation niiri:afa42bca2bc4c889ad1a2eea4afff83b ;
     prov:value "16.8094520568848"^^xsd:float ;
     nidm_equivalentZStatistic: "3.75887945181758"^^xsd:float ;
     nidm_pValueUncorrected: "8.53380207227472e-05"^^xsd:float ;
     nidm_pValueFWER: "0.997551066032961"^^xsd:float ;
     nidm_qValueFDR: "0.228878695263587"^^xsd:float .
 
-niiri:dadc8cfac50065609852eee449902fbb
+niiri:afa42bca2bc4c889ad1a2eea4afff83b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0136" ;
     nidm_coordinateVector: "[-26,-66,48]"^^xsd:string .
 
-niiri:565bbb90c34b5483f94ac309e1cf4c10 prov:wasDerivedFrom niiri:39fa289e8e1804e6c510280f0e399486 .
+niiri:953c82968cbb8941046013eaafb134b0 prov:wasDerivedFrom niiri:6e1483cf3114e5bdc77f5e480decfc71 .
 
-niiri:f7dd5bd8e78dace0e7256ee8e480a754
+niiri:3cabe98da9708d5c6d9ef929b06fe15d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0137" ;
-    prov:atLocation niiri:72bc54b51439d57273d4fc5feb6c0d07 ;
+    prov:atLocation niiri:eff0511f81e80158699d68bd98fa9405 ;
     prov:value "16.7728652954102"^^xsd:float ;
     nidm_equivalentZStatistic: "3.75476213591481"^^xsd:float ;
     nidm_pValueUncorrected: "8.67530868189359e-05"^^xsd:float ;
     nidm_pValueFWER: "0.997740205701951"^^xsd:float ;
     nidm_qValueFDR: "0.230558109866913"^^xsd:float .
 
-niiri:72bc54b51439d57273d4fc5feb6c0d07
+niiri:eff0511f81e80158699d68bd98fa9405
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0137" ;
     nidm_coordinateVector: "[28,-78,-4]"^^xsd:string .
 
-niiri:f7dd5bd8e78dace0e7256ee8e480a754 prov:wasDerivedFrom niiri:aec4d890e92fb9730ea03f8d53fbe940 .
+niiri:3cabe98da9708d5c6d9ef929b06fe15d prov:wasDerivedFrom niiri:1eb993430541f6c2dc79f73b3a96decc .
 
-niiri:0195d4add9d5b6928a841f3d28f415c7
+niiri:0483d1896bdb7110c7c114277f735ab9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0138" ;
-    prov:atLocation niiri:e2e952472cf7f089347a5890633c05b7 ;
+    prov:atLocation niiri:5a911e435abed8cd7a26c34c1d6c107f ;
     prov:value "16.7388191223145"^^xsd:float ;
     nidm_equivalentZStatistic: "3.75092555231661"^^xsd:float ;
     nidm_pValueUncorrected: "8.809150518585e-05"^^xsd:float ;
     nidm_pValueFWER: "0.997905089099941"^^xsd:float ;
     nidm_qValueFDR: "0.231105699024221"^^xsd:float .
 
-niiri:e2e952472cf7f089347a5890633c05b7
+niiri:5a911e435abed8cd7a26c34c1d6c107f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0138" ;
     nidm_coordinateVector: "[-32,16,-46]"^^xsd:string .
 
-niiri:0195d4add9d5b6928a841f3d28f415c7 prov:wasDerivedFrom niiri:6f32c27f31869cd578e8b60308359ec9 .
+niiri:0483d1896bdb7110c7c114277f735ab9 prov:wasDerivedFrom niiri:e576b0cc1b6a471310c83c2e65672f5f .
 
-niiri:550faac6b8dd2504485e40c3bbfb3073
+niiri:e91d29fc9817e2a7b36fc978ba3fe7d8
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0139" ;
-    prov:atLocation niiri:43b0118cb5db387213a156a4e1f1aff0 ;
+    prov:atLocation niiri:33167c8e22920a525f3568a883d101c6 ;
     prov:value "16.59206199646"^^xsd:float ;
     nidm_equivalentZStatistic: "3.7343303583498"^^xsd:float ;
     nidm_pValueUncorrected: "9.41076528112594e-05"^^xsd:float ;
     nidm_pValueFWER: "0.998505188879306"^^xsd:float ;
     nidm_qValueFDR: "0.241173215874839"^^xsd:float .
 
-niiri:43b0118cb5db387213a156a4e1f1aff0
+niiri:33167c8e22920a525f3568a883d101c6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0139" ;
     nidm_coordinateVector: "[20,-66,34]"^^xsd:string .
 
-niiri:550faac6b8dd2504485e40c3bbfb3073 prov:wasDerivedFrom niiri:a2bcb1ae11c4d80d14c85b5637295099 .
+niiri:e91d29fc9817e2a7b36fc978ba3fe7d8 prov:wasDerivedFrom niiri:01a6664df87623bed0fd193f07c04638 .
 
-niiri:78da07a0233d16819aa1e9e13de77ecd
+niiri:c156e4600d2260f008778fbfcc998fb4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0140" ;
-    prov:atLocation niiri:08d403b38dc368dcdb9b2fbeb03cce3f ;
+    prov:atLocation niiri:005224864c46a4f96af3799c87601109 ;
     prov:value "16.4643402099609"^^xsd:float ;
     nidm_equivalentZStatistic: "3.71981100422245"^^xsd:float ;
     nidm_pValueUncorrected: "9.96859555968399e-05"^^xsd:float ;
     nidm_pValueFWER: "0.998902236749178"^^xsd:float ;
     nidm_qValueFDR: "0.250667985672322"^^xsd:float .
 
-niiri:08d403b38dc368dcdb9b2fbeb03cce3f
+niiri:005224864c46a4f96af3799c87601109
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0140" ;
     nidm_coordinateVector: "[-46,-56,14]"^^xsd:string .
 
-niiri:78da07a0233d16819aa1e9e13de77ecd prov:wasDerivedFrom niiri:6e5d34b600dd5cfbc70efee8ab867c9f .
+niiri:c156e4600d2260f008778fbfcc998fb4 prov:wasDerivedFrom niiri:9fbbe8461310da88b0ce5b0b68e8e62c .
 
-niiri:88aebeaace0915b1e2b8cd25561c98d6
+niiri:ec175136c213f64b6858d2d67479878d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0141" ;
-    prov:atLocation niiri:e2c5c3a0379ef78f67437674a3bb1b63 ;
+    prov:atLocation niiri:b19e011215edc6c32c1ec6d92455e9ed ;
     prov:value "15.7879962921143"^^xsd:float ;
     nidm_equivalentZStatistic: "3.64169928081447"^^xsd:float ;
     nidm_pValueUncorrected: "0.000135422173195066"^^xsd:float ;
     nidm_pValueFWER: "0.999835135686248"^^xsd:float ;
     nidm_qValueFDR: "0.302609017771479"^^xsd:float .
 
-niiri:e2c5c3a0379ef78f67437674a3bb1b63
+niiri:b19e011215edc6c32c1ec6d92455e9ed
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0141" ;
     nidm_coordinateVector: "[-50,-50,20]"^^xsd:string .
 
-niiri:88aebeaace0915b1e2b8cd25561c98d6 prov:wasDerivedFrom niiri:6e5d34b600dd5cfbc70efee8ab867c9f .
+niiri:ec175136c213f64b6858d2d67479878d prov:wasDerivedFrom niiri:9fbbe8461310da88b0ce5b0b68e8e62c .
 
-niiri:2c1b864f7498eb14c461a262d2e4159c
+niiri:1a52e7aaf9f3a5bd152c0ebd9fcef4fd
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0142" ;
-    prov:atLocation niiri:5332b1080529e4f4115a33dc6f3d5e06 ;
+    prov:atLocation niiri:87d81140c3614e8c44dfad60899c3eba ;
     prov:value "16.4616966247559"^^xsd:float ;
     nidm_equivalentZStatistic: "3.71950972254369"^^xsd:float ;
     nidm_pValueUncorrected: "9.98049320762862e-05"^^xsd:float ;
     nidm_pValueFWER: "0.998909395230241"^^xsd:float ;
     nidm_qValueFDR: "0.250667985672322"^^xsd:float .
 
-niiri:5332b1080529e4f4115a33dc6f3d5e06
+niiri:87d81140c3614e8c44dfad60899c3eba
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0142" ;
     nidm_coordinateVector: "[54,-70,10]"^^xsd:string .
 
-niiri:2c1b864f7498eb14c461a262d2e4159c prov:wasDerivedFrom niiri:96be67b14048a7acaffdcf5d2d455f8b .
+niiri:1a52e7aaf9f3a5bd152c0ebd9fcef4fd prov:wasDerivedFrom niiri:ae14e5d65d87b53bd2bbf000849a1635 .
 
-niiri:1929176f6523cd3eb0f67a70edb58f7a
+niiri:2c83e3b2c475480b66ada9ebc6da746b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0143" ;
-    prov:atLocation niiri:3990057aa9042769b27afb3c4b8d8ef6 ;
+    prov:atLocation niiri:1b509c10d0feceee9f9e723c8315cfc9 ;
     prov:value "16.4018669128418"^^xsd:float ;
     nidm_equivalentZStatistic: "3.71268281226793"^^xsd:float ;
     nidm_pValueUncorrected: "0.000102536916068097"^^xsd:float ;
     nidm_pValueFWER: "0.999061078942832"^^xsd:float ;
     nidm_qValueFDR: "0.255433180603606"^^xsd:float .
 
-niiri:3990057aa9042769b27afb3c4b8d8ef6
+niiri:1b509c10d0feceee9f9e723c8315cfc9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0143" ;
     nidm_coordinateVector: "[-30,-10,66]"^^xsd:string .
 
-niiri:1929176f6523cd3eb0f67a70edb58f7a prov:wasDerivedFrom niiri:bbdf3a3cea68312933b0e0f7ac23c71f .
+niiri:2c83e3b2c475480b66ada9ebc6da746b prov:wasDerivedFrom niiri:40d7f1124d8e7cab0c81135fe2f535ad .
 
-niiri:c9ed57a259ba6e39c80121a7b2fde6e1
+niiri:c0b01d212ef6b8d37eb57b24d78fab11
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0144" ;
-    prov:atLocation niiri:df2c041128c92286725f3bba2c095857 ;
+    prov:atLocation niiri:7ac3c69eacd73432ce5a57cff71ee461 ;
     prov:value "16.3890476226807"^^xsd:float ;
     nidm_equivalentZStatistic: "3.71121798724803"^^xsd:float ;
     nidm_pValueUncorrected: "0.000103132189635535"^^xsd:float ;
     nidm_pValueFWER: "0.999091114381714"^^xsd:float ;
     nidm_qValueFDR: "0.255887110131141"^^xsd:float .
 
-niiri:df2c041128c92286725f3bba2c095857
+niiri:7ac3c69eacd73432ce5a57cff71ee461
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0144" ;
     nidm_coordinateVector: "[-10,42,4]"^^xsd:string .
 
-niiri:c9ed57a259ba6e39c80121a7b2fde6e1 prov:wasDerivedFrom niiri:3cf31cb78a4315d8e0bb0e1795c2b177 .
+niiri:c0b01d212ef6b8d37eb57b24d78fab11 prov:wasDerivedFrom niiri:3383de798490342ce6540ea70b023ffa .
 
-niiri:3e9981701d6165795315b3c65c4e1a88
+niiri:861c2c7575cf5f18aa4f01bea0b82135
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0145" ;
-    prov:atLocation niiri:405640b932db22c888695538a714a09e ;
+    prov:atLocation niiri:3817f54a70e50af79f9a6b8831c78d7a ;
     prov:value "16.298921585083"^^xsd:float ;
     nidm_equivalentZStatistic: "3.70089879419966"^^xsd:float ;
     nidm_pValueUncorrected: "0.000107418577610985"^^xsd:float ;
     nidm_pValueFWER: "0.999279946312565"^^xsd:float ;
     nidm_qValueFDR: "0.26288576268692"^^xsd:float .
 
-niiri:405640b932db22c888695538a714a09e
+niiri:3817f54a70e50af79f9a6b8831c78d7a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0145" ;
     nidm_coordinateVector: "[-48,2,50]"^^xsd:string .
 
-niiri:3e9981701d6165795315b3c65c4e1a88 prov:wasDerivedFrom niiri:2de3fe021b32432646cff16795c27e84 .
+niiri:861c2c7575cf5f18aa4f01bea0b82135 prov:wasDerivedFrom niiri:4bcfe0e6f6bc971e3e914655ca98bf82 .
 
-niiri:68a4ad5f46f51ac375b9a7e75f4a279b
+niiri:a5987a6772c4cd944a2d21945bf8cc08
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0146" ;
-    prov:atLocation niiri:c76e9f1de64e9896c08504a86ebd44a2 ;
+    prov:atLocation niiri:c934c3e1b26d7a3234b6656c39cdea38 ;
     prov:value "16.1748123168945"^^xsd:float ;
     nidm_equivalentZStatistic: "3.68662875371095"^^xsd:float ;
     nidm_pValueUncorrected: "0.000113622246557199"^^xsd:float ;
     nidm_pValueFWER: "0.999484104559633"^^xsd:float ;
     nidm_qValueFDR: "0.271891418707172"^^xsd:float .
 
-niiri:c76e9f1de64e9896c08504a86ebd44a2
+niiri:c934c3e1b26d7a3234b6656c39cdea38
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0146" ;
     nidm_coordinateVector: "[-36,-40,-36]"^^xsd:string .
 
-niiri:68a4ad5f46f51ac375b9a7e75f4a279b prov:wasDerivedFrom niiri:4899fcf255f8d47f7118cf27e2fd1a7d .
+niiri:a5987a6772c4cd944a2d21945bf8cc08 prov:wasDerivedFrom niiri:bbf13cce053679ff04cb1b23082b44ac .
 
-niiri:492da5cf15cca67420b9c9fad372f24d
+niiri:9a723a9a2cf5ca36130eb2146162ff79
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0147" ;
-    prov:atLocation niiri:5822e1bf84fdeaba21887a2231df37f7 ;
+    prov:atLocation niiri:5375c6e20f2ad76e7323a119f4565a0a ;
     prov:value "16.1662578582764"^^xsd:float ;
     nidm_equivalentZStatistic: "3.68564259218778"^^xsd:float ;
     nidm_pValueUncorrected: "0.00011406315591389"^^xsd:float ;
     nidm_pValueFWER: "0.999496106370773"^^xsd:float ;
     nidm_qValueFDR: "0.271968636129453"^^xsd:float .
 
-niiri:5822e1bf84fdeaba21887a2231df37f7
+niiri:5375c6e20f2ad76e7323a119f4565a0a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0147" ;
     nidm_coordinateVector: "[8,-16,80]"^^xsd:string .
 
-niiri:492da5cf15cca67420b9c9fad372f24d prov:wasDerivedFrom niiri:655cdd92103093b072ae23a6af82f68e .
+niiri:9a723a9a2cf5ca36130eb2146162ff79 prov:wasDerivedFrom niiri:2151f348776220c1024fdc2f0b0bc92f .
 
-niiri:25e89f9bb1a13d578dc3f9f6e0161d05
+niiri:419f74c7325474e8e1f981e499bf215a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0148" ;
-    prov:atLocation niiri:3fe76f4decfea080047eb66eea50ae5f ;
+    prov:atLocation niiri:4a3926792d8bd2558570215cd1dfc6df ;
     prov:value "15.8700971603394"^^xsd:float ;
     nidm_equivalentZStatistic: "3.65129366161918"^^xsd:float ;
     nidm_pValueUncorrected: "0.000130461342294219"^^xsd:float ;
     nidm_pValueFWER: "0.999787108603416"^^xsd:float ;
     nidm_qValueFDR: "0.297253203818069"^^xsd:float .
 
-niiri:3fe76f4decfea080047eb66eea50ae5f
+niiri:4a3926792d8bd2558570215cd1dfc6df
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0148" ;
     nidm_coordinateVector: "[64,-30,-4]"^^xsd:string .
 
-niiri:25e89f9bb1a13d578dc3f9f6e0161d05 prov:wasDerivedFrom niiri:626eb7ded63e9b32e8502a0a107f553d .
+niiri:419f74c7325474e8e1f981e499bf215a prov:wasDerivedFrom niiri:8ccfe08eafd83c22c7082eb44f58a70f .
 
-niiri:17e85dcb08c223124c8919b3ec748120
+niiri:3877f612a4c9aaac9336d7f9e3e88d69
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0149" ;
-    prov:atLocation niiri:1ab01aec73bb6b808a1130aa3526d7e3 ;
+    prov:atLocation niiri:e4fc36d8eddefb2f351cae894068f752 ;
     prov:value "15.8040924072266"^^xsd:float ;
     nidm_equivalentZStatistic: "3.64358278828341"^^xsd:float ;
     nidm_pValueUncorrected: "0.000134434558439089"^^xsd:float ;
     nidm_pValueFWER: "0.999826557542014"^^xsd:float ;
     nidm_qValueFDR: "0.302499842954719"^^xsd:float .
 
-niiri:1ab01aec73bb6b808a1130aa3526d7e3
+niiri:e4fc36d8eddefb2f351cae894068f752
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0149" ;
     nidm_coordinateVector: "[-24,58,2]"^^xsd:string .
 
-niiri:17e85dcb08c223124c8919b3ec748120 prov:wasDerivedFrom niiri:b4ad782774b491871a7992522f937437 .
+niiri:3877f612a4c9aaac9336d7f9e3e88d69 prov:wasDerivedFrom niiri:bad308d46fbeeacaf458653ab9b853d6 .
 
-niiri:4fe611bb9a85fe47c515763d486540dc
+niiri:8637dbbca99c6bf52067de598426c4d0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0150" ;
-    prov:atLocation niiri:705d8ec8ed9460150b6144ddb1c06f86 ;
+    prov:atLocation niiri:07a3802a0d3e86c0622c2132242acb1c ;
     prov:value "14.5666723251343"^^xsd:float ;
     nidm_equivalentZStatistic: "3.49506845160221"^^xsd:float ;
     nidm_pValueUncorrected: "0.000236970094563582"^^xsd:float ;
     nidm_pValueFWER: "0.999998710493543"^^xsd:float ;
     nidm_qValueFDR: "0.419549680505734"^^xsd:float .
 
-niiri:705d8ec8ed9460150b6144ddb1c06f86
+niiri:07a3802a0d3e86c0622c2132242acb1c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0150" ;
     nidm_coordinateVector: "[-22,64,8]"^^xsd:string .
 
-niiri:4fe611bb9a85fe47c515763d486540dc prov:wasDerivedFrom niiri:b4ad782774b491871a7992522f937437 .
+niiri:8637dbbca99c6bf52067de598426c4d0 prov:wasDerivedFrom niiri:bad308d46fbeeacaf458653ab9b853d6 .
 
-niiri:52e81872af24f6613bcd6c058744f5f7
+niiri:2e6563d391260b35c952b660146494c2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0151" ;
-    prov:atLocation niiri:9e3b439f91eeabe30e6cb5a6ff583901 ;
+    prov:atLocation niiri:817ffa699ebce4b3995e88c66ffdd822 ;
     prov:value "15.7909498214722"^^xsd:float ;
     nidm_equivalentZStatistic: "3.64204498343963"^^xsd:float ;
     nidm_pValueUncorrected: "0.000135240396418101"^^xsd:float ;
     nidm_pValueFWER: "0.999833590389148"^^xsd:float ;
     nidm_qValueFDR: "0.302609017771479"^^xsd:float .
 
-niiri:9e3b439f91eeabe30e6cb5a6ff583901
+niiri:817ffa699ebce4b3995e88c66ffdd822
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0151" ;
     nidm_coordinateVector: "[-64,-46,40]"^^xsd:string .
 
-niiri:52e81872af24f6613bcd6c058744f5f7 prov:wasDerivedFrom niiri:677611b98bfd5eb8fbc23315abaa9320 .
+niiri:2e6563d391260b35c952b660146494c2 prov:wasDerivedFrom niiri:687916ac6701ade9ca268dec72dc0c0d .
 
-niiri:283577c39a6db96ba450852ad3cd7244
+niiri:2d7a05b0881bcaf974a82728c80d267b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0152" ;
-    prov:atLocation niiri:9cd7919fecb35ce5ba9c556c717efe29 ;
+    prov:atLocation niiri:f16a8477087128670c6728a97eaa864d ;
     prov:value "15.7291193008423"^^xsd:float ;
     nidm_equivalentZStatistic: "3.63479927525788"^^xsd:float ;
     nidm_pValueUncorrected: "0.000139098574372776"^^xsd:float ;
     nidm_pValueFWER: "0.999863401028703"^^xsd:float ;
     nidm_qValueFDR: "0.306447101172765"^^xsd:float .
 
-niiri:9cd7919fecb35ce5ba9c556c717efe29
+niiri:f16a8477087128670c6728a97eaa864d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0152" ;
     nidm_coordinateVector: "[2,-44,56]"^^xsd:string .
 
-niiri:283577c39a6db96ba450852ad3cd7244 prov:wasDerivedFrom niiri:0dbd53cf7610b049d137c94d182a0076 .
+niiri:2d7a05b0881bcaf974a82728c80d267b prov:wasDerivedFrom niiri:9071142b0c2683c96f4377cdddced1d0 .
 
-niiri:655bfb4890539809eb32aa2fb6f639ac
+niiri:3daa0fd1f3c9c061fc41328ca9438a27
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0153" ;
-    prov:atLocation niiri:e3590f8bf2d1313c81d4c84f99bad3c7 ;
+    prov:atLocation niiri:8611ef160b9557309f5e6ad3264be190 ;
     prov:value "15.7138509750366"^^xsd:float ;
     nidm_equivalentZStatistic: "3.6330072403139"^^xsd:float ;
     nidm_pValueUncorrected: "0.000140068577241359"^^xsd:float ;
     nidm_pValueFWER: "0.999869988931104"^^xsd:float ;
     nidm_qValueFDR: "0.306447101172765"^^xsd:float .
 
-niiri:e3590f8bf2d1313c81d4c84f99bad3c7
+niiri:8611ef160b9557309f5e6ad3264be190
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0153" ;
     nidm_coordinateVector: "[18,12,-20]"^^xsd:string .
 
-niiri:655bfb4890539809eb32aa2fb6f639ac prov:wasDerivedFrom niiri:76019faf9ae4e38fc7ae7798a2f879f4 .
+niiri:3daa0fd1f3c9c061fc41328ca9438a27 prov:wasDerivedFrom niiri:884f659ac62495dd158e264f576d0fc2 .
 
-niiri:49ab401e77e69625fa593378e409ab43
+niiri:2e8cafa261c265066c3b0c06f8f7546a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0154" ;
-    prov:atLocation niiri:76f623d7e81f533aa77b3a07690095cd ;
+    prov:atLocation niiri:59510129aa2ba33613be10e00d44383a ;
     prov:value "15.708869934082"^^xsd:float ;
     nidm_equivalentZStatistic: "3.6324223784443"^^xsd:float ;
     nidm_pValueUncorrected: "0.000140386524073888"^^xsd:float ;
     nidm_pValueFWER: "0.999872076198509"^^xsd:float ;
     nidm_qValueFDR: "0.306447101172765"^^xsd:float .
 
-niiri:76f623d7e81f533aa77b3a07690095cd
+niiri:59510129aa2ba33613be10e00d44383a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0154" ;
     nidm_coordinateVector: "[4,6,32]"^^xsd:string .
 
-niiri:49ab401e77e69625fa593378e409ab43 prov:wasDerivedFrom niiri:e6b0f9d536c2b1a1fd955a8eaff2a2df .
+niiri:2e8cafa261c265066c3b0c06f8f7546a prov:wasDerivedFrom niiri:2088eea3a39320e89e2a625ec7e9f82e .
 
-niiri:417fb0d435cedfc9a69bdf8dad69ba5a
+niiri:8139ce719a3bbb4c2ad3027af6da9b91
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0155" ;
-    prov:atLocation niiri:41c7b9983f9fc691d94a24b38527dfae ;
+    prov:atLocation niiri:6159441b4ec9659addc0939d61b94795 ;
     prov:value "15.701042175293"^^xsd:float ;
     nidm_equivalentZStatistic: "3.6315030231558"^^xsd:float ;
     nidm_pValueUncorrected: "0.000140887678002244"^^xsd:float ;
     nidm_pValueFWER: "0.999875296214591"^^xsd:float ;
     nidm_qValueFDR: "0.306447101172765"^^xsd:float .
 
-niiri:41c7b9983f9fc691d94a24b38527dfae
+niiri:6159441b4ec9659addc0939d61b94795
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0155" ;
     nidm_coordinateVector: "[-50,-48,-16]"^^xsd:string .
 
-niiri:417fb0d435cedfc9a69bdf8dad69ba5a prov:wasDerivedFrom niiri:7fee2fcd04048e290bf06db1c5562ffd .
+niiri:8139ce719a3bbb4c2ad3027af6da9b91 prov:wasDerivedFrom niiri:7fc88d60dca200d4c67a0a607a345633 .
 
-niiri:9ea32e8e16dc172a558d5e2a91244ec2
+niiri:f80978e3da40bc3e863003eb710a4f97
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0156" ;
-    prov:atLocation niiri:3a67eb95091016b19b62925ff1530b09 ;
+    prov:atLocation niiri:eeb84644b683af6ceb08368cba83a580 ;
     prov:value "15.676775932312"^^xsd:float ;
     nidm_equivalentZStatistic: "3.62865114343584"^^xsd:float ;
     nidm_pValueUncorrected: "0.000142452965301465"^^xsd:float ;
     nidm_pValueFWER: "0.999884825274485"^^xsd:float ;
     nidm_qValueFDR: "0.308330257911763"^^xsd:float .
 
-niiri:3a67eb95091016b19b62925ff1530b09
+niiri:eeb84644b683af6ceb08368cba83a580
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0156" ;
     nidm_coordinateVector: "[4,-96,8]"^^xsd:string .
 
-niiri:9ea32e8e16dc172a558d5e2a91244ec2 prov:wasDerivedFrom niiri:a544035a692226b8c28c019b1e283632 .
+niiri:f80978e3da40bc3e863003eb710a4f97 prov:wasDerivedFrom niiri:ca1da2e7a46f823f402d9c62e070d0fc .
 
-niiri:4dd77395a8f425a329cea7d63ef36eb2
+niiri:4e7e46ac0c58102be99f07a84d8b80ce
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0157" ;
-    prov:atLocation niiri:430c1e1ce3c3b410797123ab1f1ba51a ;
+    prov:atLocation niiri:9b468a9909484a871d5fb8ff8e97d872 ;
     prov:value "15.6319704055786"^^xsd:float ;
     nidm_equivalentZStatistic: "3.62337799963497"^^xsd:float ;
     nidm_pValueUncorrected: "0.00014539019458093"^^xsd:float ;
     nidm_pValueFWER: "0.999900731149395"^^xsd:float ;
     nidm_qValueFDR: "0.312547307242678"^^xsd:float .
 
-niiri:430c1e1ce3c3b410797123ab1f1ba51a
+niiri:9b468a9909484a871d5fb8ff8e97d872
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0157" ;
     nidm_coordinateVector: "[-68,-28,0]"^^xsd:string .
 
-niiri:4dd77395a8f425a329cea7d63ef36eb2 prov:wasDerivedFrom niiri:9c40cb58c75073f4f983d06c6a655c74 .
+niiri:4e7e46ac0c58102be99f07a84d8b80ce prov:wasDerivedFrom niiri:ea6ee099e3b8edbdd2bde04e8682a6ce .
 
-niiri:c56cb3d4548edcef09396283f6a3311d
+niiri:a61c69f7358597f7aa5c12a588c1ce7c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0158" ;
-    prov:atLocation niiri:bcc4aedc3bba097da5f1e38542555e69 ;
+    prov:atLocation niiri:2fda99f58ae75a6c5ac429d5b6053dc7 ;
     prov:value "15.4950304031372"^^xsd:float ;
     nidm_equivalentZStatistic: "3.60720172487664"^^xsd:float ;
     nidm_pValueUncorrected: "0.000154758512821873"^^xsd:float ;
     nidm_pValueFWER: "0.999937921710337"^^xsd:float ;
     nidm_qValueFDR: "0.325857771765735"^^xsd:float .
 
-niiri:bcc4aedc3bba097da5f1e38542555e69
+niiri:2fda99f58ae75a6c5ac429d5b6053dc7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0158" ;
     nidm_coordinateVector: "[-48,-50,-38]"^^xsd:string .
 
-niiri:c56cb3d4548edcef09396283f6a3311d prov:wasDerivedFrom niiri:f8d5d9e3adb56590f1e9d795fa0fb5b7 .
+niiri:a61c69f7358597f7aa5c12a588c1ce7c prov:wasDerivedFrom niiri:1ef7113e2a59f273a63186ced0b0fc6b .
 
-niiri:6492005ac86d44d9eafa0aafd7adcac0
+niiri:ab548589200676685973c248e76b07b4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0159" ;
-    prov:atLocation niiri:0d0b6563d75959c51f007b78e8e0c2cf ;
+    prov:atLocation niiri:de558f593a64c3e86a629fa5e4ec3f3b ;
     prov:value "15.4388980865479"^^xsd:float ;
     nidm_equivalentZStatistic: "3.60054472544061"^^xsd:float ;
     nidm_pValueUncorrected: "0.000158775598232741"^^xsd:float ;
     nidm_pValueFWER: "0.99994913578297"^^xsd:float ;
     nidm_qValueFDR: "0.329941167587052"^^xsd:float .
 
-niiri:0d0b6563d75959c51f007b78e8e0c2cf
+niiri:de558f593a64c3e86a629fa5e4ec3f3b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0159" ;
     nidm_coordinateVector: "[28,-62,52]"^^xsd:string .
 
-niiri:6492005ac86d44d9eafa0aafd7adcac0 prov:wasDerivedFrom niiri:d763c6c8de6f4537a51f15146880d851 .
+niiri:ab548589200676685973c248e76b07b4 prov:wasDerivedFrom niiri:02f0aee7ff558248fe49e5f3579c0585 .
 
-niiri:d305fbf9673e2985f5e39c80181a26df
+niiri:6d8e54d85422fdb3fc4d40dcb8a7528b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0160" ;
-    prov:atLocation niiri:53e250cec29016a1a4a68e30b11d7b72 ;
+    prov:atLocation niiri:e79376ec4a6c43b7e658f206276a73d8 ;
     prov:value "15.4314498901367"^^xsd:float ;
     nidm_equivalentZStatistic: "3.59966025263468"^^xsd:float ;
     nidm_pValueUncorrected: "0.000159316609409377"^^xsd:float ;
     nidm_pValueFWER: "0.999950477945125"^^xsd:float ;
     nidm_qValueFDR: "0.329967567413556"^^xsd:float .
 
-niiri:53e250cec29016a1a4a68e30b11d7b72
+niiri:e79376ec4a6c43b7e658f206276a73d8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0160" ;
     nidm_coordinateVector: "[-26,-50,-26]"^^xsd:string .
 
-niiri:d305fbf9673e2985f5e39c80181a26df prov:wasDerivedFrom niiri:c81c855fadc265b4e1ccb72361a5ab5b .
+niiri:6d8e54d85422fdb3fc4d40dcb8a7528b prov:wasDerivedFrom niiri:c2cda63a78bcde6ae7a69f7ab8eadb2c .
 
-niiri:5afe30a0f271b9c39b5c17d5754616e6
+niiri:5deeb5d90a0af409b6cff616354e11a7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0161" ;
-    prov:atLocation niiri:90a3142db91f5d8edde9e74e68dd388e ;
+    prov:atLocation niiri:2bde547f7aec22d7518accdce026c12c ;
     prov:value "15.3998956680298"^^xsd:float ;
     nidm_equivalentZStatistic: "3.59591017819407"^^xsd:float ;
     nidm_pValueUncorrected: "0.000161629666827423"^^xsd:float ;
     nidm_pValueFWER: "0.999955817597174"^^xsd:float ;
     nidm_qValueFDR: "0.332893773024534"^^xsd:float .
 
-niiri:90a3142db91f5d8edde9e74e68dd388e
+niiri:2bde547f7aec22d7518accdce026c12c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0161" ;
     nidm_coordinateVector: "[34,12,64]"^^xsd:string .
 
-niiri:5afe30a0f271b9c39b5c17d5754616e6 prov:wasDerivedFrom niiri:adb14ea605c87220ed90422a86d00cf7 .
+niiri:5deeb5d90a0af409b6cff616354e11a7 prov:wasDerivedFrom niiri:2c7f2ff6921dbb36e89f44a3a1dd839b .
 
-niiri:385afdce90c603da6856fb145be9e564
+niiri:b9a1b6a6a5bd0918b2da9d95b2f3281d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0162" ;
-    prov:atLocation niiri:52ef5ab931812ea9d3c9597c3b43115d ;
+    prov:atLocation niiri:7c7a24b9cb1d730e5e18aacc805d3ce2 ;
     prov:value "15.3762083053589"^^xsd:float ;
     nidm_equivalentZStatistic: "3.59309183388917"^^xsd:float ;
     nidm_pValueUncorrected: "0.000163388677505649"^^xsd:float ;
     nidm_pValueFWER: "0.999959478963553"^^xsd:float ;
     nidm_qValueFDR: "0.334848055204527"^^xsd:float .
 
-niiri:52ef5ab931812ea9d3c9597c3b43115d
+niiri:7c7a24b9cb1d730e5e18aacc805d3ce2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0162" ;
     nidm_coordinateVector: "[12,-60,2]"^^xsd:string .
 
-niiri:385afdce90c603da6856fb145be9e564 prov:wasDerivedFrom niiri:d5aa67ffe10d81e16892509076504f14 .
+niiri:b9a1b6a6a5bd0918b2da9d95b2f3281d prov:wasDerivedFrom niiri:03e03b97c9ae144949ccd274ec79dd81 .
 
-niiri:bdd46b6b87a63614e7cab12c58787ae2
+niiri:77808b7180e73fc3945d40bbbd602a7c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0163" ;
-    prov:atLocation niiri:a8b1b2a07e1a026125e80b724c2110cf ;
+    prov:atLocation niiri:4e4841b781aab4f23390e4712c5dd517 ;
     prov:value "15.2871723175049"^^xsd:float ;
     nidm_equivalentZStatistic: "3.58247351023423"^^xsd:float ;
     nidm_pValueUncorrected: "0.000170178069703208"^^xsd:float ;
     nidm_pValueFWER: "0.999970922373423"^^xsd:float ;
     nidm_qValueFDR: "0.343198560123146"^^xsd:float .
 
-niiri:a8b1b2a07e1a026125e80b724c2110cf
+niiri:4e4841b781aab4f23390e4712c5dd517
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0163" ;
     nidm_coordinateVector: "[54,-24,-2]"^^xsd:string .
 
-niiri:bdd46b6b87a63614e7cab12c58787ae2 prov:wasDerivedFrom niiri:3fae830c70c9ca8cf8f3cbed4301161f .
+niiri:77808b7180e73fc3945d40bbbd602a7c prov:wasDerivedFrom niiri:036f2836a317a98100c1a6652ab21784 .
 
-niiri:562c93862da14a62c182e923b5b74ebc
+niiri:07c12d4cbb23e86fca36208cc6a9eb4f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0164" ;
-    prov:atLocation niiri:0eae67a04ae2f5080393c631873ca725 ;
+    prov:atLocation niiri:93e589f292425b950a446aa909654e13 ;
     prov:value "15.2692956924438"^^xsd:float ;
     nidm_equivalentZStatistic: "3.58033683390377"^^xsd:float ;
     nidm_pValueUncorrected: "0.00017157578503435"^^xsd:float ;
     nidm_pValueFWER: "0.999972831864908"^^xsd:float ;
     nidm_qValueFDR: "0.344539994060292"^^xsd:float .
 
-niiri:0eae67a04ae2f5080393c631873ca725
+niiri:93e589f292425b950a446aa909654e13
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0164" ;
     nidm_coordinateVector: "[-14,-98,-4]"^^xsd:string .
 
-niiri:562c93862da14a62c182e923b5b74ebc prov:wasDerivedFrom niiri:c35054132a92b4bf34b2e1b8acd96c91 .
+niiri:07c12d4cbb23e86fca36208cc6a9eb4f prov:wasDerivedFrom niiri:a029a63406d370c8869c59656bb90a54 .
 
-niiri:2a64383bd3d13df477c4aa76215a3ba3
+niiri:3a4c88d5e566a02cdf99eb0ce85232b0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0165" ;
-    prov:atLocation niiri:17d218a14f543ed5edb2bef5516204b1 ;
+    prov:atLocation niiri:33e9c66b8f9fafa079d5d5d649b33e95 ;
     prov:value "15.2561340332031"^^xsd:float ;
     nidm_equivalentZStatistic: "3.57876269120649"^^xsd:float ;
     nidm_pValueUncorrected: "0.000172612379221393"^^xsd:float ;
     nidm_pValueFWER: "0.999974164363014"^^xsd:float ;
     nidm_qValueFDR: "0.34525482719666"^^xsd:float .
 
-niiri:17d218a14f543ed5edb2bef5516204b1
+niiri:33e9c66b8f9fafa079d5d5d649b33e95
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0165" ;
     nidm_coordinateVector: "[52,40,-32]"^^xsd:string .
 
-niiri:2a64383bd3d13df477c4aa76215a3ba3 prov:wasDerivedFrom niiri:21c649902d379fc9de7f1be15e128c6b .
+niiri:3a4c88d5e566a02cdf99eb0ce85232b0 prov:wasDerivedFrom niiri:c429131bcf59cefceae4a934fd1aa80a .
 
-niiri:e124404cc77a7b89f79d5806315a547c
+niiri:24b5fea160dd2add4c0826068ad6d59a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0166" ;
-    prov:atLocation niiri:10f4332a5dea5374b9422b40d8100936 ;
+    prov:atLocation niiri:c1c6a7167e5e88a6a1b5357f8dc99d2c ;
     prov:value "15.2322616577148"^^xsd:float ;
     nidm_equivalentZStatistic: "3.57590533845626"^^xsd:float ;
     nidm_pValueUncorrected: "0.000174508968234677"^^xsd:float ;
     nidm_pValueFWER: "0.999976431095502"^^xsd:float ;
     nidm_qValueFDR: "0.345634100571722"^^xsd:float .
 
-niiri:10f4332a5dea5374b9422b40d8100936
+niiri:c1c6a7167e5e88a6a1b5357f8dc99d2c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0166" ;
     nidm_coordinateVector: "[-36,-46,-18]"^^xsd:string .
 
-niiri:e124404cc77a7b89f79d5806315a547c prov:wasDerivedFrom niiri:24ec764638d7b84cf388c10bdbf8e52e .
+niiri:24b5fea160dd2add4c0826068ad6d59a prov:wasDerivedFrom niiri:9ac7226087de1c45b555519c1250dc59 .
 
-niiri:8ba891c9418f9a9dc0a017aa2e16c3be
+niiri:1b0c82bff8134900d83ca4ab18a5f9a1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0167" ;
-    prov:atLocation niiri:44dddcfc5edd6bf1d9d603c1b073db3f ;
+    prov:atLocation niiri:41ce647be65b12c740f9a69ac2bc2072 ;
     prov:value "15.106840133667"^^xsd:float ;
     nidm_equivalentZStatistic: "3.56084639153832"^^xsd:float ;
     nidm_pValueUncorrected: "0.000184830650378665"^^xsd:float ;
     nidm_pValueFWER: "0.999985642365922"^^xsd:float ;
     nidm_qValueFDR: "0.357155778315693"^^xsd:float .
 
-niiri:44dddcfc5edd6bf1d9d603c1b073db3f
+niiri:41ce647be65b12c740f9a69ac2bc2072
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0167" ;
     nidm_coordinateVector: "[-50,-46,-32]"^^xsd:string .
 
-niiri:8ba891c9418f9a9dc0a017aa2e16c3be prov:wasDerivedFrom niiri:7e5ff536134bdc8ab5fcb743674e90c4 .
+niiri:1b0c82bff8134900d83ca4ab18a5f9a1 prov:wasDerivedFrom niiri:9c1fe61e0e5d7d3b62e90ebdfdb9d4d4 .
 
-niiri:8379520857b8af55cf1805934d42de76
+niiri:52d92ac8e74231b2934c36f68802206e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0168" ;
-    prov:atLocation niiri:1e28949330f556a725bfe8973acf49b1 ;
+    prov:atLocation niiri:7cb75652d69e9abf19d2ee2c4fa1e4fb ;
     prov:value "15.0247755050659"^^xsd:float ;
     nidm_equivalentZStatistic: "3.55095019170042"^^xsd:float ;
     nidm_pValueUncorrected: "0.000191921525476424"^^xsd:float ;
     nidm_pValueFWER: "0.999989746346377"^^xsd:float ;
     nidm_qValueFDR: "0.366093757282605"^^xsd:float .
 
-niiri:1e28949330f556a725bfe8973acf49b1
+niiri:7cb75652d69e9abf19d2ee2c4fa1e4fb
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0168" ;
     nidm_coordinateVector: "[16,-80,34]"^^xsd:string .
 
-niiri:8379520857b8af55cf1805934d42de76 prov:wasDerivedFrom niiri:ec6922a6284384102e3683f4f534bdd4 .
+niiri:52d92ac8e74231b2934c36f68802206e prov:wasDerivedFrom niiri:7489f5e950ff72b41ea437f2c2026c6f .
 
-niiri:d5fb13475ead04b97a6bc0c5cf77a7b6
+niiri:d117036fe64a05a3b7c805f5ca53e73e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0169" ;
-    prov:atLocation niiri:cd4fb279af14a2919459e77c2d68532d ;
+    prov:atLocation niiri:9a1e586581e6bddb054aee681f832543 ;
     prov:value "14.9055671691895"^^xsd:float ;
     nidm_equivalentZStatistic: "3.53651359109015"^^xsd:float ;
     nidm_pValueUncorrected: "0.00020272281950362"^^xsd:float ;
     nidm_pValueFWER: "0.999993824799586"^^xsd:float ;
     nidm_qValueFDR: "0.380347203516888"^^xsd:float .
 
-niiri:cd4fb279af14a2919459e77c2d68532d
+niiri:9a1e586581e6bddb054aee681f832543
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0169" ;
     nidm_coordinateVector: "[64,-30,-22]"^^xsd:string .
 
-niiri:d5fb13475ead04b97a6bc0c5cf77a7b6 prov:wasDerivedFrom niiri:1587d965de8a227487a386f18a622f62 .
+niiri:d117036fe64a05a3b7c805f5ca53e73e prov:wasDerivedFrom niiri:e83b9cd4cb9554eedc76bd43c766b08d .
 
-niiri:8386fab97aa78085b846ca72be1375c2
+niiri:c1fb5dac9debfbd27cdbf2c5644bd72c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0170" ;
-    prov:atLocation niiri:90135c09df01dc00b9ae6433652e1957 ;
+    prov:atLocation niiri:d8e46fdef899ea7ef1ae4932eb2a23ab ;
     prov:value "14.8710918426514"^^xsd:float ;
     nidm_equivalentZStatistic: "3.53232486243101"^^xsd:float ;
     nidm_pValueUncorrected: "0.000205961489586182"^^xsd:float ;
     nidm_pValueFWER: "0.99999468897041"^^xsd:float ;
     nidm_qValueFDR: "0.384169468988064"^^xsd:float .
 
-niiri:90135c09df01dc00b9ae6433652e1957
+niiri:d8e46fdef899ea7ef1ae4932eb2a23ab
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0170" ;
     nidm_coordinateVector: "[-10,0,-26]"^^xsd:string .
 
-niiri:8386fab97aa78085b846ca72be1375c2 prov:wasDerivedFrom niiri:cde75203fe8335e4da3e8277987b76e3 .
+niiri:c1fb5dac9debfbd27cdbf2c5644bd72c prov:wasDerivedFrom niiri:6f3ca580fb0dafec12bb76f49a9e660f .
 
-niiri:f76d49b1ed43e2533464668a6954e3f7
+niiri:3b66a36836011aa9090bd0e7407688b5
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0171" ;
-    prov:atLocation niiri:737c5b254d8053c6781fe72ecfab960e ;
+    prov:atLocation niiri:0709e326475b1e5b4645c9564c8fc035 ;
     prov:value "14.7261476516724"^^xsd:float ;
     nidm_equivalentZStatistic: "3.51464664736948"^^xsd:float ;
     nidm_pValueUncorrected: "0.000220169736176778"^^xsd:float ;
     nidm_pValueFWER: "0.999997240347399"^^xsd:float ;
     nidm_qValueFDR: "0.402613109615176"^^xsd:float .
 
-niiri:737c5b254d8053c6781fe72ecfab960e
+niiri:0709e326475b1e5b4645c9564c8fc035
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0171" ;
     nidm_coordinateVector: "[6,-86,-14]"^^xsd:string .
 
-niiri:f76d49b1ed43e2533464668a6954e3f7 prov:wasDerivedFrom niiri:1963461ba0ecaf2bdd626d72af091d83 .
+niiri:3b66a36836011aa9090bd0e7407688b5 prov:wasDerivedFrom niiri:37ee2d388f0d21999c13e5808ab4abaa .
 
-niiri:7d086b408d223ad920f53d221022020e
+niiri:8de26e655b38ebe0ae823a3c6315b489
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0172" ;
-    prov:atLocation niiri:f5eb75a18c012485610d81fd8d0f64e9 ;
+    prov:atLocation niiri:8e522834b8f477e782bc23a55b9554cb ;
     prov:value "14.6060304641724"^^xsd:float ;
     nidm_equivalentZStatistic: "3.49991285381712"^^xsd:float ;
     nidm_pValueUncorrected: "0.000232705141600564"^^xsd:float ;
     nidm_pValueFWER: "0.999998437784089"^^xsd:float ;
     nidm_qValueFDR: "0.414927735129735"^^xsd:float .
 
-niiri:f5eb75a18c012485610d81fd8d0f64e9
+niiri:8e522834b8f477e782bc23a55b9554cb
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0172" ;
     nidm_coordinateVector: "[12,52,-12]"^^xsd:string .
 
-niiri:7d086b408d223ad920f53d221022020e prov:wasDerivedFrom niiri:031b2ebac9374480bd55f336b2f0698d .
+niiri:8de26e655b38ebe0ae823a3c6315b489 prov:wasDerivedFrom niiri:17c3d65f0a2dd8b609c3139c41ebf930 .
 
-niiri:21e6f173b43fe0229a78d435762354fa
+niiri:3a28b75034719222480546a8f248e93d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0173" ;
-    prov:atLocation niiri:389cde518a3428b0670d3ca8db8ab089 ;
+    prov:atLocation niiri:54cd1db3599f092f7c78fff2e8d1615a ;
     prov:value "14.5363855361938"^^xsd:float ;
     nidm_equivalentZStatistic: "3.49133496134193"^^xsd:float ;
     nidm_pValueUncorrected: "0.000240306645747146"^^xsd:float ;
     nidm_pValueFWER: "0.999998889540591"^^xsd:float ;
     nidm_qValueFDR: "0.422120265651345"^^xsd:float .
 
-niiri:389cde518a3428b0670d3ca8db8ab089
+niiri:54cd1db3599f092f7c78fff2e8d1615a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0173" ;
     nidm_coordinateVector: "[36,54,20]"^^xsd:string .
 
-niiri:21e6f173b43fe0229a78d435762354fa prov:wasDerivedFrom niiri:8424ab2f8e8a8fcd5c99b549000e3d8a .
+niiri:3a28b75034719222480546a8f248e93d prov:wasDerivedFrom niiri:bbd0acc33408cc31d2590c5760c85985 .
 
-niiri:cfd29d6b862a9f5b8c4f5c8768652d51
+niiri:12ba61b8d3db496fc57a6862ebafea4f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0174" ;
-    prov:atLocation niiri:723b57795cebfe51b9f7ac8f922a3406 ;
+    prov:atLocation niiri:9fd3a79c0e2a551ded703808f3d2e025 ;
     prov:value "14.4983959197998"^^xsd:float ;
     nidm_equivalentZStatistic: "3.48664497650161"^^xsd:float ;
     nidm_pValueUncorrected: "0.0002445600975165"^^xsd:float ;
     nidm_pValueFWER: "0.999999081527317"^^xsd:float ;
     nidm_qValueFDR: "0.425901789152019"^^xsd:float .
 
-niiri:723b57795cebfe51b9f7ac8f922a3406
+niiri:9fd3a79c0e2a551ded703808f3d2e025
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0174" ;
     nidm_coordinateVector: "[22,-80,54]"^^xsd:string .
 
-niiri:cfd29d6b862a9f5b8c4f5c8768652d51 prov:wasDerivedFrom niiri:cb3496ce3deece902bd5c57224f82327 .
+niiri:12ba61b8d3db496fc57a6862ebafea4f prov:wasDerivedFrom niiri:04aa6294da937ca4a062fce158511fb6 .
 
-niiri:b0097d657d563c0ed526a53ad4d35cc0
+niiri:1ca1bec4b1e87f060081099329ba04c7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0175" ;
-    prov:atLocation niiri:f5cd7c9e0765c96da29c86c47396cb30 ;
+    prov:atLocation niiri:039763d5557fd6b882a82f1f2fa88193 ;
     prov:value "14.4410257339478"^^xsd:float ;
     nidm_equivalentZStatistic: "3.4795476354157"^^xsd:float ;
     nidm_pValueUncorrected: "0.00025113053481729"^^xsd:float ;
     nidm_pValueFWER: "0.999999313840959"^^xsd:float ;
     nidm_qValueFDR: "0.433055163923937"^^xsd:float .
 
-niiri:f5cd7c9e0765c96da29c86c47396cb30
+niiri:039763d5557fd6b882a82f1f2fa88193
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0175" ;
     nidm_coordinateVector: "[-22,-36,76]"^^xsd:string .
 
-niiri:b0097d657d563c0ed526a53ad4d35cc0 prov:wasDerivedFrom niiri:a3a27b078e8a7d6edcf7ae4db82c3d7a .
+niiri:1ca1bec4b1e87f060081099329ba04c7 prov:wasDerivedFrom niiri:6e2a6189013a78c14191e7633ed21b0a .
 
-niiri:59fa50d957e29dd591c676c8c178c87d
+niiri:5570619f587edcedc3276cafac9a60e6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0176" ;
-    prov:atLocation niiri:ebdfb13c9a07087afe2c7242faee2044 ;
+    prov:atLocation niiri:f0ea17a233eefa7eab37721460a7244a ;
     prov:value "14.4293870925903"^^xsd:float ;
     nidm_equivalentZStatistic: "3.47810563161417"^^xsd:float ;
     nidm_pValueUncorrected: "0.000252485443433037"^^xsd:float ;
     nidm_pValueFWER: "0.999999353730622"^^xsd:float ;
     nidm_qValueFDR: "0.43353733164354"^^xsd:float .
 
-niiri:ebdfb13c9a07087afe2c7242faee2044
+niiri:f0ea17a233eefa7eab37721460a7244a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0176" ;
     nidm_coordinateVector: "[26,62,6]"^^xsd:string .
 
-niiri:59fa50d957e29dd591c676c8c178c87d prov:wasDerivedFrom niiri:4f03ee575ea9164c216c53e2e6502c3f .
+niiri:5570619f587edcedc3276cafac9a60e6 prov:wasDerivedFrom niiri:81840f3ae0159e07fac81fc13e72fbf5 .
 
-niiri:04db5f1da5e9e02a8e3ae06f6921e16e
+niiri:191389c9f10b0de3fdc2d8f22b74563e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0177" ;
-    prov:atLocation niiri:8fb297386f41d2110208c30bb125fac6 ;
+    prov:atLocation niiri:1ebed5337c4efa7db3bac190a73c4a66 ;
     prov:value "14.3534603118896"^^xsd:float ;
     nidm_equivalentZStatistic: "3.46868038509791"^^xsd:float ;
     nidm_pValueUncorrected: "0.000261510638276841"^^xsd:float ;
     nidm_pValueFWER: "0.999999565455566"^^xsd:float ;
     nidm_qValueFDR: "0.443489346067816"^^xsd:float .
 
-niiri:8fb297386f41d2110208c30bb125fac6
+niiri:1ebed5337c4efa7db3bac190a73c4a66
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0177" ;
     nidm_coordinateVector: "[22,40,26]"^^xsd:string .
 
-niiri:04db5f1da5e9e02a8e3ae06f6921e16e prov:wasDerivedFrom niiri:8ddc263efb94c47b4f51cbca78984739 .
+niiri:191389c9f10b0de3fdc2d8f22b74563e prov:wasDerivedFrom niiri:dd602a84f4dd916125d3c669097eec23 .
 
-niiri:0da7da691d434ca45f64b54f97f14934
+niiri:aedad9f4ec6caede41f6dc10a706c84d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0178" ;
-    prov:atLocation niiri:7bc09c4d8cdb5f33e5e1defbb37268e8 ;
+    prov:atLocation niiri:ac86a4452eca6d7e0a7b5e876240c351 ;
     prov:value "14.3390064239502"^^xsd:float ;
     nidm_equivalentZStatistic: "3.46688257307826"^^xsd:float ;
     nidm_pValueUncorrected: "0.000263265928860834"^^xsd:float ;
     nidm_pValueFWER: "0.99999959757588"^^xsd:float ;
     nidm_qValueFDR: "0.443939228312532"^^xsd:float .
 
-niiri:7bc09c4d8cdb5f33e5e1defbb37268e8
+niiri:ac86a4452eca6d7e0a7b5e876240c351
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0178" ;
     nidm_coordinateVector: "[-22,-74,60]"^^xsd:string .
 
-niiri:0da7da691d434ca45f64b54f97f14934 prov:wasDerivedFrom niiri:b615db2c02106c19996d725a76dd5932 .
+niiri:aedad9f4ec6caede41f6dc10a706c84d prov:wasDerivedFrom niiri:1c2363e827044fb757d9bf0cf8e052e5 .
 
-niiri:afa775723febe159c089c9dec314c31e
+niiri:4c440fe68b006ba088752502fc89d323
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0179" ;
-    prov:atLocation niiri:efcaa7aeb871102569f97676f9904ed5 ;
+    prov:atLocation niiri:22107ce4b501a53fc85295e23a1ea347 ;
     prov:value "14.3375244140625"^^xsd:float ;
     nidm_equivalentZStatistic: "3.46669817220102"^^xsd:float ;
     nidm_pValueUncorrected: "0.000263446587826399"^^xsd:float ;
     nidm_pValueFWER: "0.999999600741004"^^xsd:float ;
     nidm_qValueFDR: "0.443939228312532"^^xsd:float .
 
-niiri:efcaa7aeb871102569f97676f9904ed5
+niiri:22107ce4b501a53fc85295e23a1ea347
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0179" ;
     nidm_coordinateVector: "[60,-58,-2]"^^xsd:string .
 
-niiri:afa775723febe159c089c9dec314c31e prov:wasDerivedFrom niiri:6e455b57979dad222384fa2bedf5c673 .
+niiri:4c440fe68b006ba088752502fc89d323 prov:wasDerivedFrom niiri:45132e41bd386f5b430c16f7c2c90e0a .
 
-niiri:17efd927653dbab6e1c8226ff36b3c4e
+niiri:293fb40452e1ad24570cc1435e986bc8
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0180" ;
-    prov:atLocation niiri:80cb4552c31fb99deaba6189e8eec2b7 ;
+    prov:atLocation niiri:ecdd542cc1f75543496cd4ccdffb2154 ;
     prov:value "14.3194494247437"^^xsd:float ;
     nidm_equivalentZStatistic: "3.46444820092492"^^xsd:float ;
     nidm_pValueUncorrected: "0.000265660226814735"^^xsd:float ;
     nidm_pValueFWER: "0.999999637520677"^^xsd:float ;
     nidm_qValueFDR: "0.445794785853199"^^xsd:float .
 
-niiri:80cb4552c31fb99deaba6189e8eec2b7
+niiri:ecdd542cc1f75543496cd4ccdffb2154
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0180" ;
     nidm_coordinateVector: "[20,-72,10]"^^xsd:string .
 
-niiri:17efd927653dbab6e1c8226ff36b3c4e prov:wasDerivedFrom niiri:59697598e154d20a6b71266d474312af .
+niiri:293fb40452e1ad24570cc1435e986bc8 prov:wasDerivedFrom niiri:c4e5f3528c31047605f368909a0632ee .
 
-niiri:b89534fb37186d46db9526e5c2fd2352
+niiri:29f6517310b6e9273df1d8b7f169679e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0181" ;
-    prov:atLocation niiri:63bc4acd1ddad561a66d67e914cbcdda ;
+    prov:atLocation niiri:30293dec841bdf9cee0f1f324755eb67 ;
     prov:value "13.9198055267334"^^xsd:float ;
     nidm_equivalentZStatistic: "3.41423607996236"^^xsd:float ;
     nidm_pValueUncorrected: "0.000319805638077209"^^xsd:float ;
     nidm_pValueFWER: "0.99999996382628"^^xsd:float ;
     nidm_qValueFDR: "0.505510989298795"^^xsd:float .
 
-niiri:63bc4acd1ddad561a66d67e914cbcdda
+niiri:30293dec841bdf9cee0f1f324755eb67
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0181" ;
     nidm_coordinateVector: "[20,18,-16]"^^xsd:string .
 
-niiri:b89534fb37186d46db9526e5c2fd2352 prov:wasDerivedFrom niiri:737e8596c1e48716edbdb5c9d774c8a2 .
+niiri:29f6517310b6e9273df1d8b7f169679e prov:wasDerivedFrom niiri:1355ee0795599ee6287d2b70ebc8d729 .
 
-niiri:14f61e442b87c6a980a9b55ce85697bc
+niiri:542b8ad9afd2cc487bc118184a9d1898
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0182" ;
-    prov:atLocation niiri:67c7b3bc1eb9e002863654c3fc2db48b ;
+    prov:atLocation niiri:2ca2e43070b78c6b911a95ec58c54372 ;
     prov:value "13.8895444869995"^^xsd:float ;
     nidm_equivalentZStatistic: "3.41039722335618"^^xsd:float ;
     nidm_pValueUncorrected: "0.000324341637228609"^^xsd:float ;
     nidm_pValueFWER: "0.999999970034447"^^xsd:float ;
     nidm_qValueFDR: "0.508910387235141"^^xsd:float .
 
-niiri:67c7b3bc1eb9e002863654c3fc2db48b
+niiri:2ca2e43070b78c6b911a95ec58c54372
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0182" ;
     nidm_coordinateVector: "[30,-94,14]"^^xsd:string .
 
-niiri:14f61e442b87c6a980a9b55ce85697bc prov:wasDerivedFrom niiri:6e426d70bd3515ce04a9030b5a306cc1 .
+niiri:542b8ad9afd2cc487bc118184a9d1898 prov:wasDerivedFrom niiri:370789fb0338d1e1885081e0362c340f .
 
-niiri:ce19e677cb4b3410c8b4155cc304c1f6
+niiri:6b45ddf4564bf60372a7295ba801c752
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0183" ;
-    prov:atLocation niiri:98e229d5de0a4985c8feaa5df5a1844b ;
+    prov:atLocation niiri:c6f990446c1cd96198a4848a9a3e7916 ;
     prov:value "13.8777379989624"^^xsd:float ;
     nidm_equivalentZStatistic: "3.40889804768482"^^xsd:float ;
     nidm_pValueUncorrected: "0.000326129256370655"^^xsd:float ;
     nidm_pValueFWER: "0.999999972172211"^^xsd:float ;
     nidm_qValueFDR: "0.508910387235141"^^xsd:float .
 
-niiri:98e229d5de0a4985c8feaa5df5a1844b
+niiri:c6f990446c1cd96198a4848a9a3e7916
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0183" ;
     nidm_coordinateVector: "[52,40,-8]"^^xsd:string .
 
-niiri:ce19e677cb4b3410c8b4155cc304c1f6 prov:wasDerivedFrom niiri:8b57f16537b5d60872068ffb74ea46c2 .
+niiri:6b45ddf4564bf60372a7295ba801c752 prov:wasDerivedFrom niiri:40392b1ab652b1fe41dac16581269fb2 .
 
-niiri:5003d318e510a88af44a500d4013e290
+niiri:31f0e1886831f0a1dbaaece14761126e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0184" ;
-    prov:atLocation niiri:4908b528270e759195bfb04b4a40f8fe ;
+    prov:atLocation niiri:acfb6cd2464d523732fc5c4f75550cbe ;
     prov:value "13.8520250320435"^^xsd:float ;
     nidm_equivalentZStatistic: "3.4056302617749"^^xsd:float ;
     nidm_pValueUncorrected: "0.000330057567596631"^^xsd:float ;
     nidm_pValueFWER: "0.999999976340597"^^xsd:float ;
     nidm_qValueFDR: "0.510923995091643"^^xsd:float .
 
-niiri:4908b528270e759195bfb04b4a40f8fe
+niiri:acfb6cd2464d523732fc5c4f75550cbe
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0184" ;
     nidm_coordinateVector: "[46,-76,-16]"^^xsd:string .
 
-niiri:5003d318e510a88af44a500d4013e290 prov:wasDerivedFrom niiri:57fac0849992a04e841522c89a1e8fad .
+niiri:31f0e1886831f0a1dbaaece14761126e prov:wasDerivedFrom niiri:65ef2c95ae3f51b5861bb20b84514bd9 .
 
-niiri:04b94afa4c0c689ec22edc0617cb5c0e
+niiri:e272d51328812cf371cc587ac58a5526
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0185" ;
-    prov:atLocation niiri:0e6554b673a6bda5e0e3c96188f27df5 ;
+    prov:atLocation niiri:fc79049bf5c6c73ad72ccc47fa125036 ;
     prov:value "13.8400564193726"^^xsd:float ;
     nidm_equivalentZStatistic: "3.4041079037944"^^xsd:float ;
     nidm_pValueUncorrected: "0.00033190262699101"^^xsd:float ;
     nidm_pValueFWER: "0.999999978073029"^^xsd:float ;
     nidm_qValueFDR: "0.511965057359758"^^xsd:float .
 
-niiri:0e6554b673a6bda5e0e3c96188f27df5
+niiri:fc79049bf5c6c73ad72ccc47fa125036
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0185" ;
     nidm_coordinateVector: "[-40,-38,66]"^^xsd:string .
 
-niiri:04b94afa4c0c689ec22edc0617cb5c0e prov:wasDerivedFrom niiri:7d9186e6ae7abd1a3b75051676646bf7 .
+niiri:e272d51328812cf371cc587ac58a5526 prov:wasDerivedFrom niiri:5cc71319d109fdb0ef9f0f9c7bd41492 .
 
-niiri:05dd7bc31b69126a43533248a520aec6
+niiri:4e23f38355e282e3d94d0ca850cd592a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0186" ;
-    prov:atLocation niiri:bae05943598e7894c560ea6634f0065a ;
+    prov:atLocation niiri:bc1ed1b5f884be34190d17a6a34ea467 ;
     prov:value "13.7650365829468"^^xsd:float ;
     nidm_equivalentZStatistic: "3.39454677341543"^^xsd:float ;
     nidm_pValueUncorrected: "0.000343711482697406"^^xsd:float ;
     nidm_pValueFWER: "0.99999998648758"^^xsd:float ;
     nidm_qValueFDR: "0.521258506668093"^^xsd:float .
 
-niiri:bae05943598e7894c560ea6634f0065a
+niiri:bc1ed1b5f884be34190d17a6a34ea467
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0186" ;
     nidm_coordinateVector: "[-30,-58,-16]"^^xsd:string .
 
-niiri:05dd7bc31b69126a43533248a520aec6 prov:wasDerivedFrom niiri:05a6f19551a73fb9cdefb486a3b7d7c7 .
+niiri:4e23f38355e282e3d94d0ca850cd592a prov:wasDerivedFrom niiri:4bf75a353d782554be968730ac4840cd .
 
-niiri:02f5beedec6151839411b6af10ce9b1d
+niiri:a5d23eefb67d323e152120970fdbfb9b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0187" ;
-    prov:atLocation niiri:afe6bb918bf7641b8c1609c51fcc2d66 ;
+    prov:atLocation niiri:f40ad9017c1996f81d9a6de18883ece2 ;
     prov:value "13.6462821960449"^^xsd:float ;
     nidm_equivalentZStatistic: "3.37934453884673"^^xsd:float ;
     nidm_pValueUncorrected: "0.000363294438112227"^^xsd:float ;
     nidm_pValueFWER: "0.999999993887608"^^xsd:float ;
     nidm_qValueFDR: "0.54285139155384"^^xsd:float .
 
-niiri:afe6bb918bf7641b8c1609c51fcc2d66
+niiri:f40ad9017c1996f81d9a6de18883ece2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0187" ;
     nidm_coordinateVector: "[50,46,-12]"^^xsd:string .
 
-niiri:02f5beedec6151839411b6af10ce9b1d prov:wasDerivedFrom niiri:f652c5b4f145cc8a8477c98b20d1e8e7 .
+niiri:a5d23eefb67d323e152120970fdbfb9b prov:wasDerivedFrom niiri:332041ad6aeaf3a74891ecd53c374a96 .
 
-niiri:38dea93aeffa24df7e703750f22f6007
+niiri:b2d310b49e85f22bad1ac328ed239ef7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0188" ;
-    prov:atLocation niiri:6d2a5164869e6cd73b4ff41bf65f99ab ;
+    prov:atLocation niiri:3188ca18da93c376e8b714dde85b69f9 ;
     prov:value "13.6285772323608"^^xsd:float ;
     nidm_equivalentZStatistic: "3.37707094032846"^^xsd:float ;
     nidm_pValueUncorrected: "0.00036631076264837"^^xsd:float ;
     nidm_pValueFWER: "0.99999999458514"^^xsd:float ;
     nidm_qValueFDR: "0.545098853746109"^^xsd:float .
 
-niiri:6d2a5164869e6cd73b4ff41bf65f99ab
+niiri:3188ca18da93c376e8b714dde85b69f9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0188" ;
     nidm_coordinateVector: "[-20,-14,70]"^^xsd:string .
 
-niiri:38dea93aeffa24df7e703750f22f6007 prov:wasDerivedFrom niiri:220f34dd841d349b45f448f4ed96568e .
+niiri:b2d310b49e85f22bad1ac328ed239ef7 prov:wasDerivedFrom niiri:b47672c30d95e784941e629a0021b66b .
 
-niiri:38711773b6e76b61aaa202f0bf111aac
+niiri:ae8fdbe9961a1dc724d425e20affb4ad
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0189" ;
-    prov:atLocation niiri:042fe332fb2a7fb78203524667da891e ;
+    prov:atLocation niiri:8d02755a1dc43a17d77f1edd70edbda3 ;
     prov:value "13.5882997512817"^^xsd:float ;
     nidm_equivalentZStatistic: "3.37189174994258"^^xsd:float ;
     nidm_pValueUncorrected: "0.000373268921653791"^^xsd:float ;
     nidm_pValueFWER: "0.999999995901462"^^xsd:float ;
     nidm_qValueFDR: "0.550594852089412"^^xsd:float .
 
-niiri:042fe332fb2a7fb78203524667da891e
+niiri:8d02755a1dc43a17d77f1edd70edbda3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0189" ;
     nidm_coordinateVector: "[-24,-28,80]"^^xsd:string .
 
-niiri:38711773b6e76b61aaa202f0bf111aac prov:wasDerivedFrom niiri:73421e1373e081b7d78772065fdc0ab7 .
+niiri:ae8fdbe9961a1dc724d425e20affb4ad prov:wasDerivedFrom niiri:4ade8b0865402c36f9bde1298af17ab4 .
 
-niiri:f88984a4e5c67384154f76c2008adbc2
+niiri:02fa43a4dca1b09dd2c3be30a44755f8
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0190" ;
-    prov:atLocation niiri:1a200c9df626205b9289babc571b3f08 ;
+    prov:atLocation niiri:4d13638d382a0721c68d1709aab16557 ;
     prov:value "13.3802738189697"^^xsd:float ;
     nidm_equivalentZStatistic: "3.34498751004771"^^xsd:float ;
     nidm_pValueUncorrected: "0.000411431379332639"^^xsd:float ;
     nidm_pValueFWER: "0.999999999088907"^^xsd:float ;
     nidm_qValueFDR: "0.589500594790403"^^xsd:float .
 
-niiri:1a200c9df626205b9289babc571b3f08
+niiri:4d13638d382a0721c68d1709aab16557
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0190" ;
     nidm_coordinateVector: "[52,-46,-12]"^^xsd:string .
 
-niiri:f88984a4e5c67384154f76c2008adbc2 prov:wasDerivedFrom niiri:fd107443c1e505341538e35623ef13ad .
+niiri:02fa43a4dca1b09dd2c3be30a44755f8 prov:wasDerivedFrom niiri:8d46ffe6156e40b274554eb8fc558f49 .
 
-niiri:731d674cf48ac57dc021de1c57121d00
+niiri:1bb674b1760d589a90a0632e34f21e8a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0191" ;
-    prov:atLocation niiri:768cc18f7bb8b84d08d5ac651841ba42 ;
+    prov:atLocation niiri:f167259377277e0b37c958e0f7afe5bc ;
     prov:value "13.3560466766357"^^xsd:float ;
     nidm_equivalentZStatistic: "3.34183716228186"^^xsd:float ;
     nidm_pValueUncorrected: "0.000416129350639172"^^xsd:float ;
     nidm_pValueFWER: "0.999999999240863"^^xsd:float ;
     nidm_qValueFDR: "0.59334627957149"^^xsd:float .
 
-niiri:768cc18f7bb8b84d08d5ac651841ba42
+niiri:f167259377277e0b37c958e0f7afe5bc
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0191" ;
     nidm_coordinateVector: "[54,8,-36]"^^xsd:string .
 
-niiri:731d674cf48ac57dc021de1c57121d00 prov:wasDerivedFrom niiri:32a1c5504e28cf0e83bddf4c41d902c9 .
+niiri:1bb674b1760d589a90a0632e34f21e8a prov:wasDerivedFrom niiri:4d3c4f523d2ecfeb9befc1c5babb099d .
 
-niiri:da3ef04b6df57b2c7e61b9f81e61edd9
+niiri:7af7dc9d762aed03c62f1ccb4dc9f1b1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0192" ;
-    prov:atLocation niiri:7e19e95d18dfe15f3b337d360ceacae9 ;
+    prov:atLocation niiri:ddcb77e03b58b0ecad10fb686502cb55 ;
     prov:value "13.2219953536987"^^xsd:float ;
     nidm_equivalentZStatistic: "3.324340860909"^^xsd:float ;
     nidm_pValueUncorrected: "0.000443138995409265"^^xsd:float ;
     nidm_pValueFWER: "0.999999999731254"^^xsd:float ;
     nidm_qValueFDR: "0.61993269765931"^^xsd:float .
 
-niiri:7e19e95d18dfe15f3b337d360ceacae9
+niiri:ddcb77e03b58b0ecad10fb686502cb55
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0192" ;
     nidm_coordinateVector: "[2,-78,-20]"^^xsd:string .
 
-niiri:da3ef04b6df57b2c7e61b9f81e61edd9 prov:wasDerivedFrom niiri:4c3e4e7060e2b7cf9ba40d556d3850b1 .
+niiri:7af7dc9d762aed03c62f1ccb4dc9f1b1 prov:wasDerivedFrom niiri:24a29d9d6136d7a26f77ad7395967c47 .
 
-niiri:2551cde3a4a21ee9a2c5655d953b1893
+niiri:75daec94f2d9f1cbc921b112d9ef9ce2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0193" ;
-    prov:atLocation niiri:fa604978205651a01310d7f693105ef4 ;
+    prov:atLocation niiri:89d682f2aee216c11881fb170e685723 ;
     prov:value "13.1609621047974"^^xsd:float ;
     nidm_equivalentZStatistic: "3.3163379950432"^^xsd:float ;
     nidm_pValueUncorrected: "0.000456027248061708"^^xsd:float ;
     nidm_pValueFWER: "0.999999999835257"^^xsd:float ;
     nidm_qValueFDR: "0.629521256290025"^^xsd:float .
 
-niiri:fa604978205651a01310d7f693105ef4
+niiri:89d682f2aee216c11881fb170e685723
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0193" ;
     nidm_coordinateVector: "[-30,-44,54]"^^xsd:string .
 
-niiri:2551cde3a4a21ee9a2c5655d953b1893 prov:wasDerivedFrom niiri:908b3d895326bd3ac6957280d4de7d76 .
+niiri:75daec94f2d9f1cbc921b112d9ef9ce2 prov:wasDerivedFrom niiri:7289b1de1e9e889ff1fb5691142cd967 .
 
-niiri:9572b8f88bd3f41aeee3af027e62eeca
+niiri:faf603f8089ae20ce68bd6964020283e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0194" ;
-    prov:atLocation niiri:bec52b58537a3d8c000e3fb1b732b22f ;
+    prov:atLocation niiri:a73940ea69cb3b5a0586787884ed744a ;
     prov:value "13.1470022201538"^^xsd:float ;
     nidm_equivalentZStatistic: "3.31450426670224"^^xsd:float ;
     nidm_pValueUncorrected: "0.000459028893888824"^^xsd:float ;
     nidm_pValueFWER: "0.999999999852923"^^xsd:float ;
     nidm_qValueFDR: "0.6313035812178"^^xsd:float .
 
-niiri:bec52b58537a3d8c000e3fb1b732b22f
+niiri:a73940ea69cb3b5a0586787884ed744a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0194" ;
     nidm_coordinateVector: "[-34,-32,-10]"^^xsd:string .
 
-niiri:9572b8f88bd3f41aeee3af027e62eeca prov:wasDerivedFrom niiri:000f81203c82e4c9e73a3c6aace6130e .
+niiri:faf603f8089ae20ce68bd6964020283e prov:wasDerivedFrom niiri:4465bf32a18439b39ae380aba9c3f3b0 .
 
-niiri:2589d8f03f59ff750fd037748b135654
+niiri:d1bf63b81607321155f8338c282e59b2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0195" ;
-    prov:atLocation niiri:ef7a18775b39641a52fcc7adcd0fa1fb ;
+    prov:atLocation niiri:2828b9a85d8b30329115bf86cdec2f09 ;
     prov:value "13.1295585632324"^^xsd:float ;
     nidm_equivalentZStatistic: "3.31221120560286"^^xsd:float ;
     nidm_pValueUncorrected: "0.000462808186444841"^^xsd:float ;
     nidm_pValueFWER: "0.999999999872459"^^xsd:float ;
     nidm_qValueFDR: "0.63388766436911"^^xsd:float .
 
-niiri:ef7a18775b39641a52fcc7adcd0fa1fb
+niiri:2828b9a85d8b30329115bf86cdec2f09
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0195" ;
     nidm_coordinateVector: "[52,-74,-4]"^^xsd:string .
 
-niiri:2589d8f03f59ff750fd037748b135654 prov:wasDerivedFrom niiri:1a6f934195839bd5aafde8865b102795 .
+niiri:d1bf63b81607321155f8338c282e59b2 prov:wasDerivedFrom niiri:1cd15156a67e7cd4faba9f06d50293c8 .
 
-niiri:4a039d31d48a4d855d37672e1fddb518
+niiri:ad40b53c8dd4e2ab45b2ef401a4c24fc
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0196" ;
-    prov:atLocation niiri:37847488c895ec745c1ceedec0a4f95d ;
+    prov:atLocation niiri:0e0b46edbad1d5cc68e5d1a4a943c4e2 ;
     prov:value "13.1201601028442"^^xsd:float ;
     nidm_equivalentZStatistic: "3.31097493716214"^^xsd:float ;
     nidm_pValueUncorrected: "0.000464857675592345"^^xsd:float ;
     nidm_pValueFWER: "0.99999999988193"^^xsd:float ;
     nidm_qValueFDR: "0.634645676204038"^^xsd:float .
 
-niiri:37847488c895ec745c1ceedec0a4f95d
+niiri:0e0b46edbad1d5cc68e5d1a4a943c4e2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0196" ;
     nidm_coordinateVector: "[24,-76,6]"^^xsd:string .
 
-niiri:4a039d31d48a4d855d37672e1fddb518 prov:wasDerivedFrom niiri:6179fefaf9c60c4a862df01568a93c88 .
+niiri:ad40b53c8dd4e2ab45b2ef401a4c24fc prov:wasDerivedFrom niiri:ad7c299b4aa35cd98fdbd415f19783a7 .
 
-niiri:abaee743c73f41b308287d222feefa29
+niiri:d5a95ad6a90a7c4b7b4c65611bcfb3ee
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0197" ;
-    prov:atLocation niiri:a477dc5da8ee5797441bd8aa5669b41b ;
+    prov:atLocation niiri:e87409f2102a691e85a72e6831af93bd ;
     prov:value "13.046257019043"^^xsd:float ;
     nidm_equivalentZStatistic: "3.30123438509586"^^xsd:float ;
     nidm_pValueUncorrected: "0.000481302154360597"^^xsd:float ;
     nidm_pValueFWER: "0.999999999936213"^^xsd:float ;
     nidm_qValueFDR: "0.650319788160183"^^xsd:float .
 
-niiri:a477dc5da8ee5797441bd8aa5669b41b
+niiri:e87409f2102a691e85a72e6831af93bd
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0197" ;
     nidm_coordinateVector: "[-60,-4,-10]"^^xsd:string .
 
-niiri:abaee743c73f41b308287d222feefa29 prov:wasDerivedFrom niiri:a1eaf067aa20aea18c22e185e1ee2f97 .
+niiri:d5a95ad6a90a7c4b7b4c65611bcfb3ee prov:wasDerivedFrom niiri:fe8b635d8a705b40fb4ced016e9d726a .
 
-niiri:a0a956b6ce2985e809d8b37dcb8d629a
+niiri:a4bd9f4aa32c821fe2cb97c3309c18de
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0198" ;
-    prov:atLocation niiri:0c3866cec09aa3ddb5dd402fd5547a98 ;
+    prov:atLocation niiri:963a82208403e301602399f8ef788246 ;
     prov:value "13.0227518081665"^^xsd:float ;
     nidm_equivalentZStatistic: "3.29812912032221"^^xsd:float ;
     nidm_pValueUncorrected: "0.000486656828599608"^^xsd:float ;
     nidm_pValueFWER: "0.999999999947735"^^xsd:float ;
     nidm_qValueFDR: "0.654413109208221"^^xsd:float .
 
-niiri:0c3866cec09aa3ddb5dd402fd5547a98
+niiri:963a82208403e301602399f8ef788246
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0198" ;
     nidm_coordinateVector: "[40,-52,68]"^^xsd:string .
 
-niiri:a0a956b6ce2985e809d8b37dcb8d629a prov:wasDerivedFrom niiri:e3d6362d81a3c6aaee10e57f2d21a4b6 .
+niiri:a4bd9f4aa32c821fe2cb97c3309c18de prov:wasDerivedFrom niiri:71e15e602f95bdd78bc912bf527abf9d .
 
-niiri:4c980131dc417cb9367514a5f5ad0574
+niiri:60b2aa1e5a1e97e22c14f51ae12c8d5c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0199" ;
-    prov:atLocation niiri:b38f693094d7eb8aa13160ebce41e820 ;
+    prov:atLocation niiri:121190025dfe1a383743f7fbe9664dc2 ;
     prov:value "12.9725027084351"^^xsd:float ;
     nidm_equivalentZStatistic: "3.29147894602831"^^xsd:float ;
     nidm_pValueUncorrected: "0.000498310382184619"^^xsd:float ;
     nidm_pValueFWER: "0.999999999966052"^^xsd:float ;
     nidm_qValueFDR: "0.66402192610552"^^xsd:float .
 
-niiri:b38f693094d7eb8aa13160ebce41e820
+niiri:121190025dfe1a383743f7fbe9664dc2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0199" ;
     nidm_coordinateVector: "[-14,58,10]"^^xsd:string .
 
-niiri:4c980131dc417cb9367514a5f5ad0574 prov:wasDerivedFrom niiri:d40597f499b8e4493f5c750b1bb49759 .
+niiri:60b2aa1e5a1e97e22c14f51ae12c8d5c prov:wasDerivedFrom niiri:46e2492f096548abf33dea89e7a868bc .
 
-niiri:2a29c30b083a91b29b72a9b04b478c5b
+niiri:98e838a33321e9ba14f44d7f98af1258
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0200" ;
-    prov:atLocation niiri:871743f71e41218b7f125aa57ee5f92d ;
+    prov:atLocation niiri:d06b3cad307d15a0de08951bdf20ae6a ;
     prov:value "12.9253482818604"^^xsd:float ;
     nidm_equivalentZStatistic: "3.28522365934433"^^xsd:float ;
     nidm_pValueUncorrected: "0.000509507233156237"^^xsd:float ;
     nidm_pValueFWER: "0.999999999977514"^^xsd:float ;
     nidm_qValueFDR: "0.670440081569804"^^xsd:float .
 
-niiri:871743f71e41218b7f125aa57ee5f92d
+niiri:d06b3cad307d15a0de08951bdf20ae6a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0200" ;
     nidm_coordinateVector: "[-28,-42,-20]"^^xsd:string .
 
-niiri:2a29c30b083a91b29b72a9b04b478c5b prov:wasDerivedFrom niiri:965898643a16b92a90cc3cfaafcd3c48 .
+niiri:98e838a33321e9ba14f44d7f98af1258 prov:wasDerivedFrom niiri:f234bb306a90feca64756c5add571e95 .
 
-niiri:20680cc9cdc4fc6c7f8c266812915f50
+niiri:b33c6c90358c64f445051a6f1ddaa146
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0201" ;
-    prov:atLocation niiri:4e254ab19b7087b758b58b01547e88b2 ;
+    prov:atLocation niiri:804b433957f0b0751f8e56a78e15792f ;
     prov:value "12.9120073318481"^^xsd:float ;
     nidm_equivalentZStatistic: "3.28345132118853"^^xsd:float ;
     nidm_pValueUncorrected: "0.000512721763674673"^^xsd:float ;
     nidm_pValueFWER: "0.999999999980013"^^xsd:float ;
     nidm_qValueFDR: "0.672215583608969"^^xsd:float .
 
-niiri:4e254ab19b7087b758b58b01547e88b2
+niiri:804b433957f0b0751f8e56a78e15792f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0201" ;
     nidm_coordinateVector: "[-30,64,10]"^^xsd:string .
 
-niiri:20680cc9cdc4fc6c7f8c266812915f50 prov:wasDerivedFrom niiri:d1ba7d5acbc118fa7879e7e4e6844b1d .
+niiri:b33c6c90358c64f445051a6f1ddaa146 prov:wasDerivedFrom niiri:9a23d6bdea30bc505d71bdea4b14cc81 .
 
-niiri:e963925f531d9bf94edaa4d6565a0b3c
+niiri:6c21781a2f968dd6b89eb9acbab79c64
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0202" ;
-    prov:atLocation niiri:c29057c71e81e51a9cadb8ce30147e8d ;
+    prov:atLocation niiri:e72f5cd5280ab8a81cdb28854ee6c88b ;
     prov:value "12.8873691558838"^^xsd:float ;
     nidm_equivalentZStatistic: "3.28017513962894"^^xsd:float ;
     nidm_pValueUncorrected: "0.000518713316777997"^^xsd:float ;
     nidm_pValueFWER: "0.999999999983944"^^xsd:float ;
     nidm_qValueFDR: "0.676739301292717"^^xsd:float .
 
-niiri:c29057c71e81e51a9cadb8ce30147e8d
+niiri:e72f5cd5280ab8a81cdb28854ee6c88b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0202" ;
     nidm_coordinateVector: "[-66,-36,22]"^^xsd:string .
 
-niiri:e963925f531d9bf94edaa4d6565a0b3c prov:wasDerivedFrom niiri:a9f3103d256c0dc28abb00c6f6a495ee .
+niiri:6c21781a2f968dd6b89eb9acbab79c64 prov:wasDerivedFrom niiri:55a2e8a69b22f0385eb446ff36f57cd5 .
 
-niiri:7f37d1f9c144579425ce0f3358580e57
+niiri:1b91a4eb434472d16421d0c377206835
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0203" ;
-    prov:atLocation niiri:9038335116cb7c698ffe37e21bc86573 ;
+    prov:atLocation niiri:3c19d9ef241dff3575137612c854cd2f ;
     prov:value "12.8246231079102"^^xsd:float ;
     nidm_equivalentZStatistic: "3.271813961984"^^xsd:float ;
     nidm_pValueUncorrected: "0.00053429933476512"^^xsd:float ;
     nidm_pValueFWER: "0.999999999990888"^^xsd:float ;
     nidm_qValueFDR: "0.687743631356335"^^xsd:float .
 
-niiri:9038335116cb7c698ffe37e21bc86573
+niiri:3c19d9ef241dff3575137612c854cd2f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0203" ;
     nidm_coordinateVector: "[44,-60,-52]"^^xsd:string .
 
-niiri:7f37d1f9c144579425ce0f3358580e57 prov:wasDerivedFrom niiri:a6963a6fd81257c75c10efb4a812813d .
+niiri:1b91a4eb434472d16421d0c377206835 prov:wasDerivedFrom niiri:c1b67e6fa1bc1b0441ef946f06fc7939 .
 
-niiri:76a919e4a9c7d1fa9bfa1930d9c7f803
+niiri:7d02ed7f20eb6fe558766caecf63c155
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0204" ;
-    prov:atLocation niiri:b0731a2e5846f8d41f36e48cbf02d4f7 ;
+    prov:atLocation niiri:28f4e80afae132d68d4b5232d5c0653c ;
     prov:value "12.7540121078491"^^xsd:float ;
     nidm_equivalentZStatistic: "3.26237411173788"^^xsd:float ;
     nidm_pValueUncorrected: "0.000552416159637859"^^xsd:float ;
     nidm_pValueFWER: "0.999999999995255"^^xsd:float ;
     nidm_qValueFDR: "0.700439054447179"^^xsd:float .
 
-niiri:b0731a2e5846f8d41f36e48cbf02d4f7
+niiri:28f4e80afae132d68d4b5232d5c0653c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0204" ;
     nidm_coordinateVector: "[48,-36,62]"^^xsd:string .
 
-niiri:76a919e4a9c7d1fa9bfa1930d9c7f803 prov:wasDerivedFrom niiri:60ac234a805ede443ca63c3de0f14e32 .
+niiri:7d02ed7f20eb6fe558766caecf63c155 prov:wasDerivedFrom niiri:598d8f8cb448fe66f29b80c3e9c6b8c7 .
 
-niiri:a49714e6df954b1973a24cabca2c16f0
+niiri:81902bcb64a59f174ed4a22dc2692239
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0205" ;
-    prov:atLocation niiri:d4b233039ca491074ca976cbdb4f7d79 ;
+    prov:atLocation niiri:0d290b8bc5ddb3996222710a9c2aa917 ;
     prov:value "12.7177801132202"^^xsd:float ;
     nidm_equivalentZStatistic: "3.25751764552706"^^xsd:float ;
     nidm_pValueUncorrected: "0.000561956352459259"^^xsd:float ;
     nidm_pValueFWER: "0.999999999996627"^^xsd:float ;
     nidm_qValueFDR: "0.707106764798581"^^xsd:float .
 
-niiri:d4b233039ca491074ca976cbdb4f7d79
+niiri:0d290b8bc5ddb3996222710a9c2aa917
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0205" ;
     nidm_coordinateVector: "[46,-74,-34]"^^xsd:string .
 
-niiri:a49714e6df954b1973a24cabca2c16f0 prov:wasDerivedFrom niiri:c00dd1395bbc6f074ad431089be26084 .
+niiri:81902bcb64a59f174ed4a22dc2692239 prov:wasDerivedFrom niiri:9e74994c43b00fa8f3c04ed564b75259 .
 
-niiri:8ee156f72ef039a467a995e472713f73
+niiri:4302df4d2f6614b3486ee45c6c620874
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0206" ;
-    prov:atLocation niiri:0a9f19f4287a24fa3a34431b5c450bf9 ;
+    prov:atLocation niiri:2607c517e39ded7c56c566e9062d1286 ;
     prov:value "12.7100811004639"^^xsd:float ;
     nidm_equivalentZStatistic: "3.25648457184145"^^xsd:float ;
     nidm_pValueUncorrected: "0.000564005302693849"^^xsd:float ;
     nidm_pValueFWER: "0.999999999996865"^^xsd:float ;
     nidm_qValueFDR: "0.707573008885887"^^xsd:float .
 
-niiri:0a9f19f4287a24fa3a34431b5c450bf9
+niiri:2607c517e39ded7c56c566e9062d1286
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0206" ;
     nidm_coordinateVector: "[-56,-60,0]"^^xsd:string .
 
-niiri:8ee156f72ef039a467a995e472713f73 prov:wasDerivedFrom niiri:911801103dad8b9c7f55df419fdee788 .
+niiri:4302df4d2f6614b3486ee45c6c620874 prov:wasDerivedFrom niiri:59f7c04e9a6910158fa3c13760b2a417 .
 
-niiri:888772eaabf2dccfc423c3ad90e71cc0
+niiri:abd2f7443e3cc8dca0d22ff7fa5b1665
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0207" ;
-    prov:atLocation niiri:864659c15bfaa9afecbbe524a7ea18a9 ;
+    prov:atLocation niiri:455db5fb74827a39d068ce266c9b9900 ;
     prov:value "12.6978673934937"^^xsd:float ;
     nidm_equivalentZStatistic: "3.25484490255242"^^xsd:float ;
     nidm_pValueUncorrected: "0.000567271531173308"^^xsd:float ;
     nidm_pValueFWER: "0.999999999997209"^^xsd:float ;
     nidm_qValueFDR: "0.709190250795189"^^xsd:float .
 
-niiri:864659c15bfaa9afecbbe524a7ea18a9
+niiri:455db5fb74827a39d068ce266c9b9900
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0207" ;
     nidm_coordinateVector: "[18,60,12]"^^xsd:string .
 
-niiri:888772eaabf2dccfc423c3ad90e71cc0 prov:wasDerivedFrom niiri:48d4b018c043db4e0876cc1418962d0a .
+niiri:abd2f7443e3cc8dca0d22ff7fa5b1665 prov:wasDerivedFrom niiri:81a8b467cb1446f1ff5cdaa2c7d6e479 .
 
-niiri:31f56b1eb2c1ff406b1c9021481a96b6
+niiri:eb863adb5a212bbe0de0abe4fb289aad
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0208" ;
-    prov:atLocation niiri:6b1b60e50a54fbb4c598ff1ccf4ac6bb ;
+    prov:atLocation niiri:2c125691782263a2065a16349878da2b ;
     prov:value "12.640664100647"^^xsd:float ;
     nidm_equivalentZStatistic: "3.24715232109298"^^xsd:float ;
     nidm_pValueUncorrected: "0.000582829932485596"^^xsd:float ;
     nidm_pValueFWER: "0.999999999998392"^^xsd:float ;
     nidm_qValueFDR: "0.722376235864621"^^xsd:float .
 
-niiri:6b1b60e50a54fbb4c598ff1ccf4ac6bb
+niiri:2c125691782263a2065a16349878da2b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0208" ;
     nidm_coordinateVector: "[-64,-34,8]"^^xsd:string .
 
-niiri:31f56b1eb2c1ff406b1c9021481a96b6 prov:wasDerivedFrom niiri:7c2265b55eb6b5357939defcb818c9dd .
+niiri:eb863adb5a212bbe0de0abe4fb289aad prov:wasDerivedFrom niiri:b6cb8a909916808e62aec6d7aa7ee1b8 .
 
-niiri:64ee191eca48627a7c9516d49d6fa858
+niiri:f5b6dec4e6c487fdf092083f6476a41e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0209" ;
-    prov:atLocation niiri:1c879164aeca46febe791915b478ad82 ;
+    prov:atLocation niiri:73c80915e2c2b11251a84ba8336fa798 ;
     prov:value "12.6130704879761"^^xsd:float ;
     nidm_equivalentZStatistic: "3.24343381706964"^^xsd:float ;
     nidm_pValueUncorrected: "0.000590491220582523"^^xsd:float ;
     nidm_pValueFWER: "0.999999999998772"^^xsd:float ;
     nidm_qValueFDR: "0.726684303777293"^^xsd:float .
 
-niiri:1c879164aeca46febe791915b478ad82
+niiri:73c80915e2c2b11251a84ba8336fa798
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0209" ;
     nidm_coordinateVector: "[64,-34,16]"^^xsd:string .
 
-niiri:64ee191eca48627a7c9516d49d6fa858 prov:wasDerivedFrom niiri:1f5d5a2bac2575d7232fa251d172c68f .
+niiri:f5b6dec4e6c487fdf092083f6476a41e prov:wasDerivedFrom niiri:50e1d73ec7323535a313db319aa8fda1 .
 
-niiri:543c0e14b5959b80c6e5e8e58a9c6300
+niiri:6d3f27e6e0aa864aa68bacd72871f8c3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0210" ;
-    prov:atLocation niiri:a4bde52a87132486564dd06fe64e7b45 ;
+    prov:atLocation niiri:231abd23ef63978da267e6cf949efc2d ;
     prov:value "12.6124353408813"^^xsd:float ;
     nidm_equivalentZStatistic: "3.2433481651477"^^xsd:float ;
     nidm_pValueUncorrected: "0.000590668781873749"^^xsd:float ;
     nidm_pValueFWER: "0.99999999999878"^^xsd:float ;
     nidm_qValueFDR: "0.726684303777293"^^xsd:float .
 
-niiri:a4bde52a87132486564dd06fe64e7b45
+niiri:231abd23ef63978da267e6cf949efc2d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0210" ;
     nidm_coordinateVector: "[-28,-72,62]"^^xsd:string .
 
-niiri:543c0e14b5959b80c6e5e8e58a9c6300 prov:wasDerivedFrom niiri:12c379cdb678fa3f360c5174016779ac .
+niiri:6d3f27e6e0aa864aa68bacd72871f8c3 prov:wasDerivedFrom niiri:7dcc4c8a94cbe8b1b1f9e1f46a8741d3 .
 
-niiri:a763bfe0f1145f2891603f2fb90de9a0
+niiri:a5774a9de179c5a31a4170040a80ba30
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0211" ;
-    prov:atLocation niiri:817b70b1a3821ff617c7a2c57d37b389 ;
+    prov:atLocation niiri:57002557123aec38be66fd4d6c272034 ;
     prov:value "12.5952806472778"^^xsd:float ;
     nidm_equivalentZStatistic: "3.24103377259091"^^xsd:float ;
     nidm_pValueUncorrected: "0.00059548536599352"^^xsd:float ;
     nidm_pValueFWER: "0.99999999999897"^^xsd:float ;
     nidm_qValueFDR: "0.728854295079526"^^xsd:float .
 
-niiri:817b70b1a3821ff617c7a2c57d37b389
+niiri:57002557123aec38be66fd4d6c272034
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0211" ;
     nidm_coordinateVector: "[-68,-2,-12]"^^xsd:string .
 
-niiri:a763bfe0f1145f2891603f2fb90de9a0 prov:wasDerivedFrom niiri:7238de23a632331ed72cd39240a7d4d5 .
+niiri:a5774a9de179c5a31a4170040a80ba30 prov:wasDerivedFrom niiri:b54fdacdf6871d0d178386e52e6bcf8e .
 
-niiri:a8060e9cb4cdb11e181b7f963ca0a64d
+niiri:abdd30b092a8fb58bf5083e43d76564b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0212" ;
-    prov:atLocation niiri:06785a8aa664ba9db55579fd59eb53e8 ;
+    prov:atLocation niiri:46d5e8ac330814012d725b0adff81c3c ;
     prov:value "12.5901155471802"^^xsd:float ;
     nidm_equivalentZStatistic: "3.24033654772109"^^xsd:float ;
     nidm_pValueUncorrected: "0.000596943488260782"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999021"^^xsd:float ;
     nidm_qValueFDR: "0.728854295079526"^^xsd:float .
 
-niiri:06785a8aa664ba9db55579fd59eb53e8
+niiri:46d5e8ac330814012d725b0adff81c3c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0212" ;
     nidm_coordinateVector: "[4,6,-12]"^^xsd:string .
 
-niiri:a8060e9cb4cdb11e181b7f963ca0a64d prov:wasDerivedFrom niiri:90c9af05cf8cff54600fa41f0a61a708 .
+niiri:abdd30b092a8fb58bf5083e43d76564b prov:wasDerivedFrom niiri:22043ef18c61c537ac8a05e639b5f722 .
 
-niiri:2ebe5ed2e266f3d20b2727456a7fbf7d
+niiri:853d2a530b3a85eb977c69e3afe8644a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0213" ;
-    prov:atLocation niiri:f71aee131a7fe7780ab7721213184a28 ;
+    prov:atLocation niiri:79927a4241953f4159a3cdc9b5130fc5 ;
     prov:value "12.583477973938"^^xsd:float ;
     nidm_equivalentZStatistic: "3.23944029497736"^^xsd:float ;
     nidm_pValueUncorrected: "0.000598822687494338"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999084"^^xsd:float ;
     nidm_qValueFDR: "0.728854295079526"^^xsd:float .
 
-niiri:f71aee131a7fe7780ab7721213184a28
+niiri:79927a4241953f4159a3cdc9b5130fc5
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0213" ;
     nidm_coordinateVector: "[2,64,32]"^^xsd:string .
 
-niiri:2ebe5ed2e266f3d20b2727456a7fbf7d prov:wasDerivedFrom niiri:1aab52c0fe0f750adfdb1e30721e6758 .
+niiri:853d2a530b3a85eb977c69e3afe8644a prov:wasDerivedFrom niiri:fd886d44827bbf7fd4cd36a6fa24a0dc .
 
-niiri:c7024af881fb2ecac3f2c0f10ef02da4
+niiri:906ee563af4ace86c7988da22e67ae3f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0214" ;
-    prov:atLocation niiri:b2b0a721a76b1f2b8bf35b0a1505e8b6 ;
+    prov:atLocation niiri:e0df519bf861a9890d949691d5d8d5dd ;
     prov:value "12.5809669494629"^^xsd:float ;
     nidm_equivalentZStatistic: "3.23910116152933"^^xsd:float ;
     nidm_pValueUncorrected: "0.000599535182603472"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999106"^^xsd:float ;
     nidm_qValueFDR: "0.728854295079526"^^xsd:float .
 
-niiri:b2b0a721a76b1f2b8bf35b0a1505e8b6
+niiri:e0df519bf861a9890d949691d5d8d5dd
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0214" ;
     nidm_coordinateVector: "[-4,32,62]"^^xsd:string .
 
-niiri:c7024af881fb2ecac3f2c0f10ef02da4 prov:wasDerivedFrom niiri:08248410e312407cc447ee8d99d1d449 .
+niiri:906ee563af4ace86c7988da22e67ae3f prov:wasDerivedFrom niiri:e782c57868e4be48647d27ca19f3f3c2 .
 
-niiri:df777ee0a227dd45031c77084105b850
+niiri:0a50255f519e99d47205e1125596b9b6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0215" ;
-    prov:atLocation niiri:2e0cb4fd63c4b84e4b5cf834e4b7bf9d ;
+    prov:atLocation niiri:daef6d48a716dbb207fa790aef629485 ;
     prov:value "12.5469427108765"^^xsd:float ;
     nidm_equivalentZStatistic: "3.2345017532799"^^xsd:float ;
     nidm_pValueUncorrected: "0.000609275862458403"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999364"^^xsd:float ;
     nidm_qValueFDR: "0.736274936039545"^^xsd:float .
 
-niiri:2e0cb4fd63c4b84e4b5cf834e4b7bf9d
+niiri:daef6d48a716dbb207fa790aef629485
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0215" ;
     nidm_coordinateVector: "[-58,-32,22]"^^xsd:string .
 
-niiri:df777ee0a227dd45031c77084105b850 prov:wasDerivedFrom niiri:837d994ade992773480832f35a3ea15b .
+niiri:0a50255f519e99d47205e1125596b9b6 prov:wasDerivedFrom niiri:f434c353ca0df61bb269a9c7f670117c .
 
-niiri:c96eb997f2b14f31707c32f47b1135da
+niiri:296160c26ce8de6d4816b73bc3fcbc6a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0216" ;
-    prov:atLocation niiri:f88728d130bd777fbd452fc7db29a753 ;
+    prov:atLocation niiri:660279d86c93ff3310e9a91bc4f125db ;
     prov:value "12.524956703186"^^xsd:float ;
     nidm_equivalentZStatistic: "3.23152553702292"^^xsd:float ;
     nidm_pValueUncorrected: "0.000615656604518122"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999491"^^xsd:float ;
     nidm_qValueFDR: "0.740571104544667"^^xsd:float .
 
-niiri:f88728d130bd777fbd452fc7db29a753
+niiri:660279d86c93ff3310e9a91bc4f125db
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0216" ;
     nidm_coordinateVector: "[10,-28,82]"^^xsd:string .
 
-niiri:c96eb997f2b14f31707c32f47b1135da prov:wasDerivedFrom niiri:ec417a43750788f61cf51df2e50808c5 .
+niiri:296160c26ce8de6d4816b73bc3fcbc6a prov:wasDerivedFrom niiri:0ccff4009d26155a785837676412d40e .
 
-niiri:eca2e3c331a843d4ad0aa7710090bf1a
+niiri:59f7ae9e78c57e6eb798ea767f4fd090
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0217" ;
-    prov:atLocation niiri:9c43af0b3f337dfbdac94c1d4bd64bc0 ;
+    prov:atLocation niiri:9e4bdcd20187d0bbf232df192ad15318 ;
     prov:value "12.4362440109253"^^xsd:float ;
     nidm_equivalentZStatistic: "3.21948340596333"^^xsd:float ;
     nidm_pValueUncorrected: "0.000642108966113164"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999796"^^xsd:float ;
     nidm_qValueFDR: "0.762909381039546"^^xsd:float .
 
-niiri:9c43af0b3f337dfbdac94c1d4bd64bc0
+niiri:9e4bdcd20187d0bbf232df192ad15318
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0217" ;
     nidm_coordinateVector: "[-56,-6,42]"^^xsd:string .
 
-niiri:eca2e3c331a843d4ad0aa7710090bf1a prov:wasDerivedFrom niiri:5f3c04257193f8ded9ef85828608888b .
+niiri:59f7ae9e78c57e6eb798ea767f4fd090 prov:wasDerivedFrom niiri:800c8b037dc30701b156bb7c32952fad .
 
-niiri:96199b266f206e1e0c82db9d24c5592c
+niiri:2c74c9e73a8754c200410a8ddc063874
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0218" ;
-    prov:atLocation niiri:14f355cf6fb1f9a87e97c08f4b05608e ;
+    prov:atLocation niiri:ab6fb86002fd943cb7cf666f118a55db ;
     prov:value "12.3832416534424"^^xsd:float ;
     nidm_equivalentZStatistic: "3.21226312911464"^^xsd:float ;
     nidm_pValueUncorrected: "0.000658468484597718"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999883"^^xsd:float ;
     nidm_qValueFDR: "0.775928724251441"^^xsd:float .
 
-niiri:14f355cf6fb1f9a87e97c08f4b05608e
+niiri:ab6fb86002fd943cb7cf666f118a55db
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0218" ;
     nidm_coordinateVector: "[-18,-74,-2]"^^xsd:string .
 
-niiri:96199b266f206e1e0c82db9d24c5592c prov:wasDerivedFrom niiri:d50af5499fc7c0898889af641bf5dae2 .
+niiri:2c74c9e73a8754c200410a8ddc063874 prov:wasDerivedFrom niiri:783b5fc0e23ce088341f9b979cd6ab07 .
 
-niiri:6553656394b274cdce05521f32bac312
+niiri:54ccde113afb801a2d42f17bcc407213
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0219" ;
-    prov:atLocation niiri:215589654fb76738a1a31c228687ea17 ;
+    prov:atLocation niiri:a3ceb25dee9ea36b3e29d0facc7e028f ;
     prov:value "12.3691940307617"^^xsd:float ;
     nidm_equivalentZStatistic: "3.21034625579366"^^xsd:float ;
     nidm_pValueUncorrected: "0.000662875839162802"^^xsd:float ;
     nidm_pValueFWER: "0.9999999999999"^^xsd:float ;
     nidm_qValueFDR: "0.778244481400815"^^xsd:float .
 
-niiri:215589654fb76738a1a31c228687ea17
+niiri:a3ceb25dee9ea36b3e29d0facc7e028f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0219" ;
     nidm_coordinateVector: "[30,48,-14]"^^xsd:string .
 
-niiri:6553656394b274cdce05521f32bac312 prov:wasDerivedFrom niiri:301ccd51f1c98193e0b8474c0344334b .
+niiri:54ccde113afb801a2d42f17bcc407213 prov:wasDerivedFrom niiri:eeecebef37458a809e6ef90a22514949 .
 
-niiri:cd0fd5013a5d6bed8167b8d5d9ef8703
+niiri:443bd980ef1188caf910159d88fbb606
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0220" ;
-    prov:atLocation niiri:604772cbf2031eb4ef0aabe8f8404186 ;
+    prov:atLocation niiri:e363d467ac24834cdb9d83f9fcca7984 ;
     prov:value "12.3557033538818"^^xsd:float ;
     nidm_equivalentZStatistic: "3.20850410332099"^^xsd:float ;
     nidm_pValueUncorrected: "0.00066713702624499"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999913"^^xsd:float ;
     nidm_qValueFDR: "0.780414436307547"^^xsd:float .
 
-niiri:604772cbf2031eb4ef0aabe8f8404186
+niiri:e363d467ac24834cdb9d83f9fcca7984
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0220" ;
     nidm_coordinateVector: "[-50,-28,50]"^^xsd:string .
 
-niiri:cd0fd5013a5d6bed8167b8d5d9ef8703 prov:wasDerivedFrom niiri:005ca6c90e1fc6c5ee2dad1ef8e090a4 .
+niiri:443bd980ef1188caf910159d88fbb606 prov:wasDerivedFrom niiri:9e9084297f3aec6679c40f52af1c9c5c .
 
-niiri:12ba3b1b76b5eba595aa1c21916733d9
+niiri:fad207295de11587bdc4ed90e387142b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0221" ;
-    prov:atLocation niiri:ec5b44fdbb38ff726d45997ba350ba77 ;
+    prov:atLocation niiri:04e3ef7c6e8524c62cde0d3294ee3869 ;
     prov:value "12.3468074798584"^^xsd:float ;
     nidm_equivalentZStatistic: "3.20728868558414"^^xsd:float ;
     nidm_pValueUncorrected: "0.000669962300702265"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999921"^^xsd:float ;
     nidm_qValueFDR: "0.781198266304304"^^xsd:float .
 
-niiri:ec5b44fdbb38ff726d45997ba350ba77
+niiri:04e3ef7c6e8524c62cde0d3294ee3869
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0221" ;
     nidm_coordinateVector: "[48,12,50]"^^xsd:string .
 
-niiri:12ba3b1b76b5eba595aa1c21916733d9 prov:wasDerivedFrom niiri:fc3a8b55f288365aa4cfd22a7a666181 .
+niiri:fad207295de11587bdc4ed90e387142b prov:wasDerivedFrom niiri:dc54137a08092762cc961c9285859566 .
 
-niiri:004670278ac8becc4c58380e118049fe
+niiri:63f4617c03904f8fe616125bfc5a9e72
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0222" ;
-    prov:atLocation niiri:ad8bfe1b803de4cf393a23ea48a00d50 ;
+    prov:atLocation niiri:52831440b618015383f7181f6b5b4b26 ;
     prov:value "12.3028221130371"^^xsd:float ;
     nidm_equivalentZStatistic: "3.20127105926381"^^xsd:float ;
     nidm_pValueUncorrected: "0.000684113775728967"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999951"^^xsd:float ;
     nidm_qValueFDR: "0.789536719399159"^^xsd:float .
 
-niiri:ad8bfe1b803de4cf393a23ea48a00d50
+niiri:52831440b618015383f7181f6b5b4b26
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0222" ;
     nidm_coordinateVector: "[60,-40,-12]"^^xsd:string .
 
-niiri:004670278ac8becc4c58380e118049fe prov:wasDerivedFrom niiri:e47c402c0100f7defbaf50bdcc093c1b .
+niiri:63f4617c03904f8fe616125bfc5a9e72 prov:wasDerivedFrom niiri:9ff86139e0b5b4951d06b07e9a923ed4 .
 
-niiri:f96073a5a47b6b6d8383e8d0fb38a6d9
+niiri:a6f44d12d066b455d18d5cf9ff1bdaee
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0223" ;
-    prov:atLocation niiri:4a9ef22179fc6e85734ab54ea4375285 ;
+    prov:atLocation niiri:a8e775408cf4088e2ab46f7c20423ab9 ;
     prov:value "12.3004894256592"^^xsd:float ;
     nidm_equivalentZStatistic: "3.20095155097531"^^xsd:float ;
     nidm_pValueUncorrected: "0.000684872807174552"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999952"^^xsd:float ;
     nidm_qValueFDR: "0.789536719399159"^^xsd:float .
 
-niiri:4a9ef22179fc6e85734ab54ea4375285
+niiri:a8e775408cf4088e2ab46f7c20423ab9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0223" ;
     nidm_coordinateVector: "[-62,-50,-10]"^^xsd:string .
 
-niiri:f96073a5a47b6b6d8383e8d0fb38a6d9 prov:wasDerivedFrom niiri:db2fdb0a656161d3af9766d9e89d922c .
+niiri:a6f44d12d066b455d18d5cf9ff1bdaee prov:wasDerivedFrom niiri:8a8ea66289482bc8790b162d4c9789ef .
 
-niiri:154502b6963e5a2eda6daf2855d7b3f1
+niiri:182ba929021f340ee67f2468e637cc44
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0224" ;
-    prov:atLocation niiri:5b705031e65c1c2b3956a95bdea4378a ;
+    prov:atLocation niiri:b4e52186e6b0a6847c84cc50c415fc7e ;
     prov:value "12.2552633285522"^^xsd:float ;
     nidm_equivalentZStatistic: "3.19474945772007"^^xsd:float ;
     nidm_pValueUncorrected: "0.000699761387021658"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999971"^^xsd:float ;
     nidm_qValueFDR: "0.80078769815287"^^xsd:float .
 
-niiri:5b705031e65c1c2b3956a95bdea4378a
+niiri:b4e52186e6b0a6847c84cc50c415fc7e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0224" ;
     nidm_coordinateVector: "[-2,58,32]"^^xsd:string .
 
-niiri:154502b6963e5a2eda6daf2855d7b3f1 prov:wasDerivedFrom niiri:9999ed39d65e3e020fe7293a38d50b01 .
+niiri:182ba929021f340ee67f2468e637cc44 prov:wasDerivedFrom niiri:05c885a40fe6550c25d2a55d7c3808dc .
 
-niiri:8119b9ec415f8238dcbf0e29213d4bf5
+niiri:f240087ba6b26ab0e7705cb6916792eb
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0225" ;
-    prov:atLocation niiri:764e2320a20fbeb430d6020256838224 ;
+    prov:atLocation niiri:51d8d61148f300b8db3cd50807339c24 ;
     prov:value "12.0593566894531"^^xsd:float ;
     nidm_equivalentZStatistic: "3.16771793453572"^^xsd:float ;
     nidm_pValueUncorrected: "0.000768202532788531"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999997"^^xsd:float ;
     nidm_qValueFDR: "0.853659787459179"^^xsd:float .
 
-niiri:764e2320a20fbeb430d6020256838224
+niiri:51d8d61148f300b8db3cd50807339c24
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0225" ;
     nidm_coordinateVector: "[20,16,50]"^^xsd:string .
 
-niiri:8119b9ec415f8238dcbf0e29213d4bf5 prov:wasDerivedFrom niiri:ef7b89c154bf8954bad4e84699ecd010 .
+niiri:f240087ba6b26ab0e7705cb6916792eb prov:wasDerivedFrom niiri:1285ada80442ae469e874ddbb7e341cc .
 
-niiri:e7c0b1cc303d37f487e7e91c92f3214f
+niiri:01c2ba3dcb7343112c96e480784b9ad1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0226" ;
-    prov:atLocation niiri:f86ef5ee9240bdaeddb5196e0c46df36 ;
+    prov:atLocation niiri:ccf7f33772892b6927718a745ad9c44b ;
     prov:value "12.0245819091797"^^xsd:float ;
     nidm_equivalentZStatistic: "3.16289116572021"^^xsd:float ;
     nidm_pValueUncorrected: "0.000781053593003622"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999998"^^xsd:float ;
     nidm_qValueFDR: "0.861413078419457"^^xsd:float .
 
-niiri:f86ef5ee9240bdaeddb5196e0c46df36
+niiri:ccf7f33772892b6927718a745ad9c44b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0226" ;
     nidm_coordinateVector: "[-12,-78,56]"^^xsd:string .
 
-niiri:e7c0b1cc303d37f487e7e91c92f3214f prov:wasDerivedFrom niiri:202b2ec8923685d33ff8474567fb097f .
+niiri:01c2ba3dcb7343112c96e480784b9ad1 prov:wasDerivedFrom niiri:7fb9b0874581a71159fdd853f93751f2 .
 
-niiri:e2229c1fec8b3b1a15ff653868ab4986
+niiri:cd8669b3a66c8ac45b3908124a6c355e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0227" ;
-    prov:atLocation niiri:2a66b0c329bac60596635d117a870372 ;
+    prov:atLocation niiri:c1e93dd2175b8f1a8aacb7c865e765d0 ;
     prov:value "12.0227870941162"^^xsd:float ;
     nidm_equivalentZStatistic: "3.16264180848804"^^xsd:float ;
     nidm_pValueUncorrected: "0.000781722842800425"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999998"^^xsd:float ;
     nidm_qValueFDR: "0.861413078419457"^^xsd:float .
 
-niiri:2a66b0c329bac60596635d117a870372
+niiri:c1e93dd2175b8f1a8aacb7c865e765d0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0227" ;
     nidm_coordinateVector: "[14,-14,72]"^^xsd:string .
 
-niiri:e2229c1fec8b3b1a15ff653868ab4986 prov:wasDerivedFrom niiri:5e31db36bebfe06aef3ad33a08c38510 .
+niiri:cd8669b3a66c8ac45b3908124a6c355e prov:wasDerivedFrom niiri:62b88250957696695608f4f9d5c33c94 .
 
-niiri:72727159e9811517f5b36fd2c43678d0
+niiri:71daf19003d4f9dfcddcf08cbdd35abd
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0228" ;
-    prov:atLocation niiri:f2f5cba9f1a0043aec7f2b059b817ab2 ;
+    prov:atLocation niiri:a3c7efc0ca1f4ef769468595f11497ea ;
     prov:value "12.0113868713379"^^xsd:float ;
     nidm_equivalentZStatistic: "3.16105741225029"^^xsd:float ;
     nidm_pValueUncorrected: "0.000785987554661749"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999998"^^xsd:float ;
     nidm_qValueFDR: "0.862288646172828"^^xsd:float .
 
-niiri:f2f5cba9f1a0043aec7f2b059b817ab2
+niiri:a3c7efc0ca1f4ef769468595f11497ea
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0228" ;
     nidm_coordinateVector: "[8,-54,-34]"^^xsd:string .
 
-niiri:72727159e9811517f5b36fd2c43678d0 prov:wasDerivedFrom niiri:c57896abf584d2b1a83fb9ad3c827d15 .
+niiri:71daf19003d4f9dfcddcf08cbdd35abd prov:wasDerivedFrom niiri:11a529a736c285cc9a00cdcf5fb4962d .
 
-niiri:2cf80c9d2ce23618d80c776c78776914
+niiri:3057043901ea2a078a58803f5a56dec7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0229" ;
-    prov:atLocation niiri:3a4812b6b94aece02ec415596e337c47 ;
+    prov:atLocation niiri:c9498ecd645e8ee7c1b2854ae6ad27b0 ;
     prov:value "12.00501537323"^^xsd:float ;
     nidm_equivalentZStatistic: "3.16017149794514"^^xsd:float ;
     nidm_pValueUncorrected: "0.000788381493643353"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999998"^^xsd:float ;
     nidm_qValueFDR: "0.862288646172828"^^xsd:float .
 
-niiri:3a4812b6b94aece02ec415596e337c47
+niiri:c9498ecd645e8ee7c1b2854ae6ad27b0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0229" ;
     nidm_coordinateVector: "[-8,-40,78]"^^xsd:string .
 
-niiri:2cf80c9d2ce23618d80c776c78776914 prov:wasDerivedFrom niiri:ea8d2f5330ef8fd7ac99fb062748cba2 .
+niiri:3057043901ea2a078a58803f5a56dec7 prov:wasDerivedFrom niiri:56c0d386be3b33d6180c1118121d2610 .
 
-niiri:2c9c8d1c090be7f9d4995486b65b0310
+niiri:f5292c900080c8c0ef7cf8ec19aa3697
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0230" ;
-    prov:atLocation niiri:091f59ed4f068443320c1b3f82fab5bf ;
+    prov:atLocation niiri:4de46218eaea869bbf89aff4b4ac9b02 ;
     prov:value "12.0031709671021"^^xsd:float ;
     nidm_equivalentZStatistic: "3.15991499103056"^^xsd:float ;
     nidm_pValueUncorrected: "0.000789075885015644"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999998"^^xsd:float ;
     nidm_qValueFDR: "0.862288646172828"^^xsd:float .
 
-niiri:091f59ed4f068443320c1b3f82fab5bf
+niiri:4de46218eaea869bbf89aff4b4ac9b02
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0230" ;
     nidm_coordinateVector: "[-60,-60,26]"^^xsd:string .
 
-niiri:2c9c8d1c090be7f9d4995486b65b0310 prov:wasDerivedFrom niiri:c638448ba82adee617884aeddb79eb28 .
+niiri:f5292c900080c8c0ef7cf8ec19aa3697 prov:wasDerivedFrom niiri:d285ba30108c36cd9e0a52ef7d0d4cec .
 
-niiri:f1ed81ce13078f158c03a0d5e7471588
+niiri:30a84acd12436a2955bf4b443a3b850c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0231" ;
-    prov:atLocation niiri:1c3507b31075438b0af48c0f54f24140 ;
+    prov:atLocation niiri:3581a3e4b5344f48549574e9392dca58 ;
     prov:value "11.9899396896362"^^xsd:float ;
     nidm_equivalentZStatistic: "3.15807416017948"^^xsd:float ;
     nidm_pValueUncorrected: "0.000794075753797419"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999999"^^xsd:float ;
     nidm_qValueFDR: "0.864648849849365"^^xsd:float .
 
-niiri:1c3507b31075438b0af48c0f54f24140
+niiri:3581a3e4b5344f48549574e9392dca58
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0231" ;
     nidm_coordinateVector: "[48,-80,10]"^^xsd:string .
 
-niiri:f1ed81ce13078f158c03a0d5e7471588 prov:wasDerivedFrom niiri:4d95857f68b5b80d99c4947f63e88283 .
+niiri:30a84acd12436a2955bf4b443a3b850c prov:wasDerivedFrom niiri:d38a6da35a3b35e251b575be2481d895 .
 
-niiri:5507595d5883d29964389d0188c6b157
+niiri:03b8a2fea9829914437905e68925e360
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0232" ;
-    prov:atLocation niiri:6203db38b560aaef834eeb8f540b491f ;
+    prov:atLocation niiri:f028b4f21a1973e22582d89d86a59e4c ;
     prov:value "11.9840250015259"^^xsd:float ;
     nidm_equivalentZStatistic: "3.1572508576916"^^xsd:float ;
     nidm_pValueUncorrected: "0.000796321345690965"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999999"^^xsd:float ;
     nidm_qValueFDR: "0.864758992605231"^^xsd:float .
 
-niiri:6203db38b560aaef834eeb8f540b491f
+niiri:f028b4f21a1973e22582d89d86a59e4c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0232" ;
     nidm_coordinateVector: "[62,-54,-8]"^^xsd:string .
 
-niiri:5507595d5883d29964389d0188c6b157 prov:wasDerivedFrom niiri:ef0d129d225ab1994fdabef30426f127 .
+niiri:03b8a2fea9829914437905e68925e360 prov:wasDerivedFrom niiri:4f56e832e623fb38abb2d199755b3aa5 .
 
-niiri:87a5ed15fe49eea54b04710a3752ed1e
+niiri:c88d9634fff92159e1df0499f5d4e04b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0233" ;
-    prov:atLocation niiri:ff666065a5b6658dc645513bf36c7121 ;
+    prov:atLocation niiri:1851842618253ccc503cfb02e8736641 ;
     prov:value "11.93297290802"^^xsd:float ;
     nidm_equivalentZStatistic: "3.15013407761285"^^xsd:float ;
     nidm_pValueUncorrected: "0.000815977744435759"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999999"^^xsd:float ;
     nidm_qValueFDR: "0.878904312044662"^^xsd:float .
 
-niiri:ff666065a5b6658dc645513bf36c7121
+niiri:1851842618253ccc503cfb02e8736641
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0233" ;
     nidm_coordinateVector: "[-38,-54,-42]"^^xsd:string .
 
-niiri:87a5ed15fe49eea54b04710a3752ed1e prov:wasDerivedFrom niiri:48094119160b8ddede68780fbf27c3d9 .
+niiri:c88d9634fff92159e1df0499f5d4e04b prov:wasDerivedFrom niiri:92f563ca517a60ccfbb3ef7b2af62dac .
 
-niiri:188e7ed2867f60504ca92b5508398d6d
+niiri:2a999512422d958e9dd451fe676d13a1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0234" ;
-    prov:atLocation niiri:16bf1c0055fb25a7afd2e00a1e33b0f7 ;
+    prov:atLocation niiri:691ae2c0b1d9726dd204612040f5685f ;
     prov:value "11.8026752471924"^^xsd:float ;
     nidm_equivalentZStatistic: "3.13188412058022"^^xsd:float ;
     nidm_pValueUncorrected: "0.000868442069883013"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.916815339863787"^^xsd:float .
 
-niiri:16bf1c0055fb25a7afd2e00a1e33b0f7
+niiri:691ae2c0b1d9726dd204612040f5685f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0234" ;
     nidm_coordinateVector: "[22,44,-16]"^^xsd:string .
 
-niiri:188e7ed2867f60504ca92b5508398d6d prov:wasDerivedFrom niiri:494d564667be2308342989663d3f52ff .
+niiri:2a999512422d958e9dd451fe676d13a1 prov:wasDerivedFrom niiri:8600387b3b7cea249641e5cdebba0daa .
 
-niiri:af993a46a0375f6a5f8320017c4f1674
+niiri:f985f79075267f7e7ea06f7a3d3b4fd0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0235" ;
-    prov:atLocation niiri:3de565782250cc9687888876a06bb48a ;
+    prov:atLocation niiri:7cda6698f70c94692a960278e4b33bf9 ;
     prov:value "11.7988748550415"^^xsd:float ;
     nidm_equivalentZStatistic: "3.13134995085887"^^xsd:float ;
     nidm_pValueUncorrected: "0.000870023394025643"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.916815339863787"^^xsd:float .
 
-niiri:3de565782250cc9687888876a06bb48a
+niiri:7cda6698f70c94692a960278e4b33bf9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0235" ;
     nidm_coordinateVector: "[24,68,20]"^^xsd:string .
 
-niiri:af993a46a0375f6a5f8320017c4f1674 prov:wasDerivedFrom niiri:ea21239ad949045b078440398a34a9c6 .
+niiri:f985f79075267f7e7ea06f7a3d3b4fd0 prov:wasDerivedFrom niiri:0f7371e43c32093550d9b7e335f29fdd .
 
-niiri:5373ecb9c5fa5f62bd4b9686506c5254
+niiri:f181b589179ed8f92f3f7f4795974d3e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0236" ;
-    prov:atLocation niiri:c88286fcf0c0dc2b44fbd7b90606f375 ;
+    prov:atLocation niiri:429847480689f42655b6238b01c24ecf ;
     prov:value "11.7978382110596"^^xsd:float ;
     nidm_equivalentZStatistic: "3.13120422529702"^^xsd:float ;
     nidm_pValueUncorrected: "0.000870455250713387"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.916815339863787"^^xsd:float .
 
-niiri:c88286fcf0c0dc2b44fbd7b90606f375
+niiri:429847480689f42655b6238b01c24ecf
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0236" ;
     nidm_coordinateVector: "[-36,-32,-22]"^^xsd:string .
 
-niiri:5373ecb9c5fa5f62bd4b9686506c5254 prov:wasDerivedFrom niiri:db760edea5f4f806e9afd9a12723ee09 .
+niiri:f181b589179ed8f92f3f7f4795974d3e prov:wasDerivedFrom niiri:60ee0a470203bf71030d2277a3fde6c3 .
 
-niiri:4242b471ef1c97b21528586c67ca68bc
+niiri:b24deafd5ea91430bd7b734255475770
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0237" ;
-    prov:atLocation niiri:09297421cb82b28e580bc19e6204f397 ;
+    prov:atLocation niiri:060b7e14bd3b6dc2f252c0b0afc1d7a1 ;
     prov:value "11.7785091400146"^^xsd:float ;
     nidm_equivalentZStatistic: "3.12848559662294"^^xsd:float ;
     nidm_pValueUncorrected: "0.000878548112890121"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.921335336720806"^^xsd:float .
 
-niiri:09297421cb82b28e580bc19e6204f397
+niiri:060b7e14bd3b6dc2f252c0b0afc1d7a1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0237" ;
     nidm_coordinateVector: "[42,-42,14]"^^xsd:string .
 
-niiri:4242b471ef1c97b21528586c67ca68bc prov:wasDerivedFrom niiri:5bbac11b8bfa6c995310ee87183ab4d6 .
+niiri:b24deafd5ea91430bd7b734255475770 prov:wasDerivedFrom niiri:7cded2bfb4aacaabc3212bf6e55636da .
 
-niiri:1f7ae5732a778aa683c4a171dbae0b98
+niiri:ed3e68d921eeb26ff4420aa1da45f707
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0238" ;
-    prov:atLocation niiri:baf7677535e711ccecef9410ee445b28 ;
+    prov:atLocation niiri:729a7087b921fe5cd9363facfa24c6f0 ;
     prov:value "11.7414026260376"^^xsd:float ;
     nidm_equivalentZStatistic: "3.12325880540281"^^xsd:float ;
     nidm_pValueUncorrected: "0.000894301978610734"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.931755566916896"^^xsd:float .
 
-niiri:baf7677535e711ccecef9410ee445b28
+niiri:729a7087b921fe5cd9363facfa24c6f0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0238" ;
     nidm_coordinateVector: "[42,46,-12]"^^xsd:string .
 
-niiri:1f7ae5732a778aa683c4a171dbae0b98 prov:wasDerivedFrom niiri:3f3b062de3ba5acf073f1b59cfb5a6e6 .
+niiri:ed3e68d921eeb26ff4420aa1da45f707 prov:wasDerivedFrom niiri:56d77ed8a1025508e9f36442b2aa1001 .
 
-niiri:8fb8b517ce468d8dcfbcedc05b4dfca5
+niiri:5d28dbbc72458950d35719ada2f35c1d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0239" ;
-    prov:atLocation niiri:bdd766aab7694eb3e5475178fd6d34c4 ;
+    prov:atLocation niiri:24cc5c274366ef4b77b9970877943695 ;
     prov:value "11.6729784011841"^^xsd:float ;
     nidm_equivalentZStatistic: "3.1135936902341"^^xsd:float ;
     nidm_pValueUncorrected: "0.000924119094904752"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.952845585496322"^^xsd:float .
 
-niiri:bdd766aab7694eb3e5475178fd6d34c4
+niiri:24cc5c274366ef4b77b9970877943695
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0239" ;
     nidm_coordinateVector: "[32,28,-24]"^^xsd:string .
 
-niiri:8fb8b517ce468d8dcfbcedc05b4dfca5 prov:wasDerivedFrom niiri:39a4606d938ba1ca81229a71c823e41d .
+niiri:5d28dbbc72458950d35719ada2f35c1d prov:wasDerivedFrom niiri:5debe73d92bf3a2e632b239ed32da2c4 .
 
-niiri:abea7107eba4f962756ca01a29b2c6c1
+niiri:49fa6fc625869e411d951c76ea01f001
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0240" ;
-    prov:atLocation niiri:7bb00425f1dcab057b4ffa37303f3f07 ;
+    prov:atLocation niiri:7341e654c7650694fa4a633b7d57e71c ;
     prov:value "11.648645401001"^^xsd:float ;
     nidm_equivalentZStatistic: "3.11014811684365"^^xsd:float ;
     nidm_pValueUncorrected: "0.000934967749947835"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.959250568995591"^^xsd:float .
 
-niiri:7bb00425f1dcab057b4ffa37303f3f07
+niiri:7341e654c7650694fa4a633b7d57e71c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0240" ;
     nidm_coordinateVector: "[42,20,-14]"^^xsd:string .
 
-niiri:abea7107eba4f962756ca01a29b2c6c1 prov:wasDerivedFrom niiri:a49d384fb03c39001132a62f5ee742ce .
+niiri:49fa6fc625869e411d951c76ea01f001 prov:wasDerivedFrom niiri:f3bc76ba4a3df529282c2ee84c68df86 .
 
-niiri:f6c3aef4b5a32a913944e0b618bb9d22
+niiri:7047971620448cda11f6eecfb2f451f4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0241" ;
-    prov:atLocation niiri:d203afcd357f0bbdba0a75f6f32c82cf ;
+    prov:atLocation niiri:4b469a270ee563c51daff07a0ec32f1e ;
     prov:value "11.6256742477417"^^xsd:float ;
     nidm_equivalentZStatistic: "3.1068912843889"^^xsd:float ;
     nidm_pValueUncorrected: "0.000945329574052578"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.963708379847036"^^xsd:float .
 
-niiri:d203afcd357f0bbdba0a75f6f32c82cf
+niiri:4b469a270ee563c51daff07a0ec32f1e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0241" ;
     nidm_coordinateVector: "[-22,-82,0]"^^xsd:string .
 
-niiri:f6c3aef4b5a32a913944e0b618bb9d22 prov:wasDerivedFrom niiri:1df9ca7cc28a8741906406c23e450c49 .
+niiri:7047971620448cda11f6eecfb2f451f4 prov:wasDerivedFrom niiri:28bbba0604724f0b5ea3c95637660afa .
 
-niiri:2622cd3d464cf135af4aac90969d14c4
+niiri:27fc8dfd0e287d18ed37abcd26235c8c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0242" ;
-    prov:atLocation niiri:1f4e92cddcda2154118f1b7337fcf3b0 ;
+    prov:atLocation niiri:1477eff6e204f38ed59b87445071b9ed ;
     prov:value "11.6246528625488"^^xsd:float ;
     nidm_equivalentZStatistic: "3.10674638057242"^^xsd:float ;
     nidm_pValueUncorrected: "0.000945793036476794"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.963708379847036"^^xsd:float .
 
-niiri:1f4e92cddcda2154118f1b7337fcf3b0
+niiri:1477eff6e204f38ed59b87445071b9ed
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0242" ;
     nidm_coordinateVector: "[2,-42,-62]"^^xsd:string .
 
-niiri:2622cd3d464cf135af4aac90969d14c4 prov:wasDerivedFrom niiri:b3a0d8de966bc74adb169669f1390504 .
+niiri:27fc8dfd0e287d18ed37abcd26235c8c prov:wasDerivedFrom niiri:e2e08d4842a9d04eb18949c6410171c2 .
 
-niiri:f38bca5aa6c461d6da7f28fd6a2a042e
+niiri:c78a4edd720ceef3e574dba70e0cc9fc
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0243" ;
-    prov:atLocation niiri:34094eeb46510e11bb2665dd446bca80 ;
+    prov:atLocation niiri:0b8fbe19681a8a8318549ff8c0485803 ;
     prov:value "11.586296081543"^^xsd:float ;
     nidm_equivalentZStatistic: "3.10129898410053"^^xsd:float ;
     nidm_pValueUncorrected: "0.000963368201000958"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.975038721030712"^^xsd:float .
 
-niiri:34094eeb46510e11bb2665dd446bca80
+niiri:0b8fbe19681a8a8318549ff8c0485803
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0243" ;
     nidm_coordinateVector: "[52,-42,18]"^^xsd:string .
 
-niiri:f38bca5aa6c461d6da7f28fd6a2a042e prov:wasDerivedFrom niiri:070e421862800af00c11e7304e4407bb .
+niiri:c78a4edd720ceef3e574dba70e0cc9fc prov:wasDerivedFrom niiri:21fbadccdcf80825edc168ed54a646dd .
 
-niiri:9ff10ca343cba033a822e58949624a59
+niiri:a9c0e06b74f100f91729fb0b3f27bb2e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0244" ;
-    prov:atLocation niiri:62ff6f37d3c90639a888eadbf051dd28 ;
+    prov:atLocation niiri:0885c3bb08b39c786df94baf46e2a0c6 ;
     prov:value "11.5521640777588"^^xsd:float ;
     nidm_equivalentZStatistic: "3.09644218031477"^^xsd:float ;
     nidm_pValueUncorrected: "0.000979290273004696"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.985021600249525"^^xsd:float .
 
-niiri:62ff6f37d3c90639a888eadbf051dd28
+niiri:0885c3bb08b39c786df94baf46e2a0c6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0244" ;
     nidm_coordinateVector: "[54,44,14]"^^xsd:string .
 
-niiri:9ff10ca343cba033a822e58949624a59 prov:wasDerivedFrom niiri:93297a88c8e657de407b42d03cd7f823 .
+niiri:a9c0e06b74f100f91729fb0b3f27bb2e prov:wasDerivedFrom niiri:37a7db920a02cc0218b6f2862406e37a .
 

--- a/spmexport/ex_spm_conjunction/nidm.json
+++ b/spmexport/ex_spm_conjunction/nidm.json
@@ -1,0 +1,7892 @@
+{
+  "prefix": {
+    "nidm": "http://purl.org/nidash/nidm#",
+    "niiri": "http://iri.nidash.org/",
+    "spm": "http://purl.org/nidash/spm#",
+    "neurolex": "http://neurolex.org/wiki/",
+    "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/",
+    "dct": "http://purl.org/dc/terms/",
+    "nfo": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#",
+    "dc": "http://purl.org/dc/elements/1.1/",
+    "dctype": "http://purl.org/dc/dcmitype/",
+    "obo": "http://purl.obolibrary.org/obo/",
+    "nidm_NIDMResults": "http://purl.org/nidash/nidm#NIDM_0000027",
+    "nidm_version": "http://purl.org/nidash/nidm#NIDM_0000127",
+    "nidm_spm_results_nidm": "http://purl.org/nidash/nidm#NIDM_0000168",
+    "nidm_softwareVersion": "http://purl.org/nidash/nidm#NIDM_0000122",
+    "nidm_NIDMResultsExport": "http://purl.org/nidash/nidm#NIDM_0000166"
+  },
+  "entity": {
+    "niiri:2e94d338ef8848aaa3096aa9c67d068b": {
+      "prov:type": [
+        {
+        "$": "prov:Bundle",
+        "type": "xsd:QName"
+        },
+        {
+        "$": "nidm_NIDMResults:",
+        "type": "xsd:QName"
+        }
+      ],
+      "prov:label": {
+        "$": "NIDM-Results",
+        "type": "xsd:string"
+      },
+      "nidm_version:": {
+        "$": "1.3.0",
+        "type": "xsd:string"
+      }
+    }
+  },
+  "activity": {
+    "niiri:c90a33b190317be7e66e9cb64ea5c0d4": {
+      "prov:type": {
+        "$": "nidm_NIDMResultsExport:",
+        "type": "xsd:QName"
+      },
+      "prov:label": {
+        "$": "NIDM-Results export",
+        "type": "xsd:string"
+      }
+    }
+  },
+  "agent": {
+    "niiri:7950d950e14199763647729c4a4e4088": {
+      "prov:type": [
+        {
+        "$": "nidm_spm_results_nidm:",
+        "type": "xsd:QName"
+        },
+        {
+        "$": "prov:SoftwareAgent",
+        "type": "xsd:QName"
+        }
+      ],
+      "prov:label": {
+        "$": "spm_results_nidm",
+        "type": "xsd:string"
+      },
+      "nidm_softwareVersion:": {
+        "$": "12.7057",
+        "type": "xsd:string"
+      }
+    }
+  },
+  "wasGeneratedBy": {
+    "_:wGB5": {
+      "prov:entity": "niiri:2e94d338ef8848aaa3096aa9c67d068b",
+      "prov:activity": "niiri:c90a33b190317be7e66e9cb64ea5c0d4",
+      "prov:time": "2017-04-19T12:17:45"
+    }
+  },
+  "wasAssociatedWith": {
+    "_:wAW4": {
+      "prov:activity": "niiri:c90a33b190317be7e66e9cb64ea5c0d4",
+      "prov:agent": "niiri:7950d950e14199763647729c4a4e4088"
+    }
+  },
+  "bundle": {
+    "niiri:2e94d338ef8848aaa3096aa9c67d068b": {
+    "prefix": {
+        "nidm_softwareVersion": "http://purl.org/nidash/nidm#NIDM_0000122",
+        "nidm_CoordinateSpace": "http://purl.org/nidash/nidm#NIDM_0000016",
+        "nidm_voxelToWorldMapping": "http://purl.org/nidash/nidm#NIDM_0000132",
+        "nidm_voxelUnits": "http://purl.org/nidash/nidm#NIDM_0000133",
+        "nidm_voxelSize": "http://purl.org/nidash/nidm#NIDM_0000131",
+        "nidm_inWorldCoordinateSystem": "http://purl.org/nidash/nidm#NIDM_0000105",
+        "nidm_numberOfDimensions": "http://purl.org/nidash/nidm#NIDM_0000112",
+        "nidm_dimensionsInVoxels": "http://purl.org/nidash/nidm#NIDM_0000090",
+        "nlx_Imaginginstrument": "http://uri.neuinfo.org/nif/nifstd/birnlex_2094",
+        "nlx_Magneticresonanceimagingscanner": "http://uri.neuinfo.org/nif/nifstd/birnlex_2100",
+        "nidm_grandMeanScaling": "http://purl.org/nidash/nidm#NIDM_0000096",
+        "nidm_targetIntensity": "http://purl.org/nidash/nidm#NIDM_0000124",
+        "nidm_hasMRIProtocol": "http://purl.org/nidash/nidm#NIDM_0000172",
+        "nlx_FunctionalMRIprotocol": "http://uri.neuinfo.org/nif/nifstd/birnlex_2250",
+        "nidm_Data": "http://purl.org/nidash/nidm#NIDM_0000169",
+        "spm_DCTDriftModel": "http://purl.org/nidash/spm#SPM_0000002",
+        "spm_SPMsDriftCutoffPeriod": "http://purl.org/nidash/spm#SPM_0000001",
+        "nidm_hasDriftModel": "http://purl.org/nidash/nidm#NIDM_0000088",
+        "nidm_hasHRFBasis": "http://purl.org/nidash/nidm#NIDM_0000102",
+        "spm_SPMsCanonicalHRF": "http://purl.org/nidash/spm#SPM_0000004",
+        "nidm_DesignMatrix": "http://purl.org/nidash/nidm#NIDM_0000019",
+        "nidm_regressorNames": "http://purl.org/nidash/nidm#NIDM_0000021",
+        "nidm_hasErrorDependence": "http://purl.org/nidash/nidm#NIDM_0000100",
+        "obo_Toeplitzcovariancestructure": "http://purl.obolibrary.org/obo/STATO_0000357",
+        "nidm_dependenceMapWiseDependence": "http://purl.org/nidash/nidm#NIDM_0000089",
+        "nidm_ConstantParameter": "http://purl.org/nidash/nidm#NIDM_0000072",
+        "nidm_errorVarianceHomogeneous": "http://purl.org/nidash/nidm#NIDM_0000094",
+        "nidm_varianceMapWiseDependence": "http://purl.org/nidash/nidm#NIDM_0000126",
+        "nidm_IndependentParameter": "http://purl.org/nidash/nidm#NIDM_0000073",
+        "nidm_withEstimationMethod": "http://purl.org/nidash/nidm#NIDM_0000134",
+        "obo_generalizedleastsquaresestimation": "http://purl.obolibrary.org/obo/STATO_0000372",
+        "nidm_ErrorModel": "http://purl.org/nidash/nidm#NIDM_0000023",
+        "nidm_hasErrorDistribution": "http://purl.org/nidash/nidm#NIDM_0000101",
+        "obo_normaldistribution": "http://purl.obolibrary.org/obo/STATO_0000227",
+        "nidm_ModelParametersEstimation": "http://purl.org/nidash/nidm#NIDM_0000056",
+        "nidm_MaskMap": "http://purl.org/nidash/nidm#NIDM_0000054",
+        "nidm_isUserDefined": "http://purl.org/nidash/nidm#NIDM_0000106",
+        "nidm_inCoordinateSpace": "http://purl.org/nidash/nidm#NIDM_0000104",
+        "nidm_GrandMeanMap": "http://purl.org/nidash/nidm#NIDM_0000033",
+        "nidm_maskedMedian": "http://purl.org/nidash/nidm#NIDM_0000107",
+        "nidm_ParameterEstimateMap": "http://purl.org/nidash/nidm#NIDM_0000061",
+        "nidm_ResidualMeanSquaresMap": "http://purl.org/nidash/nidm#NIDM_0000066",
+        "nidm_ReselsPerVoxelMap": "http://purl.org/nidash/nidm#NIDM_0000144",
+        "obo_contrastweightmatrix": "http://purl.obolibrary.org/obo/STATO_0000323",
+        "nidm_statisticType": "http://purl.org/nidash/nidm#NIDM_0000123",
+        "obo_tstatistic": "http://purl.obolibrary.org/obo/STATO_0000176",
+        "nidm_contrastName": "http://purl.org/nidash/nidm#NIDM_0000085",
+        "nidm_ContrastEstimation": "http://purl.org/nidash/nidm#NIDM_0000001",
+        "nidm_StatisticMap": "http://purl.org/nidash/nidm#NIDM_0000076",
+        "nidm_errorDegreesOfFreedom": "http://purl.org/nidash/nidm#NIDM_0000093",
+        "nidm_effectDegreesOfFreedom": "http://purl.org/nidash/nidm#NIDM_0000091",
+        "nidm_ContrastMap": "http://purl.org/nidash/nidm#NIDM_0000002",
+        "nidm_ContrastStandardErrorMap": "http://purl.org/nidash/nidm#NIDM_0000013",
+        "obo_statistic": "http://purl.obolibrary.org/obo/STATO_0000039",
+        "nidm_PValueUncorrected": "http://purl.org/nidash/nidm#NIDM_0000160",
+        "obo_FWERadjustedpvalue": "http://purl.obolibrary.org/obo/OBI_0001265",
+        "nidm_HeightThreshold": "http://purl.org/nidash/nidm#NIDM_0000034",
+        "nidm_equivalentThreshold": "http://purl.org/nidash/nidm#NIDM_0000161",
+        "nidm_ExtentThreshold": "http://purl.org/nidash/nidm#NIDM_0000026",
+        "nidm_clusterSizeInVoxels": "http://purl.org/nidash/nidm#NIDM_0000084",
+        "nidm_clusterSizeInResels": "http://purl.org/nidash/nidm#NIDM_0000156",
+        "nidm_PeakDefinitionCriteria": "http://purl.org/nidash/nidm#NIDM_0000063",
+        "nidm_maxNumberOfPeaksPerCluster": "http://purl.org/nidash/nidm#NIDM_0000108",
+        "nidm_minDistanceBetweenPeaks": "http://purl.org/nidash/nidm#NIDM_0000109",
+        "nidm_ClusterDefinitionCriteria": "http://purl.org/nidash/nidm#NIDM_0000007",
+        "nidm_hasConnectivityCriterion": "http://purl.org/nidash/nidm#NIDM_0000099",
+        "nidm_voxel18connected": "http://purl.org/nidash/nidm#NIDM_0000128",
+        "nidm_ConjunctionInference": "http://purl.org/nidash/nidm#NIDM_0000011",
+        "nidm_hasAlternativeHypothesis": "http://purl.org/nidash/nidm#NIDM_0000097",
+        "nidm_OneTailedTest": "http://purl.org/nidash/nidm#NIDM_0000060",
+        "nidm_SearchSpaceMaskMap": "http://purl.org/nidash/nidm#NIDM_0000068",
+        "nidm_searchVolumeInVoxels": "http://purl.org/nidash/nidm#NIDM_0000121",
+        "nidm_searchVolumeInUnits": "http://purl.org/nidash/nidm#NIDM_0000136",
+        "nidm_reselSizeInVoxels": "http://purl.org/nidash/nidm#NIDM_0000148",
+        "nidm_searchVolumeInResels": "http://purl.org/nidash/nidm#NIDM_0000149",
+        "spm_searchVolumeReselsGeometry": "http://purl.org/nidash/spm#SPM_0000010",
+        "nidm_noiseFWHMInVoxels": "http://purl.org/nidash/nidm#NIDM_0000159",
+        "nidm_noiseFWHMInUnits": "http://purl.org/nidash/nidm#NIDM_0000157",
+        "nidm_randomFieldStationarity": "http://purl.org/nidash/nidm#NIDM_0000120",
+        "nidm_expectedNumberOfVoxelsPerCluster": "http://purl.org/nidash/nidm#NIDM_0000143",
+        "nidm_expectedNumberOfClusters": "http://purl.org/nidash/nidm#NIDM_0000141",
+        "nidm_heightCriticalThresholdFWE05": "http://purl.org/nidash/nidm#NIDM_0000147",
+        "nidm_heightCriticalThresholdFDR05": "http://purl.org/nidash/nidm#NIDM_0000146",
+        "spm_smallestSignificantClusterSizeInVoxelsFWE05": "http://purl.org/nidash/spm#SPM_0000014",
+        "spm_smallestSignificantClusterSizeInVoxelsFDR05": "http://purl.org/nidash/spm#SPM_0000013",
+        "nidm_ExcursionSetMap": "http://purl.org/nidash/nidm#NIDM_0000025",
+        "nidm_numberOfSupraThresholdClusters": "http://purl.org/nidash/nidm#NIDM_0000111",
+        "nidm_pValue": "http://purl.org/nidash/nidm#NIDM_0000114",
+        "nidm_hasClusterLabelsMap": "http://purl.org/nidash/nidm#NIDM_0000098",
+        "nidm_hasMaximumIntensityProjection": "http://purl.org/nidash/nidm#NIDM_0000138",
+        "nidm_ClusterLabelsMap": "http://purl.org/nidash/nidm#NIDM_0000008",
+        "nidm_SupraThresholdCluster": "http://purl.org/nidash/nidm#NIDM_0000070",
+        "nidm_pValueUncorrected": "http://purl.org/nidash/nidm#NIDM_0000116",
+        "nidm_pValueFWER": "http://purl.org/nidash/nidm#NIDM_0000115",
+        "nidm_qValueFDR": "http://purl.org/nidash/nidm#NIDM_0000119",
+        "nidm_clusterLabelId": "http://purl.org/nidash/nidm#NIDM_0000082",
+        "nidm_Peak": "http://purl.org/nidash/nidm#NIDM_0000062",
+        "nidm_equivalentZStatistic": "http://purl.org/nidash/nidm#NIDM_0000092",
+        "nidm_Coordinate": "http://purl.org/nidash/nidm#NIDM_0000015",
+        "nidm_coordinateVector": "http://purl.org/nidash/nidm#NIDM_0000086"
+    },
+    "entity": {
+        "niiri:43990f91d4711220e8f4834300dbd4a5": {
+            "prov:type": {
+                "$": "nidm_CoordinateSpace:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Coordinate space 1",
+                "type": "xsd:string"
+            },
+            "nidm_voxelToWorldMapping:": {
+                "$": "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]",
+                "type": "xsd:string"
+            },
+            "nidm_voxelUnits:": {
+                "$": "[\"mm\", \"mm\", \"mm\"]",
+                "type": "xsd:string"
+            },
+            "nidm_voxelSize:": {
+                "$": "[2, 2, 2]",
+                "type": "xsd:string"
+            },
+            "nidm_inWorldCoordinateSystem:": {
+                "$": "nidm_Ixi549CoordinateSystem:",
+                "type": "xsd:string"
+            },
+            "nidm_numberOfDimensions:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_dimensionsInVoxels:": {
+                "$": "[79,95,79]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b5f5299dd88c01663688131c711c2a74": {
+            "prov:type": [
+                {
+                "$": "prov:Collection",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Data:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Data",
+                "type": "xsd:string"
+            },
+            "nidm_grandMeanScaling:": {
+                "$": "true",
+                "type": "xsd:boolean"
+            },
+            "nidm_targetIntensity:": {
+                "$": "100",
+                "type": "xsd:float"
+            },
+            "nidm_hasMRIProtocol:": {
+                "$": "nlx_FunctionalMRIprotocol:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2668d1ecdf9295cc03d6086cb0de079d": {
+            "prov:type": {
+                "$": "spm_DCTDriftModel:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "SPM's DCT Drift Model",
+                "type": "xsd:string"
+            },
+            "spm_SPMsDriftCutoffPeriod:": {
+                "$": "128",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6387ede10972f2c9e2051e4ae79a4a2e": {
+            "prov:type": {
+                "$": "nidm_DesignMatrix:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "DesignMatrix.csv",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "DesignMatrix.csv",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "text/csv",
+                "type": "xsd:string"
+            },
+            "dc:description": {
+                "$": "niiri:c139d04ac7da5b6427c94a32bc9982ac",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Design Matrix",
+                "type": "xsd:string"
+            },
+            "nidm_regressorNames:": {
+                "$": "[\"Sn(1) to*bf(1)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) constant\"]",
+                "type": "xsd:string"
+            },
+            "nidm_hasDriftModel:": {
+                "$": "niiri:2668d1ecdf9295cc03d6086cb0de079d",
+                "type": "xsd:string"
+            },
+            "nidm_hasHRFBasis:": {
+                "$": "spm_SPMsCanonicalHRF:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c139d04ac7da5b6427c94a32bc9982ac": {
+            "prov:type": {
+                "$": "dctype:Image",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "DesignMatrix.png",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "DesignMatrix.png",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/png",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0fd0329c3adb2f4836f2747833babe88": {
+            "prov:type": {
+                "$": "nidm_ErrorModel:",
+                "type": "xsd:QName"
+            },
+            "nidm_hasErrorDistribution:": {
+                "$": "obo_normaldistribution:",
+                "type": "xsd:string"
+            },
+            "nidm_hasErrorDependence:": {
+                "$": "obo_Toeplitzcovariancestructure:",
+                "type": "xsd:string"
+            },
+            "nidm_dependenceMapWiseDependence:": {
+                "$": "nidm_ConstantParameter:",
+                "type": "xsd:string"
+            },
+            "nidm_errorVarianceHomogeneous:": {
+                "$": "true",
+                "type": "xsd:boolean"
+            },
+            "nidm_varianceMapWiseDependence:": {
+                "$": "nidm_IndependentParameter:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e5a61d0bc28607c2ab613b81ddf8392a": {
+            "prov:type": {
+                "$": "nidm_MaskMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "Mask.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nidm_isUserDefined:": {
+                "$": "false",
+                "type": "xsd:boolean"
+            },
+            "nfo:fileName": {
+                "$": "Mask.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Mask",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:43990f91d4711220e8f4834300dbd4a5",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8d425ac5fbd3a8eb1e7cc62ff8035271": {
+            "prov:type": {
+                "$": "nidm_MaskMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "mask.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "36929e1f5f4143bd9cc818cd896a25f129961fab208c3a4438555f40444c08347b359142ee8c53ece6e8cca1627f49db0788a1fd3b9e2ecaef61999c6c6c67ac",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9dbd735c07b927aa96e9892b2a28602a": {
+            "prov:type": {
+                "$": "nidm_GrandMeanMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "GrandMean.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "GrandMean.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Grand Mean Map",
+                "type": "xsd:string"
+            },
+            "nidm_maskedMedian:": {
+                "$": "111.557487487793",
+                "type": "xsd:float"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:43990f91d4711220e8f4834300dbd4a5",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "512157cc6bff89d9343a09b4068226eb3edd64a8cbcee861f06231767fae6f8d4819921182adebee083a9bf309afd65529ab04a92f0aa6b0038c8098550f6124",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:892dc0fa4cc25ca47ac73ddd6f0f1a71": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0001.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0001.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 1",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:43990f91d4711220e8f4834300dbd4a5",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:565b0e81e599439b221f8fc7d899038a": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0001.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:fcebd635515316804e6601daa6f10239": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0002.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0002.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 2",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:43990f91d4711220e8f4834300dbd4a5",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2b4b7fb2c844c1b29d66eb66f2f6bb24": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0002.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0a600229532c0ed2e05bd43494a1c6c3": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0003.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0003.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 3",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:43990f91d4711220e8f4834300dbd4a5",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6e470aa79f85c054fb351adb5db48bd3": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0003.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:03bc9932821688679785b6bbb6b7186e": {
+            "prov:type": {
+                "$": "nidm_ResidualMeanSquaresMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ResidualMeanSquares.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ResidualMeanSquares.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Residual Mean Squares Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:43990f91d4711220e8f4834300dbd4a5",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "991abf563d795a43b1e2eef8643e57023f2e0b090b2031f05f839321fc0643df6f71d423486a1021519b6dc82f6b0f563e19f3fbd50cb16063bed54a0e192d3e",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1788822bb0780f90238ce40ec64b7c8f": {
+            "prov:type": {
+                "$": "nidm_ResidualMeanSquaresMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "ResMS.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "40b28d03fcf9a2f60b11f10d7fb83bf3618b234fb5aedf09df644cb7cbb6aab8c9f468897c1078166d455a3d04a83f4e3bf762cfca0b4ea982d7a4e406849f18",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:19b287a58457b527aca30843e6e34d84": {
+            "prov:type": {
+                "$": "nidm_ReselsPerVoxelMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ReselsPerVoxel.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ReselsPerVoxel.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Resels per Voxel Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:43990f91d4711220e8f4834300dbd4a5",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "1a3f9216e145249ccc0b14b2bc337d6b38b81ad45e32768001fb22b35f0c2c0f3e2bce013b40c85f7dc0fc62723ac761ee7f7e1e6aff128a05f0ba7b8b8202a3",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9536f7d3d8c806ff604d922fcfc13f49": {
+            "prov:type": {
+                "$": "nidm_ReselsPerVoxelMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "RPV.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "4f76663162857f6b38b2a45a63b15a23b2ca8b338c283b69c1e71f2ea2f43797d045a733cd14e845be9c12f8b8f84d3931c599a08e8f6d77e99fab46ad87ab8f",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:92324b5901796c34f58222905ccfed17": {
+            "prov:type": {
+                "$": "obo_contrastweightmatrix:",
+                "type": "xsd:QName"
+            },
+            "nidm_statisticType:": {
+                "$": "obo_tstatistic:",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast: tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "[1, 0, 0]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7766f91f9fb3c7a19f3ae5bf1f752bbf": {
+            "prov:type": {
+                "$": "nidm_StatisticMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "TStatistic_0001.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "TStatistic_0001.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "T-Statistic Map: tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "nidm_statisticType:": {
+                "$": "obo_tstatistic:",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "nidm_errorDegreesOfFreedom:": {
+                "$": "97.9999999998522",
+                "type": "xsd:float"
+            },
+            "nidm_effectDegreesOfFreedom:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:43990f91d4711220e8f4834300dbd4a5",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "99f578a25cc225feda31dd567e6bc05dd8229bd9ada176571e9144c7748ed3a9c8eee1258f73c6cbf0a08282094b8004f18ea0791f0f3d92d8069ec877218399",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:df8317112ad27782b9be9c9adbafa6af": {
+            "prov:type": {
+                "$": "nidm_StatisticMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "spmT_0001.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "d288b1b0f117f64502555da13c5398dffa5bf5ff0b58951510e43d5388755bc185798802a92e98a07c7e313c6991066d2908f2a44aa5153ba23433da1335970f",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:af18c6b272b9c41779a5c9b4adefcb28": {
+            "prov:type": {
+                "$": "nidm_ContrastMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "Contrast_0001.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "Contrast_0001.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast Map: tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:43990f91d4711220e8f4834300dbd4a5",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "fc5e2ad175243ee496db98f9b2e1b235c4c3bae1a8d7122ce461c897b537e40c49dfee5d6cf20f71c6a2bb9b5f0760fcb4ecd8fe2e9428910ef3d60d8f3c56a9",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f584b30e1a30a67223f05b204465e66d": {
+            "prov:type": {
+                "$": "nidm_ContrastMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "con_0001.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "d4aa46b3603ba508578e39751262d528cf6d1ed2e722ec46f1cd8194c50591e46b229deb8cb4f72d1b7e0e2640f3e6604be7a335301c5c8357f453e5d0d4daf2",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4a46cd703e5066038138c81d0134cb7b": {
+            "prov:type": {
+                "$": "nidm_ContrastStandardErrorMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ContrastStandardError_0001.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ContrastStandardError_0001.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast Standard Error Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:43990f91d4711220e8f4834300dbd4a5",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "791d48f5d1adb15079a5289271ce0c4b95c56d69bfdb3e5d41b0d24eb538d3075e1cdd15502494b5a5a18c16eaa2153cb4847a996043fa48cdaf26e938a2576d",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:42481f8ce49fff367fe85c2f158deed5": {
+            "prov:type": {
+                "$": "obo_contrastweightmatrix:",
+                "type": "xsd:QName"
+            },
+            "nidm_statisticType:": {
+                "$": "obo_tstatistic:",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "tone counting probe vs baseline",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast: tone counting probe vs baseline",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "[0, 1, 0]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d40b3bf5490868f622f2357adea722a9": {
+            "prov:type": {
+                "$": "nidm_StatisticMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "TStatistic_0002.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "TStatistic_0002.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "T-Statistic Map: tone counting probe vs baseline",
+                "type": "xsd:string"
+            },
+            "nidm_statisticType:": {
+                "$": "obo_tstatistic:",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "tone counting probe vs baseline",
+                "type": "xsd:string"
+            },
+            "nidm_errorDegreesOfFreedom:": {
+                "$": "97.9999999998522",
+                "type": "xsd:float"
+            },
+            "nidm_effectDegreesOfFreedom:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:43990f91d4711220e8f4834300dbd4a5",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "27322de6e66e2fbcc847db3bfc0f2e23b78e8524340ddee0c06b40321f74c73140a07b0baed4ff259a6d956903811b416fd7a7d8bba86bacb8e60337006cf425",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:70992ac15b69b7bd18e58cc3b80cf441": {
+            "prov:type": {
+                "$": "nidm_StatisticMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "spmT_0002.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "d4c7aa1879c2eb9ad471b3fd73e58ff0dfeace86ac0791b1d34cd1b87791a293f705b04229f028d6b05d2bd1b371c8b2a17249750eb9ba773f11a6bdee5ed203",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:98bad5417f97850e2a27b2644953d7fc": {
+            "prov:type": {
+                "$": "nidm_ContrastMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "Contrast_0002.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "Contrast_0002.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast Map: tone counting probe vs baseline",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "tone counting probe vs baseline",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:43990f91d4711220e8f4834300dbd4a5",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "63cf0302e297e04c6b46de0043888e490e940d3aa0da4ed441990ea9f28f2dac32a0505b34bc424d68929195fec579f71c2d5602fda2dfaaad3d3accb14ccc43",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:cbc99abbec6b9d1c6aedcd2e278aabcd": {
+            "prov:type": {
+                "$": "nidm_ContrastMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "con_0002.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "b0f05ae7f0bac16eecb73fb1964cede4b475b176a9a0747624b707dc165bed14f45352fa25f00c6abbf5ea12376fcadf6cc46abbe1a65d25aa03eb2ec4423474",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5755b406b2a82f8a36a4c0c23054e6ee": {
+            "prov:type": {
+                "$": "nidm_ContrastStandardErrorMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ContrastStandardError_0002.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ContrastStandardError_0002.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast Standard Error Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:43990f91d4711220e8f4834300dbd4a5",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "e897bcfa6571036e47cf7fc61934c3ba09d3e3c7d759eaccfc002401c75700c5cdff2419aca08960e27c5dbdc76c05a2e2627a4935597f9eab4dfec54c0b2872",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d929d3c4d45d3c1d6b9b03fb2445f0d9": {
+            "prov:type": [
+                {
+                "$": "nidm_HeightThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_PValueUncorrected:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Height Threshold: p<0.001 (unc.)",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "0.000999500158000544",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentThreshold:": [
+                {
+                "$": "niiri:737bba5cf2bd2f211f124fb3d262c2dc",
+                "type": "xsd:string"
+                },
+                {
+                "$": "niiri:ab6c4afffb94c13144bd1539a6ca86f9",
+                "type": "xsd:string"
+                }
+            ]
+        },
+        "niiri:737bba5cf2bd2f211f124fb3d262c2dc": {
+            "prov:type": [
+                {
+                "$": "nidm_HeightThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_statistic:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Height Threshold: T=3.175486)",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.17548628637284",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ab6c4afffb94c13144bd1539a6ca86f9": {
+            "prov:type": [
+                {
+                "$": "nidm_HeightThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_FWERadjustedpvalue:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Height Threshold: p<1.000000 (FWE)",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "0.999999999999997",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:8d783286b1c008ac28fe81706432e884": {
+            "prov:type": [
+                {
+                "$": "nidm_ExtentThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_statistic:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Extent Threshold: k>=0",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "0",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentThreshold:": [
+                {
+                "$": "niiri:aa1873254cbafe5aaada9741c3754eb2",
+                "type": "xsd:string"
+                },
+                {
+                "$": "niiri:e1b635c98c9165c9c569e7531eebeb20",
+                "type": "xsd:string"
+                }
+            ]
+        },
+        "niiri:aa1873254cbafe5aaada9741c3754eb2": {
+            "prov:type": [
+                {
+                "$": "nidm_ExtentThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_FWERadjustedpvalue:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Extent Threshold",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e1b635c98c9165c9c569e7531eebeb20": {
+            "prov:type": [
+                {
+                "$": "nidm_ExtentThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_PValueUncorrected:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Extent Threshold",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:245e81118425b6790f11b064e4eca94d": {
+            "prov:type": {
+                "$": "nidm_PeakDefinitionCriteria:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak Definition Criteria",
+                "type": "xsd:string"
+            },
+            "nidm_maxNumberOfPeaksPerCluster:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_minDistanceBetweenPeaks:": {
+                "$": "8",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:04fa6b9288815b12d59a8ed5850b4b8e": {
+            "prov:type": {
+                "$": "nidm_ClusterDefinitionCriteria:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Cluster Connectivity Criterion: 18",
+                "type": "xsd:string"
+            },
+            "nidm_hasConnectivityCriterion:": {
+                "$": "nidm_voxel18connected:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:61ba90688ed17ead0aa46ba07adc7f73": {
+            "prov:type": {
+                "$": "nidm_SearchSpaceMaskMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "SearchSpaceMask.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "SearchSpaceMask.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Search Space Mask Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:43990f91d4711220e8f4834300dbd4a5",
+                "type": "xsd:string"
+            },
+            "nidm_searchVolumeInVoxels:": {
+                "$": "223057",
+                "type": "xsd:int"
+            },
+            "nidm_searchVolumeInUnits:": {
+                "$": "1784456",
+                "type": "xsd:float"
+            },
+            "nidm_reselSizeInVoxels:": {
+                "$": "65.5786964036542",
+                "type": "xsd:float"
+            },
+            "nidm_searchVolumeInResels:": {
+                "$": "3155.84193266257",
+                "type": "xsd:float"
+            },
+            "spm_searchVolumeReselsGeometry:": {
+                "$": "[6, 97.8140592306853, 965.938819261507, 3155.84193266257]",
+                "type": "xsd:string"
+            },
+            "nidm_noiseFWHMInVoxels:": {
+                "$": "[4.09118640605185, 4.0346308705955, 3.97291894351243]",
+                "type": "xsd:string"
+            },
+            "nidm_noiseFWHMInUnits:": {
+                "$": "[8.18237281210369, 8.069261741191, 7.94583788702486]",
+                "type": "xsd:string"
+            },
+            "nidm_randomFieldStationarity:": {
+                "$": "true",
+                "type": "xsd:boolean"
+            },
+            "nidm_expectedNumberOfVoxelsPerCluster:": {
+                "$": "7.21748994812991",
+                "type": "xsd:float"
+            },
+            "nidm_expectedNumberOfClusters:": {
+                "$": "33.5642173578105",
+                "type": "xsd:float"
+            },
+            "nidm_heightCriticalThresholdFWE05:": {
+                "$": "5.30963135104407",
+                "type": "xsd:float"
+            },
+            "nidm_heightCriticalThresholdFDR05:": {
+                "$": "5.64907312393188",
+                "type": "xsd:float"
+            },
+            "crypto:sha512": {
+                "$": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876",
+                "type": "xsd:string"
+            },
+            "spm_smallestSignificantClusterSizeInVoxelsFWE05:": {
+                "$": "98",
+                "type": "xsd:int"
+            },
+            "spm_smallestSignificantClusterSizeInVoxelsFDR05:": {
+                "$": "61",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:88829929c68a059331cc3c1d60afeecb": {
+            "prov:type": {
+                "$": "nidm_ExcursionSetMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ExcursionSet.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ExcursionSet.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Excursion Set Map",
+                "type": "xsd:string"
+            },
+            "nidm_numberOfSupraThresholdClusters:": {
+                "$": "56",
+                "type": "xsd:int"
+            },
+            "nidm_pValue:": {
+                "$": "0.000247328380021838",
+                "type": "xsd:float"
+            },
+            "nidm_hasClusterLabelsMap:": {
+                "$": "niiri:e5ce76ed52cded7d1b752baf082c1886",
+                "type": "xsd:string"
+            },
+            "nidm_hasMaximumIntensityProjection:": {
+                "$": "niiri:1aee58d2fc0953d357532d51ed194f16",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:43990f91d4711220e8f4834300dbd4a5",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "a8d48d1adbe71cf263b98b98011df674a6c6b1602e9131c3ce3c96140161b1fc1c1c96359cbd6c7c0b0729cb52832ff1995a211d75748d9237df95dcd70ec0f4",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e5ce76ed52cded7d1b752baf082c1886": {
+            "prov:type": {
+                "$": "nidm_ClusterLabelsMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ClusterLabels.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ClusterLabels.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Cluster Labels Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:43990f91d4711220e8f4834300dbd4a5",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "774704e1f481e7e243dd63c13916d5e8cf0877992b8300d55bd612568c0e5bc608433c90a6c24a4618cb6117e8c232a45a5611fba7352c5a7931bdabf0d2e6b5",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1aee58d2fc0953d357532d51ed194f16": {
+            "prov:type": {
+                "$": "dctype:Image",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "MaximumIntensityProjection.png",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "MaximumIntensityProjection.png",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/png",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0fe5639ac98706c7b3899db7801a8bf2": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0001",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "71",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.08266866976093",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00388517632401976",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.122258284761589",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0268436007152825",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "1",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:2975c7a00a3fc4010192cdde06218e42": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0002",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "552",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "8.41736768602862",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.46402494575762e-10",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1.16267285799054e-08",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "9.69926984812134e-09",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "2",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:022596b73b46d7ef5ae45ede7165a0d5": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0003",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1653",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "25.2063564945748",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.21466960104582e-20",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1.24021497658566e-18",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "3",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:9170484cbff3981334345a4c47f65aa7": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0004",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "120",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.829862540441",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000379874391228937",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0126692473683625",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00425459318176409",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "4",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:25e87116b614d88934e1e8c93fcc0b63": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0005",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "61",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.930180124724177",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00662877418964967",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.199476682033478",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0371211354620382",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "5",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c71e617484a5b302959dff7c4db9cc74": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0006",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "146",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "2.22633275753655",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000126444741899023",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0042350256798831",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00236030184878177",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "6",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:b1e379a1ec5bd17c690d79aba04d4080": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0007",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "33",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.503212198621276",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0357752504977919",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.699037101834118",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.133560935191756",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "7",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:4672418600c089d526b22d32d479dd1e": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0008",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "69",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.05217096075358",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00431415011495612",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.134805612767259",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0268436007152825",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "8",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:67a283ee599be31793e69bea3826f055": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0009",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "98",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.49438774136015",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00102712996618427",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0338873275648864",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00958654635105321",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "9",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:7640c37d58f807f183dbb16f5cce885a": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0010",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "71",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.08266866976093",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00388517632401976",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.122258284761589",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0268436007152825",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "10",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:8cfc21f5bbcf34401f68b224da91bb62": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0011",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "125",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.90610681295938",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000305687640549511",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0102077104591608",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00425459318176409",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "11",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:dfe1db9cfb99ba668d8eeb1e01c32a4f": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0012",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "43",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.655700743658026",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0188122365537974",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.468162877205716",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.081037326693281",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "12",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:8b21d35a1fc7a9cfb360ad2121638da7": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0013",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "21",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.320225944577176",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0850912379420168",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.942502902202007",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.234367607276586",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "13",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:988a6212fa64a63474847b473adbd268": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0014",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "23",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.350723653584526",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0729417588872538",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.913553802238084",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.214986236720327",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "14",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:0d10036870ecd78a22c4b7434f3e940f": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0015",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "15",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.228732817555125",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.13960790316574",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.990774925440181",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.300693945280055",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "15",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:7e1995dcc209b0990e86feb660922162": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0016",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "20",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0920729885729446",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.954514323339066",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.234367607276586",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "16",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:b4757e6c4de815acef5afdb0476f0eb3": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0017",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "15",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.228732817555125",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.13960790316574",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.990774925440181",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.300693945280055",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "17",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f8221060362a62c937dd97233413a960": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0018",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "26",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.396470217095551",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0583630672052552",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.858988054642613",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.181573986860794",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "18",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:af4c8a0d8ff5cfb976a7e9746756d8e3": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0019",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "51",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.777691579687426",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0116562324834894",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.323776962785858",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.054395751589617",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "19",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:866201193f458cd1f0d7d30bfc40b674": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0020",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "52",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.792940434191101",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0109993325903037",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.308701793106052",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.054395751589617",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "20",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:2627b433d92d75102b82469256c03339": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0021",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0609954180147001",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.44232166254071",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999643232106",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.688055919507771",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "21",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:601904871dc4878169c4db748733771d": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0022",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "29",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.442216780606576",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0470937359607303",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.79416170413585",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.164828075862556",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "22",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:0a7cd6ed9222066e8fdf471bab1ee6e7": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0023",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "20",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0920729885729446",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.954514323339066",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.234367607276586",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "23",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:d2a33a86263a0cb45dbf1c9cce5a8dd4": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0024",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "41",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.625203034650676",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0212995163239923",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.51075974713709",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0851980652959692",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "24",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:ab0144b9188c24f978e07874f53ac025": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0025",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "27",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.411719071599226",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0542875242970965",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.83831709934398",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.1788294918022",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "25",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c584015fa24c7c926f0b58301e5d61f2": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0026",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "16",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.2439816720588",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.128031320700056",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.986394362860718",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.29873974830013",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "26",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:b575189f3bd68971936993d3aa187cb2": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0027",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "6",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0914931270220502",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.343388487126378",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999990125608014",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.582719856941733",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "27",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:e8cd31e50a3c32fbe2bbcc0095269056": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0028",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0457465635110251",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.509991966452308",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999963189445",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.713988753033231",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "28",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:e97474fed9ca8bf394b41d386552ec23": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0029",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "5",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0762442725183751",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.388074947166389",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999997796430203",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.620919915466222",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "29",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:abd9e58304894c9547b23ee1045ac1da": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0030",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "16",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.2439816720588",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.128031320700056",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.986394362860718",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.29873974830013",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "30",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f35fdf14b958462f212cb7e02a3f5b6a": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0031",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "14",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.21348396305145",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.152527900243506",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.994020866354823",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.316354163468013",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "31",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:65aa1110e7a5b158b24b46e37675c86f": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0032",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "8",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.1219908360294",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.273933067513935",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999898388010158",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.511341726026011",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "32",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:7d8d48b7315eff2905773178ffd49023": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0033",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "10",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.15248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.22255850848336",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999430072930499",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.429768154312695",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "33",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:62e2c2069415d9aa3cc91424a7a036cf": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0034",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "7",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.106741981525725",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.305873808816549",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999965218155016",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.53527916542896",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "34",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:2deb14df5037616ae2a96835f77312be": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0035",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0457465635110251",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.509991966452308",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999963189445",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.713988753033231",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "35",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:5b409e333f6b39e5bc61b32b5cdb5358": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0036",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "12",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.1829862540441",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.183276076907294",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.997869754572677",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.366552153814587",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "36",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:aa433f26589b155235af6a6df23091d5": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0037",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.598176099264786",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999998092195",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "37",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:d220eb8d00595929d9a913e79e63f18d": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0038",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "7",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.106741981525725",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.305873808816549",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999965218155016",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.53527916542896",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "38",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:b25a22f3e4eb9bbd1275897ff1df109d": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0039",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.598176099264786",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999998092195",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "39",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:bd4658613e97b52c7228dc395dd15873": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0040",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0457465635110251",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.509991966452308",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999963189445",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.713988753033231",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "40",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:453c0a23d3b7bdaf631090a39026b948": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0041",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.598176099264786",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999998092195",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "41",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f9cadf3213379a88a9727fcf6a9eeef1": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0042",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999997153",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "42",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:00e7e2184e288d14e023360536c4ccbb": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0043",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999997153",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "43",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:1e198daa9971af9c5562116948147b44": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0044",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999997153",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "44",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:b983603109c1a317dd80246d873f0d4a": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0045",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.598176099264786",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999998092195",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "45",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:bcad500e3ad79ca4075f62aa01a372da": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0046",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "5",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0762442725183751",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.388074947166389",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999997796430203",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.620919915466222",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "46",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:b41f8e4d939b3ddb2c20cae93fb8b7c8": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0047",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999997153",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "47",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:4545f5ed2d2381e9f6f1aaf307289882": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0048",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.598176099264786",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999998092195",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "48",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:2253c054073552510a00e5cee801efa6": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0049",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0457465635110251",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.509991966452308",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999963189445",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.713988753033231",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "49",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c2c0de5bb03471fb2a8439bc440e1a06": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0050",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999997153",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "50",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:7c7b06e42170e83d79d011d51a1ee2eb": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0051",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999997153",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "51",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:040e702ed12041e2190bf96dfbacadbb": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0052",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.598176099264786",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999998092195",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "52",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:e14e04732107aabcfe52c4ce59b579a8": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0053",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999997153",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "53",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:d77e5bf6a731dcb245ad371bed714586": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0054",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999997153",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "54",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:9575c70a2f76c6d9598daa3848deeb65": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0055",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999997153",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "55",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:75e697b6b2e295644bcfcd0111ce9380": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0056",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999997153",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "56",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:af2094f9b3bb076517fd57cfdea6eba4": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0001",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6631676ab73837c6d950866c315ccf1a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.64907312393188",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.24289493008127",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.9038282474464e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0140710030676051",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0477090229517705",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6631676ab73837c6d950866c315ccf1a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0001",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[36,-76,-12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0dbf46b534dd4d2ded0176cdc0cedff2": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0002",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0e60133e7c39e22e4a371d8f01396b30",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.42078256607056",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.05689095731376",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.13073368393601e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0332963820346506",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0570035031908581",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0e60133e7c39e22e4a371d8f01396b30": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0002",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[20,16,4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9fa6b2358072adca3ed3687d1a6ad221": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0003",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b10dc0afb7a68740e32c8b3be51324ad",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.11829614639282",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.80629858706218",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.68751121871247e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0981605381212231",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.057973541602361",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b10dc0afb7a68740e32c8b3be51324ad": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0003",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[32,26,-6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8ae0f4115317261dd462890c08bba437": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0004",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:5d8a2cdf981ab3e1af47206d152b9767",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.6295690536499",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.39160002492543",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.62597750342064e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.431266600537586",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.146151100945538",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:5d8a2cdf981ab3e1af47206d152b9767": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0004",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[14,10,0]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:50e978588351b61d3b66805ff525e612": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0005",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:9ddd565948e5d4f00a26dac1f2579a39",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.28027057647705",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.94106877436825",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.88477472079707e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0555771763913264",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.057973541602361",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:9ddd565948e5d4f00a26dac1f2579a39": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0005",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-30,26,2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6393cd494948c4e016913a024bb7521d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0006",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d43a0f137c03ba2fb045a1f9b0cf9580",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.88750791549683",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.61196523240772",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.99439861559014e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.208871803486741",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0985996618857355",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d43a0f137c03ba2fb045a1f9b0cf9580": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0006",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-10,8,-2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0e412c92bdfddc09e4e0ed8e0ee261e0": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0007",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:478f26081ca14d44a5b80d0fa6aae340",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.79167556762695",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.53048064119001",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.94248236787364e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.278401885707736",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.109724234977733",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:478f26081ca14d44a5b80d0fa6aae340": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0007",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[10,32,38]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e401e0680e4b9f39743fb11b553b1c5c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0008",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:5414198bcf0cadaac95e83d11c1e4986",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.13094520568848",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.81687144616269",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.2913285620313e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0939877807357308",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.057973541602361",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:5414198bcf0cadaac95e83d11c1e4986": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0008",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[38,-62,52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9ec7ebe2b378f433f22f85f05b5fdb45": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0009",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:29c1e188537e77306058fe2541600682",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.53375339508057",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.41974003817318",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00031340502338606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999410859557",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.627190791526275",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:29c1e188537e77306058fe2541600682": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0009",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[48,-66,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b7750f5b5fe02543fb3c7405c319cb88": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0010",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:90f2fc0acf05dba443a4b7ef95f762af",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.12427711486816",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.81129886370751",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.49762960050582e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0961670813603079",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.057973541602361",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:90f2fc0acf05dba443a4b7ef95f762af": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0010",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[34,-86,12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b974c5e811e7058e7382d5aa3c8a3528": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0011",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a8f982b50bdecc91ff4188b93fb739c1",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.81263160705566",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.54833854810518",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.70355510423315e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.261865695583998",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.109724234977733",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a8f982b50bdecc91ff4188b93fb739c1": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0011",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[38,-84,0]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:931cf9fbf27bd915854b183b1741a9f1": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0012",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f780f4f5a662be3780f45f7b4b2611bd",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.03698205947876",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.73813680545075",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.07846092800568e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.129186074985472",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0665289558024546",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f780f4f5a662be3780f45f7b4b2611bd": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0012",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[44,14,26]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5b72b70272b9bcb49dbf2e54d6ad8c22": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0013",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b6f10f5138c3660277aa70dd12032cc5",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.54248213768005",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.42769760362149",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000304361554228083",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999193580757",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.621536290238473",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b6f10f5138c3660277aa70dd12032cc5": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0013",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[44,16,36]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7bfd939e9f8cb5231d78bd0522e37846": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0014",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:255fa21c87cd23012182686c06be621e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.76414346694946",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.50698548813516",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.287756441539e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.301278778226174",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.109724234977733",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:255fa21c87cd23012182686c06be621e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0014",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-46,-66,-6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:364ab3732572016711f31f4e5557fd6e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0015",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f7f528e3ea098738c5143d0197302233",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.7637345790863",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.62829384243901",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000142650218672435",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999605970761399",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.4902514281085",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f7f528e3ea098738c5143d0197302233": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0015",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-54,-64,-8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d2ff843ea8975b57132bb865c2b6fbf9": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0016",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:2fcc314709a63be2fda7e1e532d3d4ae",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.72126770019531",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.4703211215873",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.905112123892e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.339495974343671",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.116361476817968",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:2fcc314709a63be2fda7e1e532d3d4ae": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0016",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-32,-4,54]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7236c303cef753dc17dbf884b656c94d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0017",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d131ccabcc3b8de9bb52e1695bd4aecf",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.58239698410034",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.35094179562381",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.77770174506431e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.483096159074985",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.15869051476133",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d131ccabcc3b8de9bb52e1695bd4aecf": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0017",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-48,2,36]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:302ec60308493f063ed3e5a8f5fcf98d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0018",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ed63e69d931b5fab18feaf21450ace17",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.53685760498047",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.31158680950662",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.10435570797186e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.53534199025083",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.164697949352297",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ed63e69d931b5fab18feaf21450ace17": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0018",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-36,-72,-16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6e25f8d53bb9ef507aba83f813f590dd": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0019",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6d460284a127a017683c0927fae00495",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.30497598648071",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.21002839344466",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000663609307096413",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999986374",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.833892248434202",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6d460284a127a017683c0927fae00495": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0019",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-32,-62,-18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3cc83dbc8a713c095b81fe8356546c6a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0020",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:acbec3a585d1f4c829873ee4c5c80c86",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.45032644271851",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.23652675669064",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.13501940500749e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.637567785314432",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.172553238762874",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:acbec3a585d1f4c829873ee4c5c80c86": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0020",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-40,44,26]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:385e0f68aa6fd5fcce479853df6deb5b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0021",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:5c9d7269e40a2cbf90ddd137da5e18f1",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.93534564971924",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.78237892531387",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.76683274343881e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.992232302079702",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.355534752244723",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:5c9d7269e40a2cbf90ddd137da5e18f1": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0021",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-46,36,24]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c531c20f5ce207dd2233835ea3d9bc79": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0022",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c9a7f1ed53f731f0361cedcef35b33ed",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.31582498550415",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.11913273798974",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.90150518718513e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.788829013385429",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.227629636206583",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c9a7f1ed53f731f0361cedcef35b33ed": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0022",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[36,54,6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b49b4c68f2b3604962747d8df42ab67d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0023",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:81f55f41dd8fe791358e61cb82016772",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.20391035079956",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.02078923241408",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.900174224163e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.888907080881232",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.284534794626109",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:81f55f41dd8fe791358e61cb82016772": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0023",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[34,-54,-16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:fee61dad4332e6b4e8d9275805803cb3": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0024",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e27f88e4f03cabb2cf71df1eab3c7241",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.13025856018066",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.95574355061526",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.81484867243431e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.935795859458942",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.317914169802101",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e27f88e4f03cabb2cf71df1eab3c7241": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0024",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[50,-30,42]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:fcc08bf56890d61c3eef4f4626ab1951": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0025",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:baf7846dc4e479f4fde108d36bbedb45",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.12145137786865",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.94794832362008",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.94119065879606e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.940339218142555",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.317914169802101",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:baf7846dc4e479f4fde108d36bbedb45": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0025",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-48,-72,2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8559173f67223249cf03dfbc607e0225": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0026",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4718bcf6fa2624049f2a5bb3607e1e3f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.07142877578735",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.90360423611364",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.73853530744694e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.962041692585423",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.337184393501089",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4718bcf6fa2624049f2a5bb3607e1e3f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0026",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-50,-60,54]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0db34b2e71f46d4c78dc1a96c79f4e62": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0027",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:aab8c71ecfd9fbf45ecaebd3d1fcc59f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.04910326004028",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.88377526691462",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.14234872333041e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.969614423231382",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.338354786543303",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:aab8c71ecfd9fbf45ecaebd3d1fcc59f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0027",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[40,26,50]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c0cc60840e7b9ee9aaa1c0601727437c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0028",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:8a00d1d3e16c3c30537d2845ff872d2e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.03750133514404",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.87346153970838",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.36501732217864e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.97307813993255",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.338354786543303",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:8a00d1d3e16c3c30537d2845ff872d2e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0028",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[48,36,18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8c718793e9227c3c800e12ff03cc8e56": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0029",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:09df4ed9154ca248bde0d014c6a82203",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.98517394065857",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.82686644248313",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.48924431299047e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.985149749711103",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.343725851088226",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:09df4ed9154ca248bde0d014c6a82203": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0029",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-6,12,52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0b9be6e11e869c7379662eed0530982e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0030",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:24acc291a9fc11b56b7b2f0aab86fed7",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.42912888526917",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.32410637949606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000443511765463311",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999991693936",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.67356346521577",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:24acc291a9fc11b56b7b2f0aab86fed7": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0030",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-4,8,62]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:eac0fa3f981d5ddf5d2705c3ec096b14": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0031",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c553e1d0b71b1a1f3fc893271d1a5cad",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.97802686691284",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.82049245556254",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.65927397228705e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.986398575034921",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.343725851088226",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c553e1d0b71b1a1f3fc893271d1a5cad": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0031",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[30,40,4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a6467d64303a3d5d1f6d341287e2e1f3": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0032",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:61d83d511d362b1ba93093b9044119c8",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.68345475196838",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.55575789019142",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000188445519391012",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999940398431664",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.55517289861095",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:61d83d511d362b1ba93093b9044119c8": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0032",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[36,34,18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9e53b4f1a52c9fad25b6fb328ec41bba": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0033",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:5dc74fe36ab63489094008050b9e1049",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.50704765319824",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.39537345393762",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000342675238331092",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999782961075",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.627251282283029",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:5dc74fe36ab63489094008050b9e1049": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0033",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[36,38,10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:af9e7acf6186b5253266546bc901424c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0034",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:544893eef3272ef091d0f6aacd62ac4b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.962651014328",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.80677178289556",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.03962776207323e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.988804462680345",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.343725851088226",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:544893eef3272ef091d0f6aacd62ac4b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0034",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-54,-44,58]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:fa647f9168d7f0bcd21af3ab9071c1a0": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0035",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:3ce0819bdee0231da70f1b9c83939335",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.90285301208496",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.75330746420074",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.72582920719012e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99514521861122",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.374097575292501",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3ce0819bdee0231da70f1b9c83939335": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0035",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-36,-46,-18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a16aa33cdcd4f944c2d19a1e783620b9": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0036",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a0774df5866b6378b3d45d566ac6456a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.79155707359314",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.65336542387463",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000129412734908629",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999300576231024",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.470380557191782",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a0774df5866b6378b3d45d566ac6456a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0036",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-56,-48,-16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8926147dc76517b8aeee5d7add626d9b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0037",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:61a16a71cf85ed46deb21d71fc09758b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.71668887138367",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.58582096111834",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000168009721460582",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999863860763777",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.535171903511449",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:61a16a71cf85ed46deb21d71fc09758b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0037",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[10,20,22]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f96f0aeec7dae1fca89614ddec6cd281": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0038",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e8b4f7ea40c55262e503545ee31b525a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.67520260810852",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.54828555853432",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000193873795962807",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999951944421598",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.556255483974051",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e8b4f7ea40c55262e503545ee31b525a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0038",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[32,2,42]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f569330c5f409cea60dea5a04dbe8b60": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0039",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a376eeaa2e1ae5b029e6717533b0a943",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.40211200714111",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.29933621019179",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000484568819258735",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999997648251",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.711591163402231",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a376eeaa2e1ae5b029e6717533b0a943": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0039",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[32,6,50]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2f233b855c18571a400fd833d555d620": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0040",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:3c707ee8e2672da639e6bcaeddf9c3a8",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.65790581703186",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.53261354467296",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000205736742878826",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999969815552823",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.556255483974051",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3c707ee8e2672da639e6bcaeddf9c3a8": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0040",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[52,-46,-12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:fdd6fde4db88f2a34579b6e074832d04": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0041",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:67fc1b6648133c4aeaa468978eb43c62",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.65189146995544",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.5271610730247",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000210020574100245",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999974435806052",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.556255483974051",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:67fc1b6648133c4aeaa468978eb43c62": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0041",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-58,-32,-18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d19e5a67d45d5321017795f6126c01ba": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0042",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c91b5206da9ad3a664a273dd090ed4b6",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.64102125167847",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.51730234983075",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000217978445002265",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999981178646875",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.563557397391532",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c91b5206da9ad3a664a273dd090ed4b6": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0042",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-18,-62,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7245866a3fef562524fce007658a5b36": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0043",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6b5778113070472a0309ccefc99af0fe",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.59891152381897",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.47906223189298",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000251585861886783",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999994666564726",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.608753808165271",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6b5778113070472a0309ccefc99af0fe": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0043",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-60,-16,28]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:77917bfc1da98a7e7fe2dc75f6551b37": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0044",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:1cbd357b2c0b627b8be0812023192e3f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.59028053283691",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.47121483404478",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00025905465370224",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999995943640527",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.608753808165271",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:1cbd357b2c0b627b8be0812023192e3f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0044",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[62,-44,32]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:35fb5dd9515d518d6fbdee4b3aad7697": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0045",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ee73ad3b5f7d69b81f88d9b833912dd0",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.58877372741699",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.46984449735368",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000260379883662454",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999996135035316",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.608753808165271",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ee73ad3b5f7d69b81f88d9b833912dd0": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0045",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-50,40,20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c457ecf797faf07f550dddfa0aace5e2": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0046",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:3af2d58dffdb8013ed1ab23429910b14",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.58837461471558",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.46948151508978",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000260731974812578",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999996184305011",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.608753808165271",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3af2d58dffdb8013ed1ab23429910b14": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0046",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[4,8,34]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0979a7e014454d80d5e3b40e2f809329": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0047",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:3035aa8d3d60fd9342cf2f6fb7f6a8e2",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.55357313156128",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.43780399293293",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000293226018116655",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999998808594853",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.621536290238473",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3035aa8d3d60fd9342cf2f6fb7f6a8e2": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0047",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[54,-26,-4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4194c281db5a3d0d67f0dc86fdc77920": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0048",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:2a753c708cb52b15a61196f673a461cc",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.51040363311768",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.39843715827212",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000338860153926701",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999753151302",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.627251282283029",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:2a753c708cb52b15a61196f673a461cc": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0048",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-40,-38,44]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3fd55577a54074d75160c0c642d5409a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0049",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d0c5dcc9377f764db96420f38f011a61",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.50392317771912",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.39252066023161",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000346263546256664",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999807631623",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.627251282283029",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d0c5dcc9377f764db96420f38f011a61": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0049",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-12,-98,-2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:103473966f8ff9bcc2cc5ec2a713befb": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0050",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:77583c290903d4e0cb5367a1b29849f3",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.49028921127319",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.38006733866351",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000362340362275559",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999887466235",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.63276782328386",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:77583c290903d4e0cb5367a1b29849f3": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0050",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-52,-52,20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9abbf59e1fcfcc54cc8216a4ebac476d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0051",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a43e5ac46ddb78e8178ab1b56b3625ec",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.47890019416809",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.36965850607739",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00037630695868629",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999928964277",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.634508717964232",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a43e5ac46ddb78e8178ab1b56b3625ec": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0051",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-30,-72,60]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:160afe9ba06379a115015285c8be81d6": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0052",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:bd58ee341d5220f443405c692b1b6ecf",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.46000862121582",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.35238069902703",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000400598817755116",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999967703129",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.651507233165067",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:bd58ee341d5220f443405c692b1b6ecf": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0052",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-32,-74,-34]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5fad6fb58b1dab2b17eef5948c9c92c0": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0053",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:26e681001041d03072cb023b45a19ae6",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.43550229072571",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.32994532400952",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000434315195478541",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999988927098",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.670363379742284",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:26e681001041d03072cb023b45a19ae6": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0053",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[22,44,-16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c29148dcd4002758ce86038f7b4ca401": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0054",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6a4b4afe1e56c908285ae25761fa1e7a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.39615654945374",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.29387191012244",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000494087591703773",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999998236237",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.714296799125479",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6a4b4afe1e56c908285ae25761fa1e7a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0054",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-50,-44,-34]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:adde53039c55af81c35408a4bd174215": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0055",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:175d8df12f2e8550c70e8fe728a6157b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.3674840927124",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.26754352373899",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000542425921699285",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999580025",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.757181401908473",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:175d8df12f2e8550c70e8fe728a6157b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0055",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[40,-88,6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:34836d3b3ca4536242e85f8dbf0eaec9": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0056",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0ad0ba7ec6488d93289684ea60e3d1ed",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.35621929168701",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.25719036010207",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000562604729181126",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999766468",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.769744720456333",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0ad0ba7ec6488d93289684ea60e3d1ed": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0056",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-64,-32,46]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:056318bce8477b3efd14b0f6d507c3b4": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0057",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0dac9d762d87c922e37133ba1065f763",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.32532405853271",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.22876865896546",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000621622108231912",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999995642",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.811282559503343",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0dac9d762d87c922e37133ba1065f763": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0057",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-54,-32,42]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8f0b0d4d20de8f18555fe5e10680d0c3": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0058",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c333bb1f426e6621b3f21f7cd8532aee",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.3036584854126",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.20881441467256",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000666417461998026",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999987382",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.833892248434202",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c333bb1f426e6621b3f21f7cd8532aee": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0058",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[44,16,8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5cd0e7e590a22b0339b125fff010c6c7": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0059",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:5082af9f1f2be4a41ca2e0721da7fa71",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.30078315734863",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.2061647702223",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000672584694407008",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999989338",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.833892248434202",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:5082af9f1f2be4a41ca2e0721da7fa71": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0059",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[24,36,22]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:816f143f7b83c21ef577cc3a8b9c39a3": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0060",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:db3c1c1d13496dbcae13ca3ecec8f2d1",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.28121852874756",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.18812687854183",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000715988437604564",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999996695",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.864080797399493",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:db3c1c1d13496dbcae13ca3ecec8f2d1": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0060",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[42,44,10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:cdbd489b9fe249b9a71c29b770e2f4c4": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0061",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:16ee8694a7956d27653067c326b9b5d5",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.26455140113831",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.17274820463022",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000755017120229184",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999998824",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.889209349007764",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:16ee8694a7956d27653067c326b9b5d5": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0061",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-54,6,42]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:27882a721f1cf5fa0b9ff4467a197b13": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0062",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7ba1d81106866072c384e2e653d9e606",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.2516782283783",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.16086256336622",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000786513505130482",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999482",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.898782253348965",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7ba1d81106866072c384e2e653d9e606": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0062",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[6,32,18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:692ab3bf7a5c7c16857d166b15f0fc4a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0063",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:aa568f96f20e56c9548d5ad31273d197",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.25153398513794",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.16072934780164",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000786873276886202",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999487",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.898782253348965",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:aa568f96f20e56c9548d5ad31273d197": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0063",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-32,36,18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1dfc374a28a2a395f47b36b9ee3103b1": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0064",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:237da29f8b420440ba0df45b565b6643",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.22331190109253",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.13464894829369",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000860299398633191",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999921",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.948209393065872",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:237da29f8b420440ba0df45b565b6643": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0064",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[42,-86,12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:99d98ff39073ff123cf9b9bc0586da2c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0065",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:208152a8191e8072a02647fe58186344",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.21240544319153",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.1245616797579",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000890350923619998",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999963",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.948209393065872",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:208152a8191e8072a02647fe58186344": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0065",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[6,32,22]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:847abc12c3303cd0921e0bc7775893a2": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0066",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6d6402d8a1e70f09f4b8652c55b3f9ad",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.21144485473633",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.12367301635021",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000893044111823671",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999965",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.948209393065872",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6d6402d8a1e70f09f4b8652c55b3f9ad": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0066",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[22,-66,34]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:cbcaaf82c3acb8ecaba54ed445353762": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0067",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b78bd3956f68aeb44993a6fe8f8023d8",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.21088981628418",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.12315952037414",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00089460372708472",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999966",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.948209393065872",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b78bd3956f68aeb44993a6fe8f8023d8": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0067",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-46,28,-10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:82d3cc604f3e16683c4c3de6c5e42b0a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0068",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7f5d6d95284b9c0ef666dbe7ff15a28d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.20743656158447",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.11996445543627",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000904364321047457",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999974",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.948209393065872",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7f5d6d95284b9c0ef666dbe7ff15a28d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0068",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[52,-44,18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:fbde6e6581200f6c0a84e21ed621fc09": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0069",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:3891bdd206293e275b3c60f15c905d3d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.2013533115387",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.11433488942651",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000921800539615547",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999983",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.952610967842716",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3891bdd206293e275b3c60f15c905d3d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0069",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-24,52,30]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8119527ea4cfcfa60201f74ffff03743": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0070",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:bbdbc2effb2f18786476efc80d031be4",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.17790174484253",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.09261872722341",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000991994268753738",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999997",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.994677620170821",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:bbdbc2effb2f18786476efc80d031be4": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0070",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[46,24,0]",
+                "type": "xsd:string"
+            }
+        }
+    },
+    "activity": {
+        "niiri:d07cda9b146f92aa2083034127524fe1": {
+            "prov:type": {
+                "$": "nidm_ModelParametersEstimation:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Model parameters estimation",
+                "type": "xsd:string"
+            },
+            "nidm_withEstimationMethod:": {
+                "$": "obo_generalizedleastsquaresestimation:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:113d1d799a4615cbe8865b4df8a089fa": {
+            "prov:type": {
+                "$": "nidm_ContrastEstimation:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Contrast estimation 1",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8872a3798f2cb652dd632d9e9e40ecf9": {
+            "prov:type": {
+                "$": "nidm_ContrastEstimation:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Contrast estimation 2",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:16a9b96282eb00365725e2a0f6d310c6": {
+            "prov:type": {
+                "$": "nidm_ConjunctionInference:",
+                "type": "xsd:QName"
+            },
+            "nidm_hasAlternativeHypothesis:": {
+                "$": "nidm_OneTailedTest:",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Conjunction Inference",
+                "type": "xsd:string"
+            }
+        }
+    },
+    "agent": {
+        "niiri:016e3cb0f11ba49dad327f9752892d7f": {
+            "prov:type": [
+                {
+                "$": "src_SPM:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "prov:SoftwareAgent",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "SPM",
+                "type": "xsd:string"
+            },
+            "nidm_softwareVersion:": {
+                "$": "12.6906",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ccc4cd6d044e67a15c8666fea99b3166": {
+            "prov:type": [
+                {
+                "$": "nlx_Imaginginstrument:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nlx_Magneticresonanceimagingscanner:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "MRI Scanner",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8d49fa3ebfc5510866661667640b7637": {
+            "prov:type": {
+                "$": "prov:Person",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Person",
+                "type": "xsd:string"
+            }
+        }
+    },
+    "wasGeneratedBy": {
+        "_:wGB20": {
+            "prov:entity": "niiri:e5a61d0bc28607c2ab613b81ddf8392a",
+            "prov:activity": "niiri:d07cda9b146f92aa2083034127524fe1"
+        },
+        "_:wGB22": {
+            "prov:entity": "niiri:9dbd735c07b927aa96e9892b2a28602a",
+            "prov:activity": "niiri:d07cda9b146f92aa2083034127524fe1"
+        },
+        "_:wGB26": {
+            "prov:entity": "niiri:892dc0fa4cc25ca47ac73ddd6f0f1a71",
+            "prov:activity": "niiri:d07cda9b146f92aa2083034127524fe1"
+        },
+        "_:wGB30": {
+            "prov:entity": "niiri:fcebd635515316804e6601daa6f10239",
+            "prov:activity": "niiri:d07cda9b146f92aa2083034127524fe1"
+        },
+        "_:wGB34": {
+            "prov:entity": "niiri:0a600229532c0ed2e05bd43494a1c6c3",
+            "prov:activity": "niiri:d07cda9b146f92aa2083034127524fe1"
+        },
+        "_:wGB38": {
+            "prov:entity": "niiri:03bc9932821688679785b6bbb6b7186e",
+            "prov:activity": "niiri:d07cda9b146f92aa2083034127524fe1"
+        },
+        "_:wGB42": {
+            "prov:entity": "niiri:19b287a58457b527aca30843e6e34d84",
+            "prov:activity": "niiri:d07cda9b146f92aa2083034127524fe1"
+        },
+        "_:wGB56": {
+            "prov:entity": "niiri:7766f91f9fb3c7a19f3ae5bf1f752bbf",
+            "prov:activity": "niiri:113d1d799a4615cbe8865b4df8a089fa"
+        },
+        "_:wGB60": {
+            "prov:entity": "niiri:af18c6b272b9c41779a5c9b4adefcb28",
+            "prov:activity": "niiri:113d1d799a4615cbe8865b4df8a089fa"
+        },
+        "_:wGB62": {
+            "prov:entity": "niiri:4a46cd703e5066038138c81d0134cb7b",
+            "prov:activity": "niiri:113d1d799a4615cbe8865b4df8a089fa"
+        },
+        "_:wGB76": {
+            "prov:entity": "niiri:d40b3bf5490868f622f2357adea722a9",
+            "prov:activity": "niiri:8872a3798f2cb652dd632d9e9e40ecf9"
+        },
+        "_:wGB80": {
+            "prov:entity": "niiri:98bad5417f97850e2a27b2644953d7fc",
+            "prov:activity": "niiri:8872a3798f2cb652dd632d9e9e40ecf9"
+        },
+        "_:wGB82": {
+            "prov:entity": "niiri:5755b406b2a82f8a36a4c0c23054e6ee",
+            "prov:activity": "niiri:8872a3798f2cb652dd632d9e9e40ecf9"
+        },
+        "_:wGB102": {
+            "prov:entity": "niiri:61ba90688ed17ead0aa46ba07adc7f73",
+            "prov:activity": "niiri:16a9b96282eb00365725e2a0f6d310c6"
+        },
+        "_:wGB106": {
+            "prov:entity": "niiri:88829929c68a059331cc3c1d60afeecb",
+            "prov:activity": "niiri:16a9b96282eb00365725e2a0f6d310c6"
+        }
+    },
+    "used": {
+        "_:u14": {
+            "prov:activity": "niiri:d07cda9b146f92aa2083034127524fe1",
+            "prov:entity": "niiri:6387ede10972f2c9e2051e4ae79a4a2e"
+        },
+        "_:u15": {
+            "prov:activity": "niiri:d07cda9b146f92aa2083034127524fe1",
+            "prov:entity": "niiri:b5f5299dd88c01663688131c711c2a74"
+        },
+        "_:u16": {
+            "prov:activity": "niiri:d07cda9b146f92aa2083034127524fe1",
+            "prov:entity": "niiri:0fd0329c3adb2f4836f2747833babe88"
+        },
+        "_:u46": {
+            "prov:activity": "niiri:113d1d799a4615cbe8865b4df8a089fa",
+            "prov:entity": "niiri:e5a61d0bc28607c2ab613b81ddf8392a"
+        },
+        "_:u47": {
+            "prov:activity": "niiri:113d1d799a4615cbe8865b4df8a089fa",
+            "prov:entity": "niiri:03bc9932821688679785b6bbb6b7186e"
+        },
+        "_:u48": {
+            "prov:activity": "niiri:113d1d799a4615cbe8865b4df8a089fa",
+            "prov:entity": "niiri:6387ede10972f2c9e2051e4ae79a4a2e"
+        },
+        "_:u49": {
+            "prov:activity": "niiri:113d1d799a4615cbe8865b4df8a089fa",
+            "prov:entity": "niiri:92324b5901796c34f58222905ccfed17"
+        },
+        "_:u50": {
+            "prov:activity": "niiri:113d1d799a4615cbe8865b4df8a089fa",
+            "prov:entity": "niiri:892dc0fa4cc25ca47ac73ddd6f0f1a71"
+        },
+        "_:u51": {
+            "prov:activity": "niiri:113d1d799a4615cbe8865b4df8a089fa",
+            "prov:entity": "niiri:fcebd635515316804e6601daa6f10239"
+        },
+        "_:u52": {
+            "prov:activity": "niiri:113d1d799a4615cbe8865b4df8a089fa",
+            "prov:entity": "niiri:0a600229532c0ed2e05bd43494a1c6c3"
+        },
+        "_:u66": {
+            "prov:activity": "niiri:8872a3798f2cb652dd632d9e9e40ecf9",
+            "prov:entity": "niiri:e5a61d0bc28607c2ab613b81ddf8392a"
+        },
+        "_:u67": {
+            "prov:activity": "niiri:8872a3798f2cb652dd632d9e9e40ecf9",
+            "prov:entity": "niiri:03bc9932821688679785b6bbb6b7186e"
+        },
+        "_:u68": {
+            "prov:activity": "niiri:8872a3798f2cb652dd632d9e9e40ecf9",
+            "prov:entity": "niiri:6387ede10972f2c9e2051e4ae79a4a2e"
+        },
+        "_:u69": {
+            "prov:activity": "niiri:8872a3798f2cb652dd632d9e9e40ecf9",
+            "prov:entity": "niiri:42481f8ce49fff367fe85c2f158deed5"
+        },
+        "_:u70": {
+            "prov:activity": "niiri:8872a3798f2cb652dd632d9e9e40ecf9",
+            "prov:entity": "niiri:892dc0fa4cc25ca47ac73ddd6f0f1a71"
+        },
+        "_:u71": {
+            "prov:activity": "niiri:8872a3798f2cb652dd632d9e9e40ecf9",
+            "prov:entity": "niiri:fcebd635515316804e6601daa6f10239"
+        },
+        "_:u72": {
+            "prov:activity": "niiri:8872a3798f2cb652dd632d9e9e40ecf9",
+            "prov:entity": "niiri:0a600229532c0ed2e05bd43494a1c6c3"
+        },
+        "_:u93": {
+            "prov:activity": "niiri:16a9b96282eb00365725e2a0f6d310c6",
+            "prov:entity": "niiri:d929d3c4d45d3c1d6b9b03fb2445f0d9"
+        },
+        "_:u94": {
+            "prov:activity": "niiri:16a9b96282eb00365725e2a0f6d310c6",
+            "prov:entity": "niiri:8d783286b1c008ac28fe81706432e884"
+        },
+        "_:u95": {
+            "prov:activity": "niiri:16a9b96282eb00365725e2a0f6d310c6",
+            "prov:entity": "niiri:7766f91f9fb3c7a19f3ae5bf1f752bbf"
+        },
+        "_:u96": {
+            "prov:activity": "niiri:16a9b96282eb00365725e2a0f6d310c6",
+            "prov:entity": "niiri:d40b3bf5490868f622f2357adea722a9"
+        },
+        "_:u97": {
+            "prov:activity": "niiri:16a9b96282eb00365725e2a0f6d310c6",
+            "prov:entity": "niiri:19b287a58457b527aca30843e6e34d84"
+        },
+        "_:u98": {
+            "prov:activity": "niiri:16a9b96282eb00365725e2a0f6d310c6",
+            "prov:entity": "niiri:e5a61d0bc28607c2ab613b81ddf8392a"
+        },
+        "_:u99": {
+            "prov:activity": "niiri:16a9b96282eb00365725e2a0f6d310c6",
+            "prov:entity": "niiri:245e81118425b6790f11b064e4eca94d"
+        },
+        "_:u100": {
+            "prov:activity": "niiri:16a9b96282eb00365725e2a0f6d310c6",
+            "prov:entity": "niiri:04fa6b9288815b12d59a8ed5850b4b8e"
+        }
+    },
+    "wasDerivedFrom": {
+        "_:wDF19": {
+            "prov:generatedEntity": "niiri:e5a61d0bc28607c2ab613b81ddf8392a",
+            "prov:usedEntity": "niiri:8d425ac5fbd3a8eb1e7cc62ff8035271"
+        },
+        "_:wDF25": {
+            "prov:generatedEntity": "niiri:892dc0fa4cc25ca47ac73ddd6f0f1a71",
+            "prov:usedEntity": "niiri:565b0e81e599439b221f8fc7d899038a"
+        },
+        "_:wDF29": {
+            "prov:generatedEntity": "niiri:fcebd635515316804e6601daa6f10239",
+            "prov:usedEntity": "niiri:2b4b7fb2c844c1b29d66eb66f2f6bb24"
+        },
+        "_:wDF33": {
+            "prov:generatedEntity": "niiri:0a600229532c0ed2e05bd43494a1c6c3",
+            "prov:usedEntity": "niiri:6e470aa79f85c054fb351adb5db48bd3"
+        },
+        "_:wDF37": {
+            "prov:generatedEntity": "niiri:03bc9932821688679785b6bbb6b7186e",
+            "prov:usedEntity": "niiri:1788822bb0780f90238ce40ec64b7c8f"
+        },
+        "_:wDF41": {
+            "prov:generatedEntity": "niiri:19b287a58457b527aca30843e6e34d84",
+            "prov:usedEntity": "niiri:9536f7d3d8c806ff604d922fcfc13f49"
+        },
+        "_:wDF55": {
+            "prov:generatedEntity": "niiri:7766f91f9fb3c7a19f3ae5bf1f752bbf",
+            "prov:usedEntity": "niiri:df8317112ad27782b9be9c9adbafa6af"
+        },
+        "_:wDF59": {
+            "prov:generatedEntity": "niiri:af18c6b272b9c41779a5c9b4adefcb28",
+            "prov:usedEntity": "niiri:f584b30e1a30a67223f05b204465e66d"
+        },
+        "_:wDF75": {
+            "prov:generatedEntity": "niiri:d40b3bf5490868f622f2357adea722a9",
+            "prov:usedEntity": "niiri:70992ac15b69b7bd18e58cc3b80cf441"
+        },
+        "_:wDF79": {
+            "prov:generatedEntity": "niiri:98bad5417f97850e2a27b2644953d7fc",
+            "prov:usedEntity": "niiri:cbc99abbec6b9d1c6aedcd2e278aabcd"
+        },
+        "_:wDF108": {
+            "prov:generatedEntity": "niiri:0fe5639ac98706c7b3899db7801a8bf2",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF110": {
+            "prov:generatedEntity": "niiri:2975c7a00a3fc4010192cdde06218e42",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF112": {
+            "prov:generatedEntity": "niiri:022596b73b46d7ef5ae45ede7165a0d5",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF114": {
+            "prov:generatedEntity": "niiri:9170484cbff3981334345a4c47f65aa7",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF116": {
+            "prov:generatedEntity": "niiri:25e87116b614d88934e1e8c93fcc0b63",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF118": {
+            "prov:generatedEntity": "niiri:c71e617484a5b302959dff7c4db9cc74",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF120": {
+            "prov:generatedEntity": "niiri:b1e379a1ec5bd17c690d79aba04d4080",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF122": {
+            "prov:generatedEntity": "niiri:4672418600c089d526b22d32d479dd1e",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF124": {
+            "prov:generatedEntity": "niiri:67a283ee599be31793e69bea3826f055",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF126": {
+            "prov:generatedEntity": "niiri:7640c37d58f807f183dbb16f5cce885a",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF128": {
+            "prov:generatedEntity": "niiri:8cfc21f5bbcf34401f68b224da91bb62",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF130": {
+            "prov:generatedEntity": "niiri:dfe1db9cfb99ba668d8eeb1e01c32a4f",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF132": {
+            "prov:generatedEntity": "niiri:8b21d35a1fc7a9cfb360ad2121638da7",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF134": {
+            "prov:generatedEntity": "niiri:988a6212fa64a63474847b473adbd268",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF136": {
+            "prov:generatedEntity": "niiri:0d10036870ecd78a22c4b7434f3e940f",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF138": {
+            "prov:generatedEntity": "niiri:7e1995dcc209b0990e86feb660922162",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF140": {
+            "prov:generatedEntity": "niiri:b4757e6c4de815acef5afdb0476f0eb3",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF142": {
+            "prov:generatedEntity": "niiri:f8221060362a62c937dd97233413a960",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF144": {
+            "prov:generatedEntity": "niiri:af4c8a0d8ff5cfb976a7e9746756d8e3",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF146": {
+            "prov:generatedEntity": "niiri:866201193f458cd1f0d7d30bfc40b674",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF148": {
+            "prov:generatedEntity": "niiri:2627b433d92d75102b82469256c03339",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF150": {
+            "prov:generatedEntity": "niiri:601904871dc4878169c4db748733771d",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF152": {
+            "prov:generatedEntity": "niiri:0a7cd6ed9222066e8fdf471bab1ee6e7",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF154": {
+            "prov:generatedEntity": "niiri:d2a33a86263a0cb45dbf1c9cce5a8dd4",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF156": {
+            "prov:generatedEntity": "niiri:ab0144b9188c24f978e07874f53ac025",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF158": {
+            "prov:generatedEntity": "niiri:c584015fa24c7c926f0b58301e5d61f2",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF160": {
+            "prov:generatedEntity": "niiri:b575189f3bd68971936993d3aa187cb2",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF162": {
+            "prov:generatedEntity": "niiri:e8cd31e50a3c32fbe2bbcc0095269056",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF164": {
+            "prov:generatedEntity": "niiri:e97474fed9ca8bf394b41d386552ec23",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF166": {
+            "prov:generatedEntity": "niiri:abd9e58304894c9547b23ee1045ac1da",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF168": {
+            "prov:generatedEntity": "niiri:f35fdf14b958462f212cb7e02a3f5b6a",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF170": {
+            "prov:generatedEntity": "niiri:65aa1110e7a5b158b24b46e37675c86f",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF172": {
+            "prov:generatedEntity": "niiri:7d8d48b7315eff2905773178ffd49023",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF174": {
+            "prov:generatedEntity": "niiri:62e2c2069415d9aa3cc91424a7a036cf",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF176": {
+            "prov:generatedEntity": "niiri:2deb14df5037616ae2a96835f77312be",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF178": {
+            "prov:generatedEntity": "niiri:5b409e333f6b39e5bc61b32b5cdb5358",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF180": {
+            "prov:generatedEntity": "niiri:aa433f26589b155235af6a6df23091d5",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF182": {
+            "prov:generatedEntity": "niiri:d220eb8d00595929d9a913e79e63f18d",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF184": {
+            "prov:generatedEntity": "niiri:b25a22f3e4eb9bbd1275897ff1df109d",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF186": {
+            "prov:generatedEntity": "niiri:bd4658613e97b52c7228dc395dd15873",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF188": {
+            "prov:generatedEntity": "niiri:453c0a23d3b7bdaf631090a39026b948",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF190": {
+            "prov:generatedEntity": "niiri:f9cadf3213379a88a9727fcf6a9eeef1",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF192": {
+            "prov:generatedEntity": "niiri:00e7e2184e288d14e023360536c4ccbb",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF194": {
+            "prov:generatedEntity": "niiri:1e198daa9971af9c5562116948147b44",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF196": {
+            "prov:generatedEntity": "niiri:b983603109c1a317dd80246d873f0d4a",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF198": {
+            "prov:generatedEntity": "niiri:bcad500e3ad79ca4075f62aa01a372da",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF200": {
+            "prov:generatedEntity": "niiri:b41f8e4d939b3ddb2c20cae93fb8b7c8",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF202": {
+            "prov:generatedEntity": "niiri:4545f5ed2d2381e9f6f1aaf307289882",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF204": {
+            "prov:generatedEntity": "niiri:2253c054073552510a00e5cee801efa6",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF206": {
+            "prov:generatedEntity": "niiri:c2c0de5bb03471fb2a8439bc440e1a06",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF208": {
+            "prov:generatedEntity": "niiri:7c7b06e42170e83d79d011d51a1ee2eb",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF210": {
+            "prov:generatedEntity": "niiri:040e702ed12041e2190bf96dfbacadbb",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF212": {
+            "prov:generatedEntity": "niiri:e14e04732107aabcfe52c4ce59b579a8",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF214": {
+            "prov:generatedEntity": "niiri:d77e5bf6a731dcb245ad371bed714586",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF216": {
+            "prov:generatedEntity": "niiri:9575c70a2f76c6d9598daa3848deeb65",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF218": {
+            "prov:generatedEntity": "niiri:75e697b6b2e295644bcfcd0111ce9380",
+            "prov:usedEntity": "niiri:88829929c68a059331cc3c1d60afeecb"
+        },
+        "_:wDF221": {
+            "prov:generatedEntity": "niiri:af2094f9b3bb076517fd57cfdea6eba4",
+            "prov:usedEntity": "niiri:0fe5639ac98706c7b3899db7801a8bf2"
+        },
+        "_:wDF224": {
+            "prov:generatedEntity": "niiri:0dbf46b534dd4d2ded0176cdc0cedff2",
+            "prov:usedEntity": "niiri:2975c7a00a3fc4010192cdde06218e42"
+        },
+        "_:wDF227": {
+            "prov:generatedEntity": "niiri:9fa6b2358072adca3ed3687d1a6ad221",
+            "prov:usedEntity": "niiri:2975c7a00a3fc4010192cdde06218e42"
+        },
+        "_:wDF230": {
+            "prov:generatedEntity": "niiri:8ae0f4115317261dd462890c08bba437",
+            "prov:usedEntity": "niiri:2975c7a00a3fc4010192cdde06218e42"
+        },
+        "_:wDF233": {
+            "prov:generatedEntity": "niiri:50e978588351b61d3b66805ff525e612",
+            "prov:usedEntity": "niiri:022596b73b46d7ef5ae45ede7165a0d5"
+        },
+        "_:wDF236": {
+            "prov:generatedEntity": "niiri:6393cd494948c4e016913a024bb7521d",
+            "prov:usedEntity": "niiri:022596b73b46d7ef5ae45ede7165a0d5"
+        },
+        "_:wDF239": {
+            "prov:generatedEntity": "niiri:0e412c92bdfddc09e4e0ed8e0ee261e0",
+            "prov:usedEntity": "niiri:022596b73b46d7ef5ae45ede7165a0d5"
+        },
+        "_:wDF242": {
+            "prov:generatedEntity": "niiri:e401e0680e4b9f39743fb11b553b1c5c",
+            "prov:usedEntity": "niiri:9170484cbff3981334345a4c47f65aa7"
+        },
+        "_:wDF245": {
+            "prov:generatedEntity": "niiri:9ec7ebe2b378f433f22f85f05b5fdb45",
+            "prov:usedEntity": "niiri:9170484cbff3981334345a4c47f65aa7"
+        },
+        "_:wDF248": {
+            "prov:generatedEntity": "niiri:b7750f5b5fe02543fb3c7405c319cb88",
+            "prov:usedEntity": "niiri:25e87116b614d88934e1e8c93fcc0b63"
+        },
+        "_:wDF251": {
+            "prov:generatedEntity": "niiri:b974c5e811e7058e7382d5aa3c8a3528",
+            "prov:usedEntity": "niiri:25e87116b614d88934e1e8c93fcc0b63"
+        },
+        "_:wDF254": {
+            "prov:generatedEntity": "niiri:931cf9fbf27bd915854b183b1741a9f1",
+            "prov:usedEntity": "niiri:c71e617484a5b302959dff7c4db9cc74"
+        },
+        "_:wDF257": {
+            "prov:generatedEntity": "niiri:5b72b70272b9bcb49dbf2e54d6ad8c22",
+            "prov:usedEntity": "niiri:c71e617484a5b302959dff7c4db9cc74"
+        },
+        "_:wDF260": {
+            "prov:generatedEntity": "niiri:7bfd939e9f8cb5231d78bd0522e37846",
+            "prov:usedEntity": "niiri:b1e379a1ec5bd17c690d79aba04d4080"
+        },
+        "_:wDF263": {
+            "prov:generatedEntity": "niiri:364ab3732572016711f31f4e5557fd6e",
+            "prov:usedEntity": "niiri:b1e379a1ec5bd17c690d79aba04d4080"
+        },
+        "_:wDF266": {
+            "prov:generatedEntity": "niiri:d2ff843ea8975b57132bb865c2b6fbf9",
+            "prov:usedEntity": "niiri:4672418600c089d526b22d32d479dd1e"
+        },
+        "_:wDF269": {
+            "prov:generatedEntity": "niiri:7236c303cef753dc17dbf884b656c94d",
+            "prov:usedEntity": "niiri:67a283ee599be31793e69bea3826f055"
+        },
+        "_:wDF272": {
+            "prov:generatedEntity": "niiri:302ec60308493f063ed3e5a8f5fcf98d",
+            "prov:usedEntity": "niiri:7640c37d58f807f183dbb16f5cce885a"
+        },
+        "_:wDF275": {
+            "prov:generatedEntity": "niiri:6e25f8d53bb9ef507aba83f813f590dd",
+            "prov:usedEntity": "niiri:7640c37d58f807f183dbb16f5cce885a"
+        },
+        "_:wDF278": {
+            "prov:generatedEntity": "niiri:3cc83dbc8a713c095b81fe8356546c6a",
+            "prov:usedEntity": "niiri:8cfc21f5bbcf34401f68b224da91bb62"
+        },
+        "_:wDF281": {
+            "prov:generatedEntity": "niiri:385e0f68aa6fd5fcce479853df6deb5b",
+            "prov:usedEntity": "niiri:8cfc21f5bbcf34401f68b224da91bb62"
+        },
+        "_:wDF284": {
+            "prov:generatedEntity": "niiri:c531c20f5ce207dd2233835ea3d9bc79",
+            "prov:usedEntity": "niiri:dfe1db9cfb99ba668d8eeb1e01c32a4f"
+        },
+        "_:wDF287": {
+            "prov:generatedEntity": "niiri:b49b4c68f2b3604962747d8df42ab67d",
+            "prov:usedEntity": "niiri:8b21d35a1fc7a9cfb360ad2121638da7"
+        },
+        "_:wDF290": {
+            "prov:generatedEntity": "niiri:fee61dad4332e6b4e8d9275805803cb3",
+            "prov:usedEntity": "niiri:988a6212fa64a63474847b473adbd268"
+        },
+        "_:wDF293": {
+            "prov:generatedEntity": "niiri:fcc08bf56890d61c3eef4f4626ab1951",
+            "prov:usedEntity": "niiri:0d10036870ecd78a22c4b7434f3e940f"
+        },
+        "_:wDF296": {
+            "prov:generatedEntity": "niiri:8559173f67223249cf03dfbc607e0225",
+            "prov:usedEntity": "niiri:7e1995dcc209b0990e86feb660922162"
+        },
+        "_:wDF299": {
+            "prov:generatedEntity": "niiri:0db34b2e71f46d4c78dc1a96c79f4e62",
+            "prov:usedEntity": "niiri:b4757e6c4de815acef5afdb0476f0eb3"
+        },
+        "_:wDF302": {
+            "prov:generatedEntity": "niiri:c0cc60840e7b9ee9aaa1c0601727437c",
+            "prov:usedEntity": "niiri:f8221060362a62c937dd97233413a960"
+        },
+        "_:wDF305": {
+            "prov:generatedEntity": "niiri:8c718793e9227c3c800e12ff03cc8e56",
+            "prov:usedEntity": "niiri:af4c8a0d8ff5cfb976a7e9746756d8e3"
+        },
+        "_:wDF308": {
+            "prov:generatedEntity": "niiri:0b9be6e11e869c7379662eed0530982e",
+            "prov:usedEntity": "niiri:af4c8a0d8ff5cfb976a7e9746756d8e3"
+        },
+        "_:wDF311": {
+            "prov:generatedEntity": "niiri:eac0fa3f981d5ddf5d2705c3ec096b14",
+            "prov:usedEntity": "niiri:866201193f458cd1f0d7d30bfc40b674"
+        },
+        "_:wDF314": {
+            "prov:generatedEntity": "niiri:a6467d64303a3d5d1f6d341287e2e1f3",
+            "prov:usedEntity": "niiri:866201193f458cd1f0d7d30bfc40b674"
+        },
+        "_:wDF317": {
+            "prov:generatedEntity": "niiri:9e53b4f1a52c9fad25b6fb328ec41bba",
+            "prov:usedEntity": "niiri:866201193f458cd1f0d7d30bfc40b674"
+        },
+        "_:wDF320": {
+            "prov:generatedEntity": "niiri:af9e7acf6186b5253266546bc901424c",
+            "prov:usedEntity": "niiri:2627b433d92d75102b82469256c03339"
+        },
+        "_:wDF323": {
+            "prov:generatedEntity": "niiri:fa647f9168d7f0bcd21af3ab9071c1a0",
+            "prov:usedEntity": "niiri:601904871dc4878169c4db748733771d"
+        },
+        "_:wDF326": {
+            "prov:generatedEntity": "niiri:a16aa33cdcd4f944c2d19a1e783620b9",
+            "prov:usedEntity": "niiri:0a7cd6ed9222066e8fdf471bab1ee6e7"
+        },
+        "_:wDF329": {
+            "prov:generatedEntity": "niiri:8926147dc76517b8aeee5d7add626d9b",
+            "prov:usedEntity": "niiri:d2a33a86263a0cb45dbf1c9cce5a8dd4"
+        },
+        "_:wDF332": {
+            "prov:generatedEntity": "niiri:f96f0aeec7dae1fca89614ddec6cd281",
+            "prov:usedEntity": "niiri:ab0144b9188c24f978e07874f53ac025"
+        },
+        "_:wDF335": {
+            "prov:generatedEntity": "niiri:f569330c5f409cea60dea5a04dbe8b60",
+            "prov:usedEntity": "niiri:ab0144b9188c24f978e07874f53ac025"
+        },
+        "_:wDF338": {
+            "prov:generatedEntity": "niiri:2f233b855c18571a400fd833d555d620",
+            "prov:usedEntity": "niiri:c584015fa24c7c926f0b58301e5d61f2"
+        },
+        "_:wDF341": {
+            "prov:generatedEntity": "niiri:fdd6fde4db88f2a34579b6e074832d04",
+            "prov:usedEntity": "niiri:b575189f3bd68971936993d3aa187cb2"
+        },
+        "_:wDF344": {
+            "prov:generatedEntity": "niiri:d19e5a67d45d5321017795f6126c01ba",
+            "prov:usedEntity": "niiri:e8cd31e50a3c32fbe2bbcc0095269056"
+        },
+        "_:wDF347": {
+            "prov:generatedEntity": "niiri:7245866a3fef562524fce007658a5b36",
+            "prov:usedEntity": "niiri:e97474fed9ca8bf394b41d386552ec23"
+        },
+        "_:wDF350": {
+            "prov:generatedEntity": "niiri:77917bfc1da98a7e7fe2dc75f6551b37",
+            "prov:usedEntity": "niiri:abd9e58304894c9547b23ee1045ac1da"
+        },
+        "_:wDF353": {
+            "prov:generatedEntity": "niiri:35fb5dd9515d518d6fbdee4b3aad7697",
+            "prov:usedEntity": "niiri:f35fdf14b958462f212cb7e02a3f5b6a"
+        },
+        "_:wDF356": {
+            "prov:generatedEntity": "niiri:c457ecf797faf07f550dddfa0aace5e2",
+            "prov:usedEntity": "niiri:65aa1110e7a5b158b24b46e37675c86f"
+        },
+        "_:wDF359": {
+            "prov:generatedEntity": "niiri:0979a7e014454d80d5e3b40e2f809329",
+            "prov:usedEntity": "niiri:7d8d48b7315eff2905773178ffd49023"
+        },
+        "_:wDF362": {
+            "prov:generatedEntity": "niiri:4194c281db5a3d0d67f0dc86fdc77920",
+            "prov:usedEntity": "niiri:62e2c2069415d9aa3cc91424a7a036cf"
+        },
+        "_:wDF365": {
+            "prov:generatedEntity": "niiri:3fd55577a54074d75160c0c642d5409a",
+            "prov:usedEntity": "niiri:2deb14df5037616ae2a96835f77312be"
+        },
+        "_:wDF368": {
+            "prov:generatedEntity": "niiri:103473966f8ff9bcc2cc5ec2a713befb",
+            "prov:usedEntity": "niiri:5b409e333f6b39e5bc61b32b5cdb5358"
+        },
+        "_:wDF371": {
+            "prov:generatedEntity": "niiri:9abbf59e1fcfcc54cc8216a4ebac476d",
+            "prov:usedEntity": "niiri:aa433f26589b155235af6a6df23091d5"
+        },
+        "_:wDF374": {
+            "prov:generatedEntity": "niiri:160afe9ba06379a115015285c8be81d6",
+            "prov:usedEntity": "niiri:d220eb8d00595929d9a913e79e63f18d"
+        },
+        "_:wDF377": {
+            "prov:generatedEntity": "niiri:5fad6fb58b1dab2b17eef5948c9c92c0",
+            "prov:usedEntity": "niiri:b25a22f3e4eb9bbd1275897ff1df109d"
+        },
+        "_:wDF380": {
+            "prov:generatedEntity": "niiri:c29148dcd4002758ce86038f7b4ca401",
+            "prov:usedEntity": "niiri:bd4658613e97b52c7228dc395dd15873"
+        },
+        "_:wDF383": {
+            "prov:generatedEntity": "niiri:adde53039c55af81c35408a4bd174215",
+            "prov:usedEntity": "niiri:453c0a23d3b7bdaf631090a39026b948"
+        },
+        "_:wDF386": {
+            "prov:generatedEntity": "niiri:34836d3b3ca4536242e85f8dbf0eaec9",
+            "prov:usedEntity": "niiri:f9cadf3213379a88a9727fcf6a9eeef1"
+        },
+        "_:wDF389": {
+            "prov:generatedEntity": "niiri:056318bce8477b3efd14b0f6d507c3b4",
+            "prov:usedEntity": "niiri:00e7e2184e288d14e023360536c4ccbb"
+        },
+        "_:wDF392": {
+            "prov:generatedEntity": "niiri:8f0b0d4d20de8f18555fe5e10680d0c3",
+            "prov:usedEntity": "niiri:1e198daa9971af9c5562116948147b44"
+        },
+        "_:wDF395": {
+            "prov:generatedEntity": "niiri:5cd0e7e590a22b0339b125fff010c6c7",
+            "prov:usedEntity": "niiri:b983603109c1a317dd80246d873f0d4a"
+        },
+        "_:wDF398": {
+            "prov:generatedEntity": "niiri:816f143f7b83c21ef577cc3a8b9c39a3",
+            "prov:usedEntity": "niiri:bcad500e3ad79ca4075f62aa01a372da"
+        },
+        "_:wDF401": {
+            "prov:generatedEntity": "niiri:cdbd489b9fe249b9a71c29b770e2f4c4",
+            "prov:usedEntity": "niiri:b41f8e4d939b3ddb2c20cae93fb8b7c8"
+        },
+        "_:wDF404": {
+            "prov:generatedEntity": "niiri:27882a721f1cf5fa0b9ff4467a197b13",
+            "prov:usedEntity": "niiri:4545f5ed2d2381e9f6f1aaf307289882"
+        },
+        "_:wDF407": {
+            "prov:generatedEntity": "niiri:692ab3bf7a5c7c16857d166b15f0fc4a",
+            "prov:usedEntity": "niiri:2253c054073552510a00e5cee801efa6"
+        },
+        "_:wDF410": {
+            "prov:generatedEntity": "niiri:1dfc374a28a2a395f47b36b9ee3103b1",
+            "prov:usedEntity": "niiri:c2c0de5bb03471fb2a8439bc440e1a06"
+        },
+        "_:wDF413": {
+            "prov:generatedEntity": "niiri:99d98ff39073ff123cf9b9bc0586da2c",
+            "prov:usedEntity": "niiri:7c7b06e42170e83d79d011d51a1ee2eb"
+        },
+        "_:wDF416": {
+            "prov:generatedEntity": "niiri:847abc12c3303cd0921e0bc7775893a2",
+            "prov:usedEntity": "niiri:040e702ed12041e2190bf96dfbacadbb"
+        },
+        "_:wDF419": {
+            "prov:generatedEntity": "niiri:cbcaaf82c3acb8ecaba54ed445353762",
+            "prov:usedEntity": "niiri:e14e04732107aabcfe52c4ce59b579a8"
+        },
+        "_:wDF422": {
+            "prov:generatedEntity": "niiri:82d3cc604f3e16683c4c3de6c5e42b0a",
+            "prov:usedEntity": "niiri:d77e5bf6a731dcb245ad371bed714586"
+        },
+        "_:wDF425": {
+            "prov:generatedEntity": "niiri:fbde6e6581200f6c0a84e21ed621fc09",
+            "prov:usedEntity": "niiri:9575c70a2f76c6d9598daa3848deeb65"
+        },
+        "_:wDF428": {
+            "prov:generatedEntity": "niiri:8119527ea4cfcfa60201f74ffff03743",
+            "prov:usedEntity": "niiri:75e697b6b2e295644bcfcd0111ce9380"
+        }
+    },
+    "wasAttributedTo": {
+        "_:wAT6": {
+            "prov:entity": "niiri:b5f5299dd88c01663688131c711c2a74",
+            "prov:agent": "niiri:ccc4cd6d044e67a15c8666fea99b3166"
+        },
+        "_:wAT7": {
+            "prov:entity": "niiri:b5f5299dd88c01663688131c711c2a74",
+            "prov:agent": "niiri:8d49fa3ebfc5510866661667640b7637"
+        }
+    },
+    "wasAssociatedWith": {
+        "_:wAW13": {
+            "prov:activity": "niiri:d07cda9b146f92aa2083034127524fe1",
+            "prov:agent": "niiri:016e3cb0f11ba49dad327f9752892d7f"
+        },
+        "_:wAW45": {
+            "prov:activity": "niiri:113d1d799a4615cbe8865b4df8a089fa",
+            "prov:agent": "niiri:016e3cb0f11ba49dad327f9752892d7f"
+        },
+        "_:wAW65": {
+            "prov:activity": "niiri:8872a3798f2cb652dd632d9e9e40ecf9",
+            "prov:agent": "niiri:016e3cb0f11ba49dad327f9752892d7f"
+        },
+        "_:wAW92": {
+            "prov:activity": "niiri:16a9b96282eb00365725e2a0f6d310c6",
+            "prov:agent": "niiri:016e3cb0f11ba49dad327f9752892d7f"
+        }
+    }
+    }
+  }
+}

--- a/spmexport/ex_spm_conjunction/nidm.jsonld
+++ b/spmexport/ex_spm_conjunction/nidm.jsonld
@@ -7,7 +7,7 @@
       "niiri": "http://iri.nidash.org/",
       "spm": "http://purl.org/nidash/spm#",
       "neurolex": "http://neurolex.org/wiki/",
-      "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#",
+      "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/",
       "dct": "http://purl.org/dc/terms/",
       "nfo": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#",
       "dc": "http://purl.org/dc/elements/1.1/",
@@ -22,32 +22,32 @@
   ],
   "@graph": [
     {
-      "@id": "niiri:49e2ba6984723129b413599116a11d2f",
-      "@type": ["prov:Entity","prov:Bundle","nidm_NIDMResults:"],
+      "@id": "niiri:2e94d338ef8848aaa3096aa9c67d068b",
+      "@type": ["prov:Entity","prov:Bundle","nidm_NIDMResults"],
       "rdfs:label": "NIDM-Results",
-      "nidm_version:": {"@type": "xsd:string", "@value": "1.3.0"}
+      "nidm_version": {"@type": "xsd:string", "@value": "1.3.0"}
     },
     {
-      "@id": "niiri:f6174251413335799acde3da5922fc04",
-      "@type": ["prov:Agent","nidm_spm_results_nidm:","prov:SoftwareAgent"],
+      "@id": "niiri:7950d950e14199763647729c4a4e4088",
+      "@type": ["prov:Agent","nidm_spm_results_nidm","prov:SoftwareAgent"],
       "rdfs:label": "spm_results_nidm",
-      "nidm_softwareVersion:": {"@type": "xsd:string", "@value": "12.6903"}
+      "nidm_softwareVersion": {"@type": "xsd:string", "@value": "12.7057"}
     },
     {
-      "@id": "niiri:e30146f0b01ab7fba2fdd45ec000647c",
-      "@type": ["prov:Activity","nidm_NIDMResultsExport:"],
+      "@id": "niiri:c90a33b190317be7e66e9cb64ea5c0d4",
+      "@type": ["prov:Activity","nidm_NIDMResultsExport"],
       "rdfs:label": "NIDM-Results export"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:e30146f0b01ab7fba2fdd45ec000647c",
-      "agent": "niiri:f6174251413335799acde3da5922fc04"
+      "activity_associated": "niiri:c90a33b190317be7e66e9cb64ea5c0d4",
+      "agent": "niiri:7950d950e14199763647729c4a4e4088"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:49e2ba6984723129b413599116a11d2f",
-      "activity": "niiri:e30146f0b01ab7fba2fdd45ec000647c",
-      "atTime": "2016-12-07T16:07:57"
+      "entity_generated": "niiri:2e94d338ef8848aaa3096aa9c67d068b",
+      "activity": "niiri:c90a33b190317be7e66e9cb64ea5c0d4",
+      "atTime": "2017-04-19T12:17:45"
     }
   ]
 },
@@ -158,704 +158,704 @@
       "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
     }
   ],
-  "@id": "niiri:49e2ba6984723129b413599116a11d2f",
+  "@id": "niiri:2e94d338ef8848aaa3096aa9c67d068b",
   "@graph": [
     {
-      "@id": "niiri:788d8708b4b59d898f7fb805cfa24cee",
-      "@type": ["prov:Agent","src_SPM:","prov:SoftwareAgent"],
+      "@id": "niiri:016e3cb0f11ba49dad327f9752892d7f",
+      "@type": ["prov:Agent","src_SPM","prov:SoftwareAgent"],
       "rdfs:label": "SPM",
-      "nidm_softwareVersion:": {"@type": "xsd:string", "@value": "12.12.2"}
+      "nidm_softwareVersion": {"@type": "xsd:string", "@value": "12.6906"}
     },
     {
-      "@id": "niiri:8ac2495eaa1d9630498f5dcb7ca6623a",
-      "@type": ["prov:Entity","nidm_CoordinateSpace:"],
+      "@id": "niiri:43990f91d4711220e8f4834300dbd4a5",
+      "@type": ["prov:Entity","nidm_CoordinateSpace"],
       "rdfs:label": "Coordinate space 1",
-      "nidm_voxelToWorldMapping:": {"@type": "xsd:string", "@value": "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"},
-      "nidm_voxelUnits:": {"@type": "xsd:string", "@value": "[\"mm\", \"mm\", \"mm\"]"},
-      "nidm_voxelSize:": {"@type": "xsd:string", "@value": "[2, 2, 2]"},
-      "nidm_inWorldCoordinateSystem:": {"@id": "nidm_Ixi549CoordinateSystem:"},
-      "nidm_numberOfDimensions:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_dimensionsInVoxels:": {"@type": "xsd:string", "@value": "[79,95,79]"}
+      "nidm_voxelToWorldMapping": {"@type": "xsd:string", "@value": "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"},
+      "nidm_voxelUnits": {"@type": "xsd:string", "@value": "[\"mm\", \"mm\", \"mm\"]"},
+      "nidm_voxelSize": {"@type": "xsd:string", "@value": "[2, 2, 2]"},
+      "nidm_inWorldCoordinateSystem": {"@id": "nidm_Ixi549CoordinateSystem"},
+      "nidm_numberOfDimensions": {"@type": "xsd:int", "@value": "3"},
+      "nidm_dimensionsInVoxels": {"@type": "xsd:string", "@value": "[79,95,79]"}
     },
     {
-      "@id": "niiri:a9ae33f5b966f9c430993c5e2575b448",
-      "@type": ["prov:Agent","nlx_Imaginginstrument:","nlx_Magneticresonanceimagingscanner:"],
+      "@id": "niiri:ccc4cd6d044e67a15c8666fea99b3166",
+      "@type": ["prov:Agent","nlx_Imaginginstrument","nlx_Magneticresonanceimagingscanner"],
       "rdfs:label": "MRI Scanner"
     },
     {
-      "@id": "niiri:1d5c2d3f41ab0ec83284374f5513a058",
+      "@id": "niiri:8d49fa3ebfc5510866661667640b7637",
       "@type": ["prov:Agent","prov:Person"],
       "rdfs:label": "Person"
     },
     {
-      "@id": "niiri:79a49b132c7a15acc70032b8c8c407e9",
-      "@type": ["prov:Entity","prov:Collection","nidm_Data:"],
+      "@id": "niiri:b5f5299dd88c01663688131c711c2a74",
+      "@type": ["prov:Entity","prov:Collection","nidm_Data"],
       "rdfs:label": "Data",
-      "nidm_grandMeanScaling:": {"@type": "xsd:boolean", "@value": "true"},
-      "nidm_targetIntensity:": {"@type": "xsd:float", "@value": "100"},
-      "nidm_hasMRIProtocol:": {"@id": "nlx_FunctionalMRIprotocol:"}
+      "nidm_grandMeanScaling": {"@type": "xsd:boolean", "@value": "true"},
+      "nidm_targetIntensity": {"@type": "xsd:float", "@value": "100"},
+      "nidm_hasMRIProtocol": {"@id": "nlx_FunctionalMRIprotocol"}
     },
     {
       "@type": "prov:Attribution",
-      "entity_attributed": "niiri:79a49b132c7a15acc70032b8c8c407e9",
-      "agent": "niiri:a9ae33f5b966f9c430993c5e2575b448"
+      "entity_attributed": "niiri:b5f5299dd88c01663688131c711c2a74",
+      "agent": "niiri:ccc4cd6d044e67a15c8666fea99b3166"
     },
     {
       "@type": "prov:Attribution",
-      "entity_attributed": "niiri:79a49b132c7a15acc70032b8c8c407e9",
-      "agent": "niiri:1d5c2d3f41ab0ec83284374f5513a058"
+      "entity_attributed": "niiri:b5f5299dd88c01663688131c711c2a74",
+      "agent": "niiri:8d49fa3ebfc5510866661667640b7637"
     },
     {
-      "@id": "niiri:0e863528ca8de447aced0b65722fa024",
-      "@type": ["prov:Entity","spm_DCTDriftModel:"],
+      "@id": "niiri:2668d1ecdf9295cc03d6086cb0de079d",
+      "@type": ["prov:Entity","spm_DCTDriftModel"],
       "rdfs:label": "SPM's DCT Drift Model",
-      "spm_SPMsDriftCutoffPeriod:": {"@type": "xsd:float", "@value": "128"}
+      "spm_SPMsDriftCutoffPeriod": {"@type": "xsd:float", "@value": "128"}
     },
     {
-      "@id": "niiri:2db950365c1a07764464dbc8eee7d77e",
-      "@type": ["prov:Entity","nidm_DesignMatrix:"],
+      "@id": "niiri:6387ede10972f2c9e2051e4ae79a4a2e",
+      "@type": ["prov:Entity","nidm_DesignMatrix"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "DesignMatrix.csv"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "DesignMatrix.csv"},
       "dct:format": {"@type": "xsd:string", "@value": "text/csv"},
-      "dc:description": {"@id": "niiri:22cea7ee1683b3df8805f0c7a4eaaf7a"},
+      "dc:description": {"@id": "niiri:c139d04ac7da5b6427c94a32bc9982ac"},
       "rdfs:label": "Design Matrix",
-      "nidm_regressorNames:": {"@type": "xsd:string", "@value": "[\"Sn(1) to*bf(1)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) constant\"]"},
-      "nidm_hasDriftModel:": {"@id": "niiri:0e863528ca8de447aced0b65722fa024"},
-      "nidm_hasHRFBasis:": {"@id": "spm_SPMsCanonicalHRF:"}
+      "nidm_regressorNames": {"@type": "xsd:string", "@value": "[\"Sn(1) to*bf(1)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) constant\"]"},
+      "nidm_hasDriftModel": {"@id": "niiri:2668d1ecdf9295cc03d6086cb0de079d"},
+      "nidm_hasHRFBasis": {"@id": "spm_SPMsCanonicalHRF"}
     },
     {
-      "@id": "niiri:22cea7ee1683b3df8805f0c7a4eaaf7a",
+      "@id": "niiri:c139d04ac7da5b6427c94a32bc9982ac",
       "@type": ["prov:Entity","dctype:Image"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "DesignMatrix.png"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "DesignMatrix.png"},
       "dct:format": {"@type": "xsd:string", "@value": "image/png"}
     },
     {
-      "@id": "niiri:84620a093960e98c11002a386197a347",
-      "@type": ["prov:Entity","nidm_ErrorModel:"],
-      "nidm_hasErrorDistribution:": {"@id": "obo_normaldistribution:"},
-      "nidm_hasErrorDependence:": {"@id": "obo_Toeplitzcovariancestructure:"},
-      "nidm_dependenceMapWiseDependence:": {"@id": "nidm_ConstantParameter:"},
-      "nidm_errorVarianceHomogeneous:": {"@type": "xsd:boolean", "@value": "true"},
-      "nidm_varianceMapWiseDependence:": {"@id": "nidm_IndependentParameter:"}
+      "@id": "niiri:0fd0329c3adb2f4836f2747833babe88",
+      "@type": ["prov:Entity","nidm_ErrorModel"],
+      "nidm_hasErrorDistribution": {"@id": "obo_normaldistribution"},
+      "nidm_hasErrorDependence": {"@id": "obo_Toeplitzcovariancestructure"},
+      "nidm_dependenceMapWiseDependence": {"@id": "nidm_ConstantParameter"},
+      "nidm_errorVarianceHomogeneous": {"@type": "xsd:boolean", "@value": "true"},
+      "nidm_varianceMapWiseDependence": {"@id": "nidm_IndependentParameter"}
     },
     {
-      "@id": "niiri:b68a53a0147605b9ee8b60e0f137d280",
-      "@type": ["prov:Activity","nidm_ModelParametersEstimation:"],
+      "@id": "niiri:d07cda9b146f92aa2083034127524fe1",
+      "@type": ["prov:Activity","nidm_ModelParametersEstimation"],
       "rdfs:label": "Model parameters estimation",
-      "nidm_withEstimationMethod:": {"@id": "obo_generalizedleastsquaresestimation:"}
+      "nidm_withEstimationMethod": {"@id": "obo_generalizedleastsquaresestimation"}
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:b68a53a0147605b9ee8b60e0f137d280",
-      "agent": "niiri:788d8708b4b59d898f7fb805cfa24cee"
+      "activity_associated": "niiri:d07cda9b146f92aa2083034127524fe1",
+      "agent": "niiri:016e3cb0f11ba49dad327f9752892d7f"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:b68a53a0147605b9ee8b60e0f137d280",
-      "entity": "niiri:2db950365c1a07764464dbc8eee7d77e"
+      "activity_using": "niiri:d07cda9b146f92aa2083034127524fe1",
+      "entity": "niiri:6387ede10972f2c9e2051e4ae79a4a2e"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:b68a53a0147605b9ee8b60e0f137d280",
-      "entity": "niiri:79a49b132c7a15acc70032b8c8c407e9"
+      "activity_using": "niiri:d07cda9b146f92aa2083034127524fe1",
+      "entity": "niiri:b5f5299dd88c01663688131c711c2a74"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:b68a53a0147605b9ee8b60e0f137d280",
-      "entity": "niiri:84620a093960e98c11002a386197a347"
+      "activity_using": "niiri:d07cda9b146f92aa2083034127524fe1",
+      "entity": "niiri:0fd0329c3adb2f4836f2747833babe88"
     },
     {
-      "@id": "niiri:27e2d554c75587c0f96b310d2360480e",
-      "@type": ["prov:Entity","nidm_MaskMap:"],
+      "@id": "niiri:e5a61d0bc28607c2ab613b81ddf8392a",
+      "@type": ["prov:Entity","nidm_MaskMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "Mask.nii.gz"},
-      "nidm_isUserDefined:": {"@type": "xsd:boolean", "@value": "false"},
+      "nidm_isUserDefined": {"@type": "xsd:boolean", "@value": "false"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "Mask.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Mask",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:8ac2495eaa1d9630498f5dcb7ca6623a"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:43990f91d4711220e8f4834300dbd4a5"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876"}
     },
     {
-      "@id": "niiri:a1735d57f3987406899775e32a4249cb",
-      "@type": ["prov:Entity","nidm_MaskMap:"],
+      "@id": "niiri:8d425ac5fbd3a8eb1e7cc62ff8035271",
+      "@type": ["prov:Entity","nidm_MaskMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "mask.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "36929e1f5f4143bd9cc818cd896a25f129961fab208c3a4438555f40444c08347b359142ee8c53ece6e8cca1627f49db0788a1fd3b9e2ecaef61999c6c6c67ac"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:27e2d554c75587c0f96b310d2360480e",
-      "entity": "niiri:a1735d57f3987406899775e32a4249cb"
+      "entity_derived": "niiri:e5a61d0bc28607c2ab613b81ddf8392a",
+      "entity": "niiri:8d425ac5fbd3a8eb1e7cc62ff8035271"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:27e2d554c75587c0f96b310d2360480e",
-      "activity": "niiri:b68a53a0147605b9ee8b60e0f137d280"
+      "entity_generated": "niiri:e5a61d0bc28607c2ab613b81ddf8392a",
+      "activity": "niiri:d07cda9b146f92aa2083034127524fe1"
     },
     {
-      "@id": "niiri:ccb0fd792c54f2664f9527500504c14b",
-      "@type": ["prov:Entity","nidm_GrandMeanMap:"],
+      "@id": "niiri:9dbd735c07b927aa96e9892b2a28602a",
+      "@type": ["prov:Entity","nidm_GrandMeanMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "GrandMean.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "GrandMean.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Grand Mean Map",
-      "nidm_maskedMedian:": {"@type": "xsd:float", "@value": "111.557487487793"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:8ac2495eaa1d9630498f5dcb7ca6623a"},
+      "nidm_maskedMedian": {"@type": "xsd:float", "@value": "111.557487487793"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:43990f91d4711220e8f4834300dbd4a5"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "512157cc6bff89d9343a09b4068226eb3edd64a8cbcee861f06231767fae6f8d4819921182adebee083a9bf309afd65529ab04a92f0aa6b0038c8098550f6124"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:ccb0fd792c54f2664f9527500504c14b",
-      "activity": "niiri:b68a53a0147605b9ee8b60e0f137d280"
+      "entity_generated": "niiri:9dbd735c07b927aa96e9892b2a28602a",
+      "activity": "niiri:d07cda9b146f92aa2083034127524fe1"
     },
     {
-      "@id": "niiri:9dcbb14f3d45f3e5f2ee41b72fc2bdbf",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:892dc0fa4cc25ca47ac73ddd6f0f1a71",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0001.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0001.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 1",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:8ac2495eaa1d9630498f5dcb7ca6623a"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:43990f91d4711220e8f4834300dbd4a5"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd"}
     },
     {
-      "@id": "niiri:65d633b572e4b46963ac132897627c8f",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:565b0e81e599439b221f8fc7d899038a",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0001.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9dcbb14f3d45f3e5f2ee41b72fc2bdbf",
-      "entity": "niiri:65d633b572e4b46963ac132897627c8f"
+      "entity_derived": "niiri:892dc0fa4cc25ca47ac73ddd6f0f1a71",
+      "entity": "niiri:565b0e81e599439b221f8fc7d899038a"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:9dcbb14f3d45f3e5f2ee41b72fc2bdbf",
-      "activity": "niiri:b68a53a0147605b9ee8b60e0f137d280"
+      "entity_generated": "niiri:892dc0fa4cc25ca47ac73ddd6f0f1a71",
+      "activity": "niiri:d07cda9b146f92aa2083034127524fe1"
     },
     {
-      "@id": "niiri:5c1f7aeeb3477d36479af1436084f0fc",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:fcebd635515316804e6601daa6f10239",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0002.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0002.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 2",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:8ac2495eaa1d9630498f5dcb7ca6623a"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:43990f91d4711220e8f4834300dbd4a5"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c"}
     },
     {
-      "@id": "niiri:b35909a3e9e36ae88b74418356dd9808",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:2b4b7fb2c844c1b29d66eb66f2f6bb24",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0002.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5c1f7aeeb3477d36479af1436084f0fc",
-      "entity": "niiri:b35909a3e9e36ae88b74418356dd9808"
+      "entity_derived": "niiri:fcebd635515316804e6601daa6f10239",
+      "entity": "niiri:2b4b7fb2c844c1b29d66eb66f2f6bb24"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:5c1f7aeeb3477d36479af1436084f0fc",
-      "activity": "niiri:b68a53a0147605b9ee8b60e0f137d280"
+      "entity_generated": "niiri:fcebd635515316804e6601daa6f10239",
+      "activity": "niiri:d07cda9b146f92aa2083034127524fe1"
     },
     {
-      "@id": "niiri:b40ebe60020e0b79f0779d6da70f93e4",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:0a600229532c0ed2e05bd43494a1c6c3",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0003.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0003.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 3",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:8ac2495eaa1d9630498f5dcb7ca6623a"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:43990f91d4711220e8f4834300dbd4a5"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373"}
     },
     {
-      "@id": "niiri:3e856a6b602cfdf70312041b27a8e9be",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:6e470aa79f85c054fb351adb5db48bd3",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0003.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b40ebe60020e0b79f0779d6da70f93e4",
-      "entity": "niiri:3e856a6b602cfdf70312041b27a8e9be"
+      "entity_derived": "niiri:0a600229532c0ed2e05bd43494a1c6c3",
+      "entity": "niiri:6e470aa79f85c054fb351adb5db48bd3"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:b40ebe60020e0b79f0779d6da70f93e4",
-      "activity": "niiri:b68a53a0147605b9ee8b60e0f137d280"
+      "entity_generated": "niiri:0a600229532c0ed2e05bd43494a1c6c3",
+      "activity": "niiri:d07cda9b146f92aa2083034127524fe1"
     },
     {
-      "@id": "niiri:f8194d0c603445d8f76895c1bffdb7ad",
-      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap:"],
+      "@id": "niiri:03bc9932821688679785b6bbb6b7186e",
+      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ResidualMeanSquares.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ResidualMeanSquares.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Residual Mean Squares Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:8ac2495eaa1d9630498f5dcb7ca6623a"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:43990f91d4711220e8f4834300dbd4a5"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "991abf563d795a43b1e2eef8643e57023f2e0b090b2031f05f839321fc0643df6f71d423486a1021519b6dc82f6b0f563e19f3fbd50cb16063bed54a0e192d3e"}
     },
     {
-      "@id": "niiri:79e819061231841c5ca378a6250ddac7",
-      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap:"],
+      "@id": "niiri:1788822bb0780f90238ce40ec64b7c8f",
+      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "ResMS.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "40b28d03fcf9a2f60b11f10d7fb83bf3618b234fb5aedf09df644cb7cbb6aab8c9f468897c1078166d455a3d04a83f4e3bf762cfca0b4ea982d7a4e406849f18"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f8194d0c603445d8f76895c1bffdb7ad",
-      "entity": "niiri:79e819061231841c5ca378a6250ddac7"
+      "entity_derived": "niiri:03bc9932821688679785b6bbb6b7186e",
+      "entity": "niiri:1788822bb0780f90238ce40ec64b7c8f"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:f8194d0c603445d8f76895c1bffdb7ad",
-      "activity": "niiri:b68a53a0147605b9ee8b60e0f137d280"
+      "entity_generated": "niiri:03bc9932821688679785b6bbb6b7186e",
+      "activity": "niiri:d07cda9b146f92aa2083034127524fe1"
     },
     {
-      "@id": "niiri:42a9ce7904b0f4ed1a0722c2ff773184",
-      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap:"],
+      "@id": "niiri:19b287a58457b527aca30843e6e34d84",
+      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ReselsPerVoxel.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ReselsPerVoxel.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Resels per Voxel Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:8ac2495eaa1d9630498f5dcb7ca6623a"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:43990f91d4711220e8f4834300dbd4a5"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "1a3f9216e145249ccc0b14b2bc337d6b38b81ad45e32768001fb22b35f0c2c0f3e2bce013b40c85f7dc0fc62723ac761ee7f7e1e6aff128a05f0ba7b8b8202a3"}
     },
     {
-      "@id": "niiri:38e4b2d89ff31ccd805907644af6bbac",
-      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap:"],
+      "@id": "niiri:9536f7d3d8c806ff604d922fcfc13f49",
+      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "RPV.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "4f76663162857f6b38b2a45a63b15a23b2ca8b338c283b69c1e71f2ea2f43797d045a733cd14e845be9c12f8b8f84d3931c599a08e8f6d77e99fab46ad87ab8f"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:42a9ce7904b0f4ed1a0722c2ff773184",
-      "entity": "niiri:38e4b2d89ff31ccd805907644af6bbac"
+      "entity_derived": "niiri:19b287a58457b527aca30843e6e34d84",
+      "entity": "niiri:9536f7d3d8c806ff604d922fcfc13f49"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:42a9ce7904b0f4ed1a0722c2ff773184",
-      "activity": "niiri:b68a53a0147605b9ee8b60e0f137d280"
+      "entity_generated": "niiri:19b287a58457b527aca30843e6e34d84",
+      "activity": "niiri:d07cda9b146f92aa2083034127524fe1"
     },
     {
-      "@id": "niiri:264cba0f67e2275348f6df02b548ad74",
-      "@type": ["prov:Entity","obo_contrastweightmatrix:"],
-      "nidm_statisticType:": {"@id": "obo_tstatistic:"},
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
+      "@id": "niiri:92324b5901796c34f58222905ccfed17",
+      "@type": ["prov:Entity","obo_contrastweightmatrix"],
+      "nidm_statisticType": {"@id": "obo_tstatistic"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
       "rdfs:label": "Contrast: tone counting vs baseline",
       "prov:value": {"@type": "xsd:string", "@value": "[1, 0, 0]"}
     },
     {
-      "@id": "niiri:59789a7a9a2f85ef10449639b37d1739",
-      "@type": ["prov:Activity","nidm_ContrastEstimation:"],
+      "@id": "niiri:113d1d799a4615cbe8865b4df8a089fa",
+      "@type": ["prov:Activity","nidm_ContrastEstimation"],
       "rdfs:label": "Contrast estimation 1"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:59789a7a9a2f85ef10449639b37d1739",
-      "agent": "niiri:788d8708b4b59d898f7fb805cfa24cee"
+      "activity_associated": "niiri:113d1d799a4615cbe8865b4df8a089fa",
+      "agent": "niiri:016e3cb0f11ba49dad327f9752892d7f"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:59789a7a9a2f85ef10449639b37d1739",
-      "entity": "niiri:27e2d554c75587c0f96b310d2360480e"
+      "activity_using": "niiri:113d1d799a4615cbe8865b4df8a089fa",
+      "entity": "niiri:e5a61d0bc28607c2ab613b81ddf8392a"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:59789a7a9a2f85ef10449639b37d1739",
-      "entity": "niiri:f8194d0c603445d8f76895c1bffdb7ad"
+      "activity_using": "niiri:113d1d799a4615cbe8865b4df8a089fa",
+      "entity": "niiri:03bc9932821688679785b6bbb6b7186e"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:59789a7a9a2f85ef10449639b37d1739",
-      "entity": "niiri:2db950365c1a07764464dbc8eee7d77e"
+      "activity_using": "niiri:113d1d799a4615cbe8865b4df8a089fa",
+      "entity": "niiri:6387ede10972f2c9e2051e4ae79a4a2e"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:59789a7a9a2f85ef10449639b37d1739",
-      "entity": "niiri:264cba0f67e2275348f6df02b548ad74"
+      "activity_using": "niiri:113d1d799a4615cbe8865b4df8a089fa",
+      "entity": "niiri:92324b5901796c34f58222905ccfed17"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:59789a7a9a2f85ef10449639b37d1739",
-      "entity": "niiri:9dcbb14f3d45f3e5f2ee41b72fc2bdbf"
+      "activity_using": "niiri:113d1d799a4615cbe8865b4df8a089fa",
+      "entity": "niiri:892dc0fa4cc25ca47ac73ddd6f0f1a71"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:59789a7a9a2f85ef10449639b37d1739",
-      "entity": "niiri:5c1f7aeeb3477d36479af1436084f0fc"
+      "activity_using": "niiri:113d1d799a4615cbe8865b4df8a089fa",
+      "entity": "niiri:fcebd635515316804e6601daa6f10239"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:59789a7a9a2f85ef10449639b37d1739",
-      "entity": "niiri:b40ebe60020e0b79f0779d6da70f93e4"
+      "activity_using": "niiri:113d1d799a4615cbe8865b4df8a089fa",
+      "entity": "niiri:0a600229532c0ed2e05bd43494a1c6c3"
     },
     {
-      "@id": "niiri:c19a21acb28cd19f21a1be425e49481c",
-      "@type": ["prov:Entity","nidm_StatisticMap:"],
+      "@id": "niiri:7766f91f9fb3c7a19f3ae5bf1f752bbf",
+      "@type": ["prov:Entity","nidm_StatisticMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "TStatistic_0001.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "TStatistic_0001.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "T-Statistic Map: tone counting vs baseline",
-      "nidm_statisticType:": {"@id": "obo_tstatistic:"},
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
-      "nidm_errorDegreesOfFreedom:": {"@type": "xsd:float", "@value": "97.9999999998522"},
-      "nidm_effectDegreesOfFreedom:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:8ac2495eaa1d9630498f5dcb7ca6623a"},
+      "nidm_statisticType": {"@id": "obo_tstatistic"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
+      "nidm_errorDegreesOfFreedom": {"@type": "xsd:float", "@value": "97.9999999998522"},
+      "nidm_effectDegreesOfFreedom": {"@type": "xsd:float", "@value": "1"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:43990f91d4711220e8f4834300dbd4a5"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "99f578a25cc225feda31dd567e6bc05dd8229bd9ada176571e9144c7748ed3a9c8eee1258f73c6cbf0a08282094b8004f18ea0791f0f3d92d8069ec877218399"}
     },
     {
-      "@id": "niiri:edf3aced4b659159875f1a0f23174cde",
-      "@type": ["prov:Entity","nidm_StatisticMap:"],
+      "@id": "niiri:df8317112ad27782b9be9c9adbafa6af",
+      "@type": ["prov:Entity","nidm_StatisticMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "spmT_0001.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "d288b1b0f117f64502555da13c5398dffa5bf5ff0b58951510e43d5388755bc185798802a92e98a07c7e313c6991066d2908f2a44aa5153ba23433da1335970f"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c19a21acb28cd19f21a1be425e49481c",
-      "entity": "niiri:edf3aced4b659159875f1a0f23174cde"
+      "entity_derived": "niiri:7766f91f9fb3c7a19f3ae5bf1f752bbf",
+      "entity": "niiri:df8317112ad27782b9be9c9adbafa6af"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:c19a21acb28cd19f21a1be425e49481c",
-      "activity": "niiri:59789a7a9a2f85ef10449639b37d1739"
+      "entity_generated": "niiri:7766f91f9fb3c7a19f3ae5bf1f752bbf",
+      "activity": "niiri:113d1d799a4615cbe8865b4df8a089fa"
     },
     {
-      "@id": "niiri:e390d5b8d153675e3d516d9844741469",
-      "@type": ["prov:Entity","nidm_ContrastMap:"],
+      "@id": "niiri:af18c6b272b9c41779a5c9b4adefcb28",
+      "@type": ["prov:Entity","nidm_ContrastMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "Contrast_0001.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "Contrast_0001.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Contrast Map: tone counting vs baseline",
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:8ac2495eaa1d9630498f5dcb7ca6623a"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:43990f91d4711220e8f4834300dbd4a5"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "fc5e2ad175243ee496db98f9b2e1b235c4c3bae1a8d7122ce461c897b537e40c49dfee5d6cf20f71c6a2bb9b5f0760fcb4ecd8fe2e9428910ef3d60d8f3c56a9"}
     },
     {
-      "@id": "niiri:939452a9308168d579febe093626791f",
-      "@type": ["prov:Entity","nidm_ContrastMap:"],
+      "@id": "niiri:f584b30e1a30a67223f05b204465e66d",
+      "@type": ["prov:Entity","nidm_ContrastMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "con_0001.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "d4aa46b3603ba508578e39751262d528cf6d1ed2e722ec46f1cd8194c50591e46b229deb8cb4f72d1b7e0e2640f3e6604be7a335301c5c8357f453e5d0d4daf2"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e390d5b8d153675e3d516d9844741469",
-      "entity": "niiri:939452a9308168d579febe093626791f"
+      "entity_derived": "niiri:af18c6b272b9c41779a5c9b4adefcb28",
+      "entity": "niiri:f584b30e1a30a67223f05b204465e66d"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:e390d5b8d153675e3d516d9844741469",
-      "activity": "niiri:59789a7a9a2f85ef10449639b37d1739"
+      "entity_generated": "niiri:af18c6b272b9c41779a5c9b4adefcb28",
+      "activity": "niiri:113d1d799a4615cbe8865b4df8a089fa"
     },
     {
-      "@id": "niiri:3c2b7154be2dd98ce332831ef822c0f0",
-      "@type": ["prov:Entity","nidm_ContrastStandardErrorMap:"],
+      "@id": "niiri:4a46cd703e5066038138c81d0134cb7b",
+      "@type": ["prov:Entity","nidm_ContrastStandardErrorMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ContrastStandardError_0001.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ContrastStandardError_0001.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Contrast Standard Error Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:8ac2495eaa1d9630498f5dcb7ca6623a"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:43990f91d4711220e8f4834300dbd4a5"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "791d48f5d1adb15079a5289271ce0c4b95c56d69bfdb3e5d41b0d24eb538d3075e1cdd15502494b5a5a18c16eaa2153cb4847a996043fa48cdaf26e938a2576d"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:3c2b7154be2dd98ce332831ef822c0f0",
-      "activity": "niiri:59789a7a9a2f85ef10449639b37d1739"
+      "entity_generated": "niiri:4a46cd703e5066038138c81d0134cb7b",
+      "activity": "niiri:113d1d799a4615cbe8865b4df8a089fa"
     },
     {
-      "@id": "niiri:50d266c22fda1c12960c795840352fa4",
-      "@type": ["prov:Entity","obo_contrastweightmatrix:"],
-      "nidm_statisticType:": {"@id": "obo_tstatistic:"},
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "tone counting probe vs baseline"},
+      "@id": "niiri:42481f8ce49fff367fe85c2f158deed5",
+      "@type": ["prov:Entity","obo_contrastweightmatrix"],
+      "nidm_statisticType": {"@id": "obo_tstatistic"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "tone counting probe vs baseline"},
       "rdfs:label": "Contrast: tone counting probe vs baseline",
       "prov:value": {"@type": "xsd:string", "@value": "[0, 1, 0]"}
     },
     {
-      "@id": "niiri:e6b2a7699eaf7eb4b0e65181dd9165ea",
-      "@type": ["prov:Activity","nidm_ContrastEstimation:"],
+      "@id": "niiri:8872a3798f2cb652dd632d9e9e40ecf9",
+      "@type": ["prov:Activity","nidm_ContrastEstimation"],
       "rdfs:label": "Contrast estimation 2"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:e6b2a7699eaf7eb4b0e65181dd9165ea",
-      "agent": "niiri:788d8708b4b59d898f7fb805cfa24cee"
+      "activity_associated": "niiri:8872a3798f2cb652dd632d9e9e40ecf9",
+      "agent": "niiri:016e3cb0f11ba49dad327f9752892d7f"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:e6b2a7699eaf7eb4b0e65181dd9165ea",
-      "entity": "niiri:27e2d554c75587c0f96b310d2360480e"
+      "activity_using": "niiri:8872a3798f2cb652dd632d9e9e40ecf9",
+      "entity": "niiri:e5a61d0bc28607c2ab613b81ddf8392a"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:e6b2a7699eaf7eb4b0e65181dd9165ea",
-      "entity": "niiri:f8194d0c603445d8f76895c1bffdb7ad"
+      "activity_using": "niiri:8872a3798f2cb652dd632d9e9e40ecf9",
+      "entity": "niiri:03bc9932821688679785b6bbb6b7186e"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:e6b2a7699eaf7eb4b0e65181dd9165ea",
-      "entity": "niiri:2db950365c1a07764464dbc8eee7d77e"
+      "activity_using": "niiri:8872a3798f2cb652dd632d9e9e40ecf9",
+      "entity": "niiri:6387ede10972f2c9e2051e4ae79a4a2e"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:e6b2a7699eaf7eb4b0e65181dd9165ea",
-      "entity": "niiri:50d266c22fda1c12960c795840352fa4"
+      "activity_using": "niiri:8872a3798f2cb652dd632d9e9e40ecf9",
+      "entity": "niiri:42481f8ce49fff367fe85c2f158deed5"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:e6b2a7699eaf7eb4b0e65181dd9165ea",
-      "entity": "niiri:9dcbb14f3d45f3e5f2ee41b72fc2bdbf"
+      "activity_using": "niiri:8872a3798f2cb652dd632d9e9e40ecf9",
+      "entity": "niiri:892dc0fa4cc25ca47ac73ddd6f0f1a71"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:e6b2a7699eaf7eb4b0e65181dd9165ea",
-      "entity": "niiri:5c1f7aeeb3477d36479af1436084f0fc"
+      "activity_using": "niiri:8872a3798f2cb652dd632d9e9e40ecf9",
+      "entity": "niiri:fcebd635515316804e6601daa6f10239"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:e6b2a7699eaf7eb4b0e65181dd9165ea",
-      "entity": "niiri:b40ebe60020e0b79f0779d6da70f93e4"
+      "activity_using": "niiri:8872a3798f2cb652dd632d9e9e40ecf9",
+      "entity": "niiri:0a600229532c0ed2e05bd43494a1c6c3"
     },
     {
-      "@id": "niiri:33c60c38565ba7f605e4ca032349e363",
-      "@type": ["prov:Entity","nidm_StatisticMap:"],
+      "@id": "niiri:d40b3bf5490868f622f2357adea722a9",
+      "@type": ["prov:Entity","nidm_StatisticMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "TStatistic_0002.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "TStatistic_0002.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "T-Statistic Map: tone counting probe vs baseline",
-      "nidm_statisticType:": {"@id": "obo_tstatistic:"},
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "tone counting probe vs baseline"},
-      "nidm_errorDegreesOfFreedom:": {"@type": "xsd:float", "@value": "97.9999999998522"},
-      "nidm_effectDegreesOfFreedom:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:8ac2495eaa1d9630498f5dcb7ca6623a"},
+      "nidm_statisticType": {"@id": "obo_tstatistic"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "tone counting probe vs baseline"},
+      "nidm_errorDegreesOfFreedom": {"@type": "xsd:float", "@value": "97.9999999998522"},
+      "nidm_effectDegreesOfFreedom": {"@type": "xsd:float", "@value": "1"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:43990f91d4711220e8f4834300dbd4a5"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "27322de6e66e2fbcc847db3bfc0f2e23b78e8524340ddee0c06b40321f74c73140a07b0baed4ff259a6d956903811b416fd7a7d8bba86bacb8e60337006cf425"}
     },
     {
-      "@id": "niiri:7e50e269e3c51e62e90b992191741f8c",
-      "@type": ["prov:Entity","nidm_StatisticMap:"],
+      "@id": "niiri:70992ac15b69b7bd18e58cc3b80cf441",
+      "@type": ["prov:Entity","nidm_StatisticMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "spmT_0002.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "d4c7aa1879c2eb9ad471b3fd73e58ff0dfeace86ac0791b1d34cd1b87791a293f705b04229f028d6b05d2bd1b371c8b2a17249750eb9ba773f11a6bdee5ed203"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:33c60c38565ba7f605e4ca032349e363",
-      "entity": "niiri:7e50e269e3c51e62e90b992191741f8c"
+      "entity_derived": "niiri:d40b3bf5490868f622f2357adea722a9",
+      "entity": "niiri:70992ac15b69b7bd18e58cc3b80cf441"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:33c60c38565ba7f605e4ca032349e363",
-      "activity": "niiri:e6b2a7699eaf7eb4b0e65181dd9165ea"
+      "entity_generated": "niiri:d40b3bf5490868f622f2357adea722a9",
+      "activity": "niiri:8872a3798f2cb652dd632d9e9e40ecf9"
     },
     {
-      "@id": "niiri:af1157ebc9428085c4f1fd14544c9c59",
-      "@type": ["prov:Entity","nidm_ContrastMap:"],
+      "@id": "niiri:98bad5417f97850e2a27b2644953d7fc",
+      "@type": ["prov:Entity","nidm_ContrastMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "Contrast_0002.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "Contrast_0002.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Contrast Map: tone counting probe vs baseline",
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "tone counting probe vs baseline"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:8ac2495eaa1d9630498f5dcb7ca6623a"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "tone counting probe vs baseline"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:43990f91d4711220e8f4834300dbd4a5"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "63cf0302e297e04c6b46de0043888e490e940d3aa0da4ed441990ea9f28f2dac32a0505b34bc424d68929195fec579f71c2d5602fda2dfaaad3d3accb14ccc43"}
     },
     {
-      "@id": "niiri:32def2a96a2b007c0b48160856b0eb4e",
-      "@type": ["prov:Entity","nidm_ContrastMap:"],
+      "@id": "niiri:cbc99abbec6b9d1c6aedcd2e278aabcd",
+      "@type": ["prov:Entity","nidm_ContrastMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "con_0002.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "b0f05ae7f0bac16eecb73fb1964cede4b475b176a9a0747624b707dc165bed14f45352fa25f00c6abbf5ea12376fcadf6cc46abbe1a65d25aa03eb2ec4423474"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:af1157ebc9428085c4f1fd14544c9c59",
-      "entity": "niiri:32def2a96a2b007c0b48160856b0eb4e"
+      "entity_derived": "niiri:98bad5417f97850e2a27b2644953d7fc",
+      "entity": "niiri:cbc99abbec6b9d1c6aedcd2e278aabcd"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:af1157ebc9428085c4f1fd14544c9c59",
-      "activity": "niiri:e6b2a7699eaf7eb4b0e65181dd9165ea"
+      "entity_generated": "niiri:98bad5417f97850e2a27b2644953d7fc",
+      "activity": "niiri:8872a3798f2cb652dd632d9e9e40ecf9"
     },
     {
-      "@id": "niiri:978a91d9ff72edb810642253cbfef4ab",
-      "@type": ["prov:Entity","nidm_ContrastStandardErrorMap:"],
+      "@id": "niiri:5755b406b2a82f8a36a4c0c23054e6ee",
+      "@type": ["prov:Entity","nidm_ContrastStandardErrorMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ContrastStandardError_0002.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ContrastStandardError_0002.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Contrast Standard Error Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:8ac2495eaa1d9630498f5dcb7ca6623a"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:43990f91d4711220e8f4834300dbd4a5"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "e897bcfa6571036e47cf7fc61934c3ba09d3e3c7d759eaccfc002401c75700c5cdff2419aca08960e27c5dbdc76c05a2e2627a4935597f9eab4dfec54c0b2872"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:978a91d9ff72edb810642253cbfef4ab",
-      "activity": "niiri:e6b2a7699eaf7eb4b0e65181dd9165ea"
+      "entity_generated": "niiri:5755b406b2a82f8a36a4c0c23054e6ee",
+      "activity": "niiri:8872a3798f2cb652dd632d9e9e40ecf9"
     },
     {
-      "@id": "niiri:402e10a6c963c092e7edd6c55147bda7",
-      "@type": ["prov:Entity","nidm_HeightThreshold:","nidm_PValueUncorrected:"],
-      "rdfs:label": "Height Threshold: p<0.001000 (unc.)",
+      "@id": "niiri:d929d3c4d45d3c1d6b9b03fb2445f0d9",
+      "@type": ["prov:Entity","nidm_HeightThreshold","nidm_PValueUncorrected"],
+      "rdfs:label": "Height Threshold: p<0.001 (unc.)",
       "prov:value": {"@type": "xsd:float", "@value": "0.000999500158000544"},
-      "nidm_equivalentThreshold:": [{"@id": "niiri:38d412c018e8e0157c9aadebfa63839a"},{"@id": "niiri:b2232c1ea8710f6507e791720cb3c22b"}]
+      "nidm_equivalentThreshold": [{"@id": "niiri:737bba5cf2bd2f211f124fb3d262c2dc"},{"@id": "niiri:ab6c4afffb94c13144bd1539a6ca86f9"}]
     },
     {
-      "@id": "niiri:38d412c018e8e0157c9aadebfa63839a",
-      "@type": ["prov:Entity","nidm_HeightThreshold:","obo_statistic:"],
-      "rdfs:label": "Height Threshold",
+      "@id": "niiri:737bba5cf2bd2f211f124fb3d262c2dc",
+      "@type": ["prov:Entity","nidm_HeightThreshold","obo_statistic"],
+      "rdfs:label": "Height Threshold: T=3.175486)",
       "prov:value": {"@type": "xsd:float", "@value": "3.17548628637284"}
     },
     {
-      "@id": "niiri:b2232c1ea8710f6507e791720cb3c22b",
-      "@type": ["prov:Entity","nidm_HeightThreshold:","obo_FWERadjustedpvalue:"],
-      "rdfs:label": "Height Threshold",
+      "@id": "niiri:ab6c4afffb94c13144bd1539a6ca86f9",
+      "@type": ["prov:Entity","nidm_HeightThreshold","obo_FWERadjustedpvalue"],
+      "rdfs:label": "Height Threshold: p<1.000000 (FWE)",
       "prov:value": {"@type": "xsd:float", "@value": "0.999999999999997"}
     },
     {
-      "@id": "niiri:54eb142a446c0ce834bc6f723e999197",
-      "@type": ["prov:Entity","nidm_ExtentThreshold:","obo_statistic:"],
+      "@id": "niiri:8d783286b1c008ac28fe81706432e884",
+      "@type": ["prov:Entity","nidm_ExtentThreshold","obo_statistic"],
       "rdfs:label": "Extent Threshold: k>=0",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "0"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0"},
-      "nidm_equivalentThreshold:": [{"@id": "niiri:f18c169a7bd7268074e1b754708bf0d1"},{"@id": "niiri:a19457a205b4413bcfefd900ecbb12f9"}]
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "0"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0"},
+      "nidm_equivalentThreshold": [{"@id": "niiri:aa1873254cbafe5aaada9741c3754eb2"},{"@id": "niiri:e1b635c98c9165c9c569e7531eebeb20"}]
     },
     {
-      "@id": "niiri:f18c169a7bd7268074e1b754708bf0d1",
-      "@type": ["prov:Entity","nidm_ExtentThreshold:","obo_FWERadjustedpvalue:"],
+      "@id": "niiri:aa1873254cbafe5aaada9741c3754eb2",
+      "@type": ["prov:Entity","nidm_ExtentThreshold","obo_FWERadjustedpvalue"],
       "rdfs:label": "Extent Threshold",
       "prov:value": {"@type": "xsd:float", "@value": "1"}
     },
     {
-      "@id": "niiri:a19457a205b4413bcfefd900ecbb12f9",
-      "@type": ["prov:Entity","nidm_ExtentThreshold:","nidm_PValueUncorrected:"],
+      "@id": "niiri:e1b635c98c9165c9c569e7531eebeb20",
+      "@type": ["prov:Entity","nidm_ExtentThreshold","nidm_PValueUncorrected"],
       "rdfs:label": "Extent Threshold",
       "prov:value": {"@type": "xsd:float", "@value": "1"}
     },
     {
-      "@id": "niiri:9647502cfeafec615faa64a7dbf71eb9",
-      "@type": ["prov:Entity","nidm_PeakDefinitionCriteria:"],
+      "@id": "niiri:245e81118425b6790f11b064e4eca94d",
+      "@type": ["prov:Entity","nidm_PeakDefinitionCriteria"],
       "rdfs:label": "Peak Definition Criteria",
-      "nidm_maxNumberOfPeaksPerCluster:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_minDistanceBetweenPeaks:": {"@type": "xsd:float", "@value": "8"}
+      "nidm_maxNumberOfPeaksPerCluster": {"@type": "xsd:int", "@value": "3"},
+      "nidm_minDistanceBetweenPeaks": {"@type": "xsd:float", "@value": "8"}
     },
     {
-      "@id": "niiri:49bc3950bc97bc6e6f13240764473039",
-      "@type": ["prov:Entity","nidm_ClusterDefinitionCriteria:"],
+      "@id": "niiri:04fa6b9288815b12d59a8ed5850b4b8e",
+      "@type": ["prov:Entity","nidm_ClusterDefinitionCriteria"],
       "rdfs:label": "Cluster Connectivity Criterion: 18",
-      "nidm_hasConnectivityCriterion:": {"@id": "nidm_voxel18connected:"}
+      "nidm_hasConnectivityCriterion": {"@id": "nidm_voxel18connected"}
     },
     {
-      "@id": "niiri:c20d3c1d9297836af7474d61ffe6e5d9",
-      "@type": ["prov:Activity","nidm_ConjunctionInference:"],
-      "nidm_hasAlternativeHypothesis:": {"@id": "nidm_OneTailedTest:"},
+      "@id": "niiri:16a9b96282eb00365725e2a0f6d310c6",
+      "@type": ["prov:Activity","nidm_ConjunctionInference"],
+      "nidm_hasAlternativeHypothesis": {"@id": "nidm_OneTailedTest"},
       "rdfs:label": "Conjunction Inference"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:c20d3c1d9297836af7474d61ffe6e5d9",
-      "agent": "niiri:788d8708b4b59d898f7fb805cfa24cee"
+      "activity_associated": "niiri:16a9b96282eb00365725e2a0f6d310c6",
+      "agent": "niiri:016e3cb0f11ba49dad327f9752892d7f"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:c20d3c1d9297836af7474d61ffe6e5d9",
-      "entity": "niiri:402e10a6c963c092e7edd6c55147bda7"
+      "activity_using": "niiri:16a9b96282eb00365725e2a0f6d310c6",
+      "entity": "niiri:d929d3c4d45d3c1d6b9b03fb2445f0d9"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:c20d3c1d9297836af7474d61ffe6e5d9",
-      "entity": "niiri:54eb142a446c0ce834bc6f723e999197"
+      "activity_using": "niiri:16a9b96282eb00365725e2a0f6d310c6",
+      "entity": "niiri:8d783286b1c008ac28fe81706432e884"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:c20d3c1d9297836af7474d61ffe6e5d9",
-      "entity": "niiri:c19a21acb28cd19f21a1be425e49481c"
+      "activity_using": "niiri:16a9b96282eb00365725e2a0f6d310c6",
+      "entity": "niiri:7766f91f9fb3c7a19f3ae5bf1f752bbf"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:c20d3c1d9297836af7474d61ffe6e5d9",
-      "entity": "niiri:33c60c38565ba7f605e4ca032349e363"
+      "activity_using": "niiri:16a9b96282eb00365725e2a0f6d310c6",
+      "entity": "niiri:d40b3bf5490868f622f2357adea722a9"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:c20d3c1d9297836af7474d61ffe6e5d9",
-      "entity": "niiri:42a9ce7904b0f4ed1a0722c2ff773184"
+      "activity_using": "niiri:16a9b96282eb00365725e2a0f6d310c6",
+      "entity": "niiri:19b287a58457b527aca30843e6e34d84"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:c20d3c1d9297836af7474d61ffe6e5d9",
-      "entity": "niiri:27e2d554c75587c0f96b310d2360480e"
+      "activity_using": "niiri:16a9b96282eb00365725e2a0f6d310c6",
+      "entity": "niiri:e5a61d0bc28607c2ab613b81ddf8392a"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:c20d3c1d9297836af7474d61ffe6e5d9",
-      "entity": "niiri:9647502cfeafec615faa64a7dbf71eb9"
+      "activity_using": "niiri:16a9b96282eb00365725e2a0f6d310c6",
+      "entity": "niiri:245e81118425b6790f11b064e4eca94d"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:c20d3c1d9297836af7474d61ffe6e5d9",
-      "entity": "niiri:49bc3950bc97bc6e6f13240764473039"
+      "activity_using": "niiri:16a9b96282eb00365725e2a0f6d310c6",
+      "entity": "niiri:04fa6b9288815b12d59a8ed5850b4b8e"
     },
     {
-      "@id": "niiri:4203cdd482eb37373a8117206cb4efe7",
-      "@type": ["prov:Entity","nidm_SearchSpaceMaskMap:"],
+      "@id": "niiri:61ba90688ed17ead0aa46ba07adc7f73",
+      "@type": ["prov:Entity","nidm_SearchSpaceMaskMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "SearchSpaceMask.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "SearchSpaceMask.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Search Space Mask Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:8ac2495eaa1d9630498f5dcb7ca6623a"},
-      "nidm_searchVolumeInVoxels:": {"@type": "xsd:int", "@value": "223057"},
-      "nidm_searchVolumeInUnits:": {"@type": "xsd:float", "@value": "1784456"},
-      "nidm_reselSizeInVoxels:": {"@type": "xsd:float", "@value": "65.5786964036542"},
-      "nidm_searchVolumeInResels:": {"@type": "xsd:float", "@value": "3155.84193266257"},
-      "spm_searchVolumeReselsGeometry:": {"@type": "xsd:string", "@value": "[6, 97.8140592306853, 965.938819261507, 3155.84193266257]"},
-      "nidm_noiseFWHMInVoxels:": {"@type": "xsd:string", "@value": "[4.09118640605185, 4.0346308705955, 3.97291894351243]"},
-      "nidm_noiseFWHMInUnits:": {"@type": "xsd:string", "@value": "[8.18237281210369, 8.069261741191, 7.94583788702486]"},
-      "nidm_randomFieldStationarity:": {"@type": "xsd:boolean", "@value": "true"},
-      "nidm_expectedNumberOfVoxelsPerCluster:": {"@type": "xsd:float", "@value": "7.21748994812991"},
-      "nidm_expectedNumberOfClusters:": {"@type": "xsd:float", "@value": "33.5642173578105"},
-      "nidm_heightCriticalThresholdFWE05:": {"@type": "xsd:float", "@value": "5.30963135104407"},
-      "nidm_heightCriticalThresholdFDR05:": {"@type": "xsd:float", "@value": "5.64907312393188"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:43990f91d4711220e8f4834300dbd4a5"},
+      "nidm_searchVolumeInVoxels": {"@type": "xsd:int", "@value": "223057"},
+      "nidm_searchVolumeInUnits": {"@type": "xsd:float", "@value": "1784456"},
+      "nidm_reselSizeInVoxels": {"@type": "xsd:float", "@value": "65.5786964036542"},
+      "nidm_searchVolumeInResels": {"@type": "xsd:float", "@value": "3155.84193266257"},
+      "spm_searchVolumeReselsGeometry": {"@type": "xsd:string", "@value": "[6, 97.8140592306853, 965.938819261507, 3155.84193266257]"},
+      "nidm_noiseFWHMInVoxels": {"@type": "xsd:string", "@value": "[4.09118640605185, 4.0346308705955, 3.97291894351243]"},
+      "nidm_noiseFWHMInUnits": {"@type": "xsd:string", "@value": "[8.18237281210369, 8.069261741191, 7.94583788702486]"},
+      "nidm_randomFieldStationarity": {"@type": "xsd:boolean", "@value": "true"},
+      "nidm_expectedNumberOfVoxelsPerCluster": {"@type": "xsd:float", "@value": "7.21748994812991"},
+      "nidm_expectedNumberOfClusters": {"@type": "xsd:float", "@value": "33.5642173578105"},
+      "nidm_heightCriticalThresholdFWE05": {"@type": "xsd:float", "@value": "5.30963135104407"},
+      "nidm_heightCriticalThresholdFDR05": {"@type": "xsd:float", "@value": "5.64907312393188"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876"},
-      "spm_smallestSignificantClusterSizeInVoxelsFWE05:": {"@type": "xsd:int", "@value": "98"},
-      "spm_smallestSignificantClusterSizeInVoxelsFDR05:": {"@type": "xsd:int", "@value": "61"}
+      "spm_smallestSignificantClusterSizeInVoxelsFWE05": {"@type": "xsd:int", "@value": "98"},
+      "spm_smallestSignificantClusterSizeInVoxelsFDR05": {"@type": "xsd:int", "@value": "61"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:4203cdd482eb37373a8117206cb4efe7",
-      "activity": "niiri:c20d3c1d9297836af7474d61ffe6e5d9"
+      "entity_generated": "niiri:61ba90688ed17ead0aa46ba07adc7f73",
+      "activity": "niiri:16a9b96282eb00365725e2a0f6d310c6"
     },
     {
-      "@id": "niiri:1af80adb8bcccf57b9b05ac7c52481d4",
-      "@type": ["prov:Entity","nidm_ExcursionSetMap:"],
+      "@id": "niiri:88829929c68a059331cc3c1d60afeecb",
+      "@type": ["prov:Entity","nidm_ExcursionSetMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ExcursionSet.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ExcursionSet.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Excursion Set Map",
-      "nidm_numberOfSupraThresholdClusters:": {"@type": "xsd:int", "@value": "56"},
-      "nidm_pValue:": {"@type": "xsd:float", "@value": "0.000247328380021838"},
-      "nidm_hasClusterLabelsMap:": {"@id": "niiri:097a03a58fe62d77996b29182e1c553b"},
-      "nidm_hasMaximumIntensityProjection:": {"@id": "niiri:9eaf644167e5051fc8c46c6f7df592fb"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:8ac2495eaa1d9630498f5dcb7ca6623a"},
+      "nidm_numberOfSupraThresholdClusters": {"@type": "xsd:int", "@value": "56"},
+      "nidm_pValue": {"@type": "xsd:float", "@value": "0.000247328380021838"},
+      "nidm_hasClusterLabelsMap": {"@id": "niiri:e5ce76ed52cded7d1b752baf082c1886"},
+      "nidm_hasMaximumIntensityProjection": {"@id": "niiri:1aee58d2fc0953d357532d51ed194f16"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:43990f91d4711220e8f4834300dbd4a5"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "a8d48d1adbe71cf263b98b98011df674a6c6b1602e9131c3ce3c96140161b1fc1c1c96359cbd6c7c0b0729cb52832ff1995a211d75748d9237df95dcd70ec0f4"}
     },
     {
-      "@id": "niiri:097a03a58fe62d77996b29182e1c553b",
-      "@type": ["prov:Entity","nidm_ClusterLabelsMap:"],
+      "@id": "niiri:e5ce76ed52cded7d1b752baf082c1886",
+      "@type": ["prov:Entity","nidm_ClusterLabelsMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ClusterLabels.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ClusterLabels.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Cluster Labels Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:8ac2495eaa1d9630498f5dcb7ca6623a"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:43990f91d4711220e8f4834300dbd4a5"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "774704e1f481e7e243dd63c13916d5e8cf0877992b8300d55bd612568c0e5bc608433c90a6c24a4618cb6117e8c232a45a5611fba7352c5a7931bdabf0d2e6b5"}
     },
     {
-      "@id": "niiri:9eaf644167e5051fc8c46c6f7df592fb",
+      "@id": "niiri:1aee58d2fc0953d357532d51ed194f16",
       "@type": ["prov:Entity","dctype:Image"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "MaximumIntensityProjection.png"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "MaximumIntensityProjection.png"},
@@ -863,2444 +863,2444 @@
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:1af80adb8bcccf57b9b05ac7c52481d4",
-      "activity": "niiri:c20d3c1d9297836af7474d61ffe6e5d9"
+      "entity_generated": "niiri:88829929c68a059331cc3c1d60afeecb",
+      "activity": "niiri:16a9b96282eb00365725e2a0f6d310c6"
     },
     {
-      "@id": "niiri:79e0203aa5a8ff2c1026ae98766d1fd0",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:0fe5639ac98706c7b3899db7801a8bf2",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0001",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "71"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.08266866976093"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00388517632401976"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.122258284761589"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0268436007152825"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "1"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "71"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.08266866976093"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00388517632401976"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.122258284761589"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0268436007152825"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "1"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:79e0203aa5a8ff2c1026ae98766d1fd0",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:0fe5639ac98706c7b3899db7801a8bf2",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:97cfacc05fa324f73a12205fe62c3b0e",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:2975c7a00a3fc4010192cdde06218e42",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0002",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "552"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "8.41736768602862"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.46402494575762e-10"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1.16267285799054e-08"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "9.69926984812134e-09"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "2"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "552"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "8.41736768602862"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.46402494575762e-10"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1.16267285799054e-08"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "9.69926984812134e-09"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "2"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:97cfacc05fa324f73a12205fe62c3b0e",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:2975c7a00a3fc4010192cdde06218e42",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:f751ad7b48ea46de21e54d7b384c89f1",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:022596b73b46d7ef5ae45ede7165a0d5",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0003",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1653"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "25.2063564945748"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.21466960104582e-20"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1.24021497658566e-18"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "3"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1653"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "25.2063564945748"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.21466960104582e-20"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1.24021497658566e-18"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "3"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f751ad7b48ea46de21e54d7b384c89f1",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:022596b73b46d7ef5ae45ede7165a0d5",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:c1dc7ef33bd86562827618d9eb1512eb",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:9170484cbff3981334345a4c47f65aa7",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0004",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "120"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.829862540441"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000379874391228937"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0126692473683625"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00425459318176409"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "4"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "120"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.829862540441"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000379874391228937"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0126692473683625"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00425459318176409"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "4"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c1dc7ef33bd86562827618d9eb1512eb",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:9170484cbff3981334345a4c47f65aa7",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:67d786a9d604bea82ccb2ac559f82d13",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:25e87116b614d88934e1e8c93fcc0b63",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0005",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "61"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.930180124724177"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00662877418964967"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.199476682033478"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0371211354620382"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "5"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "61"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.930180124724177"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00662877418964967"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.199476682033478"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0371211354620382"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "5"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:67d786a9d604bea82ccb2ac559f82d13",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:25e87116b614d88934e1e8c93fcc0b63",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:fad9f2a76799ff174c8bd126ac6dd441",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c71e617484a5b302959dff7c4db9cc74",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0006",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "146"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "2.22633275753655"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000126444741899023"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0042350256798831"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00236030184878177"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "6"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "146"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "2.22633275753655"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000126444741899023"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0042350256798831"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00236030184878177"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "6"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:fad9f2a76799ff174c8bd126ac6dd441",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:c71e617484a5b302959dff7c4db9cc74",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:2fac5f34a48ebec593eeef67b0204e24",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:b1e379a1ec5bd17c690d79aba04d4080",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0007",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "33"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.503212198621276"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0357752504977919"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.699037101834118"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.133560935191756"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "7"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "33"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.503212198621276"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0357752504977919"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.699037101834118"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.133560935191756"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "7"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2fac5f34a48ebec593eeef67b0204e24",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:b1e379a1ec5bd17c690d79aba04d4080",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:7225d84c7ed17dec15823366e7f7fc83",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:4672418600c089d526b22d32d479dd1e",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0008",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "69"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.05217096075358"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00431415011495612"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.134805612767259"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0268436007152825"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "8"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "69"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.05217096075358"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00431415011495612"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.134805612767259"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0268436007152825"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "8"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7225d84c7ed17dec15823366e7f7fc83",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:4672418600c089d526b22d32d479dd1e",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:cabc7bdcad758f1df0bc5478e9d6d8e1",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:67a283ee599be31793e69bea3826f055",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0009",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "98"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.49438774136015"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00102712996618427"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0338873275648864"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00958654635105321"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "9"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "98"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.49438774136015"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00102712996618427"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0338873275648864"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00958654635105321"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "9"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cabc7bdcad758f1df0bc5478e9d6d8e1",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:67a283ee599be31793e69bea3826f055",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:bc8fac8699d6afb89bc9b1fb0219744d",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:7640c37d58f807f183dbb16f5cce885a",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0010",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "71"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.08266866976093"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00388517632401976"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.122258284761589"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0268436007152825"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "10"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "71"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.08266866976093"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00388517632401976"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.122258284761589"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0268436007152825"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "10"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:bc8fac8699d6afb89bc9b1fb0219744d",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:7640c37d58f807f183dbb16f5cce885a",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:7f473f5d8bf7cb4917efbb176cc4e7db",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:8cfc21f5bbcf34401f68b224da91bb62",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0011",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "125"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.90610681295938"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000305687640549511"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0102077104591608"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00425459318176409"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "11"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "125"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.90610681295938"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000305687640549511"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0102077104591608"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00425459318176409"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "11"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7f473f5d8bf7cb4917efbb176cc4e7db",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:8cfc21f5bbcf34401f68b224da91bb62",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:cb86cbce3b49744dcf6fb45ea4518fb9",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:dfe1db9cfb99ba668d8eeb1e01c32a4f",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0012",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "43"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.655700743658026"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0188122365537974"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.468162877205716"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.081037326693281"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "12"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "43"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.655700743658026"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0188122365537974"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.468162877205716"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.081037326693281"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "12"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cb86cbce3b49744dcf6fb45ea4518fb9",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:dfe1db9cfb99ba668d8eeb1e01c32a4f",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:150da014ff9cc30caf37962658fd7687",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:8b21d35a1fc7a9cfb360ad2121638da7",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0013",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "21"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.320225944577176"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0850912379420168"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.942502902202007"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.234367607276586"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "13"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "21"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.320225944577176"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0850912379420168"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.942502902202007"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.234367607276586"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "13"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:150da014ff9cc30caf37962658fd7687",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:8b21d35a1fc7a9cfb360ad2121638da7",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:653461d881414853588331372590bd6b",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:988a6212fa64a63474847b473adbd268",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0014",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "23"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.350723653584526"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0729417588872538"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.913553802238084"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.214986236720327"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "14"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "23"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.350723653584526"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0729417588872538"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.913553802238084"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.214986236720327"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "14"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:653461d881414853588331372590bd6b",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:988a6212fa64a63474847b473adbd268",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:98ca641a6df5b460bf760c850b8528af",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:0d10036870ecd78a22c4b7434f3e940f",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0015",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "15"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.228732817555125"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.13960790316574"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.990774925440181"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.300693945280055"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "15"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "15"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.228732817555125"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.13960790316574"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.990774925440181"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.300693945280055"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "15"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:98ca641a6df5b460bf760c850b8528af",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:0d10036870ecd78a22c4b7434f3e940f",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:62781649d6e4a250a6f3378b94f51367",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:7e1995dcc209b0990e86feb660922162",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0016",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "20"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0920729885729446"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.954514323339066"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.234367607276586"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "16"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "20"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0920729885729446"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.954514323339066"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.234367607276586"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "16"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:62781649d6e4a250a6f3378b94f51367",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:7e1995dcc209b0990e86feb660922162",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:2ef53dff53e03927f9f447755a2af2df",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:b4757e6c4de815acef5afdb0476f0eb3",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0017",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "15"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.228732817555125"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.13960790316574"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.990774925440181"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.300693945280055"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "17"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "15"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.228732817555125"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.13960790316574"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.990774925440181"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.300693945280055"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "17"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2ef53dff53e03927f9f447755a2af2df",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:b4757e6c4de815acef5afdb0476f0eb3",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:689adaab2c0c4d3c1af8f26813a3b966",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f8221060362a62c937dd97233413a960",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0018",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "26"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.396470217095551"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0583630672052552"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.858988054642613"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.181573986860794"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "18"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "26"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.396470217095551"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0583630672052552"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.858988054642613"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.181573986860794"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "18"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:689adaab2c0c4d3c1af8f26813a3b966",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:f8221060362a62c937dd97233413a960",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:6d7f9eadd2ea16abe1d24c92b4094bf6",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:af4c8a0d8ff5cfb976a7e9746756d8e3",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0019",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "51"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.777691579687426"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0116562324834894"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.323776962785858"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.054395751589617"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "19"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "51"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.777691579687426"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0116562324834894"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.323776962785858"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.054395751589617"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "19"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6d7f9eadd2ea16abe1d24c92b4094bf6",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:af4c8a0d8ff5cfb976a7e9746756d8e3",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:684ce311bfd3bc478751bb8ba1bdc608",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:866201193f458cd1f0d7d30bfc40b674",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0020",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "52"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.792940434191101"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0109993325903037"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.308701793106052"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.054395751589617"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "20"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "52"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.792940434191101"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0109993325903037"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.308701793106052"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.054395751589617"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "20"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:684ce311bfd3bc478751bb8ba1bdc608",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:866201193f458cd1f0d7d30bfc40b674",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:dff5ab56a4787869bfe6b9e37cb9aac1",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:2627b433d92d75102b82469256c03339",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0021",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0609954180147001"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.44232166254071"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999643232106"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.688055919507771"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "21"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0609954180147001"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.44232166254071"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999643232106"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.688055919507771"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "21"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:dff5ab56a4787869bfe6b9e37cb9aac1",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:2627b433d92d75102b82469256c03339",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:2f77c6e25e1162cf6ea3521c6e32fc2e",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:601904871dc4878169c4db748733771d",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0022",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "29"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.442216780606576"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0470937359607303"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.79416170413585"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.164828075862556"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "22"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "29"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.442216780606576"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0470937359607303"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.79416170413585"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.164828075862556"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "22"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2f77c6e25e1162cf6ea3521c6e32fc2e",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:601904871dc4878169c4db748733771d",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:19b8938a50757611f958db8a897d6420",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:0a7cd6ed9222066e8fdf471bab1ee6e7",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0023",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "20"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0920729885729446"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.954514323339066"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.234367607276586"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "23"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "20"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0920729885729446"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.954514323339066"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.234367607276586"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "23"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:19b8938a50757611f958db8a897d6420",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:0a7cd6ed9222066e8fdf471bab1ee6e7",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:88c4835173f01a2e57f1b274727c2e78",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:d2a33a86263a0cb45dbf1c9cce5a8dd4",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0024",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "41"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.625203034650676"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0212995163239923"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.51075974713709"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0851980652959692"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "24"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "41"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.625203034650676"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0212995163239923"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.51075974713709"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0851980652959692"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "24"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:88c4835173f01a2e57f1b274727c2e78",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:d2a33a86263a0cb45dbf1c9cce5a8dd4",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:ef62449f6b6d1aca9419dce43c45ebb1",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:ab0144b9188c24f978e07874f53ac025",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0025",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "27"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.411719071599226"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0542875242970965"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.83831709934398"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.1788294918022"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "25"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "27"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.411719071599226"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0542875242970965"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.83831709934398"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.1788294918022"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "25"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ef62449f6b6d1aca9419dce43c45ebb1",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:ab0144b9188c24f978e07874f53ac025",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:1888964486bb06df70ff6f51a4b99b30",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c584015fa24c7c926f0b58301e5d61f2",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0026",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "16"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.2439816720588"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.128031320700056"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.986394362860718"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.29873974830013"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "26"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "16"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.2439816720588"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.128031320700056"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.986394362860718"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.29873974830013"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "26"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1888964486bb06df70ff6f51a4b99b30",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:c584015fa24c7c926f0b58301e5d61f2",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:036f0f4fe63d2badbd206185e824027a",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:b575189f3bd68971936993d3aa187cb2",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0027",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "6"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0914931270220502"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.343388487126378"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999990125608014"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.582719856941733"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "27"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "6"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0914931270220502"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.343388487126378"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999990125608014"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.582719856941733"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "27"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:036f0f4fe63d2badbd206185e824027a",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:b575189f3bd68971936993d3aa187cb2",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:d15bd2a66669fcb82747bebed9441dfd",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:e8cd31e50a3c32fbe2bbcc0095269056",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0028",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0457465635110251"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.509991966452308"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999963189445"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.713988753033231"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "28"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0457465635110251"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.509991966452308"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999963189445"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.713988753033231"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "28"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d15bd2a66669fcb82747bebed9441dfd",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:e8cd31e50a3c32fbe2bbcc0095269056",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:0da1df9eac44070257be237353ddcd3a",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:e97474fed9ca8bf394b41d386552ec23",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0029",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "5"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0762442725183751"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.388074947166389"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999997796430203"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.620919915466222"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "29"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "5"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0762442725183751"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.388074947166389"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999997796430203"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.620919915466222"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "29"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0da1df9eac44070257be237353ddcd3a",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:e97474fed9ca8bf394b41d386552ec23",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:4b0e06aef793ba5702452d1f3e252868",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:abd9e58304894c9547b23ee1045ac1da",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0030",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "16"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.2439816720588"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.128031320700056"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.986394362860718"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.29873974830013"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "30"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "16"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.2439816720588"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.128031320700056"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.986394362860718"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.29873974830013"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "30"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4b0e06aef793ba5702452d1f3e252868",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:abd9e58304894c9547b23ee1045ac1da",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:85bdb7fb602f14f0f33185e4228dd31d",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f35fdf14b958462f212cb7e02a3f5b6a",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0031",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "14"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.21348396305145"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.152527900243506"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.994020866354823"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.316354163468013"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "31"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "14"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.21348396305145"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.152527900243506"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.994020866354823"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.316354163468013"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "31"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:85bdb7fb602f14f0f33185e4228dd31d",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:f35fdf14b958462f212cb7e02a3f5b6a",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:70204a580679814e93ec3ee19b2e747c",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:65aa1110e7a5b158b24b46e37675c86f",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0032",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "8"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.1219908360294"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.273933067513935"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999898388010158"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.511341726026011"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "32"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "8"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.1219908360294"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.273933067513935"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999898388010158"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.511341726026011"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "32"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:70204a580679814e93ec3ee19b2e747c",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:65aa1110e7a5b158b24b46e37675c86f",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:f6f25c1b5f426f11bffb789fc0ff6d56",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:7d8d48b7315eff2905773178ffd49023",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0033",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "10"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.15248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.22255850848336"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999430072930499"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.429768154312695"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "33"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "10"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.15248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.22255850848336"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999430072930499"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.429768154312695"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "33"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f6f25c1b5f426f11bffb789fc0ff6d56",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:7d8d48b7315eff2905773178ffd49023",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:1709f46929bebc2f3c937d537403c879",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:62e2c2069415d9aa3cc91424a7a036cf",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0034",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "7"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.106741981525725"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.305873808816549"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999965218155016"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.53527916542896"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "34"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "7"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.106741981525725"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.305873808816549"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999965218155016"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.53527916542896"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "34"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1709f46929bebc2f3c937d537403c879",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:62e2c2069415d9aa3cc91424a7a036cf",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:6143b9e2dc6ccc1e23b85ae05647eb05",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:2deb14df5037616ae2a96835f77312be",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0035",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0457465635110251"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.509991966452308"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999963189445"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.713988753033231"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "35"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0457465635110251"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.509991966452308"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999963189445"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.713988753033231"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "35"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6143b9e2dc6ccc1e23b85ae05647eb05",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:2deb14df5037616ae2a96835f77312be",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:90c1e5b11aa4824f7fb9ea3eac86bf0d",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:5b409e333f6b39e5bc61b32b5cdb5358",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0036",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "12"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.1829862540441"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.183276076907294"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.997869754572677"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.366552153814587"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "36"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "12"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.1829862540441"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.183276076907294"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.997869754572677"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.366552153814587"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "36"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:90c1e5b11aa4824f7fb9ea3eac86bf0d",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:5b409e333f6b39e5bc61b32b5cdb5358",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:5e09dfc93a92598eb65ced39066c6e1f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:aa433f26589b155235af6a6df23091d5",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0037",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.598176099264786"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999998092195"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "37"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.598176099264786"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999998092195"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "37"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5e09dfc93a92598eb65ced39066c6e1f",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:aa433f26589b155235af6a6df23091d5",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:7c5ba749e2c3ebf4bc0b3ad25206415a",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:d220eb8d00595929d9a913e79e63f18d",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0038",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "7"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.106741981525725"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.305873808816549"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999965218155016"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.53527916542896"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "38"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "7"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.106741981525725"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.305873808816549"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999965218155016"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.53527916542896"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "38"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7c5ba749e2c3ebf4bc0b3ad25206415a",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:d220eb8d00595929d9a913e79e63f18d",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:48da72af2b8db06b1f889a4b6dfc0d72",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:b25a22f3e4eb9bbd1275897ff1df109d",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0039",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.598176099264786"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999998092195"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "39"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.598176099264786"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999998092195"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "39"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:48da72af2b8db06b1f889a4b6dfc0d72",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:b25a22f3e4eb9bbd1275897ff1df109d",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:a27fad4fe7cc82465f0e2f5bbe9d75f9",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:bd4658613e97b52c7228dc395dd15873",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0040",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0457465635110251"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.509991966452308"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999963189445"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.713988753033231"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "40"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0457465635110251"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.509991966452308"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999963189445"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.713988753033231"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "40"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a27fad4fe7cc82465f0e2f5bbe9d75f9",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:bd4658613e97b52c7228dc395dd15873",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:8a6fe11cd61eb1f35a28fa6bf0b6144f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:453c0a23d3b7bdaf631090a39026b948",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0041",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.598176099264786"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999998092195"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "41"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.598176099264786"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999998092195"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "41"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8a6fe11cd61eb1f35a28fa6bf0b6144f",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:453c0a23d3b7bdaf631090a39026b948",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:2e6c2c0ad60837828212538790c5db9b",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f9cadf3213379a88a9727fcf6a9eeef1",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0042",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999997153"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "42"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999997153"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "42"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2e6c2c0ad60837828212538790c5db9b",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:f9cadf3213379a88a9727fcf6a9eeef1",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:5dabb5b7488150418280d8590f704272",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:00e7e2184e288d14e023360536c4ccbb",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0043",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999997153"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "43"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999997153"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "43"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5dabb5b7488150418280d8590f704272",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:00e7e2184e288d14e023360536c4ccbb",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:f0c686d0818396b5724de255e477b7e7",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:1e198daa9971af9c5562116948147b44",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0044",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999997153"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "44"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999997153"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "44"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f0c686d0818396b5724de255e477b7e7",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:1e198daa9971af9c5562116948147b44",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:4d3b4510cff045e65b0540e3d2c3ddb5",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:b983603109c1a317dd80246d873f0d4a",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0045",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.598176099264786"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999998092195"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "45"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.598176099264786"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999998092195"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "45"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4d3b4510cff045e65b0540e3d2c3ddb5",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:b983603109c1a317dd80246d873f0d4a",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:cb783972b7209195409262a64edc55f4",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:bcad500e3ad79ca4075f62aa01a372da",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0046",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "5"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0762442725183751"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.388074947166389"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999997796430203"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.620919915466222"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "46"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "5"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0762442725183751"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.388074947166389"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999997796430203"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.620919915466222"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "46"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cb783972b7209195409262a64edc55f4",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:bcad500e3ad79ca4075f62aa01a372da",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:a972e773c5316470d7547a29677906b8",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:b41f8e4d939b3ddb2c20cae93fb8b7c8",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0047",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999997153"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "47"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999997153"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "47"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a972e773c5316470d7547a29677906b8",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:b41f8e4d939b3ddb2c20cae93fb8b7c8",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:568187a66cff2006389ae8a03beea987",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:4545f5ed2d2381e9f6f1aaf307289882",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0048",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.598176099264786"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999998092195"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "48"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.598176099264786"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999998092195"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "48"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:568187a66cff2006389ae8a03beea987",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:4545f5ed2d2381e9f6f1aaf307289882",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:31ace54320ced6fbcbbf3e9a0b06c69b",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:2253c054073552510a00e5cee801efa6",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0049",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0457465635110251"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.509991966452308"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999963189445"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.713988753033231"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "49"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0457465635110251"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.509991966452308"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999963189445"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.713988753033231"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "49"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:31ace54320ced6fbcbbf3e9a0b06c69b",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:2253c054073552510a00e5cee801efa6",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:497da5b57f3713b30ef46f853f1ed5d0",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c2c0de5bb03471fb2a8439bc440e1a06",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0050",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999997153"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "50"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999997153"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "50"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:497da5b57f3713b30ef46f853f1ed5d0",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:c2c0de5bb03471fb2a8439bc440e1a06",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:2ef352ff3d02560b512f4da34e0351c4",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:7c7b06e42170e83d79d011d51a1ee2eb",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0051",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999997153"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "51"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999997153"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "51"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2ef352ff3d02560b512f4da34e0351c4",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:7c7b06e42170e83d79d011d51a1ee2eb",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:d31015870dfb250e5f85f5b4632731c3",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:040e702ed12041e2190bf96dfbacadbb",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0052",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.598176099264786"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999998092195"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "52"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.598176099264786"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999998092195"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "52"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d31015870dfb250e5f85f5b4632731c3",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:040e702ed12041e2190bf96dfbacadbb",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:cb808a6811ec0c81f5483719bfa3da6a",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:e14e04732107aabcfe52c4ce59b579a8",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0053",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999997153"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "53"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999997153"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "53"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cb808a6811ec0c81f5483719bfa3da6a",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:e14e04732107aabcfe52c4ce59b579a8",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:da2ebf5fddf7590fea56aa4795c3c730",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:d77e5bf6a731dcb245ad371bed714586",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0054",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999997153"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "54"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999997153"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "54"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:da2ebf5fddf7590fea56aa4795c3c730",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:d77e5bf6a731dcb245ad371bed714586",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:5f270d7e12051f6614973ee4186253ff",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:9575c70a2f76c6d9598daa3848deeb65",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0055",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999997153"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "55"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999997153"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "55"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5f270d7e12051f6614973ee4186253ff",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:9575c70a2f76c6d9598daa3848deeb65",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:3165aeeecdded90d2140dbb15bc8e722",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:75e697b6b2e295644bcfcd0111ce9380",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0056",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999997153"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "56"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999997153"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "56"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3165aeeecdded90d2140dbb15bc8e722",
-      "entity": "niiri:1af80adb8bcccf57b9b05ac7c52481d4"
+      "entity_derived": "niiri:75e697b6b2e295644bcfcd0111ce9380",
+      "entity": "niiri:88829929c68a059331cc3c1d60afeecb"
     },
     {
-      "@id": "niiri:c34af718ecf50c995e6a268008d1be28",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:af2094f9b3bb076517fd57cfdea6eba4",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0001",
-      "prov:atLocation": {"@id": "niiri:585296e06e66672b3fc0fea088e1ce35"},
+      "prov:atLocation": {"@id": "niiri:6631676ab73837c6d950866c315ccf1a"},
       "prov:value": {"@type": "xsd:float", "@value": "5.64907312393188"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.24289493008127"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.9038282474464e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0140710030676051"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0477090229517705"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.24289493008127"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.9038282474464e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0140710030676051"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0477090229517705"}
     },
     {
-      "@id": "niiri:585296e06e66672b3fc0fea088e1ce35",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6631676ab73837c6d950866c315ccf1a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0001",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[36,-76,-12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[36,-76,-12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c34af718ecf50c995e6a268008d1be28",
-      "entity": "niiri:79e0203aa5a8ff2c1026ae98766d1fd0"
+      "entity_derived": "niiri:af2094f9b3bb076517fd57cfdea6eba4",
+      "entity": "niiri:0fe5639ac98706c7b3899db7801a8bf2"
     },
     {
-      "@id": "niiri:7435824662b09850d505d48ff0b947a5",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0dbf46b534dd4d2ded0176cdc0cedff2",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0002",
-      "prov:atLocation": {"@id": "niiri:ce4104f5c86d70fe197ed78aba3a700c"},
+      "prov:atLocation": {"@id": "niiri:0e60133e7c39e22e4a371d8f01396b30"},
       "prov:value": {"@type": "xsd:float", "@value": "5.42078256607056"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.05689095731376"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.13073368393601e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0332963820346506"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0570035031908581"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.05689095731376"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.13073368393601e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0332963820346506"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0570035031908581"}
     },
     {
-      "@id": "niiri:ce4104f5c86d70fe197ed78aba3a700c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0e60133e7c39e22e4a371d8f01396b30",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0002",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[20,16,4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[20,16,4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7435824662b09850d505d48ff0b947a5",
-      "entity": "niiri:97cfacc05fa324f73a12205fe62c3b0e"
+      "entity_derived": "niiri:0dbf46b534dd4d2ded0176cdc0cedff2",
+      "entity": "niiri:2975c7a00a3fc4010192cdde06218e42"
     },
     {
-      "@id": "niiri:69b4afbe837d83937f24d7e95d93fced",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:9fa6b2358072adca3ed3687d1a6ad221",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0003",
-      "prov:atLocation": {"@id": "niiri:c7f628b3032253d6e3eed6e9cf085ee7"},
+      "prov:atLocation": {"@id": "niiri:b10dc0afb7a68740e32c8b3be51324ad"},
       "prov:value": {"@type": "xsd:float", "@value": "5.11829614639282"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.80629858706218"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.68751121871247e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0981605381212231"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.057973541602361"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.80629858706218"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.68751121871247e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0981605381212231"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.057973541602361"}
     },
     {
-      "@id": "niiri:c7f628b3032253d6e3eed6e9cf085ee7",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b10dc0afb7a68740e32c8b3be51324ad",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0003",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[32,26,-6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[32,26,-6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:69b4afbe837d83937f24d7e95d93fced",
-      "entity": "niiri:97cfacc05fa324f73a12205fe62c3b0e"
+      "entity_derived": "niiri:9fa6b2358072adca3ed3687d1a6ad221",
+      "entity": "niiri:2975c7a00a3fc4010192cdde06218e42"
     },
     {
-      "@id": "niiri:356d2f82e462594d0042d6393c464ddb",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:8ae0f4115317261dd462890c08bba437",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0004",
-      "prov:atLocation": {"@id": "niiri:cf78bd7cc12e8a944e6cbf175ddaed4c"},
+      "prov:atLocation": {"@id": "niiri:5d8a2cdf981ab3e1af47206d152b9767"},
       "prov:value": {"@type": "xsd:float", "@value": "4.6295690536499"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.39160002492543"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.62597750342064e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.431266600537586"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.146151100945538"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.39160002492543"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.62597750342064e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.431266600537586"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.146151100945538"}
     },
     {
-      "@id": "niiri:cf78bd7cc12e8a944e6cbf175ddaed4c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:5d8a2cdf981ab3e1af47206d152b9767",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0004",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[14,10,0]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[14,10,0]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:356d2f82e462594d0042d6393c464ddb",
-      "entity": "niiri:97cfacc05fa324f73a12205fe62c3b0e"
+      "entity_derived": "niiri:8ae0f4115317261dd462890c08bba437",
+      "entity": "niiri:2975c7a00a3fc4010192cdde06218e42"
     },
     {
-      "@id": "niiri:6a747142599301744442efa503531015",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:50e978588351b61d3b66805ff525e612",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0005",
-      "prov:atLocation": {"@id": "niiri:acc2efcedcdbe2c06f52a8a38755b94c"},
+      "prov:atLocation": {"@id": "niiri:9ddd565948e5d4f00a26dac1f2579a39"},
       "prov:value": {"@type": "xsd:float", "@value": "5.28027057647705"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.94106877436825"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.88477472079707e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0555771763913264"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.057973541602361"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.94106877436825"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.88477472079707e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0555771763913264"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.057973541602361"}
     },
     {
-      "@id": "niiri:acc2efcedcdbe2c06f52a8a38755b94c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:9ddd565948e5d4f00a26dac1f2579a39",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0005",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-30,26,2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-30,26,2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6a747142599301744442efa503531015",
-      "entity": "niiri:f751ad7b48ea46de21e54d7b384c89f1"
+      "entity_derived": "niiri:50e978588351b61d3b66805ff525e612",
+      "entity": "niiri:022596b73b46d7ef5ae45ede7165a0d5"
     },
     {
-      "@id": "niiri:1d87d3c8a54e1832d85927f547b0fd76",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:6393cd494948c4e016913a024bb7521d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0006",
-      "prov:atLocation": {"@id": "niiri:40d92fd1bc3081d12818efce8e8031d0"},
+      "prov:atLocation": {"@id": "niiri:d43a0f137c03ba2fb045a1f9b0cf9580"},
       "prov:value": {"@type": "xsd:float", "@value": "4.88750791549683"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.61196523240772"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.99439861559014e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.208871803486741"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0985996618857355"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.61196523240772"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.99439861559014e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.208871803486741"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0985996618857355"}
     },
     {
-      "@id": "niiri:40d92fd1bc3081d12818efce8e8031d0",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d43a0f137c03ba2fb045a1f9b0cf9580",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0006",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-10,8,-2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-10,8,-2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1d87d3c8a54e1832d85927f547b0fd76",
-      "entity": "niiri:f751ad7b48ea46de21e54d7b384c89f1"
+      "entity_derived": "niiri:6393cd494948c4e016913a024bb7521d",
+      "entity": "niiri:022596b73b46d7ef5ae45ede7165a0d5"
     },
     {
-      "@id": "niiri:1b1bebb4104b731a41523cf8e81637a1",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0e412c92bdfddc09e4e0ed8e0ee261e0",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0007",
-      "prov:atLocation": {"@id": "niiri:0836ff4c53dea0b7f98729d30139aa83"},
+      "prov:atLocation": {"@id": "niiri:478f26081ca14d44a5b80d0fa6aae340"},
       "prov:value": {"@type": "xsd:float", "@value": "4.79167556762695"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.53048064119001"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.94248236787364e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.278401885707736"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.109724234977733"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.53048064119001"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.94248236787364e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.278401885707736"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.109724234977733"}
     },
     {
-      "@id": "niiri:0836ff4c53dea0b7f98729d30139aa83",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:478f26081ca14d44a5b80d0fa6aae340",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0007",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[10,32,38]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[10,32,38]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1b1bebb4104b731a41523cf8e81637a1",
-      "entity": "niiri:f751ad7b48ea46de21e54d7b384c89f1"
+      "entity_derived": "niiri:0e412c92bdfddc09e4e0ed8e0ee261e0",
+      "entity": "niiri:022596b73b46d7ef5ae45ede7165a0d5"
     },
     {
-      "@id": "niiri:08598bd3c2dada2c26e6239d4bcb86ec",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e401e0680e4b9f39743fb11b553b1c5c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0008",
-      "prov:atLocation": {"@id": "niiri:48d8c5600eccb31ef88f0bd3b6b980e0"},
+      "prov:atLocation": {"@id": "niiri:5414198bcf0cadaac95e83d11c1e4986"},
       "prov:value": {"@type": "xsd:float", "@value": "5.13094520568848"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.81687144616269"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.2913285620313e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0939877807357308"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.057973541602361"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.81687144616269"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.2913285620313e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0939877807357308"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.057973541602361"}
     },
     {
-      "@id": "niiri:48d8c5600eccb31ef88f0bd3b6b980e0",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:5414198bcf0cadaac95e83d11c1e4986",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0008",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[38,-62,52]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[38,-62,52]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:08598bd3c2dada2c26e6239d4bcb86ec",
-      "entity": "niiri:c1dc7ef33bd86562827618d9eb1512eb"
+      "entity_derived": "niiri:e401e0680e4b9f39743fb11b553b1c5c",
+      "entity": "niiri:9170484cbff3981334345a4c47f65aa7"
     },
     {
-      "@id": "niiri:9d74c6df10db1fd75a238fb34d159085",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:9ec7ebe2b378f433f22f85f05b5fdb45",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0009",
-      "prov:atLocation": {"@id": "niiri:7d3567ed1357123b1fbed6e63a26514c"},
+      "prov:atLocation": {"@id": "niiri:29c1e188537e77306058fe2541600682"},
       "prov:value": {"@type": "xsd:float", "@value": "3.53375339508057"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.41974003817318"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00031340502338606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999410859557"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.627190791526275"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.41974003817318"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00031340502338606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999410859557"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.627190791526275"}
     },
     {
-      "@id": "niiri:7d3567ed1357123b1fbed6e63a26514c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:29c1e188537e77306058fe2541600682",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0009",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[48,-66,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[48,-66,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9d74c6df10db1fd75a238fb34d159085",
-      "entity": "niiri:c1dc7ef33bd86562827618d9eb1512eb"
+      "entity_derived": "niiri:9ec7ebe2b378f433f22f85f05b5fdb45",
+      "entity": "niiri:9170484cbff3981334345a4c47f65aa7"
     },
     {
-      "@id": "niiri:1b16f4aeac9ce732d9d980d409ab21db",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b7750f5b5fe02543fb3c7405c319cb88",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0010",
-      "prov:atLocation": {"@id": "niiri:f3c06bcdeb3cb920750e0ac94d173a81"},
+      "prov:atLocation": {"@id": "niiri:90f2fc0acf05dba443a4b7ef95f762af"},
       "prov:value": {"@type": "xsd:float", "@value": "5.12427711486816"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.81129886370751"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.49762960050582e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0961670813603079"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.057973541602361"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.81129886370751"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.49762960050582e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0961670813603079"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.057973541602361"}
     },
     {
-      "@id": "niiri:f3c06bcdeb3cb920750e0ac94d173a81",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:90f2fc0acf05dba443a4b7ef95f762af",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0010",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[34,-86,12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[34,-86,12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1b16f4aeac9ce732d9d980d409ab21db",
-      "entity": "niiri:67d786a9d604bea82ccb2ac559f82d13"
+      "entity_derived": "niiri:b7750f5b5fe02543fb3c7405c319cb88",
+      "entity": "niiri:25e87116b614d88934e1e8c93fcc0b63"
     },
     {
-      "@id": "niiri:9e4d852d5337f7d6a12ba588732286ad",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b974c5e811e7058e7382d5aa3c8a3528",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0011",
-      "prov:atLocation": {"@id": "niiri:ad393b74b66534d96814d5dbab5d1e70"},
+      "prov:atLocation": {"@id": "niiri:a8f982b50bdecc91ff4188b93fb739c1"},
       "prov:value": {"@type": "xsd:float", "@value": "4.81263160705566"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.54833854810518"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.70355510423315e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.261865695583998"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.109724234977733"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.54833854810518"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.70355510423315e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.261865695583998"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.109724234977733"}
     },
     {
-      "@id": "niiri:ad393b74b66534d96814d5dbab5d1e70",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a8f982b50bdecc91ff4188b93fb739c1",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0011",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[38,-84,0]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[38,-84,0]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9e4d852d5337f7d6a12ba588732286ad",
-      "entity": "niiri:67d786a9d604bea82ccb2ac559f82d13"
+      "entity_derived": "niiri:b974c5e811e7058e7382d5aa3c8a3528",
+      "entity": "niiri:25e87116b614d88934e1e8c93fcc0b63"
     },
     {
-      "@id": "niiri:d293ab4050a8e646b12be24d95ec0ccb",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:931cf9fbf27bd915854b183b1741a9f1",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0012",
-      "prov:atLocation": {"@id": "niiri:77637a210d6abb4016347edbbde3d20f"},
+      "prov:atLocation": {"@id": "niiri:f780f4f5a662be3780f45f7b4b2611bd"},
       "prov:value": {"@type": "xsd:float", "@value": "5.03698205947876"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.73813680545075"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.07846092800568e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.129186074985472"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0665289558024546"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.73813680545075"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.07846092800568e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.129186074985472"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0665289558024546"}
     },
     {
-      "@id": "niiri:77637a210d6abb4016347edbbde3d20f",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f780f4f5a662be3780f45f7b4b2611bd",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0012",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[44,14,26]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[44,14,26]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d293ab4050a8e646b12be24d95ec0ccb",
-      "entity": "niiri:fad9f2a76799ff174c8bd126ac6dd441"
+      "entity_derived": "niiri:931cf9fbf27bd915854b183b1741a9f1",
+      "entity": "niiri:c71e617484a5b302959dff7c4db9cc74"
     },
     {
-      "@id": "niiri:4007a50d37d1624702e8e991f4f56f70",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5b72b70272b9bcb49dbf2e54d6ad8c22",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0013",
-      "prov:atLocation": {"@id": "niiri:605518ce43ed51ff2be014961d3f53b2"},
+      "prov:atLocation": {"@id": "niiri:b6f10f5138c3660277aa70dd12032cc5"},
       "prov:value": {"@type": "xsd:float", "@value": "3.54248213768005"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.42769760362149"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000304361554228083"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999193580757"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.621536290238473"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.42769760362149"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000304361554228083"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999193580757"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.621536290238473"}
     },
     {
-      "@id": "niiri:605518ce43ed51ff2be014961d3f53b2",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b6f10f5138c3660277aa70dd12032cc5",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0013",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[44,16,36]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[44,16,36]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4007a50d37d1624702e8e991f4f56f70",
-      "entity": "niiri:fad9f2a76799ff174c8bd126ac6dd441"
+      "entity_derived": "niiri:5b72b70272b9bcb49dbf2e54d6ad8c22",
+      "entity": "niiri:c71e617484a5b302959dff7c4db9cc74"
     },
     {
-      "@id": "niiri:efe559fed18b01f3fa1599cabffde2eb",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:7bfd939e9f8cb5231d78bd0522e37846",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0014",
-      "prov:atLocation": {"@id": "niiri:419c2ed4b376ef7fe75986f6bf66cf71"},
+      "prov:atLocation": {"@id": "niiri:255fa21c87cd23012182686c06be621e"},
       "prov:value": {"@type": "xsd:float", "@value": "4.76414346694946"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.50698548813516"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.287756441539e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.301278778226174"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.109724234977733"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.50698548813516"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.287756441539e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.301278778226174"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.109724234977733"}
     },
     {
-      "@id": "niiri:419c2ed4b376ef7fe75986f6bf66cf71",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:255fa21c87cd23012182686c06be621e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0014",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-46,-66,-6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-46,-66,-6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:efe559fed18b01f3fa1599cabffde2eb",
-      "entity": "niiri:2fac5f34a48ebec593eeef67b0204e24"
+      "entity_derived": "niiri:7bfd939e9f8cb5231d78bd0522e37846",
+      "entity": "niiri:b1e379a1ec5bd17c690d79aba04d4080"
     },
     {
-      "@id": "niiri:f9b13147b6ceed90e5aedd37b05e0bfc",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:364ab3732572016711f31f4e5557fd6e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0015",
-      "prov:atLocation": {"@id": "niiri:550fe7c29b405262a09bf0ec050e597c"},
+      "prov:atLocation": {"@id": "niiri:f7f528e3ea098738c5143d0197302233"},
       "prov:value": {"@type": "xsd:float", "@value": "3.7637345790863"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.62829384243901"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000142650218672435"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999605970761399"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.4902514281085"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.62829384243901"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000142650218672435"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999605970761399"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.4902514281085"}
     },
     {
-      "@id": "niiri:550fe7c29b405262a09bf0ec050e597c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f7f528e3ea098738c5143d0197302233",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0015",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-54,-64,-8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-54,-64,-8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f9b13147b6ceed90e5aedd37b05e0bfc",
-      "entity": "niiri:2fac5f34a48ebec593eeef67b0204e24"
+      "entity_derived": "niiri:364ab3732572016711f31f4e5557fd6e",
+      "entity": "niiri:b1e379a1ec5bd17c690d79aba04d4080"
     },
     {
-      "@id": "niiri:2acd24e64e69a98b2db5a9b0ade88dd4",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d2ff843ea8975b57132bb865c2b6fbf9",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0016",
-      "prov:atLocation": {"@id": "niiri:8b4976b218c7b76f443ad25423bbdc37"},
+      "prov:atLocation": {"@id": "niiri:2fcc314709a63be2fda7e1e532d3d4ae"},
       "prov:value": {"@type": "xsd:float", "@value": "4.72126770019531"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.4703211215873"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.905112123892e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.339495974343671"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.116361476817968"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.4703211215873"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.905112123892e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.339495974343671"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.116361476817968"}
     },
     {
-      "@id": "niiri:8b4976b218c7b76f443ad25423bbdc37",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:2fcc314709a63be2fda7e1e532d3d4ae",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0016",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-32,-4,54]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-32,-4,54]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2acd24e64e69a98b2db5a9b0ade88dd4",
-      "entity": "niiri:7225d84c7ed17dec15823366e7f7fc83"
+      "entity_derived": "niiri:d2ff843ea8975b57132bb865c2b6fbf9",
+      "entity": "niiri:4672418600c089d526b22d32d479dd1e"
     },
     {
-      "@id": "niiri:ca3e2e79c92665f7ae57b663356b0701",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:7236c303cef753dc17dbf884b656c94d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0017",
-      "prov:atLocation": {"@id": "niiri:a2dd6e9bd30bbbf9815dcf250d953dba"},
+      "prov:atLocation": {"@id": "niiri:d131ccabcc3b8de9bb52e1695bd4aecf"},
       "prov:value": {"@type": "xsd:float", "@value": "4.58239698410034"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.35094179562381"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.77770174506431e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.483096159074985"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.15869051476133"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.35094179562381"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.77770174506431e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.483096159074985"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.15869051476133"}
     },
     {
-      "@id": "niiri:a2dd6e9bd30bbbf9815dcf250d953dba",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d131ccabcc3b8de9bb52e1695bd4aecf",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0017",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-48,2,36]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-48,2,36]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ca3e2e79c92665f7ae57b663356b0701",
-      "entity": "niiri:cabc7bdcad758f1df0bc5478e9d6d8e1"
+      "entity_derived": "niiri:7236c303cef753dc17dbf884b656c94d",
+      "entity": "niiri:67a283ee599be31793e69bea3826f055"
     },
     {
-      "@id": "niiri:673b227a4b93dfa20f950634e984332a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:302ec60308493f063ed3e5a8f5fcf98d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0018",
-      "prov:atLocation": {"@id": "niiri:c15782d97f9202a2cff6fd9893b03bad"},
+      "prov:atLocation": {"@id": "niiri:ed63e69d931b5fab18feaf21450ace17"},
       "prov:value": {"@type": "xsd:float", "@value": "4.53685760498047"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.31158680950662"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.10435570797186e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.53534199025083"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.164697949352297"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.31158680950662"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.10435570797186e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.53534199025083"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.164697949352297"}
     },
     {
-      "@id": "niiri:c15782d97f9202a2cff6fd9893b03bad",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ed63e69d931b5fab18feaf21450ace17",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0018",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-36,-72,-16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-36,-72,-16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:673b227a4b93dfa20f950634e984332a",
-      "entity": "niiri:bc8fac8699d6afb89bc9b1fb0219744d"
+      "entity_derived": "niiri:302ec60308493f063ed3e5a8f5fcf98d",
+      "entity": "niiri:7640c37d58f807f183dbb16f5cce885a"
     },
     {
-      "@id": "niiri:8eaa8790262d3687810f66237e3c09b4",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:6e25f8d53bb9ef507aba83f813f590dd",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0019",
-      "prov:atLocation": {"@id": "niiri:57a5dc44a7ec4d28e3b18054ecc32613"},
+      "prov:atLocation": {"@id": "niiri:6d460284a127a017683c0927fae00495"},
       "prov:value": {"@type": "xsd:float", "@value": "3.30497598648071"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.21002839344466"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000663609307096413"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999986374"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.833892248434202"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.21002839344466"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000663609307096413"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999986374"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.833892248434202"}
     },
     {
-      "@id": "niiri:57a5dc44a7ec4d28e3b18054ecc32613",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6d460284a127a017683c0927fae00495",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0019",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-32,-62,-18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-32,-62,-18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8eaa8790262d3687810f66237e3c09b4",
-      "entity": "niiri:bc8fac8699d6afb89bc9b1fb0219744d"
+      "entity_derived": "niiri:6e25f8d53bb9ef507aba83f813f590dd",
+      "entity": "niiri:7640c37d58f807f183dbb16f5cce885a"
     },
     {
-      "@id": "niiri:24ac44587f8116756ad71ba897589aea",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3cc83dbc8a713c095b81fe8356546c6a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0020",
-      "prov:atLocation": {"@id": "niiri:7be1f87a0f0f5f51ba8c4612a2a76300"},
+      "prov:atLocation": {"@id": "niiri:acbec3a585d1f4c829873ee4c5c80c86"},
       "prov:value": {"@type": "xsd:float", "@value": "4.45032644271851"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.23652675669064"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.13501940500749e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.637567785314432"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.172553238762874"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.23652675669064"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.13501940500749e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.637567785314432"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.172553238762874"}
     },
     {
-      "@id": "niiri:7be1f87a0f0f5f51ba8c4612a2a76300",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:acbec3a585d1f4c829873ee4c5c80c86",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0020",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-40,44,26]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-40,44,26]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:24ac44587f8116756ad71ba897589aea",
-      "entity": "niiri:7f473f5d8bf7cb4917efbb176cc4e7db"
+      "entity_derived": "niiri:3cc83dbc8a713c095b81fe8356546c6a",
+      "entity": "niiri:8cfc21f5bbcf34401f68b224da91bb62"
     },
     {
-      "@id": "niiri:3472a26e35b8f09fe372cc154aa3c869",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:385e0f68aa6fd5fcce479853df6deb5b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0021",
-      "prov:atLocation": {"@id": "niiri:2392ddd22caac962d69c8f288cb2ce58"},
+      "prov:atLocation": {"@id": "niiri:5c9d7269e40a2cbf90ddd137da5e18f1"},
       "prov:value": {"@type": "xsd:float", "@value": "3.93534564971924"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.78237892531387"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.76683274343881e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.992232302079702"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.355534752244723"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.78237892531387"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.76683274343881e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.992232302079702"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.355534752244723"}
     },
     {
-      "@id": "niiri:2392ddd22caac962d69c8f288cb2ce58",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:5c9d7269e40a2cbf90ddd137da5e18f1",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0021",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-46,36,24]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-46,36,24]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3472a26e35b8f09fe372cc154aa3c869",
-      "entity": "niiri:7f473f5d8bf7cb4917efbb176cc4e7db"
+      "entity_derived": "niiri:385e0f68aa6fd5fcce479853df6deb5b",
+      "entity": "niiri:8cfc21f5bbcf34401f68b224da91bb62"
     },
     {
-      "@id": "niiri:8b4f5e7a7fbe5044a20b7847aaea88d4",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c531c20f5ce207dd2233835ea3d9bc79",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0022",
-      "prov:atLocation": {"@id": "niiri:08216f6fd8f18cdbec31e7db88b5bf26"},
+      "prov:atLocation": {"@id": "niiri:c9a7f1ed53f731f0361cedcef35b33ed"},
       "prov:value": {"@type": "xsd:float", "@value": "4.31582498550415"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.11913273798974"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.90150518718513e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.788829013385429"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.227629636206583"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.11913273798974"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.90150518718513e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.788829013385429"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.227629636206583"}
     },
     {
-      "@id": "niiri:08216f6fd8f18cdbec31e7db88b5bf26",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c9a7f1ed53f731f0361cedcef35b33ed",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0022",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[36,54,6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[36,54,6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8b4f5e7a7fbe5044a20b7847aaea88d4",
-      "entity": "niiri:cb86cbce3b49744dcf6fb45ea4518fb9"
+      "entity_derived": "niiri:c531c20f5ce207dd2233835ea3d9bc79",
+      "entity": "niiri:dfe1db9cfb99ba668d8eeb1e01c32a4f"
     },
     {
-      "@id": "niiri:335233ae8819d54a72638416435e5e8f",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b49b4c68f2b3604962747d8df42ab67d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0023",
-      "prov:atLocation": {"@id": "niiri:d09c7592851129dac7eed5d1363df35a"},
+      "prov:atLocation": {"@id": "niiri:81f55f41dd8fe791358e61cb82016772"},
       "prov:value": {"@type": "xsd:float", "@value": "4.20391035079956"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.02078923241408"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.900174224163e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.888907080881232"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.284534794626109"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.02078923241408"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.900174224163e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.888907080881232"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.284534794626109"}
     },
     {
-      "@id": "niiri:d09c7592851129dac7eed5d1363df35a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:81f55f41dd8fe791358e61cb82016772",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0023",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[34,-54,-16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[34,-54,-16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:335233ae8819d54a72638416435e5e8f",
-      "entity": "niiri:150da014ff9cc30caf37962658fd7687"
+      "entity_derived": "niiri:b49b4c68f2b3604962747d8df42ab67d",
+      "entity": "niiri:8b21d35a1fc7a9cfb360ad2121638da7"
     },
     {
-      "@id": "niiri:ba77f5f7dc5aaa52067c090bbb093f6a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:fee61dad4332e6b4e8d9275805803cb3",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0024",
-      "prov:atLocation": {"@id": "niiri:7089e492dc910e5947896681b5e315fe"},
+      "prov:atLocation": {"@id": "niiri:e27f88e4f03cabb2cf71df1eab3c7241"},
       "prov:value": {"@type": "xsd:float", "@value": "4.13025856018066"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.95574355061526"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.81484867243431e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.935795859458942"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.317914169802101"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.95574355061526"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.81484867243431e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.935795859458942"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.317914169802101"}
     },
     {
-      "@id": "niiri:7089e492dc910e5947896681b5e315fe",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e27f88e4f03cabb2cf71df1eab3c7241",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0024",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[50,-30,42]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[50,-30,42]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ba77f5f7dc5aaa52067c090bbb093f6a",
-      "entity": "niiri:653461d881414853588331372590bd6b"
+      "entity_derived": "niiri:fee61dad4332e6b4e8d9275805803cb3",
+      "entity": "niiri:988a6212fa64a63474847b473adbd268"
     },
     {
-      "@id": "niiri:9e2e756eb3ea30f583d0bfe7b5fb5f90",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:fcc08bf56890d61c3eef4f4626ab1951",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0025",
-      "prov:atLocation": {"@id": "niiri:a8b02ac54ab3d1b722b6b5c0044e901c"},
+      "prov:atLocation": {"@id": "niiri:baf7846dc4e479f4fde108d36bbedb45"},
       "prov:value": {"@type": "xsd:float", "@value": "4.12145137786865"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.94794832362008"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.94119065879606e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.940339218142555"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.317914169802101"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.94794832362008"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.94119065879606e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.940339218142555"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.317914169802101"}
     },
     {
-      "@id": "niiri:a8b02ac54ab3d1b722b6b5c0044e901c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:baf7846dc4e479f4fde108d36bbedb45",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0025",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-48,-72,2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-48,-72,2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9e2e756eb3ea30f583d0bfe7b5fb5f90",
-      "entity": "niiri:98ca641a6df5b460bf760c850b8528af"
+      "entity_derived": "niiri:fcc08bf56890d61c3eef4f4626ab1951",
+      "entity": "niiri:0d10036870ecd78a22c4b7434f3e940f"
     },
     {
-      "@id": "niiri:fb1ccce2fbacf835dc1f2eb39dfc01e5",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:8559173f67223249cf03dfbc607e0225",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0026",
-      "prov:atLocation": {"@id": "niiri:0a6d00e01c4d57159cbb971a7844e803"},
+      "prov:atLocation": {"@id": "niiri:4718bcf6fa2624049f2a5bb3607e1e3f"},
       "prov:value": {"@type": "xsd:float", "@value": "4.07142877578735"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.90360423611364"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.73853530744694e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.962041692585423"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.337184393501089"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.90360423611364"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.73853530744694e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.962041692585423"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.337184393501089"}
     },
     {
-      "@id": "niiri:0a6d00e01c4d57159cbb971a7844e803",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4718bcf6fa2624049f2a5bb3607e1e3f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0026",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-50,-60,54]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-50,-60,54]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:fb1ccce2fbacf835dc1f2eb39dfc01e5",
-      "entity": "niiri:62781649d6e4a250a6f3378b94f51367"
+      "entity_derived": "niiri:8559173f67223249cf03dfbc607e0225",
+      "entity": "niiri:7e1995dcc209b0990e86feb660922162"
     },
     {
-      "@id": "niiri:60489e25fa35d48a43610e9c119f212e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0db34b2e71f46d4c78dc1a96c79f4e62",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0027",
-      "prov:atLocation": {"@id": "niiri:969712b1ec925d024d4274968b79835a"},
+      "prov:atLocation": {"@id": "niiri:aab8c71ecfd9fbf45ecaebd3d1fcc59f"},
       "prov:value": {"@type": "xsd:float", "@value": "4.04910326004028"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.88377526691462"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.14234872333041e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.969614423231382"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.338354786543303"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.88377526691462"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.14234872333041e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.969614423231382"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.338354786543303"}
     },
     {
-      "@id": "niiri:969712b1ec925d024d4274968b79835a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:aab8c71ecfd9fbf45ecaebd3d1fcc59f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0027",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[40,26,50]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[40,26,50]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:60489e25fa35d48a43610e9c119f212e",
-      "entity": "niiri:2ef53dff53e03927f9f447755a2af2df"
+      "entity_derived": "niiri:0db34b2e71f46d4c78dc1a96c79f4e62",
+      "entity": "niiri:b4757e6c4de815acef5afdb0476f0eb3"
     },
     {
-      "@id": "niiri:105d5773abccadee3256497fda011392",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c0cc60840e7b9ee9aaa1c0601727437c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0028",
-      "prov:atLocation": {"@id": "niiri:4e043a1ff299c78ecd6d1d1aef0555a1"},
+      "prov:atLocation": {"@id": "niiri:8a00d1d3e16c3c30537d2845ff872d2e"},
       "prov:value": {"@type": "xsd:float", "@value": "4.03750133514404"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.87346153970838"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.36501732217864e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.97307813993255"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.338354786543303"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.87346153970838"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.36501732217864e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.97307813993255"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.338354786543303"}
     },
     {
-      "@id": "niiri:4e043a1ff299c78ecd6d1d1aef0555a1",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:8a00d1d3e16c3c30537d2845ff872d2e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0028",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[48,36,18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[48,36,18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:105d5773abccadee3256497fda011392",
-      "entity": "niiri:689adaab2c0c4d3c1af8f26813a3b966"
+      "entity_derived": "niiri:c0cc60840e7b9ee9aaa1c0601727437c",
+      "entity": "niiri:f8221060362a62c937dd97233413a960"
     },
     {
-      "@id": "niiri:7b42a46b84ec2a9ed4b04e50bba3c796",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:8c718793e9227c3c800e12ff03cc8e56",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0029",
-      "prov:atLocation": {"@id": "niiri:e64967821a705f480091ecb2c54f0bf4"},
+      "prov:atLocation": {"@id": "niiri:09df4ed9154ca248bde0d014c6a82203"},
       "prov:value": {"@type": "xsd:float", "@value": "3.98517394065857"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.82686644248313"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.48924431299047e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.985149749711103"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.343725851088226"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.82686644248313"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.48924431299047e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.985149749711103"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.343725851088226"}
     },
     {
-      "@id": "niiri:e64967821a705f480091ecb2c54f0bf4",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:09df4ed9154ca248bde0d014c6a82203",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0029",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-6,12,52]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-6,12,52]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7b42a46b84ec2a9ed4b04e50bba3c796",
-      "entity": "niiri:6d7f9eadd2ea16abe1d24c92b4094bf6"
+      "entity_derived": "niiri:8c718793e9227c3c800e12ff03cc8e56",
+      "entity": "niiri:af4c8a0d8ff5cfb976a7e9746756d8e3"
     },
     {
-      "@id": "niiri:a9e209a5c7f9c27a8803fe99160ec586",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0b9be6e11e869c7379662eed0530982e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0030",
-      "prov:atLocation": {"@id": "niiri:0d4991be2c25401146c61d12014e4ed4"},
+      "prov:atLocation": {"@id": "niiri:24acc291a9fc11b56b7b2f0aab86fed7"},
       "prov:value": {"@type": "xsd:float", "@value": "3.42912888526917"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.32410637949606"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000443511765463311"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999991693936"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.67356346521577"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.32410637949606"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000443511765463311"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999991693936"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.67356346521577"}
     },
     {
-      "@id": "niiri:0d4991be2c25401146c61d12014e4ed4",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:24acc291a9fc11b56b7b2f0aab86fed7",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0030",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-4,8,62]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-4,8,62]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a9e209a5c7f9c27a8803fe99160ec586",
-      "entity": "niiri:6d7f9eadd2ea16abe1d24c92b4094bf6"
+      "entity_derived": "niiri:0b9be6e11e869c7379662eed0530982e",
+      "entity": "niiri:af4c8a0d8ff5cfb976a7e9746756d8e3"
     },
     {
-      "@id": "niiri:f55fb920f57f1a7b39f883124a323a61",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:eac0fa3f981d5ddf5d2705c3ec096b14",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0031",
-      "prov:atLocation": {"@id": "niiri:8423dbb17e4a383c9e53fc854ebee7bb"},
+      "prov:atLocation": {"@id": "niiri:c553e1d0b71b1a1f3fc893271d1a5cad"},
       "prov:value": {"@type": "xsd:float", "@value": "3.97802686691284"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.82049245556254"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.65927397228705e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.986398575034921"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.343725851088226"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.82049245556254"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.65927397228705e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.986398575034921"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.343725851088226"}
     },
     {
-      "@id": "niiri:8423dbb17e4a383c9e53fc854ebee7bb",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c553e1d0b71b1a1f3fc893271d1a5cad",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0031",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[30,40,4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[30,40,4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f55fb920f57f1a7b39f883124a323a61",
-      "entity": "niiri:684ce311bfd3bc478751bb8ba1bdc608"
+      "entity_derived": "niiri:eac0fa3f981d5ddf5d2705c3ec096b14",
+      "entity": "niiri:866201193f458cd1f0d7d30bfc40b674"
     },
     {
-      "@id": "niiri:807a46d10cf2231bdf094ce58bf85eb3",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a6467d64303a3d5d1f6d341287e2e1f3",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0032",
-      "prov:atLocation": {"@id": "niiri:4ff5221807e724c52ffe432f225308d3"},
+      "prov:atLocation": {"@id": "niiri:61d83d511d362b1ba93093b9044119c8"},
       "prov:value": {"@type": "xsd:float", "@value": "3.68345475196838"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.55575789019142"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000188445519391012"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999940398431664"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.55517289861095"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.55575789019142"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000188445519391012"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999940398431664"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.55517289861095"}
     },
     {
-      "@id": "niiri:4ff5221807e724c52ffe432f225308d3",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:61d83d511d362b1ba93093b9044119c8",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0032",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[36,34,18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[36,34,18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:807a46d10cf2231bdf094ce58bf85eb3",
-      "entity": "niiri:684ce311bfd3bc478751bb8ba1bdc608"
+      "entity_derived": "niiri:a6467d64303a3d5d1f6d341287e2e1f3",
+      "entity": "niiri:866201193f458cd1f0d7d30bfc40b674"
     },
     {
-      "@id": "niiri:281558c1b27efd8fdee850fc09cebdd5",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:9e53b4f1a52c9fad25b6fb328ec41bba",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0033",
-      "prov:atLocation": {"@id": "niiri:0ca772203b57f69513dd47fafc3c8b25"},
+      "prov:atLocation": {"@id": "niiri:5dc74fe36ab63489094008050b9e1049"},
       "prov:value": {"@type": "xsd:float", "@value": "3.50704765319824"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.39537345393762"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000342675238331092"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999782961075"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.627251282283029"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.39537345393762"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000342675238331092"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999782961075"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.627251282283029"}
     },
     {
-      "@id": "niiri:0ca772203b57f69513dd47fafc3c8b25",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:5dc74fe36ab63489094008050b9e1049",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0033",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[36,38,10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[36,38,10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:281558c1b27efd8fdee850fc09cebdd5",
-      "entity": "niiri:684ce311bfd3bc478751bb8ba1bdc608"
+      "entity_derived": "niiri:9e53b4f1a52c9fad25b6fb328ec41bba",
+      "entity": "niiri:866201193f458cd1f0d7d30bfc40b674"
     },
     {
-      "@id": "niiri:87be41f247c0cbaec1372952113617e4",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:af9e7acf6186b5253266546bc901424c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0034",
-      "prov:atLocation": {"@id": "niiri:e922f4bcb855debf097b8fa30d6c712a"},
+      "prov:atLocation": {"@id": "niiri:544893eef3272ef091d0f6aacd62ac4b"},
       "prov:value": {"@type": "xsd:float", "@value": "3.962651014328"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.80677178289556"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.03962776207323e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.988804462680345"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.343725851088226"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.80677178289556"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.03962776207323e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.988804462680345"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.343725851088226"}
     },
     {
-      "@id": "niiri:e922f4bcb855debf097b8fa30d6c712a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:544893eef3272ef091d0f6aacd62ac4b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0034",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-54,-44,58]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-54,-44,58]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:87be41f247c0cbaec1372952113617e4",
-      "entity": "niiri:dff5ab56a4787869bfe6b9e37cb9aac1"
+      "entity_derived": "niiri:af9e7acf6186b5253266546bc901424c",
+      "entity": "niiri:2627b433d92d75102b82469256c03339"
     },
     {
-      "@id": "niiri:9a5cc57a6b9039a2dcf0b19c1ba6530c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:fa647f9168d7f0bcd21af3ab9071c1a0",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0035",
-      "prov:atLocation": {"@id": "niiri:bdf40d9de92345165117f5c8e8e923b9"},
+      "prov:atLocation": {"@id": "niiri:3ce0819bdee0231da70f1b9c83939335"},
       "prov:value": {"@type": "xsd:float", "@value": "3.90285301208496"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.75330746420074"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.72582920719012e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99514521861122"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.374097575292501"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.75330746420074"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.72582920719012e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99514521861122"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.374097575292501"}
     },
     {
-      "@id": "niiri:bdf40d9de92345165117f5c8e8e923b9",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:3ce0819bdee0231da70f1b9c83939335",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0035",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-36,-46,-18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-36,-46,-18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9a5cc57a6b9039a2dcf0b19c1ba6530c",
-      "entity": "niiri:2f77c6e25e1162cf6ea3521c6e32fc2e"
+      "entity_derived": "niiri:fa647f9168d7f0bcd21af3ab9071c1a0",
+      "entity": "niiri:601904871dc4878169c4db748733771d"
     },
     {
-      "@id": "niiri:2c6d99b33beb8a53b311cfeaa273be66",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a16aa33cdcd4f944c2d19a1e783620b9",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0036",
-      "prov:atLocation": {"@id": "niiri:6bae8376f7e0cd8d2226434d1e24f4f3"},
+      "prov:atLocation": {"@id": "niiri:a0774df5866b6378b3d45d566ac6456a"},
       "prov:value": {"@type": "xsd:float", "@value": "3.79155707359314"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.65336542387463"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000129412734908629"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999300576231024"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.470380557191782"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.65336542387463"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000129412734908629"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999300576231024"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.470380557191782"}
     },
     {
-      "@id": "niiri:6bae8376f7e0cd8d2226434d1e24f4f3",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a0774df5866b6378b3d45d566ac6456a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0036",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-56,-48,-16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-56,-48,-16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2c6d99b33beb8a53b311cfeaa273be66",
-      "entity": "niiri:19b8938a50757611f958db8a897d6420"
+      "entity_derived": "niiri:a16aa33cdcd4f944c2d19a1e783620b9",
+      "entity": "niiri:0a7cd6ed9222066e8fdf471bab1ee6e7"
     },
     {
-      "@id": "niiri:be73232bf692752dacdb68448b0af75c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:8926147dc76517b8aeee5d7add626d9b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0037",
-      "prov:atLocation": {"@id": "niiri:5e45a9aa2470c8405a0e8fac3acfae3c"},
+      "prov:atLocation": {"@id": "niiri:61a16a71cf85ed46deb21d71fc09758b"},
       "prov:value": {"@type": "xsd:float", "@value": "3.71668887138367"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.58582096111834"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000168009721460582"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999863860763777"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.535171903511449"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.58582096111834"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000168009721460582"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999863860763777"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.535171903511449"}
     },
     {
-      "@id": "niiri:5e45a9aa2470c8405a0e8fac3acfae3c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:61a16a71cf85ed46deb21d71fc09758b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0037",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[10,20,22]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[10,20,22]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:be73232bf692752dacdb68448b0af75c",
-      "entity": "niiri:88c4835173f01a2e57f1b274727c2e78"
+      "entity_derived": "niiri:8926147dc76517b8aeee5d7add626d9b",
+      "entity": "niiri:d2a33a86263a0cb45dbf1c9cce5a8dd4"
     },
     {
-      "@id": "niiri:9665714b17a830ae5104881f33ddfda5",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f96f0aeec7dae1fca89614ddec6cd281",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0038",
-      "prov:atLocation": {"@id": "niiri:b6c70b10da482483af149f76ccaa6858"},
+      "prov:atLocation": {"@id": "niiri:e8b4f7ea40c55262e503545ee31b525a"},
       "prov:value": {"@type": "xsd:float", "@value": "3.67520260810852"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.54828555853432"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000193873795962807"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999951944421598"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.556255483974051"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.54828555853432"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000193873795962807"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999951944421598"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.556255483974051"}
     },
     {
-      "@id": "niiri:b6c70b10da482483af149f76ccaa6858",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e8b4f7ea40c55262e503545ee31b525a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0038",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[32,2,42]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[32,2,42]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9665714b17a830ae5104881f33ddfda5",
-      "entity": "niiri:ef62449f6b6d1aca9419dce43c45ebb1"
+      "entity_derived": "niiri:f96f0aeec7dae1fca89614ddec6cd281",
+      "entity": "niiri:ab0144b9188c24f978e07874f53ac025"
     },
     {
-      "@id": "niiri:2a0e392009dd1cdef95ff2bd25954e6a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f569330c5f409cea60dea5a04dbe8b60",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0039",
-      "prov:atLocation": {"@id": "niiri:5caa927b8ee685ab82a6d32e2d362112"},
+      "prov:atLocation": {"@id": "niiri:a376eeaa2e1ae5b029e6717533b0a943"},
       "prov:value": {"@type": "xsd:float", "@value": "3.40211200714111"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.29933621019179"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000484568819258735"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999997648251"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.711591163402231"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.29933621019179"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000484568819258735"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999997648251"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.711591163402231"}
     },
     {
-      "@id": "niiri:5caa927b8ee685ab82a6d32e2d362112",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a376eeaa2e1ae5b029e6717533b0a943",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0039",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[32,6,50]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[32,6,50]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2a0e392009dd1cdef95ff2bd25954e6a",
-      "entity": "niiri:ef62449f6b6d1aca9419dce43c45ebb1"
+      "entity_derived": "niiri:f569330c5f409cea60dea5a04dbe8b60",
+      "entity": "niiri:ab0144b9188c24f978e07874f53ac025"
     },
     {
-      "@id": "niiri:6a22b7f47f5aa641524c552f00d1de23",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:2f233b855c18571a400fd833d555d620",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0040",
-      "prov:atLocation": {"@id": "niiri:ac0f85461b3b289a94dbc94bf2aab8c3"},
+      "prov:atLocation": {"@id": "niiri:3c707ee8e2672da639e6bcaeddf9c3a8"},
       "prov:value": {"@type": "xsd:float", "@value": "3.65790581703186"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.53261354467296"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000205736742878826"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999969815552823"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.556255483974051"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.53261354467296"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000205736742878826"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999969815552823"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.556255483974051"}
     },
     {
-      "@id": "niiri:ac0f85461b3b289a94dbc94bf2aab8c3",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:3c707ee8e2672da639e6bcaeddf9c3a8",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0040",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[52,-46,-12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[52,-46,-12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6a22b7f47f5aa641524c552f00d1de23",
-      "entity": "niiri:1888964486bb06df70ff6f51a4b99b30"
+      "entity_derived": "niiri:2f233b855c18571a400fd833d555d620",
+      "entity": "niiri:c584015fa24c7c926f0b58301e5d61f2"
     },
     {
-      "@id": "niiri:37bccfce2385cb87712fd64f6a997959",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:fdd6fde4db88f2a34579b6e074832d04",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0041",
-      "prov:atLocation": {"@id": "niiri:de2ecd4cc9826b5e4c978cd2c29029ed"},
+      "prov:atLocation": {"@id": "niiri:67fc1b6648133c4aeaa468978eb43c62"},
       "prov:value": {"@type": "xsd:float", "@value": "3.65189146995544"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.5271610730247"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000210020574100245"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999974435806052"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.556255483974051"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.5271610730247"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000210020574100245"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999974435806052"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.556255483974051"}
     },
     {
-      "@id": "niiri:de2ecd4cc9826b5e4c978cd2c29029ed",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:67fc1b6648133c4aeaa468978eb43c62",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0041",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-58,-32,-18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-58,-32,-18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:37bccfce2385cb87712fd64f6a997959",
-      "entity": "niiri:036f0f4fe63d2badbd206185e824027a"
+      "entity_derived": "niiri:fdd6fde4db88f2a34579b6e074832d04",
+      "entity": "niiri:b575189f3bd68971936993d3aa187cb2"
     },
     {
-      "@id": "niiri:cef97b28ea0e8422efda771850621079",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d19e5a67d45d5321017795f6126c01ba",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0042",
-      "prov:atLocation": {"@id": "niiri:60a897e2e881e185f75e876eeca12da9"},
+      "prov:atLocation": {"@id": "niiri:c91b5206da9ad3a664a273dd090ed4b6"},
       "prov:value": {"@type": "xsd:float", "@value": "3.64102125167847"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.51730234983075"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000217978445002265"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999981178646875"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.563557397391532"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.51730234983075"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000217978445002265"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999981178646875"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.563557397391532"}
     },
     {
-      "@id": "niiri:60a897e2e881e185f75e876eeca12da9",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c91b5206da9ad3a664a273dd090ed4b6",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0042",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-18,-62,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-18,-62,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cef97b28ea0e8422efda771850621079",
-      "entity": "niiri:d15bd2a66669fcb82747bebed9441dfd"
+      "entity_derived": "niiri:d19e5a67d45d5321017795f6126c01ba",
+      "entity": "niiri:e8cd31e50a3c32fbe2bbcc0095269056"
     },
     {
-      "@id": "niiri:eeff6667ecce9c7065c25fc1b5de9109",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:7245866a3fef562524fce007658a5b36",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0043",
-      "prov:atLocation": {"@id": "niiri:4704fc55fed5882b1a6f573a728d75ca"},
+      "prov:atLocation": {"@id": "niiri:6b5778113070472a0309ccefc99af0fe"},
       "prov:value": {"@type": "xsd:float", "@value": "3.59891152381897"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.47906223189298"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000251585861886783"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999994666564726"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.608753808165271"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.47906223189298"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000251585861886783"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999994666564726"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.608753808165271"}
     },
     {
-      "@id": "niiri:4704fc55fed5882b1a6f573a728d75ca",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6b5778113070472a0309ccefc99af0fe",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0043",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-60,-16,28]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-60,-16,28]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:eeff6667ecce9c7065c25fc1b5de9109",
-      "entity": "niiri:0da1df9eac44070257be237353ddcd3a"
+      "entity_derived": "niiri:7245866a3fef562524fce007658a5b36",
+      "entity": "niiri:e97474fed9ca8bf394b41d386552ec23"
     },
     {
-      "@id": "niiri:57e8a6f90794dfc7d8dfea24b45f5a3e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:77917bfc1da98a7e7fe2dc75f6551b37",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0044",
-      "prov:atLocation": {"@id": "niiri:a9b16178d82b281ede4962bc80c09ada"},
+      "prov:atLocation": {"@id": "niiri:1cbd357b2c0b627b8be0812023192e3f"},
       "prov:value": {"@type": "xsd:float", "@value": "3.59028053283691"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.47121483404478"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00025905465370224"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999995943640527"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.608753808165271"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.47121483404478"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00025905465370224"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999995943640527"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.608753808165271"}
     },
     {
-      "@id": "niiri:a9b16178d82b281ede4962bc80c09ada",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:1cbd357b2c0b627b8be0812023192e3f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0044",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[62,-44,32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[62,-44,32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:57e8a6f90794dfc7d8dfea24b45f5a3e",
-      "entity": "niiri:4b0e06aef793ba5702452d1f3e252868"
+      "entity_derived": "niiri:77917bfc1da98a7e7fe2dc75f6551b37",
+      "entity": "niiri:abd9e58304894c9547b23ee1045ac1da"
     },
     {
-      "@id": "niiri:1243593fc55bfafbe5ff936ec4564509",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:35fb5dd9515d518d6fbdee4b3aad7697",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0045",
-      "prov:atLocation": {"@id": "niiri:cc4e2103febe06ec027f303ee2643c3f"},
+      "prov:atLocation": {"@id": "niiri:ee73ad3b5f7d69b81f88d9b833912dd0"},
       "prov:value": {"@type": "xsd:float", "@value": "3.58877372741699"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.46984449735368"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000260379883662454"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999996135035316"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.608753808165271"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.46984449735368"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000260379883662454"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999996135035316"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.608753808165271"}
     },
     {
-      "@id": "niiri:cc4e2103febe06ec027f303ee2643c3f",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ee73ad3b5f7d69b81f88d9b833912dd0",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0045",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-50,40,20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-50,40,20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1243593fc55bfafbe5ff936ec4564509",
-      "entity": "niiri:85bdb7fb602f14f0f33185e4228dd31d"
+      "entity_derived": "niiri:35fb5dd9515d518d6fbdee4b3aad7697",
+      "entity": "niiri:f35fdf14b958462f212cb7e02a3f5b6a"
     },
     {
-      "@id": "niiri:edd8d801e1e4f1d666bedbb6b272dbec",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c457ecf797faf07f550dddfa0aace5e2",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0046",
-      "prov:atLocation": {"@id": "niiri:689cc09f0d3694c392c7d9aa6323db13"},
+      "prov:atLocation": {"@id": "niiri:3af2d58dffdb8013ed1ab23429910b14"},
       "prov:value": {"@type": "xsd:float", "@value": "3.58837461471558"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.46948151508978"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000260731974812578"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999996184305011"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.608753808165271"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.46948151508978"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000260731974812578"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999996184305011"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.608753808165271"}
     },
     {
-      "@id": "niiri:689cc09f0d3694c392c7d9aa6323db13",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:3af2d58dffdb8013ed1ab23429910b14",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0046",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[4,8,34]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[4,8,34]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:edd8d801e1e4f1d666bedbb6b272dbec",
-      "entity": "niiri:70204a580679814e93ec3ee19b2e747c"
+      "entity_derived": "niiri:c457ecf797faf07f550dddfa0aace5e2",
+      "entity": "niiri:65aa1110e7a5b158b24b46e37675c86f"
     },
     {
-      "@id": "niiri:6d1e711aa9712a2455a47326be31d602",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0979a7e014454d80d5e3b40e2f809329",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0047",
-      "prov:atLocation": {"@id": "niiri:0ae3773014db829b9d71b9fcb5c85d66"},
+      "prov:atLocation": {"@id": "niiri:3035aa8d3d60fd9342cf2f6fb7f6a8e2"},
       "prov:value": {"@type": "xsd:float", "@value": "3.55357313156128"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.43780399293293"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000293226018116655"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999998808594853"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.621536290238473"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.43780399293293"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000293226018116655"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999998808594853"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.621536290238473"}
     },
     {
-      "@id": "niiri:0ae3773014db829b9d71b9fcb5c85d66",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:3035aa8d3d60fd9342cf2f6fb7f6a8e2",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0047",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[54,-26,-4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[54,-26,-4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6d1e711aa9712a2455a47326be31d602",
-      "entity": "niiri:f6f25c1b5f426f11bffb789fc0ff6d56"
+      "entity_derived": "niiri:0979a7e014454d80d5e3b40e2f809329",
+      "entity": "niiri:7d8d48b7315eff2905773178ffd49023"
     },
     {
-      "@id": "niiri:28cd2697c577a50386376d46e0408e4e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:4194c281db5a3d0d67f0dc86fdc77920",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0048",
-      "prov:atLocation": {"@id": "niiri:23ba631fe7949fbe1109ebd4601c8399"},
+      "prov:atLocation": {"@id": "niiri:2a753c708cb52b15a61196f673a461cc"},
       "prov:value": {"@type": "xsd:float", "@value": "3.51040363311768"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.39843715827212"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000338860153926701"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999753151302"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.627251282283029"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.39843715827212"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000338860153926701"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999753151302"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.627251282283029"}
     },
     {
-      "@id": "niiri:23ba631fe7949fbe1109ebd4601c8399",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:2a753c708cb52b15a61196f673a461cc",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0048",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-40,-38,44]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-40,-38,44]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:28cd2697c577a50386376d46e0408e4e",
-      "entity": "niiri:1709f46929bebc2f3c937d537403c879"
+      "entity_derived": "niiri:4194c281db5a3d0d67f0dc86fdc77920",
+      "entity": "niiri:62e2c2069415d9aa3cc91424a7a036cf"
     },
     {
-      "@id": "niiri:f45167b574f40f7861ca7ee7d5261d0d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3fd55577a54074d75160c0c642d5409a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0049",
-      "prov:atLocation": {"@id": "niiri:9a16d69dfcd8aa1a312513e1acbe776c"},
+      "prov:atLocation": {"@id": "niiri:d0c5dcc9377f764db96420f38f011a61"},
       "prov:value": {"@type": "xsd:float", "@value": "3.50392317771912"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.39252066023161"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000346263546256664"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999807631623"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.627251282283029"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.39252066023161"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000346263546256664"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999807631623"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.627251282283029"}
     },
     {
-      "@id": "niiri:9a16d69dfcd8aa1a312513e1acbe776c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d0c5dcc9377f764db96420f38f011a61",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0049",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-12,-98,-2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-12,-98,-2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f45167b574f40f7861ca7ee7d5261d0d",
-      "entity": "niiri:6143b9e2dc6ccc1e23b85ae05647eb05"
+      "entity_derived": "niiri:3fd55577a54074d75160c0c642d5409a",
+      "entity": "niiri:2deb14df5037616ae2a96835f77312be"
     },
     {
-      "@id": "niiri:6b1c34a29ee144dcdc6d41131c8551af",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:103473966f8ff9bcc2cc5ec2a713befb",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0050",
-      "prov:atLocation": {"@id": "niiri:171d360df8c6ac46f710667ffcb39eff"},
+      "prov:atLocation": {"@id": "niiri:77583c290903d4e0cb5367a1b29849f3"},
       "prov:value": {"@type": "xsd:float", "@value": "3.49028921127319"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.38006733866351"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000362340362275559"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999887466235"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.63276782328386"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.38006733866351"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000362340362275559"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999887466235"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.63276782328386"}
     },
     {
-      "@id": "niiri:171d360df8c6ac46f710667ffcb39eff",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:77583c290903d4e0cb5367a1b29849f3",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0050",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-52,-52,20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-52,-52,20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6b1c34a29ee144dcdc6d41131c8551af",
-      "entity": "niiri:90c1e5b11aa4824f7fb9ea3eac86bf0d"
+      "entity_derived": "niiri:103473966f8ff9bcc2cc5ec2a713befb",
+      "entity": "niiri:5b409e333f6b39e5bc61b32b5cdb5358"
     },
     {
-      "@id": "niiri:33c436205406b449ab96ba67d5482647",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:9abbf59e1fcfcc54cc8216a4ebac476d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0051",
-      "prov:atLocation": {"@id": "niiri:71a69117f987ef714917c752a162a571"},
+      "prov:atLocation": {"@id": "niiri:a43e5ac46ddb78e8178ab1b56b3625ec"},
       "prov:value": {"@type": "xsd:float", "@value": "3.47890019416809"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.36965850607739"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00037630695868629"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999928964277"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.634508717964232"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.36965850607739"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00037630695868629"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999928964277"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.634508717964232"}
     },
     {
-      "@id": "niiri:71a69117f987ef714917c752a162a571",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a43e5ac46ddb78e8178ab1b56b3625ec",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0051",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-30,-72,60]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-30,-72,60]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:33c436205406b449ab96ba67d5482647",
-      "entity": "niiri:5e09dfc93a92598eb65ced39066c6e1f"
+      "entity_derived": "niiri:9abbf59e1fcfcc54cc8216a4ebac476d",
+      "entity": "niiri:aa433f26589b155235af6a6df23091d5"
     },
     {
-      "@id": "niiri:a6a511462d3284b70edaf2123ce8dbb7",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:160afe9ba06379a115015285c8be81d6",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0052",
-      "prov:atLocation": {"@id": "niiri:099cbb33543e124f5f3afe63e7c55825"},
+      "prov:atLocation": {"@id": "niiri:bd58ee341d5220f443405c692b1b6ecf"},
       "prov:value": {"@type": "xsd:float", "@value": "3.46000862121582"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.35238069902703"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000400598817755116"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999967703129"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.651507233165067"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.35238069902703"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000400598817755116"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999967703129"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.651507233165067"}
     },
     {
-      "@id": "niiri:099cbb33543e124f5f3afe63e7c55825",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:bd58ee341d5220f443405c692b1b6ecf",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0052",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-32,-74,-34]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-32,-74,-34]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a6a511462d3284b70edaf2123ce8dbb7",
-      "entity": "niiri:7c5ba749e2c3ebf4bc0b3ad25206415a"
+      "entity_derived": "niiri:160afe9ba06379a115015285c8be81d6",
+      "entity": "niiri:d220eb8d00595929d9a913e79e63f18d"
     },
     {
-      "@id": "niiri:3e13456b2eabc0608e35da367dd7dd89",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5fad6fb58b1dab2b17eef5948c9c92c0",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0053",
-      "prov:atLocation": {"@id": "niiri:6eaff9482ec8380a363bdf3a48f0c1b0"},
+      "prov:atLocation": {"@id": "niiri:26e681001041d03072cb023b45a19ae6"},
       "prov:value": {"@type": "xsd:float", "@value": "3.43550229072571"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.32994532400952"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000434315195478541"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999988927098"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.670363379742284"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.32994532400952"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000434315195478541"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999988927098"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.670363379742284"}
     },
     {
-      "@id": "niiri:6eaff9482ec8380a363bdf3a48f0c1b0",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:26e681001041d03072cb023b45a19ae6",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0053",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[22,44,-16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[22,44,-16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3e13456b2eabc0608e35da367dd7dd89",
-      "entity": "niiri:48da72af2b8db06b1f889a4b6dfc0d72"
+      "entity_derived": "niiri:5fad6fb58b1dab2b17eef5948c9c92c0",
+      "entity": "niiri:b25a22f3e4eb9bbd1275897ff1df109d"
     },
     {
-      "@id": "niiri:9a51efa3593c9e5ec78476331ec08023",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c29148dcd4002758ce86038f7b4ca401",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0054",
-      "prov:atLocation": {"@id": "niiri:5089e63d731c36a4686fed68fad4f233"},
+      "prov:atLocation": {"@id": "niiri:6a4b4afe1e56c908285ae25761fa1e7a"},
       "prov:value": {"@type": "xsd:float", "@value": "3.39615654945374"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.29387191012244"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000494087591703773"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999998236237"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.714296799125479"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.29387191012244"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000494087591703773"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999998236237"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.714296799125479"}
     },
     {
-      "@id": "niiri:5089e63d731c36a4686fed68fad4f233",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6a4b4afe1e56c908285ae25761fa1e7a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0054",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-50,-44,-34]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-50,-44,-34]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9a51efa3593c9e5ec78476331ec08023",
-      "entity": "niiri:a27fad4fe7cc82465f0e2f5bbe9d75f9"
+      "entity_derived": "niiri:c29148dcd4002758ce86038f7b4ca401",
+      "entity": "niiri:bd4658613e97b52c7228dc395dd15873"
     },
     {
-      "@id": "niiri:26bbba507d377ff39b078c33451b3b0f",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:adde53039c55af81c35408a4bd174215",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0055",
-      "prov:atLocation": {"@id": "niiri:1666a82c17efee4fec25c34044220898"},
+      "prov:atLocation": {"@id": "niiri:175d8df12f2e8550c70e8fe728a6157b"},
       "prov:value": {"@type": "xsd:float", "@value": "3.3674840927124"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.26754352373899"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000542425921699285"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999580025"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.757181401908473"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.26754352373899"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000542425921699285"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999580025"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.757181401908473"}
     },
     {
-      "@id": "niiri:1666a82c17efee4fec25c34044220898",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:175d8df12f2e8550c70e8fe728a6157b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0055",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[40,-88,6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[40,-88,6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:26bbba507d377ff39b078c33451b3b0f",
-      "entity": "niiri:8a6fe11cd61eb1f35a28fa6bf0b6144f"
+      "entity_derived": "niiri:adde53039c55af81c35408a4bd174215",
+      "entity": "niiri:453c0a23d3b7bdaf631090a39026b948"
     },
     {
-      "@id": "niiri:8cecc7af4f33a80eb8bcaf4a5288da58",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:34836d3b3ca4536242e85f8dbf0eaec9",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0056",
-      "prov:atLocation": {"@id": "niiri:ad0006b8ad648f7b63893f432c74283c"},
+      "prov:atLocation": {"@id": "niiri:0ad0ba7ec6488d93289684ea60e3d1ed"},
       "prov:value": {"@type": "xsd:float", "@value": "3.35621929168701"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.25719036010207"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000562604729181126"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999766468"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.769744720456333"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.25719036010207"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000562604729181126"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999766468"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.769744720456333"}
     },
     {
-      "@id": "niiri:ad0006b8ad648f7b63893f432c74283c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0ad0ba7ec6488d93289684ea60e3d1ed",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0056",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-64,-32,46]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-64,-32,46]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8cecc7af4f33a80eb8bcaf4a5288da58",
-      "entity": "niiri:2e6c2c0ad60837828212538790c5db9b"
+      "entity_derived": "niiri:34836d3b3ca4536242e85f8dbf0eaec9",
+      "entity": "niiri:f9cadf3213379a88a9727fcf6a9eeef1"
     },
     {
-      "@id": "niiri:80d76f48ec884d6c9308a1c29b8ba4bc",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:056318bce8477b3efd14b0f6d507c3b4",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0057",
-      "prov:atLocation": {"@id": "niiri:224595860c68088087a64fe752180870"},
+      "prov:atLocation": {"@id": "niiri:0dac9d762d87c922e37133ba1065f763"},
       "prov:value": {"@type": "xsd:float", "@value": "3.32532405853271"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.22876865896546"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000621622108231912"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999995642"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.811282559503343"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.22876865896546"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000621622108231912"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999995642"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.811282559503343"}
     },
     {
-      "@id": "niiri:224595860c68088087a64fe752180870",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0dac9d762d87c922e37133ba1065f763",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0057",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-54,-32,42]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-54,-32,42]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:80d76f48ec884d6c9308a1c29b8ba4bc",
-      "entity": "niiri:5dabb5b7488150418280d8590f704272"
+      "entity_derived": "niiri:056318bce8477b3efd14b0f6d507c3b4",
+      "entity": "niiri:00e7e2184e288d14e023360536c4ccbb"
     },
     {
-      "@id": "niiri:88d6d95a5aaf940a20b4ef0863ef4004",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:8f0b0d4d20de8f18555fe5e10680d0c3",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0058",
-      "prov:atLocation": {"@id": "niiri:9f5e299244592e86e10d8922909ac397"},
+      "prov:atLocation": {"@id": "niiri:c333bb1f426e6621b3f21f7cd8532aee"},
       "prov:value": {"@type": "xsd:float", "@value": "3.3036584854126"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.20881441467256"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000666417461998026"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999987382"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.833892248434202"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.20881441467256"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000666417461998026"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999987382"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.833892248434202"}
     },
     {
-      "@id": "niiri:9f5e299244592e86e10d8922909ac397",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c333bb1f426e6621b3f21f7cd8532aee",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0058",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[44,16,8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[44,16,8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:88d6d95a5aaf940a20b4ef0863ef4004",
-      "entity": "niiri:f0c686d0818396b5724de255e477b7e7"
+      "entity_derived": "niiri:8f0b0d4d20de8f18555fe5e10680d0c3",
+      "entity": "niiri:1e198daa9971af9c5562116948147b44"
     },
     {
-      "@id": "niiri:a96adf838fa82e5f92d02dac00ffd047",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5cd0e7e590a22b0339b125fff010c6c7",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0059",
-      "prov:atLocation": {"@id": "niiri:3361c050c9dd0f59da7c56ffe636df83"},
+      "prov:atLocation": {"@id": "niiri:5082af9f1f2be4a41ca2e0721da7fa71"},
       "prov:value": {"@type": "xsd:float", "@value": "3.30078315734863"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.2061647702223"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000672584694407008"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999989338"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.833892248434202"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.2061647702223"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000672584694407008"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999989338"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.833892248434202"}
     },
     {
-      "@id": "niiri:3361c050c9dd0f59da7c56ffe636df83",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:5082af9f1f2be4a41ca2e0721da7fa71",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0059",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[24,36,22]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[24,36,22]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a96adf838fa82e5f92d02dac00ffd047",
-      "entity": "niiri:4d3b4510cff045e65b0540e3d2c3ddb5"
+      "entity_derived": "niiri:5cd0e7e590a22b0339b125fff010c6c7",
+      "entity": "niiri:b983603109c1a317dd80246d873f0d4a"
     },
     {
-      "@id": "niiri:cf26f5bd936e3f1e70cadde50d2bdfc3",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:816f143f7b83c21ef577cc3a8b9c39a3",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0060",
-      "prov:atLocation": {"@id": "niiri:c2a74912701d6958508a3e460e5a0274"},
+      "prov:atLocation": {"@id": "niiri:db3c1c1d13496dbcae13ca3ecec8f2d1"},
       "prov:value": {"@type": "xsd:float", "@value": "3.28121852874756"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.18812687854183"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000715988437604564"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999996695"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.864080797399493"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.18812687854183"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000715988437604564"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999996695"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.864080797399493"}
     },
     {
-      "@id": "niiri:c2a74912701d6958508a3e460e5a0274",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:db3c1c1d13496dbcae13ca3ecec8f2d1",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0060",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[42,44,10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[42,44,10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cf26f5bd936e3f1e70cadde50d2bdfc3",
-      "entity": "niiri:cb783972b7209195409262a64edc55f4"
+      "entity_derived": "niiri:816f143f7b83c21ef577cc3a8b9c39a3",
+      "entity": "niiri:bcad500e3ad79ca4075f62aa01a372da"
     },
     {
-      "@id": "niiri:bd5c83ccf5605aa922aed01c907d04b2",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:cdbd489b9fe249b9a71c29b770e2f4c4",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0061",
-      "prov:atLocation": {"@id": "niiri:07f33961ff94f7ea9069564104473ec6"},
+      "prov:atLocation": {"@id": "niiri:16ee8694a7956d27653067c326b9b5d5"},
       "prov:value": {"@type": "xsd:float", "@value": "3.26455140113831"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.17274820463022"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000755017120229184"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999998824"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.889209349007764"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.17274820463022"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000755017120229184"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999998824"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.889209349007764"}
     },
     {
-      "@id": "niiri:07f33961ff94f7ea9069564104473ec6",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:16ee8694a7956d27653067c326b9b5d5",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0061",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-54,6,42]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-54,6,42]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:bd5c83ccf5605aa922aed01c907d04b2",
-      "entity": "niiri:a972e773c5316470d7547a29677906b8"
+      "entity_derived": "niiri:cdbd489b9fe249b9a71c29b770e2f4c4",
+      "entity": "niiri:b41f8e4d939b3ddb2c20cae93fb8b7c8"
     },
     {
-      "@id": "niiri:7b1230e5731a4c25cc6855297f8727c7",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:27882a721f1cf5fa0b9ff4467a197b13",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0062",
-      "prov:atLocation": {"@id": "niiri:8be2d54bb05055264f62859f989f08a9"},
+      "prov:atLocation": {"@id": "niiri:7ba1d81106866072c384e2e653d9e606"},
       "prov:value": {"@type": "xsd:float", "@value": "3.2516782283783"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.16086256336622"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000786513505130482"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999482"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.898782253348965"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.16086256336622"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000786513505130482"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999482"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.898782253348965"}
     },
     {
-      "@id": "niiri:8be2d54bb05055264f62859f989f08a9",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7ba1d81106866072c384e2e653d9e606",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0062",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[6,32,18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[6,32,18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7b1230e5731a4c25cc6855297f8727c7",
-      "entity": "niiri:568187a66cff2006389ae8a03beea987"
+      "entity_derived": "niiri:27882a721f1cf5fa0b9ff4467a197b13",
+      "entity": "niiri:4545f5ed2d2381e9f6f1aaf307289882"
     },
     {
-      "@id": "niiri:e8421f845c4ab708b53c10243a671f1e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:692ab3bf7a5c7c16857d166b15f0fc4a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0063",
-      "prov:atLocation": {"@id": "niiri:c41d8c4e47619e45a5bf9d5a3bdede1d"},
+      "prov:atLocation": {"@id": "niiri:aa568f96f20e56c9548d5ad31273d197"},
       "prov:value": {"@type": "xsd:float", "@value": "3.25153398513794"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.16072934780164"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000786873276886202"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999487"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.898782253348965"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.16072934780164"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000786873276886202"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999487"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.898782253348965"}
     },
     {
-      "@id": "niiri:c41d8c4e47619e45a5bf9d5a3bdede1d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:aa568f96f20e56c9548d5ad31273d197",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0063",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-32,36,18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-32,36,18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e8421f845c4ab708b53c10243a671f1e",
-      "entity": "niiri:31ace54320ced6fbcbbf3e9a0b06c69b"
+      "entity_derived": "niiri:692ab3bf7a5c7c16857d166b15f0fc4a",
+      "entity": "niiri:2253c054073552510a00e5cee801efa6"
     },
     {
-      "@id": "niiri:90cdfd43ecd9cecb45d9194487610277",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:1dfc374a28a2a395f47b36b9ee3103b1",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0064",
-      "prov:atLocation": {"@id": "niiri:a7325886b11721730a1406ca0acd4f20"},
+      "prov:atLocation": {"@id": "niiri:237da29f8b420440ba0df45b565b6643"},
       "prov:value": {"@type": "xsd:float", "@value": "3.22331190109253"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.13464894829369"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000860299398633191"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999921"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.948209393065872"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.13464894829369"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000860299398633191"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999921"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.948209393065872"}
     },
     {
-      "@id": "niiri:a7325886b11721730a1406ca0acd4f20",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:237da29f8b420440ba0df45b565b6643",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0064",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[42,-86,12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[42,-86,12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:90cdfd43ecd9cecb45d9194487610277",
-      "entity": "niiri:497da5b57f3713b30ef46f853f1ed5d0"
+      "entity_derived": "niiri:1dfc374a28a2a395f47b36b9ee3103b1",
+      "entity": "niiri:c2c0de5bb03471fb2a8439bc440e1a06"
     },
     {
-      "@id": "niiri:6557a144fbbbf1742b7263a377da1da9",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:99d98ff39073ff123cf9b9bc0586da2c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0065",
-      "prov:atLocation": {"@id": "niiri:b42d215de6bd0dda7e60f5b120fd9650"},
+      "prov:atLocation": {"@id": "niiri:208152a8191e8072a02647fe58186344"},
       "prov:value": {"@type": "xsd:float", "@value": "3.21240544319153"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.1245616797579"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000890350923619998"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999963"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.948209393065872"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.1245616797579"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000890350923619998"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999963"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.948209393065872"}
     },
     {
-      "@id": "niiri:b42d215de6bd0dda7e60f5b120fd9650",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:208152a8191e8072a02647fe58186344",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0065",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[6,32,22]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[6,32,22]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6557a144fbbbf1742b7263a377da1da9",
-      "entity": "niiri:2ef352ff3d02560b512f4da34e0351c4"
+      "entity_derived": "niiri:99d98ff39073ff123cf9b9bc0586da2c",
+      "entity": "niiri:7c7b06e42170e83d79d011d51a1ee2eb"
     },
     {
-      "@id": "niiri:80d1ef0ccc9de9c996dc2ee64931a9f7",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:847abc12c3303cd0921e0bc7775893a2",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0066",
-      "prov:atLocation": {"@id": "niiri:50cc2dc0cf1bbd895998105efa32ea1a"},
+      "prov:atLocation": {"@id": "niiri:6d6402d8a1e70f09f4b8652c55b3f9ad"},
       "prov:value": {"@type": "xsd:float", "@value": "3.21144485473633"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.12367301635021"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000893044111823671"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999965"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.948209393065872"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.12367301635021"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000893044111823671"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999965"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.948209393065872"}
     },
     {
-      "@id": "niiri:50cc2dc0cf1bbd895998105efa32ea1a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6d6402d8a1e70f09f4b8652c55b3f9ad",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0066",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[22,-66,34]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[22,-66,34]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:80d1ef0ccc9de9c996dc2ee64931a9f7",
-      "entity": "niiri:d31015870dfb250e5f85f5b4632731c3"
+      "entity_derived": "niiri:847abc12c3303cd0921e0bc7775893a2",
+      "entity": "niiri:040e702ed12041e2190bf96dfbacadbb"
     },
     {
-      "@id": "niiri:8139a92ae13bcfb15541743863f167b3",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:cbcaaf82c3acb8ecaba54ed445353762",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0067",
-      "prov:atLocation": {"@id": "niiri:2f91c3a04ca8b559ae2a68820cc720d3"},
+      "prov:atLocation": {"@id": "niiri:b78bd3956f68aeb44993a6fe8f8023d8"},
       "prov:value": {"@type": "xsd:float", "@value": "3.21088981628418"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.12315952037414"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00089460372708472"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999966"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.948209393065872"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.12315952037414"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00089460372708472"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999966"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.948209393065872"}
     },
     {
-      "@id": "niiri:2f91c3a04ca8b559ae2a68820cc720d3",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b78bd3956f68aeb44993a6fe8f8023d8",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0067",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-46,28,-10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-46,28,-10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8139a92ae13bcfb15541743863f167b3",
-      "entity": "niiri:cb808a6811ec0c81f5483719bfa3da6a"
+      "entity_derived": "niiri:cbcaaf82c3acb8ecaba54ed445353762",
+      "entity": "niiri:e14e04732107aabcfe52c4ce59b579a8"
     },
     {
-      "@id": "niiri:ff408fbe10be5ddbf9630242a39bb3cd",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:82d3cc604f3e16683c4c3de6c5e42b0a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0068",
-      "prov:atLocation": {"@id": "niiri:1d8438dfcb2131ad4a47775fdd847a87"},
+      "prov:atLocation": {"@id": "niiri:7f5d6d95284b9c0ef666dbe7ff15a28d"},
       "prov:value": {"@type": "xsd:float", "@value": "3.20743656158447"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.11996445543627"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000904364321047457"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999974"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.948209393065872"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.11996445543627"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000904364321047457"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999974"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.948209393065872"}
     },
     {
-      "@id": "niiri:1d8438dfcb2131ad4a47775fdd847a87",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7f5d6d95284b9c0ef666dbe7ff15a28d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0068",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[52,-44,18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[52,-44,18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ff408fbe10be5ddbf9630242a39bb3cd",
-      "entity": "niiri:da2ebf5fddf7590fea56aa4795c3c730"
+      "entity_derived": "niiri:82d3cc604f3e16683c4c3de6c5e42b0a",
+      "entity": "niiri:d77e5bf6a731dcb245ad371bed714586"
     },
     {
-      "@id": "niiri:cf186fe995906627ea7b56d73dc89e77",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:fbde6e6581200f6c0a84e21ed621fc09",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0069",
-      "prov:atLocation": {"@id": "niiri:b95c7714182effead7102cb8a522ad3f"},
+      "prov:atLocation": {"@id": "niiri:3891bdd206293e275b3c60f15c905d3d"},
       "prov:value": {"@type": "xsd:float", "@value": "3.2013533115387"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.11433488942651"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000921800539615547"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999983"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.952610967842716"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.11433488942651"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000921800539615547"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999983"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.952610967842716"}
     },
     {
-      "@id": "niiri:b95c7714182effead7102cb8a522ad3f",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:3891bdd206293e275b3c60f15c905d3d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0069",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-24,52,30]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-24,52,30]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cf186fe995906627ea7b56d73dc89e77",
-      "entity": "niiri:5f270d7e12051f6614973ee4186253ff"
+      "entity_derived": "niiri:fbde6e6581200f6c0a84e21ed621fc09",
+      "entity": "niiri:9575c70a2f76c6d9598daa3848deeb65"
     },
     {
-      "@id": "niiri:7aa837d4d3b605903a45a10118f11d19",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:8119527ea4cfcfa60201f74ffff03743",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0070",
-      "prov:atLocation": {"@id": "niiri:bcdeb5a1acbada14f6bf5d9e51e21914"},
+      "prov:atLocation": {"@id": "niiri:bbdbc2effb2f18786476efc80d031be4"},
       "prov:value": {"@type": "xsd:float", "@value": "3.17790174484253"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.09261872722341"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000991994268753738"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999997"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.994677620170821"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.09261872722341"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000991994268753738"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999997"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.994677620170821"}
     },
     {
-      "@id": "niiri:bcdeb5a1acbada14f6bf5d9e51e21914",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:bbdbc2effb2f18786476efc80d031be4",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0070",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[46,24,0]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[46,24,0]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7aa837d4d3b605903a45a10118f11d19",
-      "entity": "niiri:3165aeeecdded90d2140dbb15bc8e722"
+      "entity_derived": "niiri:8119527ea4cfcfa60201f74ffff03743",
+      "entity": "niiri:75e697b6b2e295644bcfcd0111ce9380"
     }
   ]
 }

--- a/spmexport/ex_spm_conjunction/nidm.ttl
+++ b/spmexport/ex_spm_conjunction/nidm.ttl
@@ -4,7 +4,7 @@
 @prefix niiri: <http://iri.nidash.org/> .
 @prefix spm: <http://purl.org/nidash/spm#> .
 @prefix neurolex: <http://neurolex.org/wiki/> .
-@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#> .
+@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
@@ -17,27 +17,27 @@
 @prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-niiri:49e2ba6984723129b413599116a11d2f
+niiri:2e94d338ef8848aaa3096aa9c67d068b
   a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
   rdfs:label "NIDM-Results" ;
   nidm_version: "1.3.0"^^xsd:string .
 
-niiri:f6174251413335799acde3da5922fc04
+niiri:7950d950e14199763647729c4a4e4088
   a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
   rdfs:label "spm_results_nidm" ;
-  nidm_softwareVersion: "12.6903"^^xsd:string .
+  nidm_softwareVersion: "12.7057"^^xsd:string .
 
-niiri:e30146f0b01ab7fba2fdd45ec000647c
+niiri:c90a33b190317be7e66e9cb64ea5c0d4
   a prov:Activity, nidm_NIDMResultsExport: ; 
   rdfs:label "NIDM-Results export" .
 
-niiri:e30146f0b01ab7fba2fdd45ec000647c prov:wasAssociatedWith niiri:f6174251413335799acde3da5922fc04 .
+niiri:c90a33b190317be7e66e9cb64ea5c0d4 prov:wasAssociatedWith niiri:7950d950e14199763647729c4a4e4088 .
 
 _:blank5 a prov:Generation .
 
-niiri:49e2ba6984723129b413599116a11d2f prov:qualifiedGeneration _:blank5 .
+niiri:2e94d338ef8848aaa3096aa9c67d068b prov:qualifiedGeneration _:blank5 .
 
-_:blank5 prov:atTime "2016-12-07T16:07:57"^^xsd:dateTime .
+_:blank5 prov:atTime "2017-04-19T12:17:45"^^xsd:dateTime .
 
 @prefix nidm_Ixi549CoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000050> .
 @prefix src_SPM: <http://scicrunch.org/resolver/SCR_007037> .
@@ -142,12 +142,12 @@ _:blank5 prov:atTime "2016-12-07T16:07:57"^^xsd:dateTime .
 @prefix nidm_Coordinate: <http://purl.org/nidash/nidm#NIDM_0000015> .
 @prefix nidm_coordinateVector: <http://purl.org/nidash/nidm#NIDM_0000086> .
 
-niiri:788d8708b4b59d898f7fb805cfa24cee
+niiri:016e3cb0f11ba49dad327f9752892d7f
     a prov:Agent, src_SPM:, prov:SoftwareAgent ; 
     rdfs:label "SPM" ;
-    nidm_softwareVersion: "12.12.2"^^xsd:string .
+    nidm_softwareVersion: "12.6906"^^xsd:string .
 
-niiri:8ac2495eaa1d9630498f5dcb7ca6623a
+niiri:43990f91d4711220e8f4834300dbd4a5
     a prov:Entity, nidm_CoordinateSpace: ; 
     rdfs:label "Coordinate space 1" ;
     nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
@@ -157,48 +157,48 @@ niiri:8ac2495eaa1d9630498f5dcb7ca6623a
     nidm_numberOfDimensions: "3"^^xsd:int ;
     nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
 
-niiri:a9ae33f5b966f9c430993c5e2575b448
+niiri:ccc4cd6d044e67a15c8666fea99b3166
     a prov:Agent, nlx_Imaginginstrument:, nlx_Magneticresonanceimagingscanner: ; 
     rdfs:label "MRI Scanner" .
 
-niiri:1d5c2d3f41ab0ec83284374f5513a058
+niiri:8d49fa3ebfc5510866661667640b7637
     a prov:Agent, prov:Person ; 
     rdfs:label "Person" .
 
-niiri:79a49b132c7a15acc70032b8c8c407e9
+niiri:b5f5299dd88c01663688131c711c2a74
     a prov:Entity, prov:Collection, nidm_Data: ; 
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "true"^^xsd:boolean ;
     nidm_targetIntensity: "100"^^xsd:float ;
     nidm_hasMRIProtocol: nlx_FunctionalMRIprotocol: .
 
-niiri:79a49b132c7a15acc70032b8c8c407e9 prov:wasAttributedTo niiri:a9ae33f5b966f9c430993c5e2575b448 .
+niiri:b5f5299dd88c01663688131c711c2a74 prov:wasAttributedTo niiri:ccc4cd6d044e67a15c8666fea99b3166 .
 
-niiri:79a49b132c7a15acc70032b8c8c407e9 prov:wasAttributedTo niiri:1d5c2d3f41ab0ec83284374f5513a058 .
+niiri:b5f5299dd88c01663688131c711c2a74 prov:wasAttributedTo niiri:8d49fa3ebfc5510866661667640b7637 .
 
-niiri:0e863528ca8de447aced0b65722fa024
+niiri:2668d1ecdf9295cc03d6086cb0de079d
     a prov:Entity, spm_DCTDriftModel: ; 
     rdfs:label "SPM's DCT Drift Model" ;
     spm_SPMsDriftCutoffPeriod: "128"^^xsd:float .
 
-niiri:2db950365c1a07764464dbc8eee7d77e
+niiri:6387ede10972f2c9e2051e4ae79a4a2e
     a prov:Entity, nidm_DesignMatrix: ; 
     prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.csv"^^xsd:string ;
     dct:format "text/csv"^^xsd:string ;
-    dc:description niiri:22cea7ee1683b3df8805f0c7a4eaaf7a ;
+    dc:description niiri:c139d04ac7da5b6427c94a32bc9982ac ;
     rdfs:label "Design Matrix" ;
     nidm_regressorNames: "[\"Sn(1) to*bf(1)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) constant\"]"^^xsd:string ;
-    nidm_hasDriftModel: niiri:0e863528ca8de447aced0b65722fa024 ;
+    nidm_hasDriftModel: niiri:2668d1ecdf9295cc03d6086cb0de079d ;
     nidm_hasHRFBasis: spm_SPMsCanonicalHRF: .
 
-niiri:22cea7ee1683b3df8805f0c7a4eaaf7a
+niiri:c139d04ac7da5b6427c94a32bc9982ac
     a prov:Entity, dctype:Image ; 
     prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:84620a093960e98c11002a386197a347
+niiri:0fd0329c3adb2f4836f2747833babe88
     a prov:Entity, nidm_ErrorModel: ; 
     nidm_hasErrorDistribution: obo_normaldistribution: ;
     nidm_hasErrorDependence: obo_Toeplitzcovariancestructure: ;
@@ -206,174 +206,174 @@ niiri:84620a093960e98c11002a386197a347
     nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
     nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
 
-niiri:b68a53a0147605b9ee8b60e0f137d280
+niiri:d07cda9b146f92aa2083034127524fe1
     a prov:Activity, nidm_ModelParametersEstimation: ; 
     rdfs:label "Model parameters estimation" ;
     nidm_withEstimationMethod: obo_generalizedleastsquaresestimation: .
 
-niiri:b68a53a0147605b9ee8b60e0f137d280 prov:wasAssociatedWith niiri:788d8708b4b59d898f7fb805cfa24cee .
+niiri:d07cda9b146f92aa2083034127524fe1 prov:wasAssociatedWith niiri:016e3cb0f11ba49dad327f9752892d7f .
 
-niiri:b68a53a0147605b9ee8b60e0f137d280 prov:used niiri:2db950365c1a07764464dbc8eee7d77e .
+niiri:d07cda9b146f92aa2083034127524fe1 prov:used niiri:6387ede10972f2c9e2051e4ae79a4a2e .
 
-niiri:b68a53a0147605b9ee8b60e0f137d280 prov:used niiri:79a49b132c7a15acc70032b8c8c407e9 .
+niiri:d07cda9b146f92aa2083034127524fe1 prov:used niiri:b5f5299dd88c01663688131c711c2a74 .
 
-niiri:b68a53a0147605b9ee8b60e0f137d280 prov:used niiri:84620a093960e98c11002a386197a347 .
+niiri:d07cda9b146f92aa2083034127524fe1 prov:used niiri:0fd0329c3adb2f4836f2747833babe88 .
 
-niiri:27e2d554c75587c0f96b310d2360480e
+niiri:e5a61d0bc28607c2ab613b81ddf8392a
     a prov:Entity, nidm_MaskMap: ; 
     prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
     nidm_isUserDefined: "false"^^xsd:boolean ;
     nfo:fileName "Mask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Mask" ;
-    nidm_inCoordinateSpace: niiri:8ac2495eaa1d9630498f5dcb7ca6623a ;
+    nidm_inCoordinateSpace: niiri:43990f91d4711220e8f4834300dbd4a5 ;
     crypto:sha512 "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876"^^xsd:string .
 
-niiri:a1735d57f3987406899775e32a4249cb
+niiri:8d425ac5fbd3a8eb1e7cc62ff8035271
     a prov:Entity, nidm_MaskMap: ; 
     nfo:fileName "mask.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "36929e1f5f4143bd9cc818cd896a25f129961fab208c3a4438555f40444c08347b359142ee8c53ece6e8cca1627f49db0788a1fd3b9e2ecaef61999c6c6c67ac"^^xsd:string .
 
-niiri:27e2d554c75587c0f96b310d2360480e prov:wasDerivedFrom niiri:a1735d57f3987406899775e32a4249cb .
+niiri:e5a61d0bc28607c2ab613b81ddf8392a prov:wasDerivedFrom niiri:8d425ac5fbd3a8eb1e7cc62ff8035271 .
 
-niiri:27e2d554c75587c0f96b310d2360480e prov:wasGeneratedBy niiri:b68a53a0147605b9ee8b60e0f137d280 .
+niiri:e5a61d0bc28607c2ab613b81ddf8392a prov:wasGeneratedBy niiri:d07cda9b146f92aa2083034127524fe1 .
 
-niiri:ccb0fd792c54f2664f9527500504c14b
+niiri:9dbd735c07b927aa96e9892b2a28602a
     a prov:Entity, nidm_GrandMeanMap: ; 
     prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
     nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Grand Mean Map" ;
     nidm_maskedMedian: "111.557487487793"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:8ac2495eaa1d9630498f5dcb7ca6623a ;
+    nidm_inCoordinateSpace: niiri:43990f91d4711220e8f4834300dbd4a5 ;
     crypto:sha512 "512157cc6bff89d9343a09b4068226eb3edd64a8cbcee861f06231767fae6f8d4819921182adebee083a9bf309afd65529ab04a92f0aa6b0038c8098550f6124"^^xsd:string .
 
-niiri:ccb0fd792c54f2664f9527500504c14b prov:wasGeneratedBy niiri:b68a53a0147605b9ee8b60e0f137d280 .
+niiri:9dbd735c07b927aa96e9892b2a28602a prov:wasGeneratedBy niiri:d07cda9b146f92aa2083034127524fe1 .
 
-niiri:9dcbb14f3d45f3e5f2ee41b72fc2bdbf
+niiri:892dc0fa4cc25ca47ac73ddd6f0f1a71
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0001.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0001.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 1" ;
-    nidm_inCoordinateSpace: niiri:8ac2495eaa1d9630498f5dcb7ca6623a ;
+    nidm_inCoordinateSpace: niiri:43990f91d4711220e8f4834300dbd4a5 ;
     crypto:sha512 "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd"^^xsd:string .
 
-niiri:65d633b572e4b46963ac132897627c8f
+niiri:565b0e81e599439b221f8fc7d899038a
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd"^^xsd:string .
 
-niiri:9dcbb14f3d45f3e5f2ee41b72fc2bdbf prov:wasDerivedFrom niiri:65d633b572e4b46963ac132897627c8f .
+niiri:892dc0fa4cc25ca47ac73ddd6f0f1a71 prov:wasDerivedFrom niiri:565b0e81e599439b221f8fc7d899038a .
 
-niiri:9dcbb14f3d45f3e5f2ee41b72fc2bdbf prov:wasGeneratedBy niiri:b68a53a0147605b9ee8b60e0f137d280 .
+niiri:892dc0fa4cc25ca47ac73ddd6f0f1a71 prov:wasGeneratedBy niiri:d07cda9b146f92aa2083034127524fe1 .
 
-niiri:5c1f7aeeb3477d36479af1436084f0fc
+niiri:fcebd635515316804e6601daa6f10239
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0002.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0002.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 2" ;
-    nidm_inCoordinateSpace: niiri:8ac2495eaa1d9630498f5dcb7ca6623a ;
+    nidm_inCoordinateSpace: niiri:43990f91d4711220e8f4834300dbd4a5 ;
     crypto:sha512 "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c"^^xsd:string .
 
-niiri:b35909a3e9e36ae88b74418356dd9808
+niiri:2b4b7fb2c844c1b29d66eb66f2f6bb24
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0002.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c"^^xsd:string .
 
-niiri:5c1f7aeeb3477d36479af1436084f0fc prov:wasDerivedFrom niiri:b35909a3e9e36ae88b74418356dd9808 .
+niiri:fcebd635515316804e6601daa6f10239 prov:wasDerivedFrom niiri:2b4b7fb2c844c1b29d66eb66f2f6bb24 .
 
-niiri:5c1f7aeeb3477d36479af1436084f0fc prov:wasGeneratedBy niiri:b68a53a0147605b9ee8b60e0f137d280 .
+niiri:fcebd635515316804e6601daa6f10239 prov:wasGeneratedBy niiri:d07cda9b146f92aa2083034127524fe1 .
 
-niiri:b40ebe60020e0b79f0779d6da70f93e4
+niiri:0a600229532c0ed2e05bd43494a1c6c3
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0003.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0003.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 3" ;
-    nidm_inCoordinateSpace: niiri:8ac2495eaa1d9630498f5dcb7ca6623a ;
+    nidm_inCoordinateSpace: niiri:43990f91d4711220e8f4834300dbd4a5 ;
     crypto:sha512 "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373"^^xsd:string .
 
-niiri:3e856a6b602cfdf70312041b27a8e9be
+niiri:6e470aa79f85c054fb351adb5db48bd3
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0003.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373"^^xsd:string .
 
-niiri:b40ebe60020e0b79f0779d6da70f93e4 prov:wasDerivedFrom niiri:3e856a6b602cfdf70312041b27a8e9be .
+niiri:0a600229532c0ed2e05bd43494a1c6c3 prov:wasDerivedFrom niiri:6e470aa79f85c054fb351adb5db48bd3 .
 
-niiri:b40ebe60020e0b79f0779d6da70f93e4 prov:wasGeneratedBy niiri:b68a53a0147605b9ee8b60e0f137d280 .
+niiri:0a600229532c0ed2e05bd43494a1c6c3 prov:wasGeneratedBy niiri:d07cda9b146f92aa2083034127524fe1 .
 
-niiri:f8194d0c603445d8f76895c1bffdb7ad
+niiri:03bc9932821688679785b6bbb6b7186e
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Residual Mean Squares Map" ;
-    nidm_inCoordinateSpace: niiri:8ac2495eaa1d9630498f5dcb7ca6623a ;
+    nidm_inCoordinateSpace: niiri:43990f91d4711220e8f4834300dbd4a5 ;
     crypto:sha512 "991abf563d795a43b1e2eef8643e57023f2e0b090b2031f05f839321fc0643df6f71d423486a1021519b6dc82f6b0f563e19f3fbd50cb16063bed54a0e192d3e"^^xsd:string .
 
-niiri:79e819061231841c5ca378a6250ddac7
+niiri:1788822bb0780f90238ce40ec64b7c8f
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     nfo:fileName "ResMS.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "40b28d03fcf9a2f60b11f10d7fb83bf3618b234fb5aedf09df644cb7cbb6aab8c9f468897c1078166d455a3d04a83f4e3bf762cfca0b4ea982d7a4e406849f18"^^xsd:string .
 
-niiri:f8194d0c603445d8f76895c1bffdb7ad prov:wasDerivedFrom niiri:79e819061231841c5ca378a6250ddac7 .
+niiri:03bc9932821688679785b6bbb6b7186e prov:wasDerivedFrom niiri:1788822bb0780f90238ce40ec64b7c8f .
 
-niiri:f8194d0c603445d8f76895c1bffdb7ad prov:wasGeneratedBy niiri:b68a53a0147605b9ee8b60e0f137d280 .
+niiri:03bc9932821688679785b6bbb6b7186e prov:wasGeneratedBy niiri:d07cda9b146f92aa2083034127524fe1 .
 
-niiri:42a9ce7904b0f4ed1a0722c2ff773184
+niiri:19b287a58457b527aca30843e6e34d84
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Resels per Voxel Map" ;
-    nidm_inCoordinateSpace: niiri:8ac2495eaa1d9630498f5dcb7ca6623a ;
+    nidm_inCoordinateSpace: niiri:43990f91d4711220e8f4834300dbd4a5 ;
     crypto:sha512 "1a3f9216e145249ccc0b14b2bc337d6b38b81ad45e32768001fb22b35f0c2c0f3e2bce013b40c85f7dc0fc62723ac761ee7f7e1e6aff128a05f0ba7b8b8202a3"^^xsd:string .
 
-niiri:38e4b2d89ff31ccd805907644af6bbac
+niiri:9536f7d3d8c806ff604d922fcfc13f49
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     nfo:fileName "RPV.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "4f76663162857f6b38b2a45a63b15a23b2ca8b338c283b69c1e71f2ea2f43797d045a733cd14e845be9c12f8b8f84d3931c599a08e8f6d77e99fab46ad87ab8f"^^xsd:string .
 
-niiri:42a9ce7904b0f4ed1a0722c2ff773184 prov:wasDerivedFrom niiri:38e4b2d89ff31ccd805907644af6bbac .
+niiri:19b287a58457b527aca30843e6e34d84 prov:wasDerivedFrom niiri:9536f7d3d8c806ff604d922fcfc13f49 .
 
-niiri:42a9ce7904b0f4ed1a0722c2ff773184 prov:wasGeneratedBy niiri:b68a53a0147605b9ee8b60e0f137d280 .
+niiri:19b287a58457b527aca30843e6e34d84 prov:wasGeneratedBy niiri:d07cda9b146f92aa2083034127524fe1 .
 
-niiri:264cba0f67e2275348f6df02b548ad74
+niiri:92324b5901796c34f58222905ccfed17
     a prov:Entity, obo_contrastweightmatrix: ; 
     nidm_statisticType: obo_tstatistic: ;
     nidm_contrastName: "tone counting vs baseline"^^xsd:string ;
     rdfs:label "Contrast: tone counting vs baseline" ;
     prov:value "[1, 0, 0]"^^xsd:string .
 
-niiri:59789a7a9a2f85ef10449639b37d1739
+niiri:113d1d799a4615cbe8865b4df8a089fa
     a prov:Activity, nidm_ContrastEstimation: ; 
     rdfs:label "Contrast estimation 1" .
 
-niiri:59789a7a9a2f85ef10449639b37d1739 prov:wasAssociatedWith niiri:788d8708b4b59d898f7fb805cfa24cee .
+niiri:113d1d799a4615cbe8865b4df8a089fa prov:wasAssociatedWith niiri:016e3cb0f11ba49dad327f9752892d7f .
 
-niiri:59789a7a9a2f85ef10449639b37d1739 prov:used niiri:27e2d554c75587c0f96b310d2360480e .
+niiri:113d1d799a4615cbe8865b4df8a089fa prov:used niiri:e5a61d0bc28607c2ab613b81ddf8392a .
 
-niiri:59789a7a9a2f85ef10449639b37d1739 prov:used niiri:f8194d0c603445d8f76895c1bffdb7ad .
+niiri:113d1d799a4615cbe8865b4df8a089fa prov:used niiri:03bc9932821688679785b6bbb6b7186e .
 
-niiri:59789a7a9a2f85ef10449639b37d1739 prov:used niiri:2db950365c1a07764464dbc8eee7d77e .
+niiri:113d1d799a4615cbe8865b4df8a089fa prov:used niiri:6387ede10972f2c9e2051e4ae79a4a2e .
 
-niiri:59789a7a9a2f85ef10449639b37d1739 prov:used niiri:264cba0f67e2275348f6df02b548ad74 .
+niiri:113d1d799a4615cbe8865b4df8a089fa prov:used niiri:92324b5901796c34f58222905ccfed17 .
 
-niiri:59789a7a9a2f85ef10449639b37d1739 prov:used niiri:9dcbb14f3d45f3e5f2ee41b72fc2bdbf .
+niiri:113d1d799a4615cbe8865b4df8a089fa prov:used niiri:892dc0fa4cc25ca47ac73ddd6f0f1a71 .
 
-niiri:59789a7a9a2f85ef10449639b37d1739 prov:used niiri:5c1f7aeeb3477d36479af1436084f0fc .
+niiri:113d1d799a4615cbe8865b4df8a089fa prov:used niiri:fcebd635515316804e6601daa6f10239 .
 
-niiri:59789a7a9a2f85ef10449639b37d1739 prov:used niiri:b40ebe60020e0b79f0779d6da70f93e4 .
+niiri:113d1d799a4615cbe8865b4df8a089fa prov:used niiri:0a600229532c0ed2e05bd43494a1c6c3 .
 
-niiri:c19a21acb28cd19f21a1be425e49481c
+niiri:7766f91f9fb3c7a19f3ae5bf1f752bbf
     a prov:Entity, nidm_StatisticMap: ; 
     prov:atLocation "TStatistic_0001.nii.gz"^^xsd:anyURI ;
     nfo:fileName "TStatistic_0001.nii.gz"^^xsd:string ;
@@ -383,78 +383,78 @@ niiri:c19a21acb28cd19f21a1be425e49481c
     nidm_contrastName: "tone counting vs baseline"^^xsd:string ;
     nidm_errorDegreesOfFreedom: "97.9999999998522"^^xsd:float ;
     nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:8ac2495eaa1d9630498f5dcb7ca6623a ;
+    nidm_inCoordinateSpace: niiri:43990f91d4711220e8f4834300dbd4a5 ;
     crypto:sha512 "99f578a25cc225feda31dd567e6bc05dd8229bd9ada176571e9144c7748ed3a9c8eee1258f73c6cbf0a08282094b8004f18ea0791f0f3d92d8069ec877218399"^^xsd:string .
 
-niiri:edf3aced4b659159875f1a0f23174cde
+niiri:df8317112ad27782b9be9c9adbafa6af
     a prov:Entity, nidm_StatisticMap: ; 
     nfo:fileName "spmT_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "d288b1b0f117f64502555da13c5398dffa5bf5ff0b58951510e43d5388755bc185798802a92e98a07c7e313c6991066d2908f2a44aa5153ba23433da1335970f"^^xsd:string .
 
-niiri:c19a21acb28cd19f21a1be425e49481c prov:wasDerivedFrom niiri:edf3aced4b659159875f1a0f23174cde .
+niiri:7766f91f9fb3c7a19f3ae5bf1f752bbf prov:wasDerivedFrom niiri:df8317112ad27782b9be9c9adbafa6af .
 
-niiri:c19a21acb28cd19f21a1be425e49481c prov:wasGeneratedBy niiri:59789a7a9a2f85ef10449639b37d1739 .
+niiri:7766f91f9fb3c7a19f3ae5bf1f752bbf prov:wasGeneratedBy niiri:113d1d799a4615cbe8865b4df8a089fa .
 
-niiri:e390d5b8d153675e3d516d9844741469
+niiri:af18c6b272b9c41779a5c9b4adefcb28
     a prov:Entity, nidm_ContrastMap: ; 
     prov:atLocation "Contrast_0001.nii.gz"^^xsd:anyURI ;
     nfo:fileName "Contrast_0001.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Map: tone counting vs baseline" ;
     nidm_contrastName: "tone counting vs baseline"^^xsd:string ;
-    nidm_inCoordinateSpace: niiri:8ac2495eaa1d9630498f5dcb7ca6623a ;
+    nidm_inCoordinateSpace: niiri:43990f91d4711220e8f4834300dbd4a5 ;
     crypto:sha512 "fc5e2ad175243ee496db98f9b2e1b235c4c3bae1a8d7122ce461c897b537e40c49dfee5d6cf20f71c6a2bb9b5f0760fcb4ecd8fe2e9428910ef3d60d8f3c56a9"^^xsd:string .
 
-niiri:939452a9308168d579febe093626791f
+niiri:f584b30e1a30a67223f05b204465e66d
     a prov:Entity, nidm_ContrastMap: ; 
     nfo:fileName "con_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "d4aa46b3603ba508578e39751262d528cf6d1ed2e722ec46f1cd8194c50591e46b229deb8cb4f72d1b7e0e2640f3e6604be7a335301c5c8357f453e5d0d4daf2"^^xsd:string .
 
-niiri:e390d5b8d153675e3d516d9844741469 prov:wasDerivedFrom niiri:939452a9308168d579febe093626791f .
+niiri:af18c6b272b9c41779a5c9b4adefcb28 prov:wasDerivedFrom niiri:f584b30e1a30a67223f05b204465e66d .
 
-niiri:e390d5b8d153675e3d516d9844741469 prov:wasGeneratedBy niiri:59789a7a9a2f85ef10449639b37d1739 .
+niiri:af18c6b272b9c41779a5c9b4adefcb28 prov:wasGeneratedBy niiri:113d1d799a4615cbe8865b4df8a089fa .
 
-niiri:3c2b7154be2dd98ce332831ef822c0f0
+niiri:4a46cd703e5066038138c81d0134cb7b
     a prov:Entity, nidm_ContrastStandardErrorMap: ; 
     prov:atLocation "ContrastStandardError_0001.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ContrastStandardError_0001.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Standard Error Map" ;
-    nidm_inCoordinateSpace: niiri:8ac2495eaa1d9630498f5dcb7ca6623a ;
+    nidm_inCoordinateSpace: niiri:43990f91d4711220e8f4834300dbd4a5 ;
     crypto:sha512 "791d48f5d1adb15079a5289271ce0c4b95c56d69bfdb3e5d41b0d24eb538d3075e1cdd15502494b5a5a18c16eaa2153cb4847a996043fa48cdaf26e938a2576d"^^xsd:string .
 
-niiri:3c2b7154be2dd98ce332831ef822c0f0 prov:wasGeneratedBy niiri:59789a7a9a2f85ef10449639b37d1739 .
+niiri:4a46cd703e5066038138c81d0134cb7b prov:wasGeneratedBy niiri:113d1d799a4615cbe8865b4df8a089fa .
 
-niiri:50d266c22fda1c12960c795840352fa4
+niiri:42481f8ce49fff367fe85c2f158deed5
     a prov:Entity, obo_contrastweightmatrix: ; 
     nidm_statisticType: obo_tstatistic: ;
     nidm_contrastName: "tone counting probe vs baseline"^^xsd:string ;
     rdfs:label "Contrast: tone counting probe vs baseline" ;
     prov:value "[0, 1, 0]"^^xsd:string .
 
-niiri:e6b2a7699eaf7eb4b0e65181dd9165ea
+niiri:8872a3798f2cb652dd632d9e9e40ecf9
     a prov:Activity, nidm_ContrastEstimation: ; 
     rdfs:label "Contrast estimation 2" .
 
-niiri:e6b2a7699eaf7eb4b0e65181dd9165ea prov:wasAssociatedWith niiri:788d8708b4b59d898f7fb805cfa24cee .
+niiri:8872a3798f2cb652dd632d9e9e40ecf9 prov:wasAssociatedWith niiri:016e3cb0f11ba49dad327f9752892d7f .
 
-niiri:e6b2a7699eaf7eb4b0e65181dd9165ea prov:used niiri:27e2d554c75587c0f96b310d2360480e .
+niiri:8872a3798f2cb652dd632d9e9e40ecf9 prov:used niiri:e5a61d0bc28607c2ab613b81ddf8392a .
 
-niiri:e6b2a7699eaf7eb4b0e65181dd9165ea prov:used niiri:f8194d0c603445d8f76895c1bffdb7ad .
+niiri:8872a3798f2cb652dd632d9e9e40ecf9 prov:used niiri:03bc9932821688679785b6bbb6b7186e .
 
-niiri:e6b2a7699eaf7eb4b0e65181dd9165ea prov:used niiri:2db950365c1a07764464dbc8eee7d77e .
+niiri:8872a3798f2cb652dd632d9e9e40ecf9 prov:used niiri:6387ede10972f2c9e2051e4ae79a4a2e .
 
-niiri:e6b2a7699eaf7eb4b0e65181dd9165ea prov:used niiri:50d266c22fda1c12960c795840352fa4 .
+niiri:8872a3798f2cb652dd632d9e9e40ecf9 prov:used niiri:42481f8ce49fff367fe85c2f158deed5 .
 
-niiri:e6b2a7699eaf7eb4b0e65181dd9165ea prov:used niiri:9dcbb14f3d45f3e5f2ee41b72fc2bdbf .
+niiri:8872a3798f2cb652dd632d9e9e40ecf9 prov:used niiri:892dc0fa4cc25ca47ac73ddd6f0f1a71 .
 
-niiri:e6b2a7699eaf7eb4b0e65181dd9165ea prov:used niiri:5c1f7aeeb3477d36479af1436084f0fc .
+niiri:8872a3798f2cb652dd632d9e9e40ecf9 prov:used niiri:fcebd635515316804e6601daa6f10239 .
 
-niiri:e6b2a7699eaf7eb4b0e65181dd9165ea prov:used niiri:b40ebe60020e0b79f0779d6da70f93e4 .
+niiri:8872a3798f2cb652dd632d9e9e40ecf9 prov:used niiri:0a600229532c0ed2e05bd43494a1c6c3 .
 
-niiri:33c60c38565ba7f605e4ca032349e363
+niiri:d40b3bf5490868f622f2357adea722a9
     a prov:Entity, nidm_StatisticMap: ; 
     prov:atLocation "TStatistic_0002.nii.gz"^^xsd:anyURI ;
     nfo:fileName "TStatistic_0002.nii.gz"^^xsd:string ;
@@ -464,126 +464,126 @@ niiri:33c60c38565ba7f605e4ca032349e363
     nidm_contrastName: "tone counting probe vs baseline"^^xsd:string ;
     nidm_errorDegreesOfFreedom: "97.9999999998522"^^xsd:float ;
     nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:8ac2495eaa1d9630498f5dcb7ca6623a ;
+    nidm_inCoordinateSpace: niiri:43990f91d4711220e8f4834300dbd4a5 ;
     crypto:sha512 "27322de6e66e2fbcc847db3bfc0f2e23b78e8524340ddee0c06b40321f74c73140a07b0baed4ff259a6d956903811b416fd7a7d8bba86bacb8e60337006cf425"^^xsd:string .
 
-niiri:7e50e269e3c51e62e90b992191741f8c
+niiri:70992ac15b69b7bd18e58cc3b80cf441
     a prov:Entity, nidm_StatisticMap: ; 
     nfo:fileName "spmT_0002.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "d4c7aa1879c2eb9ad471b3fd73e58ff0dfeace86ac0791b1d34cd1b87791a293f705b04229f028d6b05d2bd1b371c8b2a17249750eb9ba773f11a6bdee5ed203"^^xsd:string .
 
-niiri:33c60c38565ba7f605e4ca032349e363 prov:wasDerivedFrom niiri:7e50e269e3c51e62e90b992191741f8c .
+niiri:d40b3bf5490868f622f2357adea722a9 prov:wasDerivedFrom niiri:70992ac15b69b7bd18e58cc3b80cf441 .
 
-niiri:33c60c38565ba7f605e4ca032349e363 prov:wasGeneratedBy niiri:e6b2a7699eaf7eb4b0e65181dd9165ea .
+niiri:d40b3bf5490868f622f2357adea722a9 prov:wasGeneratedBy niiri:8872a3798f2cb652dd632d9e9e40ecf9 .
 
-niiri:af1157ebc9428085c4f1fd14544c9c59
+niiri:98bad5417f97850e2a27b2644953d7fc
     a prov:Entity, nidm_ContrastMap: ; 
     prov:atLocation "Contrast_0002.nii.gz"^^xsd:anyURI ;
     nfo:fileName "Contrast_0002.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Map: tone counting probe vs baseline" ;
     nidm_contrastName: "tone counting probe vs baseline"^^xsd:string ;
-    nidm_inCoordinateSpace: niiri:8ac2495eaa1d9630498f5dcb7ca6623a ;
+    nidm_inCoordinateSpace: niiri:43990f91d4711220e8f4834300dbd4a5 ;
     crypto:sha512 "63cf0302e297e04c6b46de0043888e490e940d3aa0da4ed441990ea9f28f2dac32a0505b34bc424d68929195fec579f71c2d5602fda2dfaaad3d3accb14ccc43"^^xsd:string .
 
-niiri:32def2a96a2b007c0b48160856b0eb4e
+niiri:cbc99abbec6b9d1c6aedcd2e278aabcd
     a prov:Entity, nidm_ContrastMap: ; 
     nfo:fileName "con_0002.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "b0f05ae7f0bac16eecb73fb1964cede4b475b176a9a0747624b707dc165bed14f45352fa25f00c6abbf5ea12376fcadf6cc46abbe1a65d25aa03eb2ec4423474"^^xsd:string .
 
-niiri:af1157ebc9428085c4f1fd14544c9c59 prov:wasDerivedFrom niiri:32def2a96a2b007c0b48160856b0eb4e .
+niiri:98bad5417f97850e2a27b2644953d7fc prov:wasDerivedFrom niiri:cbc99abbec6b9d1c6aedcd2e278aabcd .
 
-niiri:af1157ebc9428085c4f1fd14544c9c59 prov:wasGeneratedBy niiri:e6b2a7699eaf7eb4b0e65181dd9165ea .
+niiri:98bad5417f97850e2a27b2644953d7fc prov:wasGeneratedBy niiri:8872a3798f2cb652dd632d9e9e40ecf9 .
 
-niiri:978a91d9ff72edb810642253cbfef4ab
+niiri:5755b406b2a82f8a36a4c0c23054e6ee
     a prov:Entity, nidm_ContrastStandardErrorMap: ; 
     prov:atLocation "ContrastStandardError_0002.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ContrastStandardError_0002.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Standard Error Map" ;
-    nidm_inCoordinateSpace: niiri:8ac2495eaa1d9630498f5dcb7ca6623a ;
+    nidm_inCoordinateSpace: niiri:43990f91d4711220e8f4834300dbd4a5 ;
     crypto:sha512 "e897bcfa6571036e47cf7fc61934c3ba09d3e3c7d759eaccfc002401c75700c5cdff2419aca08960e27c5dbdc76c05a2e2627a4935597f9eab4dfec54c0b2872"^^xsd:string .
 
-niiri:978a91d9ff72edb810642253cbfef4ab prov:wasGeneratedBy niiri:e6b2a7699eaf7eb4b0e65181dd9165ea .
+niiri:5755b406b2a82f8a36a4c0c23054e6ee prov:wasGeneratedBy niiri:8872a3798f2cb652dd632d9e9e40ecf9 .
 
-niiri:402e10a6c963c092e7edd6c55147bda7
+niiri:d929d3c4d45d3c1d6b9b03fb2445f0d9
     a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
-    rdfs:label "Height Threshold: p<0.001000 (unc.)" ;
+    rdfs:label "Height Threshold: p<0.001 (unc.)" ;
     prov:value "0.000999500158000544"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:38d412c018e8e0157c9aadebfa63839a ;
-    nidm_equivalentThreshold: niiri:b2232c1ea8710f6507e791720cb3c22b .
+    nidm_equivalentThreshold: niiri:737bba5cf2bd2f211f124fb3d262c2dc ;
+    nidm_equivalentThreshold: niiri:ab6c4afffb94c13144bd1539a6ca86f9 .
 
-niiri:38d412c018e8e0157c9aadebfa63839a
+niiri:737bba5cf2bd2f211f124fb3d262c2dc
     a prov:Entity, nidm_HeightThreshold:, obo_statistic: ; 
-    rdfs:label "Height Threshold" ;
+    rdfs:label "Height Threshold: T=3.175486)" ;
     prov:value "3.17548628637284"^^xsd:float .
 
-niiri:b2232c1ea8710f6507e791720cb3c22b
+niiri:ab6c4afffb94c13144bd1539a6ca86f9
     a prov:Entity, nidm_HeightThreshold:, obo_FWERadjustedpvalue: ; 
-    rdfs:label "Height Threshold" ;
+    rdfs:label "Height Threshold: p<1.000000 (FWE)" ;
     prov:value "0.999999999999997"^^xsd:float .
 
-niiri:54eb142a446c0ce834bc6f723e999197
+niiri:8d783286b1c008ac28fe81706432e884
     a prov:Entity, nidm_ExtentThreshold:, obo_statistic: ; 
     rdfs:label "Extent Threshold: k>=0" ;
     nidm_clusterSizeInVoxels: "0"^^xsd:int ;
     nidm_clusterSizeInResels: "0"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:f18c169a7bd7268074e1b754708bf0d1 ;
-    nidm_equivalentThreshold: niiri:a19457a205b4413bcfefd900ecbb12f9 .
+    nidm_equivalentThreshold: niiri:aa1873254cbafe5aaada9741c3754eb2 ;
+    nidm_equivalentThreshold: niiri:e1b635c98c9165c9c569e7531eebeb20 .
 
-niiri:f18c169a7bd7268074e1b754708bf0d1
+niiri:aa1873254cbafe5aaada9741c3754eb2
     a prov:Entity, nidm_ExtentThreshold:, obo_FWERadjustedpvalue: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:a19457a205b4413bcfefd900ecbb12f9
+niiri:e1b635c98c9165c9c569e7531eebeb20
     a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:9647502cfeafec615faa64a7dbf71eb9
+niiri:245e81118425b6790f11b064e4eca94d
     a prov:Entity, nidm_PeakDefinitionCriteria: ; 
     rdfs:label "Peak Definition Criteria" ;
     nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
     nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
 
-niiri:49bc3950bc97bc6e6f13240764473039
+niiri:04fa6b9288815b12d59a8ed5850b4b8e
     a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
     rdfs:label "Cluster Connectivity Criterion: 18" ;
     nidm_hasConnectivityCriterion: nidm_voxel18connected: .
 
-niiri:c20d3c1d9297836af7474d61ffe6e5d9
+niiri:16a9b96282eb00365725e2a0f6d310c6
     a prov:Activity, nidm_ConjunctionInference: ; 
     nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
     rdfs:label "Conjunction Inference" .
 
-niiri:c20d3c1d9297836af7474d61ffe6e5d9 prov:wasAssociatedWith niiri:788d8708b4b59d898f7fb805cfa24cee .
+niiri:16a9b96282eb00365725e2a0f6d310c6 prov:wasAssociatedWith niiri:016e3cb0f11ba49dad327f9752892d7f .
 
-niiri:c20d3c1d9297836af7474d61ffe6e5d9 prov:used niiri:402e10a6c963c092e7edd6c55147bda7 .
+niiri:16a9b96282eb00365725e2a0f6d310c6 prov:used niiri:d929d3c4d45d3c1d6b9b03fb2445f0d9 .
 
-niiri:c20d3c1d9297836af7474d61ffe6e5d9 prov:used niiri:54eb142a446c0ce834bc6f723e999197 .
+niiri:16a9b96282eb00365725e2a0f6d310c6 prov:used niiri:8d783286b1c008ac28fe81706432e884 .
 
-niiri:c20d3c1d9297836af7474d61ffe6e5d9 prov:used niiri:c19a21acb28cd19f21a1be425e49481c .
+niiri:16a9b96282eb00365725e2a0f6d310c6 prov:used niiri:7766f91f9fb3c7a19f3ae5bf1f752bbf .
 
-niiri:c20d3c1d9297836af7474d61ffe6e5d9 prov:used niiri:33c60c38565ba7f605e4ca032349e363 .
+niiri:16a9b96282eb00365725e2a0f6d310c6 prov:used niiri:d40b3bf5490868f622f2357adea722a9 .
 
-niiri:c20d3c1d9297836af7474d61ffe6e5d9 prov:used niiri:42a9ce7904b0f4ed1a0722c2ff773184 .
+niiri:16a9b96282eb00365725e2a0f6d310c6 prov:used niiri:19b287a58457b527aca30843e6e34d84 .
 
-niiri:c20d3c1d9297836af7474d61ffe6e5d9 prov:used niiri:27e2d554c75587c0f96b310d2360480e .
+niiri:16a9b96282eb00365725e2a0f6d310c6 prov:used niiri:e5a61d0bc28607c2ab613b81ddf8392a .
 
-niiri:c20d3c1d9297836af7474d61ffe6e5d9 prov:used niiri:9647502cfeafec615faa64a7dbf71eb9 .
+niiri:16a9b96282eb00365725e2a0f6d310c6 prov:used niiri:245e81118425b6790f11b064e4eca94d .
 
-niiri:c20d3c1d9297836af7474d61ffe6e5d9 prov:used niiri:49bc3950bc97bc6e6f13240764473039 .
+niiri:16a9b96282eb00365725e2a0f6d310c6 prov:used niiri:04fa6b9288815b12d59a8ed5850b4b8e .
 
-niiri:4203cdd482eb37373a8117206cb4efe7
+niiri:61ba90688ed17ead0aa46ba07adc7f73
     a prov:Entity, nidm_SearchSpaceMaskMap: ; 
     prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
     nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Search Space Mask Map" ;
-    nidm_inCoordinateSpace: niiri:8ac2495eaa1d9630498f5dcb7ca6623a ;
+    nidm_inCoordinateSpace: niiri:43990f91d4711220e8f4834300dbd4a5 ;
     nidm_searchVolumeInVoxels: "223057"^^xsd:int ;
     nidm_searchVolumeInUnits: "1784456"^^xsd:float ;
     nidm_reselSizeInVoxels: "65.5786964036542"^^xsd:float ;
@@ -600,9 +600,9 @@ niiri:4203cdd482eb37373a8117206cb4efe7
     spm_smallestSignificantClusterSizeInVoxelsFWE05: "98"^^xsd:int ;
     spm_smallestSignificantClusterSizeInVoxelsFDR05: "61"^^xsd:int .
 
-niiri:4203cdd482eb37373a8117206cb4efe7 prov:wasGeneratedBy niiri:c20d3c1d9297836af7474d61ffe6e5d9 .
+niiri:61ba90688ed17ead0aa46ba07adc7f73 prov:wasGeneratedBy niiri:16a9b96282eb00365725e2a0f6d310c6 .
 
-niiri:1af80adb8bcccf57b9b05ac7c52481d4
+niiri:88829929c68a059331cc3c1d60afeecb
     a prov:Entity, nidm_ExcursionSetMap: ; 
     prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
@@ -610,29 +610,29 @@ niiri:1af80adb8bcccf57b9b05ac7c52481d4
     rdfs:label "Excursion Set Map" ;
     nidm_numberOfSupraThresholdClusters: "56"^^xsd:int ;
     nidm_pValue: "0.000247328380021838"^^xsd:float ;
-    nidm_hasClusterLabelsMap: niiri:097a03a58fe62d77996b29182e1c553b ;
-    nidm_hasMaximumIntensityProjection: niiri:9eaf644167e5051fc8c46c6f7df592fb ;
-    nidm_inCoordinateSpace: niiri:8ac2495eaa1d9630498f5dcb7ca6623a ;
+    nidm_hasClusterLabelsMap: niiri:e5ce76ed52cded7d1b752baf082c1886 ;
+    nidm_hasMaximumIntensityProjection: niiri:1aee58d2fc0953d357532d51ed194f16 ;
+    nidm_inCoordinateSpace: niiri:43990f91d4711220e8f4834300dbd4a5 ;
     crypto:sha512 "a8d48d1adbe71cf263b98b98011df674a6c6b1602e9131c3ce3c96140161b1fc1c1c96359cbd6c7c0b0729cb52832ff1995a211d75748d9237df95dcd70ec0f4"^^xsd:string .
 
-niiri:097a03a58fe62d77996b29182e1c553b
+niiri:e5ce76ed52cded7d1b752baf082c1886
     a prov:Entity, nidm_ClusterLabelsMap: ; 
     prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Cluster Labels Map" ;
-    nidm_inCoordinateSpace: niiri:8ac2495eaa1d9630498f5dcb7ca6623a ;
+    nidm_inCoordinateSpace: niiri:43990f91d4711220e8f4834300dbd4a5 ;
     crypto:sha512 "774704e1f481e7e243dd63c13916d5e8cf0877992b8300d55bd612568c0e5bc608433c90a6c24a4618cb6117e8c232a45a5611fba7352c5a7931bdabf0d2e6b5"^^xsd:string .
 
-niiri:9eaf644167e5051fc8c46c6f7df592fb
+niiri:1aee58d2fc0953d357532d51ed194f16
     a prov:Entity, dctype:Image ; 
     prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
     nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:1af80adb8bcccf57b9b05ac7c52481d4 prov:wasGeneratedBy niiri:c20d3c1d9297836af7474d61ffe6e5d9 .
+niiri:88829929c68a059331cc3c1d60afeecb prov:wasGeneratedBy niiri:16a9b96282eb00365725e2a0f6d310c6 .
 
-niiri:79e0203aa5a8ff2c1026ae98766d1fd0
+niiri:0fe5639ac98706c7b3899db7801a8bf2
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0001" ;
     nidm_clusterSizeInVoxels: "71"^^xsd:int ;
@@ -642,9 +642,9 @@ niiri:79e0203aa5a8ff2c1026ae98766d1fd0
     nidm_qValueFDR: "0.0268436007152825"^^xsd:float ;
     nidm_clusterLabelId: "1"^^xsd:int .
 
-niiri:79e0203aa5a8ff2c1026ae98766d1fd0 prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:0fe5639ac98706c7b3899db7801a8bf2 prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:97cfacc05fa324f73a12205fe62c3b0e
+niiri:2975c7a00a3fc4010192cdde06218e42
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0002" ;
     nidm_clusterSizeInVoxels: "552"^^xsd:int ;
@@ -654,9 +654,9 @@ niiri:97cfacc05fa324f73a12205fe62c3b0e
     nidm_qValueFDR: "9.69926984812134e-09"^^xsd:float ;
     nidm_clusterLabelId: "2"^^xsd:int .
 
-niiri:97cfacc05fa324f73a12205fe62c3b0e prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:2975c7a00a3fc4010192cdde06218e42 prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:f751ad7b48ea46de21e54d7b384c89f1
+niiri:022596b73b46d7ef5ae45ede7165a0d5
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0003" ;
     nidm_clusterSizeInVoxels: "1653"^^xsd:int ;
@@ -666,9 +666,9 @@ niiri:f751ad7b48ea46de21e54d7b384c89f1
     nidm_qValueFDR: "1.24021497658566e-18"^^xsd:float ;
     nidm_clusterLabelId: "3"^^xsd:int .
 
-niiri:f751ad7b48ea46de21e54d7b384c89f1 prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:022596b73b46d7ef5ae45ede7165a0d5 prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:c1dc7ef33bd86562827618d9eb1512eb
+niiri:9170484cbff3981334345a4c47f65aa7
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0004" ;
     nidm_clusterSizeInVoxels: "120"^^xsd:int ;
@@ -678,9 +678,9 @@ niiri:c1dc7ef33bd86562827618d9eb1512eb
     nidm_qValueFDR: "0.00425459318176409"^^xsd:float ;
     nidm_clusterLabelId: "4"^^xsd:int .
 
-niiri:c1dc7ef33bd86562827618d9eb1512eb prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:9170484cbff3981334345a4c47f65aa7 prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:67d786a9d604bea82ccb2ac559f82d13
+niiri:25e87116b614d88934e1e8c93fcc0b63
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0005" ;
     nidm_clusterSizeInVoxels: "61"^^xsd:int ;
@@ -690,9 +690,9 @@ niiri:67d786a9d604bea82ccb2ac559f82d13
     nidm_qValueFDR: "0.0371211354620382"^^xsd:float ;
     nidm_clusterLabelId: "5"^^xsd:int .
 
-niiri:67d786a9d604bea82ccb2ac559f82d13 prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:25e87116b614d88934e1e8c93fcc0b63 prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:fad9f2a76799ff174c8bd126ac6dd441
+niiri:c71e617484a5b302959dff7c4db9cc74
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0006" ;
     nidm_clusterSizeInVoxels: "146"^^xsd:int ;
@@ -702,9 +702,9 @@ niiri:fad9f2a76799ff174c8bd126ac6dd441
     nidm_qValueFDR: "0.00236030184878177"^^xsd:float ;
     nidm_clusterLabelId: "6"^^xsd:int .
 
-niiri:fad9f2a76799ff174c8bd126ac6dd441 prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:c71e617484a5b302959dff7c4db9cc74 prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:2fac5f34a48ebec593eeef67b0204e24
+niiri:b1e379a1ec5bd17c690d79aba04d4080
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0007" ;
     nidm_clusterSizeInVoxels: "33"^^xsd:int ;
@@ -714,9 +714,9 @@ niiri:2fac5f34a48ebec593eeef67b0204e24
     nidm_qValueFDR: "0.133560935191756"^^xsd:float ;
     nidm_clusterLabelId: "7"^^xsd:int .
 
-niiri:2fac5f34a48ebec593eeef67b0204e24 prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:b1e379a1ec5bd17c690d79aba04d4080 prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:7225d84c7ed17dec15823366e7f7fc83
+niiri:4672418600c089d526b22d32d479dd1e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0008" ;
     nidm_clusterSizeInVoxels: "69"^^xsd:int ;
@@ -726,9 +726,9 @@ niiri:7225d84c7ed17dec15823366e7f7fc83
     nidm_qValueFDR: "0.0268436007152825"^^xsd:float ;
     nidm_clusterLabelId: "8"^^xsd:int .
 
-niiri:7225d84c7ed17dec15823366e7f7fc83 prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:4672418600c089d526b22d32d479dd1e prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:cabc7bdcad758f1df0bc5478e9d6d8e1
+niiri:67a283ee599be31793e69bea3826f055
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0009" ;
     nidm_clusterSizeInVoxels: "98"^^xsd:int ;
@@ -738,9 +738,9 @@ niiri:cabc7bdcad758f1df0bc5478e9d6d8e1
     nidm_qValueFDR: "0.00958654635105321"^^xsd:float ;
     nidm_clusterLabelId: "9"^^xsd:int .
 
-niiri:cabc7bdcad758f1df0bc5478e9d6d8e1 prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:67a283ee599be31793e69bea3826f055 prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:bc8fac8699d6afb89bc9b1fb0219744d
+niiri:7640c37d58f807f183dbb16f5cce885a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0010" ;
     nidm_clusterSizeInVoxels: "71"^^xsd:int ;
@@ -750,9 +750,9 @@ niiri:bc8fac8699d6afb89bc9b1fb0219744d
     nidm_qValueFDR: "0.0268436007152825"^^xsd:float ;
     nidm_clusterLabelId: "10"^^xsd:int .
 
-niiri:bc8fac8699d6afb89bc9b1fb0219744d prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:7640c37d58f807f183dbb16f5cce885a prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:7f473f5d8bf7cb4917efbb176cc4e7db
+niiri:8cfc21f5bbcf34401f68b224da91bb62
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0011" ;
     nidm_clusterSizeInVoxels: "125"^^xsd:int ;
@@ -762,9 +762,9 @@ niiri:7f473f5d8bf7cb4917efbb176cc4e7db
     nidm_qValueFDR: "0.00425459318176409"^^xsd:float ;
     nidm_clusterLabelId: "11"^^xsd:int .
 
-niiri:7f473f5d8bf7cb4917efbb176cc4e7db prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:8cfc21f5bbcf34401f68b224da91bb62 prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:cb86cbce3b49744dcf6fb45ea4518fb9
+niiri:dfe1db9cfb99ba668d8eeb1e01c32a4f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0012" ;
     nidm_clusterSizeInVoxels: "43"^^xsd:int ;
@@ -774,9 +774,9 @@ niiri:cb86cbce3b49744dcf6fb45ea4518fb9
     nidm_qValueFDR: "0.081037326693281"^^xsd:float ;
     nidm_clusterLabelId: "12"^^xsd:int .
 
-niiri:cb86cbce3b49744dcf6fb45ea4518fb9 prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:dfe1db9cfb99ba668d8eeb1e01c32a4f prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:150da014ff9cc30caf37962658fd7687
+niiri:8b21d35a1fc7a9cfb360ad2121638da7
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0013" ;
     nidm_clusterSizeInVoxels: "21"^^xsd:int ;
@@ -786,9 +786,9 @@ niiri:150da014ff9cc30caf37962658fd7687
     nidm_qValueFDR: "0.234367607276586"^^xsd:float ;
     nidm_clusterLabelId: "13"^^xsd:int .
 
-niiri:150da014ff9cc30caf37962658fd7687 prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:8b21d35a1fc7a9cfb360ad2121638da7 prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:653461d881414853588331372590bd6b
+niiri:988a6212fa64a63474847b473adbd268
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0014" ;
     nidm_clusterSizeInVoxels: "23"^^xsd:int ;
@@ -798,9 +798,9 @@ niiri:653461d881414853588331372590bd6b
     nidm_qValueFDR: "0.214986236720327"^^xsd:float ;
     nidm_clusterLabelId: "14"^^xsd:int .
 
-niiri:653461d881414853588331372590bd6b prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:988a6212fa64a63474847b473adbd268 prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:98ca641a6df5b460bf760c850b8528af
+niiri:0d10036870ecd78a22c4b7434f3e940f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0015" ;
     nidm_clusterSizeInVoxels: "15"^^xsd:int ;
@@ -810,9 +810,9 @@ niiri:98ca641a6df5b460bf760c850b8528af
     nidm_qValueFDR: "0.300693945280055"^^xsd:float ;
     nidm_clusterLabelId: "15"^^xsd:int .
 
-niiri:98ca641a6df5b460bf760c850b8528af prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:0d10036870ecd78a22c4b7434f3e940f prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:62781649d6e4a250a6f3378b94f51367
+niiri:7e1995dcc209b0990e86feb660922162
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0016" ;
     nidm_clusterSizeInVoxels: "20"^^xsd:int ;
@@ -822,9 +822,9 @@ niiri:62781649d6e4a250a6f3378b94f51367
     nidm_qValueFDR: "0.234367607276586"^^xsd:float ;
     nidm_clusterLabelId: "16"^^xsd:int .
 
-niiri:62781649d6e4a250a6f3378b94f51367 prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:7e1995dcc209b0990e86feb660922162 prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:2ef53dff53e03927f9f447755a2af2df
+niiri:b4757e6c4de815acef5afdb0476f0eb3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0017" ;
     nidm_clusterSizeInVoxels: "15"^^xsd:int ;
@@ -834,9 +834,9 @@ niiri:2ef53dff53e03927f9f447755a2af2df
     nidm_qValueFDR: "0.300693945280055"^^xsd:float ;
     nidm_clusterLabelId: "17"^^xsd:int .
 
-niiri:2ef53dff53e03927f9f447755a2af2df prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:b4757e6c4de815acef5afdb0476f0eb3 prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:689adaab2c0c4d3c1af8f26813a3b966
+niiri:f8221060362a62c937dd97233413a960
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0018" ;
     nidm_clusterSizeInVoxels: "26"^^xsd:int ;
@@ -846,9 +846,9 @@ niiri:689adaab2c0c4d3c1af8f26813a3b966
     nidm_qValueFDR: "0.181573986860794"^^xsd:float ;
     nidm_clusterLabelId: "18"^^xsd:int .
 
-niiri:689adaab2c0c4d3c1af8f26813a3b966 prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:f8221060362a62c937dd97233413a960 prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:6d7f9eadd2ea16abe1d24c92b4094bf6
+niiri:af4c8a0d8ff5cfb976a7e9746756d8e3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0019" ;
     nidm_clusterSizeInVoxels: "51"^^xsd:int ;
@@ -858,9 +858,9 @@ niiri:6d7f9eadd2ea16abe1d24c92b4094bf6
     nidm_qValueFDR: "0.054395751589617"^^xsd:float ;
     nidm_clusterLabelId: "19"^^xsd:int .
 
-niiri:6d7f9eadd2ea16abe1d24c92b4094bf6 prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:af4c8a0d8ff5cfb976a7e9746756d8e3 prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:684ce311bfd3bc478751bb8ba1bdc608
+niiri:866201193f458cd1f0d7d30bfc40b674
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0020" ;
     nidm_clusterSizeInVoxels: "52"^^xsd:int ;
@@ -870,9 +870,9 @@ niiri:684ce311bfd3bc478751bb8ba1bdc608
     nidm_qValueFDR: "0.054395751589617"^^xsd:float ;
     nidm_clusterLabelId: "20"^^xsd:int .
 
-niiri:684ce311bfd3bc478751bb8ba1bdc608 prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:866201193f458cd1f0d7d30bfc40b674 prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:dff5ab56a4787869bfe6b9e37cb9aac1
+niiri:2627b433d92d75102b82469256c03339
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0021" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -882,9 +882,9 @@ niiri:dff5ab56a4787869bfe6b9e37cb9aac1
     nidm_qValueFDR: "0.688055919507771"^^xsd:float ;
     nidm_clusterLabelId: "21"^^xsd:int .
 
-niiri:dff5ab56a4787869bfe6b9e37cb9aac1 prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:2627b433d92d75102b82469256c03339 prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:2f77c6e25e1162cf6ea3521c6e32fc2e
+niiri:601904871dc4878169c4db748733771d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0022" ;
     nidm_clusterSizeInVoxels: "29"^^xsd:int ;
@@ -894,9 +894,9 @@ niiri:2f77c6e25e1162cf6ea3521c6e32fc2e
     nidm_qValueFDR: "0.164828075862556"^^xsd:float ;
     nidm_clusterLabelId: "22"^^xsd:int .
 
-niiri:2f77c6e25e1162cf6ea3521c6e32fc2e prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:601904871dc4878169c4db748733771d prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:19b8938a50757611f958db8a897d6420
+niiri:0a7cd6ed9222066e8fdf471bab1ee6e7
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0023" ;
     nidm_clusterSizeInVoxels: "20"^^xsd:int ;
@@ -906,9 +906,9 @@ niiri:19b8938a50757611f958db8a897d6420
     nidm_qValueFDR: "0.234367607276586"^^xsd:float ;
     nidm_clusterLabelId: "23"^^xsd:int .
 
-niiri:19b8938a50757611f958db8a897d6420 prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:0a7cd6ed9222066e8fdf471bab1ee6e7 prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:88c4835173f01a2e57f1b274727c2e78
+niiri:d2a33a86263a0cb45dbf1c9cce5a8dd4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0024" ;
     nidm_clusterSizeInVoxels: "41"^^xsd:int ;
@@ -918,9 +918,9 @@ niiri:88c4835173f01a2e57f1b274727c2e78
     nidm_qValueFDR: "0.0851980652959692"^^xsd:float ;
     nidm_clusterLabelId: "24"^^xsd:int .
 
-niiri:88c4835173f01a2e57f1b274727c2e78 prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:d2a33a86263a0cb45dbf1c9cce5a8dd4 prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:ef62449f6b6d1aca9419dce43c45ebb1
+niiri:ab0144b9188c24f978e07874f53ac025
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0025" ;
     nidm_clusterSizeInVoxels: "27"^^xsd:int ;
@@ -930,9 +930,9 @@ niiri:ef62449f6b6d1aca9419dce43c45ebb1
     nidm_qValueFDR: "0.1788294918022"^^xsd:float ;
     nidm_clusterLabelId: "25"^^xsd:int .
 
-niiri:ef62449f6b6d1aca9419dce43c45ebb1 prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:ab0144b9188c24f978e07874f53ac025 prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:1888964486bb06df70ff6f51a4b99b30
+niiri:c584015fa24c7c926f0b58301e5d61f2
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0026" ;
     nidm_clusterSizeInVoxels: "16"^^xsd:int ;
@@ -942,9 +942,9 @@ niiri:1888964486bb06df70ff6f51a4b99b30
     nidm_qValueFDR: "0.29873974830013"^^xsd:float ;
     nidm_clusterLabelId: "26"^^xsd:int .
 
-niiri:1888964486bb06df70ff6f51a4b99b30 prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:c584015fa24c7c926f0b58301e5d61f2 prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:036f0f4fe63d2badbd206185e824027a
+niiri:b575189f3bd68971936993d3aa187cb2
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0027" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -954,9 +954,9 @@ niiri:036f0f4fe63d2badbd206185e824027a
     nidm_qValueFDR: "0.582719856941733"^^xsd:float ;
     nidm_clusterLabelId: "27"^^xsd:int .
 
-niiri:036f0f4fe63d2badbd206185e824027a prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:b575189f3bd68971936993d3aa187cb2 prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:d15bd2a66669fcb82747bebed9441dfd
+niiri:e8cd31e50a3c32fbe2bbcc0095269056
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0028" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -966,9 +966,9 @@ niiri:d15bd2a66669fcb82747bebed9441dfd
     nidm_qValueFDR: "0.713988753033231"^^xsd:float ;
     nidm_clusterLabelId: "28"^^xsd:int .
 
-niiri:d15bd2a66669fcb82747bebed9441dfd prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:e8cd31e50a3c32fbe2bbcc0095269056 prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:0da1df9eac44070257be237353ddcd3a
+niiri:e97474fed9ca8bf394b41d386552ec23
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0029" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -978,9 +978,9 @@ niiri:0da1df9eac44070257be237353ddcd3a
     nidm_qValueFDR: "0.620919915466222"^^xsd:float ;
     nidm_clusterLabelId: "29"^^xsd:int .
 
-niiri:0da1df9eac44070257be237353ddcd3a prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:e97474fed9ca8bf394b41d386552ec23 prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:4b0e06aef793ba5702452d1f3e252868
+niiri:abd9e58304894c9547b23ee1045ac1da
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0030" ;
     nidm_clusterSizeInVoxels: "16"^^xsd:int ;
@@ -990,9 +990,9 @@ niiri:4b0e06aef793ba5702452d1f3e252868
     nidm_qValueFDR: "0.29873974830013"^^xsd:float ;
     nidm_clusterLabelId: "30"^^xsd:int .
 
-niiri:4b0e06aef793ba5702452d1f3e252868 prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:abd9e58304894c9547b23ee1045ac1da prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:85bdb7fb602f14f0f33185e4228dd31d
+niiri:f35fdf14b958462f212cb7e02a3f5b6a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0031" ;
     nidm_clusterSizeInVoxels: "14"^^xsd:int ;
@@ -1002,9 +1002,9 @@ niiri:85bdb7fb602f14f0f33185e4228dd31d
     nidm_qValueFDR: "0.316354163468013"^^xsd:float ;
     nidm_clusterLabelId: "31"^^xsd:int .
 
-niiri:85bdb7fb602f14f0f33185e4228dd31d prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:f35fdf14b958462f212cb7e02a3f5b6a prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:70204a580679814e93ec3ee19b2e747c
+niiri:65aa1110e7a5b158b24b46e37675c86f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0032" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -1014,9 +1014,9 @@ niiri:70204a580679814e93ec3ee19b2e747c
     nidm_qValueFDR: "0.511341726026011"^^xsd:float ;
     nidm_clusterLabelId: "32"^^xsd:int .
 
-niiri:70204a580679814e93ec3ee19b2e747c prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:65aa1110e7a5b158b24b46e37675c86f prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:f6f25c1b5f426f11bffb789fc0ff6d56
+niiri:7d8d48b7315eff2905773178ffd49023
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0033" ;
     nidm_clusterSizeInVoxels: "10"^^xsd:int ;
@@ -1026,9 +1026,9 @@ niiri:f6f25c1b5f426f11bffb789fc0ff6d56
     nidm_qValueFDR: "0.429768154312695"^^xsd:float ;
     nidm_clusterLabelId: "33"^^xsd:int .
 
-niiri:f6f25c1b5f426f11bffb789fc0ff6d56 prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:7d8d48b7315eff2905773178ffd49023 prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:1709f46929bebc2f3c937d537403c879
+niiri:62e2c2069415d9aa3cc91424a7a036cf
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0034" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -1038,9 +1038,9 @@ niiri:1709f46929bebc2f3c937d537403c879
     nidm_qValueFDR: "0.53527916542896"^^xsd:float ;
     nidm_clusterLabelId: "34"^^xsd:int .
 
-niiri:1709f46929bebc2f3c937d537403c879 prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:62e2c2069415d9aa3cc91424a7a036cf prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:6143b9e2dc6ccc1e23b85ae05647eb05
+niiri:2deb14df5037616ae2a96835f77312be
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0035" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1050,9 +1050,9 @@ niiri:6143b9e2dc6ccc1e23b85ae05647eb05
     nidm_qValueFDR: "0.713988753033231"^^xsd:float ;
     nidm_clusterLabelId: "35"^^xsd:int .
 
-niiri:6143b9e2dc6ccc1e23b85ae05647eb05 prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:2deb14df5037616ae2a96835f77312be prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:90c1e5b11aa4824f7fb9ea3eac86bf0d
+niiri:5b409e333f6b39e5bc61b32b5cdb5358
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0036" ;
     nidm_clusterSizeInVoxels: "12"^^xsd:int ;
@@ -1062,9 +1062,9 @@ niiri:90c1e5b11aa4824f7fb9ea3eac86bf0d
     nidm_qValueFDR: "0.366552153814587"^^xsd:float ;
     nidm_clusterLabelId: "36"^^xsd:int .
 
-niiri:90c1e5b11aa4824f7fb9ea3eac86bf0d prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:5b409e333f6b39e5bc61b32b5cdb5358 prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:5e09dfc93a92598eb65ced39066c6e1f
+niiri:aa433f26589b155235af6a6df23091d5
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0037" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1074,9 +1074,9 @@ niiri:5e09dfc93a92598eb65ced39066c6e1f
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "37"^^xsd:int .
 
-niiri:5e09dfc93a92598eb65ced39066c6e1f prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:aa433f26589b155235af6a6df23091d5 prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:7c5ba749e2c3ebf4bc0b3ad25206415a
+niiri:d220eb8d00595929d9a913e79e63f18d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0038" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -1086,9 +1086,9 @@ niiri:7c5ba749e2c3ebf4bc0b3ad25206415a
     nidm_qValueFDR: "0.53527916542896"^^xsd:float ;
     nidm_clusterLabelId: "38"^^xsd:int .
 
-niiri:7c5ba749e2c3ebf4bc0b3ad25206415a prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:d220eb8d00595929d9a913e79e63f18d prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:48da72af2b8db06b1f889a4b6dfc0d72
+niiri:b25a22f3e4eb9bbd1275897ff1df109d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0039" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1098,9 +1098,9 @@ niiri:48da72af2b8db06b1f889a4b6dfc0d72
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "39"^^xsd:int .
 
-niiri:48da72af2b8db06b1f889a4b6dfc0d72 prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:b25a22f3e4eb9bbd1275897ff1df109d prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:a27fad4fe7cc82465f0e2f5bbe9d75f9
+niiri:bd4658613e97b52c7228dc395dd15873
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0040" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1110,9 +1110,9 @@ niiri:a27fad4fe7cc82465f0e2f5bbe9d75f9
     nidm_qValueFDR: "0.713988753033231"^^xsd:float ;
     nidm_clusterLabelId: "40"^^xsd:int .
 
-niiri:a27fad4fe7cc82465f0e2f5bbe9d75f9 prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:bd4658613e97b52c7228dc395dd15873 prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:8a6fe11cd61eb1f35a28fa6bf0b6144f
+niiri:453c0a23d3b7bdaf631090a39026b948
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0041" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1122,9 +1122,9 @@ niiri:8a6fe11cd61eb1f35a28fa6bf0b6144f
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "41"^^xsd:int .
 
-niiri:8a6fe11cd61eb1f35a28fa6bf0b6144f prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:453c0a23d3b7bdaf631090a39026b948 prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:2e6c2c0ad60837828212538790c5db9b
+niiri:f9cadf3213379a88a9727fcf6a9eeef1
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0042" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1134,9 +1134,9 @@ niiri:2e6c2c0ad60837828212538790c5db9b
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "42"^^xsd:int .
 
-niiri:2e6c2c0ad60837828212538790c5db9b prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:f9cadf3213379a88a9727fcf6a9eeef1 prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:5dabb5b7488150418280d8590f704272
+niiri:00e7e2184e288d14e023360536c4ccbb
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0043" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1146,9 +1146,9 @@ niiri:5dabb5b7488150418280d8590f704272
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "43"^^xsd:int .
 
-niiri:5dabb5b7488150418280d8590f704272 prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:00e7e2184e288d14e023360536c4ccbb prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:f0c686d0818396b5724de255e477b7e7
+niiri:1e198daa9971af9c5562116948147b44
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0044" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1158,9 +1158,9 @@ niiri:f0c686d0818396b5724de255e477b7e7
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "44"^^xsd:int .
 
-niiri:f0c686d0818396b5724de255e477b7e7 prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:1e198daa9971af9c5562116948147b44 prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:4d3b4510cff045e65b0540e3d2c3ddb5
+niiri:b983603109c1a317dd80246d873f0d4a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0045" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1170,9 +1170,9 @@ niiri:4d3b4510cff045e65b0540e3d2c3ddb5
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "45"^^xsd:int .
 
-niiri:4d3b4510cff045e65b0540e3d2c3ddb5 prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:b983603109c1a317dd80246d873f0d4a prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:cb783972b7209195409262a64edc55f4
+niiri:bcad500e3ad79ca4075f62aa01a372da
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0046" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -1182,9 +1182,9 @@ niiri:cb783972b7209195409262a64edc55f4
     nidm_qValueFDR: "0.620919915466222"^^xsd:float ;
     nidm_clusterLabelId: "46"^^xsd:int .
 
-niiri:cb783972b7209195409262a64edc55f4 prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:bcad500e3ad79ca4075f62aa01a372da prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:a972e773c5316470d7547a29677906b8
+niiri:b41f8e4d939b3ddb2c20cae93fb8b7c8
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0047" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1194,9 +1194,9 @@ niiri:a972e773c5316470d7547a29677906b8
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "47"^^xsd:int .
 
-niiri:a972e773c5316470d7547a29677906b8 prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:b41f8e4d939b3ddb2c20cae93fb8b7c8 prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:568187a66cff2006389ae8a03beea987
+niiri:4545f5ed2d2381e9f6f1aaf307289882
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0048" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1206,9 +1206,9 @@ niiri:568187a66cff2006389ae8a03beea987
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "48"^^xsd:int .
 
-niiri:568187a66cff2006389ae8a03beea987 prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:4545f5ed2d2381e9f6f1aaf307289882 prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:31ace54320ced6fbcbbf3e9a0b06c69b
+niiri:2253c054073552510a00e5cee801efa6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0049" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1218,9 +1218,9 @@ niiri:31ace54320ced6fbcbbf3e9a0b06c69b
     nidm_qValueFDR: "0.713988753033231"^^xsd:float ;
     nidm_clusterLabelId: "49"^^xsd:int .
 
-niiri:31ace54320ced6fbcbbf3e9a0b06c69b prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:2253c054073552510a00e5cee801efa6 prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:497da5b57f3713b30ef46f853f1ed5d0
+niiri:c2c0de5bb03471fb2a8439bc440e1a06
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0050" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1230,9 +1230,9 @@ niiri:497da5b57f3713b30ef46f853f1ed5d0
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "50"^^xsd:int .
 
-niiri:497da5b57f3713b30ef46f853f1ed5d0 prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:c2c0de5bb03471fb2a8439bc440e1a06 prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:2ef352ff3d02560b512f4da34e0351c4
+niiri:7c7b06e42170e83d79d011d51a1ee2eb
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0051" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1242,9 +1242,9 @@ niiri:2ef352ff3d02560b512f4da34e0351c4
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "51"^^xsd:int .
 
-niiri:2ef352ff3d02560b512f4da34e0351c4 prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:7c7b06e42170e83d79d011d51a1ee2eb prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:d31015870dfb250e5f85f5b4632731c3
+niiri:040e702ed12041e2190bf96dfbacadbb
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0052" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1254,9 +1254,9 @@ niiri:d31015870dfb250e5f85f5b4632731c3
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "52"^^xsd:int .
 
-niiri:d31015870dfb250e5f85f5b4632731c3 prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:040e702ed12041e2190bf96dfbacadbb prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:cb808a6811ec0c81f5483719bfa3da6a
+niiri:e14e04732107aabcfe52c4ce59b579a8
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0053" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1266,9 +1266,9 @@ niiri:cb808a6811ec0c81f5483719bfa3da6a
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "53"^^xsd:int .
 
-niiri:cb808a6811ec0c81f5483719bfa3da6a prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:e14e04732107aabcfe52c4ce59b579a8 prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:da2ebf5fddf7590fea56aa4795c3c730
+niiri:d77e5bf6a731dcb245ad371bed714586
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0054" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1278,9 +1278,9 @@ niiri:da2ebf5fddf7590fea56aa4795c3c730
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "54"^^xsd:int .
 
-niiri:da2ebf5fddf7590fea56aa4795c3c730 prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:d77e5bf6a731dcb245ad371bed714586 prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:5f270d7e12051f6614973ee4186253ff
+niiri:9575c70a2f76c6d9598daa3848deeb65
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0055" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1290,9 +1290,9 @@ niiri:5f270d7e12051f6614973ee4186253ff
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "55"^^xsd:int .
 
-niiri:5f270d7e12051f6614973ee4186253ff prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:9575c70a2f76c6d9598daa3848deeb65 prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:3165aeeecdded90d2140dbb15bc8e722
+niiri:75e697b6b2e295644bcfcd0111ce9380
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0056" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1302,1195 +1302,1195 @@ niiri:3165aeeecdded90d2140dbb15bc8e722
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "56"^^xsd:int .
 
-niiri:3165aeeecdded90d2140dbb15bc8e722 prov:wasDerivedFrom niiri:1af80adb8bcccf57b9b05ac7c52481d4 .
+niiri:75e697b6b2e295644bcfcd0111ce9380 prov:wasDerivedFrom niiri:88829929c68a059331cc3c1d60afeecb .
 
-niiri:c34af718ecf50c995e6a268008d1be28
+niiri:af2094f9b3bb076517fd57cfdea6eba4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0001" ;
-    prov:atLocation niiri:585296e06e66672b3fc0fea088e1ce35 ;
+    prov:atLocation niiri:6631676ab73837c6d950866c315ccf1a ;
     prov:value "5.64907312393188"^^xsd:float ;
     nidm_equivalentZStatistic: "5.24289493008127"^^xsd:float ;
     nidm_pValueUncorrected: "7.9038282474464e-08"^^xsd:float ;
     nidm_pValueFWER: "0.0140710030676051"^^xsd:float ;
     nidm_qValueFDR: "0.0477090229517705"^^xsd:float .
 
-niiri:585296e06e66672b3fc0fea088e1ce35
+niiri:6631676ab73837c6d950866c315ccf1a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0001" ;
     nidm_coordinateVector: "[36,-76,-12]"^^xsd:string .
 
-niiri:c34af718ecf50c995e6a268008d1be28 prov:wasDerivedFrom niiri:79e0203aa5a8ff2c1026ae98766d1fd0 .
+niiri:af2094f9b3bb076517fd57cfdea6eba4 prov:wasDerivedFrom niiri:0fe5639ac98706c7b3899db7801a8bf2 .
 
-niiri:7435824662b09850d505d48ff0b947a5
+niiri:0dbf46b534dd4d2ded0176cdc0cedff2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0002" ;
-    prov:atLocation niiri:ce4104f5c86d70fe197ed78aba3a700c ;
+    prov:atLocation niiri:0e60133e7c39e22e4a371d8f01396b30 ;
     prov:value "5.42078256607056"^^xsd:float ;
     nidm_equivalentZStatistic: "5.05689095731376"^^xsd:float ;
     nidm_pValueUncorrected: "2.13073368393601e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0332963820346506"^^xsd:float ;
     nidm_qValueFDR: "0.0570035031908581"^^xsd:float .
 
-niiri:ce4104f5c86d70fe197ed78aba3a700c
+niiri:0e60133e7c39e22e4a371d8f01396b30
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0002" ;
     nidm_coordinateVector: "[20,16,4]"^^xsd:string .
 
-niiri:7435824662b09850d505d48ff0b947a5 prov:wasDerivedFrom niiri:97cfacc05fa324f73a12205fe62c3b0e .
+niiri:0dbf46b534dd4d2ded0176cdc0cedff2 prov:wasDerivedFrom niiri:2975c7a00a3fc4010192cdde06218e42 .
 
-niiri:69b4afbe837d83937f24d7e95d93fced
+niiri:9fa6b2358072adca3ed3687d1a6ad221
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0003" ;
-    prov:atLocation niiri:c7f628b3032253d6e3eed6e9cf085ee7 ;
+    prov:atLocation niiri:b10dc0afb7a68740e32c8b3be51324ad ;
     prov:value "5.11829614639282"^^xsd:float ;
     nidm_equivalentZStatistic: "4.80629858706218"^^xsd:float ;
     nidm_pValueUncorrected: "7.68751121871247e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0981605381212231"^^xsd:float ;
     nidm_qValueFDR: "0.057973541602361"^^xsd:float .
 
-niiri:c7f628b3032253d6e3eed6e9cf085ee7
+niiri:b10dc0afb7a68740e32c8b3be51324ad
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0003" ;
     nidm_coordinateVector: "[32,26,-6]"^^xsd:string .
 
-niiri:69b4afbe837d83937f24d7e95d93fced prov:wasDerivedFrom niiri:97cfacc05fa324f73a12205fe62c3b0e .
+niiri:9fa6b2358072adca3ed3687d1a6ad221 prov:wasDerivedFrom niiri:2975c7a00a3fc4010192cdde06218e42 .
 
-niiri:356d2f82e462594d0042d6393c464ddb
+niiri:8ae0f4115317261dd462890c08bba437
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0004" ;
-    prov:atLocation niiri:cf78bd7cc12e8a944e6cbf175ddaed4c ;
+    prov:atLocation niiri:5d8a2cdf981ab3e1af47206d152b9767 ;
     prov:value "4.6295690536499"^^xsd:float ;
     nidm_equivalentZStatistic: "4.39160002492543"^^xsd:float ;
     nidm_pValueUncorrected: "5.62597750342064e-06"^^xsd:float ;
     nidm_pValueFWER: "0.431266600537586"^^xsd:float ;
     nidm_qValueFDR: "0.146151100945538"^^xsd:float .
 
-niiri:cf78bd7cc12e8a944e6cbf175ddaed4c
+niiri:5d8a2cdf981ab3e1af47206d152b9767
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0004" ;
     nidm_coordinateVector: "[14,10,0]"^^xsd:string .
 
-niiri:356d2f82e462594d0042d6393c464ddb prov:wasDerivedFrom niiri:97cfacc05fa324f73a12205fe62c3b0e .
+niiri:8ae0f4115317261dd462890c08bba437 prov:wasDerivedFrom niiri:2975c7a00a3fc4010192cdde06218e42 .
 
-niiri:6a747142599301744442efa503531015
+niiri:50e978588351b61d3b66805ff525e612
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0005" ;
-    prov:atLocation niiri:acc2efcedcdbe2c06f52a8a38755b94c ;
+    prov:atLocation niiri:9ddd565948e5d4f00a26dac1f2579a39 ;
     prov:value "5.28027057647705"^^xsd:float ;
     nidm_equivalentZStatistic: "4.94106877436825"^^xsd:float ;
     nidm_pValueUncorrected: "3.88477472079707e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0555771763913264"^^xsd:float ;
     nidm_qValueFDR: "0.057973541602361"^^xsd:float .
 
-niiri:acc2efcedcdbe2c06f52a8a38755b94c
+niiri:9ddd565948e5d4f00a26dac1f2579a39
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0005" ;
     nidm_coordinateVector: "[-30,26,2]"^^xsd:string .
 
-niiri:6a747142599301744442efa503531015 prov:wasDerivedFrom niiri:f751ad7b48ea46de21e54d7b384c89f1 .
+niiri:50e978588351b61d3b66805ff525e612 prov:wasDerivedFrom niiri:022596b73b46d7ef5ae45ede7165a0d5 .
 
-niiri:1d87d3c8a54e1832d85927f547b0fd76
+niiri:6393cd494948c4e016913a024bb7521d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0006" ;
-    prov:atLocation niiri:40d92fd1bc3081d12818efce8e8031d0 ;
+    prov:atLocation niiri:d43a0f137c03ba2fb045a1f9b0cf9580 ;
     prov:value "4.88750791549683"^^xsd:float ;
     nidm_equivalentZStatistic: "4.61196523240772"^^xsd:float ;
     nidm_pValueUncorrected: "1.99439861559014e-06"^^xsd:float ;
     nidm_pValueFWER: "0.208871803486741"^^xsd:float ;
     nidm_qValueFDR: "0.0985996618857355"^^xsd:float .
 
-niiri:40d92fd1bc3081d12818efce8e8031d0
+niiri:d43a0f137c03ba2fb045a1f9b0cf9580
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0006" ;
     nidm_coordinateVector: "[-10,8,-2]"^^xsd:string .
 
-niiri:1d87d3c8a54e1832d85927f547b0fd76 prov:wasDerivedFrom niiri:f751ad7b48ea46de21e54d7b384c89f1 .
+niiri:6393cd494948c4e016913a024bb7521d prov:wasDerivedFrom niiri:022596b73b46d7ef5ae45ede7165a0d5 .
 
-niiri:1b1bebb4104b731a41523cf8e81637a1
+niiri:0e412c92bdfddc09e4e0ed8e0ee261e0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0007" ;
-    prov:atLocation niiri:0836ff4c53dea0b7f98729d30139aa83 ;
+    prov:atLocation niiri:478f26081ca14d44a5b80d0fa6aae340 ;
     prov:value "4.79167556762695"^^xsd:float ;
     nidm_equivalentZStatistic: "4.53048064119001"^^xsd:float ;
     nidm_pValueUncorrected: "2.94248236787364e-06"^^xsd:float ;
     nidm_pValueFWER: "0.278401885707736"^^xsd:float ;
     nidm_qValueFDR: "0.109724234977733"^^xsd:float .
 
-niiri:0836ff4c53dea0b7f98729d30139aa83
+niiri:478f26081ca14d44a5b80d0fa6aae340
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0007" ;
     nidm_coordinateVector: "[10,32,38]"^^xsd:string .
 
-niiri:1b1bebb4104b731a41523cf8e81637a1 prov:wasDerivedFrom niiri:f751ad7b48ea46de21e54d7b384c89f1 .
+niiri:0e412c92bdfddc09e4e0ed8e0ee261e0 prov:wasDerivedFrom niiri:022596b73b46d7ef5ae45ede7165a0d5 .
 
-niiri:08598bd3c2dada2c26e6239d4bcb86ec
+niiri:e401e0680e4b9f39743fb11b553b1c5c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0008" ;
-    prov:atLocation niiri:48d8c5600eccb31ef88f0bd3b6b980e0 ;
+    prov:atLocation niiri:5414198bcf0cadaac95e83d11c1e4986 ;
     prov:value "5.13094520568848"^^xsd:float ;
     nidm_equivalentZStatistic: "4.81687144616269"^^xsd:float ;
     nidm_pValueUncorrected: "7.2913285620313e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0939877807357308"^^xsd:float ;
     nidm_qValueFDR: "0.057973541602361"^^xsd:float .
 
-niiri:48d8c5600eccb31ef88f0bd3b6b980e0
+niiri:5414198bcf0cadaac95e83d11c1e4986
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0008" ;
     nidm_coordinateVector: "[38,-62,52]"^^xsd:string .
 
-niiri:08598bd3c2dada2c26e6239d4bcb86ec prov:wasDerivedFrom niiri:c1dc7ef33bd86562827618d9eb1512eb .
+niiri:e401e0680e4b9f39743fb11b553b1c5c prov:wasDerivedFrom niiri:9170484cbff3981334345a4c47f65aa7 .
 
-niiri:9d74c6df10db1fd75a238fb34d159085
+niiri:9ec7ebe2b378f433f22f85f05b5fdb45
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0009" ;
-    prov:atLocation niiri:7d3567ed1357123b1fbed6e63a26514c ;
+    prov:atLocation niiri:29c1e188537e77306058fe2541600682 ;
     prov:value "3.53375339508057"^^xsd:float ;
     nidm_equivalentZStatistic: "3.41974003817318"^^xsd:float ;
     nidm_pValueUncorrected: "0.00031340502338606"^^xsd:float ;
     nidm_pValueFWER: "0.999999410859557"^^xsd:float ;
     nidm_qValueFDR: "0.627190791526275"^^xsd:float .
 
-niiri:7d3567ed1357123b1fbed6e63a26514c
+niiri:29c1e188537e77306058fe2541600682
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0009" ;
     nidm_coordinateVector: "[48,-66,48]"^^xsd:string .
 
-niiri:9d74c6df10db1fd75a238fb34d159085 prov:wasDerivedFrom niiri:c1dc7ef33bd86562827618d9eb1512eb .
+niiri:9ec7ebe2b378f433f22f85f05b5fdb45 prov:wasDerivedFrom niiri:9170484cbff3981334345a4c47f65aa7 .
 
-niiri:1b16f4aeac9ce732d9d980d409ab21db
+niiri:b7750f5b5fe02543fb3c7405c319cb88
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0010" ;
-    prov:atLocation niiri:f3c06bcdeb3cb920750e0ac94d173a81 ;
+    prov:atLocation niiri:90f2fc0acf05dba443a4b7ef95f762af ;
     prov:value "5.12427711486816"^^xsd:float ;
     nidm_equivalentZStatistic: "4.81129886370751"^^xsd:float ;
     nidm_pValueUncorrected: "7.49762960050582e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0961670813603079"^^xsd:float ;
     nidm_qValueFDR: "0.057973541602361"^^xsd:float .
 
-niiri:f3c06bcdeb3cb920750e0ac94d173a81
+niiri:90f2fc0acf05dba443a4b7ef95f762af
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0010" ;
     nidm_coordinateVector: "[34,-86,12]"^^xsd:string .
 
-niiri:1b16f4aeac9ce732d9d980d409ab21db prov:wasDerivedFrom niiri:67d786a9d604bea82ccb2ac559f82d13 .
+niiri:b7750f5b5fe02543fb3c7405c319cb88 prov:wasDerivedFrom niiri:25e87116b614d88934e1e8c93fcc0b63 .
 
-niiri:9e4d852d5337f7d6a12ba588732286ad
+niiri:b974c5e811e7058e7382d5aa3c8a3528
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0011" ;
-    prov:atLocation niiri:ad393b74b66534d96814d5dbab5d1e70 ;
+    prov:atLocation niiri:a8f982b50bdecc91ff4188b93fb739c1 ;
     prov:value "4.81263160705566"^^xsd:float ;
     nidm_equivalentZStatistic: "4.54833854810518"^^xsd:float ;
     nidm_pValueUncorrected: "2.70355510423315e-06"^^xsd:float ;
     nidm_pValueFWER: "0.261865695583998"^^xsd:float ;
     nidm_qValueFDR: "0.109724234977733"^^xsd:float .
 
-niiri:ad393b74b66534d96814d5dbab5d1e70
+niiri:a8f982b50bdecc91ff4188b93fb739c1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0011" ;
     nidm_coordinateVector: "[38,-84,0]"^^xsd:string .
 
-niiri:9e4d852d5337f7d6a12ba588732286ad prov:wasDerivedFrom niiri:67d786a9d604bea82ccb2ac559f82d13 .
+niiri:b974c5e811e7058e7382d5aa3c8a3528 prov:wasDerivedFrom niiri:25e87116b614d88934e1e8c93fcc0b63 .
 
-niiri:d293ab4050a8e646b12be24d95ec0ccb
+niiri:931cf9fbf27bd915854b183b1741a9f1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0012" ;
-    prov:atLocation niiri:77637a210d6abb4016347edbbde3d20f ;
+    prov:atLocation niiri:f780f4f5a662be3780f45f7b4b2611bd ;
     prov:value "5.03698205947876"^^xsd:float ;
     nidm_equivalentZStatistic: "4.73813680545075"^^xsd:float ;
     nidm_pValueUncorrected: "1.07846092800568e-06"^^xsd:float ;
     nidm_pValueFWER: "0.129186074985472"^^xsd:float ;
     nidm_qValueFDR: "0.0665289558024546"^^xsd:float .
 
-niiri:77637a210d6abb4016347edbbde3d20f
+niiri:f780f4f5a662be3780f45f7b4b2611bd
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0012" ;
     nidm_coordinateVector: "[44,14,26]"^^xsd:string .
 
-niiri:d293ab4050a8e646b12be24d95ec0ccb prov:wasDerivedFrom niiri:fad9f2a76799ff174c8bd126ac6dd441 .
+niiri:931cf9fbf27bd915854b183b1741a9f1 prov:wasDerivedFrom niiri:c71e617484a5b302959dff7c4db9cc74 .
 
-niiri:4007a50d37d1624702e8e991f4f56f70
+niiri:5b72b70272b9bcb49dbf2e54d6ad8c22
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0013" ;
-    prov:atLocation niiri:605518ce43ed51ff2be014961d3f53b2 ;
+    prov:atLocation niiri:b6f10f5138c3660277aa70dd12032cc5 ;
     prov:value "3.54248213768005"^^xsd:float ;
     nidm_equivalentZStatistic: "3.42769760362149"^^xsd:float ;
     nidm_pValueUncorrected: "0.000304361554228083"^^xsd:float ;
     nidm_pValueFWER: "0.999999193580757"^^xsd:float ;
     nidm_qValueFDR: "0.621536290238473"^^xsd:float .
 
-niiri:605518ce43ed51ff2be014961d3f53b2
+niiri:b6f10f5138c3660277aa70dd12032cc5
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0013" ;
     nidm_coordinateVector: "[44,16,36]"^^xsd:string .
 
-niiri:4007a50d37d1624702e8e991f4f56f70 prov:wasDerivedFrom niiri:fad9f2a76799ff174c8bd126ac6dd441 .
+niiri:5b72b70272b9bcb49dbf2e54d6ad8c22 prov:wasDerivedFrom niiri:c71e617484a5b302959dff7c4db9cc74 .
 
-niiri:efe559fed18b01f3fa1599cabffde2eb
+niiri:7bfd939e9f8cb5231d78bd0522e37846
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0014" ;
-    prov:atLocation niiri:419c2ed4b376ef7fe75986f6bf66cf71 ;
+    prov:atLocation niiri:255fa21c87cd23012182686c06be621e ;
     prov:value "4.76414346694946"^^xsd:float ;
     nidm_equivalentZStatistic: "4.50698548813516"^^xsd:float ;
     nidm_pValueUncorrected: "3.287756441539e-06"^^xsd:float ;
     nidm_pValueFWER: "0.301278778226174"^^xsd:float ;
     nidm_qValueFDR: "0.109724234977733"^^xsd:float .
 
-niiri:419c2ed4b376ef7fe75986f6bf66cf71
+niiri:255fa21c87cd23012182686c06be621e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0014" ;
     nidm_coordinateVector: "[-46,-66,-6]"^^xsd:string .
 
-niiri:efe559fed18b01f3fa1599cabffde2eb prov:wasDerivedFrom niiri:2fac5f34a48ebec593eeef67b0204e24 .
+niiri:7bfd939e9f8cb5231d78bd0522e37846 prov:wasDerivedFrom niiri:b1e379a1ec5bd17c690d79aba04d4080 .
 
-niiri:f9b13147b6ceed90e5aedd37b05e0bfc
+niiri:364ab3732572016711f31f4e5557fd6e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0015" ;
-    prov:atLocation niiri:550fe7c29b405262a09bf0ec050e597c ;
+    prov:atLocation niiri:f7f528e3ea098738c5143d0197302233 ;
     prov:value "3.7637345790863"^^xsd:float ;
     nidm_equivalentZStatistic: "3.62829384243901"^^xsd:float ;
     nidm_pValueUncorrected: "0.000142650218672435"^^xsd:float ;
     nidm_pValueFWER: "0.999605970761399"^^xsd:float ;
     nidm_qValueFDR: "0.4902514281085"^^xsd:float .
 
-niiri:550fe7c29b405262a09bf0ec050e597c
+niiri:f7f528e3ea098738c5143d0197302233
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0015" ;
     nidm_coordinateVector: "[-54,-64,-8]"^^xsd:string .
 
-niiri:f9b13147b6ceed90e5aedd37b05e0bfc prov:wasDerivedFrom niiri:2fac5f34a48ebec593eeef67b0204e24 .
+niiri:364ab3732572016711f31f4e5557fd6e prov:wasDerivedFrom niiri:b1e379a1ec5bd17c690d79aba04d4080 .
 
-niiri:2acd24e64e69a98b2db5a9b0ade88dd4
+niiri:d2ff843ea8975b57132bb865c2b6fbf9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0016" ;
-    prov:atLocation niiri:8b4976b218c7b76f443ad25423bbdc37 ;
+    prov:atLocation niiri:2fcc314709a63be2fda7e1e532d3d4ae ;
     prov:value "4.72126770019531"^^xsd:float ;
     nidm_equivalentZStatistic: "4.4703211215873"^^xsd:float ;
     nidm_pValueUncorrected: "3.905112123892e-06"^^xsd:float ;
     nidm_pValueFWER: "0.339495974343671"^^xsd:float ;
     nidm_qValueFDR: "0.116361476817968"^^xsd:float .
 
-niiri:8b4976b218c7b76f443ad25423bbdc37
+niiri:2fcc314709a63be2fda7e1e532d3d4ae
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0016" ;
     nidm_coordinateVector: "[-32,-4,54]"^^xsd:string .
 
-niiri:2acd24e64e69a98b2db5a9b0ade88dd4 prov:wasDerivedFrom niiri:7225d84c7ed17dec15823366e7f7fc83 .
+niiri:d2ff843ea8975b57132bb865c2b6fbf9 prov:wasDerivedFrom niiri:4672418600c089d526b22d32d479dd1e .
 
-niiri:ca3e2e79c92665f7ae57b663356b0701
+niiri:7236c303cef753dc17dbf884b656c94d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0017" ;
-    prov:atLocation niiri:a2dd6e9bd30bbbf9815dcf250d953dba ;
+    prov:atLocation niiri:d131ccabcc3b8de9bb52e1695bd4aecf ;
     prov:value "4.58239698410034"^^xsd:float ;
     nidm_equivalentZStatistic: "4.35094179562381"^^xsd:float ;
     nidm_pValueUncorrected: "6.77770174506431e-06"^^xsd:float ;
     nidm_pValueFWER: "0.483096159074985"^^xsd:float ;
     nidm_qValueFDR: "0.15869051476133"^^xsd:float .
 
-niiri:a2dd6e9bd30bbbf9815dcf250d953dba
+niiri:d131ccabcc3b8de9bb52e1695bd4aecf
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0017" ;
     nidm_coordinateVector: "[-48,2,36]"^^xsd:string .
 
-niiri:ca3e2e79c92665f7ae57b663356b0701 prov:wasDerivedFrom niiri:cabc7bdcad758f1df0bc5478e9d6d8e1 .
+niiri:7236c303cef753dc17dbf884b656c94d prov:wasDerivedFrom niiri:67a283ee599be31793e69bea3826f055 .
 
-niiri:673b227a4b93dfa20f950634e984332a
+niiri:302ec60308493f063ed3e5a8f5fcf98d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0018" ;
-    prov:atLocation niiri:c15782d97f9202a2cff6fd9893b03bad ;
+    prov:atLocation niiri:ed63e69d931b5fab18feaf21450ace17 ;
     prov:value "4.53685760498047"^^xsd:float ;
     nidm_equivalentZStatistic: "4.31158680950662"^^xsd:float ;
     nidm_pValueUncorrected: "8.10435570797186e-06"^^xsd:float ;
     nidm_pValueFWER: "0.53534199025083"^^xsd:float ;
     nidm_qValueFDR: "0.164697949352297"^^xsd:float .
 
-niiri:c15782d97f9202a2cff6fd9893b03bad
+niiri:ed63e69d931b5fab18feaf21450ace17
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0018" ;
     nidm_coordinateVector: "[-36,-72,-16]"^^xsd:string .
 
-niiri:673b227a4b93dfa20f950634e984332a prov:wasDerivedFrom niiri:bc8fac8699d6afb89bc9b1fb0219744d .
+niiri:302ec60308493f063ed3e5a8f5fcf98d prov:wasDerivedFrom niiri:7640c37d58f807f183dbb16f5cce885a .
 
-niiri:8eaa8790262d3687810f66237e3c09b4
+niiri:6e25f8d53bb9ef507aba83f813f590dd
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0019" ;
-    prov:atLocation niiri:57a5dc44a7ec4d28e3b18054ecc32613 ;
+    prov:atLocation niiri:6d460284a127a017683c0927fae00495 ;
     prov:value "3.30497598648071"^^xsd:float ;
     nidm_equivalentZStatistic: "3.21002839344466"^^xsd:float ;
     nidm_pValueUncorrected: "0.000663609307096413"^^xsd:float ;
     nidm_pValueFWER: "0.999999999986374"^^xsd:float ;
     nidm_qValueFDR: "0.833892248434202"^^xsd:float .
 
-niiri:57a5dc44a7ec4d28e3b18054ecc32613
+niiri:6d460284a127a017683c0927fae00495
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0019" ;
     nidm_coordinateVector: "[-32,-62,-18]"^^xsd:string .
 
-niiri:8eaa8790262d3687810f66237e3c09b4 prov:wasDerivedFrom niiri:bc8fac8699d6afb89bc9b1fb0219744d .
+niiri:6e25f8d53bb9ef507aba83f813f590dd prov:wasDerivedFrom niiri:7640c37d58f807f183dbb16f5cce885a .
 
-niiri:24ac44587f8116756ad71ba897589aea
+niiri:3cc83dbc8a713c095b81fe8356546c6a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0020" ;
-    prov:atLocation niiri:7be1f87a0f0f5f51ba8c4612a2a76300 ;
+    prov:atLocation niiri:acbec3a585d1f4c829873ee4c5c80c86 ;
     prov:value "4.45032644271851"^^xsd:float ;
     nidm_equivalentZStatistic: "4.23652675669064"^^xsd:float ;
     nidm_pValueUncorrected: "1.13501940500749e-05"^^xsd:float ;
     nidm_pValueFWER: "0.637567785314432"^^xsd:float ;
     nidm_qValueFDR: "0.172553238762874"^^xsd:float .
 
-niiri:7be1f87a0f0f5f51ba8c4612a2a76300
+niiri:acbec3a585d1f4c829873ee4c5c80c86
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0020" ;
     nidm_coordinateVector: "[-40,44,26]"^^xsd:string .
 
-niiri:24ac44587f8116756ad71ba897589aea prov:wasDerivedFrom niiri:7f473f5d8bf7cb4917efbb176cc4e7db .
+niiri:3cc83dbc8a713c095b81fe8356546c6a prov:wasDerivedFrom niiri:8cfc21f5bbcf34401f68b224da91bb62 .
 
-niiri:3472a26e35b8f09fe372cc154aa3c869
+niiri:385e0f68aa6fd5fcce479853df6deb5b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0021" ;
-    prov:atLocation niiri:2392ddd22caac962d69c8f288cb2ce58 ;
+    prov:atLocation niiri:5c9d7269e40a2cbf90ddd137da5e18f1 ;
     prov:value "3.93534564971924"^^xsd:float ;
     nidm_equivalentZStatistic: "3.78237892531387"^^xsd:float ;
     nidm_pValueUncorrected: "7.76683274343881e-05"^^xsd:float ;
     nidm_pValueFWER: "0.992232302079702"^^xsd:float ;
     nidm_qValueFDR: "0.355534752244723"^^xsd:float .
 
-niiri:2392ddd22caac962d69c8f288cb2ce58
+niiri:5c9d7269e40a2cbf90ddd137da5e18f1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0021" ;
     nidm_coordinateVector: "[-46,36,24]"^^xsd:string .
 
-niiri:3472a26e35b8f09fe372cc154aa3c869 prov:wasDerivedFrom niiri:7f473f5d8bf7cb4917efbb176cc4e7db .
+niiri:385e0f68aa6fd5fcce479853df6deb5b prov:wasDerivedFrom niiri:8cfc21f5bbcf34401f68b224da91bb62 .
 
-niiri:8b4f5e7a7fbe5044a20b7847aaea88d4
+niiri:c531c20f5ce207dd2233835ea3d9bc79
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0022" ;
-    prov:atLocation niiri:08216f6fd8f18cdbec31e7db88b5bf26 ;
+    prov:atLocation niiri:c9a7f1ed53f731f0361cedcef35b33ed ;
     prov:value "4.31582498550415"^^xsd:float ;
     nidm_equivalentZStatistic: "4.11913273798974"^^xsd:float ;
     nidm_pValueUncorrected: "1.90150518718513e-05"^^xsd:float ;
     nidm_pValueFWER: "0.788829013385429"^^xsd:float ;
     nidm_qValueFDR: "0.227629636206583"^^xsd:float .
 
-niiri:08216f6fd8f18cdbec31e7db88b5bf26
+niiri:c9a7f1ed53f731f0361cedcef35b33ed
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0022" ;
     nidm_coordinateVector: "[36,54,6]"^^xsd:string .
 
-niiri:8b4f5e7a7fbe5044a20b7847aaea88d4 prov:wasDerivedFrom niiri:cb86cbce3b49744dcf6fb45ea4518fb9 .
+niiri:c531c20f5ce207dd2233835ea3d9bc79 prov:wasDerivedFrom niiri:dfe1db9cfb99ba668d8eeb1e01c32a4f .
 
-niiri:335233ae8819d54a72638416435e5e8f
+niiri:b49b4c68f2b3604962747d8df42ab67d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0023" ;
-    prov:atLocation niiri:d09c7592851129dac7eed5d1363df35a ;
+    prov:atLocation niiri:81f55f41dd8fe791358e61cb82016772 ;
     prov:value "4.20391035079956"^^xsd:float ;
     nidm_equivalentZStatistic: "4.02078923241408"^^xsd:float ;
     nidm_pValueUncorrected: "2.900174224163e-05"^^xsd:float ;
     nidm_pValueFWER: "0.888907080881232"^^xsd:float ;
     nidm_qValueFDR: "0.284534794626109"^^xsd:float .
 
-niiri:d09c7592851129dac7eed5d1363df35a
+niiri:81f55f41dd8fe791358e61cb82016772
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0023" ;
     nidm_coordinateVector: "[34,-54,-16]"^^xsd:string .
 
-niiri:335233ae8819d54a72638416435e5e8f prov:wasDerivedFrom niiri:150da014ff9cc30caf37962658fd7687 .
+niiri:b49b4c68f2b3604962747d8df42ab67d prov:wasDerivedFrom niiri:8b21d35a1fc7a9cfb360ad2121638da7 .
 
-niiri:ba77f5f7dc5aaa52067c090bbb093f6a
+niiri:fee61dad4332e6b4e8d9275805803cb3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0024" ;
-    prov:atLocation niiri:7089e492dc910e5947896681b5e315fe ;
+    prov:atLocation niiri:e27f88e4f03cabb2cf71df1eab3c7241 ;
     prov:value "4.13025856018066"^^xsd:float ;
     nidm_equivalentZStatistic: "3.95574355061526"^^xsd:float ;
     nidm_pValueUncorrected: "3.81484867243431e-05"^^xsd:float ;
     nidm_pValueFWER: "0.935795859458942"^^xsd:float ;
     nidm_qValueFDR: "0.317914169802101"^^xsd:float .
 
-niiri:7089e492dc910e5947896681b5e315fe
+niiri:e27f88e4f03cabb2cf71df1eab3c7241
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0024" ;
     nidm_coordinateVector: "[50,-30,42]"^^xsd:string .
 
-niiri:ba77f5f7dc5aaa52067c090bbb093f6a prov:wasDerivedFrom niiri:653461d881414853588331372590bd6b .
+niiri:fee61dad4332e6b4e8d9275805803cb3 prov:wasDerivedFrom niiri:988a6212fa64a63474847b473adbd268 .
 
-niiri:9e2e756eb3ea30f583d0bfe7b5fb5f90
+niiri:fcc08bf56890d61c3eef4f4626ab1951
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0025" ;
-    prov:atLocation niiri:a8b02ac54ab3d1b722b6b5c0044e901c ;
+    prov:atLocation niiri:baf7846dc4e479f4fde108d36bbedb45 ;
     prov:value "4.12145137786865"^^xsd:float ;
     nidm_equivalentZStatistic: "3.94794832362008"^^xsd:float ;
     nidm_pValueUncorrected: "3.94119065879606e-05"^^xsd:float ;
     nidm_pValueFWER: "0.940339218142555"^^xsd:float ;
     nidm_qValueFDR: "0.317914169802101"^^xsd:float .
 
-niiri:a8b02ac54ab3d1b722b6b5c0044e901c
+niiri:baf7846dc4e479f4fde108d36bbedb45
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0025" ;
     nidm_coordinateVector: "[-48,-72,2]"^^xsd:string .
 
-niiri:9e2e756eb3ea30f583d0bfe7b5fb5f90 prov:wasDerivedFrom niiri:98ca641a6df5b460bf760c850b8528af .
+niiri:fcc08bf56890d61c3eef4f4626ab1951 prov:wasDerivedFrom niiri:0d10036870ecd78a22c4b7434f3e940f .
 
-niiri:fb1ccce2fbacf835dc1f2eb39dfc01e5
+niiri:8559173f67223249cf03dfbc607e0225
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0026" ;
-    prov:atLocation niiri:0a6d00e01c4d57159cbb971a7844e803 ;
+    prov:atLocation niiri:4718bcf6fa2624049f2a5bb3607e1e3f ;
     prov:value "4.07142877578735"^^xsd:float ;
     nidm_equivalentZStatistic: "3.90360423611364"^^xsd:float ;
     nidm_pValueUncorrected: "4.73853530744694e-05"^^xsd:float ;
     nidm_pValueFWER: "0.962041692585423"^^xsd:float ;
     nidm_qValueFDR: "0.337184393501089"^^xsd:float .
 
-niiri:0a6d00e01c4d57159cbb971a7844e803
+niiri:4718bcf6fa2624049f2a5bb3607e1e3f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0026" ;
     nidm_coordinateVector: "[-50,-60,54]"^^xsd:string .
 
-niiri:fb1ccce2fbacf835dc1f2eb39dfc01e5 prov:wasDerivedFrom niiri:62781649d6e4a250a6f3378b94f51367 .
+niiri:8559173f67223249cf03dfbc607e0225 prov:wasDerivedFrom niiri:7e1995dcc209b0990e86feb660922162 .
 
-niiri:60489e25fa35d48a43610e9c119f212e
+niiri:0db34b2e71f46d4c78dc1a96c79f4e62
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0027" ;
-    prov:atLocation niiri:969712b1ec925d024d4274968b79835a ;
+    prov:atLocation niiri:aab8c71ecfd9fbf45ecaebd3d1fcc59f ;
     prov:value "4.04910326004028"^^xsd:float ;
     nidm_equivalentZStatistic: "3.88377526691462"^^xsd:float ;
     nidm_pValueUncorrected: "5.14234872333041e-05"^^xsd:float ;
     nidm_pValueFWER: "0.969614423231382"^^xsd:float ;
     nidm_qValueFDR: "0.338354786543303"^^xsd:float .
 
-niiri:969712b1ec925d024d4274968b79835a
+niiri:aab8c71ecfd9fbf45ecaebd3d1fcc59f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0027" ;
     nidm_coordinateVector: "[40,26,50]"^^xsd:string .
 
-niiri:60489e25fa35d48a43610e9c119f212e prov:wasDerivedFrom niiri:2ef53dff53e03927f9f447755a2af2df .
+niiri:0db34b2e71f46d4c78dc1a96c79f4e62 prov:wasDerivedFrom niiri:b4757e6c4de815acef5afdb0476f0eb3 .
 
-niiri:105d5773abccadee3256497fda011392
+niiri:c0cc60840e7b9ee9aaa1c0601727437c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0028" ;
-    prov:atLocation niiri:4e043a1ff299c78ecd6d1d1aef0555a1 ;
+    prov:atLocation niiri:8a00d1d3e16c3c30537d2845ff872d2e ;
     prov:value "4.03750133514404"^^xsd:float ;
     nidm_equivalentZStatistic: "3.87346153970838"^^xsd:float ;
     nidm_pValueUncorrected: "5.36501732217864e-05"^^xsd:float ;
     nidm_pValueFWER: "0.97307813993255"^^xsd:float ;
     nidm_qValueFDR: "0.338354786543303"^^xsd:float .
 
-niiri:4e043a1ff299c78ecd6d1d1aef0555a1
+niiri:8a00d1d3e16c3c30537d2845ff872d2e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0028" ;
     nidm_coordinateVector: "[48,36,18]"^^xsd:string .
 
-niiri:105d5773abccadee3256497fda011392 prov:wasDerivedFrom niiri:689adaab2c0c4d3c1af8f26813a3b966 .
+niiri:c0cc60840e7b9ee9aaa1c0601727437c prov:wasDerivedFrom niiri:f8221060362a62c937dd97233413a960 .
 
-niiri:7b42a46b84ec2a9ed4b04e50bba3c796
+niiri:8c718793e9227c3c800e12ff03cc8e56
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0029" ;
-    prov:atLocation niiri:e64967821a705f480091ecb2c54f0bf4 ;
+    prov:atLocation niiri:09df4ed9154ca248bde0d014c6a82203 ;
     prov:value "3.98517394065857"^^xsd:float ;
     nidm_equivalentZStatistic: "3.82686644248313"^^xsd:float ;
     nidm_pValueUncorrected: "6.48924431299047e-05"^^xsd:float ;
     nidm_pValueFWER: "0.985149749711103"^^xsd:float ;
     nidm_qValueFDR: "0.343725851088226"^^xsd:float .
 
-niiri:e64967821a705f480091ecb2c54f0bf4
+niiri:09df4ed9154ca248bde0d014c6a82203
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0029" ;
     nidm_coordinateVector: "[-6,12,52]"^^xsd:string .
 
-niiri:7b42a46b84ec2a9ed4b04e50bba3c796 prov:wasDerivedFrom niiri:6d7f9eadd2ea16abe1d24c92b4094bf6 .
+niiri:8c718793e9227c3c800e12ff03cc8e56 prov:wasDerivedFrom niiri:af4c8a0d8ff5cfb976a7e9746756d8e3 .
 
-niiri:a9e209a5c7f9c27a8803fe99160ec586
+niiri:0b9be6e11e869c7379662eed0530982e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0030" ;
-    prov:atLocation niiri:0d4991be2c25401146c61d12014e4ed4 ;
+    prov:atLocation niiri:24acc291a9fc11b56b7b2f0aab86fed7 ;
     prov:value "3.42912888526917"^^xsd:float ;
     nidm_equivalentZStatistic: "3.32410637949606"^^xsd:float ;
     nidm_pValueUncorrected: "0.000443511765463311"^^xsd:float ;
     nidm_pValueFWER: "0.999999991693936"^^xsd:float ;
     nidm_qValueFDR: "0.67356346521577"^^xsd:float .
 
-niiri:0d4991be2c25401146c61d12014e4ed4
+niiri:24acc291a9fc11b56b7b2f0aab86fed7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0030" ;
     nidm_coordinateVector: "[-4,8,62]"^^xsd:string .
 
-niiri:a9e209a5c7f9c27a8803fe99160ec586 prov:wasDerivedFrom niiri:6d7f9eadd2ea16abe1d24c92b4094bf6 .
+niiri:0b9be6e11e869c7379662eed0530982e prov:wasDerivedFrom niiri:af4c8a0d8ff5cfb976a7e9746756d8e3 .
 
-niiri:f55fb920f57f1a7b39f883124a323a61
+niiri:eac0fa3f981d5ddf5d2705c3ec096b14
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0031" ;
-    prov:atLocation niiri:8423dbb17e4a383c9e53fc854ebee7bb ;
+    prov:atLocation niiri:c553e1d0b71b1a1f3fc893271d1a5cad ;
     prov:value "3.97802686691284"^^xsd:float ;
     nidm_equivalentZStatistic: "3.82049245556254"^^xsd:float ;
     nidm_pValueUncorrected: "6.65927397228705e-05"^^xsd:float ;
     nidm_pValueFWER: "0.986398575034921"^^xsd:float ;
     nidm_qValueFDR: "0.343725851088226"^^xsd:float .
 
-niiri:8423dbb17e4a383c9e53fc854ebee7bb
+niiri:c553e1d0b71b1a1f3fc893271d1a5cad
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0031" ;
     nidm_coordinateVector: "[30,40,4]"^^xsd:string .
 
-niiri:f55fb920f57f1a7b39f883124a323a61 prov:wasDerivedFrom niiri:684ce311bfd3bc478751bb8ba1bdc608 .
+niiri:eac0fa3f981d5ddf5d2705c3ec096b14 prov:wasDerivedFrom niiri:866201193f458cd1f0d7d30bfc40b674 .
 
-niiri:807a46d10cf2231bdf094ce58bf85eb3
+niiri:a6467d64303a3d5d1f6d341287e2e1f3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0032" ;
-    prov:atLocation niiri:4ff5221807e724c52ffe432f225308d3 ;
+    prov:atLocation niiri:61d83d511d362b1ba93093b9044119c8 ;
     prov:value "3.68345475196838"^^xsd:float ;
     nidm_equivalentZStatistic: "3.55575789019142"^^xsd:float ;
     nidm_pValueUncorrected: "0.000188445519391012"^^xsd:float ;
     nidm_pValueFWER: "0.999940398431664"^^xsd:float ;
     nidm_qValueFDR: "0.55517289861095"^^xsd:float .
 
-niiri:4ff5221807e724c52ffe432f225308d3
+niiri:61d83d511d362b1ba93093b9044119c8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0032" ;
     nidm_coordinateVector: "[36,34,18]"^^xsd:string .
 
-niiri:807a46d10cf2231bdf094ce58bf85eb3 prov:wasDerivedFrom niiri:684ce311bfd3bc478751bb8ba1bdc608 .
+niiri:a6467d64303a3d5d1f6d341287e2e1f3 prov:wasDerivedFrom niiri:866201193f458cd1f0d7d30bfc40b674 .
 
-niiri:281558c1b27efd8fdee850fc09cebdd5
+niiri:9e53b4f1a52c9fad25b6fb328ec41bba
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0033" ;
-    prov:atLocation niiri:0ca772203b57f69513dd47fafc3c8b25 ;
+    prov:atLocation niiri:5dc74fe36ab63489094008050b9e1049 ;
     prov:value "3.50704765319824"^^xsd:float ;
     nidm_equivalentZStatistic: "3.39537345393762"^^xsd:float ;
     nidm_pValueUncorrected: "0.000342675238331092"^^xsd:float ;
     nidm_pValueFWER: "0.999999782961075"^^xsd:float ;
     nidm_qValueFDR: "0.627251282283029"^^xsd:float .
 
-niiri:0ca772203b57f69513dd47fafc3c8b25
+niiri:5dc74fe36ab63489094008050b9e1049
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0033" ;
     nidm_coordinateVector: "[36,38,10]"^^xsd:string .
 
-niiri:281558c1b27efd8fdee850fc09cebdd5 prov:wasDerivedFrom niiri:684ce311bfd3bc478751bb8ba1bdc608 .
+niiri:9e53b4f1a52c9fad25b6fb328ec41bba prov:wasDerivedFrom niiri:866201193f458cd1f0d7d30bfc40b674 .
 
-niiri:87be41f247c0cbaec1372952113617e4
+niiri:af9e7acf6186b5253266546bc901424c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0034" ;
-    prov:atLocation niiri:e922f4bcb855debf097b8fa30d6c712a ;
+    prov:atLocation niiri:544893eef3272ef091d0f6aacd62ac4b ;
     prov:value "3.962651014328"^^xsd:float ;
     nidm_equivalentZStatistic: "3.80677178289556"^^xsd:float ;
     nidm_pValueUncorrected: "7.03962776207323e-05"^^xsd:float ;
     nidm_pValueFWER: "0.988804462680345"^^xsd:float ;
     nidm_qValueFDR: "0.343725851088226"^^xsd:float .
 
-niiri:e922f4bcb855debf097b8fa30d6c712a
+niiri:544893eef3272ef091d0f6aacd62ac4b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0034" ;
     nidm_coordinateVector: "[-54,-44,58]"^^xsd:string .
 
-niiri:87be41f247c0cbaec1372952113617e4 prov:wasDerivedFrom niiri:dff5ab56a4787869bfe6b9e37cb9aac1 .
+niiri:af9e7acf6186b5253266546bc901424c prov:wasDerivedFrom niiri:2627b433d92d75102b82469256c03339 .
 
-niiri:9a5cc57a6b9039a2dcf0b19c1ba6530c
+niiri:fa647f9168d7f0bcd21af3ab9071c1a0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0035" ;
-    prov:atLocation niiri:bdf40d9de92345165117f5c8e8e923b9 ;
+    prov:atLocation niiri:3ce0819bdee0231da70f1b9c83939335 ;
     prov:value "3.90285301208496"^^xsd:float ;
     nidm_equivalentZStatistic: "3.75330746420074"^^xsd:float ;
     nidm_pValueUncorrected: "8.72582920719012e-05"^^xsd:float ;
     nidm_pValueFWER: "0.99514521861122"^^xsd:float ;
     nidm_qValueFDR: "0.374097575292501"^^xsd:float .
 
-niiri:bdf40d9de92345165117f5c8e8e923b9
+niiri:3ce0819bdee0231da70f1b9c83939335
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0035" ;
     nidm_coordinateVector: "[-36,-46,-18]"^^xsd:string .
 
-niiri:9a5cc57a6b9039a2dcf0b19c1ba6530c prov:wasDerivedFrom niiri:2f77c6e25e1162cf6ea3521c6e32fc2e .
+niiri:fa647f9168d7f0bcd21af3ab9071c1a0 prov:wasDerivedFrom niiri:601904871dc4878169c4db748733771d .
 
-niiri:2c6d99b33beb8a53b311cfeaa273be66
+niiri:a16aa33cdcd4f944c2d19a1e783620b9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0036" ;
-    prov:atLocation niiri:6bae8376f7e0cd8d2226434d1e24f4f3 ;
+    prov:atLocation niiri:a0774df5866b6378b3d45d566ac6456a ;
     prov:value "3.79155707359314"^^xsd:float ;
     nidm_equivalentZStatistic: "3.65336542387463"^^xsd:float ;
     nidm_pValueUncorrected: "0.000129412734908629"^^xsd:float ;
     nidm_pValueFWER: "0.999300576231024"^^xsd:float ;
     nidm_qValueFDR: "0.470380557191782"^^xsd:float .
 
-niiri:6bae8376f7e0cd8d2226434d1e24f4f3
+niiri:a0774df5866b6378b3d45d566ac6456a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0036" ;
     nidm_coordinateVector: "[-56,-48,-16]"^^xsd:string .
 
-niiri:2c6d99b33beb8a53b311cfeaa273be66 prov:wasDerivedFrom niiri:19b8938a50757611f958db8a897d6420 .
+niiri:a16aa33cdcd4f944c2d19a1e783620b9 prov:wasDerivedFrom niiri:0a7cd6ed9222066e8fdf471bab1ee6e7 .
 
-niiri:be73232bf692752dacdb68448b0af75c
+niiri:8926147dc76517b8aeee5d7add626d9b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0037" ;
-    prov:atLocation niiri:5e45a9aa2470c8405a0e8fac3acfae3c ;
+    prov:atLocation niiri:61a16a71cf85ed46deb21d71fc09758b ;
     prov:value "3.71668887138367"^^xsd:float ;
     nidm_equivalentZStatistic: "3.58582096111834"^^xsd:float ;
     nidm_pValueUncorrected: "0.000168009721460582"^^xsd:float ;
     nidm_pValueFWER: "0.999863860763777"^^xsd:float ;
     nidm_qValueFDR: "0.535171903511449"^^xsd:float .
 
-niiri:5e45a9aa2470c8405a0e8fac3acfae3c
+niiri:61a16a71cf85ed46deb21d71fc09758b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0037" ;
     nidm_coordinateVector: "[10,20,22]"^^xsd:string .
 
-niiri:be73232bf692752dacdb68448b0af75c prov:wasDerivedFrom niiri:88c4835173f01a2e57f1b274727c2e78 .
+niiri:8926147dc76517b8aeee5d7add626d9b prov:wasDerivedFrom niiri:d2a33a86263a0cb45dbf1c9cce5a8dd4 .
 
-niiri:9665714b17a830ae5104881f33ddfda5
+niiri:f96f0aeec7dae1fca89614ddec6cd281
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0038" ;
-    prov:atLocation niiri:b6c70b10da482483af149f76ccaa6858 ;
+    prov:atLocation niiri:e8b4f7ea40c55262e503545ee31b525a ;
     prov:value "3.67520260810852"^^xsd:float ;
     nidm_equivalentZStatistic: "3.54828555853432"^^xsd:float ;
     nidm_pValueUncorrected: "0.000193873795962807"^^xsd:float ;
     nidm_pValueFWER: "0.999951944421598"^^xsd:float ;
     nidm_qValueFDR: "0.556255483974051"^^xsd:float .
 
-niiri:b6c70b10da482483af149f76ccaa6858
+niiri:e8b4f7ea40c55262e503545ee31b525a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0038" ;
     nidm_coordinateVector: "[32,2,42]"^^xsd:string .
 
-niiri:9665714b17a830ae5104881f33ddfda5 prov:wasDerivedFrom niiri:ef62449f6b6d1aca9419dce43c45ebb1 .
+niiri:f96f0aeec7dae1fca89614ddec6cd281 prov:wasDerivedFrom niiri:ab0144b9188c24f978e07874f53ac025 .
 
-niiri:2a0e392009dd1cdef95ff2bd25954e6a
+niiri:f569330c5f409cea60dea5a04dbe8b60
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0039" ;
-    prov:atLocation niiri:5caa927b8ee685ab82a6d32e2d362112 ;
+    prov:atLocation niiri:a376eeaa2e1ae5b029e6717533b0a943 ;
     prov:value "3.40211200714111"^^xsd:float ;
     nidm_equivalentZStatistic: "3.29933621019179"^^xsd:float ;
     nidm_pValueUncorrected: "0.000484568819258735"^^xsd:float ;
     nidm_pValueFWER: "0.999999997648251"^^xsd:float ;
     nidm_qValueFDR: "0.711591163402231"^^xsd:float .
 
-niiri:5caa927b8ee685ab82a6d32e2d362112
+niiri:a376eeaa2e1ae5b029e6717533b0a943
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0039" ;
     nidm_coordinateVector: "[32,6,50]"^^xsd:string .
 
-niiri:2a0e392009dd1cdef95ff2bd25954e6a prov:wasDerivedFrom niiri:ef62449f6b6d1aca9419dce43c45ebb1 .
+niiri:f569330c5f409cea60dea5a04dbe8b60 prov:wasDerivedFrom niiri:ab0144b9188c24f978e07874f53ac025 .
 
-niiri:6a22b7f47f5aa641524c552f00d1de23
+niiri:2f233b855c18571a400fd833d555d620
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0040" ;
-    prov:atLocation niiri:ac0f85461b3b289a94dbc94bf2aab8c3 ;
+    prov:atLocation niiri:3c707ee8e2672da639e6bcaeddf9c3a8 ;
     prov:value "3.65790581703186"^^xsd:float ;
     nidm_equivalentZStatistic: "3.53261354467296"^^xsd:float ;
     nidm_pValueUncorrected: "0.000205736742878826"^^xsd:float ;
     nidm_pValueFWER: "0.999969815552823"^^xsd:float ;
     nidm_qValueFDR: "0.556255483974051"^^xsd:float .
 
-niiri:ac0f85461b3b289a94dbc94bf2aab8c3
+niiri:3c707ee8e2672da639e6bcaeddf9c3a8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0040" ;
     nidm_coordinateVector: "[52,-46,-12]"^^xsd:string .
 
-niiri:6a22b7f47f5aa641524c552f00d1de23 prov:wasDerivedFrom niiri:1888964486bb06df70ff6f51a4b99b30 .
+niiri:2f233b855c18571a400fd833d555d620 prov:wasDerivedFrom niiri:c584015fa24c7c926f0b58301e5d61f2 .
 
-niiri:37bccfce2385cb87712fd64f6a997959
+niiri:fdd6fde4db88f2a34579b6e074832d04
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0041" ;
-    prov:atLocation niiri:de2ecd4cc9826b5e4c978cd2c29029ed ;
+    prov:atLocation niiri:67fc1b6648133c4aeaa468978eb43c62 ;
     prov:value "3.65189146995544"^^xsd:float ;
     nidm_equivalentZStatistic: "3.5271610730247"^^xsd:float ;
     nidm_pValueUncorrected: "0.000210020574100245"^^xsd:float ;
     nidm_pValueFWER: "0.999974435806052"^^xsd:float ;
     nidm_qValueFDR: "0.556255483974051"^^xsd:float .
 
-niiri:de2ecd4cc9826b5e4c978cd2c29029ed
+niiri:67fc1b6648133c4aeaa468978eb43c62
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0041" ;
     nidm_coordinateVector: "[-58,-32,-18]"^^xsd:string .
 
-niiri:37bccfce2385cb87712fd64f6a997959 prov:wasDerivedFrom niiri:036f0f4fe63d2badbd206185e824027a .
+niiri:fdd6fde4db88f2a34579b6e074832d04 prov:wasDerivedFrom niiri:b575189f3bd68971936993d3aa187cb2 .
 
-niiri:cef97b28ea0e8422efda771850621079
+niiri:d19e5a67d45d5321017795f6126c01ba
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0042" ;
-    prov:atLocation niiri:60a897e2e881e185f75e876eeca12da9 ;
+    prov:atLocation niiri:c91b5206da9ad3a664a273dd090ed4b6 ;
     prov:value "3.64102125167847"^^xsd:float ;
     nidm_equivalentZStatistic: "3.51730234983075"^^xsd:float ;
     nidm_pValueUncorrected: "0.000217978445002265"^^xsd:float ;
     nidm_pValueFWER: "0.999981178646875"^^xsd:float ;
     nidm_qValueFDR: "0.563557397391532"^^xsd:float .
 
-niiri:60a897e2e881e185f75e876eeca12da9
+niiri:c91b5206da9ad3a664a273dd090ed4b6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0042" ;
     nidm_coordinateVector: "[-18,-62,48]"^^xsd:string .
 
-niiri:cef97b28ea0e8422efda771850621079 prov:wasDerivedFrom niiri:d15bd2a66669fcb82747bebed9441dfd .
+niiri:d19e5a67d45d5321017795f6126c01ba prov:wasDerivedFrom niiri:e8cd31e50a3c32fbe2bbcc0095269056 .
 
-niiri:eeff6667ecce9c7065c25fc1b5de9109
+niiri:7245866a3fef562524fce007658a5b36
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0043" ;
-    prov:atLocation niiri:4704fc55fed5882b1a6f573a728d75ca ;
+    prov:atLocation niiri:6b5778113070472a0309ccefc99af0fe ;
     prov:value "3.59891152381897"^^xsd:float ;
     nidm_equivalentZStatistic: "3.47906223189298"^^xsd:float ;
     nidm_pValueUncorrected: "0.000251585861886783"^^xsd:float ;
     nidm_pValueFWER: "0.999994666564726"^^xsd:float ;
     nidm_qValueFDR: "0.608753808165271"^^xsd:float .
 
-niiri:4704fc55fed5882b1a6f573a728d75ca
+niiri:6b5778113070472a0309ccefc99af0fe
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0043" ;
     nidm_coordinateVector: "[-60,-16,28]"^^xsd:string .
 
-niiri:eeff6667ecce9c7065c25fc1b5de9109 prov:wasDerivedFrom niiri:0da1df9eac44070257be237353ddcd3a .
+niiri:7245866a3fef562524fce007658a5b36 prov:wasDerivedFrom niiri:e97474fed9ca8bf394b41d386552ec23 .
 
-niiri:57e8a6f90794dfc7d8dfea24b45f5a3e
+niiri:77917bfc1da98a7e7fe2dc75f6551b37
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0044" ;
-    prov:atLocation niiri:a9b16178d82b281ede4962bc80c09ada ;
+    prov:atLocation niiri:1cbd357b2c0b627b8be0812023192e3f ;
     prov:value "3.59028053283691"^^xsd:float ;
     nidm_equivalentZStatistic: "3.47121483404478"^^xsd:float ;
     nidm_pValueUncorrected: "0.00025905465370224"^^xsd:float ;
     nidm_pValueFWER: "0.999995943640527"^^xsd:float ;
     nidm_qValueFDR: "0.608753808165271"^^xsd:float .
 
-niiri:a9b16178d82b281ede4962bc80c09ada
+niiri:1cbd357b2c0b627b8be0812023192e3f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0044" ;
     nidm_coordinateVector: "[62,-44,32]"^^xsd:string .
 
-niiri:57e8a6f90794dfc7d8dfea24b45f5a3e prov:wasDerivedFrom niiri:4b0e06aef793ba5702452d1f3e252868 .
+niiri:77917bfc1da98a7e7fe2dc75f6551b37 prov:wasDerivedFrom niiri:abd9e58304894c9547b23ee1045ac1da .
 
-niiri:1243593fc55bfafbe5ff936ec4564509
+niiri:35fb5dd9515d518d6fbdee4b3aad7697
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0045" ;
-    prov:atLocation niiri:cc4e2103febe06ec027f303ee2643c3f ;
+    prov:atLocation niiri:ee73ad3b5f7d69b81f88d9b833912dd0 ;
     prov:value "3.58877372741699"^^xsd:float ;
     nidm_equivalentZStatistic: "3.46984449735368"^^xsd:float ;
     nidm_pValueUncorrected: "0.000260379883662454"^^xsd:float ;
     nidm_pValueFWER: "0.999996135035316"^^xsd:float ;
     nidm_qValueFDR: "0.608753808165271"^^xsd:float .
 
-niiri:cc4e2103febe06ec027f303ee2643c3f
+niiri:ee73ad3b5f7d69b81f88d9b833912dd0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0045" ;
     nidm_coordinateVector: "[-50,40,20]"^^xsd:string .
 
-niiri:1243593fc55bfafbe5ff936ec4564509 prov:wasDerivedFrom niiri:85bdb7fb602f14f0f33185e4228dd31d .
+niiri:35fb5dd9515d518d6fbdee4b3aad7697 prov:wasDerivedFrom niiri:f35fdf14b958462f212cb7e02a3f5b6a .
 
-niiri:edd8d801e1e4f1d666bedbb6b272dbec
+niiri:c457ecf797faf07f550dddfa0aace5e2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0046" ;
-    prov:atLocation niiri:689cc09f0d3694c392c7d9aa6323db13 ;
+    prov:atLocation niiri:3af2d58dffdb8013ed1ab23429910b14 ;
     prov:value "3.58837461471558"^^xsd:float ;
     nidm_equivalentZStatistic: "3.46948151508978"^^xsd:float ;
     nidm_pValueUncorrected: "0.000260731974812578"^^xsd:float ;
     nidm_pValueFWER: "0.999996184305011"^^xsd:float ;
     nidm_qValueFDR: "0.608753808165271"^^xsd:float .
 
-niiri:689cc09f0d3694c392c7d9aa6323db13
+niiri:3af2d58dffdb8013ed1ab23429910b14
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0046" ;
     nidm_coordinateVector: "[4,8,34]"^^xsd:string .
 
-niiri:edd8d801e1e4f1d666bedbb6b272dbec prov:wasDerivedFrom niiri:70204a580679814e93ec3ee19b2e747c .
+niiri:c457ecf797faf07f550dddfa0aace5e2 prov:wasDerivedFrom niiri:65aa1110e7a5b158b24b46e37675c86f .
 
-niiri:6d1e711aa9712a2455a47326be31d602
+niiri:0979a7e014454d80d5e3b40e2f809329
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0047" ;
-    prov:atLocation niiri:0ae3773014db829b9d71b9fcb5c85d66 ;
+    prov:atLocation niiri:3035aa8d3d60fd9342cf2f6fb7f6a8e2 ;
     prov:value "3.55357313156128"^^xsd:float ;
     nidm_equivalentZStatistic: "3.43780399293293"^^xsd:float ;
     nidm_pValueUncorrected: "0.000293226018116655"^^xsd:float ;
     nidm_pValueFWER: "0.999998808594853"^^xsd:float ;
     nidm_qValueFDR: "0.621536290238473"^^xsd:float .
 
-niiri:0ae3773014db829b9d71b9fcb5c85d66
+niiri:3035aa8d3d60fd9342cf2f6fb7f6a8e2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0047" ;
     nidm_coordinateVector: "[54,-26,-4]"^^xsd:string .
 
-niiri:6d1e711aa9712a2455a47326be31d602 prov:wasDerivedFrom niiri:f6f25c1b5f426f11bffb789fc0ff6d56 .
+niiri:0979a7e014454d80d5e3b40e2f809329 prov:wasDerivedFrom niiri:7d8d48b7315eff2905773178ffd49023 .
 
-niiri:28cd2697c577a50386376d46e0408e4e
+niiri:4194c281db5a3d0d67f0dc86fdc77920
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0048" ;
-    prov:atLocation niiri:23ba631fe7949fbe1109ebd4601c8399 ;
+    prov:atLocation niiri:2a753c708cb52b15a61196f673a461cc ;
     prov:value "3.51040363311768"^^xsd:float ;
     nidm_equivalentZStatistic: "3.39843715827212"^^xsd:float ;
     nidm_pValueUncorrected: "0.000338860153926701"^^xsd:float ;
     nidm_pValueFWER: "0.999999753151302"^^xsd:float ;
     nidm_qValueFDR: "0.627251282283029"^^xsd:float .
 
-niiri:23ba631fe7949fbe1109ebd4601c8399
+niiri:2a753c708cb52b15a61196f673a461cc
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0048" ;
     nidm_coordinateVector: "[-40,-38,44]"^^xsd:string .
 
-niiri:28cd2697c577a50386376d46e0408e4e prov:wasDerivedFrom niiri:1709f46929bebc2f3c937d537403c879 .
+niiri:4194c281db5a3d0d67f0dc86fdc77920 prov:wasDerivedFrom niiri:62e2c2069415d9aa3cc91424a7a036cf .
 
-niiri:f45167b574f40f7861ca7ee7d5261d0d
+niiri:3fd55577a54074d75160c0c642d5409a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0049" ;
-    prov:atLocation niiri:9a16d69dfcd8aa1a312513e1acbe776c ;
+    prov:atLocation niiri:d0c5dcc9377f764db96420f38f011a61 ;
     prov:value "3.50392317771912"^^xsd:float ;
     nidm_equivalentZStatistic: "3.39252066023161"^^xsd:float ;
     nidm_pValueUncorrected: "0.000346263546256664"^^xsd:float ;
     nidm_pValueFWER: "0.999999807631623"^^xsd:float ;
     nidm_qValueFDR: "0.627251282283029"^^xsd:float .
 
-niiri:9a16d69dfcd8aa1a312513e1acbe776c
+niiri:d0c5dcc9377f764db96420f38f011a61
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0049" ;
     nidm_coordinateVector: "[-12,-98,-2]"^^xsd:string .
 
-niiri:f45167b574f40f7861ca7ee7d5261d0d prov:wasDerivedFrom niiri:6143b9e2dc6ccc1e23b85ae05647eb05 .
+niiri:3fd55577a54074d75160c0c642d5409a prov:wasDerivedFrom niiri:2deb14df5037616ae2a96835f77312be .
 
-niiri:6b1c34a29ee144dcdc6d41131c8551af
+niiri:103473966f8ff9bcc2cc5ec2a713befb
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0050" ;
-    prov:atLocation niiri:171d360df8c6ac46f710667ffcb39eff ;
+    prov:atLocation niiri:77583c290903d4e0cb5367a1b29849f3 ;
     prov:value "3.49028921127319"^^xsd:float ;
     nidm_equivalentZStatistic: "3.38006733866351"^^xsd:float ;
     nidm_pValueUncorrected: "0.000362340362275559"^^xsd:float ;
     nidm_pValueFWER: "0.999999887466235"^^xsd:float ;
     nidm_qValueFDR: "0.63276782328386"^^xsd:float .
 
-niiri:171d360df8c6ac46f710667ffcb39eff
+niiri:77583c290903d4e0cb5367a1b29849f3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0050" ;
     nidm_coordinateVector: "[-52,-52,20]"^^xsd:string .
 
-niiri:6b1c34a29ee144dcdc6d41131c8551af prov:wasDerivedFrom niiri:90c1e5b11aa4824f7fb9ea3eac86bf0d .
+niiri:103473966f8ff9bcc2cc5ec2a713befb prov:wasDerivedFrom niiri:5b409e333f6b39e5bc61b32b5cdb5358 .
 
-niiri:33c436205406b449ab96ba67d5482647
+niiri:9abbf59e1fcfcc54cc8216a4ebac476d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0051" ;
-    prov:atLocation niiri:71a69117f987ef714917c752a162a571 ;
+    prov:atLocation niiri:a43e5ac46ddb78e8178ab1b56b3625ec ;
     prov:value "3.47890019416809"^^xsd:float ;
     nidm_equivalentZStatistic: "3.36965850607739"^^xsd:float ;
     nidm_pValueUncorrected: "0.00037630695868629"^^xsd:float ;
     nidm_pValueFWER: "0.999999928964277"^^xsd:float ;
     nidm_qValueFDR: "0.634508717964232"^^xsd:float .
 
-niiri:71a69117f987ef714917c752a162a571
+niiri:a43e5ac46ddb78e8178ab1b56b3625ec
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0051" ;
     nidm_coordinateVector: "[-30,-72,60]"^^xsd:string .
 
-niiri:33c436205406b449ab96ba67d5482647 prov:wasDerivedFrom niiri:5e09dfc93a92598eb65ced39066c6e1f .
+niiri:9abbf59e1fcfcc54cc8216a4ebac476d prov:wasDerivedFrom niiri:aa433f26589b155235af6a6df23091d5 .
 
-niiri:a6a511462d3284b70edaf2123ce8dbb7
+niiri:160afe9ba06379a115015285c8be81d6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0052" ;
-    prov:atLocation niiri:099cbb33543e124f5f3afe63e7c55825 ;
+    prov:atLocation niiri:bd58ee341d5220f443405c692b1b6ecf ;
     prov:value "3.46000862121582"^^xsd:float ;
     nidm_equivalentZStatistic: "3.35238069902703"^^xsd:float ;
     nidm_pValueUncorrected: "0.000400598817755116"^^xsd:float ;
     nidm_pValueFWER: "0.999999967703129"^^xsd:float ;
     nidm_qValueFDR: "0.651507233165067"^^xsd:float .
 
-niiri:099cbb33543e124f5f3afe63e7c55825
+niiri:bd58ee341d5220f443405c692b1b6ecf
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0052" ;
     nidm_coordinateVector: "[-32,-74,-34]"^^xsd:string .
 
-niiri:a6a511462d3284b70edaf2123ce8dbb7 prov:wasDerivedFrom niiri:7c5ba749e2c3ebf4bc0b3ad25206415a .
+niiri:160afe9ba06379a115015285c8be81d6 prov:wasDerivedFrom niiri:d220eb8d00595929d9a913e79e63f18d .
 
-niiri:3e13456b2eabc0608e35da367dd7dd89
+niiri:5fad6fb58b1dab2b17eef5948c9c92c0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0053" ;
-    prov:atLocation niiri:6eaff9482ec8380a363bdf3a48f0c1b0 ;
+    prov:atLocation niiri:26e681001041d03072cb023b45a19ae6 ;
     prov:value "3.43550229072571"^^xsd:float ;
     nidm_equivalentZStatistic: "3.32994532400952"^^xsd:float ;
     nidm_pValueUncorrected: "0.000434315195478541"^^xsd:float ;
     nidm_pValueFWER: "0.999999988927098"^^xsd:float ;
     nidm_qValueFDR: "0.670363379742284"^^xsd:float .
 
-niiri:6eaff9482ec8380a363bdf3a48f0c1b0
+niiri:26e681001041d03072cb023b45a19ae6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0053" ;
     nidm_coordinateVector: "[22,44,-16]"^^xsd:string .
 
-niiri:3e13456b2eabc0608e35da367dd7dd89 prov:wasDerivedFrom niiri:48da72af2b8db06b1f889a4b6dfc0d72 .
+niiri:5fad6fb58b1dab2b17eef5948c9c92c0 prov:wasDerivedFrom niiri:b25a22f3e4eb9bbd1275897ff1df109d .
 
-niiri:9a51efa3593c9e5ec78476331ec08023
+niiri:c29148dcd4002758ce86038f7b4ca401
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0054" ;
-    prov:atLocation niiri:5089e63d731c36a4686fed68fad4f233 ;
+    prov:atLocation niiri:6a4b4afe1e56c908285ae25761fa1e7a ;
     prov:value "3.39615654945374"^^xsd:float ;
     nidm_equivalentZStatistic: "3.29387191012244"^^xsd:float ;
     nidm_pValueUncorrected: "0.000494087591703773"^^xsd:float ;
     nidm_pValueFWER: "0.999999998236237"^^xsd:float ;
     nidm_qValueFDR: "0.714296799125479"^^xsd:float .
 
-niiri:5089e63d731c36a4686fed68fad4f233
+niiri:6a4b4afe1e56c908285ae25761fa1e7a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0054" ;
     nidm_coordinateVector: "[-50,-44,-34]"^^xsd:string .
 
-niiri:9a51efa3593c9e5ec78476331ec08023 prov:wasDerivedFrom niiri:a27fad4fe7cc82465f0e2f5bbe9d75f9 .
+niiri:c29148dcd4002758ce86038f7b4ca401 prov:wasDerivedFrom niiri:bd4658613e97b52c7228dc395dd15873 .
 
-niiri:26bbba507d377ff39b078c33451b3b0f
+niiri:adde53039c55af81c35408a4bd174215
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0055" ;
-    prov:atLocation niiri:1666a82c17efee4fec25c34044220898 ;
+    prov:atLocation niiri:175d8df12f2e8550c70e8fe728a6157b ;
     prov:value "3.3674840927124"^^xsd:float ;
     nidm_equivalentZStatistic: "3.26754352373899"^^xsd:float ;
     nidm_pValueUncorrected: "0.000542425921699285"^^xsd:float ;
     nidm_pValueFWER: "0.999999999580025"^^xsd:float ;
     nidm_qValueFDR: "0.757181401908473"^^xsd:float .
 
-niiri:1666a82c17efee4fec25c34044220898
+niiri:175d8df12f2e8550c70e8fe728a6157b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0055" ;
     nidm_coordinateVector: "[40,-88,6]"^^xsd:string .
 
-niiri:26bbba507d377ff39b078c33451b3b0f prov:wasDerivedFrom niiri:8a6fe11cd61eb1f35a28fa6bf0b6144f .
+niiri:adde53039c55af81c35408a4bd174215 prov:wasDerivedFrom niiri:453c0a23d3b7bdaf631090a39026b948 .
 
-niiri:8cecc7af4f33a80eb8bcaf4a5288da58
+niiri:34836d3b3ca4536242e85f8dbf0eaec9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0056" ;
-    prov:atLocation niiri:ad0006b8ad648f7b63893f432c74283c ;
+    prov:atLocation niiri:0ad0ba7ec6488d93289684ea60e3d1ed ;
     prov:value "3.35621929168701"^^xsd:float ;
     nidm_equivalentZStatistic: "3.25719036010207"^^xsd:float ;
     nidm_pValueUncorrected: "0.000562604729181126"^^xsd:float ;
     nidm_pValueFWER: "0.999999999766468"^^xsd:float ;
     nidm_qValueFDR: "0.769744720456333"^^xsd:float .
 
-niiri:ad0006b8ad648f7b63893f432c74283c
+niiri:0ad0ba7ec6488d93289684ea60e3d1ed
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0056" ;
     nidm_coordinateVector: "[-64,-32,46]"^^xsd:string .
 
-niiri:8cecc7af4f33a80eb8bcaf4a5288da58 prov:wasDerivedFrom niiri:2e6c2c0ad60837828212538790c5db9b .
+niiri:34836d3b3ca4536242e85f8dbf0eaec9 prov:wasDerivedFrom niiri:f9cadf3213379a88a9727fcf6a9eeef1 .
 
-niiri:80d76f48ec884d6c9308a1c29b8ba4bc
+niiri:056318bce8477b3efd14b0f6d507c3b4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0057" ;
-    prov:atLocation niiri:224595860c68088087a64fe752180870 ;
+    prov:atLocation niiri:0dac9d762d87c922e37133ba1065f763 ;
     prov:value "3.32532405853271"^^xsd:float ;
     nidm_equivalentZStatistic: "3.22876865896546"^^xsd:float ;
     nidm_pValueUncorrected: "0.000621622108231912"^^xsd:float ;
     nidm_pValueFWER: "0.99999999995642"^^xsd:float ;
     nidm_qValueFDR: "0.811282559503343"^^xsd:float .
 
-niiri:224595860c68088087a64fe752180870
+niiri:0dac9d762d87c922e37133ba1065f763
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0057" ;
     nidm_coordinateVector: "[-54,-32,42]"^^xsd:string .
 
-niiri:80d76f48ec884d6c9308a1c29b8ba4bc prov:wasDerivedFrom niiri:5dabb5b7488150418280d8590f704272 .
+niiri:056318bce8477b3efd14b0f6d507c3b4 prov:wasDerivedFrom niiri:00e7e2184e288d14e023360536c4ccbb .
 
-niiri:88d6d95a5aaf940a20b4ef0863ef4004
+niiri:8f0b0d4d20de8f18555fe5e10680d0c3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0058" ;
-    prov:atLocation niiri:9f5e299244592e86e10d8922909ac397 ;
+    prov:atLocation niiri:c333bb1f426e6621b3f21f7cd8532aee ;
     prov:value "3.3036584854126"^^xsd:float ;
     nidm_equivalentZStatistic: "3.20881441467256"^^xsd:float ;
     nidm_pValueUncorrected: "0.000666417461998026"^^xsd:float ;
     nidm_pValueFWER: "0.999999999987382"^^xsd:float ;
     nidm_qValueFDR: "0.833892248434202"^^xsd:float .
 
-niiri:9f5e299244592e86e10d8922909ac397
+niiri:c333bb1f426e6621b3f21f7cd8532aee
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0058" ;
     nidm_coordinateVector: "[44,16,8]"^^xsd:string .
 
-niiri:88d6d95a5aaf940a20b4ef0863ef4004 prov:wasDerivedFrom niiri:f0c686d0818396b5724de255e477b7e7 .
+niiri:8f0b0d4d20de8f18555fe5e10680d0c3 prov:wasDerivedFrom niiri:1e198daa9971af9c5562116948147b44 .
 
-niiri:a96adf838fa82e5f92d02dac00ffd047
+niiri:5cd0e7e590a22b0339b125fff010c6c7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0059" ;
-    prov:atLocation niiri:3361c050c9dd0f59da7c56ffe636df83 ;
+    prov:atLocation niiri:5082af9f1f2be4a41ca2e0721da7fa71 ;
     prov:value "3.30078315734863"^^xsd:float ;
     nidm_equivalentZStatistic: "3.2061647702223"^^xsd:float ;
     nidm_pValueUncorrected: "0.000672584694407008"^^xsd:float ;
     nidm_pValueFWER: "0.999999999989338"^^xsd:float ;
     nidm_qValueFDR: "0.833892248434202"^^xsd:float .
 
-niiri:3361c050c9dd0f59da7c56ffe636df83
+niiri:5082af9f1f2be4a41ca2e0721da7fa71
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0059" ;
     nidm_coordinateVector: "[24,36,22]"^^xsd:string .
 
-niiri:a96adf838fa82e5f92d02dac00ffd047 prov:wasDerivedFrom niiri:4d3b4510cff045e65b0540e3d2c3ddb5 .
+niiri:5cd0e7e590a22b0339b125fff010c6c7 prov:wasDerivedFrom niiri:b983603109c1a317dd80246d873f0d4a .
 
-niiri:cf26f5bd936e3f1e70cadde50d2bdfc3
+niiri:816f143f7b83c21ef577cc3a8b9c39a3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0060" ;
-    prov:atLocation niiri:c2a74912701d6958508a3e460e5a0274 ;
+    prov:atLocation niiri:db3c1c1d13496dbcae13ca3ecec8f2d1 ;
     prov:value "3.28121852874756"^^xsd:float ;
     nidm_equivalentZStatistic: "3.18812687854183"^^xsd:float ;
     nidm_pValueUncorrected: "0.000715988437604564"^^xsd:float ;
     nidm_pValueFWER: "0.999999999996695"^^xsd:float ;
     nidm_qValueFDR: "0.864080797399493"^^xsd:float .
 
-niiri:c2a74912701d6958508a3e460e5a0274
+niiri:db3c1c1d13496dbcae13ca3ecec8f2d1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0060" ;
     nidm_coordinateVector: "[42,44,10]"^^xsd:string .
 
-niiri:cf26f5bd936e3f1e70cadde50d2bdfc3 prov:wasDerivedFrom niiri:cb783972b7209195409262a64edc55f4 .
+niiri:816f143f7b83c21ef577cc3a8b9c39a3 prov:wasDerivedFrom niiri:bcad500e3ad79ca4075f62aa01a372da .
 
-niiri:bd5c83ccf5605aa922aed01c907d04b2
+niiri:cdbd489b9fe249b9a71c29b770e2f4c4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0061" ;
-    prov:atLocation niiri:07f33961ff94f7ea9069564104473ec6 ;
+    prov:atLocation niiri:16ee8694a7956d27653067c326b9b5d5 ;
     prov:value "3.26455140113831"^^xsd:float ;
     nidm_equivalentZStatistic: "3.17274820463022"^^xsd:float ;
     nidm_pValueUncorrected: "0.000755017120229184"^^xsd:float ;
     nidm_pValueFWER: "0.999999999998824"^^xsd:float ;
     nidm_qValueFDR: "0.889209349007764"^^xsd:float .
 
-niiri:07f33961ff94f7ea9069564104473ec6
+niiri:16ee8694a7956d27653067c326b9b5d5
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0061" ;
     nidm_coordinateVector: "[-54,6,42]"^^xsd:string .
 
-niiri:bd5c83ccf5605aa922aed01c907d04b2 prov:wasDerivedFrom niiri:a972e773c5316470d7547a29677906b8 .
+niiri:cdbd489b9fe249b9a71c29b770e2f4c4 prov:wasDerivedFrom niiri:b41f8e4d939b3ddb2c20cae93fb8b7c8 .
 
-niiri:7b1230e5731a4c25cc6855297f8727c7
+niiri:27882a721f1cf5fa0b9ff4467a197b13
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0062" ;
-    prov:atLocation niiri:8be2d54bb05055264f62859f989f08a9 ;
+    prov:atLocation niiri:7ba1d81106866072c384e2e653d9e606 ;
     prov:value "3.2516782283783"^^xsd:float ;
     nidm_equivalentZStatistic: "3.16086256336622"^^xsd:float ;
     nidm_pValueUncorrected: "0.000786513505130482"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999482"^^xsd:float ;
     nidm_qValueFDR: "0.898782253348965"^^xsd:float .
 
-niiri:8be2d54bb05055264f62859f989f08a9
+niiri:7ba1d81106866072c384e2e653d9e606
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0062" ;
     nidm_coordinateVector: "[6,32,18]"^^xsd:string .
 
-niiri:7b1230e5731a4c25cc6855297f8727c7 prov:wasDerivedFrom niiri:568187a66cff2006389ae8a03beea987 .
+niiri:27882a721f1cf5fa0b9ff4467a197b13 prov:wasDerivedFrom niiri:4545f5ed2d2381e9f6f1aaf307289882 .
 
-niiri:e8421f845c4ab708b53c10243a671f1e
+niiri:692ab3bf7a5c7c16857d166b15f0fc4a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0063" ;
-    prov:atLocation niiri:c41d8c4e47619e45a5bf9d5a3bdede1d ;
+    prov:atLocation niiri:aa568f96f20e56c9548d5ad31273d197 ;
     prov:value "3.25153398513794"^^xsd:float ;
     nidm_equivalentZStatistic: "3.16072934780164"^^xsd:float ;
     nidm_pValueUncorrected: "0.000786873276886202"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999487"^^xsd:float ;
     nidm_qValueFDR: "0.898782253348965"^^xsd:float .
 
-niiri:c41d8c4e47619e45a5bf9d5a3bdede1d
+niiri:aa568f96f20e56c9548d5ad31273d197
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0063" ;
     nidm_coordinateVector: "[-32,36,18]"^^xsd:string .
 
-niiri:e8421f845c4ab708b53c10243a671f1e prov:wasDerivedFrom niiri:31ace54320ced6fbcbbf3e9a0b06c69b .
+niiri:692ab3bf7a5c7c16857d166b15f0fc4a prov:wasDerivedFrom niiri:2253c054073552510a00e5cee801efa6 .
 
-niiri:90cdfd43ecd9cecb45d9194487610277
+niiri:1dfc374a28a2a395f47b36b9ee3103b1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0064" ;
-    prov:atLocation niiri:a7325886b11721730a1406ca0acd4f20 ;
+    prov:atLocation niiri:237da29f8b420440ba0df45b565b6643 ;
     prov:value "3.22331190109253"^^xsd:float ;
     nidm_equivalentZStatistic: "3.13464894829369"^^xsd:float ;
     nidm_pValueUncorrected: "0.000860299398633191"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999921"^^xsd:float ;
     nidm_qValueFDR: "0.948209393065872"^^xsd:float .
 
-niiri:a7325886b11721730a1406ca0acd4f20
+niiri:237da29f8b420440ba0df45b565b6643
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0064" ;
     nidm_coordinateVector: "[42,-86,12]"^^xsd:string .
 
-niiri:90cdfd43ecd9cecb45d9194487610277 prov:wasDerivedFrom niiri:497da5b57f3713b30ef46f853f1ed5d0 .
+niiri:1dfc374a28a2a395f47b36b9ee3103b1 prov:wasDerivedFrom niiri:c2c0de5bb03471fb2a8439bc440e1a06 .
 
-niiri:6557a144fbbbf1742b7263a377da1da9
+niiri:99d98ff39073ff123cf9b9bc0586da2c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0065" ;
-    prov:atLocation niiri:b42d215de6bd0dda7e60f5b120fd9650 ;
+    prov:atLocation niiri:208152a8191e8072a02647fe58186344 ;
     prov:value "3.21240544319153"^^xsd:float ;
     nidm_equivalentZStatistic: "3.1245616797579"^^xsd:float ;
     nidm_pValueUncorrected: "0.000890350923619998"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999963"^^xsd:float ;
     nidm_qValueFDR: "0.948209393065872"^^xsd:float .
 
-niiri:b42d215de6bd0dda7e60f5b120fd9650
+niiri:208152a8191e8072a02647fe58186344
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0065" ;
     nidm_coordinateVector: "[6,32,22]"^^xsd:string .
 
-niiri:6557a144fbbbf1742b7263a377da1da9 prov:wasDerivedFrom niiri:2ef352ff3d02560b512f4da34e0351c4 .
+niiri:99d98ff39073ff123cf9b9bc0586da2c prov:wasDerivedFrom niiri:7c7b06e42170e83d79d011d51a1ee2eb .
 
-niiri:80d1ef0ccc9de9c996dc2ee64931a9f7
+niiri:847abc12c3303cd0921e0bc7775893a2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0066" ;
-    prov:atLocation niiri:50cc2dc0cf1bbd895998105efa32ea1a ;
+    prov:atLocation niiri:6d6402d8a1e70f09f4b8652c55b3f9ad ;
     prov:value "3.21144485473633"^^xsd:float ;
     nidm_equivalentZStatistic: "3.12367301635021"^^xsd:float ;
     nidm_pValueUncorrected: "0.000893044111823671"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999965"^^xsd:float ;
     nidm_qValueFDR: "0.948209393065872"^^xsd:float .
 
-niiri:50cc2dc0cf1bbd895998105efa32ea1a
+niiri:6d6402d8a1e70f09f4b8652c55b3f9ad
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0066" ;
     nidm_coordinateVector: "[22,-66,34]"^^xsd:string .
 
-niiri:80d1ef0ccc9de9c996dc2ee64931a9f7 prov:wasDerivedFrom niiri:d31015870dfb250e5f85f5b4632731c3 .
+niiri:847abc12c3303cd0921e0bc7775893a2 prov:wasDerivedFrom niiri:040e702ed12041e2190bf96dfbacadbb .
 
-niiri:8139a92ae13bcfb15541743863f167b3
+niiri:cbcaaf82c3acb8ecaba54ed445353762
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0067" ;
-    prov:atLocation niiri:2f91c3a04ca8b559ae2a68820cc720d3 ;
+    prov:atLocation niiri:b78bd3956f68aeb44993a6fe8f8023d8 ;
     prov:value "3.21088981628418"^^xsd:float ;
     nidm_equivalentZStatistic: "3.12315952037414"^^xsd:float ;
     nidm_pValueUncorrected: "0.00089460372708472"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999966"^^xsd:float ;
     nidm_qValueFDR: "0.948209393065872"^^xsd:float .
 
-niiri:2f91c3a04ca8b559ae2a68820cc720d3
+niiri:b78bd3956f68aeb44993a6fe8f8023d8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0067" ;
     nidm_coordinateVector: "[-46,28,-10]"^^xsd:string .
 
-niiri:8139a92ae13bcfb15541743863f167b3 prov:wasDerivedFrom niiri:cb808a6811ec0c81f5483719bfa3da6a .
+niiri:cbcaaf82c3acb8ecaba54ed445353762 prov:wasDerivedFrom niiri:e14e04732107aabcfe52c4ce59b579a8 .
 
-niiri:ff408fbe10be5ddbf9630242a39bb3cd
+niiri:82d3cc604f3e16683c4c3de6c5e42b0a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0068" ;
-    prov:atLocation niiri:1d8438dfcb2131ad4a47775fdd847a87 ;
+    prov:atLocation niiri:7f5d6d95284b9c0ef666dbe7ff15a28d ;
     prov:value "3.20743656158447"^^xsd:float ;
     nidm_equivalentZStatistic: "3.11996445543627"^^xsd:float ;
     nidm_pValueUncorrected: "0.000904364321047457"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999974"^^xsd:float ;
     nidm_qValueFDR: "0.948209393065872"^^xsd:float .
 
-niiri:1d8438dfcb2131ad4a47775fdd847a87
+niiri:7f5d6d95284b9c0ef666dbe7ff15a28d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0068" ;
     nidm_coordinateVector: "[52,-44,18]"^^xsd:string .
 
-niiri:ff408fbe10be5ddbf9630242a39bb3cd prov:wasDerivedFrom niiri:da2ebf5fddf7590fea56aa4795c3c730 .
+niiri:82d3cc604f3e16683c4c3de6c5e42b0a prov:wasDerivedFrom niiri:d77e5bf6a731dcb245ad371bed714586 .
 
-niiri:cf186fe995906627ea7b56d73dc89e77
+niiri:fbde6e6581200f6c0a84e21ed621fc09
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0069" ;
-    prov:atLocation niiri:b95c7714182effead7102cb8a522ad3f ;
+    prov:atLocation niiri:3891bdd206293e275b3c60f15c905d3d ;
     prov:value "3.2013533115387"^^xsd:float ;
     nidm_equivalentZStatistic: "3.11433488942651"^^xsd:float ;
     nidm_pValueUncorrected: "0.000921800539615547"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999983"^^xsd:float ;
     nidm_qValueFDR: "0.952610967842716"^^xsd:float .
 
-niiri:b95c7714182effead7102cb8a522ad3f
+niiri:3891bdd206293e275b3c60f15c905d3d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0069" ;
     nidm_coordinateVector: "[-24,52,30]"^^xsd:string .
 
-niiri:cf186fe995906627ea7b56d73dc89e77 prov:wasDerivedFrom niiri:5f270d7e12051f6614973ee4186253ff .
+niiri:fbde6e6581200f6c0a84e21ed621fc09 prov:wasDerivedFrom niiri:9575c70a2f76c6d9598daa3848deeb65 .
 
-niiri:7aa837d4d3b605903a45a10118f11d19
+niiri:8119527ea4cfcfa60201f74ffff03743
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0070" ;
-    prov:atLocation niiri:bcdeb5a1acbada14f6bf5d9e51e21914 ;
+    prov:atLocation niiri:bbdbc2effb2f18786476efc80d031be4 ;
     prov:value "3.17790174484253"^^xsd:float ;
     nidm_equivalentZStatistic: "3.09261872722341"^^xsd:float ;
     nidm_pValueUncorrected: "0.000991994268753738"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999997"^^xsd:float ;
     nidm_qValueFDR: "0.994677620170821"^^xsd:float .
 
-niiri:bcdeb5a1acbada14f6bf5d9e51e21914
+niiri:bbdbc2effb2f18786476efc80d031be4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0070" ;
     nidm_coordinateVector: "[46,24,0]"^^xsd:string .
 
-niiri:7aa837d4d3b605903a45a10118f11d19 prov:wasDerivedFrom niiri:3165aeeecdded90d2140dbb15bc8e722 .
+niiri:8119527ea4cfcfa60201f74ffff03743 prov:wasDerivedFrom niiri:75e697b6b2e295644bcfcd0111ce9380 .
 

--- a/spmexport/ex_spm_contrast_mask/nidm.json
+++ b/spmexport/ex_spm_contrast_mask/nidm.json
@@ -1,0 +1,10367 @@
+{
+  "prefix": {
+    "nidm": "http://purl.org/nidash/nidm#",
+    "niiri": "http://iri.nidash.org/",
+    "spm": "http://purl.org/nidash/spm#",
+    "neurolex": "http://neurolex.org/wiki/",
+    "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/",
+    "dct": "http://purl.org/dc/terms/",
+    "nfo": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#",
+    "dc": "http://purl.org/dc/elements/1.1/",
+    "dctype": "http://purl.org/dc/dcmitype/",
+    "obo": "http://purl.obolibrary.org/obo/",
+    "nidm_NIDMResults": "http://purl.org/nidash/nidm#NIDM_0000027",
+    "nidm_version": "http://purl.org/nidash/nidm#NIDM_0000127",
+    "nidm_spm_results_nidm": "http://purl.org/nidash/nidm#NIDM_0000168",
+    "nidm_softwareVersion": "http://purl.org/nidash/nidm#NIDM_0000122",
+    "nidm_NIDMResultsExport": "http://purl.org/nidash/nidm#NIDM_0000166"
+  },
+  "entity": {
+    "niiri:c0fc11f77219f72f64535275dfd76104": {
+      "prov:type": [
+        {
+        "$": "prov:Bundle",
+        "type": "xsd:QName"
+        },
+        {
+        "$": "nidm_NIDMResults:",
+        "type": "xsd:QName"
+        }
+      ],
+      "prov:label": {
+        "$": "NIDM-Results",
+        "type": "xsd:string"
+      },
+      "nidm_version:": {
+        "$": "1.3.0",
+        "type": "xsd:string"
+      }
+    }
+  },
+  "activity": {
+    "niiri:95688b75812d93e59bb028a4360014e7": {
+      "prov:type": {
+        "$": "nidm_NIDMResultsExport:",
+        "type": "xsd:QName"
+      },
+      "prov:label": {
+        "$": "NIDM-Results export",
+        "type": "xsd:string"
+      }
+    }
+  },
+  "agent": {
+    "niiri:a578ca65ebc21d2f8a367638a428ecb2": {
+      "prov:type": [
+        {
+        "$": "nidm_spm_results_nidm:",
+        "type": "xsd:QName"
+        },
+        {
+        "$": "prov:SoftwareAgent",
+        "type": "xsd:QName"
+        }
+      ],
+      "prov:label": {
+        "$": "spm_results_nidm",
+        "type": "xsd:string"
+      },
+      "nidm_softwareVersion:": {
+        "$": "12.7057",
+        "type": "xsd:string"
+      }
+    }
+  },
+  "wasGeneratedBy": {
+    "_:wGB5": {
+      "prov:entity": "niiri:c0fc11f77219f72f64535275dfd76104",
+      "prov:activity": "niiri:95688b75812d93e59bb028a4360014e7",
+      "prov:time": "2017-04-19T12:17:53"
+    }
+  },
+  "wasAssociatedWith": {
+    "_:wAW4": {
+      "prov:activity": "niiri:95688b75812d93e59bb028a4360014e7",
+      "prov:agent": "niiri:a578ca65ebc21d2f8a367638a428ecb2"
+    }
+  },
+  "bundle": {
+    "niiri:c0fc11f77219f72f64535275dfd76104": {
+    "prefix": {
+        "nidm_softwareVersion": "http://purl.org/nidash/nidm#NIDM_0000122",
+        "nidm_CoordinateSpace": "http://purl.org/nidash/nidm#NIDM_0000016",
+        "nidm_voxelToWorldMapping": "http://purl.org/nidash/nidm#NIDM_0000132",
+        "nidm_voxelUnits": "http://purl.org/nidash/nidm#NIDM_0000133",
+        "nidm_voxelSize": "http://purl.org/nidash/nidm#NIDM_0000131",
+        "nidm_inWorldCoordinateSystem": "http://purl.org/nidash/nidm#NIDM_0000105",
+        "nidm_numberOfDimensions": "http://purl.org/nidash/nidm#NIDM_0000112",
+        "nidm_dimensionsInVoxels": "http://purl.org/nidash/nidm#NIDM_0000090",
+        "nlx_Imaginginstrument": "http://uri.neuinfo.org/nif/nifstd/birnlex_2094",
+        "nlx_Magneticresonanceimagingscanner": "http://uri.neuinfo.org/nif/nifstd/birnlex_2100",
+        "nidm_grandMeanScaling": "http://purl.org/nidash/nidm#NIDM_0000096",
+        "nidm_targetIntensity": "http://purl.org/nidash/nidm#NIDM_0000124",
+        "nidm_hasMRIProtocol": "http://purl.org/nidash/nidm#NIDM_0000172",
+        "nlx_FunctionalMRIprotocol": "http://uri.neuinfo.org/nif/nifstd/birnlex_2250",
+        "nidm_Data": "http://purl.org/nidash/nidm#NIDM_0000169",
+        "spm_DCTDriftModel": "http://purl.org/nidash/spm#SPM_0000002",
+        "spm_SPMsDriftCutoffPeriod": "http://purl.org/nidash/spm#SPM_0000001",
+        "nidm_hasDriftModel": "http://purl.org/nidash/nidm#NIDM_0000088",
+        "nidm_hasHRFBasis": "http://purl.org/nidash/nidm#NIDM_0000102",
+        "spm_SPMsCanonicalHRF": "http://purl.org/nidash/spm#SPM_0000004",
+        "nidm_DesignMatrix": "http://purl.org/nidash/nidm#NIDM_0000019",
+        "nidm_regressorNames": "http://purl.org/nidash/nidm#NIDM_0000021",
+        "nidm_hasErrorDependence": "http://purl.org/nidash/nidm#NIDM_0000100",
+        "obo_Toeplitzcovariancestructure": "http://purl.obolibrary.org/obo/STATO_0000357",
+        "nidm_dependenceMapWiseDependence": "http://purl.org/nidash/nidm#NIDM_0000089",
+        "nidm_ConstantParameter": "http://purl.org/nidash/nidm#NIDM_0000072",
+        "nidm_errorVarianceHomogeneous": "http://purl.org/nidash/nidm#NIDM_0000094",
+        "nidm_varianceMapWiseDependence": "http://purl.org/nidash/nidm#NIDM_0000126",
+        "nidm_IndependentParameter": "http://purl.org/nidash/nidm#NIDM_0000073",
+        "nidm_withEstimationMethod": "http://purl.org/nidash/nidm#NIDM_0000134",
+        "obo_generalizedleastsquaresestimation": "http://purl.obolibrary.org/obo/STATO_0000372",
+        "nidm_ErrorModel": "http://purl.org/nidash/nidm#NIDM_0000023",
+        "nidm_hasErrorDistribution": "http://purl.org/nidash/nidm#NIDM_0000101",
+        "obo_normaldistribution": "http://purl.obolibrary.org/obo/STATO_0000227",
+        "nidm_ModelParametersEstimation": "http://purl.org/nidash/nidm#NIDM_0000056",
+        "nidm_MaskMap": "http://purl.org/nidash/nidm#NIDM_0000054",
+        "nidm_isUserDefined": "http://purl.org/nidash/nidm#NIDM_0000106",
+        "nidm_inCoordinateSpace": "http://purl.org/nidash/nidm#NIDM_0000104",
+        "nidm_GrandMeanMap": "http://purl.org/nidash/nidm#NIDM_0000033",
+        "nidm_maskedMedian": "http://purl.org/nidash/nidm#NIDM_0000107",
+        "nidm_ParameterEstimateMap": "http://purl.org/nidash/nidm#NIDM_0000061",
+        "nidm_ResidualMeanSquaresMap": "http://purl.org/nidash/nidm#NIDM_0000066",
+        "nidm_ReselsPerVoxelMap": "http://purl.org/nidash/nidm#NIDM_0000144",
+        "obo_contrastweightmatrix": "http://purl.obolibrary.org/obo/STATO_0000323",
+        "nidm_statisticType": "http://purl.org/nidash/nidm#NIDM_0000123",
+        "obo_tstatistic": "http://purl.obolibrary.org/obo/STATO_0000176",
+        "nidm_contrastName": "http://purl.org/nidash/nidm#NIDM_0000085",
+        "nidm_ContrastEstimation": "http://purl.org/nidash/nidm#NIDM_0000001",
+        "nidm_StatisticMap": "http://purl.org/nidash/nidm#NIDM_0000076",
+        "nidm_errorDegreesOfFreedom": "http://purl.org/nidash/nidm#NIDM_0000093",
+        "nidm_effectDegreesOfFreedom": "http://purl.org/nidash/nidm#NIDM_0000091",
+        "nidm_ContrastMap": "http://purl.org/nidash/nidm#NIDM_0000002",
+        "nidm_ContrastStandardErrorMap": "http://purl.org/nidash/nidm#NIDM_0000013",
+        "obo_statistic": "http://purl.obolibrary.org/obo/STATO_0000039",
+        "nidm_PValueUncorrected": "http://purl.org/nidash/nidm#NIDM_0000160",
+        "obo_FWERadjustedpvalue": "http://purl.obolibrary.org/obo/OBI_0001265",
+        "nidm_HeightThreshold": "http://purl.org/nidash/nidm#NIDM_0000034",
+        "nidm_equivalentThreshold": "http://purl.org/nidash/nidm#NIDM_0000161",
+        "nidm_ExtentThreshold": "http://purl.org/nidash/nidm#NIDM_0000026",
+        "nidm_clusterSizeInVoxels": "http://purl.org/nidash/nidm#NIDM_0000084",
+        "nidm_clusterSizeInResels": "http://purl.org/nidash/nidm#NIDM_0000156",
+        "nidm_PeakDefinitionCriteria": "http://purl.org/nidash/nidm#NIDM_0000063",
+        "nidm_maxNumberOfPeaksPerCluster": "http://purl.org/nidash/nidm#NIDM_0000108",
+        "nidm_minDistanceBetweenPeaks": "http://purl.org/nidash/nidm#NIDM_0000109",
+        "nidm_ClusterDefinitionCriteria": "http://purl.org/nidash/nidm#NIDM_0000007",
+        "nidm_hasConnectivityCriterion": "http://purl.org/nidash/nidm#NIDM_0000099",
+        "nidm_voxel18connected": "http://purl.org/nidash/nidm#NIDM_0000128",
+        "nidm_Inference": "http://purl.org/nidash/nidm#NIDM_0000049",
+        "nidm_hasAlternativeHypothesis": "http://purl.org/nidash/nidm#NIDM_0000097",
+        "nidm_OneTailedTest": "http://purl.org/nidash/nidm#NIDM_0000060",
+        "nidm_DisplayMaskMap": "http://purl.org/nidash/nidm#NIDM_0000020",
+        "nidm_SearchSpaceMaskMap": "http://purl.org/nidash/nidm#NIDM_0000068",
+        "nidm_searchVolumeInVoxels": "http://purl.org/nidash/nidm#NIDM_0000121",
+        "nidm_searchVolumeInUnits": "http://purl.org/nidash/nidm#NIDM_0000136",
+        "nidm_reselSizeInVoxels": "http://purl.org/nidash/nidm#NIDM_0000148",
+        "nidm_searchVolumeInResels": "http://purl.org/nidash/nidm#NIDM_0000149",
+        "spm_searchVolumeReselsGeometry": "http://purl.org/nidash/spm#SPM_0000010",
+        "nidm_noiseFWHMInVoxels": "http://purl.org/nidash/nidm#NIDM_0000159",
+        "nidm_noiseFWHMInUnits": "http://purl.org/nidash/nidm#NIDM_0000157",
+        "nidm_randomFieldStationarity": "http://purl.org/nidash/nidm#NIDM_0000120",
+        "nidm_expectedNumberOfVoxelsPerCluster": "http://purl.org/nidash/nidm#NIDM_0000143",
+        "nidm_expectedNumberOfClusters": "http://purl.org/nidash/nidm#NIDM_0000141",
+        "nidm_heightCriticalThresholdFWE05": "http://purl.org/nidash/nidm#NIDM_0000147",
+        "nidm_heightCriticalThresholdFDR05": "http://purl.org/nidash/nidm#NIDM_0000146",
+        "spm_smallestSignificantClusterSizeInVoxelsFWE05": "http://purl.org/nidash/spm#SPM_0000014",
+        "spm_smallestSignificantClusterSizeInVoxelsFDR05": "http://purl.org/nidash/spm#SPM_0000013",
+        "nidm_ExcursionSetMap": "http://purl.org/nidash/nidm#NIDM_0000025",
+        "nidm_numberOfSupraThresholdClusters": "http://purl.org/nidash/nidm#NIDM_0000111",
+        "nidm_pValue": "http://purl.org/nidash/nidm#NIDM_0000114",
+        "nidm_hasClusterLabelsMap": "http://purl.org/nidash/nidm#NIDM_0000098",
+        "nidm_hasMaximumIntensityProjection": "http://purl.org/nidash/nidm#NIDM_0000138",
+        "nidm_ClusterLabelsMap": "http://purl.org/nidash/nidm#NIDM_0000008",
+        "nidm_SupraThresholdCluster": "http://purl.org/nidash/nidm#NIDM_0000070",
+        "nidm_pValueUncorrected": "http://purl.org/nidash/nidm#NIDM_0000116",
+        "nidm_pValueFWER": "http://purl.org/nidash/nidm#NIDM_0000115",
+        "nidm_qValueFDR": "http://purl.org/nidash/nidm#NIDM_0000119",
+        "nidm_clusterLabelId": "http://purl.org/nidash/nidm#NIDM_0000082",
+        "nidm_Peak": "http://purl.org/nidash/nidm#NIDM_0000062",
+        "nidm_equivalentZStatistic": "http://purl.org/nidash/nidm#NIDM_0000092",
+        "nidm_Coordinate": "http://purl.org/nidash/nidm#NIDM_0000015",
+        "nidm_coordinateVector": "http://purl.org/nidash/nidm#NIDM_0000086"
+    },
+    "entity": {
+        "niiri:d11490ae37fde7aa8e3ddc508c115313": {
+            "prov:type": {
+                "$": "nidm_CoordinateSpace:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Coordinate space 1",
+                "type": "xsd:string"
+            },
+            "nidm_voxelToWorldMapping:": {
+                "$": "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]",
+                "type": "xsd:string"
+            },
+            "nidm_voxelUnits:": {
+                "$": "[\"mm\", \"mm\", \"mm\"]",
+                "type": "xsd:string"
+            },
+            "nidm_voxelSize:": {
+                "$": "[2, 2, 2]",
+                "type": "xsd:string"
+            },
+            "nidm_inWorldCoordinateSystem:": {
+                "$": "nidm_Ixi549CoordinateSystem:",
+                "type": "xsd:string"
+            },
+            "nidm_numberOfDimensions:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_dimensionsInVoxels:": {
+                "$": "[79,95,79]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3eafaf3b0d4fb27e0273cf883045c71c": {
+            "prov:type": [
+                {
+                "$": "prov:Collection",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Data:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Data",
+                "type": "xsd:string"
+            },
+            "nidm_grandMeanScaling:": {
+                "$": "true",
+                "type": "xsd:boolean"
+            },
+            "nidm_targetIntensity:": {
+                "$": "100",
+                "type": "xsd:float"
+            },
+            "nidm_hasMRIProtocol:": {
+                "$": "nlx_FunctionalMRIprotocol:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1b66176fa0492dcad18cbabb1ac94ea3": {
+            "prov:type": {
+                "$": "spm_DCTDriftModel:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "SPM's DCT Drift Model",
+                "type": "xsd:string"
+            },
+            "spm_SPMsDriftCutoffPeriod:": {
+                "$": "128",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:55ba018663409d2f002b8707d5149e83": {
+            "prov:type": {
+                "$": "nidm_DesignMatrix:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "DesignMatrix.csv",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "DesignMatrix.csv",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "text/csv",
+                "type": "xsd:string"
+            },
+            "dc:description": {
+                "$": "niiri:967bf8ed0debd31706b3c4341edc203f",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Design Matrix",
+                "type": "xsd:string"
+            },
+            "nidm_regressorNames:": {
+                "$": "[\"Sn(1) to*bf(1)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) constant\"]",
+                "type": "xsd:string"
+            },
+            "nidm_hasDriftModel:": {
+                "$": "niiri:1b66176fa0492dcad18cbabb1ac94ea3",
+                "type": "xsd:string"
+            },
+            "nidm_hasHRFBasis:": {
+                "$": "spm_SPMsCanonicalHRF:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:967bf8ed0debd31706b3c4341edc203f": {
+            "prov:type": {
+                "$": "dctype:Image",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "DesignMatrix.png",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "DesignMatrix.png",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/png",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b4b0efe73f8e31624573c955a3b91929": {
+            "prov:type": {
+                "$": "nidm_ErrorModel:",
+                "type": "xsd:QName"
+            },
+            "nidm_hasErrorDistribution:": {
+                "$": "obo_normaldistribution:",
+                "type": "xsd:string"
+            },
+            "nidm_hasErrorDependence:": {
+                "$": "obo_Toeplitzcovariancestructure:",
+                "type": "xsd:string"
+            },
+            "nidm_dependenceMapWiseDependence:": {
+                "$": "nidm_ConstantParameter:",
+                "type": "xsd:string"
+            },
+            "nidm_errorVarianceHomogeneous:": {
+                "$": "true",
+                "type": "xsd:boolean"
+            },
+            "nidm_varianceMapWiseDependence:": {
+                "$": "nidm_IndependentParameter:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b129871a86340316a5e71da151467968": {
+            "prov:type": {
+                "$": "nidm_MaskMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "Mask.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nidm_isUserDefined:": {
+                "$": "false",
+                "type": "xsd:boolean"
+            },
+            "nfo:fileName": {
+                "$": "Mask.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Mask",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:d11490ae37fde7aa8e3ddc508c115313",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b64466758d550b4120028710711baae1": {
+            "prov:type": {
+                "$": "nidm_MaskMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "mask.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "36929e1f5f4143bd9cc818cd896a25f129961fab208c3a4438555f40444c08347b359142ee8c53ece6e8cca1627f49db0788a1fd3b9e2ecaef61999c6c6c67ac",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5452b79c7f6c0fb6d103555e4ba5ab0b": {
+            "prov:type": {
+                "$": "nidm_GrandMeanMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "GrandMean.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "GrandMean.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Grand Mean Map",
+                "type": "xsd:string"
+            },
+            "nidm_maskedMedian:": {
+                "$": "111.557487487793",
+                "type": "xsd:float"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:d11490ae37fde7aa8e3ddc508c115313",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "512157cc6bff89d9343a09b4068226eb3edd64a8cbcee861f06231767fae6f8d4819921182adebee083a9bf309afd65529ab04a92f0aa6b0038c8098550f6124",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:fac828643e618f4bd2bcc17d9b2c23db": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0001.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0001.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 1",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:d11490ae37fde7aa8e3ddc508c115313",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:83ed43088ba6e13e15e23f0722815231": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0001.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:648e908d9842014984d36e153dd159b3": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0002.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0002.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 2",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:d11490ae37fde7aa8e3ddc508c115313",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:71301a90cafdf2e089e984789a19c3b0": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0002.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:cecb740cce9e1407b8cd6a8aeb90385e": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0003.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0003.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 3",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:d11490ae37fde7aa8e3ddc508c115313",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f947acbd818877cfe83bc57648200186": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0003.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:71f2801581b2abe311d3914ca638ba77": {
+            "prov:type": {
+                "$": "nidm_ResidualMeanSquaresMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ResidualMeanSquares.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ResidualMeanSquares.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Residual Mean Squares Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:d11490ae37fde7aa8e3ddc508c115313",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "991abf563d795a43b1e2eef8643e57023f2e0b090b2031f05f839321fc0643df6f71d423486a1021519b6dc82f6b0f563e19f3fbd50cb16063bed54a0e192d3e",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e704c1b77b30444afce8a702d4e3ac9c": {
+            "prov:type": {
+                "$": "nidm_ResidualMeanSquaresMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "ResMS.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "40b28d03fcf9a2f60b11f10d7fb83bf3618b234fb5aedf09df644cb7cbb6aab8c9f468897c1078166d455a3d04a83f4e3bf762cfca0b4ea982d7a4e406849f18",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7adfaca483dfbb4c69fe57814c2e7ba5": {
+            "prov:type": {
+                "$": "nidm_ReselsPerVoxelMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ReselsPerVoxel.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ReselsPerVoxel.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Resels per Voxel Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:d11490ae37fde7aa8e3ddc508c115313",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "1a3f9216e145249ccc0b14b2bc337d6b38b81ad45e32768001fb22b35f0c2c0f3e2bce013b40c85f7dc0fc62723ac761ee7f7e1e6aff128a05f0ba7b8b8202a3",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4c53149058cf0977f0f71d080e3a55bd": {
+            "prov:type": {
+                "$": "nidm_ReselsPerVoxelMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "RPV.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "4f76663162857f6b38b2a45a63b15a23b2ca8b338c283b69c1e71f2ea2f43797d045a733cd14e845be9c12f8b8f84d3931c599a08e8f6d77e99fab46ad87ab8f",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:32ab289c9b156044343a8e1edd8ec1d0": {
+            "prov:type": {
+                "$": "obo_contrastweightmatrix:",
+                "type": "xsd:QName"
+            },
+            "nidm_statisticType:": {
+                "$": "obo_tstatistic:",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast: tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "[1, 0, 0]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:730c67ccd0e52a39ba60c5796037b4e0": {
+            "prov:type": {
+                "$": "nidm_StatisticMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "TStatistic.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "TStatistic.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "T-Statistic Map: tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "nidm_statisticType:": {
+                "$": "obo_tstatistic:",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "nidm_errorDegreesOfFreedom:": {
+                "$": "97.9999999998522",
+                "type": "xsd:float"
+            },
+            "nidm_effectDegreesOfFreedom:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:d11490ae37fde7aa8e3ddc508c115313",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "9e1714c2d86a050b38b4e10a4d2d23253a24c5e1d228ae16a9c3be8872739278505ac0729ecab54265a717e3a54f9f782d0ed72eea904e0d482a6072bb817bd4",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:19e8074493373e095fbeb5d7d0137351": {
+            "prov:type": {
+                "$": "nidm_StatisticMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "spmT_0001.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "d288b1b0f117f64502555da13c5398dffa5bf5ff0b58951510e43d5388755bc185798802a92e98a07c7e313c6991066d2908f2a44aa5153ba23433da1335970f",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4f98291a207d3b592ea963c5b2efee61": {
+            "prov:type": {
+                "$": "nidm_ContrastMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "Contrast.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "Contrast.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast Map: tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:d11490ae37fde7aa8e3ddc508c115313",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "fc5e2ad175243ee496db98f9b2e1b235c4c3bae1a8d7122ce461c897b537e40c49dfee5d6cf20f71c6a2bb9b5f0760fcb4ecd8fe2e9428910ef3d60d8f3c56a9",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:fa1e177a50edc20148667f0c1cfb02fc": {
+            "prov:type": {
+                "$": "nidm_ContrastMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "con_0001.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "d4aa46b3603ba508578e39751262d528cf6d1ed2e722ec46f1cd8194c50591e46b229deb8cb4f72d1b7e0e2640f3e6604be7a335301c5c8357f453e5d0d4daf2",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d590545b386aedf38aa5ec2c2ea31ee5": {
+            "prov:type": {
+                "$": "nidm_ContrastStandardErrorMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ContrastStandardError.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ContrastStandardError.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast Standard Error Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:d11490ae37fde7aa8e3ddc508c115313",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "791d48f5d1adb15079a5289271ce0c4b95c56d69bfdb3e5d41b0d24eb538d3075e1cdd15502494b5a5a18c16eaa2153cb4847a996043fa48cdaf26e938a2576d",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:53e9321dbde376b31728c3d81f4a0a0b": {
+            "prov:type": [
+                {
+                "$": "nidm_HeightThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_PValueUncorrected:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Height Threshold: p<0.001 (unc.)",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "0.000999500158000544",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentThreshold:": [
+                {
+                "$": "niiri:c87fc63ec6a46693c3ca483567ad054c",
+                "type": "xsd:string"
+                },
+                {
+                "$": "niiri:1d698ce69f7c205e4e33223fd7699059",
+                "type": "xsd:string"
+                }
+            ]
+        },
+        "niiri:c87fc63ec6a46693c3ca483567ad054c": {
+            "prov:type": [
+                {
+                "$": "nidm_HeightThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_statistic:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Height Threshold: T=3.175486)",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.17548628637284",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:1d698ce69f7c205e4e33223fd7699059": {
+            "prov:type": [
+                {
+                "$": "nidm_HeightThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_FWERadjustedpvalue:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Height Threshold: p<1.000000 (FWE)",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "0.999999999999997",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:49c3b76bda9a7fe81e3019e52927592d": {
+            "prov:type": [
+                {
+                "$": "nidm_ExtentThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_statistic:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Extent Threshold: k>=0",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "0",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentThreshold:": [
+                {
+                "$": "niiri:d8ad697fc9fe8926d011b79c7a5eed54",
+                "type": "xsd:string"
+                },
+                {
+                "$": "niiri:9ab21986a7652c9329dd2f23b2b37581",
+                "type": "xsd:string"
+                }
+            ]
+        },
+        "niiri:d8ad697fc9fe8926d011b79c7a5eed54": {
+            "prov:type": [
+                {
+                "$": "nidm_ExtentThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_FWERadjustedpvalue:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Extent Threshold",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:9ab21986a7652c9329dd2f23b2b37581": {
+            "prov:type": [
+                {
+                "$": "nidm_ExtentThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_PValueUncorrected:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Extent Threshold",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:40cd831e46a683970a4d9ab47538c686": {
+            "prov:type": {
+                "$": "nidm_PeakDefinitionCriteria:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak Definition Criteria",
+                "type": "xsd:string"
+            },
+            "nidm_maxNumberOfPeaksPerCluster:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_minDistanceBetweenPeaks:": {
+                "$": "8",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:aec88dac07772a2bd5f7281a97725360": {
+            "prov:type": {
+                "$": "nidm_ClusterDefinitionCriteria:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Cluster Connectivity Criterion: 18",
+                "type": "xsd:string"
+            },
+            "nidm_hasConnectivityCriterion:": {
+                "$": "nidm_voxel18connected:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1268daf6616504ca924affa8b4071eb7": {
+            "prov:type": {
+                "$": "nidm_DisplayMaskMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "DisplayMask_0001.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "DisplayMask_0001.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Display Mask Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:d11490ae37fde7aa8e3ddc508c115313",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "46fab45d854a777ac313b6e0d479d7c81c4a52633816ebdee43ad7403951265b761b58bbf0633c9abbd266f10a5e99bdbb24f02fc57ce4c475a69dc7f6120084",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:939e38d7108636351d4b59905ee376fc": {
+            "prov:type": {
+                "$": "nidm_DisplayMaskMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "DisplayMask_0001.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "46fab45d854a777ac313b6e0d479d7c81c4a52633816ebdee43ad7403951265b761b58bbf0633c9abbd266f10a5e99bdbb24f02fc57ce4c475a69dc7f6120084",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:73df7ed02a3cef4b6cbeb78f33bff831": {
+            "prov:type": {
+                "$": "nidm_SearchSpaceMaskMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "SearchSpaceMask.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "SearchSpaceMask.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Search Space Mask Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:d11490ae37fde7aa8e3ddc508c115313",
+                "type": "xsd:string"
+            },
+            "nidm_searchVolumeInVoxels:": {
+                "$": "223057",
+                "type": "xsd:int"
+            },
+            "nidm_searchVolumeInUnits:": {
+                "$": "1784456",
+                "type": "xsd:float"
+            },
+            "nidm_reselSizeInVoxels:": {
+                "$": "65.5786964036542",
+                "type": "xsd:float"
+            },
+            "nidm_searchVolumeInResels:": {
+                "$": "3155.84193266257",
+                "type": "xsd:float"
+            },
+            "spm_searchVolumeReselsGeometry:": {
+                "$": "[6, 97.8140592306853, 965.938819261507, 3155.84193266257]",
+                "type": "xsd:string"
+            },
+            "nidm_noiseFWHMInVoxels:": {
+                "$": "[4.09118640605185, 4.0346308705955, 3.97291894351243]",
+                "type": "xsd:string"
+            },
+            "nidm_noiseFWHMInUnits:": {
+                "$": "[8.18237281210369, 8.069261741191, 7.94583788702486]",
+                "type": "xsd:string"
+            },
+            "nidm_randomFieldStationarity:": {
+                "$": "true",
+                "type": "xsd:boolean"
+            },
+            "nidm_expectedNumberOfVoxelsPerCluster:": {
+                "$": "7.21748994812991",
+                "type": "xsd:float"
+            },
+            "nidm_expectedNumberOfClusters:": {
+                "$": "33.5642173578105",
+                "type": "xsd:float"
+            },
+            "nidm_heightCriticalThresholdFWE05:": {
+                "$": "5.30963135104407",
+                "type": "xsd:float"
+            },
+            "nidm_heightCriticalThresholdFDR05:": {
+                "$": "4.69981384277344",
+                "type": "xsd:float"
+            },
+            "crypto:sha512": {
+                "$": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876",
+                "type": "xsd:string"
+            },
+            "spm_smallestSignificantClusterSizeInVoxelsFWE05:": {
+                "$": "116",
+                "type": "xsd:int"
+            },
+            "spm_smallestSignificantClusterSizeInVoxelsFDR05:": {
+                "$": "61",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:275a137c82db0d48c36216f7ba80d8d2": {
+            "prov:type": {
+                "$": "nidm_ExcursionSetMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ExcursionSet.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ExcursionSet.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Excursion Set Map",
+                "type": "xsd:string"
+            },
+            "nidm_numberOfSupraThresholdClusters:": {
+                "$": "80",
+                "type": "xsd:int"
+            },
+            "nidm_pValue:": {
+                "$": "7.38731298355333e-12",
+                "type": "xsd:float"
+            },
+            "nidm_hasClusterLabelsMap:": {
+                "$": "niiri:88d834b9ce15f8537feb3bd97e96e717",
+                "type": "xsd:string"
+            },
+            "nidm_hasMaximumIntensityProjection:": {
+                "$": "niiri:d243649d29fccf080be6c8ea1a6e7819",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:d11490ae37fde7aa8e3ddc508c115313",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "54596a95519bdf2c4ca115cd15edb36766890d6bff09c37e0921f662a1090d005971b58b638ed7efb060eaf4bec1980868aa8f88e5a7f57d803f9a2a76b544f2",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:88d834b9ce15f8537feb3bd97e96e717": {
+            "prov:type": {
+                "$": "nidm_ClusterLabelsMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ClusterLabels.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ClusterLabels.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Cluster Labels Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:d11490ae37fde7aa8e3ddc508c115313",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "6ab7aa2a0d22ba2ea42152b22400d3afa337ce2556c46fb9a065c8dc80c2af310314dac55a5add1fe3a02292d97e725c655994c105485139e49b003af55cafdd",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d243649d29fccf080be6c8ea1a6e7819": {
+            "prov:type": {
+                "$": "dctype:Image",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "MaximumIntensityProjection.png",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "MaximumIntensityProjection.png",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/png",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:fefba803c839cbd72009efffd0596397": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0001",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1591",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "24.260927515347",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.91671618308799e-20",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "4.58706002591263e-11",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "1",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:92d29aeefcd3cfea4144809ceee1698b": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0002",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "256",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "3.90370675294081",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.1468976906843e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "7.20563445519851e-05",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000672150622508277",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "2",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:ce42f33dd5918ee27ba8f8f6ccae137b": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0003",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4797",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "73.1487550541291",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.02777333984009e-40",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "5.93371085041799e-20",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "3",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:4ceeccbd429ca3c7d49d9b7ebbcbd0c0": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0004",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "109",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.66212514090058",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000619430978345348",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0205760791179098",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.022111501908576",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "4",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:caaf1d53a3cdfedef4ec795140a8062d": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0005",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "479",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "7.30420130726034",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.47290588891981e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "8.30011472885417e-08",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1.22279946227405e-07",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "5",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:4e4124102f807b660cd900fcbb6a1dad": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0006",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "216",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "3.29375257279381",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.68560644295496e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.000291483093082134",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000672150622508277",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "6",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:8a537453623b3e259868fdc3d34a15c0": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0007",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "258",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "3.93420446194816",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.00598573324675e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "6.73270745981114e-05",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000672150622508277",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "7",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:ceaad5cdc25363799f97feba2f347a03": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0008",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "115",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.75361826792263",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000473502560841437",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0157671196134005",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.022111501908576",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "8",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:00cf15c153fb34e5bdc7c627fc153666": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0009",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "14",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.21348396305145",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.152527900243506",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.994020866354823",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.374386664234061",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "9",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:9fa05d9e51da6e1bf65e29c91292c1f9": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0010",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "8",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.1219908360294",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.273933067513935",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999898388010158",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.554714461715718",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "10",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:fdf70ff4bf081216be7e467153d2d4d8": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0011",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "32",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.487963344117601",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0382783172210746",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.723289033362049",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.190729630640958",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "11",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:bca5fdf4d900bd8486f16dfcd5ab7ade": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0012",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "354",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "5.39809449430096",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "9.21801193020289e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "3.09394877406888e-06",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "9.4369593516496e-06",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "12",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:a310e577676878e8eb7499da29ff53b4": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0013",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "135",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "2.05859535799613",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00019963673720055",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00667825153705648",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00187402776443535",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "13",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:4e10b0470621dd6f66d32e5f0d86796f": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0014",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "29",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.442216780606576",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0470937359607303",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.79416170413585",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.190729630640958",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "14",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:8d02357e68e2217c76b2789fc556a1e0": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0015",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "38",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.579456471139651",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0257597057294564",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.578781830495109",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.130408510255373",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "15",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:4f5f4e9dc219044ae730379a51a53a84": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0016",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "66",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.00642439724255",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00505772986700848",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.156131620150842",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0447442257801353",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "16",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:770c988e0434c5ba8e4392759de30eea": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0017",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "76",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.1589129422793",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00300279655548563",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0958739715182708",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.022111501908576",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "17",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:ce1649f53d38c28c5b0d7cacaaf4f448": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0018",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "26",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.396470217095551",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0583630672052552",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.858988054642613",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.205539497548942",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "18",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:11d8aaf31a0f50da63a5edcfdc834eac": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0019",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "10",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.15248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.22255850848336",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999430072930499",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.487222680733842",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "19",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:18af84b83a63dcee2acfd1b9003ffe17": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0020",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "28",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.426967926102901",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.050541462694511",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.81665481379022",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.194945641821685",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "20",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:bc47992403400de624fca0326bfeca0a": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0021",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "8",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.1219908360294",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.273933067513935",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999898388010158",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.554714461715718",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "21",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:0c6b532ae8d28e2999918870be27c672": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0022",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "8",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.1219908360294",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.273933067513935",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999898388010158",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.554714461715718",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "22",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:58f0b66e88ddd39190a49cc289e1a6a9": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0023",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "46",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.701447307169051",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0156706594865274",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.409020187961064",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.130408510255373",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "23",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:6864ea0388f90fdf3d5a0840769fb194": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0024",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "5",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0762442725183751",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.388074947166389",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999997796430203",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.604501360009182",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "24",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:560b390e6daf7bdacebd6f81fc2498ed": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0025",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "21",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.320225944577176",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0850912379420168",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.942502902202007",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.255273713826051",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "25",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:b02b8c006088cba013305b13d972edc8": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0026",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "30",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.457465635110251",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.043916653732793",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.770998817460931",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.190729630640958",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "26",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:a4e0cdaf05e785d8dd95f23ce74745d2": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0027",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0609954180147001",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.44232166254071",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999643232106",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.628562362557851",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "27",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:a57f08ef6a63ebebf16d1533899bc25f": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0028",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "27",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.411719071599226",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0542875242970965",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.83831709934398",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.199876794002946",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "28",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:61ed7bccd640009bb231b2a1982f0622": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0029",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "9",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.137239690533075",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.24643774370434",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999744295990386",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.511832236924399",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "29",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:0095bc91a1253454e74d41690d9f6df3": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0030",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "59",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.899682415716827",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00740144045603054",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.219970513046964",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.061094648971533",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "30",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:fdd0f25c58dffbc950780afac712f03c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0031",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "7",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.106741981525725",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.305873808816549",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999965218155016",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.604287280832693",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "31",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:19300df9cc64fa2764a0780af7af6f84": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0032",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "14",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.21348396305145",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.152527900243506",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.994020866354823",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.374386664234061",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "32",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:5ef4fb1358a9a6249f348a6eb79516e7": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0033",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "9",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.137239690533075",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.24643774370434",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999744295990386",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.511832236924399",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "33",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:520bd6c8ac4aa6408335f0e0c324688b": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0034",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "18",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.27447938106615",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.108241900089372",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.973564689982443",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.292253130241304",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "34",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f881e9cbe818d5f8b37dfed6dec527cc": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0035",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "28",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.426967926102901",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.050541462694511",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.81665481379022",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.194945641821685",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "35",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:4aa4a0455dab2440720331d043f09ec2": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0036",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "13",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.198235108547775",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.166999709083906",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.996321368733297",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.39785224811166",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "36",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:69ca7568c07230cf3584aaca638281b0": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0037",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0609954180147001",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.44232166254071",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999643232106",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.628562362557851",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "37",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:350dbc35c571e3a5c09f2cdc4c910d34": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0038",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "20",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0920729885729446",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.954514323339066",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.278639392496977",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "38",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:5d231bb78e3753cb8f1f83f432b012a4": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0039",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "6",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0914931270220502",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.343388487126378",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999990125608014",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.604501360009182",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "39",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:d962ed566ab823dc017d65a55c96005b": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0040",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "29",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.442216780606576",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0470937359607303",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.79416170413585",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.190729630640958",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "40",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:5ca18f66be2a0317891dd14ae924d09a": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0041",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "24",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.365972508088201",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0676477474681771",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.896743975460065",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.228311147705098",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "41",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:bf714e8e855430179f84817bfe8aa9f4": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0042",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "8",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.1219908360294",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.273933067513935",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999898388010158",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.554714461715718",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "42",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:404e791392df064f45734040de92da30": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0043",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "8",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.1219908360294",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.273933067513935",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999898388010158",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.554714461715718",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "43",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:def46784463991aed85ece366ca75ad8": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0044",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999997153",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "44",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c2de51d4065404a70c8e75ad7f34a79f": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0045",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "21",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.320225944577176",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0850912379420168",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.942502902202007",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.255273713826051",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "45",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f11cdd5ae11ea581dcd3882d3540354b": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0046",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "7",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.106741981525725",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.305873808816549",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999965218155016",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.604287280832693",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "46",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:37773f3cd9125252813f9101750c8618": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0047",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0457465635110251",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.509991966452308",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999963189445",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.688489154710615",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "47",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:b9bf3dcf444022a80942813a2e7f252d": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0048",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0609954180147001",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.44232166254071",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999643232106",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.628562362557851",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "48",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:06de03bbb8e40178692ae6ec9dd3f5d5": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0049",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "16",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.2439816720588",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.128031320700056",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.986394362860718",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.324079280522016",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "49",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:ae0af12ba47d22765200496a05e3cc2e": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0050",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "5",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0762442725183751",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.388074947166389",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999997796430203",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.604501360009182",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "50",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f5ac1b556f82f90ca54e1755f459aeb0": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0051",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999997153",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "51",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:e0f350ef000b2636edd606950fbacdd8": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0052",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.598176099264786",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999998092195",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "52",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:208e0aa56bc32fd1c4efbe75ea40b1a0": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0053",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.598176099264786",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999998092195",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "53",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:6270b7e521adb112773419d81745ba32": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0054",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0457465635110251",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.509991966452308",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999963189445",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.688489154710615",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "54",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:6e8c7efcd65fd269ae1163d977b34228": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0055",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0609954180147001",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.44232166254071",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999643232106",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.628562362557851",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "55",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:8bdb7c1cfc0e4c28f73b9ebb2067be4a": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0056",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "8",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.1219908360294",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.273933067513935",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999898388010158",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.554714461715718",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "56",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:bb0ea248bef4b3a56f8b7bd4674e079a": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0057",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0457465635110251",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.509991966452308",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999963189445",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.688489154710615",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "57",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:3ba5f3e50f85d1172dccf7cdc87e047a": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0058",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0457465635110251",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.509991966452308",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999963189445",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.688489154710615",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "58",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:221ffcb9e61912db0c8ea94c83c806f3": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0059",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0457465635110251",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.509991966452308",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999963189445",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.688489154710615",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "59",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:680f2d4ea6ccf9065674d450817a8a71": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0060",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.598176099264786",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999998092195",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "60",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:cf57b893da54bea9529d4c0bc8ff02f0": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0061",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "6",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0914931270220502",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.343388487126378",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999990125608014",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.604501360009182",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "61",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:06f83c4cb0758a1db3af7b9ac9595bd1": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0062",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0609954180147001",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.44232166254071",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999643232106",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.628562362557851",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "62",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:33c167d8677c415c916bc8b906fd4db4": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0063",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.598176099264786",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999998092195",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "63",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:6f398d8313ba8da3802bd6174fad64a9": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0064",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0609954180147001",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.44232166254071",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999643232106",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.628562362557851",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "64",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:441c62b804db7724fe069a4683eabbb3": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0065",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0609954180147001",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.44232166254071",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999643232106",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.628562362557851",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "65",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:9573a33cf8de1d0d7462efcefe1aa3b3": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0066",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999997153",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "66",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:adc671bb3b8aead7b73b777448e0d974": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0067",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "5",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0762442725183751",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.388074947166389",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999997796430203",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.604501360009182",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "67",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:e9779649e0e322514fd2b0963b83e9b3": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0068",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.598176099264786",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999998092195",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "68",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:41fb45bc18bea4725f44ca167cd99df1": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0069",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.598176099264786",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999998092195",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "69",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:eea8668c9a2e77333db7bb9162d0d4ef": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0070",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999997153",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "70",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:dd0835679f1bd959157bd71b4d4ada4a": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0071",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999997153",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "71",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:7cdc9365fde87ad8333e6618dc3a8a51": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0072",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999997153",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "72",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:7de4f98c4ea2239ac1a4b37fb8737ebb": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0073",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999997153",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "73",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:392bbfa2f02e1783423c67df389a3772": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0074",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999997153",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "74",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:e08ea74eba6d829dc8f77ccdfebbc2e1": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0075",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999997153",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "75",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:81ce1dbb2b4b3915a17f1002f7600876": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0076",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999997153",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "76",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:8ab01cc9ec9b9c9144318b6ebf4b61e5": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0077",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999997153",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "77",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:e00f285b0f3ca710fd516c8d96d4953b": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0078",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999997153",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "78",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:b113d084583b1c858c15b076e563ba0c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0079",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999997153",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "79",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f9a8bd72695ec56fe97eefd5b04d42d4": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0080",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.598176099264786",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999998092195",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "80",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:3a4ff3f083b479126599de2b93ee4494": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0001",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e8cb4af6e2287b93daaa35d9368e138f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "7.92007970809937",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "6.94608360738412",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.87783122385099e-12",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "4.18813870695089e-07",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "5.21674435923017e-06",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e8cb4af6e2287b93daaa35d9368e138f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0001",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[46,16,24]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c1930c3f0150f6f5873ea6a691551e74": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0002",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ddb568a298d8393fcda5254093cef5a1",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.31603479385376",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.77079466112137",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.94492849498107e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.000879943865776389",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000830722551601523",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ddb568a298d8393fcda5254093cef5a1": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0002",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[32,24,-4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:517d6fcfeee2d840a2f52301d1beebd1": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0003",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:bf75fde12cfced38bab64da3a1c7e7bd",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.68819808959961",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.27450168515333",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.655864770444e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0121028975026269",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00350091530962783",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:bf75fde12cfced38bab64da3a1c7e7bd": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0003",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[18,16,4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:be45fc5c8318611dbeb6926eff14603d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0004",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0bb09b273612bdec706a34e18f9bcded",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "7.11683940887451",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "6.37404871703245",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "9.20510334623259e-11",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "2.05325778424026e-05",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "9.33757664730496e-05",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0bb09b273612bdec706a34e18f9bcded": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0004",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[34,-88,-2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f732c2c67e196714c26505f667b9c2d1": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0005",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0f15cb6ae5a62f7643842075286cf4fe",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.48292255401611",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.8992593141605",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.82568493656277e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.000407231755366277",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000830722551601523",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0f15cb6ae5a62f7643842075286cf4fe": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0005",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[42,-72,-10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:cd40c3fa5c01d430365872162ed32735": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0006",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:dcffc4466433c7a4343c26a918e412f8",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.2275915145874",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.89738468004472",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.85602978606003e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0670610253017228",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0118363293065346",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:dcffc4466433c7a4343c26a918e412f8": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0006",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[34,-86,12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2850c3df9bf571ce4f3306beddf5444f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0007",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:bfd22ab330963feb1e9bfb0094e06fad",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.28007745742798",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.74292583422276",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.65272453897825e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00103782272796227",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000830722551601523",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:bfd22ab330963feb1e9bfb0094e06fad": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0007",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[8,18,50]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f822a28c39d3ea42481d34bbc8df22dd": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0008",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e2981bd8238c191c38e7681182953e91",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.15222215652466",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.64328512810061",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.34178537356678e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00186069357054308",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000972721201433817",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e2981bd8238c191c38e7681182953e91": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0008",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-6,12,52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0601bd281b645fc4e7cea6590daaea37": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0009",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4223785a2c52847776be8e182b12c3a7",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.98517084121704",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.51181334779297",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.77577724747024e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00376326218366319",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00136419627856355",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4223785a2c52847776be8e182b12c3a7": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0009",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[8,32,38]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:eeb7eca4dd37f5ca956393c13b86f395": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0010",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:9350f7883a57d93d1d3bf27b2227a68d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.25127363204956",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.72055271981637",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.30890376104765e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0011841880966994",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000830722551601523",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:9350f7883a57d93d1d3bf27b2227a68d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0010",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[52,-32,42]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4fad84948d108d419b34432aba0aaf97": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0011",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:9443d25369cbea84515f23e7d0f92386",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.24752378463745",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.71763687476157",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.40078304300806e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00120468241369565",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000830722551601523",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:9443d25369cbea84515f23e7d0f92386": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0011",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[40,-62,50]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:25794aacdb036e5295f9624245fbac2d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0012",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e07f914385d7440f95f63702677992f0",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.70337772369385",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.28674301747281",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.22566831420812e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.011413186758684",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00350091530962783",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e07f914385d7440f95f63702677992f0": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0012",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[56,-44,52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:cb9ecebff84e7c0bcff30f16d62e415c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0013",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d53d6dc777cb961845f7af09a33453e0",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.69516134262085",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.28011855642631",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.45501619933597e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0117816592148946",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00350091530962783",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d53d6dc777cb961845f7af09a33453e0": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0013",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[60,-36,54]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0108e1dedeb535eeacb8a83cdebc4299": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0014",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0c45c162c51c7e916c4ae63fd56c3aed",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.10109901428223",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.60320502193174",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.05212039080982e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00234682813060005",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00104518293275697",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0c45c162c51c7e916c4ae63fd56c3aed": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0014",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[32,2,46]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a83bcc10e77d0eaa4587d34a0f971292": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0015",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:bd5f175b844254cd01005a778cafe8ff",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.6086859703064",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.3736141683061",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.11031435759912e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.453877178455514",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0599714495109201",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:bd5f175b844254cd01005a778cafe8ff": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0015",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[28,4,58]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c560dc9de917957ed93bc5ed23e74ca3": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0016",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:3e99bb8f1bc3edfb1797aa2727ed8adf",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.98348569869995",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.51047970249337",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.78928538652201e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00378871596531738",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00136419627856355",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3e99bb8f1bc3edfb1797aa2727ed8adf": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0016",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-52,0,38]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:afb5bbe52a67b2392f36dae9544d164a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0017",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e0bb2d0e4116aafc8738a07ec9fc9a59",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.98950004577637",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.69817956585148",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.31245304380023e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.151048137890434",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0233609510296683",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e0bb2d0e4116aafc8738a07ec9fc9a59": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0017",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-44,6,28]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2f7f394faa4711ed3169c6970ab86c8c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0018",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:9fe79a527627db4bf120eb97627c5ba7",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.52650570869446",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.41313019486981",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000321106265798399",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999548134574",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.545515072619331",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:9fe79a527627db4bf120eb97627c5ba7": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0018",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-56,-6,42]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:60597e96058be6ccc3c820043eb1f0ad": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0019",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:9ad31699bbc5f159347fe96fef53bddf",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.78093099594116",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.34909755317379",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.41969442155354e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00844151822925698",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00286742427823329",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:9ad31699bbc5f159347fe96fef53bddf": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0019",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-34,-2,52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:787ff7b095f58a2e09fb3664f762f1c8": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0020",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:2f6cbfedd61275c7b99e20bc3e0b4018",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.40964078903198",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.04774404642803",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.23528758724889e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0346958937061391",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00846044059259994",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:2f6cbfedd61275c7b99e20bc3e0b4018": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0020",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-54,-46,58]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f4ca1c6a92843304c08668c4cebb90a9": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0021",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7701a76f43b9fef7a78168a4da944cb1",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.40141773223877",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.04098917180003",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.31565837394143e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0357643345560115",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0106752417476244",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7701a76f43b9fef7a78168a4da944cb1": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0021",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-28,-94,2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:05f82a99448b178e8b7d8ecb6d85d07b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0022",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a8fb5389016788e2b146dc701cbdc00c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.31841945648193",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.97261482231588",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.30279114724163e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0484353441449864",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0106752417476244",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a8fb5389016788e2b146dc701cbdc00c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0022",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-62,-38,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:be00ee78cfab94c36be515c9ca78cb48": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0023",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:8da199a5d41709f457ea9104658c0771",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.57099342346191",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.34109644800954",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.08867353027554e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.496004086968197",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0635474729952592",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:8da199a5d41709f457ea9104658c0771": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0023",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-60,-50,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:af6e82fac7bbf3d7f1621abbe68ecb05": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0024",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:10b939b5d1d5994f17ba7c7ff8d864c8",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.30699443817139",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.96317509467693",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.46750043123123e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0504786376455083",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0106752417476244",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:10b939b5d1d5994f17ba7c7ff8d864c8": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0024",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[32,40,16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:af063a2fc9451b1a0f6d15b4c16c6d93": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0025",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:21d15b73a290e3ff6af5dfd0e0823244",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.5497465133667",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.32273570618355",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.7053150754347e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.520378392891944",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0649997423676262",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:21d15b73a290e3ff6af5dfd0e0823244": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0025",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[40,46,12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5ed2c66afda9fc1f8f0e1230a1423370": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0026",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a28b17ed80d2b68fdc921f59f0f167eb",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.31582498550415",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.11913273798974",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.90150518718513e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.788829013385429",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.116130094830597",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a28b17ed80d2b68fdc921f59f0f167eb": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0026",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[36,54,6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4ecf61302a9d659bed84b678acd8b8a3": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0027",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:36fb1e060c03001906e067f973d6addd",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.27030229568481",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.93281349716267",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.05267701952816e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0575990926145485",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0110040663565173",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:36fb1e060c03001906e067f973d6addd": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0027",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[40,26,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:136c9c9df0e52f1962b71b13186923b6": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0028",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:49d23550974006889f810999f02b6b52",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.93343877792358",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.65085575575197",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.6528024058271e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.180887232162623",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0254967087736733",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:49d23550974006889f810999f02b6b52": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0028",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-58,-30,-18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f946131984efa63e6aeba7b2a660d9a2": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0029",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:cf3fb8e35e4c268c2eeb328480decb9c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.76414346694946",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.50698548813516",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.287756441539e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.301278778226174",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0396433885053995",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:cf3fb8e35e4c268c2eeb328480decb9c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0029",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-46,-66,-6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:65cd1425049190819614ec8b724da79c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0030",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:88d00fbb1ce3816c9097d2466e1ade94",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.7637345790863",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.62829384243901",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000142650218672435",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999605970761399",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.34409224637793",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:88d00fbb1ce3816c9097d2466e1ade94": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0030",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-54,-64,-8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1038f5b8ec149150369ced9f4ef14d84": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0031",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:556ae55aaa299d4d49dc193ab39255bf",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.72232866287231",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.47122948835043",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.88855941602095e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.338512677882141",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.044836631144536",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:556ae55aaa299d4d49dc193ab39255bf": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0031",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[58,-38,6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ecf27cff24accc7da10b3c89a35e94bd": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0032",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:38ca5b29b1a44ecc2f165779c9f6945f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.88437390327454",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.73675248173504",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "9.32061303765552e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.996350207228297",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.273673640636879",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:38ca5b29b1a44ecc2f165779c9f6945f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0032",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[64,-32,-4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9d277a53a24699d648dda94e1edb30a0": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0033",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7188d7ddb6523611068b2892e353d78a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.50753784179688",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.39582098150001",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000342115474631921",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999778829603",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.564856004417035",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7188d7ddb6523611068b2892e353d78a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0033",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[60,-40,-12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:29818f2935a525fc4869ee33b8cc7b28": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0034",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d530a8fef909fd9f9de09043bc6a29b8",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.70483255386353",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.45624265093732",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.17043099876224e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.354967306449537",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0466228196503302",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d530a8fef909fd9f9de09043bc6a29b8": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0034",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-36,-74,-14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:fecb6f93c50d8f21e158114c7bc5c612": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0035",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:87b30d0dacfbf3a6baea12b321dbe3ca",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.08770418167114",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.91804495668",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.46350297789166e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.955724279224547",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.186719971332974",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:87b30d0dacfbf3a6baea12b321dbe3ca": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0035",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-36,-68,-20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:edde077bec74c6cf6f6e249592b326c1": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0036",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f3774aa2c82de202d63a2de644c906a7",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.71012616157532",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.57988831343959",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000171870546999631",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999883757236262",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.385893135248467",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f3774aa2c82de202d63a2de644c906a7": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0036",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-30,-58,-16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a96987019566061347adea1fb3ca7702": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0037",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:14a79f1b76bb47c7ca62842d674145d2",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.57891654968262",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.34793761600864",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.87118388575936e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.487021764768749",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0629240173925056",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:14a79f1b76bb47c7ca62842d674145d2": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0037",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-60,-16,28]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9bb5d42691cee918ce4d479afc518088": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0038",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b82ab7eaee85ede4d79638cc7b03af67",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.48185300827026",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.26391634421444",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.00437338077519e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.600177833033677",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0894660991036064",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b82ab7eaee85ede4d79638cc7b03af67": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0038",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[18,16,62]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3ab755e42b6e08f17828f58fe2dd123b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0039",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:5f932ae285e704d39f11ceec314ec660",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.37013816833496",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.16664310578498",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.54558935169247e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.730405153245217",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.101858458171742",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:5f932ae285e704d39f11ceec314ec660": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0039",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-52,-62,52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:86f0d921cd39a0e58bec940eba62746e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0040",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:066a0f8c565a7cecb402e87bb821a838",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.24533367156982",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.05725918601008",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.4825985211363e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.855631833511506",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.135717263652471",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:066a0f8c565a7cecb402e87bb821a838": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0040",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-18,-60,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c2069dff2662c758ed500ee4348b7b32": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0041",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:aa8f70fe82ef3aa7629e2e97b230ab16",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.22729349136353",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.04138628171284",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.65680735640483e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.870712357794855",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.138603763901635",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:aa8f70fe82ef3aa7629e2e97b230ab16": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0041",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-20,-98,22]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:01af14b9357e03fab37d07283367aa67": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0042",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b19e680fa92673699b5d7811f246dc5a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.22599840164185",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.04024618213588",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.66975618669063e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.871760516202526",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.138603763901635",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b19e680fa92673699b5d7811f246dc5a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0042",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-36,-74,-34]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:feb2ebab3443b1487f09e60430381080": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0043",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:30864274adf86d85cec9fa93ad094f06",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.21435213088989",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.02999009325983",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.78896018329755e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.880974433980664",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.143583628261646",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:30864274adf86d85cec9fa93ad094f06": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0043",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-26,-92,30]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b20862f472f9d77c1662db6b2eca294f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0044",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:72a654d54ab595719acda55869b4754f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.20391035079956",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.02078923241408",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.900174224163e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.888907080881232",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.143583628261646",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:72a654d54ab595719acda55869b4754f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0044",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[34,-54,-16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:fd4266dd0bb219a6a241ff6533c36ff6": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0045",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:fc644bec2a9708abb95907ff040d5630",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.17404651641846",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.99444589181498",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.24228638075574e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.909844421846994",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.153735203854581",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:fc644bec2a9708abb95907ff040d5630": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0045",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-40,-38,44]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:109fbb4d397a1909eb3b295464058f51": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0046",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f06d5ad7743673ee5c44accc1ccd4693",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.12488555908203",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.95098834792843",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.89145570423022e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.938594159355111",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.172448885449819",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f06d5ad7743673ee5c44accc1ccd4693": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0046",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[14,-98,4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2d19dc148fa248efc7a3df765c6a06cb": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0047",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:01b946515c1c0572e49c00274feae5bc",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.12145137786865",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.94794832362008",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.94119065879606e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.940339218142555",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.172448885449819",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:01b946515c1c0572e49c00274feae5bc": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0047",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-48,-72,2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:13cbba597089b29e46b69027980a685e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0048",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:187d5d28119342c706dc84a629c3f64c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.07333517074585",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.9052963692066",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.70549882543025e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.961337330645756",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.192831151077206",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:187d5d28119342c706dc84a629c3f64c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0048",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[20,-66,34]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:46ae4164bfa8a7fd52ad313b6b95ad52": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0049",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:95c55eeeed13d264184e830910c60b20",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.05762767791748",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.89134919103145",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.98441713834286e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.966867400896655",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.199920408224698",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:95c55eeeed13d264184e830910c60b20": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0049",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-46,-56,14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6ec3e0f95a4dca384d07f9fba19f7d96": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0050",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0393612c8584550483fc955cb87af40e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.97341108322144",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.81637469850314",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.7713399346081e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.987160063394768",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.237117251115433",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0393612c8584550483fc955cb87af40e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0050",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-50,-50,20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3f8990df299e6c17b1734919846f4c6f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0051",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:78a29eee84d8fb0874ce0bc42c8d8c0c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.03719234466553",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.87318677164159",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.37107204765519e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.973166168280088",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.210147957128937",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:78a29eee84d8fb0874ce0bc42c8d8c0c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0051",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-48,2,50]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:aa18f0ad742a246e138666daf0480e72": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0052",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0bcb0950fefd4e3b5cbefda9af5fd682",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.0217924118042",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.85948683644491",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.68126885931441e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.977286609355005",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.217632520436791",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0bcb0950fefd4e3b5cbefda9af5fd682": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0052",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-36,-40,-36]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:bcaf0c8e6a688a504f644ea44b72c874": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0053",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c18ca0f70ac22ec9bab26c8c3ac14734",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.97676801681519",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.81936952854042",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.68966021436512e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.986609697042008",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.237117251115433",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c18ca0f70ac22ec9bab26c8c3ac14734": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0053",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[50,-52,60]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:32ff477de924235c5522ee862332ff7c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0054",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6bef910ff6ac94722e287b9d2729d1e1",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.9634416103363",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.80747753892992",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.01957428701494e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.988689669381963",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.237117251115433",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6bef910ff6ac94722e287b9d2729d1e1": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0054",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[4,6,32]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f538dc161505199a9d4a9dc200bbfbd1": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0055",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:af082644064d49a87df191a50e018a1f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.96245408058167",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.80659597790245",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.04463150378309e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.988832912076595",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.237117251115433",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:af082644064d49a87df191a50e018a1f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0055",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-50,-48,-16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d0d01153923178a42866f6f64e32d01c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0056",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6e604072f92df73cd898dcd2f349304a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.95309829711914",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.79824190359279",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.28630328464819e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.990119383011277",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.243341582944922",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6e604072f92df73cd898dcd2f349304a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0056",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[44,4,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:970399f54bebe49057e2e105ecea663c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0057",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:2deadff2e7be322b63ec9667a75a3e66",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.92427015304565",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.77247501519699",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.08180782938539e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.993353008667813",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.257401847609111",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:2deadff2e7be322b63ec9667a75a3e66": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0057",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[34,12,64]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1a51f95440dce51af59c428b51c26851": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0058",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:da6ab50c8b91b09b511975b823c28c39",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.9098813533783",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.75959988615137",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.50926599039736e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.994607633788328",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.264100967145263",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:da6ab50c8b91b09b511975b823c28c39": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0058",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[54,-24,-2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:87fdac079acb3a60695755078ec9ff23": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0059",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:2b2fc48f07fee7b33d6bccd9c1aaf3e2",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.90759468078613",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.75755289319297",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.57915531067288e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.994787688943672",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.264100967145263",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:2b2fc48f07fee7b33d6bccd9c1aaf3e2": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0059",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-14,-98,-4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:dc459f0a0e3ee90c5e29e061346c5e6a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0060",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:3c7c82e3cab9399987475ea5f2e30a60",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.90285301208496",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.75330746420074",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.72582920719012e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99514521861122",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.264100967145263",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3c7c82e3cab9399987475ea5f2e30a60": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0060",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-36,-46,-18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f41100c4c035a126bb3e090ac5b96ef2": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0061",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:189bf1ada1eef7b44db4d193f2a65962",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.8867518901825",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.73888373627584",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "9.24195907030523e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.996210852184447",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.271701156704036",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:189bf1ada1eef7b44db4d193f2a65962": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0061",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-50,-46,-32]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:12d30f83fba50c448c40e1fea8540142": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0062",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e74e6fef095025d78f7d87d10fe04d0b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.82178378105164",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.68056404693028",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000116359297336222",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.998750111206092",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.307505393775956",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e74e6fef095025d78f7d87d10fe04d0b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0062",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[12,52,-12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3b77fd4f30cbd966a672c142e10cd1ec": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0063",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:937f76ecbce55de2fa752519e4da8b1e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.81266117095947",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.67235967240763",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000120160560553639",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.998946217488595",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.312228840798665",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:937f76ecbce55de2fa752519e4da8b1e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0063",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[36,54,20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8636582fe5845fabfeeef03ea097da99": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0064",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:dea96efaeecd8d7265aff2a6bf2a2ae8",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.80767583847046",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.66787455107711",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000122287561408974",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999041631710947",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.312228840798665",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:dea96efaeecd8d7265aff2a6bf2a2ae8": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0064",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[22,-80,54]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:82603814879a87f0ffb468aa32aadf1d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0065",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c94ea4de157b0c9d29d9fd4d205f5607",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.7885959148407",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.65069869844077",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000130763947768786",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999340802437346",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.325675502417125",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c94ea4de157b0c9d29d9fd4d205f5607": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0065",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[22,40,26]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ce7014584411a4e6030e1b6874e61edb": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0066",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a2ec71c72c91d6abcb527c15c9c3f40d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.78668808937073",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.64898036269368",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000131641613210109",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999365630484476",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.325675502417125",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a2ec71c72c91d6abcb527c15c9c3f40d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0066",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-22,-74,60]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1914d7526225245a6b8afde3e39c1ba6": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0067",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:5af3e20e07b7118fe0888052b8cfcab7",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.71480798721313",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.58412084932714",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000169107736440521",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999869855188705",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.383925327139989",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:5af3e20e07b7118fe0888052b8cfcab7": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0067",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-34,-84,-2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:34abe905d1d081ef06aa532dca4df55e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0068",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:980e6c21a07dfe3b31d1697a47c25f1d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.69408750534058",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.56538143418403",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000181663694368006",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999921818129803",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.399826018660701",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:980e6c21a07dfe3b31d1697a47c25f1d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0068",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[50,46,-12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7f523ca7243bef20f31c8eb562ee6271": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0069",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d62e229f0b52ec9242d7f41c5d3e36bf",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.65790581703186",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.53261354467296",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000205736742878826",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999969815552823",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.430567192397012",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d62e229f0b52ec9242d7f41c5d3e36bf": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0069",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[52,-46,-12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:11cc93907e041bf61389cd50514f54ae": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0070",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c9a383c2a53704da619a4a92b0b47a77",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.65459251403809",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.52960997534834",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000208086348004177",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999972447579615",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.431239033859527",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c9a383c2a53704da619a4a92b0b47a77": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0070",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[54,8,-36]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e0c55ebec0ecd249a6a1221b9000af8b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0071",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6ad9741eec3138fb7501dba131b7c01a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.60870504379272",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.48796269267718",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000243357993216953",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999992770534091",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.475991356580954",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6ad9741eec3138fb7501dba131b7c01a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0071",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[40,-52,68]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:010e57748e944b9a5344c65b7dcca649": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0072",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:3c7a921ea450332ded31c7e83f039528",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.60173606872559",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.48162963814792",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000249186237945009",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999994173508246",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.477936808108637",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3c7a921ea450332ded31c7e83f039528": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0072",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-14,58,10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7c4a82dba1a9aef0c16e95acba02ea74": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0073",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b64f47ef39dc6d1ee386d9414e21721c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.58989810943604",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.47086705539024",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000259390388114844",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999995993033212",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.486123239113482",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b64f47ef39dc6d1ee386d9414e21721c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0073",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-66,-36,22]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1ee2a189ddde50048e5bc2471880d25e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0074",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6da0792c18731727d1fd106d98144c77",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.56340670585632",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.44676015888715",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000283676007278189",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999998329299787",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.513357841480064",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6da0792c18731727d1fd106d98144c77": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0074",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[18,60,12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:17365311e977a0f7612d95a39cd6fdc2": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0075",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:3d8fb7e482b175f8eeba0bb983116a40",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.55537104606628",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.43944179853069",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000291457553818653",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999998731920076",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.518882279088377",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3d8fb7e482b175f8eeba0bb983116a40": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0075",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-64,-34,8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1aa22f63d5d63be3e71695c4f2ce2cf2": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0076",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:bacf64ffb57e108f35e206bfb1eea36e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.55148839950562",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.43590473729199",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000295289297083445",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999889206113",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.518882279088377",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:bacf64ffb57e108f35e206bfb1eea36e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0076",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[64,-34,16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c6643c3287ba5b3c7c9ae880836c753c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0077",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:50f9cac6df1136e4e7d38b392707df25",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.51380252838135",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.40153955037634",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000335037159349127",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999971905221",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.559625109906516",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:50f9cac6df1136e4e7d38b392707df25": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0077",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[48,12,50]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d0858c2460bb3887c10ea7cc932fda7e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0078",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:91f4aee1b203764ec626f1b44c205485",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.46123600006104",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.353503690367",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000398976748636981",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999965973308",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.628488500556802",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:91f4aee1b203764ec626f1b44c205485": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0078",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[14,-14,70]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ce7fafbed4002da1a8d55bef85886de8": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0079",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f43bc57e246dba1a18fe143d2e61fabb",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.45441365242004",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.34726077209469",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000408071982705316",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999974583179",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.628488500556802",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f43bc57e246dba1a18fe143d2e61fabb": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0079",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-38,-54,-42]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:703dca43a303429db425b818bc12c6a4": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0080",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:3c414ad1fd71de414c026f189f78779b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.43550229072571",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.32994532400952",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000434315195478541",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999988927098",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.654261098812949",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3c414ad1fd71de414c026f189f78779b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0080",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[22,44,-16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:43941dd0099dba7340078c94b1f176e4": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0081",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:14d4d48691f4187769651ca7e448575f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.43198323249817",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.32672157755253",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000439370628491198",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999990548038",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.655840530088522",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:14d4d48691f4187769651ca7e448575f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0081",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[42,-42,14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9a9c1fe4c7f0e8236338ec3ccf5fb8c1": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0082",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e8cd739d9997617595ca094639c0d767",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.40386486053467",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.30094422133281",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000481800187664638",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999997442132",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.689466168942319",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e8cd739d9997617595ca094639c0d767": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0082",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[52,-42,18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5aaecc8f07f4c4f973768fbf89a146da": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0083",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6d64cee175b474ae9c60ccad84bf5aed",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.36533284187317",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.26556677338515",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000546226226643243",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999624169",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.751744172496132",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6d64cee175b474ae9c60ccad84bf5aed": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0083",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[44,-48,-26]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:48bf8ce794db930df930c41d224bdc16": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0084",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a186d322a8d32a9dcd3c456718013455",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.3379864692688",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.24042202275062",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000596764555146345",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999912202",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.787874793017543",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a186d322a8d32a9dcd3c456718013455": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0084",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[46,-40,44]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:553299baed01f241bd72ebf115908e51": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0085",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:089c8164018121709a50c5c000adb8b4",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.33372783660889",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.23650348537689",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000605018743711327",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999930494",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.791142662581953",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:089c8164018121709a50c5c000adb8b4": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0085",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[16,4,16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6eaf36636b84719dcdad3b87ac63db9d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0086",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:48ea271c59c0d27824322ff2afca20a5",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.32532405853271",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.22876865896546",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000621622108231912",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999995642",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.802213727911317",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:48ea271c59c0d27824322ff2afca20a5": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0086",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-54,-32,42]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e375fd72351a936406457560ff4bf243": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0087",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e8219e816a81544fd1542b7c43739e8d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.3035409450531",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.20870610659348",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000666668530368786",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999987468",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.829570299628891",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e8219e816a81544fd1542b7c43739e8d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0087",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[22,38,10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:19a0feb2eced3573854928d35a375bea": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0088",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0865df5da5b73976893b2a73cf860d9d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.29107904434204",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.19721985733158",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000693795605607228",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999994003",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.839453948823053",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0865df5da5b73976893b2a73cf860d9d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0088",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[30,34,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0e5f9cfe273ad2b56c5d941a8fa1d751": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0089",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:831e9d6a1c1a2ca8f3a901a82bb321af",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.27154183387756",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.17919960131803",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000738411785119797",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999998178",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.858755937068456",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:831e9d6a1c1a2ca8f3a901a82bb321af": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0089",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[10,-76,-12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9ae75a88cde46be90790ef06a7e29dee": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0090",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:8f64ab79b8b00ebd627396d051504046",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.2669575214386",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.17496900913942",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000749262523860983",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999998632",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.863075307004762",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:8f64ab79b8b00ebd627396d051504046": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0090",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[20,32,54]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7e114fc2dca77ff7f26aca5c69c3b36c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0091",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c125b47469686fd33678c1b78d004968",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.26226496696472",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.17063765299814",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000760523733375762",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999998982",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.867640730428823",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c125b47469686fd33678c1b78d004968": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0091",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-60,-14,10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:65129edf8c444af2b8ae3ebfb73d5a95": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0092",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c218dfdf71b575e423a61a71046e3254",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.25743293762207",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.16617663527645",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000772284854291594",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999251",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.872516606801204",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c218dfdf71b575e423a61a71046e3254": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0092",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-22,-94,28]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3d4630be29adc78b6133a798da406017": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0093",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e30ef537b55de5d1df0298565809152d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.25416302680969",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.16315726358056",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000780339994975288",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999392",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.874305136305167",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e30ef537b55de5d1df0298565809152d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0093",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-66,-46,8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3399f5c31ecf4ca8aaa4e0dc4d2629cb": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0094",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:5ffd97e765bdcd6a40cee30a818bf20b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.24836373329163",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.15780125799237",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000794819459152607",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999582",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.881177035765112",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:5ffd97e765bdcd6a40cee30a818bf20b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0094",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-68,-34,-8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b0d26737223ecac9b30bc4e6d357903d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0095",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:724852999b8744da36a792174695ead8",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.23741388320923",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.14768473672474",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000822845399445549",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999796",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.899808991491498",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:724852999b8744da36a792174695ead8": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0095",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-16,2,64]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e2f4bde66682178e0070983ec98c509e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0096",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ba9cc9e29049445b143af1ec4b4403bf",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.23679161071777",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.14710967833961",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000824465484375092",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999804",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.899808991491498",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ba9cc9e29049445b143af1ec4b4403bf": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0096",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-56,34,-20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a5e53303ae16c0a4417cd3327ff317ba": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0097",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:9b75309624d284042d8f748c6299b979",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.22331190109253",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.13464894829369",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000860299398633191",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999921",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.917823543835361",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:9b75309624d284042d8f748c6299b979": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0097",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[42,-86,12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:acda002ca084ac39e0dc294ad4a29af7": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0098",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d76d5a8db54f907ce0bcdb7be6430159",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.19609522819519",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.10946777700093",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000937123635013748",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999988",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.958204454708765",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d76d5a8db54f907ce0bcdb7be6430159": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0098",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[14,40,20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1aebec9df0ae7e94b35fcd5f1681e2b8": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0099",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e3d8e69139ddc1af81e4b6a9cc70c133",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.19474077224731",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.10821385730133",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000941109068576473",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999989",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.958204454708765",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e3d8e69139ddc1af81e4b6a9cc70c133": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0099",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-44,-42,-36]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e95fde56ae83d5db12a5db6e6b137be0": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0100",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:81fbc09a7af80e50862290bf64c5c485",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.18584132194519",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.0999731910723",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000967690796773613",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999994",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:81fbc09a7af80e50862290bf64c5c485": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0100",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-16,4,60]",
+                "type": "xsd:string"
+            }
+        }
+    },
+    "activity": {
+        "niiri:b67465cae2012be9d953c04ba0ee6bb4": {
+            "prov:type": {
+                "$": "nidm_ModelParametersEstimation:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Model parameters estimation",
+                "type": "xsd:string"
+            },
+            "nidm_withEstimationMethod:": {
+                "$": "obo_generalizedleastsquaresestimation:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d1e92a419c3d7e1b91add9945c81aa9b": {
+            "prov:type": {
+                "$": "nidm_ContrastEstimation:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Contrast estimation",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1101ecb253f39161ef657cfcf8181ba6": {
+            "prov:type": {
+                "$": "nidm_Inference:",
+                "type": "xsd:QName"
+            },
+            "nidm_hasAlternativeHypothesis:": {
+                "$": "nidm_OneTailedTest:",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Inference",
+                "type": "xsd:string"
+            }
+        }
+    },
+    "agent": {
+        "niiri:7d55eee26233e3ffebe8fb466230d746": {
+            "prov:type": [
+                {
+                "$": "src_SPM:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "prov:SoftwareAgent",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "SPM",
+                "type": "xsd:string"
+            },
+            "nidm_softwareVersion:": {
+                "$": "12.6906",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:fcffff56d818fa0f4fd06f330c7fd209": {
+            "prov:type": [
+                {
+                "$": "nlx_Imaginginstrument:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nlx_Magneticresonanceimagingscanner:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "MRI Scanner",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:db4e0548483590dda7e45661cf53201d": {
+            "prov:type": {
+                "$": "prov:Person",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Person",
+                "type": "xsd:string"
+            }
+        }
+    },
+    "wasGeneratedBy": {
+        "_:wGB20": {
+            "prov:entity": "niiri:b129871a86340316a5e71da151467968",
+            "prov:activity": "niiri:b67465cae2012be9d953c04ba0ee6bb4"
+        },
+        "_:wGB22": {
+            "prov:entity": "niiri:5452b79c7f6c0fb6d103555e4ba5ab0b",
+            "prov:activity": "niiri:b67465cae2012be9d953c04ba0ee6bb4"
+        },
+        "_:wGB26": {
+            "prov:entity": "niiri:fac828643e618f4bd2bcc17d9b2c23db",
+            "prov:activity": "niiri:b67465cae2012be9d953c04ba0ee6bb4"
+        },
+        "_:wGB30": {
+            "prov:entity": "niiri:648e908d9842014984d36e153dd159b3",
+            "prov:activity": "niiri:b67465cae2012be9d953c04ba0ee6bb4"
+        },
+        "_:wGB34": {
+            "prov:entity": "niiri:cecb740cce9e1407b8cd6a8aeb90385e",
+            "prov:activity": "niiri:b67465cae2012be9d953c04ba0ee6bb4"
+        },
+        "_:wGB38": {
+            "prov:entity": "niiri:71f2801581b2abe311d3914ca638ba77",
+            "prov:activity": "niiri:b67465cae2012be9d953c04ba0ee6bb4"
+        },
+        "_:wGB42": {
+            "prov:entity": "niiri:7adfaca483dfbb4c69fe57814c2e7ba5",
+            "prov:activity": "niiri:b67465cae2012be9d953c04ba0ee6bb4"
+        },
+        "_:wGB56": {
+            "prov:entity": "niiri:730c67ccd0e52a39ba60c5796037b4e0",
+            "prov:activity": "niiri:d1e92a419c3d7e1b91add9945c81aa9b"
+        },
+        "_:wGB60": {
+            "prov:entity": "niiri:4f98291a207d3b592ea963c5b2efee61",
+            "prov:activity": "niiri:d1e92a419c3d7e1b91add9945c81aa9b"
+        },
+        "_:wGB62": {
+            "prov:entity": "niiri:d590545b386aedf38aa5ec2c2ea31ee5",
+            "prov:activity": "niiri:d1e92a419c3d7e1b91add9945c81aa9b"
+        },
+        "_:wGB85": {
+            "prov:entity": "niiri:73df7ed02a3cef4b6cbeb78f33bff831",
+            "prov:activity": "niiri:1101ecb253f39161ef657cfcf8181ba6"
+        },
+        "_:wGB89": {
+            "prov:entity": "niiri:275a137c82db0d48c36216f7ba80d8d2",
+            "prov:activity": "niiri:1101ecb253f39161ef657cfcf8181ba6"
+        }
+    },
+    "used": {
+        "_:u14": {
+            "prov:activity": "niiri:b67465cae2012be9d953c04ba0ee6bb4",
+            "prov:entity": "niiri:55ba018663409d2f002b8707d5149e83"
+        },
+        "_:u15": {
+            "prov:activity": "niiri:b67465cae2012be9d953c04ba0ee6bb4",
+            "prov:entity": "niiri:3eafaf3b0d4fb27e0273cf883045c71c"
+        },
+        "_:u16": {
+            "prov:activity": "niiri:b67465cae2012be9d953c04ba0ee6bb4",
+            "prov:entity": "niiri:b4b0efe73f8e31624573c955a3b91929"
+        },
+        "_:u46": {
+            "prov:activity": "niiri:d1e92a419c3d7e1b91add9945c81aa9b",
+            "prov:entity": "niiri:b129871a86340316a5e71da151467968"
+        },
+        "_:u47": {
+            "prov:activity": "niiri:d1e92a419c3d7e1b91add9945c81aa9b",
+            "prov:entity": "niiri:71f2801581b2abe311d3914ca638ba77"
+        },
+        "_:u48": {
+            "prov:activity": "niiri:d1e92a419c3d7e1b91add9945c81aa9b",
+            "prov:entity": "niiri:55ba018663409d2f002b8707d5149e83"
+        },
+        "_:u49": {
+            "prov:activity": "niiri:d1e92a419c3d7e1b91add9945c81aa9b",
+            "prov:entity": "niiri:32ab289c9b156044343a8e1edd8ec1d0"
+        },
+        "_:u50": {
+            "prov:activity": "niiri:d1e92a419c3d7e1b91add9945c81aa9b",
+            "prov:entity": "niiri:fac828643e618f4bd2bcc17d9b2c23db"
+        },
+        "_:u51": {
+            "prov:activity": "niiri:d1e92a419c3d7e1b91add9945c81aa9b",
+            "prov:entity": "niiri:648e908d9842014984d36e153dd159b3"
+        },
+        "_:u52": {
+            "prov:activity": "niiri:d1e92a419c3d7e1b91add9945c81aa9b",
+            "prov:entity": "niiri:cecb740cce9e1407b8cd6a8aeb90385e"
+        },
+        "_:u73": {
+            "prov:activity": "niiri:1101ecb253f39161ef657cfcf8181ba6",
+            "prov:entity": "niiri:53e9321dbde376b31728c3d81f4a0a0b"
+        },
+        "_:u74": {
+            "prov:activity": "niiri:1101ecb253f39161ef657cfcf8181ba6",
+            "prov:entity": "niiri:49c3b76bda9a7fe81e3019e52927592d"
+        },
+        "_:u75": {
+            "prov:activity": "niiri:1101ecb253f39161ef657cfcf8181ba6",
+            "prov:entity": "niiri:730c67ccd0e52a39ba60c5796037b4e0"
+        },
+        "_:u76": {
+            "prov:activity": "niiri:1101ecb253f39161ef657cfcf8181ba6",
+            "prov:entity": "niiri:7adfaca483dfbb4c69fe57814c2e7ba5"
+        },
+        "_:u77": {
+            "prov:activity": "niiri:1101ecb253f39161ef657cfcf8181ba6",
+            "prov:entity": "niiri:b129871a86340316a5e71da151467968"
+        },
+        "_:u78": {
+            "prov:activity": "niiri:1101ecb253f39161ef657cfcf8181ba6",
+            "prov:entity": "niiri:40cd831e46a683970a4d9ab47538c686"
+        },
+        "_:u79": {
+            "prov:activity": "niiri:1101ecb253f39161ef657cfcf8181ba6",
+            "prov:entity": "niiri:aec88dac07772a2bd5f7281a97725360"
+        },
+        "_:u83": {
+            "prov:activity": "niiri:1101ecb253f39161ef657cfcf8181ba6",
+            "prov:entity": "niiri:1268daf6616504ca924affa8b4071eb7"
+        }
+    },
+    "wasDerivedFrom": {
+        "_:wDF19": {
+            "prov:generatedEntity": "niiri:b129871a86340316a5e71da151467968",
+            "prov:usedEntity": "niiri:b64466758d550b4120028710711baae1"
+        },
+        "_:wDF25": {
+            "prov:generatedEntity": "niiri:fac828643e618f4bd2bcc17d9b2c23db",
+            "prov:usedEntity": "niiri:83ed43088ba6e13e15e23f0722815231"
+        },
+        "_:wDF29": {
+            "prov:generatedEntity": "niiri:648e908d9842014984d36e153dd159b3",
+            "prov:usedEntity": "niiri:71301a90cafdf2e089e984789a19c3b0"
+        },
+        "_:wDF33": {
+            "prov:generatedEntity": "niiri:cecb740cce9e1407b8cd6a8aeb90385e",
+            "prov:usedEntity": "niiri:f947acbd818877cfe83bc57648200186"
+        },
+        "_:wDF37": {
+            "prov:generatedEntity": "niiri:71f2801581b2abe311d3914ca638ba77",
+            "prov:usedEntity": "niiri:e704c1b77b30444afce8a702d4e3ac9c"
+        },
+        "_:wDF41": {
+            "prov:generatedEntity": "niiri:7adfaca483dfbb4c69fe57814c2e7ba5",
+            "prov:usedEntity": "niiri:4c53149058cf0977f0f71d080e3a55bd"
+        },
+        "_:wDF55": {
+            "prov:generatedEntity": "niiri:730c67ccd0e52a39ba60c5796037b4e0",
+            "prov:usedEntity": "niiri:19e8074493373e095fbeb5d7d0137351"
+        },
+        "_:wDF59": {
+            "prov:generatedEntity": "niiri:4f98291a207d3b592ea963c5b2efee61",
+            "prov:usedEntity": "niiri:fa1e177a50edc20148667f0c1cfb02fc"
+        },
+        "_:wDF82": {
+            "prov:generatedEntity": "niiri:1268daf6616504ca924affa8b4071eb7",
+            "prov:usedEntity": "niiri:939e38d7108636351d4b59905ee376fc"
+        },
+        "_:wDF91": {
+            "prov:generatedEntity": "niiri:fefba803c839cbd72009efffd0596397",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF93": {
+            "prov:generatedEntity": "niiri:92d29aeefcd3cfea4144809ceee1698b",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF95": {
+            "prov:generatedEntity": "niiri:ce42f33dd5918ee27ba8f8f6ccae137b",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF97": {
+            "prov:generatedEntity": "niiri:4ceeccbd429ca3c7d49d9b7ebbcbd0c0",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF99": {
+            "prov:generatedEntity": "niiri:caaf1d53a3cdfedef4ec795140a8062d",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF101": {
+            "prov:generatedEntity": "niiri:4e4124102f807b660cd900fcbb6a1dad",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF103": {
+            "prov:generatedEntity": "niiri:8a537453623b3e259868fdc3d34a15c0",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF105": {
+            "prov:generatedEntity": "niiri:ceaad5cdc25363799f97feba2f347a03",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF107": {
+            "prov:generatedEntity": "niiri:00cf15c153fb34e5bdc7c627fc153666",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF109": {
+            "prov:generatedEntity": "niiri:9fa05d9e51da6e1bf65e29c91292c1f9",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF111": {
+            "prov:generatedEntity": "niiri:fdf70ff4bf081216be7e467153d2d4d8",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF113": {
+            "prov:generatedEntity": "niiri:bca5fdf4d900bd8486f16dfcd5ab7ade",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF115": {
+            "prov:generatedEntity": "niiri:a310e577676878e8eb7499da29ff53b4",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF117": {
+            "prov:generatedEntity": "niiri:4e10b0470621dd6f66d32e5f0d86796f",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF119": {
+            "prov:generatedEntity": "niiri:8d02357e68e2217c76b2789fc556a1e0",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF121": {
+            "prov:generatedEntity": "niiri:4f5f4e9dc219044ae730379a51a53a84",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF123": {
+            "prov:generatedEntity": "niiri:770c988e0434c5ba8e4392759de30eea",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF125": {
+            "prov:generatedEntity": "niiri:ce1649f53d38c28c5b0d7cacaaf4f448",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF127": {
+            "prov:generatedEntity": "niiri:11d8aaf31a0f50da63a5edcfdc834eac",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF129": {
+            "prov:generatedEntity": "niiri:18af84b83a63dcee2acfd1b9003ffe17",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF131": {
+            "prov:generatedEntity": "niiri:bc47992403400de624fca0326bfeca0a",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF133": {
+            "prov:generatedEntity": "niiri:0c6b532ae8d28e2999918870be27c672",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF135": {
+            "prov:generatedEntity": "niiri:58f0b66e88ddd39190a49cc289e1a6a9",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF137": {
+            "prov:generatedEntity": "niiri:6864ea0388f90fdf3d5a0840769fb194",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF139": {
+            "prov:generatedEntity": "niiri:560b390e6daf7bdacebd6f81fc2498ed",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF141": {
+            "prov:generatedEntity": "niiri:b02b8c006088cba013305b13d972edc8",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF143": {
+            "prov:generatedEntity": "niiri:a4e0cdaf05e785d8dd95f23ce74745d2",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF145": {
+            "prov:generatedEntity": "niiri:a57f08ef6a63ebebf16d1533899bc25f",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF147": {
+            "prov:generatedEntity": "niiri:61ed7bccd640009bb231b2a1982f0622",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF149": {
+            "prov:generatedEntity": "niiri:0095bc91a1253454e74d41690d9f6df3",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF151": {
+            "prov:generatedEntity": "niiri:fdd0f25c58dffbc950780afac712f03c",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF153": {
+            "prov:generatedEntity": "niiri:19300df9cc64fa2764a0780af7af6f84",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF155": {
+            "prov:generatedEntity": "niiri:5ef4fb1358a9a6249f348a6eb79516e7",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF157": {
+            "prov:generatedEntity": "niiri:520bd6c8ac4aa6408335f0e0c324688b",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF159": {
+            "prov:generatedEntity": "niiri:f881e9cbe818d5f8b37dfed6dec527cc",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF161": {
+            "prov:generatedEntity": "niiri:4aa4a0455dab2440720331d043f09ec2",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF163": {
+            "prov:generatedEntity": "niiri:69ca7568c07230cf3584aaca638281b0",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF165": {
+            "prov:generatedEntity": "niiri:350dbc35c571e3a5c09f2cdc4c910d34",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF167": {
+            "prov:generatedEntity": "niiri:5d231bb78e3753cb8f1f83f432b012a4",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF169": {
+            "prov:generatedEntity": "niiri:d962ed566ab823dc017d65a55c96005b",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF171": {
+            "prov:generatedEntity": "niiri:5ca18f66be2a0317891dd14ae924d09a",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF173": {
+            "prov:generatedEntity": "niiri:bf714e8e855430179f84817bfe8aa9f4",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF175": {
+            "prov:generatedEntity": "niiri:404e791392df064f45734040de92da30",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF177": {
+            "prov:generatedEntity": "niiri:def46784463991aed85ece366ca75ad8",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF179": {
+            "prov:generatedEntity": "niiri:c2de51d4065404a70c8e75ad7f34a79f",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF181": {
+            "prov:generatedEntity": "niiri:f11cdd5ae11ea581dcd3882d3540354b",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF183": {
+            "prov:generatedEntity": "niiri:37773f3cd9125252813f9101750c8618",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF185": {
+            "prov:generatedEntity": "niiri:b9bf3dcf444022a80942813a2e7f252d",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF187": {
+            "prov:generatedEntity": "niiri:06de03bbb8e40178692ae6ec9dd3f5d5",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF189": {
+            "prov:generatedEntity": "niiri:ae0af12ba47d22765200496a05e3cc2e",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF191": {
+            "prov:generatedEntity": "niiri:f5ac1b556f82f90ca54e1755f459aeb0",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF193": {
+            "prov:generatedEntity": "niiri:e0f350ef000b2636edd606950fbacdd8",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF195": {
+            "prov:generatedEntity": "niiri:208e0aa56bc32fd1c4efbe75ea40b1a0",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF197": {
+            "prov:generatedEntity": "niiri:6270b7e521adb112773419d81745ba32",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF199": {
+            "prov:generatedEntity": "niiri:6e8c7efcd65fd269ae1163d977b34228",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF201": {
+            "prov:generatedEntity": "niiri:8bdb7c1cfc0e4c28f73b9ebb2067be4a",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF203": {
+            "prov:generatedEntity": "niiri:bb0ea248bef4b3a56f8b7bd4674e079a",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF205": {
+            "prov:generatedEntity": "niiri:3ba5f3e50f85d1172dccf7cdc87e047a",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF207": {
+            "prov:generatedEntity": "niiri:221ffcb9e61912db0c8ea94c83c806f3",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF209": {
+            "prov:generatedEntity": "niiri:680f2d4ea6ccf9065674d450817a8a71",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF211": {
+            "prov:generatedEntity": "niiri:cf57b893da54bea9529d4c0bc8ff02f0",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF213": {
+            "prov:generatedEntity": "niiri:06f83c4cb0758a1db3af7b9ac9595bd1",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF215": {
+            "prov:generatedEntity": "niiri:33c167d8677c415c916bc8b906fd4db4",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF217": {
+            "prov:generatedEntity": "niiri:6f398d8313ba8da3802bd6174fad64a9",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF219": {
+            "prov:generatedEntity": "niiri:441c62b804db7724fe069a4683eabbb3",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF221": {
+            "prov:generatedEntity": "niiri:9573a33cf8de1d0d7462efcefe1aa3b3",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF223": {
+            "prov:generatedEntity": "niiri:adc671bb3b8aead7b73b777448e0d974",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF225": {
+            "prov:generatedEntity": "niiri:e9779649e0e322514fd2b0963b83e9b3",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF227": {
+            "prov:generatedEntity": "niiri:41fb45bc18bea4725f44ca167cd99df1",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF229": {
+            "prov:generatedEntity": "niiri:eea8668c9a2e77333db7bb9162d0d4ef",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF231": {
+            "prov:generatedEntity": "niiri:dd0835679f1bd959157bd71b4d4ada4a",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF233": {
+            "prov:generatedEntity": "niiri:7cdc9365fde87ad8333e6618dc3a8a51",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF235": {
+            "prov:generatedEntity": "niiri:7de4f98c4ea2239ac1a4b37fb8737ebb",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF237": {
+            "prov:generatedEntity": "niiri:392bbfa2f02e1783423c67df389a3772",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF239": {
+            "prov:generatedEntity": "niiri:e08ea74eba6d829dc8f77ccdfebbc2e1",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF241": {
+            "prov:generatedEntity": "niiri:81ce1dbb2b4b3915a17f1002f7600876",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF243": {
+            "prov:generatedEntity": "niiri:8ab01cc9ec9b9c9144318b6ebf4b61e5",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF245": {
+            "prov:generatedEntity": "niiri:e00f285b0f3ca710fd516c8d96d4953b",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF247": {
+            "prov:generatedEntity": "niiri:b113d084583b1c858c15b076e563ba0c",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF249": {
+            "prov:generatedEntity": "niiri:f9a8bd72695ec56fe97eefd5b04d42d4",
+            "prov:usedEntity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
+        },
+        "_:wDF252": {
+            "prov:generatedEntity": "niiri:3a4ff3f083b479126599de2b93ee4494",
+            "prov:usedEntity": "niiri:fefba803c839cbd72009efffd0596397"
+        },
+        "_:wDF255": {
+            "prov:generatedEntity": "niiri:c1930c3f0150f6f5873ea6a691551e74",
+            "prov:usedEntity": "niiri:fefba803c839cbd72009efffd0596397"
+        },
+        "_:wDF258": {
+            "prov:generatedEntity": "niiri:517d6fcfeee2d840a2f52301d1beebd1",
+            "prov:usedEntity": "niiri:fefba803c839cbd72009efffd0596397"
+        },
+        "_:wDF261": {
+            "prov:generatedEntity": "niiri:be45fc5c8318611dbeb6926eff14603d",
+            "prov:usedEntity": "niiri:92d29aeefcd3cfea4144809ceee1698b"
+        },
+        "_:wDF264": {
+            "prov:generatedEntity": "niiri:f732c2c67e196714c26505f667b9c2d1",
+            "prov:usedEntity": "niiri:92d29aeefcd3cfea4144809ceee1698b"
+        },
+        "_:wDF267": {
+            "prov:generatedEntity": "niiri:cd40c3fa5c01d430365872162ed32735",
+            "prov:usedEntity": "niiri:92d29aeefcd3cfea4144809ceee1698b"
+        },
+        "_:wDF270": {
+            "prov:generatedEntity": "niiri:2850c3df9bf571ce4f3306beddf5444f",
+            "prov:usedEntity": "niiri:ce42f33dd5918ee27ba8f8f6ccae137b"
+        },
+        "_:wDF273": {
+            "prov:generatedEntity": "niiri:f822a28c39d3ea42481d34bbc8df22dd",
+            "prov:usedEntity": "niiri:ce42f33dd5918ee27ba8f8f6ccae137b"
+        },
+        "_:wDF276": {
+            "prov:generatedEntity": "niiri:0601bd281b645fc4e7cea6590daaea37",
+            "prov:usedEntity": "niiri:ce42f33dd5918ee27ba8f8f6ccae137b"
+        },
+        "_:wDF279": {
+            "prov:generatedEntity": "niiri:eeb7eca4dd37f5ca956393c13b86f395",
+            "prov:usedEntity": "niiri:4ceeccbd429ca3c7d49d9b7ebbcbd0c0"
+        },
+        "_:wDF282": {
+            "prov:generatedEntity": "niiri:4fad84948d108d419b34432aba0aaf97",
+            "prov:usedEntity": "niiri:caaf1d53a3cdfedef4ec795140a8062d"
+        },
+        "_:wDF285": {
+            "prov:generatedEntity": "niiri:25794aacdb036e5295f9624245fbac2d",
+            "prov:usedEntity": "niiri:caaf1d53a3cdfedef4ec795140a8062d"
+        },
+        "_:wDF288": {
+            "prov:generatedEntity": "niiri:cb9ecebff84e7c0bcff30f16d62e415c",
+            "prov:usedEntity": "niiri:caaf1d53a3cdfedef4ec795140a8062d"
+        },
+        "_:wDF291": {
+            "prov:generatedEntity": "niiri:0108e1dedeb535eeacb8a83cdebc4299",
+            "prov:usedEntity": "niiri:4e4124102f807b660cd900fcbb6a1dad"
+        },
+        "_:wDF294": {
+            "prov:generatedEntity": "niiri:a83bcc10e77d0eaa4587d34a0f971292",
+            "prov:usedEntity": "niiri:4e4124102f807b660cd900fcbb6a1dad"
+        },
+        "_:wDF297": {
+            "prov:generatedEntity": "niiri:c560dc9de917957ed93bc5ed23e74ca3",
+            "prov:usedEntity": "niiri:8a537453623b3e259868fdc3d34a15c0"
+        },
+        "_:wDF300": {
+            "prov:generatedEntity": "niiri:afb5bbe52a67b2392f36dae9544d164a",
+            "prov:usedEntity": "niiri:8a537453623b3e259868fdc3d34a15c0"
+        },
+        "_:wDF303": {
+            "prov:generatedEntity": "niiri:2f7f394faa4711ed3169c6970ab86c8c",
+            "prov:usedEntity": "niiri:8a537453623b3e259868fdc3d34a15c0"
+        },
+        "_:wDF306": {
+            "prov:generatedEntity": "niiri:60597e96058be6ccc3c820043eb1f0ad",
+            "prov:usedEntity": "niiri:ceaad5cdc25363799f97feba2f347a03"
+        },
+        "_:wDF309": {
+            "prov:generatedEntity": "niiri:787ff7b095f58a2e09fb3664f762f1c8",
+            "prov:usedEntity": "niiri:00cf15c153fb34e5bdc7c627fc153666"
+        },
+        "_:wDF312": {
+            "prov:generatedEntity": "niiri:f4ca1c6a92843304c08668c4cebb90a9",
+            "prov:usedEntity": "niiri:9fa05d9e51da6e1bf65e29c91292c1f9"
+        },
+        "_:wDF315": {
+            "prov:generatedEntity": "niiri:05f82a99448b178e8b7d8ecb6d85d07b",
+            "prov:usedEntity": "niiri:fdf70ff4bf081216be7e467153d2d4d8"
+        },
+        "_:wDF318": {
+            "prov:generatedEntity": "niiri:be00ee78cfab94c36be515c9ca78cb48",
+            "prov:usedEntity": "niiri:fdf70ff4bf081216be7e467153d2d4d8"
+        },
+        "_:wDF321": {
+            "prov:generatedEntity": "niiri:af6e82fac7bbf3d7f1621abbe68ecb05",
+            "prov:usedEntity": "niiri:bca5fdf4d900bd8486f16dfcd5ab7ade"
+        },
+        "_:wDF324": {
+            "prov:generatedEntity": "niiri:af063a2fc9451b1a0f6d15b4c16c6d93",
+            "prov:usedEntity": "niiri:bca5fdf4d900bd8486f16dfcd5ab7ade"
+        },
+        "_:wDF327": {
+            "prov:generatedEntity": "niiri:5ed2c66afda9fc1f8f0e1230a1423370",
+            "prov:usedEntity": "niiri:bca5fdf4d900bd8486f16dfcd5ab7ade"
+        },
+        "_:wDF330": {
+            "prov:generatedEntity": "niiri:4ecf61302a9d659bed84b678acd8b8a3",
+            "prov:usedEntity": "niiri:a310e577676878e8eb7499da29ff53b4"
+        },
+        "_:wDF333": {
+            "prov:generatedEntity": "niiri:136c9c9df0e52f1962b71b13186923b6",
+            "prov:usedEntity": "niiri:4e10b0470621dd6f66d32e5f0d86796f"
+        },
+        "_:wDF336": {
+            "prov:generatedEntity": "niiri:f946131984efa63e6aeba7b2a660d9a2",
+            "prov:usedEntity": "niiri:8d02357e68e2217c76b2789fc556a1e0"
+        },
+        "_:wDF339": {
+            "prov:generatedEntity": "niiri:65cd1425049190819614ec8b724da79c",
+            "prov:usedEntity": "niiri:8d02357e68e2217c76b2789fc556a1e0"
+        },
+        "_:wDF342": {
+            "prov:generatedEntity": "niiri:1038f5b8ec149150369ced9f4ef14d84",
+            "prov:usedEntity": "niiri:4f5f4e9dc219044ae730379a51a53a84"
+        },
+        "_:wDF345": {
+            "prov:generatedEntity": "niiri:ecf27cff24accc7da10b3c89a35e94bd",
+            "prov:usedEntity": "niiri:4f5f4e9dc219044ae730379a51a53a84"
+        },
+        "_:wDF348": {
+            "prov:generatedEntity": "niiri:9d277a53a24699d648dda94e1edb30a0",
+            "prov:usedEntity": "niiri:4f5f4e9dc219044ae730379a51a53a84"
+        },
+        "_:wDF351": {
+            "prov:generatedEntity": "niiri:29818f2935a525fc4869ee33b8cc7b28",
+            "prov:usedEntity": "niiri:770c988e0434c5ba8e4392759de30eea"
+        },
+        "_:wDF354": {
+            "prov:generatedEntity": "niiri:fecb6f93c50d8f21e158114c7bc5c612",
+            "prov:usedEntity": "niiri:770c988e0434c5ba8e4392759de30eea"
+        },
+        "_:wDF357": {
+            "prov:generatedEntity": "niiri:edde077bec74c6cf6f6e249592b326c1",
+            "prov:usedEntity": "niiri:770c988e0434c5ba8e4392759de30eea"
+        },
+        "_:wDF360": {
+            "prov:generatedEntity": "niiri:a96987019566061347adea1fb3ca7702",
+            "prov:usedEntity": "niiri:ce1649f53d38c28c5b0d7cacaaf4f448"
+        },
+        "_:wDF363": {
+            "prov:generatedEntity": "niiri:9bb5d42691cee918ce4d479afc518088",
+            "prov:usedEntity": "niiri:11d8aaf31a0f50da63a5edcfdc834eac"
+        },
+        "_:wDF366": {
+            "prov:generatedEntity": "niiri:3ab755e42b6e08f17828f58fe2dd123b",
+            "prov:usedEntity": "niiri:18af84b83a63dcee2acfd1b9003ffe17"
+        },
+        "_:wDF369": {
+            "prov:generatedEntity": "niiri:86f0d921cd39a0e58bec940eba62746e",
+            "prov:usedEntity": "niiri:bc47992403400de624fca0326bfeca0a"
+        },
+        "_:wDF372": {
+            "prov:generatedEntity": "niiri:c2069dff2662c758ed500ee4348b7b32",
+            "prov:usedEntity": "niiri:0c6b532ae8d28e2999918870be27c672"
+        },
+        "_:wDF375": {
+            "prov:generatedEntity": "niiri:01af14b9357e03fab37d07283367aa67",
+            "prov:usedEntity": "niiri:58f0b66e88ddd39190a49cc289e1a6a9"
+        },
+        "_:wDF378": {
+            "prov:generatedEntity": "niiri:feb2ebab3443b1487f09e60430381080",
+            "prov:usedEntity": "niiri:6864ea0388f90fdf3d5a0840769fb194"
+        },
+        "_:wDF381": {
+            "prov:generatedEntity": "niiri:b20862f472f9d77c1662db6b2eca294f",
+            "prov:usedEntity": "niiri:560b390e6daf7bdacebd6f81fc2498ed"
+        },
+        "_:wDF384": {
+            "prov:generatedEntity": "niiri:fd4266dd0bb219a6a241ff6533c36ff6",
+            "prov:usedEntity": "niiri:b02b8c006088cba013305b13d972edc8"
+        },
+        "_:wDF387": {
+            "prov:generatedEntity": "niiri:109fbb4d397a1909eb3b295464058f51",
+            "prov:usedEntity": "niiri:a4e0cdaf05e785d8dd95f23ce74745d2"
+        },
+        "_:wDF390": {
+            "prov:generatedEntity": "niiri:2d19dc148fa248efc7a3df765c6a06cb",
+            "prov:usedEntity": "niiri:a57f08ef6a63ebebf16d1533899bc25f"
+        },
+        "_:wDF393": {
+            "prov:generatedEntity": "niiri:13cbba597089b29e46b69027980a685e",
+            "prov:usedEntity": "niiri:61ed7bccd640009bb231b2a1982f0622"
+        },
+        "_:wDF396": {
+            "prov:generatedEntity": "niiri:46ae4164bfa8a7fd52ad313b6b95ad52",
+            "prov:usedEntity": "niiri:0095bc91a1253454e74d41690d9f6df3"
+        },
+        "_:wDF399": {
+            "prov:generatedEntity": "niiri:6ec3e0f95a4dca384d07f9fba19f7d96",
+            "prov:usedEntity": "niiri:0095bc91a1253454e74d41690d9f6df3"
+        },
+        "_:wDF402": {
+            "prov:generatedEntity": "niiri:3f8990df299e6c17b1734919846f4c6f",
+            "prov:usedEntity": "niiri:fdd0f25c58dffbc950780afac712f03c"
+        },
+        "_:wDF405": {
+            "prov:generatedEntity": "niiri:aa18f0ad742a246e138666daf0480e72",
+            "prov:usedEntity": "niiri:19300df9cc64fa2764a0780af7af6f84"
+        },
+        "_:wDF408": {
+            "prov:generatedEntity": "niiri:bcaf0c8e6a688a504f644ea44b72c874",
+            "prov:usedEntity": "niiri:5ef4fb1358a9a6249f348a6eb79516e7"
+        },
+        "_:wDF411": {
+            "prov:generatedEntity": "niiri:32ff477de924235c5522ee862332ff7c",
+            "prov:usedEntity": "niiri:520bd6c8ac4aa6408335f0e0c324688b"
+        },
+        "_:wDF414": {
+            "prov:generatedEntity": "niiri:f538dc161505199a9d4a9dc200bbfbd1",
+            "prov:usedEntity": "niiri:f881e9cbe818d5f8b37dfed6dec527cc"
+        },
+        "_:wDF417": {
+            "prov:generatedEntity": "niiri:d0d01153923178a42866f6f64e32d01c",
+            "prov:usedEntity": "niiri:4aa4a0455dab2440720331d043f09ec2"
+        },
+        "_:wDF420": {
+            "prov:generatedEntity": "niiri:970399f54bebe49057e2e105ecea663c",
+            "prov:usedEntity": "niiri:69ca7568c07230cf3584aaca638281b0"
+        },
+        "_:wDF423": {
+            "prov:generatedEntity": "niiri:1a51f95440dce51af59c428b51c26851",
+            "prov:usedEntity": "niiri:350dbc35c571e3a5c09f2cdc4c910d34"
+        },
+        "_:wDF426": {
+            "prov:generatedEntity": "niiri:87fdac079acb3a60695755078ec9ff23",
+            "prov:usedEntity": "niiri:5d231bb78e3753cb8f1f83f432b012a4"
+        },
+        "_:wDF429": {
+            "prov:generatedEntity": "niiri:dc459f0a0e3ee90c5e29e061346c5e6a",
+            "prov:usedEntity": "niiri:d962ed566ab823dc017d65a55c96005b"
+        },
+        "_:wDF432": {
+            "prov:generatedEntity": "niiri:f41100c4c035a126bb3e090ac5b96ef2",
+            "prov:usedEntity": "niiri:5ca18f66be2a0317891dd14ae924d09a"
+        },
+        "_:wDF435": {
+            "prov:generatedEntity": "niiri:12d30f83fba50c448c40e1fea8540142",
+            "prov:usedEntity": "niiri:bf714e8e855430179f84817bfe8aa9f4"
+        },
+        "_:wDF438": {
+            "prov:generatedEntity": "niiri:3b77fd4f30cbd966a672c142e10cd1ec",
+            "prov:usedEntity": "niiri:404e791392df064f45734040de92da30"
+        },
+        "_:wDF441": {
+            "prov:generatedEntity": "niiri:8636582fe5845fabfeeef03ea097da99",
+            "prov:usedEntity": "niiri:def46784463991aed85ece366ca75ad8"
+        },
+        "_:wDF444": {
+            "prov:generatedEntity": "niiri:82603814879a87f0ffb468aa32aadf1d",
+            "prov:usedEntity": "niiri:c2de51d4065404a70c8e75ad7f34a79f"
+        },
+        "_:wDF447": {
+            "prov:generatedEntity": "niiri:ce7014584411a4e6030e1b6874e61edb",
+            "prov:usedEntity": "niiri:f11cdd5ae11ea581dcd3882d3540354b"
+        },
+        "_:wDF450": {
+            "prov:generatedEntity": "niiri:1914d7526225245a6b8afde3e39c1ba6",
+            "prov:usedEntity": "niiri:37773f3cd9125252813f9101750c8618"
+        },
+        "_:wDF453": {
+            "prov:generatedEntity": "niiri:34abe905d1d081ef06aa532dca4df55e",
+            "prov:usedEntity": "niiri:b9bf3dcf444022a80942813a2e7f252d"
+        },
+        "_:wDF456": {
+            "prov:generatedEntity": "niiri:7f523ca7243bef20f31c8eb562ee6271",
+            "prov:usedEntity": "niiri:06de03bbb8e40178692ae6ec9dd3f5d5"
+        },
+        "_:wDF459": {
+            "prov:generatedEntity": "niiri:11cc93907e041bf61389cd50514f54ae",
+            "prov:usedEntity": "niiri:ae0af12ba47d22765200496a05e3cc2e"
+        },
+        "_:wDF462": {
+            "prov:generatedEntity": "niiri:e0c55ebec0ecd249a6a1221b9000af8b",
+            "prov:usedEntity": "niiri:f5ac1b556f82f90ca54e1755f459aeb0"
+        },
+        "_:wDF465": {
+            "prov:generatedEntity": "niiri:010e57748e944b9a5344c65b7dcca649",
+            "prov:usedEntity": "niiri:e0f350ef000b2636edd606950fbacdd8"
+        },
+        "_:wDF468": {
+            "prov:generatedEntity": "niiri:7c4a82dba1a9aef0c16e95acba02ea74",
+            "prov:usedEntity": "niiri:208e0aa56bc32fd1c4efbe75ea40b1a0"
+        },
+        "_:wDF471": {
+            "prov:generatedEntity": "niiri:1ee2a189ddde50048e5bc2471880d25e",
+            "prov:usedEntity": "niiri:6270b7e521adb112773419d81745ba32"
+        },
+        "_:wDF474": {
+            "prov:generatedEntity": "niiri:17365311e977a0f7612d95a39cd6fdc2",
+            "prov:usedEntity": "niiri:6e8c7efcd65fd269ae1163d977b34228"
+        },
+        "_:wDF477": {
+            "prov:generatedEntity": "niiri:1aa22f63d5d63be3e71695c4f2ce2cf2",
+            "prov:usedEntity": "niiri:8bdb7c1cfc0e4c28f73b9ebb2067be4a"
+        },
+        "_:wDF480": {
+            "prov:generatedEntity": "niiri:c6643c3287ba5b3c7c9ae880836c753c",
+            "prov:usedEntity": "niiri:bb0ea248bef4b3a56f8b7bd4674e079a"
+        },
+        "_:wDF483": {
+            "prov:generatedEntity": "niiri:d0858c2460bb3887c10ea7cc932fda7e",
+            "prov:usedEntity": "niiri:3ba5f3e50f85d1172dccf7cdc87e047a"
+        },
+        "_:wDF486": {
+            "prov:generatedEntity": "niiri:ce7fafbed4002da1a8d55bef85886de8",
+            "prov:usedEntity": "niiri:221ffcb9e61912db0c8ea94c83c806f3"
+        },
+        "_:wDF489": {
+            "prov:generatedEntity": "niiri:703dca43a303429db425b818bc12c6a4",
+            "prov:usedEntity": "niiri:680f2d4ea6ccf9065674d450817a8a71"
+        },
+        "_:wDF492": {
+            "prov:generatedEntity": "niiri:43941dd0099dba7340078c94b1f176e4",
+            "prov:usedEntity": "niiri:cf57b893da54bea9529d4c0bc8ff02f0"
+        },
+        "_:wDF495": {
+            "prov:generatedEntity": "niiri:9a9c1fe4c7f0e8236338ec3ccf5fb8c1",
+            "prov:usedEntity": "niiri:06f83c4cb0758a1db3af7b9ac9595bd1"
+        },
+        "_:wDF498": {
+            "prov:generatedEntity": "niiri:5aaecc8f07f4c4f973768fbf89a146da",
+            "prov:usedEntity": "niiri:33c167d8677c415c916bc8b906fd4db4"
+        },
+        "_:wDF501": {
+            "prov:generatedEntity": "niiri:48bf8ce794db930df930c41d224bdc16",
+            "prov:usedEntity": "niiri:6f398d8313ba8da3802bd6174fad64a9"
+        },
+        "_:wDF504": {
+            "prov:generatedEntity": "niiri:553299baed01f241bd72ebf115908e51",
+            "prov:usedEntity": "niiri:441c62b804db7724fe069a4683eabbb3"
+        },
+        "_:wDF507": {
+            "prov:generatedEntity": "niiri:6eaf36636b84719dcdad3b87ac63db9d",
+            "prov:usedEntity": "niiri:9573a33cf8de1d0d7462efcefe1aa3b3"
+        },
+        "_:wDF510": {
+            "prov:generatedEntity": "niiri:e375fd72351a936406457560ff4bf243",
+            "prov:usedEntity": "niiri:adc671bb3b8aead7b73b777448e0d974"
+        },
+        "_:wDF513": {
+            "prov:generatedEntity": "niiri:19a0feb2eced3573854928d35a375bea",
+            "prov:usedEntity": "niiri:e9779649e0e322514fd2b0963b83e9b3"
+        },
+        "_:wDF516": {
+            "prov:generatedEntity": "niiri:0e5f9cfe273ad2b56c5d941a8fa1d751",
+            "prov:usedEntity": "niiri:41fb45bc18bea4725f44ca167cd99df1"
+        },
+        "_:wDF519": {
+            "prov:generatedEntity": "niiri:9ae75a88cde46be90790ef06a7e29dee",
+            "prov:usedEntity": "niiri:eea8668c9a2e77333db7bb9162d0d4ef"
+        },
+        "_:wDF522": {
+            "prov:generatedEntity": "niiri:7e114fc2dca77ff7f26aca5c69c3b36c",
+            "prov:usedEntity": "niiri:dd0835679f1bd959157bd71b4d4ada4a"
+        },
+        "_:wDF525": {
+            "prov:generatedEntity": "niiri:65129edf8c444af2b8ae3ebfb73d5a95",
+            "prov:usedEntity": "niiri:7cdc9365fde87ad8333e6618dc3a8a51"
+        },
+        "_:wDF528": {
+            "prov:generatedEntity": "niiri:3d4630be29adc78b6133a798da406017",
+            "prov:usedEntity": "niiri:7de4f98c4ea2239ac1a4b37fb8737ebb"
+        },
+        "_:wDF531": {
+            "prov:generatedEntity": "niiri:3399f5c31ecf4ca8aaa4e0dc4d2629cb",
+            "prov:usedEntity": "niiri:392bbfa2f02e1783423c67df389a3772"
+        },
+        "_:wDF534": {
+            "prov:generatedEntity": "niiri:b0d26737223ecac9b30bc4e6d357903d",
+            "prov:usedEntity": "niiri:e08ea74eba6d829dc8f77ccdfebbc2e1"
+        },
+        "_:wDF537": {
+            "prov:generatedEntity": "niiri:e2f4bde66682178e0070983ec98c509e",
+            "prov:usedEntity": "niiri:81ce1dbb2b4b3915a17f1002f7600876"
+        },
+        "_:wDF540": {
+            "prov:generatedEntity": "niiri:a5e53303ae16c0a4417cd3327ff317ba",
+            "prov:usedEntity": "niiri:8ab01cc9ec9b9c9144318b6ebf4b61e5"
+        },
+        "_:wDF543": {
+            "prov:generatedEntity": "niiri:acda002ca084ac39e0dc294ad4a29af7",
+            "prov:usedEntity": "niiri:e00f285b0f3ca710fd516c8d96d4953b"
+        },
+        "_:wDF546": {
+            "prov:generatedEntity": "niiri:1aebec9df0ae7e94b35fcd5f1681e2b8",
+            "prov:usedEntity": "niiri:b113d084583b1c858c15b076e563ba0c"
+        },
+        "_:wDF549": {
+            "prov:generatedEntity": "niiri:e95fde56ae83d5db12a5db6e6b137be0",
+            "prov:usedEntity": "niiri:f9a8bd72695ec56fe97eefd5b04d42d4"
+        }
+    },
+    "wasAttributedTo": {
+        "_:wAT6": {
+            "prov:entity": "niiri:3eafaf3b0d4fb27e0273cf883045c71c",
+            "prov:agent": "niiri:fcffff56d818fa0f4fd06f330c7fd209"
+        },
+        "_:wAT7": {
+            "prov:entity": "niiri:3eafaf3b0d4fb27e0273cf883045c71c",
+            "prov:agent": "niiri:db4e0548483590dda7e45661cf53201d"
+        }
+    },
+    "wasAssociatedWith": {
+        "_:wAW13": {
+            "prov:activity": "niiri:b67465cae2012be9d953c04ba0ee6bb4",
+            "prov:agent": "niiri:7d55eee26233e3ffebe8fb466230d746"
+        },
+        "_:wAW45": {
+            "prov:activity": "niiri:d1e92a419c3d7e1b91add9945c81aa9b",
+            "prov:agent": "niiri:7d55eee26233e3ffebe8fb466230d746"
+        },
+        "_:wAW72": {
+            "prov:activity": "niiri:1101ecb253f39161ef657cfcf8181ba6",
+            "prov:agent": "niiri:7d55eee26233e3ffebe8fb466230d746"
+        }
+    }
+    }
+  }
+}

--- a/spmexport/ex_spm_contrast_mask/nidm.jsonld
+++ b/spmexport/ex_spm_contrast_mask/nidm.jsonld
@@ -7,7 +7,7 @@
       "niiri": "http://iri.nidash.org/",
       "spm": "http://purl.org/nidash/spm#",
       "neurolex": "http://neurolex.org/wiki/",
-      "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#",
+      "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/",
       "dct": "http://purl.org/dc/terms/",
       "nfo": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#",
       "dc": "http://purl.org/dc/elements/1.1/",
@@ -22,32 +22,32 @@
   ],
   "@graph": [
     {
-      "@id": "niiri:672c2ac2a415db6f1748d04e9a0f30bd",
-      "@type": ["prov:Entity","prov:Bundle","nidm_NIDMResults:"],
+      "@id": "niiri:c0fc11f77219f72f64535275dfd76104",
+      "@type": ["prov:Entity","prov:Bundle","nidm_NIDMResults"],
       "rdfs:label": "NIDM-Results",
-      "nidm_version:": {"@type": "xsd:string", "@value": "1.3.0"}
+      "nidm_version": {"@type": "xsd:string", "@value": "1.3.0"}
     },
     {
-      "@id": "niiri:86ec330980a5667ce9ea17bac929283a",
-      "@type": ["prov:Agent","nidm_spm_results_nidm:","prov:SoftwareAgent"],
+      "@id": "niiri:a578ca65ebc21d2f8a367638a428ecb2",
+      "@type": ["prov:Agent","nidm_spm_results_nidm","prov:SoftwareAgent"],
       "rdfs:label": "spm_results_nidm",
-      "nidm_softwareVersion:": {"@type": "xsd:string", "@value": "12.6903"}
+      "nidm_softwareVersion": {"@type": "xsd:string", "@value": "12.7057"}
     },
     {
-      "@id": "niiri:c61dda563833b6322557e795e27e21c1",
-      "@type": ["prov:Activity","nidm_NIDMResultsExport:"],
+      "@id": "niiri:95688b75812d93e59bb028a4360014e7",
+      "@type": ["prov:Activity","nidm_NIDMResultsExport"],
       "rdfs:label": "NIDM-Results export"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:c61dda563833b6322557e795e27e21c1",
-      "agent": "niiri:86ec330980a5667ce9ea17bac929283a"
+      "activity_associated": "niiri:95688b75812d93e59bb028a4360014e7",
+      "agent": "niiri:a578ca65ebc21d2f8a367638a428ecb2"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:672c2ac2a415db6f1748d04e9a0f30bd",
-      "activity": "niiri:c61dda563833b6322557e795e27e21c1",
-      "atTime": "2016-12-07T16:08:07"
+      "entity_generated": "niiri:c0fc11f77219f72f64535275dfd76104",
+      "activity": "niiri:95688b75812d93e59bb028a4360014e7",
+      "atTime": "2017-04-19T12:17:53"
     }
   ]
 },
@@ -159,599 +159,599 @@
       "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
     }
   ],
-  "@id": "niiri:672c2ac2a415db6f1748d04e9a0f30bd",
+  "@id": "niiri:c0fc11f77219f72f64535275dfd76104",
   "@graph": [
     {
-      "@id": "niiri:01d87cfa40547d4de2e2e6acb69d8796",
-      "@type": ["prov:Agent","src_SPM:","prov:SoftwareAgent"],
+      "@id": "niiri:7d55eee26233e3ffebe8fb466230d746",
+      "@type": ["prov:Agent","src_SPM","prov:SoftwareAgent"],
       "rdfs:label": "SPM",
-      "nidm_softwareVersion:": {"@type": "xsd:string", "@value": "12.12.2"}
+      "nidm_softwareVersion": {"@type": "xsd:string", "@value": "12.6906"}
     },
     {
-      "@id": "niiri:d18f183003db6780cdc9b347b4af5993",
-      "@type": ["prov:Entity","nidm_CoordinateSpace:"],
+      "@id": "niiri:d11490ae37fde7aa8e3ddc508c115313",
+      "@type": ["prov:Entity","nidm_CoordinateSpace"],
       "rdfs:label": "Coordinate space 1",
-      "nidm_voxelToWorldMapping:": {"@type": "xsd:string", "@value": "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"},
-      "nidm_voxelUnits:": {"@type": "xsd:string", "@value": "[\"mm\", \"mm\", \"mm\"]"},
-      "nidm_voxelSize:": {"@type": "xsd:string", "@value": "[2, 2, 2]"},
-      "nidm_inWorldCoordinateSystem:": {"@id": "nidm_Ixi549CoordinateSystem:"},
-      "nidm_numberOfDimensions:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_dimensionsInVoxels:": {"@type": "xsd:string", "@value": "[79,95,79]"}
+      "nidm_voxelToWorldMapping": {"@type": "xsd:string", "@value": "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"},
+      "nidm_voxelUnits": {"@type": "xsd:string", "@value": "[\"mm\", \"mm\", \"mm\"]"},
+      "nidm_voxelSize": {"@type": "xsd:string", "@value": "[2, 2, 2]"},
+      "nidm_inWorldCoordinateSystem": {"@id": "nidm_Ixi549CoordinateSystem"},
+      "nidm_numberOfDimensions": {"@type": "xsd:int", "@value": "3"},
+      "nidm_dimensionsInVoxels": {"@type": "xsd:string", "@value": "[79,95,79]"}
     },
     {
-      "@id": "niiri:8a0f59a0eb263d3f972122ed2f59f2c0",
-      "@type": ["prov:Agent","nlx_Imaginginstrument:","nlx_Magneticresonanceimagingscanner:"],
+      "@id": "niiri:fcffff56d818fa0f4fd06f330c7fd209",
+      "@type": ["prov:Agent","nlx_Imaginginstrument","nlx_Magneticresonanceimagingscanner"],
       "rdfs:label": "MRI Scanner"
     },
     {
-      "@id": "niiri:61457c67587ef15f640d478149a8a2c8",
+      "@id": "niiri:db4e0548483590dda7e45661cf53201d",
       "@type": ["prov:Agent","prov:Person"],
       "rdfs:label": "Person"
     },
     {
-      "@id": "niiri:2d072058cbc02804a6f8806a179381c4",
-      "@type": ["prov:Entity","prov:Collection","nidm_Data:"],
+      "@id": "niiri:3eafaf3b0d4fb27e0273cf883045c71c",
+      "@type": ["prov:Entity","prov:Collection","nidm_Data"],
       "rdfs:label": "Data",
-      "nidm_grandMeanScaling:": {"@type": "xsd:boolean", "@value": "true"},
-      "nidm_targetIntensity:": {"@type": "xsd:float", "@value": "100"},
-      "nidm_hasMRIProtocol:": {"@id": "nlx_FunctionalMRIprotocol:"}
+      "nidm_grandMeanScaling": {"@type": "xsd:boolean", "@value": "true"},
+      "nidm_targetIntensity": {"@type": "xsd:float", "@value": "100"},
+      "nidm_hasMRIProtocol": {"@id": "nlx_FunctionalMRIprotocol"}
     },
     {
       "@type": "prov:Attribution",
-      "entity_attributed": "niiri:2d072058cbc02804a6f8806a179381c4",
-      "agent": "niiri:8a0f59a0eb263d3f972122ed2f59f2c0"
+      "entity_attributed": "niiri:3eafaf3b0d4fb27e0273cf883045c71c",
+      "agent": "niiri:fcffff56d818fa0f4fd06f330c7fd209"
     },
     {
       "@type": "prov:Attribution",
-      "entity_attributed": "niiri:2d072058cbc02804a6f8806a179381c4",
-      "agent": "niiri:61457c67587ef15f640d478149a8a2c8"
+      "entity_attributed": "niiri:3eafaf3b0d4fb27e0273cf883045c71c",
+      "agent": "niiri:db4e0548483590dda7e45661cf53201d"
     },
     {
-      "@id": "niiri:4ebdf7a11506de3c5fe02716ed14ee65",
-      "@type": ["prov:Entity","spm_DCTDriftModel:"],
+      "@id": "niiri:1b66176fa0492dcad18cbabb1ac94ea3",
+      "@type": ["prov:Entity","spm_DCTDriftModel"],
       "rdfs:label": "SPM's DCT Drift Model",
-      "spm_SPMsDriftCutoffPeriod:": {"@type": "xsd:float", "@value": "128"}
+      "spm_SPMsDriftCutoffPeriod": {"@type": "xsd:float", "@value": "128"}
     },
     {
-      "@id": "niiri:2acb212c883d251b598ba63a18deb237",
-      "@type": ["prov:Entity","nidm_DesignMatrix:"],
+      "@id": "niiri:55ba018663409d2f002b8707d5149e83",
+      "@type": ["prov:Entity","nidm_DesignMatrix"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "DesignMatrix.csv"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "DesignMatrix.csv"},
       "dct:format": {"@type": "xsd:string", "@value": "text/csv"},
-      "dc:description": {"@id": "niiri:57633e9bf742e0bbdc59207427b10827"},
+      "dc:description": {"@id": "niiri:967bf8ed0debd31706b3c4341edc203f"},
       "rdfs:label": "Design Matrix",
-      "nidm_regressorNames:": {"@type": "xsd:string", "@value": "[\"Sn(1) to*bf(1)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) constant\"]"},
-      "nidm_hasDriftModel:": {"@id": "niiri:4ebdf7a11506de3c5fe02716ed14ee65"},
-      "nidm_hasHRFBasis:": {"@id": "spm_SPMsCanonicalHRF:"}
+      "nidm_regressorNames": {"@type": "xsd:string", "@value": "[\"Sn(1) to*bf(1)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) constant\"]"},
+      "nidm_hasDriftModel": {"@id": "niiri:1b66176fa0492dcad18cbabb1ac94ea3"},
+      "nidm_hasHRFBasis": {"@id": "spm_SPMsCanonicalHRF"}
     },
     {
-      "@id": "niiri:57633e9bf742e0bbdc59207427b10827",
+      "@id": "niiri:967bf8ed0debd31706b3c4341edc203f",
       "@type": ["prov:Entity","dctype:Image"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "DesignMatrix.png"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "DesignMatrix.png"},
       "dct:format": {"@type": "xsd:string", "@value": "image/png"}
     },
     {
-      "@id": "niiri:029e264b9da50c69326142fb810919f5",
-      "@type": ["prov:Entity","nidm_ErrorModel:"],
-      "nidm_hasErrorDistribution:": {"@id": "obo_normaldistribution:"},
-      "nidm_hasErrorDependence:": {"@id": "obo_Toeplitzcovariancestructure:"},
-      "nidm_dependenceMapWiseDependence:": {"@id": "nidm_ConstantParameter:"},
-      "nidm_errorVarianceHomogeneous:": {"@type": "xsd:boolean", "@value": "true"},
-      "nidm_varianceMapWiseDependence:": {"@id": "nidm_IndependentParameter:"}
+      "@id": "niiri:b4b0efe73f8e31624573c955a3b91929",
+      "@type": ["prov:Entity","nidm_ErrorModel"],
+      "nidm_hasErrorDistribution": {"@id": "obo_normaldistribution"},
+      "nidm_hasErrorDependence": {"@id": "obo_Toeplitzcovariancestructure"},
+      "nidm_dependenceMapWiseDependence": {"@id": "nidm_ConstantParameter"},
+      "nidm_errorVarianceHomogeneous": {"@type": "xsd:boolean", "@value": "true"},
+      "nidm_varianceMapWiseDependence": {"@id": "nidm_IndependentParameter"}
     },
     {
-      "@id": "niiri:6a8e811f6c315817e40dd84dfdae79a3",
-      "@type": ["prov:Activity","nidm_ModelParametersEstimation:"],
+      "@id": "niiri:b67465cae2012be9d953c04ba0ee6bb4",
+      "@type": ["prov:Activity","nidm_ModelParametersEstimation"],
       "rdfs:label": "Model parameters estimation",
-      "nidm_withEstimationMethod:": {"@id": "obo_generalizedleastsquaresestimation:"}
+      "nidm_withEstimationMethod": {"@id": "obo_generalizedleastsquaresestimation"}
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:6a8e811f6c315817e40dd84dfdae79a3",
-      "agent": "niiri:01d87cfa40547d4de2e2e6acb69d8796"
+      "activity_associated": "niiri:b67465cae2012be9d953c04ba0ee6bb4",
+      "agent": "niiri:7d55eee26233e3ffebe8fb466230d746"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:6a8e811f6c315817e40dd84dfdae79a3",
-      "entity": "niiri:2acb212c883d251b598ba63a18deb237"
+      "activity_using": "niiri:b67465cae2012be9d953c04ba0ee6bb4",
+      "entity": "niiri:55ba018663409d2f002b8707d5149e83"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:6a8e811f6c315817e40dd84dfdae79a3",
-      "entity": "niiri:2d072058cbc02804a6f8806a179381c4"
+      "activity_using": "niiri:b67465cae2012be9d953c04ba0ee6bb4",
+      "entity": "niiri:3eafaf3b0d4fb27e0273cf883045c71c"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:6a8e811f6c315817e40dd84dfdae79a3",
-      "entity": "niiri:029e264b9da50c69326142fb810919f5"
+      "activity_using": "niiri:b67465cae2012be9d953c04ba0ee6bb4",
+      "entity": "niiri:b4b0efe73f8e31624573c955a3b91929"
     },
     {
-      "@id": "niiri:1bff00d2a3c64ac18b7820d9ec2a5c1a",
-      "@type": ["prov:Entity","nidm_MaskMap:"],
+      "@id": "niiri:b129871a86340316a5e71da151467968",
+      "@type": ["prov:Entity","nidm_MaskMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "Mask.nii.gz"},
-      "nidm_isUserDefined:": {"@type": "xsd:boolean", "@value": "false"},
+      "nidm_isUserDefined": {"@type": "xsd:boolean", "@value": "false"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "Mask.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Mask",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:d18f183003db6780cdc9b347b4af5993"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:d11490ae37fde7aa8e3ddc508c115313"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876"}
     },
     {
-      "@id": "niiri:e3c2a48a9fe4c61e98dfd0e42459332e",
-      "@type": ["prov:Entity","nidm_MaskMap:"],
+      "@id": "niiri:b64466758d550b4120028710711baae1",
+      "@type": ["prov:Entity","nidm_MaskMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "mask.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "36929e1f5f4143bd9cc818cd896a25f129961fab208c3a4438555f40444c08347b359142ee8c53ece6e8cca1627f49db0788a1fd3b9e2ecaef61999c6c6c67ac"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1bff00d2a3c64ac18b7820d9ec2a5c1a",
-      "entity": "niiri:e3c2a48a9fe4c61e98dfd0e42459332e"
+      "entity_derived": "niiri:b129871a86340316a5e71da151467968",
+      "entity": "niiri:b64466758d550b4120028710711baae1"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:1bff00d2a3c64ac18b7820d9ec2a5c1a",
-      "activity": "niiri:6a8e811f6c315817e40dd84dfdae79a3"
+      "entity_generated": "niiri:b129871a86340316a5e71da151467968",
+      "activity": "niiri:b67465cae2012be9d953c04ba0ee6bb4"
     },
     {
-      "@id": "niiri:233937d2a232be927ee7b652922d8760",
-      "@type": ["prov:Entity","nidm_GrandMeanMap:"],
+      "@id": "niiri:5452b79c7f6c0fb6d103555e4ba5ab0b",
+      "@type": ["prov:Entity","nidm_GrandMeanMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "GrandMean.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "GrandMean.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Grand Mean Map",
-      "nidm_maskedMedian:": {"@type": "xsd:float", "@value": "111.557487487793"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:d18f183003db6780cdc9b347b4af5993"},
+      "nidm_maskedMedian": {"@type": "xsd:float", "@value": "111.557487487793"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:d11490ae37fde7aa8e3ddc508c115313"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "512157cc6bff89d9343a09b4068226eb3edd64a8cbcee861f06231767fae6f8d4819921182adebee083a9bf309afd65529ab04a92f0aa6b0038c8098550f6124"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:233937d2a232be927ee7b652922d8760",
-      "activity": "niiri:6a8e811f6c315817e40dd84dfdae79a3"
+      "entity_generated": "niiri:5452b79c7f6c0fb6d103555e4ba5ab0b",
+      "activity": "niiri:b67465cae2012be9d953c04ba0ee6bb4"
     },
     {
-      "@id": "niiri:66c80a9d0dd323ea250a58745156cae8",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:fac828643e618f4bd2bcc17d9b2c23db",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0001.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0001.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 1",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:d18f183003db6780cdc9b347b4af5993"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:d11490ae37fde7aa8e3ddc508c115313"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd"}
     },
     {
-      "@id": "niiri:01b496635aca4250b5af60666a57fd00",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:83ed43088ba6e13e15e23f0722815231",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0001.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:66c80a9d0dd323ea250a58745156cae8",
-      "entity": "niiri:01b496635aca4250b5af60666a57fd00"
+      "entity_derived": "niiri:fac828643e618f4bd2bcc17d9b2c23db",
+      "entity": "niiri:83ed43088ba6e13e15e23f0722815231"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:66c80a9d0dd323ea250a58745156cae8",
-      "activity": "niiri:6a8e811f6c315817e40dd84dfdae79a3"
+      "entity_generated": "niiri:fac828643e618f4bd2bcc17d9b2c23db",
+      "activity": "niiri:b67465cae2012be9d953c04ba0ee6bb4"
     },
     {
-      "@id": "niiri:528dc036f80ec3749fae0f1beb01681b",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:648e908d9842014984d36e153dd159b3",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0002.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0002.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 2",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:d18f183003db6780cdc9b347b4af5993"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:d11490ae37fde7aa8e3ddc508c115313"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c"}
     },
     {
-      "@id": "niiri:c747f0dbb1007e818904c8088efd3799",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:71301a90cafdf2e089e984789a19c3b0",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0002.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:528dc036f80ec3749fae0f1beb01681b",
-      "entity": "niiri:c747f0dbb1007e818904c8088efd3799"
+      "entity_derived": "niiri:648e908d9842014984d36e153dd159b3",
+      "entity": "niiri:71301a90cafdf2e089e984789a19c3b0"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:528dc036f80ec3749fae0f1beb01681b",
-      "activity": "niiri:6a8e811f6c315817e40dd84dfdae79a3"
+      "entity_generated": "niiri:648e908d9842014984d36e153dd159b3",
+      "activity": "niiri:b67465cae2012be9d953c04ba0ee6bb4"
     },
     {
-      "@id": "niiri:0b0d1304a9a24e042bc54f017e7c1b74",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:cecb740cce9e1407b8cd6a8aeb90385e",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0003.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0003.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 3",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:d18f183003db6780cdc9b347b4af5993"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:d11490ae37fde7aa8e3ddc508c115313"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373"}
     },
     {
-      "@id": "niiri:12b05b6bde3deb9f0632eb70478f1a70",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:f947acbd818877cfe83bc57648200186",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0003.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0b0d1304a9a24e042bc54f017e7c1b74",
-      "entity": "niiri:12b05b6bde3deb9f0632eb70478f1a70"
+      "entity_derived": "niiri:cecb740cce9e1407b8cd6a8aeb90385e",
+      "entity": "niiri:f947acbd818877cfe83bc57648200186"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:0b0d1304a9a24e042bc54f017e7c1b74",
-      "activity": "niiri:6a8e811f6c315817e40dd84dfdae79a3"
+      "entity_generated": "niiri:cecb740cce9e1407b8cd6a8aeb90385e",
+      "activity": "niiri:b67465cae2012be9d953c04ba0ee6bb4"
     },
     {
-      "@id": "niiri:166f71a6b0ee725b67d28223e8aae31a",
-      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap:"],
+      "@id": "niiri:71f2801581b2abe311d3914ca638ba77",
+      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ResidualMeanSquares.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ResidualMeanSquares.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Residual Mean Squares Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:d18f183003db6780cdc9b347b4af5993"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:d11490ae37fde7aa8e3ddc508c115313"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "991abf563d795a43b1e2eef8643e57023f2e0b090b2031f05f839321fc0643df6f71d423486a1021519b6dc82f6b0f563e19f3fbd50cb16063bed54a0e192d3e"}
     },
     {
-      "@id": "niiri:4d9cff67969b1c457a1ca50df4dfea66",
-      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap:"],
+      "@id": "niiri:e704c1b77b30444afce8a702d4e3ac9c",
+      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "ResMS.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "40b28d03fcf9a2f60b11f10d7fb83bf3618b234fb5aedf09df644cb7cbb6aab8c9f468897c1078166d455a3d04a83f4e3bf762cfca0b4ea982d7a4e406849f18"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:166f71a6b0ee725b67d28223e8aae31a",
-      "entity": "niiri:4d9cff67969b1c457a1ca50df4dfea66"
+      "entity_derived": "niiri:71f2801581b2abe311d3914ca638ba77",
+      "entity": "niiri:e704c1b77b30444afce8a702d4e3ac9c"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:166f71a6b0ee725b67d28223e8aae31a",
-      "activity": "niiri:6a8e811f6c315817e40dd84dfdae79a3"
+      "entity_generated": "niiri:71f2801581b2abe311d3914ca638ba77",
+      "activity": "niiri:b67465cae2012be9d953c04ba0ee6bb4"
     },
     {
-      "@id": "niiri:85a893b3abb0636607b7910a8b9ba1f7",
-      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap:"],
+      "@id": "niiri:7adfaca483dfbb4c69fe57814c2e7ba5",
+      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ReselsPerVoxel.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ReselsPerVoxel.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Resels per Voxel Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:d18f183003db6780cdc9b347b4af5993"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:d11490ae37fde7aa8e3ddc508c115313"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "1a3f9216e145249ccc0b14b2bc337d6b38b81ad45e32768001fb22b35f0c2c0f3e2bce013b40c85f7dc0fc62723ac761ee7f7e1e6aff128a05f0ba7b8b8202a3"}
     },
     {
-      "@id": "niiri:20b767b4ac770494bf091cfef7993218",
-      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap:"],
+      "@id": "niiri:4c53149058cf0977f0f71d080e3a55bd",
+      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "RPV.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "4f76663162857f6b38b2a45a63b15a23b2ca8b338c283b69c1e71f2ea2f43797d045a733cd14e845be9c12f8b8f84d3931c599a08e8f6d77e99fab46ad87ab8f"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:85a893b3abb0636607b7910a8b9ba1f7",
-      "entity": "niiri:20b767b4ac770494bf091cfef7993218"
+      "entity_derived": "niiri:7adfaca483dfbb4c69fe57814c2e7ba5",
+      "entity": "niiri:4c53149058cf0977f0f71d080e3a55bd"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:85a893b3abb0636607b7910a8b9ba1f7",
-      "activity": "niiri:6a8e811f6c315817e40dd84dfdae79a3"
+      "entity_generated": "niiri:7adfaca483dfbb4c69fe57814c2e7ba5",
+      "activity": "niiri:b67465cae2012be9d953c04ba0ee6bb4"
     },
     {
-      "@id": "niiri:e1905e083c4c752effeb2b0a17b37dcc",
-      "@type": ["prov:Entity","obo_contrastweightmatrix:"],
-      "nidm_statisticType:": {"@id": "obo_tstatistic:"},
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
+      "@id": "niiri:32ab289c9b156044343a8e1edd8ec1d0",
+      "@type": ["prov:Entity","obo_contrastweightmatrix"],
+      "nidm_statisticType": {"@id": "obo_tstatistic"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
       "rdfs:label": "Contrast: tone counting vs baseline",
       "prov:value": {"@type": "xsd:string", "@value": "[1, 0, 0]"}
     },
     {
-      "@id": "niiri:e5b452dedb5772acbf6cb6d40e609ec6",
-      "@type": ["prov:Activity","nidm_ContrastEstimation:"],
+      "@id": "niiri:d1e92a419c3d7e1b91add9945c81aa9b",
+      "@type": ["prov:Activity","nidm_ContrastEstimation"],
       "rdfs:label": "Contrast estimation"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:e5b452dedb5772acbf6cb6d40e609ec6",
-      "agent": "niiri:01d87cfa40547d4de2e2e6acb69d8796"
+      "activity_associated": "niiri:d1e92a419c3d7e1b91add9945c81aa9b",
+      "agent": "niiri:7d55eee26233e3ffebe8fb466230d746"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:e5b452dedb5772acbf6cb6d40e609ec6",
-      "entity": "niiri:1bff00d2a3c64ac18b7820d9ec2a5c1a"
+      "activity_using": "niiri:d1e92a419c3d7e1b91add9945c81aa9b",
+      "entity": "niiri:b129871a86340316a5e71da151467968"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:e5b452dedb5772acbf6cb6d40e609ec6",
-      "entity": "niiri:166f71a6b0ee725b67d28223e8aae31a"
+      "activity_using": "niiri:d1e92a419c3d7e1b91add9945c81aa9b",
+      "entity": "niiri:71f2801581b2abe311d3914ca638ba77"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:e5b452dedb5772acbf6cb6d40e609ec6",
-      "entity": "niiri:2acb212c883d251b598ba63a18deb237"
+      "activity_using": "niiri:d1e92a419c3d7e1b91add9945c81aa9b",
+      "entity": "niiri:55ba018663409d2f002b8707d5149e83"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:e5b452dedb5772acbf6cb6d40e609ec6",
-      "entity": "niiri:e1905e083c4c752effeb2b0a17b37dcc"
+      "activity_using": "niiri:d1e92a419c3d7e1b91add9945c81aa9b",
+      "entity": "niiri:32ab289c9b156044343a8e1edd8ec1d0"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:e5b452dedb5772acbf6cb6d40e609ec6",
-      "entity": "niiri:66c80a9d0dd323ea250a58745156cae8"
+      "activity_using": "niiri:d1e92a419c3d7e1b91add9945c81aa9b",
+      "entity": "niiri:fac828643e618f4bd2bcc17d9b2c23db"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:e5b452dedb5772acbf6cb6d40e609ec6",
-      "entity": "niiri:528dc036f80ec3749fae0f1beb01681b"
+      "activity_using": "niiri:d1e92a419c3d7e1b91add9945c81aa9b",
+      "entity": "niiri:648e908d9842014984d36e153dd159b3"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:e5b452dedb5772acbf6cb6d40e609ec6",
-      "entity": "niiri:0b0d1304a9a24e042bc54f017e7c1b74"
+      "activity_using": "niiri:d1e92a419c3d7e1b91add9945c81aa9b",
+      "entity": "niiri:cecb740cce9e1407b8cd6a8aeb90385e"
     },
     {
-      "@id": "niiri:3e21b67f13781900c9629e35a248bed3",
-      "@type": ["prov:Entity","nidm_StatisticMap:"],
+      "@id": "niiri:730c67ccd0e52a39ba60c5796037b4e0",
+      "@type": ["prov:Entity","nidm_StatisticMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "TStatistic.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "TStatistic.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "T-Statistic Map: tone counting vs baseline",
-      "nidm_statisticType:": {"@id": "obo_tstatistic:"},
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
-      "nidm_errorDegreesOfFreedom:": {"@type": "xsd:float", "@value": "97.9999999998522"},
-      "nidm_effectDegreesOfFreedom:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:d18f183003db6780cdc9b347b4af5993"},
+      "nidm_statisticType": {"@id": "obo_tstatistic"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
+      "nidm_errorDegreesOfFreedom": {"@type": "xsd:float", "@value": "97.9999999998522"},
+      "nidm_effectDegreesOfFreedom": {"@type": "xsd:float", "@value": "1"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:d11490ae37fde7aa8e3ddc508c115313"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "9e1714c2d86a050b38b4e10a4d2d23253a24c5e1d228ae16a9c3be8872739278505ac0729ecab54265a717e3a54f9f782d0ed72eea904e0d482a6072bb817bd4"}
     },
     {
-      "@id": "niiri:5ad3aea2e6813a8e97e5013b3075bf06",
-      "@type": ["prov:Entity","nidm_StatisticMap:"],
+      "@id": "niiri:19e8074493373e095fbeb5d7d0137351",
+      "@type": ["prov:Entity","nidm_StatisticMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "spmT_0001.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "d288b1b0f117f64502555da13c5398dffa5bf5ff0b58951510e43d5388755bc185798802a92e98a07c7e313c6991066d2908f2a44aa5153ba23433da1335970f"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3e21b67f13781900c9629e35a248bed3",
-      "entity": "niiri:5ad3aea2e6813a8e97e5013b3075bf06"
+      "entity_derived": "niiri:730c67ccd0e52a39ba60c5796037b4e0",
+      "entity": "niiri:19e8074493373e095fbeb5d7d0137351"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:3e21b67f13781900c9629e35a248bed3",
-      "activity": "niiri:e5b452dedb5772acbf6cb6d40e609ec6"
+      "entity_generated": "niiri:730c67ccd0e52a39ba60c5796037b4e0",
+      "activity": "niiri:d1e92a419c3d7e1b91add9945c81aa9b"
     },
     {
-      "@id": "niiri:8c0ddb20c4bedf13b412e4f6bd94f729",
-      "@type": ["prov:Entity","nidm_ContrastMap:"],
+      "@id": "niiri:4f98291a207d3b592ea963c5b2efee61",
+      "@type": ["prov:Entity","nidm_ContrastMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "Contrast.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "Contrast.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Contrast Map: tone counting vs baseline",
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:d18f183003db6780cdc9b347b4af5993"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:d11490ae37fde7aa8e3ddc508c115313"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "fc5e2ad175243ee496db98f9b2e1b235c4c3bae1a8d7122ce461c897b537e40c49dfee5d6cf20f71c6a2bb9b5f0760fcb4ecd8fe2e9428910ef3d60d8f3c56a9"}
     },
     {
-      "@id": "niiri:ba567500b6f98025f5028377a682d495",
-      "@type": ["prov:Entity","nidm_ContrastMap:"],
+      "@id": "niiri:fa1e177a50edc20148667f0c1cfb02fc",
+      "@type": ["prov:Entity","nidm_ContrastMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "con_0001.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "d4aa46b3603ba508578e39751262d528cf6d1ed2e722ec46f1cd8194c50591e46b229deb8cb4f72d1b7e0e2640f3e6604be7a335301c5c8357f453e5d0d4daf2"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8c0ddb20c4bedf13b412e4f6bd94f729",
-      "entity": "niiri:ba567500b6f98025f5028377a682d495"
+      "entity_derived": "niiri:4f98291a207d3b592ea963c5b2efee61",
+      "entity": "niiri:fa1e177a50edc20148667f0c1cfb02fc"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:8c0ddb20c4bedf13b412e4f6bd94f729",
-      "activity": "niiri:e5b452dedb5772acbf6cb6d40e609ec6"
+      "entity_generated": "niiri:4f98291a207d3b592ea963c5b2efee61",
+      "activity": "niiri:d1e92a419c3d7e1b91add9945c81aa9b"
     },
     {
-      "@id": "niiri:59228b58841dd98008376655e745ae6e",
-      "@type": ["prov:Entity","nidm_ContrastStandardErrorMap:"],
+      "@id": "niiri:d590545b386aedf38aa5ec2c2ea31ee5",
+      "@type": ["prov:Entity","nidm_ContrastStandardErrorMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ContrastStandardError.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ContrastStandardError.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Contrast Standard Error Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:d18f183003db6780cdc9b347b4af5993"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:d11490ae37fde7aa8e3ddc508c115313"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "791d48f5d1adb15079a5289271ce0c4b95c56d69bfdb3e5d41b0d24eb538d3075e1cdd15502494b5a5a18c16eaa2153cb4847a996043fa48cdaf26e938a2576d"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:59228b58841dd98008376655e745ae6e",
-      "activity": "niiri:e5b452dedb5772acbf6cb6d40e609ec6"
+      "entity_generated": "niiri:d590545b386aedf38aa5ec2c2ea31ee5",
+      "activity": "niiri:d1e92a419c3d7e1b91add9945c81aa9b"
     },
     {
-      "@id": "niiri:7c7ed0f76f76f1117dfa57e232de3a30",
-      "@type": ["prov:Entity","nidm_HeightThreshold:","nidm_PValueUncorrected:"],
-      "rdfs:label": "Height Threshold: p<0.001000 (unc.)",
+      "@id": "niiri:53e9321dbde376b31728c3d81f4a0a0b",
+      "@type": ["prov:Entity","nidm_HeightThreshold","nidm_PValueUncorrected"],
+      "rdfs:label": "Height Threshold: p<0.001 (unc.)",
       "prov:value": {"@type": "xsd:float", "@value": "0.000999500158000544"},
-      "nidm_equivalentThreshold:": [{"@id": "niiri:9f3fbe76666cadf0ad70d8ef3da4c368"},{"@id": "niiri:8e6bdebe0aff733bb1d1d7a9ce971b0d"}]
+      "nidm_equivalentThreshold": [{"@id": "niiri:c87fc63ec6a46693c3ca483567ad054c"},{"@id": "niiri:1d698ce69f7c205e4e33223fd7699059"}]
     },
     {
-      "@id": "niiri:9f3fbe76666cadf0ad70d8ef3da4c368",
-      "@type": ["prov:Entity","nidm_HeightThreshold:","obo_statistic:"],
-      "rdfs:label": "Height Threshold",
+      "@id": "niiri:c87fc63ec6a46693c3ca483567ad054c",
+      "@type": ["prov:Entity","nidm_HeightThreshold","obo_statistic"],
+      "rdfs:label": "Height Threshold: T=3.175486)",
       "prov:value": {"@type": "xsd:float", "@value": "3.17548628637284"}
     },
     {
-      "@id": "niiri:8e6bdebe0aff733bb1d1d7a9ce971b0d",
-      "@type": ["prov:Entity","nidm_HeightThreshold:","obo_FWERadjustedpvalue:"],
-      "rdfs:label": "Height Threshold",
+      "@id": "niiri:1d698ce69f7c205e4e33223fd7699059",
+      "@type": ["prov:Entity","nidm_HeightThreshold","obo_FWERadjustedpvalue"],
+      "rdfs:label": "Height Threshold: p<1.000000 (FWE)",
       "prov:value": {"@type": "xsd:float", "@value": "0.999999999999997"}
     },
     {
-      "@id": "niiri:d7141484113de2469933a41936781235",
-      "@type": ["prov:Entity","nidm_ExtentThreshold:","obo_statistic:"],
+      "@id": "niiri:49c3b76bda9a7fe81e3019e52927592d",
+      "@type": ["prov:Entity","nidm_ExtentThreshold","obo_statistic"],
       "rdfs:label": "Extent Threshold: k>=0",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "0"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0"},
-      "nidm_equivalentThreshold:": [{"@id": "niiri:1fcabee08f59d5f43e7b0f23fa58641b"},{"@id": "niiri:e3a1985da2c64b397c01aa2cb5f0cfa8"}]
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "0"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0"},
+      "nidm_equivalentThreshold": [{"@id": "niiri:d8ad697fc9fe8926d011b79c7a5eed54"},{"@id": "niiri:9ab21986a7652c9329dd2f23b2b37581"}]
     },
     {
-      "@id": "niiri:1fcabee08f59d5f43e7b0f23fa58641b",
-      "@type": ["prov:Entity","nidm_ExtentThreshold:","obo_FWERadjustedpvalue:"],
+      "@id": "niiri:d8ad697fc9fe8926d011b79c7a5eed54",
+      "@type": ["prov:Entity","nidm_ExtentThreshold","obo_FWERadjustedpvalue"],
       "rdfs:label": "Extent Threshold",
       "prov:value": {"@type": "xsd:float", "@value": "1"}
     },
     {
-      "@id": "niiri:e3a1985da2c64b397c01aa2cb5f0cfa8",
-      "@type": ["prov:Entity","nidm_ExtentThreshold:","nidm_PValueUncorrected:"],
+      "@id": "niiri:9ab21986a7652c9329dd2f23b2b37581",
+      "@type": ["prov:Entity","nidm_ExtentThreshold","nidm_PValueUncorrected"],
       "rdfs:label": "Extent Threshold",
       "prov:value": {"@type": "xsd:float", "@value": "1"}
     },
     {
-      "@id": "niiri:effb144efe8c690eddfe2a5b5779d7a3",
-      "@type": ["prov:Entity","nidm_PeakDefinitionCriteria:"],
+      "@id": "niiri:40cd831e46a683970a4d9ab47538c686",
+      "@type": ["prov:Entity","nidm_PeakDefinitionCriteria"],
       "rdfs:label": "Peak Definition Criteria",
-      "nidm_maxNumberOfPeaksPerCluster:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_minDistanceBetweenPeaks:": {"@type": "xsd:float", "@value": "8"}
+      "nidm_maxNumberOfPeaksPerCluster": {"@type": "xsd:int", "@value": "3"},
+      "nidm_minDistanceBetweenPeaks": {"@type": "xsd:float", "@value": "8"}
     },
     {
-      "@id": "niiri:4ea97e5a5032b048f157d17ebe23d3dd",
-      "@type": ["prov:Entity","nidm_ClusterDefinitionCriteria:"],
+      "@id": "niiri:aec88dac07772a2bd5f7281a97725360",
+      "@type": ["prov:Entity","nidm_ClusterDefinitionCriteria"],
       "rdfs:label": "Cluster Connectivity Criterion: 18",
-      "nidm_hasConnectivityCriterion:": {"@id": "nidm_voxel18connected:"}
+      "nidm_hasConnectivityCriterion": {"@id": "nidm_voxel18connected"}
     },
     {
-      "@id": "niiri:ed463e8b4eba4764a73ae6571db2f829",
-      "@type": ["prov:Activity","nidm_Inference:"],
-      "nidm_hasAlternativeHypothesis:": {"@id": "nidm_OneTailedTest:"},
+      "@id": "niiri:1101ecb253f39161ef657cfcf8181ba6",
+      "@type": ["prov:Activity","nidm_Inference"],
+      "nidm_hasAlternativeHypothesis": {"@id": "nidm_OneTailedTest"},
       "rdfs:label": "Inference"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:ed463e8b4eba4764a73ae6571db2f829",
-      "agent": "niiri:01d87cfa40547d4de2e2e6acb69d8796"
+      "activity_associated": "niiri:1101ecb253f39161ef657cfcf8181ba6",
+      "agent": "niiri:7d55eee26233e3ffebe8fb466230d746"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:ed463e8b4eba4764a73ae6571db2f829",
-      "entity": "niiri:7c7ed0f76f76f1117dfa57e232de3a30"
+      "activity_using": "niiri:1101ecb253f39161ef657cfcf8181ba6",
+      "entity": "niiri:53e9321dbde376b31728c3d81f4a0a0b"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:ed463e8b4eba4764a73ae6571db2f829",
-      "entity": "niiri:d7141484113de2469933a41936781235"
+      "activity_using": "niiri:1101ecb253f39161ef657cfcf8181ba6",
+      "entity": "niiri:49c3b76bda9a7fe81e3019e52927592d"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:ed463e8b4eba4764a73ae6571db2f829",
-      "entity": "niiri:3e21b67f13781900c9629e35a248bed3"
+      "activity_using": "niiri:1101ecb253f39161ef657cfcf8181ba6",
+      "entity": "niiri:730c67ccd0e52a39ba60c5796037b4e0"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:ed463e8b4eba4764a73ae6571db2f829",
-      "entity": "niiri:85a893b3abb0636607b7910a8b9ba1f7"
+      "activity_using": "niiri:1101ecb253f39161ef657cfcf8181ba6",
+      "entity": "niiri:7adfaca483dfbb4c69fe57814c2e7ba5"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:ed463e8b4eba4764a73ae6571db2f829",
-      "entity": "niiri:1bff00d2a3c64ac18b7820d9ec2a5c1a"
+      "activity_using": "niiri:1101ecb253f39161ef657cfcf8181ba6",
+      "entity": "niiri:b129871a86340316a5e71da151467968"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:ed463e8b4eba4764a73ae6571db2f829",
-      "entity": "niiri:effb144efe8c690eddfe2a5b5779d7a3"
+      "activity_using": "niiri:1101ecb253f39161ef657cfcf8181ba6",
+      "entity": "niiri:40cd831e46a683970a4d9ab47538c686"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:ed463e8b4eba4764a73ae6571db2f829",
-      "entity": "niiri:4ea97e5a5032b048f157d17ebe23d3dd"
+      "activity_using": "niiri:1101ecb253f39161ef657cfcf8181ba6",
+      "entity": "niiri:aec88dac07772a2bd5f7281a97725360"
     },
     {
-      "@id": "niiri:e208d053ac178467d76b50bb1949baa4",
-      "@type": ["prov:Entity","nidm_DisplayMaskMap:"],
+      "@id": "niiri:1268daf6616504ca924affa8b4071eb7",
+      "@type": ["prov:Entity","nidm_DisplayMaskMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "DisplayMask_0001.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "DisplayMask_0001.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Display Mask Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:d18f183003db6780cdc9b347b4af5993"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:d11490ae37fde7aa8e3ddc508c115313"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "46fab45d854a777ac313b6e0d479d7c81c4a52633816ebdee43ad7403951265b761b58bbf0633c9abbd266f10a5e99bdbb24f02fc57ce4c475a69dc7f6120084"}
     },
     {
-      "@id": "niiri:f2eb921ac781980c4cd99cb23cb21456",
-      "@type": ["prov:Entity","nidm_DisplayMaskMap:"],
+      "@id": "niiri:939e38d7108636351d4b59905ee376fc",
+      "@type": ["prov:Entity","nidm_DisplayMaskMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "DisplayMask_0001.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "46fab45d854a777ac313b6e0d479d7c81c4a52633816ebdee43ad7403951265b761b58bbf0633c9abbd266f10a5e99bdbb24f02fc57ce4c475a69dc7f6120084"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e208d053ac178467d76b50bb1949baa4",
-      "entity": "niiri:f2eb921ac781980c4cd99cb23cb21456"
+      "entity_derived": "niiri:1268daf6616504ca924affa8b4071eb7",
+      "entity": "niiri:939e38d7108636351d4b59905ee376fc"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:ed463e8b4eba4764a73ae6571db2f829",
-      "entity": "niiri:e208d053ac178467d76b50bb1949baa4"
+      "activity_using": "niiri:1101ecb253f39161ef657cfcf8181ba6",
+      "entity": "niiri:1268daf6616504ca924affa8b4071eb7"
     },
     {
-      "@id": "niiri:b62857b85ec9896333e1f8552b5d7a2d",
-      "@type": ["prov:Entity","nidm_SearchSpaceMaskMap:"],
+      "@id": "niiri:73df7ed02a3cef4b6cbeb78f33bff831",
+      "@type": ["prov:Entity","nidm_SearchSpaceMaskMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "SearchSpaceMask.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "SearchSpaceMask.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Search Space Mask Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:d18f183003db6780cdc9b347b4af5993"},
-      "nidm_searchVolumeInVoxels:": {"@type": "xsd:int", "@value": "223057"},
-      "nidm_searchVolumeInUnits:": {"@type": "xsd:float", "@value": "1784456"},
-      "nidm_reselSizeInVoxels:": {"@type": "xsd:float", "@value": "65.5786964036542"},
-      "nidm_searchVolumeInResels:": {"@type": "xsd:float", "@value": "3155.84193266257"},
-      "spm_searchVolumeReselsGeometry:": {"@type": "xsd:string", "@value": "[6, 97.8140592306853, 965.938819261507, 3155.84193266257]"},
-      "nidm_noiseFWHMInVoxels:": {"@type": "xsd:string", "@value": "[4.09118640605185, 4.0346308705955, 3.97291894351243]"},
-      "nidm_noiseFWHMInUnits:": {"@type": "xsd:string", "@value": "[8.18237281210369, 8.069261741191, 7.94583788702486]"},
-      "nidm_randomFieldStationarity:": {"@type": "xsd:boolean", "@value": "true"},
-      "nidm_expectedNumberOfVoxelsPerCluster:": {"@type": "xsd:float", "@value": "7.21748994812991"},
-      "nidm_expectedNumberOfClusters:": {"@type": "xsd:float", "@value": "33.5642173578105"},
-      "nidm_heightCriticalThresholdFWE05:": {"@type": "xsd:float", "@value": "5.30963135104407"},
-      "nidm_heightCriticalThresholdFDR05:": {"@type": "xsd:float", "@value": "4.69981384277344"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:d11490ae37fde7aa8e3ddc508c115313"},
+      "nidm_searchVolumeInVoxels": {"@type": "xsd:int", "@value": "223057"},
+      "nidm_searchVolumeInUnits": {"@type": "xsd:float", "@value": "1784456"},
+      "nidm_reselSizeInVoxels": {"@type": "xsd:float", "@value": "65.5786964036542"},
+      "nidm_searchVolumeInResels": {"@type": "xsd:float", "@value": "3155.84193266257"},
+      "spm_searchVolumeReselsGeometry": {"@type": "xsd:string", "@value": "[6, 97.8140592306853, 965.938819261507, 3155.84193266257]"},
+      "nidm_noiseFWHMInVoxels": {"@type": "xsd:string", "@value": "[4.09118640605185, 4.0346308705955, 3.97291894351243]"},
+      "nidm_noiseFWHMInUnits": {"@type": "xsd:string", "@value": "[8.18237281210369, 8.069261741191, 7.94583788702486]"},
+      "nidm_randomFieldStationarity": {"@type": "xsd:boolean", "@value": "true"},
+      "nidm_expectedNumberOfVoxelsPerCluster": {"@type": "xsd:float", "@value": "7.21748994812991"},
+      "nidm_expectedNumberOfClusters": {"@type": "xsd:float", "@value": "33.5642173578105"},
+      "nidm_heightCriticalThresholdFWE05": {"@type": "xsd:float", "@value": "5.30963135104407"},
+      "nidm_heightCriticalThresholdFDR05": {"@type": "xsd:float", "@value": "4.69981384277344"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876"},
-      "spm_smallestSignificantClusterSizeInVoxelsFWE05:": {"@type": "xsd:int", "@value": "116"},
-      "spm_smallestSignificantClusterSizeInVoxelsFDR05:": {"@type": "xsd:int", "@value": "61"}
+      "spm_smallestSignificantClusterSizeInVoxelsFWE05": {"@type": "xsd:int", "@value": "116"},
+      "spm_smallestSignificantClusterSizeInVoxelsFDR05": {"@type": "xsd:int", "@value": "61"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:b62857b85ec9896333e1f8552b5d7a2d",
-      "activity": "niiri:ed463e8b4eba4764a73ae6571db2f829"
+      "entity_generated": "niiri:73df7ed02a3cef4b6cbeb78f33bff831",
+      "activity": "niiri:1101ecb253f39161ef657cfcf8181ba6"
     },
     {
-      "@id": "niiri:319501d11f59d427be0a95daa1d6c9ec",
-      "@type": ["prov:Entity","nidm_ExcursionSetMap:"],
+      "@id": "niiri:275a137c82db0d48c36216f7ba80d8d2",
+      "@type": ["prov:Entity","nidm_ExcursionSetMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ExcursionSet.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ExcursionSet.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Excursion Set Map",
-      "nidm_numberOfSupraThresholdClusters:": {"@type": "xsd:int", "@value": "80"},
-      "nidm_pValue:": {"@type": "xsd:float", "@value": "7.38731298355333e-12"},
-      "nidm_hasClusterLabelsMap:": {"@id": "niiri:cb3b802b67916e52a5d56d007cd63d0e"},
-      "nidm_hasMaximumIntensityProjection:": {"@id": "niiri:d783d0864d6ff0e23f6397fdfa195d0b"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:d18f183003db6780cdc9b347b4af5993"},
+      "nidm_numberOfSupraThresholdClusters": {"@type": "xsd:int", "@value": "80"},
+      "nidm_pValue": {"@type": "xsd:float", "@value": "7.38731298355333e-12"},
+      "nidm_hasClusterLabelsMap": {"@id": "niiri:88d834b9ce15f8537feb3bd97e96e717"},
+      "nidm_hasMaximumIntensityProjection": {"@id": "niiri:d243649d29fccf080be6c8ea1a6e7819"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:d11490ae37fde7aa8e3ddc508c115313"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "54596a95519bdf2c4ca115cd15edb36766890d6bff09c37e0921f662a1090d005971b58b638ed7efb060eaf4bec1980868aa8f88e5a7f57d803f9a2a76b544f2"}
     },
     {
-      "@id": "niiri:cb3b802b67916e52a5d56d007cd63d0e",
-      "@type": ["prov:Entity","nidm_ClusterLabelsMap:"],
+      "@id": "niiri:88d834b9ce15f8537feb3bd97e96e717",
+      "@type": ["prov:Entity","nidm_ClusterLabelsMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ClusterLabels.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ClusterLabels.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Cluster Labels Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:d18f183003db6780cdc9b347b4af5993"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:d11490ae37fde7aa8e3ddc508c115313"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "6ab7aa2a0d22ba2ea42152b22400d3afa337ce2556c46fb9a065c8dc80c2af310314dac55a5add1fe3a02292d97e725c655994c105485139e49b003af55cafdd"}
     },
     {
-      "@id": "niiri:d783d0864d6ff0e23f6397fdfa195d0b",
+      "@id": "niiri:d243649d29fccf080be6c8ea1a6e7819",
       "@type": ["prov:Entity","dctype:Image"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "MaximumIntensityProjection.png"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "MaximumIntensityProjection.png"},
@@ -759,3488 +759,3488 @@
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:319501d11f59d427be0a95daa1d6c9ec",
-      "activity": "niiri:ed463e8b4eba4764a73ae6571db2f829"
+      "entity_generated": "niiri:275a137c82db0d48c36216f7ba80d8d2",
+      "activity": "niiri:1101ecb253f39161ef657cfcf8181ba6"
     },
     {
-      "@id": "niiri:15be626f283e4842ffd8314f2d3e1b16",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:fefba803c839cbd72009efffd0596397",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0001",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1591"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "24.260927515347"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.91671618308799e-20"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "4.58706002591263e-11"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "1"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1591"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "24.260927515347"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.91671618308799e-20"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "4.58706002591263e-11"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "1"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:15be626f283e4842ffd8314f2d3e1b16",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:fefba803c839cbd72009efffd0596397",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:0db4cde09719c963f970eb48ae2552e8",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:92d29aeefcd3cfea4144809ceee1698b",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0002",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "256"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "3.90370675294081"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.1468976906843e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "7.20563445519851e-05"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000672150622508277"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "2"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "256"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "3.90370675294081"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.1468976906843e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "7.20563445519851e-05"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000672150622508277"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "2"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0db4cde09719c963f970eb48ae2552e8",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:92d29aeefcd3cfea4144809ceee1698b",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:6ea1bac2d55c2ba420c4f23fed407a68",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:ce42f33dd5918ee27ba8f8f6ccae137b",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0003",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4797"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "73.1487550541291"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.02777333984009e-40"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "5.93371085041799e-20"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "3"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4797"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "73.1487550541291"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.02777333984009e-40"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "5.93371085041799e-20"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "3"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6ea1bac2d55c2ba420c4f23fed407a68",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:ce42f33dd5918ee27ba8f8f6ccae137b",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:a09617bcbda951297c2f5a30eb214dc8",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:4ceeccbd429ca3c7d49d9b7ebbcbd0c0",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0004",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "109"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.66212514090058"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000619430978345348"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0205760791179098"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.022111501908576"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "4"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "109"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.66212514090058"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000619430978345348"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0205760791179098"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.022111501908576"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "4"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a09617bcbda951297c2f5a30eb214dc8",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:4ceeccbd429ca3c7d49d9b7ebbcbd0c0",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:5093925a984c3130f741f5e59fc218b0",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:caaf1d53a3cdfedef4ec795140a8062d",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0005",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "479"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "7.30420130726034"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.47290588891981e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "8.30011472885417e-08"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1.22279946227405e-07"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "5"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "479"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "7.30420130726034"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.47290588891981e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "8.30011472885417e-08"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1.22279946227405e-07"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "5"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5093925a984c3130f741f5e59fc218b0",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:caaf1d53a3cdfedef4ec795140a8062d",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:e14a70de96226faafe4fda4afc1b78d5",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:4e4124102f807b660cd900fcbb6a1dad",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0006",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "216"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "3.29375257279381"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.68560644295496e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.000291483093082134"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000672150622508277"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "6"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "216"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "3.29375257279381"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.68560644295496e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.000291483093082134"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000672150622508277"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "6"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e14a70de96226faafe4fda4afc1b78d5",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:4e4124102f807b660cd900fcbb6a1dad",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:349c921f1331e272395f14c01123038e",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:8a537453623b3e259868fdc3d34a15c0",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0007",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "258"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "3.93420446194816"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.00598573324675e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "6.73270745981114e-05"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000672150622508277"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "7"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "258"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "3.93420446194816"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.00598573324675e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "6.73270745981114e-05"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000672150622508277"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "7"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:349c921f1331e272395f14c01123038e",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:8a537453623b3e259868fdc3d34a15c0",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:9204e7e7da9650b9d4bc408770a00fdb",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:ceaad5cdc25363799f97feba2f347a03",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0008",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "115"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.75361826792263"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000473502560841437"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0157671196134005"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.022111501908576"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "8"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "115"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.75361826792263"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000473502560841437"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0157671196134005"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.022111501908576"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "8"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9204e7e7da9650b9d4bc408770a00fdb",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:ceaad5cdc25363799f97feba2f347a03",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:e09b8959852a4e5d12cc0ed7036f61f0",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:00cf15c153fb34e5bdc7c627fc153666",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0009",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "14"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.21348396305145"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.152527900243506"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.994020866354823"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.374386664234061"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "9"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "14"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.21348396305145"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.152527900243506"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.994020866354823"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.374386664234061"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "9"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e09b8959852a4e5d12cc0ed7036f61f0",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:00cf15c153fb34e5bdc7c627fc153666",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:6f02516841dde7aca88f672df0319963",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:9fa05d9e51da6e1bf65e29c91292c1f9",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0010",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "8"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.1219908360294"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.273933067513935"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999898388010158"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.554714461715718"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "10"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "8"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.1219908360294"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.273933067513935"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999898388010158"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.554714461715718"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "10"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6f02516841dde7aca88f672df0319963",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:9fa05d9e51da6e1bf65e29c91292c1f9",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:ff5aee3969c7de59773c94fa04a5a85f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:fdf70ff4bf081216be7e467153d2d4d8",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0011",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "32"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.487963344117601"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0382783172210746"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.723289033362049"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.190729630640958"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "11"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "32"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.487963344117601"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0382783172210746"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.723289033362049"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.190729630640958"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "11"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ff5aee3969c7de59773c94fa04a5a85f",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:fdf70ff4bf081216be7e467153d2d4d8",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:7cafb1e5ff245f47dacb09ebc1f3d273",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:bca5fdf4d900bd8486f16dfcd5ab7ade",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0012",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "354"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "5.39809449430096"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "9.21801193020289e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "3.09394877406888e-06"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "9.4369593516496e-06"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "12"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "354"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "5.39809449430096"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "9.21801193020289e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "3.09394877406888e-06"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "9.4369593516496e-06"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "12"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7cafb1e5ff245f47dacb09ebc1f3d273",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:bca5fdf4d900bd8486f16dfcd5ab7ade",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:bccdf03045b0a0de8d422d00c46014f1",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:a310e577676878e8eb7499da29ff53b4",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0013",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "135"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "2.05859535799613"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00019963673720055"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00667825153705648"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00187402776443535"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "13"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "135"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "2.05859535799613"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00019963673720055"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00667825153705648"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00187402776443535"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "13"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:bccdf03045b0a0de8d422d00c46014f1",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:a310e577676878e8eb7499da29ff53b4",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:2ecde1198137ba8c84d7f2b8ee573a34",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:4e10b0470621dd6f66d32e5f0d86796f",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0014",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "29"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.442216780606576"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0470937359607303"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.79416170413585"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.190729630640958"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "14"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "29"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.442216780606576"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0470937359607303"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.79416170413585"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.190729630640958"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "14"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2ecde1198137ba8c84d7f2b8ee573a34",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:4e10b0470621dd6f66d32e5f0d86796f",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:f195588e037cf5066c03b040bdd17c5c",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:8d02357e68e2217c76b2789fc556a1e0",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0015",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "38"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.579456471139651"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0257597057294564"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.578781830495109"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.130408510255373"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "15"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "38"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.579456471139651"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0257597057294564"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.578781830495109"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.130408510255373"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "15"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f195588e037cf5066c03b040bdd17c5c",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:8d02357e68e2217c76b2789fc556a1e0",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:ae3238820d20eca8be6dc34ce2ca54dc",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:4f5f4e9dc219044ae730379a51a53a84",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0016",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "66"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.00642439724255"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00505772986700848"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.156131620150842"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0447442257801353"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "16"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "66"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.00642439724255"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00505772986700848"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.156131620150842"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0447442257801353"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "16"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ae3238820d20eca8be6dc34ce2ca54dc",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:4f5f4e9dc219044ae730379a51a53a84",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:5a36931b22b3ff3ae34e9ab8b27bca1e",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:770c988e0434c5ba8e4392759de30eea",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0017",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "76"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.1589129422793"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00300279655548563"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0958739715182708"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.022111501908576"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "17"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "76"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.1589129422793"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00300279655548563"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0958739715182708"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.022111501908576"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "17"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5a36931b22b3ff3ae34e9ab8b27bca1e",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:770c988e0434c5ba8e4392759de30eea",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:6def1f951e1919c60434a8119f03801a",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:ce1649f53d38c28c5b0d7cacaaf4f448",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0018",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "26"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.396470217095551"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0583630672052552"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.858988054642613"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.205539497548942"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "18"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "26"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.396470217095551"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0583630672052552"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.858988054642613"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.205539497548942"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "18"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6def1f951e1919c60434a8119f03801a",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:ce1649f53d38c28c5b0d7cacaaf4f448",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:f3a4e60499161232255b1ced0a699ecc",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:11d8aaf31a0f50da63a5edcfdc834eac",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0019",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "10"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.15248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.22255850848336"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999430072930499"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.487222680733842"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "19"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "10"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.15248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.22255850848336"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999430072930499"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.487222680733842"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "19"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f3a4e60499161232255b1ced0a699ecc",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:11d8aaf31a0f50da63a5edcfdc834eac",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:7c9ccbac3cd845dfc0c233005757f05f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:18af84b83a63dcee2acfd1b9003ffe17",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0020",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "28"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.426967926102901"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.050541462694511"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.81665481379022"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.194945641821685"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "20"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "28"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.426967926102901"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.050541462694511"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.81665481379022"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.194945641821685"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "20"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7c9ccbac3cd845dfc0c233005757f05f",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:18af84b83a63dcee2acfd1b9003ffe17",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:e89936e52b02ce3aa8a79b72737894c6",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:bc47992403400de624fca0326bfeca0a",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0021",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "8"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.1219908360294"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.273933067513935"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999898388010158"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.554714461715718"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "21"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "8"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.1219908360294"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.273933067513935"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999898388010158"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.554714461715718"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "21"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e89936e52b02ce3aa8a79b72737894c6",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:bc47992403400de624fca0326bfeca0a",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:18e987f3604a0d6c7d127a9be6b0fb68",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:0c6b532ae8d28e2999918870be27c672",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0022",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "8"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.1219908360294"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.273933067513935"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999898388010158"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.554714461715718"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "22"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "8"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.1219908360294"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.273933067513935"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999898388010158"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.554714461715718"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "22"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:18e987f3604a0d6c7d127a9be6b0fb68",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:0c6b532ae8d28e2999918870be27c672",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:b19fa2f74715b8879a4263e734abff89",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:58f0b66e88ddd39190a49cc289e1a6a9",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0023",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "46"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.701447307169051"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0156706594865274"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.409020187961064"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.130408510255373"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "23"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "46"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.701447307169051"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0156706594865274"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.409020187961064"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.130408510255373"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "23"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b19fa2f74715b8879a4263e734abff89",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:58f0b66e88ddd39190a49cc289e1a6a9",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:0c6a4c5eab9814c8a104ac2ab9ba8e00",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:6864ea0388f90fdf3d5a0840769fb194",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0024",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "5"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0762442725183751"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.388074947166389"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999997796430203"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.604501360009182"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "24"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "5"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0762442725183751"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.388074947166389"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999997796430203"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.604501360009182"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "24"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0c6a4c5eab9814c8a104ac2ab9ba8e00",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:6864ea0388f90fdf3d5a0840769fb194",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:2c0e11ce65487da45bf7a9358ee57871",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:560b390e6daf7bdacebd6f81fc2498ed",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0025",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "21"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.320225944577176"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0850912379420168"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.942502902202007"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.255273713826051"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "25"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "21"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.320225944577176"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0850912379420168"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.942502902202007"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.255273713826051"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "25"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2c0e11ce65487da45bf7a9358ee57871",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:560b390e6daf7bdacebd6f81fc2498ed",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:0b550e722b76049b2f7ca0131da7d9c2",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:b02b8c006088cba013305b13d972edc8",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0026",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "30"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.457465635110251"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.043916653732793"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.770998817460931"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.190729630640958"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "26"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "30"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.457465635110251"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.043916653732793"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.770998817460931"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.190729630640958"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "26"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0b550e722b76049b2f7ca0131da7d9c2",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:b02b8c006088cba013305b13d972edc8",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:72450de63634a896c274e40a3163e02f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:a4e0cdaf05e785d8dd95f23ce74745d2",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0027",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0609954180147001"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.44232166254071"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999643232106"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.628562362557851"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "27"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0609954180147001"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.44232166254071"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999643232106"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.628562362557851"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "27"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:72450de63634a896c274e40a3163e02f",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:a4e0cdaf05e785d8dd95f23ce74745d2",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:cd940e6e9b2162b03485c9d3045fe2cf",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:a57f08ef6a63ebebf16d1533899bc25f",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0028",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "27"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.411719071599226"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0542875242970965"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.83831709934398"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.199876794002946"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "28"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "27"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.411719071599226"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0542875242970965"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.83831709934398"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.199876794002946"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "28"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cd940e6e9b2162b03485c9d3045fe2cf",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:a57f08ef6a63ebebf16d1533899bc25f",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:e32122a83b7d8bb16e3180c78f7eda7c",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:61ed7bccd640009bb231b2a1982f0622",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0029",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "9"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.137239690533075"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.24643774370434"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999744295990386"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.511832236924399"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "29"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "9"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.137239690533075"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.24643774370434"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999744295990386"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.511832236924399"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "29"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e32122a83b7d8bb16e3180c78f7eda7c",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:61ed7bccd640009bb231b2a1982f0622",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:6ae34632238cbeb521e67cef26caf7eb",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:0095bc91a1253454e74d41690d9f6df3",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0030",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "59"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.899682415716827"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00740144045603054"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.219970513046964"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.061094648971533"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "30"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "59"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.899682415716827"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00740144045603054"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.219970513046964"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.061094648971533"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "30"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6ae34632238cbeb521e67cef26caf7eb",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:0095bc91a1253454e74d41690d9f6df3",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:5559b2a8337e94bc2084c45d5600922b",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:fdd0f25c58dffbc950780afac712f03c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0031",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "7"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.106741981525725"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.305873808816549"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999965218155016"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.604287280832693"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "31"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "7"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.106741981525725"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.305873808816549"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999965218155016"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.604287280832693"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "31"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5559b2a8337e94bc2084c45d5600922b",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:fdd0f25c58dffbc950780afac712f03c",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:853079021e568a419ad6b8ad88952642",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:19300df9cc64fa2764a0780af7af6f84",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0032",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "14"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.21348396305145"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.152527900243506"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.994020866354823"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.374386664234061"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "32"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "14"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.21348396305145"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.152527900243506"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.994020866354823"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.374386664234061"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "32"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:853079021e568a419ad6b8ad88952642",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:19300df9cc64fa2764a0780af7af6f84",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:0cf1dc899a75152a30a291b0a2560db3",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:5ef4fb1358a9a6249f348a6eb79516e7",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0033",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "9"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.137239690533075"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.24643774370434"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999744295990386"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.511832236924399"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "33"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "9"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.137239690533075"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.24643774370434"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999744295990386"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.511832236924399"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "33"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0cf1dc899a75152a30a291b0a2560db3",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:5ef4fb1358a9a6249f348a6eb79516e7",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:678b8fa6b0f9293b49f20d1427d409e0",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:520bd6c8ac4aa6408335f0e0c324688b",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0034",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "18"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.27447938106615"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.108241900089372"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.973564689982443"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.292253130241304"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "34"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "18"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.27447938106615"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.108241900089372"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.973564689982443"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.292253130241304"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "34"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:678b8fa6b0f9293b49f20d1427d409e0",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:520bd6c8ac4aa6408335f0e0c324688b",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:45253dc06118b1b5a6a77ba54c4b1490",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f881e9cbe818d5f8b37dfed6dec527cc",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0035",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "28"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.426967926102901"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.050541462694511"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.81665481379022"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.194945641821685"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "35"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "28"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.426967926102901"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.050541462694511"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.81665481379022"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.194945641821685"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "35"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:45253dc06118b1b5a6a77ba54c4b1490",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:f881e9cbe818d5f8b37dfed6dec527cc",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:a5e4bc181e94cafee69b551c62f10925",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:4aa4a0455dab2440720331d043f09ec2",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0036",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "13"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.198235108547775"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.166999709083906"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.996321368733297"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.39785224811166"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "36"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "13"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.198235108547775"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.166999709083906"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.996321368733297"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.39785224811166"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "36"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a5e4bc181e94cafee69b551c62f10925",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:4aa4a0455dab2440720331d043f09ec2",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:ce3143388409a30de94c45862dcc1603",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:69ca7568c07230cf3584aaca638281b0",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0037",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0609954180147001"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.44232166254071"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999643232106"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.628562362557851"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "37"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0609954180147001"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.44232166254071"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999643232106"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.628562362557851"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "37"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ce3143388409a30de94c45862dcc1603",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:69ca7568c07230cf3584aaca638281b0",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:76c08ff817708a0abbb42fa1bb47a0cf",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:350dbc35c571e3a5c09f2cdc4c910d34",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0038",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "20"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0920729885729446"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.954514323339066"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.278639392496977"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "38"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "20"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0920729885729446"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.954514323339066"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.278639392496977"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "38"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:76c08ff817708a0abbb42fa1bb47a0cf",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:350dbc35c571e3a5c09f2cdc4c910d34",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:47fed6da7f0600bc158182bd59714d25",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:5d231bb78e3753cb8f1f83f432b012a4",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0039",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "6"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0914931270220502"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.343388487126378"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999990125608014"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.604501360009182"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "39"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "6"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0914931270220502"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.343388487126378"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999990125608014"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.604501360009182"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "39"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:47fed6da7f0600bc158182bd59714d25",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:5d231bb78e3753cb8f1f83f432b012a4",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:3aaffeb437aa651f0d21d28a688e78dd",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:d962ed566ab823dc017d65a55c96005b",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0040",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "29"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.442216780606576"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0470937359607303"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.79416170413585"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.190729630640958"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "40"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "29"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.442216780606576"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0470937359607303"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.79416170413585"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.190729630640958"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "40"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3aaffeb437aa651f0d21d28a688e78dd",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:d962ed566ab823dc017d65a55c96005b",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:902f31a0f58308cc0d2941ed3096a18c",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:5ca18f66be2a0317891dd14ae924d09a",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0041",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "24"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.365972508088201"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0676477474681771"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.896743975460065"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.228311147705098"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "41"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "24"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.365972508088201"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0676477474681771"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.896743975460065"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.228311147705098"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "41"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:902f31a0f58308cc0d2941ed3096a18c",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:5ca18f66be2a0317891dd14ae924d09a",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:6fcbec37cf34db5ad09da73b06411a40",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:bf714e8e855430179f84817bfe8aa9f4",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0042",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "8"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.1219908360294"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.273933067513935"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999898388010158"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.554714461715718"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "42"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "8"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.1219908360294"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.273933067513935"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999898388010158"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.554714461715718"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "42"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6fcbec37cf34db5ad09da73b06411a40",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:bf714e8e855430179f84817bfe8aa9f4",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:f7fec6797003228e9250ccd152a5c37f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:404e791392df064f45734040de92da30",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0043",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "8"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.1219908360294"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.273933067513935"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999898388010158"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.554714461715718"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "43"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "8"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.1219908360294"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.273933067513935"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999898388010158"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.554714461715718"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "43"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f7fec6797003228e9250ccd152a5c37f",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:404e791392df064f45734040de92da30",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:35377dee19e22bb0a24fdb50eccf1b74",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:def46784463991aed85ece366ca75ad8",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0044",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999997153"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "44"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999997153"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "44"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:35377dee19e22bb0a24fdb50eccf1b74",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:def46784463991aed85ece366ca75ad8",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:662b849d101be496cda3a65d2f69da2b",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c2de51d4065404a70c8e75ad7f34a79f",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0045",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "21"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.320225944577176"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0850912379420168"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.942502902202007"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.255273713826051"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "45"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "21"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.320225944577176"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0850912379420168"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.942502902202007"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.255273713826051"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "45"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:662b849d101be496cda3a65d2f69da2b",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:c2de51d4065404a70c8e75ad7f34a79f",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:bb8721fcbfb280a841be169cb5e433b5",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f11cdd5ae11ea581dcd3882d3540354b",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0046",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "7"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.106741981525725"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.305873808816549"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999965218155016"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.604287280832693"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "46"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "7"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.106741981525725"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.305873808816549"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999965218155016"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.604287280832693"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "46"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:bb8721fcbfb280a841be169cb5e433b5",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:f11cdd5ae11ea581dcd3882d3540354b",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:8b2e8095aa6535f320b2113605db7dba",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:37773f3cd9125252813f9101750c8618",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0047",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0457465635110251"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.509991966452308"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999963189445"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.688489154710615"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "47"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0457465635110251"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.509991966452308"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999963189445"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.688489154710615"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "47"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8b2e8095aa6535f320b2113605db7dba",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:37773f3cd9125252813f9101750c8618",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:e7305b9c4bb3949423d41a45d18d3fcf",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:b9bf3dcf444022a80942813a2e7f252d",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0048",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0609954180147001"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.44232166254071"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999643232106"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.628562362557851"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "48"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0609954180147001"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.44232166254071"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999643232106"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.628562362557851"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "48"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e7305b9c4bb3949423d41a45d18d3fcf",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:b9bf3dcf444022a80942813a2e7f252d",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:fe1342908b2c590f0d205c54b090c224",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:06de03bbb8e40178692ae6ec9dd3f5d5",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0049",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "16"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.2439816720588"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.128031320700056"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.986394362860718"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.324079280522016"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "49"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "16"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.2439816720588"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.128031320700056"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.986394362860718"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.324079280522016"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "49"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:fe1342908b2c590f0d205c54b090c224",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:06de03bbb8e40178692ae6ec9dd3f5d5",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:ad067a0d2a64875916d47893c9bf91b0",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:ae0af12ba47d22765200496a05e3cc2e",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0050",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "5"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0762442725183751"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.388074947166389"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999997796430203"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.604501360009182"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "50"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "5"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0762442725183751"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.388074947166389"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999997796430203"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.604501360009182"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "50"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ad067a0d2a64875916d47893c9bf91b0",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:ae0af12ba47d22765200496a05e3cc2e",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:4426798282ac8143b4291fc9731c0d21",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f5ac1b556f82f90ca54e1755f459aeb0",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0051",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999997153"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "51"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999997153"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "51"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4426798282ac8143b4291fc9731c0d21",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:f5ac1b556f82f90ca54e1755f459aeb0",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:094ca018251a2b17ad5bbde342203d06",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:e0f350ef000b2636edd606950fbacdd8",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0052",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.598176099264786"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999998092195"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "52"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.598176099264786"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999998092195"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "52"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:094ca018251a2b17ad5bbde342203d06",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:e0f350ef000b2636edd606950fbacdd8",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:e765876280bde3e4bebecc566c8bd29c",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:208e0aa56bc32fd1c4efbe75ea40b1a0",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0053",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.598176099264786"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999998092195"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "53"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.598176099264786"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999998092195"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "53"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e765876280bde3e4bebecc566c8bd29c",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:208e0aa56bc32fd1c4efbe75ea40b1a0",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:b6238a8e3e93a9273be55294f38a7061",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:6270b7e521adb112773419d81745ba32",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0054",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0457465635110251"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.509991966452308"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999963189445"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.688489154710615"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "54"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0457465635110251"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.509991966452308"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999963189445"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.688489154710615"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "54"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b6238a8e3e93a9273be55294f38a7061",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:6270b7e521adb112773419d81745ba32",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:cedb782dada08c65c4916daa0ad6e465",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:6e8c7efcd65fd269ae1163d977b34228",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0055",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0609954180147001"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.44232166254071"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999643232106"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.628562362557851"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "55"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0609954180147001"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.44232166254071"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999643232106"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.628562362557851"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "55"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cedb782dada08c65c4916daa0ad6e465",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:6e8c7efcd65fd269ae1163d977b34228",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:47f716a7866282e59c2437414f29fb67",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:8bdb7c1cfc0e4c28f73b9ebb2067be4a",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0056",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "8"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.1219908360294"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.273933067513935"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999898388010158"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.554714461715718"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "56"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "8"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.1219908360294"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.273933067513935"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999898388010158"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.554714461715718"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "56"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:47f716a7866282e59c2437414f29fb67",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:8bdb7c1cfc0e4c28f73b9ebb2067be4a",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:e6b8fc7731810aa6f311348e0b1cc140",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:bb0ea248bef4b3a56f8b7bd4674e079a",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0057",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0457465635110251"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.509991966452308"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999963189445"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.688489154710615"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "57"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0457465635110251"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.509991966452308"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999963189445"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.688489154710615"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "57"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e6b8fc7731810aa6f311348e0b1cc140",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:bb0ea248bef4b3a56f8b7bd4674e079a",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:9e7a68deeddb09104c97844d6208138a",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:3ba5f3e50f85d1172dccf7cdc87e047a",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0058",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0457465635110251"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.509991966452308"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999963189445"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.688489154710615"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "58"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0457465635110251"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.509991966452308"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999963189445"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.688489154710615"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "58"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9e7a68deeddb09104c97844d6208138a",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:3ba5f3e50f85d1172dccf7cdc87e047a",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:9f7250b2986229e27c73d4ee533b5581",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:221ffcb9e61912db0c8ea94c83c806f3",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0059",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0457465635110251"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.509991966452308"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999963189445"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.688489154710615"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "59"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0457465635110251"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.509991966452308"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999963189445"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.688489154710615"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "59"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9f7250b2986229e27c73d4ee533b5581",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:221ffcb9e61912db0c8ea94c83c806f3",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:f895b7fb895eba3b656944c4b6b3efb7",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:680f2d4ea6ccf9065674d450817a8a71",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0060",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.598176099264786"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999998092195"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "60"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.598176099264786"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999998092195"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "60"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f895b7fb895eba3b656944c4b6b3efb7",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:680f2d4ea6ccf9065674d450817a8a71",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:1a924fb418bec3cd95c0a03c9ae66f54",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:cf57b893da54bea9529d4c0bc8ff02f0",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0061",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "6"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0914931270220502"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.343388487126378"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999990125608014"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.604501360009182"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "61"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "6"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0914931270220502"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.343388487126378"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999990125608014"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.604501360009182"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "61"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1a924fb418bec3cd95c0a03c9ae66f54",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:cf57b893da54bea9529d4c0bc8ff02f0",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:e8f2997ff1833098ebac8c27365f5882",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:06f83c4cb0758a1db3af7b9ac9595bd1",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0062",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0609954180147001"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.44232166254071"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999643232106"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.628562362557851"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "62"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0609954180147001"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.44232166254071"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999643232106"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.628562362557851"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "62"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e8f2997ff1833098ebac8c27365f5882",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:06f83c4cb0758a1db3af7b9ac9595bd1",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:af1ebc888c3ec8f9fad9e0c771ed7a78",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:33c167d8677c415c916bc8b906fd4db4",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0063",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.598176099264786"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999998092195"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "63"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.598176099264786"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999998092195"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "63"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:af1ebc888c3ec8f9fad9e0c771ed7a78",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:33c167d8677c415c916bc8b906fd4db4",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:93eff452c29120a5015af008a69e2b85",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:6f398d8313ba8da3802bd6174fad64a9",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0064",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0609954180147001"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.44232166254071"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999643232106"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.628562362557851"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "64"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0609954180147001"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.44232166254071"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999643232106"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.628562362557851"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "64"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:93eff452c29120a5015af008a69e2b85",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:6f398d8313ba8da3802bd6174fad64a9",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:eadc69190fdc6d634404fa8f12f510eb",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:441c62b804db7724fe069a4683eabbb3",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0065",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0609954180147001"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.44232166254071"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999643232106"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.628562362557851"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "65"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0609954180147001"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.44232166254071"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999643232106"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.628562362557851"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "65"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:eadc69190fdc6d634404fa8f12f510eb",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:441c62b804db7724fe069a4683eabbb3",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:fdf3341a871a270775355dceeb623541",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:9573a33cf8de1d0d7462efcefe1aa3b3",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0066",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999997153"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "66"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999997153"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "66"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:fdf3341a871a270775355dceeb623541",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:9573a33cf8de1d0d7462efcefe1aa3b3",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:d53a0a4ae6e04c2856dad6f7de113409",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:adc671bb3b8aead7b73b777448e0d974",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0067",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "5"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0762442725183751"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.388074947166389"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999997796430203"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.604501360009182"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "67"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "5"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0762442725183751"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.388074947166389"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999997796430203"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.604501360009182"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "67"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d53a0a4ae6e04c2856dad6f7de113409",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:adc671bb3b8aead7b73b777448e0d974",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:cf7aba36a552e6ca5812f44e1297b2e9",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:e9779649e0e322514fd2b0963b83e9b3",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0068",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.598176099264786"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999998092195"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "68"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.598176099264786"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999998092195"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "68"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cf7aba36a552e6ca5812f44e1297b2e9",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:e9779649e0e322514fd2b0963b83e9b3",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:43852b81a09cf6e877d19e5df6f9977b",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:41fb45bc18bea4725f44ca167cd99df1",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0069",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.598176099264786"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999998092195"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "69"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.598176099264786"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999998092195"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "69"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:43852b81a09cf6e877d19e5df6f9977b",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:41fb45bc18bea4725f44ca167cd99df1",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:a0bcd52b78a9ad004b1f13878095b584",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:eea8668c9a2e77333db7bb9162d0d4ef",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0070",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999997153"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "70"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999997153"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "70"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a0bcd52b78a9ad004b1f13878095b584",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:eea8668c9a2e77333db7bb9162d0d4ef",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:315508af939cde7c660dac4093bd5f63",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:dd0835679f1bd959157bd71b4d4ada4a",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0071",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999997153"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "71"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999997153"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "71"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:315508af939cde7c660dac4093bd5f63",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:dd0835679f1bd959157bd71b4d4ada4a",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:415cf023223ce3eb6f3ea193de2e66d0",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:7cdc9365fde87ad8333e6618dc3a8a51",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0072",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999997153"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "72"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999997153"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "72"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:415cf023223ce3eb6f3ea193de2e66d0",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:7cdc9365fde87ad8333e6618dc3a8a51",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:688e11a39a0754d2ec0a74d65774433a",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:7de4f98c4ea2239ac1a4b37fb8737ebb",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0073",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999997153"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "73"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999997153"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "73"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:688e11a39a0754d2ec0a74d65774433a",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:7de4f98c4ea2239ac1a4b37fb8737ebb",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:7a715e1614e6866276cb5725bccf59a3",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:392bbfa2f02e1783423c67df389a3772",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0074",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999997153"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "74"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999997153"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "74"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7a715e1614e6866276cb5725bccf59a3",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:392bbfa2f02e1783423c67df389a3772",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:fcab5dc9b5ee7cb3164b6fcfb041800b",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:e08ea74eba6d829dc8f77ccdfebbc2e1",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0075",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999997153"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "75"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999997153"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "75"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:fcab5dc9b5ee7cb3164b6fcfb041800b",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:e08ea74eba6d829dc8f77ccdfebbc2e1",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:62711d2ee0c0429ed4fbe29698cac6fd",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:81ce1dbb2b4b3915a17f1002f7600876",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0076",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999997153"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "76"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999997153"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "76"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:62711d2ee0c0429ed4fbe29698cac6fd",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:81ce1dbb2b4b3915a17f1002f7600876",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:485ed7c2aeeaf61df445bf323937617d",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:8ab01cc9ec9b9c9144318b6ebf4b61e5",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0077",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999997153"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "77"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999997153"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "77"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:485ed7c2aeeaf61df445bf323937617d",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:8ab01cc9ec9b9c9144318b6ebf4b61e5",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:78ffd46fab5c7ea256ba49f6155cee5b",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:e00f285b0f3ca710fd516c8d96d4953b",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0078",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999997153"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "78"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999997153"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "78"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:78ffd46fab5c7ea256ba49f6155cee5b",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:e00f285b0f3ca710fd516c8d96d4953b",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:1273746a68b63344576d89035c4af958",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:b113d084583b1c858c15b076e563ba0c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0079",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999997153"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "79"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999997153"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "79"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1273746a68b63344576d89035c4af958",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:b113d084583b1c858c15b076e563ba0c",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:00d8da85844fdb0d453c7cffeb50aef0",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f9a8bd72695ec56fe97eefd5b04d42d4",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0080",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.598176099264786"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999998092195"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "80"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.598176099264786"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999998092195"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "80"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:00d8da85844fdb0d453c7cffeb50aef0",
-      "entity": "niiri:319501d11f59d427be0a95daa1d6c9ec"
+      "entity_derived": "niiri:f9a8bd72695ec56fe97eefd5b04d42d4",
+      "entity": "niiri:275a137c82db0d48c36216f7ba80d8d2"
     },
     {
-      "@id": "niiri:d8f1062e1e54f9e2a3ff314951c0aa05",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3a4ff3f083b479126599de2b93ee4494",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0001",
-      "prov:atLocation": {"@id": "niiri:21ef7f7e02f40a4754f61c619ed70ed8"},
+      "prov:atLocation": {"@id": "niiri:e8cb4af6e2287b93daaa35d9368e138f"},
       "prov:value": {"@type": "xsd:float", "@value": "7.92007970809937"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "6.94608360738412"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.87783122385099e-12"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "4.18813870695089e-07"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "5.21674435923017e-06"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "6.94608360738412"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.87783122385099e-12"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "4.18813870695089e-07"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "5.21674435923017e-06"}
     },
     {
-      "@id": "niiri:21ef7f7e02f40a4754f61c619ed70ed8",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e8cb4af6e2287b93daaa35d9368e138f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0001",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[46,16,24]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[46,16,24]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d8f1062e1e54f9e2a3ff314951c0aa05",
-      "entity": "niiri:15be626f283e4842ffd8314f2d3e1b16"
+      "entity_derived": "niiri:3a4ff3f083b479126599de2b93ee4494",
+      "entity": "niiri:fefba803c839cbd72009efffd0596397"
     },
     {
-      "@id": "niiri:930d018c1c6671eae04e6470cf7e4d41",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c1930c3f0150f6f5873ea6a691551e74",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0002",
-      "prov:atLocation": {"@id": "niiri:de0aede430b18974ce871c3365148733"},
+      "prov:atLocation": {"@id": "niiri:ddb568a298d8393fcda5254093cef5a1"},
       "prov:value": {"@type": "xsd:float", "@value": "6.31603479385376"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.77079466112137"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.94492849498107e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.000879943865776389"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000830722551601523"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.77079466112137"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.94492849498107e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.000879943865776389"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000830722551601523"}
     },
     {
-      "@id": "niiri:de0aede430b18974ce871c3365148733",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ddb568a298d8393fcda5254093cef5a1",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0002",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[32,24,-4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[32,24,-4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:930d018c1c6671eae04e6470cf7e4d41",
-      "entity": "niiri:15be626f283e4842ffd8314f2d3e1b16"
+      "entity_derived": "niiri:c1930c3f0150f6f5873ea6a691551e74",
+      "entity": "niiri:fefba803c839cbd72009efffd0596397"
     },
     {
-      "@id": "niiri:806250470178babe07a529853a8145be",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:517d6fcfeee2d840a2f52301d1beebd1",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0003",
-      "prov:atLocation": {"@id": "niiri:adf7353342f6c4026bc080a9604a61e2"},
+      "prov:atLocation": {"@id": "niiri:bf75fde12cfced38bab64da3a1c7e7bd"},
       "prov:value": {"@type": "xsd:float", "@value": "5.68819808959961"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.27450168515333"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.655864770444e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0121028975026269"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00350091530962783"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.27450168515333"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.655864770444e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0121028975026269"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00350091530962783"}
     },
     {
-      "@id": "niiri:adf7353342f6c4026bc080a9604a61e2",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:bf75fde12cfced38bab64da3a1c7e7bd",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0003",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[18,16,4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[18,16,4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:806250470178babe07a529853a8145be",
-      "entity": "niiri:15be626f283e4842ffd8314f2d3e1b16"
+      "entity_derived": "niiri:517d6fcfeee2d840a2f52301d1beebd1",
+      "entity": "niiri:fefba803c839cbd72009efffd0596397"
     },
     {
-      "@id": "niiri:705892c44a96334c05f8892302b0be49",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:be45fc5c8318611dbeb6926eff14603d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0004",
-      "prov:atLocation": {"@id": "niiri:3d18591e9e24b856fbbeab504e6b2536"},
+      "prov:atLocation": {"@id": "niiri:0bb09b273612bdec706a34e18f9bcded"},
       "prov:value": {"@type": "xsd:float", "@value": "7.11683940887451"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "6.37404871703245"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "9.20510334623259e-11"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "2.05325778424026e-05"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "9.33757664730496e-05"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "6.37404871703245"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "9.20510334623259e-11"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "2.05325778424026e-05"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "9.33757664730496e-05"}
     },
     {
-      "@id": "niiri:3d18591e9e24b856fbbeab504e6b2536",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0bb09b273612bdec706a34e18f9bcded",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0004",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[34,-88,-2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[34,-88,-2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:705892c44a96334c05f8892302b0be49",
-      "entity": "niiri:0db4cde09719c963f970eb48ae2552e8"
+      "entity_derived": "niiri:be45fc5c8318611dbeb6926eff14603d",
+      "entity": "niiri:92d29aeefcd3cfea4144809ceee1698b"
     },
     {
-      "@id": "niiri:554afe506d3af35cae9f1989577ad77d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f732c2c67e196714c26505f667b9c2d1",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0005",
-      "prov:atLocation": {"@id": "niiri:11740dc9cebfcb0636315b88af1574cc"},
+      "prov:atLocation": {"@id": "niiri:0f15cb6ae5a62f7643842075286cf4fe"},
       "prov:value": {"@type": "xsd:float", "@value": "6.48292255401611"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.8992593141605"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.82568493656277e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.000407231755366277"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000830722551601523"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.8992593141605"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.82568493656277e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.000407231755366277"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000830722551601523"}
     },
     {
-      "@id": "niiri:11740dc9cebfcb0636315b88af1574cc",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0f15cb6ae5a62f7643842075286cf4fe",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0005",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[42,-72,-10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[42,-72,-10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:554afe506d3af35cae9f1989577ad77d",
-      "entity": "niiri:0db4cde09719c963f970eb48ae2552e8"
+      "entity_derived": "niiri:f732c2c67e196714c26505f667b9c2d1",
+      "entity": "niiri:92d29aeefcd3cfea4144809ceee1698b"
     },
     {
-      "@id": "niiri:758c32c1a97be19a51909978cb78c3f9",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:cd40c3fa5c01d430365872162ed32735",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0006",
-      "prov:atLocation": {"@id": "niiri:8183fb9497de339be77600251139961b"},
+      "prov:atLocation": {"@id": "niiri:dcffc4466433c7a4343c26a918e412f8"},
       "prov:value": {"@type": "xsd:float", "@value": "5.2275915145874"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.89738468004472"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.85602978606003e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0670610253017228"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0118363293065346"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.89738468004472"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.85602978606003e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0670610253017228"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0118363293065346"}
     },
     {
-      "@id": "niiri:8183fb9497de339be77600251139961b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:dcffc4466433c7a4343c26a918e412f8",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0006",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[34,-86,12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[34,-86,12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:758c32c1a97be19a51909978cb78c3f9",
-      "entity": "niiri:0db4cde09719c963f970eb48ae2552e8"
+      "entity_derived": "niiri:cd40c3fa5c01d430365872162ed32735",
+      "entity": "niiri:92d29aeefcd3cfea4144809ceee1698b"
     },
     {
-      "@id": "niiri:581ec0522b560e452912b9eef2f0e8c5",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:2850c3df9bf571ce4f3306beddf5444f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0007",
-      "prov:atLocation": {"@id": "niiri:0a196bd3badb45f310dde176acb28cfc"},
+      "prov:atLocation": {"@id": "niiri:bfd22ab330963feb1e9bfb0094e06fad"},
       "prov:value": {"@type": "xsd:float", "@value": "6.28007745742798"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.74292583422276"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.65272453897825e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00103782272796227"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000830722551601523"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.74292583422276"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.65272453897825e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00103782272796227"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000830722551601523"}
     },
     {
-      "@id": "niiri:0a196bd3badb45f310dde176acb28cfc",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:bfd22ab330963feb1e9bfb0094e06fad",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0007",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[8,18,50]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[8,18,50]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:581ec0522b560e452912b9eef2f0e8c5",
-      "entity": "niiri:6ea1bac2d55c2ba420c4f23fed407a68"
+      "entity_derived": "niiri:2850c3df9bf571ce4f3306beddf5444f",
+      "entity": "niiri:ce42f33dd5918ee27ba8f8f6ccae137b"
     },
     {
-      "@id": "niiri:3d55b69824ac802a33ea866ca06d5e47",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f822a28c39d3ea42481d34bbc8df22dd",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0008",
-      "prov:atLocation": {"@id": "niiri:7bdcf38ff7a4e78ab0ef3784b67e4ff0"},
+      "prov:atLocation": {"@id": "niiri:e2981bd8238c191c38e7681182953e91"},
       "prov:value": {"@type": "xsd:float", "@value": "6.15222215652466"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.64328512810061"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.34178537356678e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00186069357054308"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000972721201433817"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.64328512810061"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.34178537356678e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00186069357054308"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000972721201433817"}
     },
     {
-      "@id": "niiri:7bdcf38ff7a4e78ab0ef3784b67e4ff0",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e2981bd8238c191c38e7681182953e91",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0008",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-6,12,52]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-6,12,52]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3d55b69824ac802a33ea866ca06d5e47",
-      "entity": "niiri:6ea1bac2d55c2ba420c4f23fed407a68"
+      "entity_derived": "niiri:f822a28c39d3ea42481d34bbc8df22dd",
+      "entity": "niiri:ce42f33dd5918ee27ba8f8f6ccae137b"
     },
     {
-      "@id": "niiri:d8d831684924ab6a424864bf6a56224a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0601bd281b645fc4e7cea6590daaea37",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0009",
-      "prov:atLocation": {"@id": "niiri:d3db44b97cabf3a4a72fbe343656ca60"},
+      "prov:atLocation": {"@id": "niiri:4223785a2c52847776be8e182b12c3a7"},
       "prov:value": {"@type": "xsd:float", "@value": "5.98517084121704"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.51181334779297"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.77577724747024e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00376326218366319"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00136419627856355"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.51181334779297"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.77577724747024e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00376326218366319"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00136419627856355"}
     },
     {
-      "@id": "niiri:d3db44b97cabf3a4a72fbe343656ca60",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4223785a2c52847776be8e182b12c3a7",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0009",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[8,32,38]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[8,32,38]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d8d831684924ab6a424864bf6a56224a",
-      "entity": "niiri:6ea1bac2d55c2ba420c4f23fed407a68"
+      "entity_derived": "niiri:0601bd281b645fc4e7cea6590daaea37",
+      "entity": "niiri:ce42f33dd5918ee27ba8f8f6ccae137b"
     },
     {
-      "@id": "niiri:8bd4848ac7623298803f1a34787fa966",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:eeb7eca4dd37f5ca956393c13b86f395",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0010",
-      "prov:atLocation": {"@id": "niiri:8de5a5730461bca9655e8bc03421f590"},
+      "prov:atLocation": {"@id": "niiri:9350f7883a57d93d1d3bf27b2227a68d"},
       "prov:value": {"@type": "xsd:float", "@value": "6.25127363204956"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.72055271981637"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.30890376104765e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0011841880966994"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000830722551601523"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.72055271981637"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.30890376104765e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0011841880966994"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000830722551601523"}
     },
     {
-      "@id": "niiri:8de5a5730461bca9655e8bc03421f590",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:9350f7883a57d93d1d3bf27b2227a68d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0010",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[52,-32,42]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[52,-32,42]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8bd4848ac7623298803f1a34787fa966",
-      "entity": "niiri:a09617bcbda951297c2f5a30eb214dc8"
+      "entity_derived": "niiri:eeb7eca4dd37f5ca956393c13b86f395",
+      "entity": "niiri:4ceeccbd429ca3c7d49d9b7ebbcbd0c0"
     },
     {
-      "@id": "niiri:8a46b0279756f6415a018c7711b1a4cb",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:4fad84948d108d419b34432aba0aaf97",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0011",
-      "prov:atLocation": {"@id": "niiri:11298449eeae494e6b78c62c62147081"},
+      "prov:atLocation": {"@id": "niiri:9443d25369cbea84515f23e7d0f92386"},
       "prov:value": {"@type": "xsd:float", "@value": "6.24752378463745"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.71763687476157"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.40078304300806e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00120468241369565"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000830722551601523"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.71763687476157"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.40078304300806e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00120468241369565"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000830722551601523"}
     },
     {
-      "@id": "niiri:11298449eeae494e6b78c62c62147081",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:9443d25369cbea84515f23e7d0f92386",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0011",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[40,-62,50]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[40,-62,50]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8a46b0279756f6415a018c7711b1a4cb",
-      "entity": "niiri:5093925a984c3130f741f5e59fc218b0"
+      "entity_derived": "niiri:4fad84948d108d419b34432aba0aaf97",
+      "entity": "niiri:caaf1d53a3cdfedef4ec795140a8062d"
     },
     {
-      "@id": "niiri:508e522a3771bd47c48a85e2503ec95e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:25794aacdb036e5295f9624245fbac2d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0012",
-      "prov:atLocation": {"@id": "niiri:bc7a498f8663f0f24d67c6c80c21bf98"},
+      "prov:atLocation": {"@id": "niiri:e07f914385d7440f95f63702677992f0"},
       "prov:value": {"@type": "xsd:float", "@value": "5.70337772369385"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.28674301747281"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.22566831420812e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.011413186758684"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00350091530962783"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.28674301747281"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.22566831420812e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.011413186758684"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00350091530962783"}
     },
     {
-      "@id": "niiri:bc7a498f8663f0f24d67c6c80c21bf98",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e07f914385d7440f95f63702677992f0",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0012",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[56,-44,52]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[56,-44,52]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:508e522a3771bd47c48a85e2503ec95e",
-      "entity": "niiri:5093925a984c3130f741f5e59fc218b0"
+      "entity_derived": "niiri:25794aacdb036e5295f9624245fbac2d",
+      "entity": "niiri:caaf1d53a3cdfedef4ec795140a8062d"
     },
     {
-      "@id": "niiri:843fee814dd98b6545f8be55d8dac863",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:cb9ecebff84e7c0bcff30f16d62e415c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0013",
-      "prov:atLocation": {"@id": "niiri:8156244ae431d17d5e84fbc488d4ee87"},
+      "prov:atLocation": {"@id": "niiri:d53d6dc777cb961845f7af09a33453e0"},
       "prov:value": {"@type": "xsd:float", "@value": "5.69516134262085"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.28011855642631"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.45501619933597e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0117816592148946"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00350091530962783"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.28011855642631"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.45501619933597e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0117816592148946"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00350091530962783"}
     },
     {
-      "@id": "niiri:8156244ae431d17d5e84fbc488d4ee87",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d53d6dc777cb961845f7af09a33453e0",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0013",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[60,-36,54]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[60,-36,54]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:843fee814dd98b6545f8be55d8dac863",
-      "entity": "niiri:5093925a984c3130f741f5e59fc218b0"
+      "entity_derived": "niiri:cb9ecebff84e7c0bcff30f16d62e415c",
+      "entity": "niiri:caaf1d53a3cdfedef4ec795140a8062d"
     },
     {
-      "@id": "niiri:afb566c89e494d1668c1dfe84e585fce",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0108e1dedeb535eeacb8a83cdebc4299",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0014",
-      "prov:atLocation": {"@id": "niiri:b9e748b9c817f1ca063fc3c73b314ad0"},
+      "prov:atLocation": {"@id": "niiri:0c45c162c51c7e916c4ae63fd56c3aed"},
       "prov:value": {"@type": "xsd:float", "@value": "6.10109901428223"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.60320502193174"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.05212039080982e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00234682813060005"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00104518293275697"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.60320502193174"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.05212039080982e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00234682813060005"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00104518293275697"}
     },
     {
-      "@id": "niiri:b9e748b9c817f1ca063fc3c73b314ad0",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0c45c162c51c7e916c4ae63fd56c3aed",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0014",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[32,2,46]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[32,2,46]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:afb566c89e494d1668c1dfe84e585fce",
-      "entity": "niiri:e14a70de96226faafe4fda4afc1b78d5"
+      "entity_derived": "niiri:0108e1dedeb535eeacb8a83cdebc4299",
+      "entity": "niiri:4e4124102f807b660cd900fcbb6a1dad"
     },
     {
-      "@id": "niiri:4299a4375397892dfe75cb1a0aa4ecbc",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a83bcc10e77d0eaa4587d34a0f971292",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0015",
-      "prov:atLocation": {"@id": "niiri:601f78fa9f596cbdc2e60f0f3e73f5fc"},
+      "prov:atLocation": {"@id": "niiri:bd5f175b844254cd01005a778cafe8ff"},
       "prov:value": {"@type": "xsd:float", "@value": "4.6086859703064"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.3736141683061"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.11031435759912e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.453877178455514"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0599714495109201"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.3736141683061"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.11031435759912e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.453877178455514"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0599714495109201"}
     },
     {
-      "@id": "niiri:601f78fa9f596cbdc2e60f0f3e73f5fc",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:bd5f175b844254cd01005a778cafe8ff",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0015",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[28,4,58]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[28,4,58]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4299a4375397892dfe75cb1a0aa4ecbc",
-      "entity": "niiri:e14a70de96226faafe4fda4afc1b78d5"
+      "entity_derived": "niiri:a83bcc10e77d0eaa4587d34a0f971292",
+      "entity": "niiri:4e4124102f807b660cd900fcbb6a1dad"
     },
     {
-      "@id": "niiri:10eae3e429ecacc5b6e190b25d61ce0b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c560dc9de917957ed93bc5ed23e74ca3",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0016",
-      "prov:atLocation": {"@id": "niiri:a56f038f8a44eaf3c54322b07b8fb041"},
+      "prov:atLocation": {"@id": "niiri:3e99bb8f1bc3edfb1797aa2727ed8adf"},
       "prov:value": {"@type": "xsd:float", "@value": "5.98348569869995"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.51047970249337"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.78928538652201e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00378871596531738"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00136419627856355"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.51047970249337"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.78928538652201e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00378871596531738"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00136419627856355"}
     },
     {
-      "@id": "niiri:a56f038f8a44eaf3c54322b07b8fb041",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:3e99bb8f1bc3edfb1797aa2727ed8adf",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0016",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-52,0,38]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-52,0,38]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:10eae3e429ecacc5b6e190b25d61ce0b",
-      "entity": "niiri:349c921f1331e272395f14c01123038e"
+      "entity_derived": "niiri:c560dc9de917957ed93bc5ed23e74ca3",
+      "entity": "niiri:8a537453623b3e259868fdc3d34a15c0"
     },
     {
-      "@id": "niiri:569db1fa1f02eabd48742d0c089d7d3b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:afb5bbe52a67b2392f36dae9544d164a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0017",
-      "prov:atLocation": {"@id": "niiri:74f433f97c7a4b2cc5d1e161dfee67a7"},
+      "prov:atLocation": {"@id": "niiri:e0bb2d0e4116aafc8738a07ec9fc9a59"},
       "prov:value": {"@type": "xsd:float", "@value": "4.98950004577637"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.69817956585148"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.31245304380023e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.151048137890434"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0233609510296683"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.69817956585148"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.31245304380023e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.151048137890434"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0233609510296683"}
     },
     {
-      "@id": "niiri:74f433f97c7a4b2cc5d1e161dfee67a7",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e0bb2d0e4116aafc8738a07ec9fc9a59",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0017",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-44,6,28]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-44,6,28]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:569db1fa1f02eabd48742d0c089d7d3b",
-      "entity": "niiri:349c921f1331e272395f14c01123038e"
+      "entity_derived": "niiri:afb5bbe52a67b2392f36dae9544d164a",
+      "entity": "niiri:8a537453623b3e259868fdc3d34a15c0"
     },
     {
-      "@id": "niiri:ebf667f0ca27e498723bf1deab582795",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:2f7f394faa4711ed3169c6970ab86c8c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0018",
-      "prov:atLocation": {"@id": "niiri:61f5748b29becc6179e42040a27ded00"},
+      "prov:atLocation": {"@id": "niiri:9fe79a527627db4bf120eb97627c5ba7"},
       "prov:value": {"@type": "xsd:float", "@value": "3.52650570869446"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.41313019486981"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000321106265798399"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999548134574"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.545515072619331"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.41313019486981"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000321106265798399"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999548134574"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.545515072619331"}
     },
     {
-      "@id": "niiri:61f5748b29becc6179e42040a27ded00",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:9fe79a527627db4bf120eb97627c5ba7",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0018",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-56,-6,42]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-56,-6,42]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ebf667f0ca27e498723bf1deab582795",
-      "entity": "niiri:349c921f1331e272395f14c01123038e"
+      "entity_derived": "niiri:2f7f394faa4711ed3169c6970ab86c8c",
+      "entity": "niiri:8a537453623b3e259868fdc3d34a15c0"
     },
     {
-      "@id": "niiri:69488ca9d2d42b6d92bd2b949ed627b5",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:60597e96058be6ccc3c820043eb1f0ad",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0019",
-      "prov:atLocation": {"@id": "niiri:626a918ba98dd4e53dad9e1b4c7be71a"},
+      "prov:atLocation": {"@id": "niiri:9ad31699bbc5f159347fe96fef53bddf"},
       "prov:value": {"@type": "xsd:float", "@value": "5.78093099594116"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.34909755317379"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.41969442155354e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00844151822925698"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00286742427823329"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.34909755317379"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.41969442155354e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00844151822925698"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00286742427823329"}
     },
     {
-      "@id": "niiri:626a918ba98dd4e53dad9e1b4c7be71a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:9ad31699bbc5f159347fe96fef53bddf",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0019",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-34,-2,52]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-34,-2,52]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:69488ca9d2d42b6d92bd2b949ed627b5",
-      "entity": "niiri:9204e7e7da9650b9d4bc408770a00fdb"
+      "entity_derived": "niiri:60597e96058be6ccc3c820043eb1f0ad",
+      "entity": "niiri:ceaad5cdc25363799f97feba2f347a03"
     },
     {
-      "@id": "niiri:d667ad297d53f529690e2abfb3ac71fc",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:787ff7b095f58a2e09fb3664f762f1c8",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0020",
-      "prov:atLocation": {"@id": "niiri:4f350d59c1f0c58b8f28decf6b73c93b"},
+      "prov:atLocation": {"@id": "niiri:2f6cbfedd61275c7b99e20bc3e0b4018"},
       "prov:value": {"@type": "xsd:float", "@value": "5.40964078903198"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.04774404642803"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.23528758724889e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0346958937061391"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00846044059259994"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.04774404642803"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.23528758724889e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0346958937061391"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00846044059259994"}
     },
     {
-      "@id": "niiri:4f350d59c1f0c58b8f28decf6b73c93b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:2f6cbfedd61275c7b99e20bc3e0b4018",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0020",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-54,-46,58]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-54,-46,58]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d667ad297d53f529690e2abfb3ac71fc",
-      "entity": "niiri:e09b8959852a4e5d12cc0ed7036f61f0"
+      "entity_derived": "niiri:787ff7b095f58a2e09fb3664f762f1c8",
+      "entity": "niiri:00cf15c153fb34e5bdc7c627fc153666"
     },
     {
-      "@id": "niiri:fda9b55fc5901fb946545dcd6078b371",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f4ca1c6a92843304c08668c4cebb90a9",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0021",
-      "prov:atLocation": {"@id": "niiri:7b45208ba6aa97addcd922b6cbf3b436"},
+      "prov:atLocation": {"@id": "niiri:7701a76f43b9fef7a78168a4da944cb1"},
       "prov:value": {"@type": "xsd:float", "@value": "5.40141773223877"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.04098917180003"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.31565837394143e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0357643345560115"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0106752417476244"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.04098917180003"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.31565837394143e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0357643345560115"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0106752417476244"}
     },
     {
-      "@id": "niiri:7b45208ba6aa97addcd922b6cbf3b436",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7701a76f43b9fef7a78168a4da944cb1",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0021",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-28,-94,2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-28,-94,2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:fda9b55fc5901fb946545dcd6078b371",
-      "entity": "niiri:6f02516841dde7aca88f672df0319963"
+      "entity_derived": "niiri:f4ca1c6a92843304c08668c4cebb90a9",
+      "entity": "niiri:9fa05d9e51da6e1bf65e29c91292c1f9"
     },
     {
-      "@id": "niiri:383ba7c1e9d76ef9d7ee73c5ae07841e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:05f82a99448b178e8b7d8ecb6d85d07b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0022",
-      "prov:atLocation": {"@id": "niiri:137d0f5723227aefac91f2b5a34cff28"},
+      "prov:atLocation": {"@id": "niiri:a8fb5389016788e2b146dc701cbdc00c"},
       "prov:value": {"@type": "xsd:float", "@value": "5.31841945648193"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.97261482231588"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.30279114724163e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0484353441449864"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0106752417476244"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.97261482231588"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.30279114724163e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0484353441449864"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0106752417476244"}
     },
     {
-      "@id": "niiri:137d0f5723227aefac91f2b5a34cff28",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a8fb5389016788e2b146dc701cbdc00c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0022",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-62,-38,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-62,-38,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:383ba7c1e9d76ef9d7ee73c5ae07841e",
-      "entity": "niiri:ff5aee3969c7de59773c94fa04a5a85f"
+      "entity_derived": "niiri:05f82a99448b178e8b7d8ecb6d85d07b",
+      "entity": "niiri:fdf70ff4bf081216be7e467153d2d4d8"
     },
     {
-      "@id": "niiri:ef6681fb7fd348dfcb9472814c0af2e0",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:be00ee78cfab94c36be515c9ca78cb48",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0023",
-      "prov:atLocation": {"@id": "niiri:44e0c656c84cdde51692e18f3512f600"},
+      "prov:atLocation": {"@id": "niiri:8da199a5d41709f457ea9104658c0771"},
       "prov:value": {"@type": "xsd:float", "@value": "4.57099342346191"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.34109644800954"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.08867353027554e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.496004086968197"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0635474729952592"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.34109644800954"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.08867353027554e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.496004086968197"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0635474729952592"}
     },
     {
-      "@id": "niiri:44e0c656c84cdde51692e18f3512f600",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:8da199a5d41709f457ea9104658c0771",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0023",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-60,-50,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-60,-50,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ef6681fb7fd348dfcb9472814c0af2e0",
-      "entity": "niiri:ff5aee3969c7de59773c94fa04a5a85f"
+      "entity_derived": "niiri:be00ee78cfab94c36be515c9ca78cb48",
+      "entity": "niiri:fdf70ff4bf081216be7e467153d2d4d8"
     },
     {
-      "@id": "niiri:ce11a63e7102de829a73aea266cc4b64",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:af6e82fac7bbf3d7f1621abbe68ecb05",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0024",
-      "prov:atLocation": {"@id": "niiri:6bd09e245b6f90538ba36c324cac83ab"},
+      "prov:atLocation": {"@id": "niiri:10b939b5d1d5994f17ba7c7ff8d864c8"},
       "prov:value": {"@type": "xsd:float", "@value": "5.30699443817139"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.96317509467693"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.46750043123123e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0504786376455083"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0106752417476244"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.96317509467693"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.46750043123123e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0504786376455083"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0106752417476244"}
     },
     {
-      "@id": "niiri:6bd09e245b6f90538ba36c324cac83ab",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:10b939b5d1d5994f17ba7c7ff8d864c8",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0024",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[32,40,16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[32,40,16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ce11a63e7102de829a73aea266cc4b64",
-      "entity": "niiri:7cafb1e5ff245f47dacb09ebc1f3d273"
+      "entity_derived": "niiri:af6e82fac7bbf3d7f1621abbe68ecb05",
+      "entity": "niiri:bca5fdf4d900bd8486f16dfcd5ab7ade"
     },
     {
-      "@id": "niiri:7ab1bfd5aa2d9144300b6d31e5f53038",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:af063a2fc9451b1a0f6d15b4c16c6d93",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0025",
-      "prov:atLocation": {"@id": "niiri:bd6418405e1be506e8f46369f1e2659e"},
+      "prov:atLocation": {"@id": "niiri:21d15b73a290e3ff6af5dfd0e0823244"},
       "prov:value": {"@type": "xsd:float", "@value": "4.5497465133667"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.32273570618355"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.7053150754347e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.520378392891944"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0649997423676262"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.32273570618355"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.7053150754347e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.520378392891944"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0649997423676262"}
     },
     {
-      "@id": "niiri:bd6418405e1be506e8f46369f1e2659e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:21d15b73a290e3ff6af5dfd0e0823244",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0025",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[40,46,12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[40,46,12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7ab1bfd5aa2d9144300b6d31e5f53038",
-      "entity": "niiri:7cafb1e5ff245f47dacb09ebc1f3d273"
+      "entity_derived": "niiri:af063a2fc9451b1a0f6d15b4c16c6d93",
+      "entity": "niiri:bca5fdf4d900bd8486f16dfcd5ab7ade"
     },
     {
-      "@id": "niiri:5a564d2ce1a5327309ee698a83e15c49",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5ed2c66afda9fc1f8f0e1230a1423370",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0026",
-      "prov:atLocation": {"@id": "niiri:1bd2ac8ac3423d81fb072bc2f95b0599"},
+      "prov:atLocation": {"@id": "niiri:a28b17ed80d2b68fdc921f59f0f167eb"},
       "prov:value": {"@type": "xsd:float", "@value": "4.31582498550415"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.11913273798974"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.90150518718513e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.788829013385429"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.116130094830597"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.11913273798974"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.90150518718513e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.788829013385429"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.116130094830597"}
     },
     {
-      "@id": "niiri:1bd2ac8ac3423d81fb072bc2f95b0599",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a28b17ed80d2b68fdc921f59f0f167eb",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0026",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[36,54,6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[36,54,6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5a564d2ce1a5327309ee698a83e15c49",
-      "entity": "niiri:7cafb1e5ff245f47dacb09ebc1f3d273"
+      "entity_derived": "niiri:5ed2c66afda9fc1f8f0e1230a1423370",
+      "entity": "niiri:bca5fdf4d900bd8486f16dfcd5ab7ade"
     },
     {
-      "@id": "niiri:b03e17965d7a204222b0b3a109b619b4",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:4ecf61302a9d659bed84b678acd8b8a3",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0027",
-      "prov:atLocation": {"@id": "niiri:1d09c8cd00dd02766f23b87e7d4d07f6"},
+      "prov:atLocation": {"@id": "niiri:36fb1e060c03001906e067f973d6addd"},
       "prov:value": {"@type": "xsd:float", "@value": "5.27030229568481"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.93281349716267"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.05267701952816e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0575990926145485"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0110040663565173"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.93281349716267"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.05267701952816e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0575990926145485"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0110040663565173"}
     },
     {
-      "@id": "niiri:1d09c8cd00dd02766f23b87e7d4d07f6",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:36fb1e060c03001906e067f973d6addd",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0027",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[40,26,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[40,26,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b03e17965d7a204222b0b3a109b619b4",
-      "entity": "niiri:bccdf03045b0a0de8d422d00c46014f1"
+      "entity_derived": "niiri:4ecf61302a9d659bed84b678acd8b8a3",
+      "entity": "niiri:a310e577676878e8eb7499da29ff53b4"
     },
     {
-      "@id": "niiri:5391dbf014e7d50b21918bce0a6e6da6",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:136c9c9df0e52f1962b71b13186923b6",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0028",
-      "prov:atLocation": {"@id": "niiri:1fcfb3f247e177e7f3a5d4eae48e70a9"},
+      "prov:atLocation": {"@id": "niiri:49d23550974006889f810999f02b6b52"},
       "prov:value": {"@type": "xsd:float", "@value": "4.93343877792358"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.65085575575197"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.6528024058271e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.180887232162623"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0254967087736733"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.65085575575197"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.6528024058271e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.180887232162623"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0254967087736733"}
     },
     {
-      "@id": "niiri:1fcfb3f247e177e7f3a5d4eae48e70a9",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:49d23550974006889f810999f02b6b52",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0028",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-58,-30,-18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-58,-30,-18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5391dbf014e7d50b21918bce0a6e6da6",
-      "entity": "niiri:2ecde1198137ba8c84d7f2b8ee573a34"
+      "entity_derived": "niiri:136c9c9df0e52f1962b71b13186923b6",
+      "entity": "niiri:4e10b0470621dd6f66d32e5f0d86796f"
     },
     {
-      "@id": "niiri:d972e7ca24da18203c2911cfaa636bba",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f946131984efa63e6aeba7b2a660d9a2",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0029",
-      "prov:atLocation": {"@id": "niiri:550e291997b9a924a4f50de8dd44e992"},
+      "prov:atLocation": {"@id": "niiri:cf3fb8e35e4c268c2eeb328480decb9c"},
       "prov:value": {"@type": "xsd:float", "@value": "4.76414346694946"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.50698548813516"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.287756441539e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.301278778226174"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0396433885053995"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.50698548813516"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.287756441539e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.301278778226174"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0396433885053995"}
     },
     {
-      "@id": "niiri:550e291997b9a924a4f50de8dd44e992",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:cf3fb8e35e4c268c2eeb328480decb9c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0029",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-46,-66,-6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-46,-66,-6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d972e7ca24da18203c2911cfaa636bba",
-      "entity": "niiri:f195588e037cf5066c03b040bdd17c5c"
+      "entity_derived": "niiri:f946131984efa63e6aeba7b2a660d9a2",
+      "entity": "niiri:8d02357e68e2217c76b2789fc556a1e0"
     },
     {
-      "@id": "niiri:509ba4b81e2e1747769f93c7df752feb",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:65cd1425049190819614ec8b724da79c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0030",
-      "prov:atLocation": {"@id": "niiri:238dae6cc3f4dbe99828008d147abf03"},
+      "prov:atLocation": {"@id": "niiri:88d00fbb1ce3816c9097d2466e1ade94"},
       "prov:value": {"@type": "xsd:float", "@value": "3.7637345790863"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.62829384243901"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000142650218672435"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999605970761399"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.34409224637793"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.62829384243901"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000142650218672435"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999605970761399"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.34409224637793"}
     },
     {
-      "@id": "niiri:238dae6cc3f4dbe99828008d147abf03",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:88d00fbb1ce3816c9097d2466e1ade94",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0030",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-54,-64,-8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-54,-64,-8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:509ba4b81e2e1747769f93c7df752feb",
-      "entity": "niiri:f195588e037cf5066c03b040bdd17c5c"
+      "entity_derived": "niiri:65cd1425049190819614ec8b724da79c",
+      "entity": "niiri:8d02357e68e2217c76b2789fc556a1e0"
     },
     {
-      "@id": "niiri:66bb41c5b59bb5cb8f697e5c97a3d810",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:1038f5b8ec149150369ced9f4ef14d84",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0031",
-      "prov:atLocation": {"@id": "niiri:594b66781a74218782498262f481182a"},
+      "prov:atLocation": {"@id": "niiri:556ae55aaa299d4d49dc193ab39255bf"},
       "prov:value": {"@type": "xsd:float", "@value": "4.72232866287231"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.47122948835043"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.88855941602095e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.338512677882141"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.044836631144536"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.47122948835043"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.88855941602095e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.338512677882141"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.044836631144536"}
     },
     {
-      "@id": "niiri:594b66781a74218782498262f481182a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:556ae55aaa299d4d49dc193ab39255bf",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0031",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[58,-38,6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[58,-38,6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:66bb41c5b59bb5cb8f697e5c97a3d810",
-      "entity": "niiri:ae3238820d20eca8be6dc34ce2ca54dc"
+      "entity_derived": "niiri:1038f5b8ec149150369ced9f4ef14d84",
+      "entity": "niiri:4f5f4e9dc219044ae730379a51a53a84"
     },
     {
-      "@id": "niiri:bc68c970f7cc0c0d6665afb53e17d21c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ecf27cff24accc7da10b3c89a35e94bd",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0032",
-      "prov:atLocation": {"@id": "niiri:909322dc52bad8d70be56166acfbc671"},
+      "prov:atLocation": {"@id": "niiri:38ca5b29b1a44ecc2f165779c9f6945f"},
       "prov:value": {"@type": "xsd:float", "@value": "3.88437390327454"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.73675248173504"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "9.32061303765552e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.996350207228297"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.273673640636879"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.73675248173504"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "9.32061303765552e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.996350207228297"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.273673640636879"}
     },
     {
-      "@id": "niiri:909322dc52bad8d70be56166acfbc671",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:38ca5b29b1a44ecc2f165779c9f6945f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0032",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[64,-32,-4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[64,-32,-4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:bc68c970f7cc0c0d6665afb53e17d21c",
-      "entity": "niiri:ae3238820d20eca8be6dc34ce2ca54dc"
+      "entity_derived": "niiri:ecf27cff24accc7da10b3c89a35e94bd",
+      "entity": "niiri:4f5f4e9dc219044ae730379a51a53a84"
     },
     {
-      "@id": "niiri:5d09dd263c7ece698c4b7eefb01f6ca7",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:9d277a53a24699d648dda94e1edb30a0",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0033",
-      "prov:atLocation": {"@id": "niiri:42b5e20c2419faf646dd747b914cd4fc"},
+      "prov:atLocation": {"@id": "niiri:7188d7ddb6523611068b2892e353d78a"},
       "prov:value": {"@type": "xsd:float", "@value": "3.50753784179688"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.39582098150001"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000342115474631921"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999778829603"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.564856004417035"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.39582098150001"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000342115474631921"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999778829603"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.564856004417035"}
     },
     {
-      "@id": "niiri:42b5e20c2419faf646dd747b914cd4fc",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7188d7ddb6523611068b2892e353d78a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0033",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[60,-40,-12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[60,-40,-12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5d09dd263c7ece698c4b7eefb01f6ca7",
-      "entity": "niiri:ae3238820d20eca8be6dc34ce2ca54dc"
+      "entity_derived": "niiri:9d277a53a24699d648dda94e1edb30a0",
+      "entity": "niiri:4f5f4e9dc219044ae730379a51a53a84"
     },
     {
-      "@id": "niiri:45b9069c26a126013fda8da6853dd90c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:29818f2935a525fc4869ee33b8cc7b28",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0034",
-      "prov:atLocation": {"@id": "niiri:c776509aded558cd3b9be7f9aa30fd6a"},
+      "prov:atLocation": {"@id": "niiri:d530a8fef909fd9f9de09043bc6a29b8"},
       "prov:value": {"@type": "xsd:float", "@value": "4.70483255386353"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.45624265093732"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.17043099876224e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.354967306449537"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0466228196503302"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.45624265093732"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.17043099876224e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.354967306449537"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0466228196503302"}
     },
     {
-      "@id": "niiri:c776509aded558cd3b9be7f9aa30fd6a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d530a8fef909fd9f9de09043bc6a29b8",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0034",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-36,-74,-14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-36,-74,-14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:45b9069c26a126013fda8da6853dd90c",
-      "entity": "niiri:5a36931b22b3ff3ae34e9ab8b27bca1e"
+      "entity_derived": "niiri:29818f2935a525fc4869ee33b8cc7b28",
+      "entity": "niiri:770c988e0434c5ba8e4392759de30eea"
     },
     {
-      "@id": "niiri:9b9a5a7e06da367ca321b6ed12583191",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:fecb6f93c50d8f21e158114c7bc5c612",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0035",
-      "prov:atLocation": {"@id": "niiri:ac6152f5696faa63646e0de651766d16"},
+      "prov:atLocation": {"@id": "niiri:87b30d0dacfbf3a6baea12b321dbe3ca"},
       "prov:value": {"@type": "xsd:float", "@value": "4.08770418167114"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.91804495668"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.46350297789166e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.955724279224547"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.186719971332974"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.91804495668"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.46350297789166e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.955724279224547"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.186719971332974"}
     },
     {
-      "@id": "niiri:ac6152f5696faa63646e0de651766d16",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:87b30d0dacfbf3a6baea12b321dbe3ca",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0035",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-36,-68,-20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-36,-68,-20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9b9a5a7e06da367ca321b6ed12583191",
-      "entity": "niiri:5a36931b22b3ff3ae34e9ab8b27bca1e"
+      "entity_derived": "niiri:fecb6f93c50d8f21e158114c7bc5c612",
+      "entity": "niiri:770c988e0434c5ba8e4392759de30eea"
     },
     {
-      "@id": "niiri:ad689fae9bae33e039be5c09c0adf096",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:edde077bec74c6cf6f6e249592b326c1",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0036",
-      "prov:atLocation": {"@id": "niiri:e29220741d4935ec2231005723d49c67"},
+      "prov:atLocation": {"@id": "niiri:f3774aa2c82de202d63a2de644c906a7"},
       "prov:value": {"@type": "xsd:float", "@value": "3.71012616157532"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.57988831343959"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000171870546999631"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999883757236262"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.385893135248467"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.57988831343959"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000171870546999631"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999883757236262"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.385893135248467"}
     },
     {
-      "@id": "niiri:e29220741d4935ec2231005723d49c67",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f3774aa2c82de202d63a2de644c906a7",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0036",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-30,-58,-16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-30,-58,-16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ad689fae9bae33e039be5c09c0adf096",
-      "entity": "niiri:5a36931b22b3ff3ae34e9ab8b27bca1e"
+      "entity_derived": "niiri:edde077bec74c6cf6f6e249592b326c1",
+      "entity": "niiri:770c988e0434c5ba8e4392759de30eea"
     },
     {
-      "@id": "niiri:c9b957724aaf9f82d49b8bb95421eec0",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a96987019566061347adea1fb3ca7702",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0037",
-      "prov:atLocation": {"@id": "niiri:8ef291e4b237ad48e36560e63da4495c"},
+      "prov:atLocation": {"@id": "niiri:14a79f1b76bb47c7ca62842d674145d2"},
       "prov:value": {"@type": "xsd:float", "@value": "4.57891654968262"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.34793761600864"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.87118388575936e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.487021764768749"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0629240173925056"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.34793761600864"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.87118388575936e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.487021764768749"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0629240173925056"}
     },
     {
-      "@id": "niiri:8ef291e4b237ad48e36560e63da4495c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:14a79f1b76bb47c7ca62842d674145d2",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0037",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-60,-16,28]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-60,-16,28]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c9b957724aaf9f82d49b8bb95421eec0",
-      "entity": "niiri:6def1f951e1919c60434a8119f03801a"
+      "entity_derived": "niiri:a96987019566061347adea1fb3ca7702",
+      "entity": "niiri:ce1649f53d38c28c5b0d7cacaaf4f448"
     },
     {
-      "@id": "niiri:180b86e774e9f17cfc45c4446c203b97",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:9bb5d42691cee918ce4d479afc518088",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0038",
-      "prov:atLocation": {"@id": "niiri:e3b63a61d3fdda47494885009dc4d07c"},
+      "prov:atLocation": {"@id": "niiri:b82ab7eaee85ede4d79638cc7b03af67"},
       "prov:value": {"@type": "xsd:float", "@value": "4.48185300827026"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.26391634421444"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.00437338077519e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.600177833033677"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0894660991036064"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.26391634421444"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.00437338077519e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.600177833033677"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0894660991036064"}
     },
     {
-      "@id": "niiri:e3b63a61d3fdda47494885009dc4d07c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b82ab7eaee85ede4d79638cc7b03af67",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0038",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[18,16,62]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[18,16,62]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:180b86e774e9f17cfc45c4446c203b97",
-      "entity": "niiri:f3a4e60499161232255b1ced0a699ecc"
+      "entity_derived": "niiri:9bb5d42691cee918ce4d479afc518088",
+      "entity": "niiri:11d8aaf31a0f50da63a5edcfdc834eac"
     },
     {
-      "@id": "niiri:192c104526b6e954e1bcd32e7eccb4db",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3ab755e42b6e08f17828f58fe2dd123b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0039",
-      "prov:atLocation": {"@id": "niiri:3b613316773c1bdad9a973b2f3aae4b7"},
+      "prov:atLocation": {"@id": "niiri:5f932ae285e704d39f11ceec314ec660"},
       "prov:value": {"@type": "xsd:float", "@value": "4.37013816833496"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.16664310578498"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.54558935169247e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.730405153245217"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.101858458171742"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.16664310578498"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.54558935169247e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.730405153245217"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.101858458171742"}
     },
     {
-      "@id": "niiri:3b613316773c1bdad9a973b2f3aae4b7",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:5f932ae285e704d39f11ceec314ec660",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0039",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-52,-62,52]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-52,-62,52]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:192c104526b6e954e1bcd32e7eccb4db",
-      "entity": "niiri:7c9ccbac3cd845dfc0c233005757f05f"
+      "entity_derived": "niiri:3ab755e42b6e08f17828f58fe2dd123b",
+      "entity": "niiri:18af84b83a63dcee2acfd1b9003ffe17"
     },
     {
-      "@id": "niiri:9807390605b098701abbf0e61ada1df3",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:86f0d921cd39a0e58bec940eba62746e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0040",
-      "prov:atLocation": {"@id": "niiri:1c77f5b258b84f3b0c9beccdc6b730fb"},
+      "prov:atLocation": {"@id": "niiri:066a0f8c565a7cecb402e87bb821a838"},
       "prov:value": {"@type": "xsd:float", "@value": "4.24533367156982"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.05725918601008"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.4825985211363e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.855631833511506"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.135717263652471"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.05725918601008"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.4825985211363e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.855631833511506"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.135717263652471"}
     },
     {
-      "@id": "niiri:1c77f5b258b84f3b0c9beccdc6b730fb",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:066a0f8c565a7cecb402e87bb821a838",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0040",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-18,-60,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-18,-60,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9807390605b098701abbf0e61ada1df3",
-      "entity": "niiri:e89936e52b02ce3aa8a79b72737894c6"
+      "entity_derived": "niiri:86f0d921cd39a0e58bec940eba62746e",
+      "entity": "niiri:bc47992403400de624fca0326bfeca0a"
     },
     {
-      "@id": "niiri:1000fbe292d57558b4be662738bf2153",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c2069dff2662c758ed500ee4348b7b32",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0041",
-      "prov:atLocation": {"@id": "niiri:5cfa6c776b739dbd5c3f058edb9aaebf"},
+      "prov:atLocation": {"@id": "niiri:aa8f70fe82ef3aa7629e2e97b230ab16"},
       "prov:value": {"@type": "xsd:float", "@value": "4.22729349136353"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.04138628171284"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.65680735640483e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.870712357794855"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.138603763901635"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.04138628171284"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.65680735640483e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.870712357794855"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.138603763901635"}
     },
     {
-      "@id": "niiri:5cfa6c776b739dbd5c3f058edb9aaebf",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:aa8f70fe82ef3aa7629e2e97b230ab16",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0041",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-20,-98,22]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-20,-98,22]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1000fbe292d57558b4be662738bf2153",
-      "entity": "niiri:18e987f3604a0d6c7d127a9be6b0fb68"
+      "entity_derived": "niiri:c2069dff2662c758ed500ee4348b7b32",
+      "entity": "niiri:0c6b532ae8d28e2999918870be27c672"
     },
     {
-      "@id": "niiri:bae87f65b9eeb2d209f8066f91b6c297",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:01af14b9357e03fab37d07283367aa67",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0042",
-      "prov:atLocation": {"@id": "niiri:2e9b9fca51582a9d17298a000969d2e4"},
+      "prov:atLocation": {"@id": "niiri:b19e680fa92673699b5d7811f246dc5a"},
       "prov:value": {"@type": "xsd:float", "@value": "4.22599840164185"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.04024618213588"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.66975618669063e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.871760516202526"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.138603763901635"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.04024618213588"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.66975618669063e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.871760516202526"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.138603763901635"}
     },
     {
-      "@id": "niiri:2e9b9fca51582a9d17298a000969d2e4",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b19e680fa92673699b5d7811f246dc5a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0042",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-36,-74,-34]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-36,-74,-34]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:bae87f65b9eeb2d209f8066f91b6c297",
-      "entity": "niiri:b19fa2f74715b8879a4263e734abff89"
+      "entity_derived": "niiri:01af14b9357e03fab37d07283367aa67",
+      "entity": "niiri:58f0b66e88ddd39190a49cc289e1a6a9"
     },
     {
-      "@id": "niiri:f6d338b44225d278f02e33e0da877ab5",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:feb2ebab3443b1487f09e60430381080",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0043",
-      "prov:atLocation": {"@id": "niiri:3daeb8c71524fc3999fa71376db5b18e"},
+      "prov:atLocation": {"@id": "niiri:30864274adf86d85cec9fa93ad094f06"},
       "prov:value": {"@type": "xsd:float", "@value": "4.21435213088989"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.02999009325983"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.78896018329755e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.880974433980664"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.143583628261646"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.02999009325983"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.78896018329755e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.880974433980664"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.143583628261646"}
     },
     {
-      "@id": "niiri:3daeb8c71524fc3999fa71376db5b18e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:30864274adf86d85cec9fa93ad094f06",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0043",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-26,-92,30]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-26,-92,30]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f6d338b44225d278f02e33e0da877ab5",
-      "entity": "niiri:0c6a4c5eab9814c8a104ac2ab9ba8e00"
+      "entity_derived": "niiri:feb2ebab3443b1487f09e60430381080",
+      "entity": "niiri:6864ea0388f90fdf3d5a0840769fb194"
     },
     {
-      "@id": "niiri:f307201c48340bce70a23de634f9ec3c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b20862f472f9d77c1662db6b2eca294f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0044",
-      "prov:atLocation": {"@id": "niiri:83eb7747ee02a020ed521fb9d67b7872"},
+      "prov:atLocation": {"@id": "niiri:72a654d54ab595719acda55869b4754f"},
       "prov:value": {"@type": "xsd:float", "@value": "4.20391035079956"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.02078923241408"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.900174224163e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.888907080881232"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.143583628261646"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.02078923241408"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.900174224163e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.888907080881232"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.143583628261646"}
     },
     {
-      "@id": "niiri:83eb7747ee02a020ed521fb9d67b7872",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:72a654d54ab595719acda55869b4754f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0044",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[34,-54,-16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[34,-54,-16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f307201c48340bce70a23de634f9ec3c",
-      "entity": "niiri:2c0e11ce65487da45bf7a9358ee57871"
+      "entity_derived": "niiri:b20862f472f9d77c1662db6b2eca294f",
+      "entity": "niiri:560b390e6daf7bdacebd6f81fc2498ed"
     },
     {
-      "@id": "niiri:54ffbced568329bc9f82ee5f4dbc1841",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:fd4266dd0bb219a6a241ff6533c36ff6",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0045",
-      "prov:atLocation": {"@id": "niiri:b63300446b864767556af57bde222bf4"},
+      "prov:atLocation": {"@id": "niiri:fc644bec2a9708abb95907ff040d5630"},
       "prov:value": {"@type": "xsd:float", "@value": "4.17404651641846"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.99444589181498"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.24228638075574e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.909844421846994"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.153735203854581"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.99444589181498"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.24228638075574e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.909844421846994"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.153735203854581"}
     },
     {
-      "@id": "niiri:b63300446b864767556af57bde222bf4",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:fc644bec2a9708abb95907ff040d5630",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0045",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-40,-38,44]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-40,-38,44]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:54ffbced568329bc9f82ee5f4dbc1841",
-      "entity": "niiri:0b550e722b76049b2f7ca0131da7d9c2"
+      "entity_derived": "niiri:fd4266dd0bb219a6a241ff6533c36ff6",
+      "entity": "niiri:b02b8c006088cba013305b13d972edc8"
     },
     {
-      "@id": "niiri:c70d2ff92028de2c80d7404c7d274cd3",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:109fbb4d397a1909eb3b295464058f51",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0046",
-      "prov:atLocation": {"@id": "niiri:f8d2684d77f31e59502459d7b548de93"},
+      "prov:atLocation": {"@id": "niiri:f06d5ad7743673ee5c44accc1ccd4693"},
       "prov:value": {"@type": "xsd:float", "@value": "4.12488555908203"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.95098834792843"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.89145570423022e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.938594159355111"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.172448885449819"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.95098834792843"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.89145570423022e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.938594159355111"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.172448885449819"}
     },
     {
-      "@id": "niiri:f8d2684d77f31e59502459d7b548de93",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f06d5ad7743673ee5c44accc1ccd4693",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0046",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[14,-98,4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[14,-98,4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c70d2ff92028de2c80d7404c7d274cd3",
-      "entity": "niiri:72450de63634a896c274e40a3163e02f"
+      "entity_derived": "niiri:109fbb4d397a1909eb3b295464058f51",
+      "entity": "niiri:a4e0cdaf05e785d8dd95f23ce74745d2"
     },
     {
-      "@id": "niiri:dfae772dc0866f88082cc01fccdd4633",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:2d19dc148fa248efc7a3df765c6a06cb",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0047",
-      "prov:atLocation": {"@id": "niiri:40253ac0f41ee20d2dbf716aac798f63"},
+      "prov:atLocation": {"@id": "niiri:01b946515c1c0572e49c00274feae5bc"},
       "prov:value": {"@type": "xsd:float", "@value": "4.12145137786865"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.94794832362008"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.94119065879606e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.940339218142555"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.172448885449819"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.94794832362008"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.94119065879606e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.940339218142555"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.172448885449819"}
     },
     {
-      "@id": "niiri:40253ac0f41ee20d2dbf716aac798f63",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:01b946515c1c0572e49c00274feae5bc",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0047",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-48,-72,2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-48,-72,2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:dfae772dc0866f88082cc01fccdd4633",
-      "entity": "niiri:cd940e6e9b2162b03485c9d3045fe2cf"
+      "entity_derived": "niiri:2d19dc148fa248efc7a3df765c6a06cb",
+      "entity": "niiri:a57f08ef6a63ebebf16d1533899bc25f"
     },
     {
-      "@id": "niiri:763e9a5ddb64d79a4963dd0c08f20ec3",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:13cbba597089b29e46b69027980a685e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0048",
-      "prov:atLocation": {"@id": "niiri:0342deb3954ed20c2903ef704d4f3287"},
+      "prov:atLocation": {"@id": "niiri:187d5d28119342c706dc84a629c3f64c"},
       "prov:value": {"@type": "xsd:float", "@value": "4.07333517074585"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.9052963692066"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.70549882543025e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.961337330645756"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.192831151077206"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.9052963692066"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.70549882543025e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.961337330645756"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.192831151077206"}
     },
     {
-      "@id": "niiri:0342deb3954ed20c2903ef704d4f3287",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:187d5d28119342c706dc84a629c3f64c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0048",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[20,-66,34]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[20,-66,34]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:763e9a5ddb64d79a4963dd0c08f20ec3",
-      "entity": "niiri:e32122a83b7d8bb16e3180c78f7eda7c"
+      "entity_derived": "niiri:13cbba597089b29e46b69027980a685e",
+      "entity": "niiri:61ed7bccd640009bb231b2a1982f0622"
     },
     {
-      "@id": "niiri:5e496faaa2325b69842de4796343c369",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:46ae4164bfa8a7fd52ad313b6b95ad52",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0049",
-      "prov:atLocation": {"@id": "niiri:fa54128151b6e9ba93c9743bac5b7810"},
+      "prov:atLocation": {"@id": "niiri:95c55eeeed13d264184e830910c60b20"},
       "prov:value": {"@type": "xsd:float", "@value": "4.05762767791748"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.89134919103145"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.98441713834286e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.966867400896655"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.199920408224698"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.89134919103145"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.98441713834286e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.966867400896655"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.199920408224698"}
     },
     {
-      "@id": "niiri:fa54128151b6e9ba93c9743bac5b7810",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:95c55eeeed13d264184e830910c60b20",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0049",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-46,-56,14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-46,-56,14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5e496faaa2325b69842de4796343c369",
-      "entity": "niiri:6ae34632238cbeb521e67cef26caf7eb"
+      "entity_derived": "niiri:46ae4164bfa8a7fd52ad313b6b95ad52",
+      "entity": "niiri:0095bc91a1253454e74d41690d9f6df3"
     },
     {
-      "@id": "niiri:626bc5b24a804a5a21acebd988be2e61",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:6ec3e0f95a4dca384d07f9fba19f7d96",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0050",
-      "prov:atLocation": {"@id": "niiri:06343ebc6fe179c7b610559b432c0030"},
+      "prov:atLocation": {"@id": "niiri:0393612c8584550483fc955cb87af40e"},
       "prov:value": {"@type": "xsd:float", "@value": "3.97341108322144"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.81637469850314"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.7713399346081e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.987160063394768"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.237117251115433"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.81637469850314"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.7713399346081e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.987160063394768"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.237117251115433"}
     },
     {
-      "@id": "niiri:06343ebc6fe179c7b610559b432c0030",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0393612c8584550483fc955cb87af40e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0050",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-50,-50,20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-50,-50,20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:626bc5b24a804a5a21acebd988be2e61",
-      "entity": "niiri:6ae34632238cbeb521e67cef26caf7eb"
+      "entity_derived": "niiri:6ec3e0f95a4dca384d07f9fba19f7d96",
+      "entity": "niiri:0095bc91a1253454e74d41690d9f6df3"
     },
     {
-      "@id": "niiri:ec00c90a90ca813778eb1e94775cb9d9",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3f8990df299e6c17b1734919846f4c6f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0051",
-      "prov:atLocation": {"@id": "niiri:ae286cede70d2e06338412f0ca028263"},
+      "prov:atLocation": {"@id": "niiri:78a29eee84d8fb0874ce0bc42c8d8c0c"},
       "prov:value": {"@type": "xsd:float", "@value": "4.03719234466553"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.87318677164159"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.37107204765519e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.973166168280088"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.210147957128937"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.87318677164159"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.37107204765519e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.973166168280088"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.210147957128937"}
     },
     {
-      "@id": "niiri:ae286cede70d2e06338412f0ca028263",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:78a29eee84d8fb0874ce0bc42c8d8c0c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0051",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-48,2,50]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-48,2,50]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ec00c90a90ca813778eb1e94775cb9d9",
-      "entity": "niiri:5559b2a8337e94bc2084c45d5600922b"
+      "entity_derived": "niiri:3f8990df299e6c17b1734919846f4c6f",
+      "entity": "niiri:fdd0f25c58dffbc950780afac712f03c"
     },
     {
-      "@id": "niiri:a8f71dfdc8ef6d2ac7c90360a6fdf106",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:aa18f0ad742a246e138666daf0480e72",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0052",
-      "prov:atLocation": {"@id": "niiri:c153a603b30ff7cdbc1f03f4334cae80"},
+      "prov:atLocation": {"@id": "niiri:0bcb0950fefd4e3b5cbefda9af5fd682"},
       "prov:value": {"@type": "xsd:float", "@value": "4.0217924118042"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.85948683644491"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.68126885931441e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.977286609355005"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.217632520436791"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.85948683644491"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.68126885931441e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.977286609355005"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.217632520436791"}
     },
     {
-      "@id": "niiri:c153a603b30ff7cdbc1f03f4334cae80",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0bcb0950fefd4e3b5cbefda9af5fd682",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0052",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-36,-40,-36]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-36,-40,-36]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a8f71dfdc8ef6d2ac7c90360a6fdf106",
-      "entity": "niiri:853079021e568a419ad6b8ad88952642"
+      "entity_derived": "niiri:aa18f0ad742a246e138666daf0480e72",
+      "entity": "niiri:19300df9cc64fa2764a0780af7af6f84"
     },
     {
-      "@id": "niiri:0fe40a31dce9c91b7e238b2efb60f066",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:bcaf0c8e6a688a504f644ea44b72c874",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0053",
-      "prov:atLocation": {"@id": "niiri:d3909b6b2738c4fe53dbbab649c1f79a"},
+      "prov:atLocation": {"@id": "niiri:c18ca0f70ac22ec9bab26c8c3ac14734"},
       "prov:value": {"@type": "xsd:float", "@value": "3.97676801681519"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.81936952854042"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.68966021436512e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.986609697042008"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.237117251115433"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.81936952854042"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.68966021436512e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.986609697042008"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.237117251115433"}
     },
     {
-      "@id": "niiri:d3909b6b2738c4fe53dbbab649c1f79a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c18ca0f70ac22ec9bab26c8c3ac14734",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0053",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[50,-52,60]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[50,-52,60]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0fe40a31dce9c91b7e238b2efb60f066",
-      "entity": "niiri:0cf1dc899a75152a30a291b0a2560db3"
+      "entity_derived": "niiri:bcaf0c8e6a688a504f644ea44b72c874",
+      "entity": "niiri:5ef4fb1358a9a6249f348a6eb79516e7"
     },
     {
-      "@id": "niiri:84698a1d0ecbfce2248e5a4818536e14",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:32ff477de924235c5522ee862332ff7c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0054",
-      "prov:atLocation": {"@id": "niiri:cd00d2e8ae4225f520d00f40bb2893a7"},
+      "prov:atLocation": {"@id": "niiri:6bef910ff6ac94722e287b9d2729d1e1"},
       "prov:value": {"@type": "xsd:float", "@value": "3.9634416103363"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.80747753892992"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.01957428701494e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.988689669381963"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.237117251115433"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.80747753892992"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.01957428701494e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.988689669381963"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.237117251115433"}
     },
     {
-      "@id": "niiri:cd00d2e8ae4225f520d00f40bb2893a7",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6bef910ff6ac94722e287b9d2729d1e1",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0054",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[4,6,32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[4,6,32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:84698a1d0ecbfce2248e5a4818536e14",
-      "entity": "niiri:678b8fa6b0f9293b49f20d1427d409e0"
+      "entity_derived": "niiri:32ff477de924235c5522ee862332ff7c",
+      "entity": "niiri:520bd6c8ac4aa6408335f0e0c324688b"
     },
     {
-      "@id": "niiri:24a6789ba2036a9952a8413c3b376013",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f538dc161505199a9d4a9dc200bbfbd1",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0055",
-      "prov:atLocation": {"@id": "niiri:be9c0a7a9f305f6267e4cab4122b3985"},
+      "prov:atLocation": {"@id": "niiri:af082644064d49a87df191a50e018a1f"},
       "prov:value": {"@type": "xsd:float", "@value": "3.96245408058167"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.80659597790245"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.04463150378309e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.988832912076595"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.237117251115433"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.80659597790245"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.04463150378309e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.988832912076595"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.237117251115433"}
     },
     {
-      "@id": "niiri:be9c0a7a9f305f6267e4cab4122b3985",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:af082644064d49a87df191a50e018a1f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0055",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-50,-48,-16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-50,-48,-16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:24a6789ba2036a9952a8413c3b376013",
-      "entity": "niiri:45253dc06118b1b5a6a77ba54c4b1490"
+      "entity_derived": "niiri:f538dc161505199a9d4a9dc200bbfbd1",
+      "entity": "niiri:f881e9cbe818d5f8b37dfed6dec527cc"
     },
     {
-      "@id": "niiri:0062a939c1eee665c50ee4abd8f63b2f",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d0d01153923178a42866f6f64e32d01c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0056",
-      "prov:atLocation": {"@id": "niiri:3d14aa99f7ec458fc842e78731256bf0"},
+      "prov:atLocation": {"@id": "niiri:6e604072f92df73cd898dcd2f349304a"},
       "prov:value": {"@type": "xsd:float", "@value": "3.95309829711914"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.79824190359279"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.28630328464819e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.990119383011277"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.243341582944922"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.79824190359279"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.28630328464819e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.990119383011277"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.243341582944922"}
     },
     {
-      "@id": "niiri:3d14aa99f7ec458fc842e78731256bf0",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6e604072f92df73cd898dcd2f349304a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0056",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[44,4,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[44,4,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0062a939c1eee665c50ee4abd8f63b2f",
-      "entity": "niiri:a5e4bc181e94cafee69b551c62f10925"
+      "entity_derived": "niiri:d0d01153923178a42866f6f64e32d01c",
+      "entity": "niiri:4aa4a0455dab2440720331d043f09ec2"
     },
     {
-      "@id": "niiri:aaf1d5898881a1966667867eb1616aae",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:970399f54bebe49057e2e105ecea663c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0057",
-      "prov:atLocation": {"@id": "niiri:cbc5239baf97fef8d1e2c457a4a53cc8"},
+      "prov:atLocation": {"@id": "niiri:2deadff2e7be322b63ec9667a75a3e66"},
       "prov:value": {"@type": "xsd:float", "@value": "3.92427015304565"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.77247501519699"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.08180782938539e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.993353008667813"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.257401847609111"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.77247501519699"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.08180782938539e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.993353008667813"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.257401847609111"}
     },
     {
-      "@id": "niiri:cbc5239baf97fef8d1e2c457a4a53cc8",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:2deadff2e7be322b63ec9667a75a3e66",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0057",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[34,12,64]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[34,12,64]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:aaf1d5898881a1966667867eb1616aae",
-      "entity": "niiri:ce3143388409a30de94c45862dcc1603"
+      "entity_derived": "niiri:970399f54bebe49057e2e105ecea663c",
+      "entity": "niiri:69ca7568c07230cf3584aaca638281b0"
     },
     {
-      "@id": "niiri:0dc1329f25297e93e8c0460a58d173cc",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:1a51f95440dce51af59c428b51c26851",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0058",
-      "prov:atLocation": {"@id": "niiri:30cbf5888756940aeeb4a89421c50833"},
+      "prov:atLocation": {"@id": "niiri:da6ab50c8b91b09b511975b823c28c39"},
       "prov:value": {"@type": "xsd:float", "@value": "3.9098813533783"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.75959988615137"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.50926599039736e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.994607633788328"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.264100967145263"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.75959988615137"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.50926599039736e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.994607633788328"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.264100967145263"}
     },
     {
-      "@id": "niiri:30cbf5888756940aeeb4a89421c50833",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:da6ab50c8b91b09b511975b823c28c39",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0058",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[54,-24,-2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[54,-24,-2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0dc1329f25297e93e8c0460a58d173cc",
-      "entity": "niiri:76c08ff817708a0abbb42fa1bb47a0cf"
+      "entity_derived": "niiri:1a51f95440dce51af59c428b51c26851",
+      "entity": "niiri:350dbc35c571e3a5c09f2cdc4c910d34"
     },
     {
-      "@id": "niiri:1fb4e43da779ff8bd8d2331d2f9864e1",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:87fdac079acb3a60695755078ec9ff23",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0059",
-      "prov:atLocation": {"@id": "niiri:346d98428f4ca87d175e3fee210b0d72"},
+      "prov:atLocation": {"@id": "niiri:2b2fc48f07fee7b33d6bccd9c1aaf3e2"},
       "prov:value": {"@type": "xsd:float", "@value": "3.90759468078613"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.75755289319297"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.57915531067288e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.994787688943672"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.264100967145263"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.75755289319297"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.57915531067288e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.994787688943672"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.264100967145263"}
     },
     {
-      "@id": "niiri:346d98428f4ca87d175e3fee210b0d72",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:2b2fc48f07fee7b33d6bccd9c1aaf3e2",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0059",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-14,-98,-4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-14,-98,-4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1fb4e43da779ff8bd8d2331d2f9864e1",
-      "entity": "niiri:47fed6da7f0600bc158182bd59714d25"
+      "entity_derived": "niiri:87fdac079acb3a60695755078ec9ff23",
+      "entity": "niiri:5d231bb78e3753cb8f1f83f432b012a4"
     },
     {
-      "@id": "niiri:86d4a5331879dd3c7fadbc94b1f1ae62",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:dc459f0a0e3ee90c5e29e061346c5e6a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0060",
-      "prov:atLocation": {"@id": "niiri:c328279f3a63ea8585497c804b21b951"},
+      "prov:atLocation": {"@id": "niiri:3c7c82e3cab9399987475ea5f2e30a60"},
       "prov:value": {"@type": "xsd:float", "@value": "3.90285301208496"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.75330746420074"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.72582920719012e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99514521861122"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.264100967145263"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.75330746420074"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.72582920719012e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99514521861122"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.264100967145263"}
     },
     {
-      "@id": "niiri:c328279f3a63ea8585497c804b21b951",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:3c7c82e3cab9399987475ea5f2e30a60",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0060",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-36,-46,-18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-36,-46,-18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:86d4a5331879dd3c7fadbc94b1f1ae62",
-      "entity": "niiri:3aaffeb437aa651f0d21d28a688e78dd"
+      "entity_derived": "niiri:dc459f0a0e3ee90c5e29e061346c5e6a",
+      "entity": "niiri:d962ed566ab823dc017d65a55c96005b"
     },
     {
-      "@id": "niiri:05e5020143d70e64995b69f8756df39d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f41100c4c035a126bb3e090ac5b96ef2",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0061",
-      "prov:atLocation": {"@id": "niiri:ed2bda47df044137ff7c87b426d33de9"},
+      "prov:atLocation": {"@id": "niiri:189bf1ada1eef7b44db4d193f2a65962"},
       "prov:value": {"@type": "xsd:float", "@value": "3.8867518901825"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.73888373627584"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "9.24195907030523e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.996210852184447"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.271701156704036"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.73888373627584"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "9.24195907030523e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.996210852184447"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.271701156704036"}
     },
     {
-      "@id": "niiri:ed2bda47df044137ff7c87b426d33de9",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:189bf1ada1eef7b44db4d193f2a65962",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0061",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-50,-46,-32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-50,-46,-32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:05e5020143d70e64995b69f8756df39d",
-      "entity": "niiri:902f31a0f58308cc0d2941ed3096a18c"
+      "entity_derived": "niiri:f41100c4c035a126bb3e090ac5b96ef2",
+      "entity": "niiri:5ca18f66be2a0317891dd14ae924d09a"
     },
     {
-      "@id": "niiri:44db62c0993869cd21f00cabf2e8af08",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:12d30f83fba50c448c40e1fea8540142",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0062",
-      "prov:atLocation": {"@id": "niiri:40234c37348bd37ac581575825a90b9a"},
+      "prov:atLocation": {"@id": "niiri:e74e6fef095025d78f7d87d10fe04d0b"},
       "prov:value": {"@type": "xsd:float", "@value": "3.82178378105164"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.68056404693028"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000116359297336222"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.998750111206092"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.307505393775956"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.68056404693028"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000116359297336222"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.998750111206092"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.307505393775956"}
     },
     {
-      "@id": "niiri:40234c37348bd37ac581575825a90b9a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e74e6fef095025d78f7d87d10fe04d0b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0062",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[12,52,-12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[12,52,-12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:44db62c0993869cd21f00cabf2e8af08",
-      "entity": "niiri:6fcbec37cf34db5ad09da73b06411a40"
+      "entity_derived": "niiri:12d30f83fba50c448c40e1fea8540142",
+      "entity": "niiri:bf714e8e855430179f84817bfe8aa9f4"
     },
     {
-      "@id": "niiri:da102df177c6d704c38aacb85be36982",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3b77fd4f30cbd966a672c142e10cd1ec",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0063",
-      "prov:atLocation": {"@id": "niiri:062830474981e1d2ba13ceed932a801e"},
+      "prov:atLocation": {"@id": "niiri:937f76ecbce55de2fa752519e4da8b1e"},
       "prov:value": {"@type": "xsd:float", "@value": "3.81266117095947"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.67235967240763"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000120160560553639"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.998946217488595"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.312228840798665"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.67235967240763"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000120160560553639"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.998946217488595"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.312228840798665"}
     },
     {
-      "@id": "niiri:062830474981e1d2ba13ceed932a801e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:937f76ecbce55de2fa752519e4da8b1e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0063",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[36,54,20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[36,54,20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:da102df177c6d704c38aacb85be36982",
-      "entity": "niiri:f7fec6797003228e9250ccd152a5c37f"
+      "entity_derived": "niiri:3b77fd4f30cbd966a672c142e10cd1ec",
+      "entity": "niiri:404e791392df064f45734040de92da30"
     },
     {
-      "@id": "niiri:30a6a9c3a1e992761478114beb6cd83c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:8636582fe5845fabfeeef03ea097da99",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0064",
-      "prov:atLocation": {"@id": "niiri:691977ec4c5992f167733ac50b857d36"},
+      "prov:atLocation": {"@id": "niiri:dea96efaeecd8d7265aff2a6bf2a2ae8"},
       "prov:value": {"@type": "xsd:float", "@value": "3.80767583847046"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.66787455107711"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000122287561408974"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999041631710947"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.312228840798665"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.66787455107711"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000122287561408974"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999041631710947"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.312228840798665"}
     },
     {
-      "@id": "niiri:691977ec4c5992f167733ac50b857d36",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:dea96efaeecd8d7265aff2a6bf2a2ae8",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0064",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[22,-80,54]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[22,-80,54]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:30a6a9c3a1e992761478114beb6cd83c",
-      "entity": "niiri:35377dee19e22bb0a24fdb50eccf1b74"
+      "entity_derived": "niiri:8636582fe5845fabfeeef03ea097da99",
+      "entity": "niiri:def46784463991aed85ece366ca75ad8"
     },
     {
-      "@id": "niiri:57f5cb1301cb0ec2e5344369714f88fe",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:82603814879a87f0ffb468aa32aadf1d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0065",
-      "prov:atLocation": {"@id": "niiri:8d9aa683ac84ad8c4f7b91ade6acbd91"},
+      "prov:atLocation": {"@id": "niiri:c94ea4de157b0c9d29d9fd4d205f5607"},
       "prov:value": {"@type": "xsd:float", "@value": "3.7885959148407"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.65069869844077"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000130763947768786"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999340802437346"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.325675502417125"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.65069869844077"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000130763947768786"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999340802437346"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.325675502417125"}
     },
     {
-      "@id": "niiri:8d9aa683ac84ad8c4f7b91ade6acbd91",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c94ea4de157b0c9d29d9fd4d205f5607",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0065",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[22,40,26]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[22,40,26]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:57f5cb1301cb0ec2e5344369714f88fe",
-      "entity": "niiri:662b849d101be496cda3a65d2f69da2b"
+      "entity_derived": "niiri:82603814879a87f0ffb468aa32aadf1d",
+      "entity": "niiri:c2de51d4065404a70c8e75ad7f34a79f"
     },
     {
-      "@id": "niiri:e103f97c657699dbaf09a36090171a99",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ce7014584411a4e6030e1b6874e61edb",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0066",
-      "prov:atLocation": {"@id": "niiri:2052d8263e350348d11ea4187b75e730"},
+      "prov:atLocation": {"@id": "niiri:a2ec71c72c91d6abcb527c15c9c3f40d"},
       "prov:value": {"@type": "xsd:float", "@value": "3.78668808937073"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.64898036269368"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000131641613210109"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999365630484476"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.325675502417125"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.64898036269368"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000131641613210109"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999365630484476"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.325675502417125"}
     },
     {
-      "@id": "niiri:2052d8263e350348d11ea4187b75e730",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a2ec71c72c91d6abcb527c15c9c3f40d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0066",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-22,-74,60]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-22,-74,60]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e103f97c657699dbaf09a36090171a99",
-      "entity": "niiri:bb8721fcbfb280a841be169cb5e433b5"
+      "entity_derived": "niiri:ce7014584411a4e6030e1b6874e61edb",
+      "entity": "niiri:f11cdd5ae11ea581dcd3882d3540354b"
     },
     {
-      "@id": "niiri:35bd49a168370574c7f77d091b60b6e8",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:1914d7526225245a6b8afde3e39c1ba6",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0067",
-      "prov:atLocation": {"@id": "niiri:23641c588e77eba9190a5aea981daeef"},
+      "prov:atLocation": {"@id": "niiri:5af3e20e07b7118fe0888052b8cfcab7"},
       "prov:value": {"@type": "xsd:float", "@value": "3.71480798721313"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.58412084932714"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000169107736440521"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999869855188705"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.383925327139989"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.58412084932714"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000169107736440521"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999869855188705"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.383925327139989"}
     },
     {
-      "@id": "niiri:23641c588e77eba9190a5aea981daeef",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:5af3e20e07b7118fe0888052b8cfcab7",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0067",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-34,-84,-2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-34,-84,-2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:35bd49a168370574c7f77d091b60b6e8",
-      "entity": "niiri:8b2e8095aa6535f320b2113605db7dba"
+      "entity_derived": "niiri:1914d7526225245a6b8afde3e39c1ba6",
+      "entity": "niiri:37773f3cd9125252813f9101750c8618"
     },
     {
-      "@id": "niiri:5aebbcf97cbcbee6a9ed3f90454b3328",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:34abe905d1d081ef06aa532dca4df55e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0068",
-      "prov:atLocation": {"@id": "niiri:8f772bf50dbd17f1023835fe30a113e5"},
+      "prov:atLocation": {"@id": "niiri:980e6c21a07dfe3b31d1697a47c25f1d"},
       "prov:value": {"@type": "xsd:float", "@value": "3.69408750534058"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.56538143418403"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000181663694368006"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999921818129803"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.399826018660701"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.56538143418403"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000181663694368006"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999921818129803"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.399826018660701"}
     },
     {
-      "@id": "niiri:8f772bf50dbd17f1023835fe30a113e5",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:980e6c21a07dfe3b31d1697a47c25f1d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0068",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[50,46,-12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[50,46,-12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5aebbcf97cbcbee6a9ed3f90454b3328",
-      "entity": "niiri:e7305b9c4bb3949423d41a45d18d3fcf"
+      "entity_derived": "niiri:34abe905d1d081ef06aa532dca4df55e",
+      "entity": "niiri:b9bf3dcf444022a80942813a2e7f252d"
     },
     {
-      "@id": "niiri:940a6014aaed122dcf5fd43384f0a5d5",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:7f523ca7243bef20f31c8eb562ee6271",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0069",
-      "prov:atLocation": {"@id": "niiri:f4581185e3edc4e58b1c20a1a91f4dc8"},
+      "prov:atLocation": {"@id": "niiri:d62e229f0b52ec9242d7f41c5d3e36bf"},
       "prov:value": {"@type": "xsd:float", "@value": "3.65790581703186"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.53261354467296"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000205736742878826"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999969815552823"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.430567192397012"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.53261354467296"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000205736742878826"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999969815552823"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.430567192397012"}
     },
     {
-      "@id": "niiri:f4581185e3edc4e58b1c20a1a91f4dc8",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d62e229f0b52ec9242d7f41c5d3e36bf",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0069",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[52,-46,-12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[52,-46,-12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:940a6014aaed122dcf5fd43384f0a5d5",
-      "entity": "niiri:fe1342908b2c590f0d205c54b090c224"
+      "entity_derived": "niiri:7f523ca7243bef20f31c8eb562ee6271",
+      "entity": "niiri:06de03bbb8e40178692ae6ec9dd3f5d5"
     },
     {
-      "@id": "niiri:7c5c6e8d715a000785be71ff81c99299",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:11cc93907e041bf61389cd50514f54ae",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0070",
-      "prov:atLocation": {"@id": "niiri:236353457645394e22d80a2c71e9e9d4"},
+      "prov:atLocation": {"@id": "niiri:c9a383c2a53704da619a4a92b0b47a77"},
       "prov:value": {"@type": "xsd:float", "@value": "3.65459251403809"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.52960997534834"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000208086348004177"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999972447579615"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.431239033859527"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.52960997534834"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000208086348004177"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999972447579615"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.431239033859527"}
     },
     {
-      "@id": "niiri:236353457645394e22d80a2c71e9e9d4",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c9a383c2a53704da619a4a92b0b47a77",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0070",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[54,8,-36]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[54,8,-36]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7c5c6e8d715a000785be71ff81c99299",
-      "entity": "niiri:ad067a0d2a64875916d47893c9bf91b0"
+      "entity_derived": "niiri:11cc93907e041bf61389cd50514f54ae",
+      "entity": "niiri:ae0af12ba47d22765200496a05e3cc2e"
     },
     {
-      "@id": "niiri:661a3a0bf3ee22fc68637091b9eb8d21",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e0c55ebec0ecd249a6a1221b9000af8b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0071",
-      "prov:atLocation": {"@id": "niiri:b8c0b2299ce9f7ee7a75bb8d211f6c46"},
+      "prov:atLocation": {"@id": "niiri:6ad9741eec3138fb7501dba131b7c01a"},
       "prov:value": {"@type": "xsd:float", "@value": "3.60870504379272"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.48796269267718"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000243357993216953"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999992770534091"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.475991356580954"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.48796269267718"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000243357993216953"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999992770534091"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.475991356580954"}
     },
     {
-      "@id": "niiri:b8c0b2299ce9f7ee7a75bb8d211f6c46",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6ad9741eec3138fb7501dba131b7c01a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0071",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[40,-52,68]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[40,-52,68]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:661a3a0bf3ee22fc68637091b9eb8d21",
-      "entity": "niiri:4426798282ac8143b4291fc9731c0d21"
+      "entity_derived": "niiri:e0c55ebec0ecd249a6a1221b9000af8b",
+      "entity": "niiri:f5ac1b556f82f90ca54e1755f459aeb0"
     },
     {
-      "@id": "niiri:b2b7b7692f5aa26cb11995e3a85e0f60",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:010e57748e944b9a5344c65b7dcca649",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0072",
-      "prov:atLocation": {"@id": "niiri:625b71154320941f351eb8e0610bb4a9"},
+      "prov:atLocation": {"@id": "niiri:3c7a921ea450332ded31c7e83f039528"},
       "prov:value": {"@type": "xsd:float", "@value": "3.60173606872559"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.48162963814792"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000249186237945009"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999994173508246"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.477936808108637"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.48162963814792"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000249186237945009"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999994173508246"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.477936808108637"}
     },
     {
-      "@id": "niiri:625b71154320941f351eb8e0610bb4a9",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:3c7a921ea450332ded31c7e83f039528",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0072",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-14,58,10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-14,58,10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b2b7b7692f5aa26cb11995e3a85e0f60",
-      "entity": "niiri:094ca018251a2b17ad5bbde342203d06"
+      "entity_derived": "niiri:010e57748e944b9a5344c65b7dcca649",
+      "entity": "niiri:e0f350ef000b2636edd606950fbacdd8"
     },
     {
-      "@id": "niiri:48f37e3e3778678617889255991dd32b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:7c4a82dba1a9aef0c16e95acba02ea74",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0073",
-      "prov:atLocation": {"@id": "niiri:c0aa3153ab7b9798444ef5a0d2160603"},
+      "prov:atLocation": {"@id": "niiri:b64f47ef39dc6d1ee386d9414e21721c"},
       "prov:value": {"@type": "xsd:float", "@value": "3.58989810943604"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.47086705539024"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000259390388114844"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999995993033212"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.486123239113482"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.47086705539024"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000259390388114844"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999995993033212"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.486123239113482"}
     },
     {
-      "@id": "niiri:c0aa3153ab7b9798444ef5a0d2160603",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b64f47ef39dc6d1ee386d9414e21721c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0073",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-66,-36,22]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-66,-36,22]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:48f37e3e3778678617889255991dd32b",
-      "entity": "niiri:e765876280bde3e4bebecc566c8bd29c"
+      "entity_derived": "niiri:7c4a82dba1a9aef0c16e95acba02ea74",
+      "entity": "niiri:208e0aa56bc32fd1c4efbe75ea40b1a0"
     },
     {
-      "@id": "niiri:1a64ed947fc053d9e4a3a2232b21f553",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:1ee2a189ddde50048e5bc2471880d25e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0074",
-      "prov:atLocation": {"@id": "niiri:9e25d55ac03149402f6368fbff8cd8f8"},
+      "prov:atLocation": {"@id": "niiri:6da0792c18731727d1fd106d98144c77"},
       "prov:value": {"@type": "xsd:float", "@value": "3.56340670585632"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.44676015888715"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000283676007278189"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999998329299787"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.513357841480064"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.44676015888715"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000283676007278189"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999998329299787"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.513357841480064"}
     },
     {
-      "@id": "niiri:9e25d55ac03149402f6368fbff8cd8f8",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6da0792c18731727d1fd106d98144c77",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0074",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[18,60,12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[18,60,12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1a64ed947fc053d9e4a3a2232b21f553",
-      "entity": "niiri:b6238a8e3e93a9273be55294f38a7061"
+      "entity_derived": "niiri:1ee2a189ddde50048e5bc2471880d25e",
+      "entity": "niiri:6270b7e521adb112773419d81745ba32"
     },
     {
-      "@id": "niiri:e0ebd33047b60463151cb6665224b6f0",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:17365311e977a0f7612d95a39cd6fdc2",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0075",
-      "prov:atLocation": {"@id": "niiri:d1815b9f59348c4536edbc8565583355"},
+      "prov:atLocation": {"@id": "niiri:3d8fb7e482b175f8eeba0bb983116a40"},
       "prov:value": {"@type": "xsd:float", "@value": "3.55537104606628"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.43944179853069"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000291457553818653"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999998731920076"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.518882279088377"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.43944179853069"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000291457553818653"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999998731920076"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.518882279088377"}
     },
     {
-      "@id": "niiri:d1815b9f59348c4536edbc8565583355",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:3d8fb7e482b175f8eeba0bb983116a40",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0075",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-64,-34,8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-64,-34,8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e0ebd33047b60463151cb6665224b6f0",
-      "entity": "niiri:cedb782dada08c65c4916daa0ad6e465"
+      "entity_derived": "niiri:17365311e977a0f7612d95a39cd6fdc2",
+      "entity": "niiri:6e8c7efcd65fd269ae1163d977b34228"
     },
     {
-      "@id": "niiri:c1c88dff04830e47aa47afc9c4fac17d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:1aa22f63d5d63be3e71695c4f2ce2cf2",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0076",
-      "prov:atLocation": {"@id": "niiri:82f63ba4bd070f22267f249ea665eeaf"},
+      "prov:atLocation": {"@id": "niiri:bacf64ffb57e108f35e206bfb1eea36e"},
       "prov:value": {"@type": "xsd:float", "@value": "3.55148839950562"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.43590473729199"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000295289297083445"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999889206113"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.518882279088377"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.43590473729199"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000295289297083445"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999889206113"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.518882279088377"}
     },
     {
-      "@id": "niiri:82f63ba4bd070f22267f249ea665eeaf",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:bacf64ffb57e108f35e206bfb1eea36e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0076",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[64,-34,16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[64,-34,16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c1c88dff04830e47aa47afc9c4fac17d",
-      "entity": "niiri:47f716a7866282e59c2437414f29fb67"
+      "entity_derived": "niiri:1aa22f63d5d63be3e71695c4f2ce2cf2",
+      "entity": "niiri:8bdb7c1cfc0e4c28f73b9ebb2067be4a"
     },
     {
-      "@id": "niiri:ff928eaadfedd741182cbded3233112a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c6643c3287ba5b3c7c9ae880836c753c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0077",
-      "prov:atLocation": {"@id": "niiri:e8a10ec98b3eed51c1409f98d5b0d591"},
+      "prov:atLocation": {"@id": "niiri:50f9cac6df1136e4e7d38b392707df25"},
       "prov:value": {"@type": "xsd:float", "@value": "3.51380252838135"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.40153955037634"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000335037159349127"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999971905221"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.559625109906516"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.40153955037634"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000335037159349127"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999971905221"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.559625109906516"}
     },
     {
-      "@id": "niiri:e8a10ec98b3eed51c1409f98d5b0d591",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:50f9cac6df1136e4e7d38b392707df25",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0077",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[48,12,50]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[48,12,50]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ff928eaadfedd741182cbded3233112a",
-      "entity": "niiri:e6b8fc7731810aa6f311348e0b1cc140"
+      "entity_derived": "niiri:c6643c3287ba5b3c7c9ae880836c753c",
+      "entity": "niiri:bb0ea248bef4b3a56f8b7bd4674e079a"
     },
     {
-      "@id": "niiri:1408e93ad1851d9792bfacd6962fb96f",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d0858c2460bb3887c10ea7cc932fda7e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0078",
-      "prov:atLocation": {"@id": "niiri:16a27ce79d9c5118048286ef0e7664b6"},
+      "prov:atLocation": {"@id": "niiri:91f4aee1b203764ec626f1b44c205485"},
       "prov:value": {"@type": "xsd:float", "@value": "3.46123600006104"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.353503690367"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000398976748636981"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999965973308"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.628488500556802"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.353503690367"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000398976748636981"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999965973308"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.628488500556802"}
     },
     {
-      "@id": "niiri:16a27ce79d9c5118048286ef0e7664b6",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:91f4aee1b203764ec626f1b44c205485",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0078",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[14,-14,70]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[14,-14,70]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1408e93ad1851d9792bfacd6962fb96f",
-      "entity": "niiri:9e7a68deeddb09104c97844d6208138a"
+      "entity_derived": "niiri:d0858c2460bb3887c10ea7cc932fda7e",
+      "entity": "niiri:3ba5f3e50f85d1172dccf7cdc87e047a"
     },
     {
-      "@id": "niiri:f11f999d153a5c371e14a2eeb7b4d67d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ce7fafbed4002da1a8d55bef85886de8",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0079",
-      "prov:atLocation": {"@id": "niiri:7d99e4e09c14e281690ee87ee2ddb1bd"},
+      "prov:atLocation": {"@id": "niiri:f43bc57e246dba1a18fe143d2e61fabb"},
       "prov:value": {"@type": "xsd:float", "@value": "3.45441365242004"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.34726077209469"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000408071982705316"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999974583179"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.628488500556802"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.34726077209469"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000408071982705316"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999974583179"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.628488500556802"}
     },
     {
-      "@id": "niiri:7d99e4e09c14e281690ee87ee2ddb1bd",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f43bc57e246dba1a18fe143d2e61fabb",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0079",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-38,-54,-42]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-38,-54,-42]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f11f999d153a5c371e14a2eeb7b4d67d",
-      "entity": "niiri:9f7250b2986229e27c73d4ee533b5581"
+      "entity_derived": "niiri:ce7fafbed4002da1a8d55bef85886de8",
+      "entity": "niiri:221ffcb9e61912db0c8ea94c83c806f3"
     },
     {
-      "@id": "niiri:d37743c2f9e1a162338e1a5b050c758b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:703dca43a303429db425b818bc12c6a4",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0080",
-      "prov:atLocation": {"@id": "niiri:0b9fd817b3f65dd363c55c7058ed28ad"},
+      "prov:atLocation": {"@id": "niiri:3c414ad1fd71de414c026f189f78779b"},
       "prov:value": {"@type": "xsd:float", "@value": "3.43550229072571"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.32994532400952"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000434315195478541"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999988927098"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.654261098812949"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.32994532400952"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000434315195478541"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999988927098"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.654261098812949"}
     },
     {
-      "@id": "niiri:0b9fd817b3f65dd363c55c7058ed28ad",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:3c414ad1fd71de414c026f189f78779b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0080",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[22,44,-16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[22,44,-16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d37743c2f9e1a162338e1a5b050c758b",
-      "entity": "niiri:f895b7fb895eba3b656944c4b6b3efb7"
+      "entity_derived": "niiri:703dca43a303429db425b818bc12c6a4",
+      "entity": "niiri:680f2d4ea6ccf9065674d450817a8a71"
     },
     {
-      "@id": "niiri:13e122ce299b2d1e7cf72040e14d82d5",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:43941dd0099dba7340078c94b1f176e4",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0081",
-      "prov:atLocation": {"@id": "niiri:0d4a093240dd121e9a286d0f15282a3b"},
+      "prov:atLocation": {"@id": "niiri:14d4d48691f4187769651ca7e448575f"},
       "prov:value": {"@type": "xsd:float", "@value": "3.43198323249817"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.32672157755253"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000439370628491198"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999990548038"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.655840530088522"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.32672157755253"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000439370628491198"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999990548038"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.655840530088522"}
     },
     {
-      "@id": "niiri:0d4a093240dd121e9a286d0f15282a3b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:14d4d48691f4187769651ca7e448575f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0081",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[42,-42,14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[42,-42,14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:13e122ce299b2d1e7cf72040e14d82d5",
-      "entity": "niiri:1a924fb418bec3cd95c0a03c9ae66f54"
+      "entity_derived": "niiri:43941dd0099dba7340078c94b1f176e4",
+      "entity": "niiri:cf57b893da54bea9529d4c0bc8ff02f0"
     },
     {
-      "@id": "niiri:c1609883ce93d4f3a7644077172aa74c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:9a9c1fe4c7f0e8236338ec3ccf5fb8c1",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0082",
-      "prov:atLocation": {"@id": "niiri:8135fa25879ec1de7f1702afb81fc631"},
+      "prov:atLocation": {"@id": "niiri:e8cd739d9997617595ca094639c0d767"},
       "prov:value": {"@type": "xsd:float", "@value": "3.40386486053467"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.30094422133281"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000481800187664638"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999997442132"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.689466168942319"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.30094422133281"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000481800187664638"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999997442132"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.689466168942319"}
     },
     {
-      "@id": "niiri:8135fa25879ec1de7f1702afb81fc631",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e8cd739d9997617595ca094639c0d767",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0082",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[52,-42,18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[52,-42,18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c1609883ce93d4f3a7644077172aa74c",
-      "entity": "niiri:e8f2997ff1833098ebac8c27365f5882"
+      "entity_derived": "niiri:9a9c1fe4c7f0e8236338ec3ccf5fb8c1",
+      "entity": "niiri:06f83c4cb0758a1db3af7b9ac9595bd1"
     },
     {
-      "@id": "niiri:ccb0cbfacba02c3f3c0aebf6cc526afa",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5aaecc8f07f4c4f973768fbf89a146da",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0083",
-      "prov:atLocation": {"@id": "niiri:4462a75d1ee425538428f9db9a7ebf85"},
+      "prov:atLocation": {"@id": "niiri:6d64cee175b474ae9c60ccad84bf5aed"},
       "prov:value": {"@type": "xsd:float", "@value": "3.36533284187317"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.26556677338515"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000546226226643243"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999624169"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.751744172496132"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.26556677338515"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000546226226643243"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999624169"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.751744172496132"}
     },
     {
-      "@id": "niiri:4462a75d1ee425538428f9db9a7ebf85",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6d64cee175b474ae9c60ccad84bf5aed",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0083",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[44,-48,-26]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[44,-48,-26]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ccb0cbfacba02c3f3c0aebf6cc526afa",
-      "entity": "niiri:af1ebc888c3ec8f9fad9e0c771ed7a78"
+      "entity_derived": "niiri:5aaecc8f07f4c4f973768fbf89a146da",
+      "entity": "niiri:33c167d8677c415c916bc8b906fd4db4"
     },
     {
-      "@id": "niiri:4110f602cbcf1840e8e4015bf63dc181",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:48bf8ce794db930df930c41d224bdc16",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0084",
-      "prov:atLocation": {"@id": "niiri:154c5a85bf34ecccb8b3e64fe364d7b0"},
+      "prov:atLocation": {"@id": "niiri:a186d322a8d32a9dcd3c456718013455"},
       "prov:value": {"@type": "xsd:float", "@value": "3.3379864692688"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.24042202275062"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000596764555146345"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999912202"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.787874793017543"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.24042202275062"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000596764555146345"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999912202"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.787874793017543"}
     },
     {
-      "@id": "niiri:154c5a85bf34ecccb8b3e64fe364d7b0",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a186d322a8d32a9dcd3c456718013455",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0084",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[46,-40,44]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[46,-40,44]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4110f602cbcf1840e8e4015bf63dc181",
-      "entity": "niiri:93eff452c29120a5015af008a69e2b85"
+      "entity_derived": "niiri:48bf8ce794db930df930c41d224bdc16",
+      "entity": "niiri:6f398d8313ba8da3802bd6174fad64a9"
     },
     {
-      "@id": "niiri:7e00fc9195554320e63dd74c7c844f43",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:553299baed01f241bd72ebf115908e51",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0085",
-      "prov:atLocation": {"@id": "niiri:a717960733802b20ec0357c684696cee"},
+      "prov:atLocation": {"@id": "niiri:089c8164018121709a50c5c000adb8b4"},
       "prov:value": {"@type": "xsd:float", "@value": "3.33372783660889"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.23650348537689"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000605018743711327"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999930494"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.791142662581953"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.23650348537689"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000605018743711327"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999930494"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.791142662581953"}
     },
     {
-      "@id": "niiri:a717960733802b20ec0357c684696cee",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:089c8164018121709a50c5c000adb8b4",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0085",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[16,4,16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[16,4,16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7e00fc9195554320e63dd74c7c844f43",
-      "entity": "niiri:eadc69190fdc6d634404fa8f12f510eb"
+      "entity_derived": "niiri:553299baed01f241bd72ebf115908e51",
+      "entity": "niiri:441c62b804db7724fe069a4683eabbb3"
     },
     {
-      "@id": "niiri:7c518ba27edef4f0933ea4750087fe00",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:6eaf36636b84719dcdad3b87ac63db9d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0086",
-      "prov:atLocation": {"@id": "niiri:cfc0fc18cb48322234eec2b8adf838e3"},
+      "prov:atLocation": {"@id": "niiri:48ea271c59c0d27824322ff2afca20a5"},
       "prov:value": {"@type": "xsd:float", "@value": "3.32532405853271"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.22876865896546"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000621622108231912"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999995642"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.802213727911317"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.22876865896546"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000621622108231912"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999995642"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.802213727911317"}
     },
     {
-      "@id": "niiri:cfc0fc18cb48322234eec2b8adf838e3",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:48ea271c59c0d27824322ff2afca20a5",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0086",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-54,-32,42]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-54,-32,42]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7c518ba27edef4f0933ea4750087fe00",
-      "entity": "niiri:fdf3341a871a270775355dceeb623541"
+      "entity_derived": "niiri:6eaf36636b84719dcdad3b87ac63db9d",
+      "entity": "niiri:9573a33cf8de1d0d7462efcefe1aa3b3"
     },
     {
-      "@id": "niiri:92dbb4f064c8dffea3d0b3dc7f7936a3",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e375fd72351a936406457560ff4bf243",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0087",
-      "prov:atLocation": {"@id": "niiri:005cc9e6032d3220d252231334197152"},
+      "prov:atLocation": {"@id": "niiri:e8219e816a81544fd1542b7c43739e8d"},
       "prov:value": {"@type": "xsd:float", "@value": "3.3035409450531"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.20870610659348"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000666668530368786"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999987468"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.829570299628891"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.20870610659348"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000666668530368786"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999987468"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.829570299628891"}
     },
     {
-      "@id": "niiri:005cc9e6032d3220d252231334197152",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e8219e816a81544fd1542b7c43739e8d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0087",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[22,38,10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[22,38,10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:92dbb4f064c8dffea3d0b3dc7f7936a3",
-      "entity": "niiri:d53a0a4ae6e04c2856dad6f7de113409"
+      "entity_derived": "niiri:e375fd72351a936406457560ff4bf243",
+      "entity": "niiri:adc671bb3b8aead7b73b777448e0d974"
     },
     {
-      "@id": "niiri:620973253c62a151921fc9a1c9d5dfa2",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:19a0feb2eced3573854928d35a375bea",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0088",
-      "prov:atLocation": {"@id": "niiri:da864c21a52816da3b0190478e49caae"},
+      "prov:atLocation": {"@id": "niiri:0865df5da5b73976893b2a73cf860d9d"},
       "prov:value": {"@type": "xsd:float", "@value": "3.29107904434204"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.19721985733158"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000693795605607228"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999994003"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.839453948823053"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.19721985733158"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000693795605607228"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999994003"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.839453948823053"}
     },
     {
-      "@id": "niiri:da864c21a52816da3b0190478e49caae",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0865df5da5b73976893b2a73cf860d9d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0088",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[30,34,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[30,34,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:620973253c62a151921fc9a1c9d5dfa2",
-      "entity": "niiri:cf7aba36a552e6ca5812f44e1297b2e9"
+      "entity_derived": "niiri:19a0feb2eced3573854928d35a375bea",
+      "entity": "niiri:e9779649e0e322514fd2b0963b83e9b3"
     },
     {
-      "@id": "niiri:440111cd7e19e50738e336a36656bf0b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0e5f9cfe273ad2b56c5d941a8fa1d751",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0089",
-      "prov:atLocation": {"@id": "niiri:4f6e4659ace26929d99204d0904b13df"},
+      "prov:atLocation": {"@id": "niiri:831e9d6a1c1a2ca8f3a901a82bb321af"},
       "prov:value": {"@type": "xsd:float", "@value": "3.27154183387756"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.17919960131803"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000738411785119797"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999998178"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.858755937068456"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.17919960131803"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000738411785119797"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999998178"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.858755937068456"}
     },
     {
-      "@id": "niiri:4f6e4659ace26929d99204d0904b13df",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:831e9d6a1c1a2ca8f3a901a82bb321af",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0089",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[10,-76,-12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[10,-76,-12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:440111cd7e19e50738e336a36656bf0b",
-      "entity": "niiri:43852b81a09cf6e877d19e5df6f9977b"
+      "entity_derived": "niiri:0e5f9cfe273ad2b56c5d941a8fa1d751",
+      "entity": "niiri:41fb45bc18bea4725f44ca167cd99df1"
     },
     {
-      "@id": "niiri:4f84c599f455625d062b8e65b802ab8c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:9ae75a88cde46be90790ef06a7e29dee",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0090",
-      "prov:atLocation": {"@id": "niiri:f89dda8a627ed3bf3657e54cbacfadcc"},
+      "prov:atLocation": {"@id": "niiri:8f64ab79b8b00ebd627396d051504046"},
       "prov:value": {"@type": "xsd:float", "@value": "3.2669575214386"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.17496900913942"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000749262523860983"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999998632"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.863075307004762"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.17496900913942"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000749262523860983"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999998632"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.863075307004762"}
     },
     {
-      "@id": "niiri:f89dda8a627ed3bf3657e54cbacfadcc",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:8f64ab79b8b00ebd627396d051504046",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0090",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[20,32,54]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[20,32,54]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4f84c599f455625d062b8e65b802ab8c",
-      "entity": "niiri:a0bcd52b78a9ad004b1f13878095b584"
+      "entity_derived": "niiri:9ae75a88cde46be90790ef06a7e29dee",
+      "entity": "niiri:eea8668c9a2e77333db7bb9162d0d4ef"
     },
     {
-      "@id": "niiri:87aeb61d09b8ed3ecc86948bd241107b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:7e114fc2dca77ff7f26aca5c69c3b36c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0091",
-      "prov:atLocation": {"@id": "niiri:5f9fca926c517d3aea0593e330aa9bdd"},
+      "prov:atLocation": {"@id": "niiri:c125b47469686fd33678c1b78d004968"},
       "prov:value": {"@type": "xsd:float", "@value": "3.26226496696472"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.17063765299814"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000760523733375762"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999998982"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.867640730428823"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.17063765299814"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000760523733375762"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999998982"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.867640730428823"}
     },
     {
-      "@id": "niiri:5f9fca926c517d3aea0593e330aa9bdd",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c125b47469686fd33678c1b78d004968",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0091",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-60,-14,10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-60,-14,10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:87aeb61d09b8ed3ecc86948bd241107b",
-      "entity": "niiri:315508af939cde7c660dac4093bd5f63"
+      "entity_derived": "niiri:7e114fc2dca77ff7f26aca5c69c3b36c",
+      "entity": "niiri:dd0835679f1bd959157bd71b4d4ada4a"
     },
     {
-      "@id": "niiri:4d68f5ce2e83a0ebec736d32656f74f1",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:65129edf8c444af2b8ae3ebfb73d5a95",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0092",
-      "prov:atLocation": {"@id": "niiri:e003e96d659ec853a8be0de10428a8b0"},
+      "prov:atLocation": {"@id": "niiri:c218dfdf71b575e423a61a71046e3254"},
       "prov:value": {"@type": "xsd:float", "@value": "3.25743293762207"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.16617663527645"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000772284854291594"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999251"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.872516606801204"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.16617663527645"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000772284854291594"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999251"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.872516606801204"}
     },
     {
-      "@id": "niiri:e003e96d659ec853a8be0de10428a8b0",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c218dfdf71b575e423a61a71046e3254",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0092",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-22,-94,28]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-22,-94,28]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4d68f5ce2e83a0ebec736d32656f74f1",
-      "entity": "niiri:415cf023223ce3eb6f3ea193de2e66d0"
+      "entity_derived": "niiri:65129edf8c444af2b8ae3ebfb73d5a95",
+      "entity": "niiri:7cdc9365fde87ad8333e6618dc3a8a51"
     },
     {
-      "@id": "niiri:8664244aebf3c8a36b9e9665e962c1ec",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3d4630be29adc78b6133a798da406017",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0093",
-      "prov:atLocation": {"@id": "niiri:39036215cb38b5650d990b5ece73ad97"},
+      "prov:atLocation": {"@id": "niiri:e30ef537b55de5d1df0298565809152d"},
       "prov:value": {"@type": "xsd:float", "@value": "3.25416302680969"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.16315726358056"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000780339994975288"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999392"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.874305136305167"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.16315726358056"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000780339994975288"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999392"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.874305136305167"}
     },
     {
-      "@id": "niiri:39036215cb38b5650d990b5ece73ad97",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e30ef537b55de5d1df0298565809152d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0093",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-66,-46,8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-66,-46,8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8664244aebf3c8a36b9e9665e962c1ec",
-      "entity": "niiri:688e11a39a0754d2ec0a74d65774433a"
+      "entity_derived": "niiri:3d4630be29adc78b6133a798da406017",
+      "entity": "niiri:7de4f98c4ea2239ac1a4b37fb8737ebb"
     },
     {
-      "@id": "niiri:9b9b2ef57e28b344957456512066c471",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3399f5c31ecf4ca8aaa4e0dc4d2629cb",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0094",
-      "prov:atLocation": {"@id": "niiri:f9b694a8cf7dc1b99809ac4c60026737"},
+      "prov:atLocation": {"@id": "niiri:5ffd97e765bdcd6a40cee30a818bf20b"},
       "prov:value": {"@type": "xsd:float", "@value": "3.24836373329163"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.15780125799237"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000794819459152607"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999582"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.881177035765112"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.15780125799237"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000794819459152607"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999582"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.881177035765112"}
     },
     {
-      "@id": "niiri:f9b694a8cf7dc1b99809ac4c60026737",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:5ffd97e765bdcd6a40cee30a818bf20b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0094",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-68,-34,-8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-68,-34,-8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9b9b2ef57e28b344957456512066c471",
-      "entity": "niiri:7a715e1614e6866276cb5725bccf59a3"
+      "entity_derived": "niiri:3399f5c31ecf4ca8aaa4e0dc4d2629cb",
+      "entity": "niiri:392bbfa2f02e1783423c67df389a3772"
     },
     {
-      "@id": "niiri:fc68fcdb2d7ea6ecf1b753ff553dab73",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b0d26737223ecac9b30bc4e6d357903d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0095",
-      "prov:atLocation": {"@id": "niiri:b26f7ba046631013d0386f159502667a"},
+      "prov:atLocation": {"@id": "niiri:724852999b8744da36a792174695ead8"},
       "prov:value": {"@type": "xsd:float", "@value": "3.23741388320923"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.14768473672474"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000822845399445549"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999796"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.899808991491498"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.14768473672474"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000822845399445549"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999796"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.899808991491498"}
     },
     {
-      "@id": "niiri:b26f7ba046631013d0386f159502667a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:724852999b8744da36a792174695ead8",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0095",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-16,2,64]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-16,2,64]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:fc68fcdb2d7ea6ecf1b753ff553dab73",
-      "entity": "niiri:fcab5dc9b5ee7cb3164b6fcfb041800b"
+      "entity_derived": "niiri:b0d26737223ecac9b30bc4e6d357903d",
+      "entity": "niiri:e08ea74eba6d829dc8f77ccdfebbc2e1"
     },
     {
-      "@id": "niiri:4b9d5324c991dbf9c955d16b6be9e350",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e2f4bde66682178e0070983ec98c509e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0096",
-      "prov:atLocation": {"@id": "niiri:2f724fbf26dc28087784e44e413cace9"},
+      "prov:atLocation": {"@id": "niiri:ba9cc9e29049445b143af1ec4b4403bf"},
       "prov:value": {"@type": "xsd:float", "@value": "3.23679161071777"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.14710967833961"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000824465484375092"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999804"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.899808991491498"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.14710967833961"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000824465484375092"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999804"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.899808991491498"}
     },
     {
-      "@id": "niiri:2f724fbf26dc28087784e44e413cace9",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ba9cc9e29049445b143af1ec4b4403bf",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0096",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-56,34,-20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-56,34,-20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4b9d5324c991dbf9c955d16b6be9e350",
-      "entity": "niiri:62711d2ee0c0429ed4fbe29698cac6fd"
+      "entity_derived": "niiri:e2f4bde66682178e0070983ec98c509e",
+      "entity": "niiri:81ce1dbb2b4b3915a17f1002f7600876"
     },
     {
-      "@id": "niiri:86a14c6a5207006da29629c9a675a39b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a5e53303ae16c0a4417cd3327ff317ba",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0097",
-      "prov:atLocation": {"@id": "niiri:51322f21443be51e4277c524c474bd84"},
+      "prov:atLocation": {"@id": "niiri:9b75309624d284042d8f748c6299b979"},
       "prov:value": {"@type": "xsd:float", "@value": "3.22331190109253"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.13464894829369"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000860299398633191"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999921"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.917823543835361"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.13464894829369"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000860299398633191"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999921"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.917823543835361"}
     },
     {
-      "@id": "niiri:51322f21443be51e4277c524c474bd84",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:9b75309624d284042d8f748c6299b979",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0097",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[42,-86,12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[42,-86,12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:86a14c6a5207006da29629c9a675a39b",
-      "entity": "niiri:485ed7c2aeeaf61df445bf323937617d"
+      "entity_derived": "niiri:a5e53303ae16c0a4417cd3327ff317ba",
+      "entity": "niiri:8ab01cc9ec9b9c9144318b6ebf4b61e5"
     },
     {
-      "@id": "niiri:746e32e138528d33390c23c66ccd9226",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:acda002ca084ac39e0dc294ad4a29af7",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0098",
-      "prov:atLocation": {"@id": "niiri:e377146f96f9a7ef6738156416ebfa62"},
+      "prov:atLocation": {"@id": "niiri:d76d5a8db54f907ce0bcdb7be6430159"},
       "prov:value": {"@type": "xsd:float", "@value": "3.19609522819519"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.10946777700093"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000937123635013748"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999988"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.958204454708765"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.10946777700093"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000937123635013748"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999988"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.958204454708765"}
     },
     {
-      "@id": "niiri:e377146f96f9a7ef6738156416ebfa62",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d76d5a8db54f907ce0bcdb7be6430159",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0098",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[14,40,20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[14,40,20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:746e32e138528d33390c23c66ccd9226",
-      "entity": "niiri:78ffd46fab5c7ea256ba49f6155cee5b"
+      "entity_derived": "niiri:acda002ca084ac39e0dc294ad4a29af7",
+      "entity": "niiri:e00f285b0f3ca710fd516c8d96d4953b"
     },
     {
-      "@id": "niiri:9f01d6bb46569d89f6d406f8c1ec9c29",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:1aebec9df0ae7e94b35fcd5f1681e2b8",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0099",
-      "prov:atLocation": {"@id": "niiri:16ab3321bd5f8419971b333165a1c5bb"},
+      "prov:atLocation": {"@id": "niiri:e3d8e69139ddc1af81e4b6a9cc70c133"},
       "prov:value": {"@type": "xsd:float", "@value": "3.19474077224731"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.10821385730133"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000941109068576473"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999989"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.958204454708765"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.10821385730133"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000941109068576473"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999989"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.958204454708765"}
     },
     {
-      "@id": "niiri:16ab3321bd5f8419971b333165a1c5bb",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e3d8e69139ddc1af81e4b6a9cc70c133",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0099",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-44,-42,-36]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-44,-42,-36]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9f01d6bb46569d89f6d406f8c1ec9c29",
-      "entity": "niiri:1273746a68b63344576d89035c4af958"
+      "entity_derived": "niiri:1aebec9df0ae7e94b35fcd5f1681e2b8",
+      "entity": "niiri:b113d084583b1c858c15b076e563ba0c"
     },
     {
-      "@id": "niiri:4dab90a4878fc6fe161f501468e5811b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e95fde56ae83d5db12a5db6e6b137be0",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0100",
-      "prov:atLocation": {"@id": "niiri:c7174cd0ebcbf60604768ef1bba962b1"},
+      "prov:atLocation": {"@id": "niiri:81fbc09a7af80e50862290bf64c5c485"},
       "prov:value": {"@type": "xsd:float", "@value": "3.18584132194519"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.0999731910723"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000967690796773613"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999994"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.0999731910723"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000967690796773613"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999994"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"}
     },
     {
-      "@id": "niiri:c7174cd0ebcbf60604768ef1bba962b1",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:81fbc09a7af80e50862290bf64c5c485",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0100",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-16,4,60]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-16,4,60]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4dab90a4878fc6fe161f501468e5811b",
-      "entity": "niiri:00d8da85844fdb0d453c7cffeb50aef0"
+      "entity_derived": "niiri:e95fde56ae83d5db12a5db6e6b137be0",
+      "entity": "niiri:f9a8bd72695ec56fe97eefd5b04d42d4"
     }
   ]
 }

--- a/spmexport/ex_spm_contrast_mask/nidm.ttl
+++ b/spmexport/ex_spm_contrast_mask/nidm.ttl
@@ -4,7 +4,7 @@
 @prefix niiri: <http://iri.nidash.org/> .
 @prefix spm: <http://purl.org/nidash/spm#> .
 @prefix neurolex: <http://neurolex.org/wiki/> .
-@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#> .
+@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
@@ -17,27 +17,27 @@
 @prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-niiri:672c2ac2a415db6f1748d04e9a0f30bd
+niiri:c0fc11f77219f72f64535275dfd76104
   a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
   rdfs:label "NIDM-Results" ;
   nidm_version: "1.3.0"^^xsd:string .
 
-niiri:86ec330980a5667ce9ea17bac929283a
+niiri:a578ca65ebc21d2f8a367638a428ecb2
   a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
   rdfs:label "spm_results_nidm" ;
-  nidm_softwareVersion: "12.6903"^^xsd:string .
+  nidm_softwareVersion: "12.7057"^^xsd:string .
 
-niiri:c61dda563833b6322557e795e27e21c1
+niiri:95688b75812d93e59bb028a4360014e7
   a prov:Activity, nidm_NIDMResultsExport: ; 
   rdfs:label "NIDM-Results export" .
 
-niiri:c61dda563833b6322557e795e27e21c1 prov:wasAssociatedWith niiri:86ec330980a5667ce9ea17bac929283a .
+niiri:95688b75812d93e59bb028a4360014e7 prov:wasAssociatedWith niiri:a578ca65ebc21d2f8a367638a428ecb2 .
 
 _:blank5 a prov:Generation .
 
-niiri:672c2ac2a415db6f1748d04e9a0f30bd prov:qualifiedGeneration _:blank5 .
+niiri:c0fc11f77219f72f64535275dfd76104 prov:qualifiedGeneration _:blank5 .
 
-_:blank5 prov:atTime "2016-12-07T16:08:07"^^xsd:dateTime .
+_:blank5 prov:atTime "2017-04-19T12:17:53"^^xsd:dateTime .
 
 @prefix nidm_Ixi549CoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000050> .
 @prefix src_SPM: <http://scicrunch.org/resolver/SCR_007037> .
@@ -143,12 +143,12 @@ _:blank5 prov:atTime "2016-12-07T16:08:07"^^xsd:dateTime .
 @prefix nidm_Coordinate: <http://purl.org/nidash/nidm#NIDM_0000015> .
 @prefix nidm_coordinateVector: <http://purl.org/nidash/nidm#NIDM_0000086> .
 
-niiri:01d87cfa40547d4de2e2e6acb69d8796
+niiri:7d55eee26233e3ffebe8fb466230d746
     a prov:Agent, src_SPM:, prov:SoftwareAgent ; 
     rdfs:label "SPM" ;
-    nidm_softwareVersion: "12.12.2"^^xsd:string .
+    nidm_softwareVersion: "12.6906"^^xsd:string .
 
-niiri:d18f183003db6780cdc9b347b4af5993
+niiri:d11490ae37fde7aa8e3ddc508c115313
     a prov:Entity, nidm_CoordinateSpace: ; 
     rdfs:label "Coordinate space 1" ;
     nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
@@ -158,48 +158,48 @@ niiri:d18f183003db6780cdc9b347b4af5993
     nidm_numberOfDimensions: "3"^^xsd:int ;
     nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
 
-niiri:8a0f59a0eb263d3f972122ed2f59f2c0
+niiri:fcffff56d818fa0f4fd06f330c7fd209
     a prov:Agent, nlx_Imaginginstrument:, nlx_Magneticresonanceimagingscanner: ; 
     rdfs:label "MRI Scanner" .
 
-niiri:61457c67587ef15f640d478149a8a2c8
+niiri:db4e0548483590dda7e45661cf53201d
     a prov:Agent, prov:Person ; 
     rdfs:label "Person" .
 
-niiri:2d072058cbc02804a6f8806a179381c4
+niiri:3eafaf3b0d4fb27e0273cf883045c71c
     a prov:Entity, prov:Collection, nidm_Data: ; 
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "true"^^xsd:boolean ;
     nidm_targetIntensity: "100"^^xsd:float ;
     nidm_hasMRIProtocol: nlx_FunctionalMRIprotocol: .
 
-niiri:2d072058cbc02804a6f8806a179381c4 prov:wasAttributedTo niiri:8a0f59a0eb263d3f972122ed2f59f2c0 .
+niiri:3eafaf3b0d4fb27e0273cf883045c71c prov:wasAttributedTo niiri:fcffff56d818fa0f4fd06f330c7fd209 .
 
-niiri:2d072058cbc02804a6f8806a179381c4 prov:wasAttributedTo niiri:61457c67587ef15f640d478149a8a2c8 .
+niiri:3eafaf3b0d4fb27e0273cf883045c71c prov:wasAttributedTo niiri:db4e0548483590dda7e45661cf53201d .
 
-niiri:4ebdf7a11506de3c5fe02716ed14ee65
+niiri:1b66176fa0492dcad18cbabb1ac94ea3
     a prov:Entity, spm_DCTDriftModel: ; 
     rdfs:label "SPM's DCT Drift Model" ;
     spm_SPMsDriftCutoffPeriod: "128"^^xsd:float .
 
-niiri:2acb212c883d251b598ba63a18deb237
+niiri:55ba018663409d2f002b8707d5149e83
     a prov:Entity, nidm_DesignMatrix: ; 
     prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.csv"^^xsd:string ;
     dct:format "text/csv"^^xsd:string ;
-    dc:description niiri:57633e9bf742e0bbdc59207427b10827 ;
+    dc:description niiri:967bf8ed0debd31706b3c4341edc203f ;
     rdfs:label "Design Matrix" ;
     nidm_regressorNames: "[\"Sn(1) to*bf(1)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) constant\"]"^^xsd:string ;
-    nidm_hasDriftModel: niiri:4ebdf7a11506de3c5fe02716ed14ee65 ;
+    nidm_hasDriftModel: niiri:1b66176fa0492dcad18cbabb1ac94ea3 ;
     nidm_hasHRFBasis: spm_SPMsCanonicalHRF: .
 
-niiri:57633e9bf742e0bbdc59207427b10827
+niiri:967bf8ed0debd31706b3c4341edc203f
     a prov:Entity, dctype:Image ; 
     prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:029e264b9da50c69326142fb810919f5
+niiri:b4b0efe73f8e31624573c955a3b91929
     a prov:Entity, nidm_ErrorModel: ; 
     nidm_hasErrorDistribution: obo_normaldistribution: ;
     nidm_hasErrorDependence: obo_Toeplitzcovariancestructure: ;
@@ -207,174 +207,174 @@ niiri:029e264b9da50c69326142fb810919f5
     nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
     nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
 
-niiri:6a8e811f6c315817e40dd84dfdae79a3
+niiri:b67465cae2012be9d953c04ba0ee6bb4
     a prov:Activity, nidm_ModelParametersEstimation: ; 
     rdfs:label "Model parameters estimation" ;
     nidm_withEstimationMethod: obo_generalizedleastsquaresestimation: .
 
-niiri:6a8e811f6c315817e40dd84dfdae79a3 prov:wasAssociatedWith niiri:01d87cfa40547d4de2e2e6acb69d8796 .
+niiri:b67465cae2012be9d953c04ba0ee6bb4 prov:wasAssociatedWith niiri:7d55eee26233e3ffebe8fb466230d746 .
 
-niiri:6a8e811f6c315817e40dd84dfdae79a3 prov:used niiri:2acb212c883d251b598ba63a18deb237 .
+niiri:b67465cae2012be9d953c04ba0ee6bb4 prov:used niiri:55ba018663409d2f002b8707d5149e83 .
 
-niiri:6a8e811f6c315817e40dd84dfdae79a3 prov:used niiri:2d072058cbc02804a6f8806a179381c4 .
+niiri:b67465cae2012be9d953c04ba0ee6bb4 prov:used niiri:3eafaf3b0d4fb27e0273cf883045c71c .
 
-niiri:6a8e811f6c315817e40dd84dfdae79a3 prov:used niiri:029e264b9da50c69326142fb810919f5 .
+niiri:b67465cae2012be9d953c04ba0ee6bb4 prov:used niiri:b4b0efe73f8e31624573c955a3b91929 .
 
-niiri:1bff00d2a3c64ac18b7820d9ec2a5c1a
+niiri:b129871a86340316a5e71da151467968
     a prov:Entity, nidm_MaskMap: ; 
     prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
     nidm_isUserDefined: "false"^^xsd:boolean ;
     nfo:fileName "Mask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Mask" ;
-    nidm_inCoordinateSpace: niiri:d18f183003db6780cdc9b347b4af5993 ;
+    nidm_inCoordinateSpace: niiri:d11490ae37fde7aa8e3ddc508c115313 ;
     crypto:sha512 "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876"^^xsd:string .
 
-niiri:e3c2a48a9fe4c61e98dfd0e42459332e
+niiri:b64466758d550b4120028710711baae1
     a prov:Entity, nidm_MaskMap: ; 
     nfo:fileName "mask.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "36929e1f5f4143bd9cc818cd896a25f129961fab208c3a4438555f40444c08347b359142ee8c53ece6e8cca1627f49db0788a1fd3b9e2ecaef61999c6c6c67ac"^^xsd:string .
 
-niiri:1bff00d2a3c64ac18b7820d9ec2a5c1a prov:wasDerivedFrom niiri:e3c2a48a9fe4c61e98dfd0e42459332e .
+niiri:b129871a86340316a5e71da151467968 prov:wasDerivedFrom niiri:b64466758d550b4120028710711baae1 .
 
-niiri:1bff00d2a3c64ac18b7820d9ec2a5c1a prov:wasGeneratedBy niiri:6a8e811f6c315817e40dd84dfdae79a3 .
+niiri:b129871a86340316a5e71da151467968 prov:wasGeneratedBy niiri:b67465cae2012be9d953c04ba0ee6bb4 .
 
-niiri:233937d2a232be927ee7b652922d8760
+niiri:5452b79c7f6c0fb6d103555e4ba5ab0b
     a prov:Entity, nidm_GrandMeanMap: ; 
     prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
     nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Grand Mean Map" ;
     nidm_maskedMedian: "111.557487487793"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:d18f183003db6780cdc9b347b4af5993 ;
+    nidm_inCoordinateSpace: niiri:d11490ae37fde7aa8e3ddc508c115313 ;
     crypto:sha512 "512157cc6bff89d9343a09b4068226eb3edd64a8cbcee861f06231767fae6f8d4819921182adebee083a9bf309afd65529ab04a92f0aa6b0038c8098550f6124"^^xsd:string .
 
-niiri:233937d2a232be927ee7b652922d8760 prov:wasGeneratedBy niiri:6a8e811f6c315817e40dd84dfdae79a3 .
+niiri:5452b79c7f6c0fb6d103555e4ba5ab0b prov:wasGeneratedBy niiri:b67465cae2012be9d953c04ba0ee6bb4 .
 
-niiri:66c80a9d0dd323ea250a58745156cae8
+niiri:fac828643e618f4bd2bcc17d9b2c23db
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0001.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0001.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 1" ;
-    nidm_inCoordinateSpace: niiri:d18f183003db6780cdc9b347b4af5993 ;
+    nidm_inCoordinateSpace: niiri:d11490ae37fde7aa8e3ddc508c115313 ;
     crypto:sha512 "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd"^^xsd:string .
 
-niiri:01b496635aca4250b5af60666a57fd00
+niiri:83ed43088ba6e13e15e23f0722815231
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd"^^xsd:string .
 
-niiri:66c80a9d0dd323ea250a58745156cae8 prov:wasDerivedFrom niiri:01b496635aca4250b5af60666a57fd00 .
+niiri:fac828643e618f4bd2bcc17d9b2c23db prov:wasDerivedFrom niiri:83ed43088ba6e13e15e23f0722815231 .
 
-niiri:66c80a9d0dd323ea250a58745156cae8 prov:wasGeneratedBy niiri:6a8e811f6c315817e40dd84dfdae79a3 .
+niiri:fac828643e618f4bd2bcc17d9b2c23db prov:wasGeneratedBy niiri:b67465cae2012be9d953c04ba0ee6bb4 .
 
-niiri:528dc036f80ec3749fae0f1beb01681b
+niiri:648e908d9842014984d36e153dd159b3
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0002.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0002.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 2" ;
-    nidm_inCoordinateSpace: niiri:d18f183003db6780cdc9b347b4af5993 ;
+    nidm_inCoordinateSpace: niiri:d11490ae37fde7aa8e3ddc508c115313 ;
     crypto:sha512 "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c"^^xsd:string .
 
-niiri:c747f0dbb1007e818904c8088efd3799
+niiri:71301a90cafdf2e089e984789a19c3b0
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0002.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c"^^xsd:string .
 
-niiri:528dc036f80ec3749fae0f1beb01681b prov:wasDerivedFrom niiri:c747f0dbb1007e818904c8088efd3799 .
+niiri:648e908d9842014984d36e153dd159b3 prov:wasDerivedFrom niiri:71301a90cafdf2e089e984789a19c3b0 .
 
-niiri:528dc036f80ec3749fae0f1beb01681b prov:wasGeneratedBy niiri:6a8e811f6c315817e40dd84dfdae79a3 .
+niiri:648e908d9842014984d36e153dd159b3 prov:wasGeneratedBy niiri:b67465cae2012be9d953c04ba0ee6bb4 .
 
-niiri:0b0d1304a9a24e042bc54f017e7c1b74
+niiri:cecb740cce9e1407b8cd6a8aeb90385e
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0003.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0003.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 3" ;
-    nidm_inCoordinateSpace: niiri:d18f183003db6780cdc9b347b4af5993 ;
+    nidm_inCoordinateSpace: niiri:d11490ae37fde7aa8e3ddc508c115313 ;
     crypto:sha512 "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373"^^xsd:string .
 
-niiri:12b05b6bde3deb9f0632eb70478f1a70
+niiri:f947acbd818877cfe83bc57648200186
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0003.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373"^^xsd:string .
 
-niiri:0b0d1304a9a24e042bc54f017e7c1b74 prov:wasDerivedFrom niiri:12b05b6bde3deb9f0632eb70478f1a70 .
+niiri:cecb740cce9e1407b8cd6a8aeb90385e prov:wasDerivedFrom niiri:f947acbd818877cfe83bc57648200186 .
 
-niiri:0b0d1304a9a24e042bc54f017e7c1b74 prov:wasGeneratedBy niiri:6a8e811f6c315817e40dd84dfdae79a3 .
+niiri:cecb740cce9e1407b8cd6a8aeb90385e prov:wasGeneratedBy niiri:b67465cae2012be9d953c04ba0ee6bb4 .
 
-niiri:166f71a6b0ee725b67d28223e8aae31a
+niiri:71f2801581b2abe311d3914ca638ba77
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Residual Mean Squares Map" ;
-    nidm_inCoordinateSpace: niiri:d18f183003db6780cdc9b347b4af5993 ;
+    nidm_inCoordinateSpace: niiri:d11490ae37fde7aa8e3ddc508c115313 ;
     crypto:sha512 "991abf563d795a43b1e2eef8643e57023f2e0b090b2031f05f839321fc0643df6f71d423486a1021519b6dc82f6b0f563e19f3fbd50cb16063bed54a0e192d3e"^^xsd:string .
 
-niiri:4d9cff67969b1c457a1ca50df4dfea66
+niiri:e704c1b77b30444afce8a702d4e3ac9c
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     nfo:fileName "ResMS.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "40b28d03fcf9a2f60b11f10d7fb83bf3618b234fb5aedf09df644cb7cbb6aab8c9f468897c1078166d455a3d04a83f4e3bf762cfca0b4ea982d7a4e406849f18"^^xsd:string .
 
-niiri:166f71a6b0ee725b67d28223e8aae31a prov:wasDerivedFrom niiri:4d9cff67969b1c457a1ca50df4dfea66 .
+niiri:71f2801581b2abe311d3914ca638ba77 prov:wasDerivedFrom niiri:e704c1b77b30444afce8a702d4e3ac9c .
 
-niiri:166f71a6b0ee725b67d28223e8aae31a prov:wasGeneratedBy niiri:6a8e811f6c315817e40dd84dfdae79a3 .
+niiri:71f2801581b2abe311d3914ca638ba77 prov:wasGeneratedBy niiri:b67465cae2012be9d953c04ba0ee6bb4 .
 
-niiri:85a893b3abb0636607b7910a8b9ba1f7
+niiri:7adfaca483dfbb4c69fe57814c2e7ba5
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Resels per Voxel Map" ;
-    nidm_inCoordinateSpace: niiri:d18f183003db6780cdc9b347b4af5993 ;
+    nidm_inCoordinateSpace: niiri:d11490ae37fde7aa8e3ddc508c115313 ;
     crypto:sha512 "1a3f9216e145249ccc0b14b2bc337d6b38b81ad45e32768001fb22b35f0c2c0f3e2bce013b40c85f7dc0fc62723ac761ee7f7e1e6aff128a05f0ba7b8b8202a3"^^xsd:string .
 
-niiri:20b767b4ac770494bf091cfef7993218
+niiri:4c53149058cf0977f0f71d080e3a55bd
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     nfo:fileName "RPV.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "4f76663162857f6b38b2a45a63b15a23b2ca8b338c283b69c1e71f2ea2f43797d045a733cd14e845be9c12f8b8f84d3931c599a08e8f6d77e99fab46ad87ab8f"^^xsd:string .
 
-niiri:85a893b3abb0636607b7910a8b9ba1f7 prov:wasDerivedFrom niiri:20b767b4ac770494bf091cfef7993218 .
+niiri:7adfaca483dfbb4c69fe57814c2e7ba5 prov:wasDerivedFrom niiri:4c53149058cf0977f0f71d080e3a55bd .
 
-niiri:85a893b3abb0636607b7910a8b9ba1f7 prov:wasGeneratedBy niiri:6a8e811f6c315817e40dd84dfdae79a3 .
+niiri:7adfaca483dfbb4c69fe57814c2e7ba5 prov:wasGeneratedBy niiri:b67465cae2012be9d953c04ba0ee6bb4 .
 
-niiri:e1905e083c4c752effeb2b0a17b37dcc
+niiri:32ab289c9b156044343a8e1edd8ec1d0
     a prov:Entity, obo_contrastweightmatrix: ; 
     nidm_statisticType: obo_tstatistic: ;
     nidm_contrastName: "tone counting vs baseline"^^xsd:string ;
     rdfs:label "Contrast: tone counting vs baseline" ;
     prov:value "[1, 0, 0]"^^xsd:string .
 
-niiri:e5b452dedb5772acbf6cb6d40e609ec6
+niiri:d1e92a419c3d7e1b91add9945c81aa9b
     a prov:Activity, nidm_ContrastEstimation: ; 
     rdfs:label "Contrast estimation" .
 
-niiri:e5b452dedb5772acbf6cb6d40e609ec6 prov:wasAssociatedWith niiri:01d87cfa40547d4de2e2e6acb69d8796 .
+niiri:d1e92a419c3d7e1b91add9945c81aa9b prov:wasAssociatedWith niiri:7d55eee26233e3ffebe8fb466230d746 .
 
-niiri:e5b452dedb5772acbf6cb6d40e609ec6 prov:used niiri:1bff00d2a3c64ac18b7820d9ec2a5c1a .
+niiri:d1e92a419c3d7e1b91add9945c81aa9b prov:used niiri:b129871a86340316a5e71da151467968 .
 
-niiri:e5b452dedb5772acbf6cb6d40e609ec6 prov:used niiri:166f71a6b0ee725b67d28223e8aae31a .
+niiri:d1e92a419c3d7e1b91add9945c81aa9b prov:used niiri:71f2801581b2abe311d3914ca638ba77 .
 
-niiri:e5b452dedb5772acbf6cb6d40e609ec6 prov:used niiri:2acb212c883d251b598ba63a18deb237 .
+niiri:d1e92a419c3d7e1b91add9945c81aa9b prov:used niiri:55ba018663409d2f002b8707d5149e83 .
 
-niiri:e5b452dedb5772acbf6cb6d40e609ec6 prov:used niiri:e1905e083c4c752effeb2b0a17b37dcc .
+niiri:d1e92a419c3d7e1b91add9945c81aa9b prov:used niiri:32ab289c9b156044343a8e1edd8ec1d0 .
 
-niiri:e5b452dedb5772acbf6cb6d40e609ec6 prov:used niiri:66c80a9d0dd323ea250a58745156cae8 .
+niiri:d1e92a419c3d7e1b91add9945c81aa9b prov:used niiri:fac828643e618f4bd2bcc17d9b2c23db .
 
-niiri:e5b452dedb5772acbf6cb6d40e609ec6 prov:used niiri:528dc036f80ec3749fae0f1beb01681b .
+niiri:d1e92a419c3d7e1b91add9945c81aa9b prov:used niiri:648e908d9842014984d36e153dd159b3 .
 
-niiri:e5b452dedb5772acbf6cb6d40e609ec6 prov:used niiri:0b0d1304a9a24e042bc54f017e7c1b74 .
+niiri:d1e92a419c3d7e1b91add9945c81aa9b prov:used niiri:cecb740cce9e1407b8cd6a8aeb90385e .
 
-niiri:3e21b67f13781900c9629e35a248bed3
+niiri:730c67ccd0e52a39ba60c5796037b4e0
     a prov:Entity, nidm_StatisticMap: ; 
     prov:atLocation "TStatistic.nii.gz"^^xsd:anyURI ;
     nfo:fileName "TStatistic.nii.gz"^^xsd:string ;
@@ -384,143 +384,143 @@ niiri:3e21b67f13781900c9629e35a248bed3
     nidm_contrastName: "tone counting vs baseline"^^xsd:string ;
     nidm_errorDegreesOfFreedom: "97.9999999998522"^^xsd:float ;
     nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:d18f183003db6780cdc9b347b4af5993 ;
+    nidm_inCoordinateSpace: niiri:d11490ae37fde7aa8e3ddc508c115313 ;
     crypto:sha512 "9e1714c2d86a050b38b4e10a4d2d23253a24c5e1d228ae16a9c3be8872739278505ac0729ecab54265a717e3a54f9f782d0ed72eea904e0d482a6072bb817bd4"^^xsd:string .
 
-niiri:5ad3aea2e6813a8e97e5013b3075bf06
+niiri:19e8074493373e095fbeb5d7d0137351
     a prov:Entity, nidm_StatisticMap: ; 
     nfo:fileName "spmT_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "d288b1b0f117f64502555da13c5398dffa5bf5ff0b58951510e43d5388755bc185798802a92e98a07c7e313c6991066d2908f2a44aa5153ba23433da1335970f"^^xsd:string .
 
-niiri:3e21b67f13781900c9629e35a248bed3 prov:wasDerivedFrom niiri:5ad3aea2e6813a8e97e5013b3075bf06 .
+niiri:730c67ccd0e52a39ba60c5796037b4e0 prov:wasDerivedFrom niiri:19e8074493373e095fbeb5d7d0137351 .
 
-niiri:3e21b67f13781900c9629e35a248bed3 prov:wasGeneratedBy niiri:e5b452dedb5772acbf6cb6d40e609ec6 .
+niiri:730c67ccd0e52a39ba60c5796037b4e0 prov:wasGeneratedBy niiri:d1e92a419c3d7e1b91add9945c81aa9b .
 
-niiri:8c0ddb20c4bedf13b412e4f6bd94f729
+niiri:4f98291a207d3b592ea963c5b2efee61
     a prov:Entity, nidm_ContrastMap: ; 
     prov:atLocation "Contrast.nii.gz"^^xsd:anyURI ;
     nfo:fileName "Contrast.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Map: tone counting vs baseline" ;
     nidm_contrastName: "tone counting vs baseline"^^xsd:string ;
-    nidm_inCoordinateSpace: niiri:d18f183003db6780cdc9b347b4af5993 ;
+    nidm_inCoordinateSpace: niiri:d11490ae37fde7aa8e3ddc508c115313 ;
     crypto:sha512 "fc5e2ad175243ee496db98f9b2e1b235c4c3bae1a8d7122ce461c897b537e40c49dfee5d6cf20f71c6a2bb9b5f0760fcb4ecd8fe2e9428910ef3d60d8f3c56a9"^^xsd:string .
 
-niiri:ba567500b6f98025f5028377a682d495
+niiri:fa1e177a50edc20148667f0c1cfb02fc
     a prov:Entity, nidm_ContrastMap: ; 
     nfo:fileName "con_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "d4aa46b3603ba508578e39751262d528cf6d1ed2e722ec46f1cd8194c50591e46b229deb8cb4f72d1b7e0e2640f3e6604be7a335301c5c8357f453e5d0d4daf2"^^xsd:string .
 
-niiri:8c0ddb20c4bedf13b412e4f6bd94f729 prov:wasDerivedFrom niiri:ba567500b6f98025f5028377a682d495 .
+niiri:4f98291a207d3b592ea963c5b2efee61 prov:wasDerivedFrom niiri:fa1e177a50edc20148667f0c1cfb02fc .
 
-niiri:8c0ddb20c4bedf13b412e4f6bd94f729 prov:wasGeneratedBy niiri:e5b452dedb5772acbf6cb6d40e609ec6 .
+niiri:4f98291a207d3b592ea963c5b2efee61 prov:wasGeneratedBy niiri:d1e92a419c3d7e1b91add9945c81aa9b .
 
-niiri:59228b58841dd98008376655e745ae6e
+niiri:d590545b386aedf38aa5ec2c2ea31ee5
     a prov:Entity, nidm_ContrastStandardErrorMap: ; 
     prov:atLocation "ContrastStandardError.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ContrastStandardError.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Standard Error Map" ;
-    nidm_inCoordinateSpace: niiri:d18f183003db6780cdc9b347b4af5993 ;
+    nidm_inCoordinateSpace: niiri:d11490ae37fde7aa8e3ddc508c115313 ;
     crypto:sha512 "791d48f5d1adb15079a5289271ce0c4b95c56d69bfdb3e5d41b0d24eb538d3075e1cdd15502494b5a5a18c16eaa2153cb4847a996043fa48cdaf26e938a2576d"^^xsd:string .
 
-niiri:59228b58841dd98008376655e745ae6e prov:wasGeneratedBy niiri:e5b452dedb5772acbf6cb6d40e609ec6 .
+niiri:d590545b386aedf38aa5ec2c2ea31ee5 prov:wasGeneratedBy niiri:d1e92a419c3d7e1b91add9945c81aa9b .
 
-niiri:7c7ed0f76f76f1117dfa57e232de3a30
+niiri:53e9321dbde376b31728c3d81f4a0a0b
     a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
-    rdfs:label "Height Threshold: p<0.001000 (unc.)" ;
+    rdfs:label "Height Threshold: p<0.001 (unc.)" ;
     prov:value "0.000999500158000544"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:9f3fbe76666cadf0ad70d8ef3da4c368 ;
-    nidm_equivalentThreshold: niiri:8e6bdebe0aff733bb1d1d7a9ce971b0d .
+    nidm_equivalentThreshold: niiri:c87fc63ec6a46693c3ca483567ad054c ;
+    nidm_equivalentThreshold: niiri:1d698ce69f7c205e4e33223fd7699059 .
 
-niiri:9f3fbe76666cadf0ad70d8ef3da4c368
+niiri:c87fc63ec6a46693c3ca483567ad054c
     a prov:Entity, nidm_HeightThreshold:, obo_statistic: ; 
-    rdfs:label "Height Threshold" ;
+    rdfs:label "Height Threshold: T=3.175486)" ;
     prov:value "3.17548628637284"^^xsd:float .
 
-niiri:8e6bdebe0aff733bb1d1d7a9ce971b0d
+niiri:1d698ce69f7c205e4e33223fd7699059
     a prov:Entity, nidm_HeightThreshold:, obo_FWERadjustedpvalue: ; 
-    rdfs:label "Height Threshold" ;
+    rdfs:label "Height Threshold: p<1.000000 (FWE)" ;
     prov:value "0.999999999999997"^^xsd:float .
 
-niiri:d7141484113de2469933a41936781235
+niiri:49c3b76bda9a7fe81e3019e52927592d
     a prov:Entity, nidm_ExtentThreshold:, obo_statistic: ; 
     rdfs:label "Extent Threshold: k>=0" ;
     nidm_clusterSizeInVoxels: "0"^^xsd:int ;
     nidm_clusterSizeInResels: "0"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:1fcabee08f59d5f43e7b0f23fa58641b ;
-    nidm_equivalentThreshold: niiri:e3a1985da2c64b397c01aa2cb5f0cfa8 .
+    nidm_equivalentThreshold: niiri:d8ad697fc9fe8926d011b79c7a5eed54 ;
+    nidm_equivalentThreshold: niiri:9ab21986a7652c9329dd2f23b2b37581 .
 
-niiri:1fcabee08f59d5f43e7b0f23fa58641b
+niiri:d8ad697fc9fe8926d011b79c7a5eed54
     a prov:Entity, nidm_ExtentThreshold:, obo_FWERadjustedpvalue: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:e3a1985da2c64b397c01aa2cb5f0cfa8
+niiri:9ab21986a7652c9329dd2f23b2b37581
     a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:effb144efe8c690eddfe2a5b5779d7a3
+niiri:40cd831e46a683970a4d9ab47538c686
     a prov:Entity, nidm_PeakDefinitionCriteria: ; 
     rdfs:label "Peak Definition Criteria" ;
     nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
     nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
 
-niiri:4ea97e5a5032b048f157d17ebe23d3dd
+niiri:aec88dac07772a2bd5f7281a97725360
     a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
     rdfs:label "Cluster Connectivity Criterion: 18" ;
     nidm_hasConnectivityCriterion: nidm_voxel18connected: .
 
-niiri:ed463e8b4eba4764a73ae6571db2f829
+niiri:1101ecb253f39161ef657cfcf8181ba6
     a prov:Activity, nidm_Inference: ; 
     nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
     rdfs:label "Inference" .
 
-niiri:ed463e8b4eba4764a73ae6571db2f829 prov:wasAssociatedWith niiri:01d87cfa40547d4de2e2e6acb69d8796 .
+niiri:1101ecb253f39161ef657cfcf8181ba6 prov:wasAssociatedWith niiri:7d55eee26233e3ffebe8fb466230d746 .
 
-niiri:ed463e8b4eba4764a73ae6571db2f829 prov:used niiri:7c7ed0f76f76f1117dfa57e232de3a30 .
+niiri:1101ecb253f39161ef657cfcf8181ba6 prov:used niiri:53e9321dbde376b31728c3d81f4a0a0b .
 
-niiri:ed463e8b4eba4764a73ae6571db2f829 prov:used niiri:d7141484113de2469933a41936781235 .
+niiri:1101ecb253f39161ef657cfcf8181ba6 prov:used niiri:49c3b76bda9a7fe81e3019e52927592d .
 
-niiri:ed463e8b4eba4764a73ae6571db2f829 prov:used niiri:3e21b67f13781900c9629e35a248bed3 .
+niiri:1101ecb253f39161ef657cfcf8181ba6 prov:used niiri:730c67ccd0e52a39ba60c5796037b4e0 .
 
-niiri:ed463e8b4eba4764a73ae6571db2f829 prov:used niiri:85a893b3abb0636607b7910a8b9ba1f7 .
+niiri:1101ecb253f39161ef657cfcf8181ba6 prov:used niiri:7adfaca483dfbb4c69fe57814c2e7ba5 .
 
-niiri:ed463e8b4eba4764a73ae6571db2f829 prov:used niiri:1bff00d2a3c64ac18b7820d9ec2a5c1a .
+niiri:1101ecb253f39161ef657cfcf8181ba6 prov:used niiri:b129871a86340316a5e71da151467968 .
 
-niiri:ed463e8b4eba4764a73ae6571db2f829 prov:used niiri:effb144efe8c690eddfe2a5b5779d7a3 .
+niiri:1101ecb253f39161ef657cfcf8181ba6 prov:used niiri:40cd831e46a683970a4d9ab47538c686 .
 
-niiri:ed463e8b4eba4764a73ae6571db2f829 prov:used niiri:4ea97e5a5032b048f157d17ebe23d3dd .
+niiri:1101ecb253f39161ef657cfcf8181ba6 prov:used niiri:aec88dac07772a2bd5f7281a97725360 .
 
-niiri:e208d053ac178467d76b50bb1949baa4
+niiri:1268daf6616504ca924affa8b4071eb7
     a prov:Entity, nidm_DisplayMaskMap: ; 
     prov:atLocation "DisplayMask_0001.nii.gz"^^xsd:anyURI ;
     nfo:fileName "DisplayMask_0001.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Display Mask Map" ;
-    nidm_inCoordinateSpace: niiri:d18f183003db6780cdc9b347b4af5993 ;
+    nidm_inCoordinateSpace: niiri:d11490ae37fde7aa8e3ddc508c115313 ;
     crypto:sha512 "46fab45d854a777ac313b6e0d479d7c81c4a52633816ebdee43ad7403951265b761b58bbf0633c9abbd266f10a5e99bdbb24f02fc57ce4c475a69dc7f6120084"^^xsd:string .
 
-niiri:f2eb921ac781980c4cd99cb23cb21456
+niiri:939e38d7108636351d4b59905ee376fc
     a prov:Entity, nidm_DisplayMaskMap: ; 
     nfo:fileName "DisplayMask_0001.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "46fab45d854a777ac313b6e0d479d7c81c4a52633816ebdee43ad7403951265b761b58bbf0633c9abbd266f10a5e99bdbb24f02fc57ce4c475a69dc7f6120084"^^xsd:string .
 
-niiri:e208d053ac178467d76b50bb1949baa4 prov:wasDerivedFrom niiri:f2eb921ac781980c4cd99cb23cb21456 .
+niiri:1268daf6616504ca924affa8b4071eb7 prov:wasDerivedFrom niiri:939e38d7108636351d4b59905ee376fc .
 
-niiri:ed463e8b4eba4764a73ae6571db2f829 prov:used niiri:e208d053ac178467d76b50bb1949baa4 .
+niiri:1101ecb253f39161ef657cfcf8181ba6 prov:used niiri:1268daf6616504ca924affa8b4071eb7 .
 
-niiri:b62857b85ec9896333e1f8552b5d7a2d
+niiri:73df7ed02a3cef4b6cbeb78f33bff831
     a prov:Entity, nidm_SearchSpaceMaskMap: ; 
     prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
     nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Search Space Mask Map" ;
-    nidm_inCoordinateSpace: niiri:d18f183003db6780cdc9b347b4af5993 ;
+    nidm_inCoordinateSpace: niiri:d11490ae37fde7aa8e3ddc508c115313 ;
     nidm_searchVolumeInVoxels: "223057"^^xsd:int ;
     nidm_searchVolumeInUnits: "1784456"^^xsd:float ;
     nidm_reselSizeInVoxels: "65.5786964036542"^^xsd:float ;
@@ -537,9 +537,9 @@ niiri:b62857b85ec9896333e1f8552b5d7a2d
     spm_smallestSignificantClusterSizeInVoxelsFWE05: "116"^^xsd:int ;
     spm_smallestSignificantClusterSizeInVoxelsFDR05: "61"^^xsd:int .
 
-niiri:b62857b85ec9896333e1f8552b5d7a2d prov:wasGeneratedBy niiri:ed463e8b4eba4764a73ae6571db2f829 .
+niiri:73df7ed02a3cef4b6cbeb78f33bff831 prov:wasGeneratedBy niiri:1101ecb253f39161ef657cfcf8181ba6 .
 
-niiri:319501d11f59d427be0a95daa1d6c9ec
+niiri:275a137c82db0d48c36216f7ba80d8d2
     a prov:Entity, nidm_ExcursionSetMap: ; 
     prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
@@ -547,29 +547,29 @@ niiri:319501d11f59d427be0a95daa1d6c9ec
     rdfs:label "Excursion Set Map" ;
     nidm_numberOfSupraThresholdClusters: "80"^^xsd:int ;
     nidm_pValue: "7.38731298355333e-12"^^xsd:float ;
-    nidm_hasClusterLabelsMap: niiri:cb3b802b67916e52a5d56d007cd63d0e ;
-    nidm_hasMaximumIntensityProjection: niiri:d783d0864d6ff0e23f6397fdfa195d0b ;
-    nidm_inCoordinateSpace: niiri:d18f183003db6780cdc9b347b4af5993 ;
+    nidm_hasClusterLabelsMap: niiri:88d834b9ce15f8537feb3bd97e96e717 ;
+    nidm_hasMaximumIntensityProjection: niiri:d243649d29fccf080be6c8ea1a6e7819 ;
+    nidm_inCoordinateSpace: niiri:d11490ae37fde7aa8e3ddc508c115313 ;
     crypto:sha512 "54596a95519bdf2c4ca115cd15edb36766890d6bff09c37e0921f662a1090d005971b58b638ed7efb060eaf4bec1980868aa8f88e5a7f57d803f9a2a76b544f2"^^xsd:string .
 
-niiri:cb3b802b67916e52a5d56d007cd63d0e
+niiri:88d834b9ce15f8537feb3bd97e96e717
     a prov:Entity, nidm_ClusterLabelsMap: ; 
     prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Cluster Labels Map" ;
-    nidm_inCoordinateSpace: niiri:d18f183003db6780cdc9b347b4af5993 ;
+    nidm_inCoordinateSpace: niiri:d11490ae37fde7aa8e3ddc508c115313 ;
     crypto:sha512 "6ab7aa2a0d22ba2ea42152b22400d3afa337ce2556c46fb9a065c8dc80c2af310314dac55a5add1fe3a02292d97e725c655994c105485139e49b003af55cafdd"^^xsd:string .
 
-niiri:d783d0864d6ff0e23f6397fdfa195d0b
+niiri:d243649d29fccf080be6c8ea1a6e7819
     a prov:Entity, dctype:Image ; 
     prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
     nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:319501d11f59d427be0a95daa1d6c9ec prov:wasGeneratedBy niiri:ed463e8b4eba4764a73ae6571db2f829 .
+niiri:275a137c82db0d48c36216f7ba80d8d2 prov:wasGeneratedBy niiri:1101ecb253f39161ef657cfcf8181ba6 .
 
-niiri:15be626f283e4842ffd8314f2d3e1b16
+niiri:fefba803c839cbd72009efffd0596397
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0001" ;
     nidm_clusterSizeInVoxels: "1591"^^xsd:int ;
@@ -579,9 +579,9 @@ niiri:15be626f283e4842ffd8314f2d3e1b16
     nidm_qValueFDR: "4.58706002591263e-11"^^xsd:float ;
     nidm_clusterLabelId: "1"^^xsd:int .
 
-niiri:15be626f283e4842ffd8314f2d3e1b16 prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:fefba803c839cbd72009efffd0596397 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:0db4cde09719c963f970eb48ae2552e8
+niiri:92d29aeefcd3cfea4144809ceee1698b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0002" ;
     nidm_clusterSizeInVoxels: "256"^^xsd:int ;
@@ -591,9 +591,9 @@ niiri:0db4cde09719c963f970eb48ae2552e8
     nidm_qValueFDR: "0.000672150622508277"^^xsd:float ;
     nidm_clusterLabelId: "2"^^xsd:int .
 
-niiri:0db4cde09719c963f970eb48ae2552e8 prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:92d29aeefcd3cfea4144809ceee1698b prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:6ea1bac2d55c2ba420c4f23fed407a68
+niiri:ce42f33dd5918ee27ba8f8f6ccae137b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0003" ;
     nidm_clusterSizeInVoxels: "4797"^^xsd:int ;
@@ -603,9 +603,9 @@ niiri:6ea1bac2d55c2ba420c4f23fed407a68
     nidm_qValueFDR: "5.93371085041799e-20"^^xsd:float ;
     nidm_clusterLabelId: "3"^^xsd:int .
 
-niiri:6ea1bac2d55c2ba420c4f23fed407a68 prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:ce42f33dd5918ee27ba8f8f6ccae137b prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:a09617bcbda951297c2f5a30eb214dc8
+niiri:4ceeccbd429ca3c7d49d9b7ebbcbd0c0
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0004" ;
     nidm_clusterSizeInVoxels: "109"^^xsd:int ;
@@ -615,9 +615,9 @@ niiri:a09617bcbda951297c2f5a30eb214dc8
     nidm_qValueFDR: "0.022111501908576"^^xsd:float ;
     nidm_clusterLabelId: "4"^^xsd:int .
 
-niiri:a09617bcbda951297c2f5a30eb214dc8 prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:4ceeccbd429ca3c7d49d9b7ebbcbd0c0 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:5093925a984c3130f741f5e59fc218b0
+niiri:caaf1d53a3cdfedef4ec795140a8062d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0005" ;
     nidm_clusterSizeInVoxels: "479"^^xsd:int ;
@@ -627,9 +627,9 @@ niiri:5093925a984c3130f741f5e59fc218b0
     nidm_qValueFDR: "1.22279946227405e-07"^^xsd:float ;
     nidm_clusterLabelId: "5"^^xsd:int .
 
-niiri:5093925a984c3130f741f5e59fc218b0 prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:caaf1d53a3cdfedef4ec795140a8062d prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:e14a70de96226faafe4fda4afc1b78d5
+niiri:4e4124102f807b660cd900fcbb6a1dad
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0006" ;
     nidm_clusterSizeInVoxels: "216"^^xsd:int ;
@@ -639,9 +639,9 @@ niiri:e14a70de96226faafe4fda4afc1b78d5
     nidm_qValueFDR: "0.000672150622508277"^^xsd:float ;
     nidm_clusterLabelId: "6"^^xsd:int .
 
-niiri:e14a70de96226faafe4fda4afc1b78d5 prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:4e4124102f807b660cd900fcbb6a1dad prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:349c921f1331e272395f14c01123038e
+niiri:8a537453623b3e259868fdc3d34a15c0
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0007" ;
     nidm_clusterSizeInVoxels: "258"^^xsd:int ;
@@ -651,9 +651,9 @@ niiri:349c921f1331e272395f14c01123038e
     nidm_qValueFDR: "0.000672150622508277"^^xsd:float ;
     nidm_clusterLabelId: "7"^^xsd:int .
 
-niiri:349c921f1331e272395f14c01123038e prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:8a537453623b3e259868fdc3d34a15c0 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:9204e7e7da9650b9d4bc408770a00fdb
+niiri:ceaad5cdc25363799f97feba2f347a03
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0008" ;
     nidm_clusterSizeInVoxels: "115"^^xsd:int ;
@@ -663,9 +663,9 @@ niiri:9204e7e7da9650b9d4bc408770a00fdb
     nidm_qValueFDR: "0.022111501908576"^^xsd:float ;
     nidm_clusterLabelId: "8"^^xsd:int .
 
-niiri:9204e7e7da9650b9d4bc408770a00fdb prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:ceaad5cdc25363799f97feba2f347a03 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:e09b8959852a4e5d12cc0ed7036f61f0
+niiri:00cf15c153fb34e5bdc7c627fc153666
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0009" ;
     nidm_clusterSizeInVoxels: "14"^^xsd:int ;
@@ -675,9 +675,9 @@ niiri:e09b8959852a4e5d12cc0ed7036f61f0
     nidm_qValueFDR: "0.374386664234061"^^xsd:float ;
     nidm_clusterLabelId: "9"^^xsd:int .
 
-niiri:e09b8959852a4e5d12cc0ed7036f61f0 prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:00cf15c153fb34e5bdc7c627fc153666 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:6f02516841dde7aca88f672df0319963
+niiri:9fa05d9e51da6e1bf65e29c91292c1f9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0010" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -687,9 +687,9 @@ niiri:6f02516841dde7aca88f672df0319963
     nidm_qValueFDR: "0.554714461715718"^^xsd:float ;
     nidm_clusterLabelId: "10"^^xsd:int .
 
-niiri:6f02516841dde7aca88f672df0319963 prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:9fa05d9e51da6e1bf65e29c91292c1f9 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:ff5aee3969c7de59773c94fa04a5a85f
+niiri:fdf70ff4bf081216be7e467153d2d4d8
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0011" ;
     nidm_clusterSizeInVoxels: "32"^^xsd:int ;
@@ -699,9 +699,9 @@ niiri:ff5aee3969c7de59773c94fa04a5a85f
     nidm_qValueFDR: "0.190729630640958"^^xsd:float ;
     nidm_clusterLabelId: "11"^^xsd:int .
 
-niiri:ff5aee3969c7de59773c94fa04a5a85f prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:fdf70ff4bf081216be7e467153d2d4d8 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:7cafb1e5ff245f47dacb09ebc1f3d273
+niiri:bca5fdf4d900bd8486f16dfcd5ab7ade
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0012" ;
     nidm_clusterSizeInVoxels: "354"^^xsd:int ;
@@ -711,9 +711,9 @@ niiri:7cafb1e5ff245f47dacb09ebc1f3d273
     nidm_qValueFDR: "9.4369593516496e-06"^^xsd:float ;
     nidm_clusterLabelId: "12"^^xsd:int .
 
-niiri:7cafb1e5ff245f47dacb09ebc1f3d273 prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:bca5fdf4d900bd8486f16dfcd5ab7ade prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:bccdf03045b0a0de8d422d00c46014f1
+niiri:a310e577676878e8eb7499da29ff53b4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0013" ;
     nidm_clusterSizeInVoxels: "135"^^xsd:int ;
@@ -723,9 +723,9 @@ niiri:bccdf03045b0a0de8d422d00c46014f1
     nidm_qValueFDR: "0.00187402776443535"^^xsd:float ;
     nidm_clusterLabelId: "13"^^xsd:int .
 
-niiri:bccdf03045b0a0de8d422d00c46014f1 prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:a310e577676878e8eb7499da29ff53b4 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:2ecde1198137ba8c84d7f2b8ee573a34
+niiri:4e10b0470621dd6f66d32e5f0d86796f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0014" ;
     nidm_clusterSizeInVoxels: "29"^^xsd:int ;
@@ -735,9 +735,9 @@ niiri:2ecde1198137ba8c84d7f2b8ee573a34
     nidm_qValueFDR: "0.190729630640958"^^xsd:float ;
     nidm_clusterLabelId: "14"^^xsd:int .
 
-niiri:2ecde1198137ba8c84d7f2b8ee573a34 prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:4e10b0470621dd6f66d32e5f0d86796f prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:f195588e037cf5066c03b040bdd17c5c
+niiri:8d02357e68e2217c76b2789fc556a1e0
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0015" ;
     nidm_clusterSizeInVoxels: "38"^^xsd:int ;
@@ -747,9 +747,9 @@ niiri:f195588e037cf5066c03b040bdd17c5c
     nidm_qValueFDR: "0.130408510255373"^^xsd:float ;
     nidm_clusterLabelId: "15"^^xsd:int .
 
-niiri:f195588e037cf5066c03b040bdd17c5c prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:8d02357e68e2217c76b2789fc556a1e0 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:ae3238820d20eca8be6dc34ce2ca54dc
+niiri:4f5f4e9dc219044ae730379a51a53a84
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0016" ;
     nidm_clusterSizeInVoxels: "66"^^xsd:int ;
@@ -759,9 +759,9 @@ niiri:ae3238820d20eca8be6dc34ce2ca54dc
     nidm_qValueFDR: "0.0447442257801353"^^xsd:float ;
     nidm_clusterLabelId: "16"^^xsd:int .
 
-niiri:ae3238820d20eca8be6dc34ce2ca54dc prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:4f5f4e9dc219044ae730379a51a53a84 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:5a36931b22b3ff3ae34e9ab8b27bca1e
+niiri:770c988e0434c5ba8e4392759de30eea
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0017" ;
     nidm_clusterSizeInVoxels: "76"^^xsd:int ;
@@ -771,9 +771,9 @@ niiri:5a36931b22b3ff3ae34e9ab8b27bca1e
     nidm_qValueFDR: "0.022111501908576"^^xsd:float ;
     nidm_clusterLabelId: "17"^^xsd:int .
 
-niiri:5a36931b22b3ff3ae34e9ab8b27bca1e prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:770c988e0434c5ba8e4392759de30eea prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:6def1f951e1919c60434a8119f03801a
+niiri:ce1649f53d38c28c5b0d7cacaaf4f448
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0018" ;
     nidm_clusterSizeInVoxels: "26"^^xsd:int ;
@@ -783,9 +783,9 @@ niiri:6def1f951e1919c60434a8119f03801a
     nidm_qValueFDR: "0.205539497548942"^^xsd:float ;
     nidm_clusterLabelId: "18"^^xsd:int .
 
-niiri:6def1f951e1919c60434a8119f03801a prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:ce1649f53d38c28c5b0d7cacaaf4f448 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:f3a4e60499161232255b1ced0a699ecc
+niiri:11d8aaf31a0f50da63a5edcfdc834eac
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0019" ;
     nidm_clusterSizeInVoxels: "10"^^xsd:int ;
@@ -795,9 +795,9 @@ niiri:f3a4e60499161232255b1ced0a699ecc
     nidm_qValueFDR: "0.487222680733842"^^xsd:float ;
     nidm_clusterLabelId: "19"^^xsd:int .
 
-niiri:f3a4e60499161232255b1ced0a699ecc prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:11d8aaf31a0f50da63a5edcfdc834eac prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:7c9ccbac3cd845dfc0c233005757f05f
+niiri:18af84b83a63dcee2acfd1b9003ffe17
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0020" ;
     nidm_clusterSizeInVoxels: "28"^^xsd:int ;
@@ -807,9 +807,9 @@ niiri:7c9ccbac3cd845dfc0c233005757f05f
     nidm_qValueFDR: "0.194945641821685"^^xsd:float ;
     nidm_clusterLabelId: "20"^^xsd:int .
 
-niiri:7c9ccbac3cd845dfc0c233005757f05f prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:18af84b83a63dcee2acfd1b9003ffe17 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:e89936e52b02ce3aa8a79b72737894c6
+niiri:bc47992403400de624fca0326bfeca0a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0021" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -819,9 +819,9 @@ niiri:e89936e52b02ce3aa8a79b72737894c6
     nidm_qValueFDR: "0.554714461715718"^^xsd:float ;
     nidm_clusterLabelId: "21"^^xsd:int .
 
-niiri:e89936e52b02ce3aa8a79b72737894c6 prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:bc47992403400de624fca0326bfeca0a prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:18e987f3604a0d6c7d127a9be6b0fb68
+niiri:0c6b532ae8d28e2999918870be27c672
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0022" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -831,9 +831,9 @@ niiri:18e987f3604a0d6c7d127a9be6b0fb68
     nidm_qValueFDR: "0.554714461715718"^^xsd:float ;
     nidm_clusterLabelId: "22"^^xsd:int .
 
-niiri:18e987f3604a0d6c7d127a9be6b0fb68 prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:0c6b532ae8d28e2999918870be27c672 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:b19fa2f74715b8879a4263e734abff89
+niiri:58f0b66e88ddd39190a49cc289e1a6a9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0023" ;
     nidm_clusterSizeInVoxels: "46"^^xsd:int ;
@@ -843,9 +843,9 @@ niiri:b19fa2f74715b8879a4263e734abff89
     nidm_qValueFDR: "0.130408510255373"^^xsd:float ;
     nidm_clusterLabelId: "23"^^xsd:int .
 
-niiri:b19fa2f74715b8879a4263e734abff89 prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:58f0b66e88ddd39190a49cc289e1a6a9 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:0c6a4c5eab9814c8a104ac2ab9ba8e00
+niiri:6864ea0388f90fdf3d5a0840769fb194
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0024" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -855,9 +855,9 @@ niiri:0c6a4c5eab9814c8a104ac2ab9ba8e00
     nidm_qValueFDR: "0.604501360009182"^^xsd:float ;
     nidm_clusterLabelId: "24"^^xsd:int .
 
-niiri:0c6a4c5eab9814c8a104ac2ab9ba8e00 prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:6864ea0388f90fdf3d5a0840769fb194 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:2c0e11ce65487da45bf7a9358ee57871
+niiri:560b390e6daf7bdacebd6f81fc2498ed
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0025" ;
     nidm_clusterSizeInVoxels: "21"^^xsd:int ;
@@ -867,9 +867,9 @@ niiri:2c0e11ce65487da45bf7a9358ee57871
     nidm_qValueFDR: "0.255273713826051"^^xsd:float ;
     nidm_clusterLabelId: "25"^^xsd:int .
 
-niiri:2c0e11ce65487da45bf7a9358ee57871 prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:560b390e6daf7bdacebd6f81fc2498ed prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:0b550e722b76049b2f7ca0131da7d9c2
+niiri:b02b8c006088cba013305b13d972edc8
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0026" ;
     nidm_clusterSizeInVoxels: "30"^^xsd:int ;
@@ -879,9 +879,9 @@ niiri:0b550e722b76049b2f7ca0131da7d9c2
     nidm_qValueFDR: "0.190729630640958"^^xsd:float ;
     nidm_clusterLabelId: "26"^^xsd:int .
 
-niiri:0b550e722b76049b2f7ca0131da7d9c2 prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:b02b8c006088cba013305b13d972edc8 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:72450de63634a896c274e40a3163e02f
+niiri:a4e0cdaf05e785d8dd95f23ce74745d2
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0027" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -891,9 +891,9 @@ niiri:72450de63634a896c274e40a3163e02f
     nidm_qValueFDR: "0.628562362557851"^^xsd:float ;
     nidm_clusterLabelId: "27"^^xsd:int .
 
-niiri:72450de63634a896c274e40a3163e02f prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:a4e0cdaf05e785d8dd95f23ce74745d2 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:cd940e6e9b2162b03485c9d3045fe2cf
+niiri:a57f08ef6a63ebebf16d1533899bc25f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0028" ;
     nidm_clusterSizeInVoxels: "27"^^xsd:int ;
@@ -903,9 +903,9 @@ niiri:cd940e6e9b2162b03485c9d3045fe2cf
     nidm_qValueFDR: "0.199876794002946"^^xsd:float ;
     nidm_clusterLabelId: "28"^^xsd:int .
 
-niiri:cd940e6e9b2162b03485c9d3045fe2cf prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:a57f08ef6a63ebebf16d1533899bc25f prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:e32122a83b7d8bb16e3180c78f7eda7c
+niiri:61ed7bccd640009bb231b2a1982f0622
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0029" ;
     nidm_clusterSizeInVoxels: "9"^^xsd:int ;
@@ -915,9 +915,9 @@ niiri:e32122a83b7d8bb16e3180c78f7eda7c
     nidm_qValueFDR: "0.511832236924399"^^xsd:float ;
     nidm_clusterLabelId: "29"^^xsd:int .
 
-niiri:e32122a83b7d8bb16e3180c78f7eda7c prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:61ed7bccd640009bb231b2a1982f0622 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:6ae34632238cbeb521e67cef26caf7eb
+niiri:0095bc91a1253454e74d41690d9f6df3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0030" ;
     nidm_clusterSizeInVoxels: "59"^^xsd:int ;
@@ -927,9 +927,9 @@ niiri:6ae34632238cbeb521e67cef26caf7eb
     nidm_qValueFDR: "0.061094648971533"^^xsd:float ;
     nidm_clusterLabelId: "30"^^xsd:int .
 
-niiri:6ae34632238cbeb521e67cef26caf7eb prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:0095bc91a1253454e74d41690d9f6df3 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:5559b2a8337e94bc2084c45d5600922b
+niiri:fdd0f25c58dffbc950780afac712f03c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0031" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -939,9 +939,9 @@ niiri:5559b2a8337e94bc2084c45d5600922b
     nidm_qValueFDR: "0.604287280832693"^^xsd:float ;
     nidm_clusterLabelId: "31"^^xsd:int .
 
-niiri:5559b2a8337e94bc2084c45d5600922b prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:fdd0f25c58dffbc950780afac712f03c prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:853079021e568a419ad6b8ad88952642
+niiri:19300df9cc64fa2764a0780af7af6f84
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0032" ;
     nidm_clusterSizeInVoxels: "14"^^xsd:int ;
@@ -951,9 +951,9 @@ niiri:853079021e568a419ad6b8ad88952642
     nidm_qValueFDR: "0.374386664234061"^^xsd:float ;
     nidm_clusterLabelId: "32"^^xsd:int .
 
-niiri:853079021e568a419ad6b8ad88952642 prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:19300df9cc64fa2764a0780af7af6f84 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:0cf1dc899a75152a30a291b0a2560db3
+niiri:5ef4fb1358a9a6249f348a6eb79516e7
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0033" ;
     nidm_clusterSizeInVoxels: "9"^^xsd:int ;
@@ -963,9 +963,9 @@ niiri:0cf1dc899a75152a30a291b0a2560db3
     nidm_qValueFDR: "0.511832236924399"^^xsd:float ;
     nidm_clusterLabelId: "33"^^xsd:int .
 
-niiri:0cf1dc899a75152a30a291b0a2560db3 prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:5ef4fb1358a9a6249f348a6eb79516e7 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:678b8fa6b0f9293b49f20d1427d409e0
+niiri:520bd6c8ac4aa6408335f0e0c324688b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0034" ;
     nidm_clusterSizeInVoxels: "18"^^xsd:int ;
@@ -975,9 +975,9 @@ niiri:678b8fa6b0f9293b49f20d1427d409e0
     nidm_qValueFDR: "0.292253130241304"^^xsd:float ;
     nidm_clusterLabelId: "34"^^xsd:int .
 
-niiri:678b8fa6b0f9293b49f20d1427d409e0 prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:520bd6c8ac4aa6408335f0e0c324688b prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:45253dc06118b1b5a6a77ba54c4b1490
+niiri:f881e9cbe818d5f8b37dfed6dec527cc
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0035" ;
     nidm_clusterSizeInVoxels: "28"^^xsd:int ;
@@ -987,9 +987,9 @@ niiri:45253dc06118b1b5a6a77ba54c4b1490
     nidm_qValueFDR: "0.194945641821685"^^xsd:float ;
     nidm_clusterLabelId: "35"^^xsd:int .
 
-niiri:45253dc06118b1b5a6a77ba54c4b1490 prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:f881e9cbe818d5f8b37dfed6dec527cc prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:a5e4bc181e94cafee69b551c62f10925
+niiri:4aa4a0455dab2440720331d043f09ec2
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0036" ;
     nidm_clusterSizeInVoxels: "13"^^xsd:int ;
@@ -999,9 +999,9 @@ niiri:a5e4bc181e94cafee69b551c62f10925
     nidm_qValueFDR: "0.39785224811166"^^xsd:float ;
     nidm_clusterLabelId: "36"^^xsd:int .
 
-niiri:a5e4bc181e94cafee69b551c62f10925 prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:4aa4a0455dab2440720331d043f09ec2 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:ce3143388409a30de94c45862dcc1603
+niiri:69ca7568c07230cf3584aaca638281b0
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0037" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1011,9 +1011,9 @@ niiri:ce3143388409a30de94c45862dcc1603
     nidm_qValueFDR: "0.628562362557851"^^xsd:float ;
     nidm_clusterLabelId: "37"^^xsd:int .
 
-niiri:ce3143388409a30de94c45862dcc1603 prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:69ca7568c07230cf3584aaca638281b0 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:76c08ff817708a0abbb42fa1bb47a0cf
+niiri:350dbc35c571e3a5c09f2cdc4c910d34
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0038" ;
     nidm_clusterSizeInVoxels: "20"^^xsd:int ;
@@ -1023,9 +1023,9 @@ niiri:76c08ff817708a0abbb42fa1bb47a0cf
     nidm_qValueFDR: "0.278639392496977"^^xsd:float ;
     nidm_clusterLabelId: "38"^^xsd:int .
 
-niiri:76c08ff817708a0abbb42fa1bb47a0cf prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:350dbc35c571e3a5c09f2cdc4c910d34 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:47fed6da7f0600bc158182bd59714d25
+niiri:5d231bb78e3753cb8f1f83f432b012a4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0039" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -1035,9 +1035,9 @@ niiri:47fed6da7f0600bc158182bd59714d25
     nidm_qValueFDR: "0.604501360009182"^^xsd:float ;
     nidm_clusterLabelId: "39"^^xsd:int .
 
-niiri:47fed6da7f0600bc158182bd59714d25 prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:5d231bb78e3753cb8f1f83f432b012a4 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:3aaffeb437aa651f0d21d28a688e78dd
+niiri:d962ed566ab823dc017d65a55c96005b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0040" ;
     nidm_clusterSizeInVoxels: "29"^^xsd:int ;
@@ -1047,9 +1047,9 @@ niiri:3aaffeb437aa651f0d21d28a688e78dd
     nidm_qValueFDR: "0.190729630640958"^^xsd:float ;
     nidm_clusterLabelId: "40"^^xsd:int .
 
-niiri:3aaffeb437aa651f0d21d28a688e78dd prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:d962ed566ab823dc017d65a55c96005b prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:902f31a0f58308cc0d2941ed3096a18c
+niiri:5ca18f66be2a0317891dd14ae924d09a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0041" ;
     nidm_clusterSizeInVoxels: "24"^^xsd:int ;
@@ -1059,9 +1059,9 @@ niiri:902f31a0f58308cc0d2941ed3096a18c
     nidm_qValueFDR: "0.228311147705098"^^xsd:float ;
     nidm_clusterLabelId: "41"^^xsd:int .
 
-niiri:902f31a0f58308cc0d2941ed3096a18c prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:5ca18f66be2a0317891dd14ae924d09a prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:6fcbec37cf34db5ad09da73b06411a40
+niiri:bf714e8e855430179f84817bfe8aa9f4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0042" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -1071,9 +1071,9 @@ niiri:6fcbec37cf34db5ad09da73b06411a40
     nidm_qValueFDR: "0.554714461715718"^^xsd:float ;
     nidm_clusterLabelId: "42"^^xsd:int .
 
-niiri:6fcbec37cf34db5ad09da73b06411a40 prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:bf714e8e855430179f84817bfe8aa9f4 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:f7fec6797003228e9250ccd152a5c37f
+niiri:404e791392df064f45734040de92da30
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0043" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -1083,9 +1083,9 @@ niiri:f7fec6797003228e9250ccd152a5c37f
     nidm_qValueFDR: "0.554714461715718"^^xsd:float ;
     nidm_clusterLabelId: "43"^^xsd:int .
 
-niiri:f7fec6797003228e9250ccd152a5c37f prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:404e791392df064f45734040de92da30 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:35377dee19e22bb0a24fdb50eccf1b74
+niiri:def46784463991aed85ece366ca75ad8
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0044" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1095,9 +1095,9 @@ niiri:35377dee19e22bb0a24fdb50eccf1b74
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "44"^^xsd:int .
 
-niiri:35377dee19e22bb0a24fdb50eccf1b74 prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:def46784463991aed85ece366ca75ad8 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:662b849d101be496cda3a65d2f69da2b
+niiri:c2de51d4065404a70c8e75ad7f34a79f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0045" ;
     nidm_clusterSizeInVoxels: "21"^^xsd:int ;
@@ -1107,9 +1107,9 @@ niiri:662b849d101be496cda3a65d2f69da2b
     nidm_qValueFDR: "0.255273713826051"^^xsd:float ;
     nidm_clusterLabelId: "45"^^xsd:int .
 
-niiri:662b849d101be496cda3a65d2f69da2b prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:c2de51d4065404a70c8e75ad7f34a79f prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:bb8721fcbfb280a841be169cb5e433b5
+niiri:f11cdd5ae11ea581dcd3882d3540354b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0046" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -1119,9 +1119,9 @@ niiri:bb8721fcbfb280a841be169cb5e433b5
     nidm_qValueFDR: "0.604287280832693"^^xsd:float ;
     nidm_clusterLabelId: "46"^^xsd:int .
 
-niiri:bb8721fcbfb280a841be169cb5e433b5 prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:f11cdd5ae11ea581dcd3882d3540354b prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:8b2e8095aa6535f320b2113605db7dba
+niiri:37773f3cd9125252813f9101750c8618
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0047" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1131,9 +1131,9 @@ niiri:8b2e8095aa6535f320b2113605db7dba
     nidm_qValueFDR: "0.688489154710615"^^xsd:float ;
     nidm_clusterLabelId: "47"^^xsd:int .
 
-niiri:8b2e8095aa6535f320b2113605db7dba prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:37773f3cd9125252813f9101750c8618 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:e7305b9c4bb3949423d41a45d18d3fcf
+niiri:b9bf3dcf444022a80942813a2e7f252d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0048" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1143,9 +1143,9 @@ niiri:e7305b9c4bb3949423d41a45d18d3fcf
     nidm_qValueFDR: "0.628562362557851"^^xsd:float ;
     nidm_clusterLabelId: "48"^^xsd:int .
 
-niiri:e7305b9c4bb3949423d41a45d18d3fcf prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:b9bf3dcf444022a80942813a2e7f252d prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:fe1342908b2c590f0d205c54b090c224
+niiri:06de03bbb8e40178692ae6ec9dd3f5d5
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0049" ;
     nidm_clusterSizeInVoxels: "16"^^xsd:int ;
@@ -1155,9 +1155,9 @@ niiri:fe1342908b2c590f0d205c54b090c224
     nidm_qValueFDR: "0.324079280522016"^^xsd:float ;
     nidm_clusterLabelId: "49"^^xsd:int .
 
-niiri:fe1342908b2c590f0d205c54b090c224 prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:06de03bbb8e40178692ae6ec9dd3f5d5 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:ad067a0d2a64875916d47893c9bf91b0
+niiri:ae0af12ba47d22765200496a05e3cc2e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0050" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -1167,9 +1167,9 @@ niiri:ad067a0d2a64875916d47893c9bf91b0
     nidm_qValueFDR: "0.604501360009182"^^xsd:float ;
     nidm_clusterLabelId: "50"^^xsd:int .
 
-niiri:ad067a0d2a64875916d47893c9bf91b0 prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:ae0af12ba47d22765200496a05e3cc2e prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:4426798282ac8143b4291fc9731c0d21
+niiri:f5ac1b556f82f90ca54e1755f459aeb0
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0051" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1179,9 +1179,9 @@ niiri:4426798282ac8143b4291fc9731c0d21
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "51"^^xsd:int .
 
-niiri:4426798282ac8143b4291fc9731c0d21 prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:f5ac1b556f82f90ca54e1755f459aeb0 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:094ca018251a2b17ad5bbde342203d06
+niiri:e0f350ef000b2636edd606950fbacdd8
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0052" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1191,9 +1191,9 @@ niiri:094ca018251a2b17ad5bbde342203d06
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "52"^^xsd:int .
 
-niiri:094ca018251a2b17ad5bbde342203d06 prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:e0f350ef000b2636edd606950fbacdd8 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:e765876280bde3e4bebecc566c8bd29c
+niiri:208e0aa56bc32fd1c4efbe75ea40b1a0
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0053" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1203,9 +1203,9 @@ niiri:e765876280bde3e4bebecc566c8bd29c
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "53"^^xsd:int .
 
-niiri:e765876280bde3e4bebecc566c8bd29c prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:208e0aa56bc32fd1c4efbe75ea40b1a0 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:b6238a8e3e93a9273be55294f38a7061
+niiri:6270b7e521adb112773419d81745ba32
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0054" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1215,9 +1215,9 @@ niiri:b6238a8e3e93a9273be55294f38a7061
     nidm_qValueFDR: "0.688489154710615"^^xsd:float ;
     nidm_clusterLabelId: "54"^^xsd:int .
 
-niiri:b6238a8e3e93a9273be55294f38a7061 prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:6270b7e521adb112773419d81745ba32 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:cedb782dada08c65c4916daa0ad6e465
+niiri:6e8c7efcd65fd269ae1163d977b34228
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0055" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1227,9 +1227,9 @@ niiri:cedb782dada08c65c4916daa0ad6e465
     nidm_qValueFDR: "0.628562362557851"^^xsd:float ;
     nidm_clusterLabelId: "55"^^xsd:int .
 
-niiri:cedb782dada08c65c4916daa0ad6e465 prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:6e8c7efcd65fd269ae1163d977b34228 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:47f716a7866282e59c2437414f29fb67
+niiri:8bdb7c1cfc0e4c28f73b9ebb2067be4a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0056" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -1239,9 +1239,9 @@ niiri:47f716a7866282e59c2437414f29fb67
     nidm_qValueFDR: "0.554714461715718"^^xsd:float ;
     nidm_clusterLabelId: "56"^^xsd:int .
 
-niiri:47f716a7866282e59c2437414f29fb67 prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:8bdb7c1cfc0e4c28f73b9ebb2067be4a prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:e6b8fc7731810aa6f311348e0b1cc140
+niiri:bb0ea248bef4b3a56f8b7bd4674e079a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0057" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1251,9 +1251,9 @@ niiri:e6b8fc7731810aa6f311348e0b1cc140
     nidm_qValueFDR: "0.688489154710615"^^xsd:float ;
     nidm_clusterLabelId: "57"^^xsd:int .
 
-niiri:e6b8fc7731810aa6f311348e0b1cc140 prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:bb0ea248bef4b3a56f8b7bd4674e079a prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:9e7a68deeddb09104c97844d6208138a
+niiri:3ba5f3e50f85d1172dccf7cdc87e047a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0058" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1263,9 +1263,9 @@ niiri:9e7a68deeddb09104c97844d6208138a
     nidm_qValueFDR: "0.688489154710615"^^xsd:float ;
     nidm_clusterLabelId: "58"^^xsd:int .
 
-niiri:9e7a68deeddb09104c97844d6208138a prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:3ba5f3e50f85d1172dccf7cdc87e047a prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:9f7250b2986229e27c73d4ee533b5581
+niiri:221ffcb9e61912db0c8ea94c83c806f3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0059" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1275,9 +1275,9 @@ niiri:9f7250b2986229e27c73d4ee533b5581
     nidm_qValueFDR: "0.688489154710615"^^xsd:float ;
     nidm_clusterLabelId: "59"^^xsd:int .
 
-niiri:9f7250b2986229e27c73d4ee533b5581 prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:221ffcb9e61912db0c8ea94c83c806f3 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:f895b7fb895eba3b656944c4b6b3efb7
+niiri:680f2d4ea6ccf9065674d450817a8a71
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0060" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1287,9 +1287,9 @@ niiri:f895b7fb895eba3b656944c4b6b3efb7
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "60"^^xsd:int .
 
-niiri:f895b7fb895eba3b656944c4b6b3efb7 prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:680f2d4ea6ccf9065674d450817a8a71 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:1a924fb418bec3cd95c0a03c9ae66f54
+niiri:cf57b893da54bea9529d4c0bc8ff02f0
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0061" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -1299,9 +1299,9 @@ niiri:1a924fb418bec3cd95c0a03c9ae66f54
     nidm_qValueFDR: "0.604501360009182"^^xsd:float ;
     nidm_clusterLabelId: "61"^^xsd:int .
 
-niiri:1a924fb418bec3cd95c0a03c9ae66f54 prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:cf57b893da54bea9529d4c0bc8ff02f0 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:e8f2997ff1833098ebac8c27365f5882
+niiri:06f83c4cb0758a1db3af7b9ac9595bd1
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0062" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1311,9 +1311,9 @@ niiri:e8f2997ff1833098ebac8c27365f5882
     nidm_qValueFDR: "0.628562362557851"^^xsd:float ;
     nidm_clusterLabelId: "62"^^xsd:int .
 
-niiri:e8f2997ff1833098ebac8c27365f5882 prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:06f83c4cb0758a1db3af7b9ac9595bd1 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:af1ebc888c3ec8f9fad9e0c771ed7a78
+niiri:33c167d8677c415c916bc8b906fd4db4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0063" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1323,9 +1323,9 @@ niiri:af1ebc888c3ec8f9fad9e0c771ed7a78
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "63"^^xsd:int .
 
-niiri:af1ebc888c3ec8f9fad9e0c771ed7a78 prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:33c167d8677c415c916bc8b906fd4db4 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:93eff452c29120a5015af008a69e2b85
+niiri:6f398d8313ba8da3802bd6174fad64a9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0064" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1335,9 +1335,9 @@ niiri:93eff452c29120a5015af008a69e2b85
     nidm_qValueFDR: "0.628562362557851"^^xsd:float ;
     nidm_clusterLabelId: "64"^^xsd:int .
 
-niiri:93eff452c29120a5015af008a69e2b85 prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:6f398d8313ba8da3802bd6174fad64a9 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:eadc69190fdc6d634404fa8f12f510eb
+niiri:441c62b804db7724fe069a4683eabbb3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0065" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1347,9 +1347,9 @@ niiri:eadc69190fdc6d634404fa8f12f510eb
     nidm_qValueFDR: "0.628562362557851"^^xsd:float ;
     nidm_clusterLabelId: "65"^^xsd:int .
 
-niiri:eadc69190fdc6d634404fa8f12f510eb prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:441c62b804db7724fe069a4683eabbb3 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:fdf3341a871a270775355dceeb623541
+niiri:9573a33cf8de1d0d7462efcefe1aa3b3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0066" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1359,9 +1359,9 @@ niiri:fdf3341a871a270775355dceeb623541
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "66"^^xsd:int .
 
-niiri:fdf3341a871a270775355dceeb623541 prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:9573a33cf8de1d0d7462efcefe1aa3b3 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:d53a0a4ae6e04c2856dad6f7de113409
+niiri:adc671bb3b8aead7b73b777448e0d974
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0067" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -1371,9 +1371,9 @@ niiri:d53a0a4ae6e04c2856dad6f7de113409
     nidm_qValueFDR: "0.604501360009182"^^xsd:float ;
     nidm_clusterLabelId: "67"^^xsd:int .
 
-niiri:d53a0a4ae6e04c2856dad6f7de113409 prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:adc671bb3b8aead7b73b777448e0d974 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:cf7aba36a552e6ca5812f44e1297b2e9
+niiri:e9779649e0e322514fd2b0963b83e9b3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0068" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1383,9 +1383,9 @@ niiri:cf7aba36a552e6ca5812f44e1297b2e9
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "68"^^xsd:int .
 
-niiri:cf7aba36a552e6ca5812f44e1297b2e9 prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:e9779649e0e322514fd2b0963b83e9b3 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:43852b81a09cf6e877d19e5df6f9977b
+niiri:41fb45bc18bea4725f44ca167cd99df1
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0069" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1395,9 +1395,9 @@ niiri:43852b81a09cf6e877d19e5df6f9977b
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "69"^^xsd:int .
 
-niiri:43852b81a09cf6e877d19e5df6f9977b prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:41fb45bc18bea4725f44ca167cd99df1 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:a0bcd52b78a9ad004b1f13878095b584
+niiri:eea8668c9a2e77333db7bb9162d0d4ef
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0070" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1407,9 +1407,9 @@ niiri:a0bcd52b78a9ad004b1f13878095b584
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "70"^^xsd:int .
 
-niiri:a0bcd52b78a9ad004b1f13878095b584 prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:eea8668c9a2e77333db7bb9162d0d4ef prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:315508af939cde7c660dac4093bd5f63
+niiri:dd0835679f1bd959157bd71b4d4ada4a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0071" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1419,9 +1419,9 @@ niiri:315508af939cde7c660dac4093bd5f63
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "71"^^xsd:int .
 
-niiri:315508af939cde7c660dac4093bd5f63 prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:dd0835679f1bd959157bd71b4d4ada4a prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:415cf023223ce3eb6f3ea193de2e66d0
+niiri:7cdc9365fde87ad8333e6618dc3a8a51
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0072" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1431,9 +1431,9 @@ niiri:415cf023223ce3eb6f3ea193de2e66d0
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "72"^^xsd:int .
 
-niiri:415cf023223ce3eb6f3ea193de2e66d0 prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:7cdc9365fde87ad8333e6618dc3a8a51 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:688e11a39a0754d2ec0a74d65774433a
+niiri:7de4f98c4ea2239ac1a4b37fb8737ebb
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0073" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1443,9 +1443,9 @@ niiri:688e11a39a0754d2ec0a74d65774433a
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "73"^^xsd:int .
 
-niiri:688e11a39a0754d2ec0a74d65774433a prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:7de4f98c4ea2239ac1a4b37fb8737ebb prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:7a715e1614e6866276cb5725bccf59a3
+niiri:392bbfa2f02e1783423c67df389a3772
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0074" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1455,9 +1455,9 @@ niiri:7a715e1614e6866276cb5725bccf59a3
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "74"^^xsd:int .
 
-niiri:7a715e1614e6866276cb5725bccf59a3 prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:392bbfa2f02e1783423c67df389a3772 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:fcab5dc9b5ee7cb3164b6fcfb041800b
+niiri:e08ea74eba6d829dc8f77ccdfebbc2e1
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0075" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1467,9 +1467,9 @@ niiri:fcab5dc9b5ee7cb3164b6fcfb041800b
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "75"^^xsd:int .
 
-niiri:fcab5dc9b5ee7cb3164b6fcfb041800b prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:e08ea74eba6d829dc8f77ccdfebbc2e1 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:62711d2ee0c0429ed4fbe29698cac6fd
+niiri:81ce1dbb2b4b3915a17f1002f7600876
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0076" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1479,9 +1479,9 @@ niiri:62711d2ee0c0429ed4fbe29698cac6fd
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "76"^^xsd:int .
 
-niiri:62711d2ee0c0429ed4fbe29698cac6fd prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:81ce1dbb2b4b3915a17f1002f7600876 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:485ed7c2aeeaf61df445bf323937617d
+niiri:8ab01cc9ec9b9c9144318b6ebf4b61e5
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0077" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1491,9 +1491,9 @@ niiri:485ed7c2aeeaf61df445bf323937617d
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "77"^^xsd:int .
 
-niiri:485ed7c2aeeaf61df445bf323937617d prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:8ab01cc9ec9b9c9144318b6ebf4b61e5 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:78ffd46fab5c7ea256ba49f6155cee5b
+niiri:e00f285b0f3ca710fd516c8d96d4953b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0078" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1503,9 +1503,9 @@ niiri:78ffd46fab5c7ea256ba49f6155cee5b
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "78"^^xsd:int .
 
-niiri:78ffd46fab5c7ea256ba49f6155cee5b prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:e00f285b0f3ca710fd516c8d96d4953b prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:1273746a68b63344576d89035c4af958
+niiri:b113d084583b1c858c15b076e563ba0c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0079" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1515,9 +1515,9 @@ niiri:1273746a68b63344576d89035c4af958
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "79"^^xsd:int .
 
-niiri:1273746a68b63344576d89035c4af958 prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:b113d084583b1c858c15b076e563ba0c prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:00d8da85844fdb0d453c7cffeb50aef0
+niiri:f9a8bd72695ec56fe97eefd5b04d42d4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0080" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1527,1705 +1527,1705 @@ niiri:00d8da85844fdb0d453c7cffeb50aef0
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "80"^^xsd:int .
 
-niiri:00d8da85844fdb0d453c7cffeb50aef0 prov:wasDerivedFrom niiri:319501d11f59d427be0a95daa1d6c9ec .
+niiri:f9a8bd72695ec56fe97eefd5b04d42d4 prov:wasDerivedFrom niiri:275a137c82db0d48c36216f7ba80d8d2 .
 
-niiri:d8f1062e1e54f9e2a3ff314951c0aa05
+niiri:3a4ff3f083b479126599de2b93ee4494
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0001" ;
-    prov:atLocation niiri:21ef7f7e02f40a4754f61c619ed70ed8 ;
+    prov:atLocation niiri:e8cb4af6e2287b93daaa35d9368e138f ;
     prov:value "7.92007970809937"^^xsd:float ;
     nidm_equivalentZStatistic: "6.94608360738412"^^xsd:float ;
     nidm_pValueUncorrected: "1.87783122385099e-12"^^xsd:float ;
     nidm_pValueFWER: "4.18813870695089e-07"^^xsd:float ;
     nidm_qValueFDR: "5.21674435923017e-06"^^xsd:float .
 
-niiri:21ef7f7e02f40a4754f61c619ed70ed8
+niiri:e8cb4af6e2287b93daaa35d9368e138f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0001" ;
     nidm_coordinateVector: "[46,16,24]"^^xsd:string .
 
-niiri:d8f1062e1e54f9e2a3ff314951c0aa05 prov:wasDerivedFrom niiri:15be626f283e4842ffd8314f2d3e1b16 .
+niiri:3a4ff3f083b479126599de2b93ee4494 prov:wasDerivedFrom niiri:fefba803c839cbd72009efffd0596397 .
 
-niiri:930d018c1c6671eae04e6470cf7e4d41
+niiri:c1930c3f0150f6f5873ea6a691551e74
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0002" ;
-    prov:atLocation niiri:de0aede430b18974ce871c3365148733 ;
+    prov:atLocation niiri:ddb568a298d8393fcda5254093cef5a1 ;
     prov:value "6.31603479385376"^^xsd:float ;
     nidm_equivalentZStatistic: "5.77079466112137"^^xsd:float ;
     nidm_pValueUncorrected: "3.94492849498107e-09"^^xsd:float ;
     nidm_pValueFWER: "0.000879943865776389"^^xsd:float ;
     nidm_qValueFDR: "0.000830722551601523"^^xsd:float .
 
-niiri:de0aede430b18974ce871c3365148733
+niiri:ddb568a298d8393fcda5254093cef5a1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0002" ;
     nidm_coordinateVector: "[32,24,-4]"^^xsd:string .
 
-niiri:930d018c1c6671eae04e6470cf7e4d41 prov:wasDerivedFrom niiri:15be626f283e4842ffd8314f2d3e1b16 .
+niiri:c1930c3f0150f6f5873ea6a691551e74 prov:wasDerivedFrom niiri:fefba803c839cbd72009efffd0596397 .
 
-niiri:806250470178babe07a529853a8145be
+niiri:517d6fcfeee2d840a2f52301d1beebd1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0003" ;
-    prov:atLocation niiri:adf7353342f6c4026bc080a9604a61e2 ;
+    prov:atLocation niiri:bf75fde12cfced38bab64da3a1c7e7bd ;
     prov:value "5.68819808959961"^^xsd:float ;
     nidm_equivalentZStatistic: "5.27450168515333"^^xsd:float ;
     nidm_pValueUncorrected: "6.655864770444e-08"^^xsd:float ;
     nidm_pValueFWER: "0.0121028975026269"^^xsd:float ;
     nidm_qValueFDR: "0.00350091530962783"^^xsd:float .
 
-niiri:adf7353342f6c4026bc080a9604a61e2
+niiri:bf75fde12cfced38bab64da3a1c7e7bd
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0003" ;
     nidm_coordinateVector: "[18,16,4]"^^xsd:string .
 
-niiri:806250470178babe07a529853a8145be prov:wasDerivedFrom niiri:15be626f283e4842ffd8314f2d3e1b16 .
+niiri:517d6fcfeee2d840a2f52301d1beebd1 prov:wasDerivedFrom niiri:fefba803c839cbd72009efffd0596397 .
 
-niiri:705892c44a96334c05f8892302b0be49
+niiri:be45fc5c8318611dbeb6926eff14603d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0004" ;
-    prov:atLocation niiri:3d18591e9e24b856fbbeab504e6b2536 ;
+    prov:atLocation niiri:0bb09b273612bdec706a34e18f9bcded ;
     prov:value "7.11683940887451"^^xsd:float ;
     nidm_equivalentZStatistic: "6.37404871703245"^^xsd:float ;
     nidm_pValueUncorrected: "9.20510334623259e-11"^^xsd:float ;
     nidm_pValueFWER: "2.05325778424026e-05"^^xsd:float ;
     nidm_qValueFDR: "9.33757664730496e-05"^^xsd:float .
 
-niiri:3d18591e9e24b856fbbeab504e6b2536
+niiri:0bb09b273612bdec706a34e18f9bcded
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0004" ;
     nidm_coordinateVector: "[34,-88,-2]"^^xsd:string .
 
-niiri:705892c44a96334c05f8892302b0be49 prov:wasDerivedFrom niiri:0db4cde09719c963f970eb48ae2552e8 .
+niiri:be45fc5c8318611dbeb6926eff14603d prov:wasDerivedFrom niiri:92d29aeefcd3cfea4144809ceee1698b .
 
-niiri:554afe506d3af35cae9f1989577ad77d
+niiri:f732c2c67e196714c26505f667b9c2d1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0005" ;
-    prov:atLocation niiri:11740dc9cebfcb0636315b88af1574cc ;
+    prov:atLocation niiri:0f15cb6ae5a62f7643842075286cf4fe ;
     prov:value "6.48292255401611"^^xsd:float ;
     nidm_equivalentZStatistic: "5.8992593141605"^^xsd:float ;
     nidm_pValueUncorrected: "1.82568493656277e-09"^^xsd:float ;
     nidm_pValueFWER: "0.000407231755366277"^^xsd:float ;
     nidm_qValueFDR: "0.000830722551601523"^^xsd:float .
 
-niiri:11740dc9cebfcb0636315b88af1574cc
+niiri:0f15cb6ae5a62f7643842075286cf4fe
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0005" ;
     nidm_coordinateVector: "[42,-72,-10]"^^xsd:string .
 
-niiri:554afe506d3af35cae9f1989577ad77d prov:wasDerivedFrom niiri:0db4cde09719c963f970eb48ae2552e8 .
+niiri:f732c2c67e196714c26505f667b9c2d1 prov:wasDerivedFrom niiri:92d29aeefcd3cfea4144809ceee1698b .
 
-niiri:758c32c1a97be19a51909978cb78c3f9
+niiri:cd40c3fa5c01d430365872162ed32735
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0006" ;
-    prov:atLocation niiri:8183fb9497de339be77600251139961b ;
+    prov:atLocation niiri:dcffc4466433c7a4343c26a918e412f8 ;
     prov:value "5.2275915145874"^^xsd:float ;
     nidm_equivalentZStatistic: "4.89738468004472"^^xsd:float ;
     nidm_pValueUncorrected: "4.85602978606003e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0670610253017228"^^xsd:float ;
     nidm_qValueFDR: "0.0118363293065346"^^xsd:float .
 
-niiri:8183fb9497de339be77600251139961b
+niiri:dcffc4466433c7a4343c26a918e412f8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0006" ;
     nidm_coordinateVector: "[34,-86,12]"^^xsd:string .
 
-niiri:758c32c1a97be19a51909978cb78c3f9 prov:wasDerivedFrom niiri:0db4cde09719c963f970eb48ae2552e8 .
+niiri:cd40c3fa5c01d430365872162ed32735 prov:wasDerivedFrom niiri:92d29aeefcd3cfea4144809ceee1698b .
 
-niiri:581ec0522b560e452912b9eef2f0e8c5
+niiri:2850c3df9bf571ce4f3306beddf5444f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0007" ;
-    prov:atLocation niiri:0a196bd3badb45f310dde176acb28cfc ;
+    prov:atLocation niiri:bfd22ab330963feb1e9bfb0094e06fad ;
     prov:value "6.28007745742798"^^xsd:float ;
     nidm_equivalentZStatistic: "5.74292583422276"^^xsd:float ;
     nidm_pValueUncorrected: "4.65272453897825e-09"^^xsd:float ;
     nidm_pValueFWER: "0.00103782272796227"^^xsd:float ;
     nidm_qValueFDR: "0.000830722551601523"^^xsd:float .
 
-niiri:0a196bd3badb45f310dde176acb28cfc
+niiri:bfd22ab330963feb1e9bfb0094e06fad
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0007" ;
     nidm_coordinateVector: "[8,18,50]"^^xsd:string .
 
-niiri:581ec0522b560e452912b9eef2f0e8c5 prov:wasDerivedFrom niiri:6ea1bac2d55c2ba420c4f23fed407a68 .
+niiri:2850c3df9bf571ce4f3306beddf5444f prov:wasDerivedFrom niiri:ce42f33dd5918ee27ba8f8f6ccae137b .
 
-niiri:3d55b69824ac802a33ea866ca06d5e47
+niiri:f822a28c39d3ea42481d34bbc8df22dd
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0008" ;
-    prov:atLocation niiri:7bdcf38ff7a4e78ab0ef3784b67e4ff0 ;
+    prov:atLocation niiri:e2981bd8238c191c38e7681182953e91 ;
     prov:value "6.15222215652466"^^xsd:float ;
     nidm_equivalentZStatistic: "5.64328512810061"^^xsd:float ;
     nidm_pValueUncorrected: "8.34178537356678e-09"^^xsd:float ;
     nidm_pValueFWER: "0.00186069357054308"^^xsd:float ;
     nidm_qValueFDR: "0.000972721201433817"^^xsd:float .
 
-niiri:7bdcf38ff7a4e78ab0ef3784b67e4ff0
+niiri:e2981bd8238c191c38e7681182953e91
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0008" ;
     nidm_coordinateVector: "[-6,12,52]"^^xsd:string .
 
-niiri:3d55b69824ac802a33ea866ca06d5e47 prov:wasDerivedFrom niiri:6ea1bac2d55c2ba420c4f23fed407a68 .
+niiri:f822a28c39d3ea42481d34bbc8df22dd prov:wasDerivedFrom niiri:ce42f33dd5918ee27ba8f8f6ccae137b .
 
-niiri:d8d831684924ab6a424864bf6a56224a
+niiri:0601bd281b645fc4e7cea6590daaea37
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0009" ;
-    prov:atLocation niiri:d3db44b97cabf3a4a72fbe343656ca60 ;
+    prov:atLocation niiri:4223785a2c52847776be8e182b12c3a7 ;
     prov:value "5.98517084121704"^^xsd:float ;
     nidm_equivalentZStatistic: "5.51181334779297"^^xsd:float ;
     nidm_pValueUncorrected: "1.77577724747024e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00376326218366319"^^xsd:float ;
     nidm_qValueFDR: "0.00136419627856355"^^xsd:float .
 
-niiri:d3db44b97cabf3a4a72fbe343656ca60
+niiri:4223785a2c52847776be8e182b12c3a7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0009" ;
     nidm_coordinateVector: "[8,32,38]"^^xsd:string .
 
-niiri:d8d831684924ab6a424864bf6a56224a prov:wasDerivedFrom niiri:6ea1bac2d55c2ba420c4f23fed407a68 .
+niiri:0601bd281b645fc4e7cea6590daaea37 prov:wasDerivedFrom niiri:ce42f33dd5918ee27ba8f8f6ccae137b .
 
-niiri:8bd4848ac7623298803f1a34787fa966
+niiri:eeb7eca4dd37f5ca956393c13b86f395
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0010" ;
-    prov:atLocation niiri:8de5a5730461bca9655e8bc03421f590 ;
+    prov:atLocation niiri:9350f7883a57d93d1d3bf27b2227a68d ;
     prov:value "6.25127363204956"^^xsd:float ;
     nidm_equivalentZStatistic: "5.72055271981637"^^xsd:float ;
     nidm_pValueUncorrected: "5.30890376104765e-09"^^xsd:float ;
     nidm_pValueFWER: "0.0011841880966994"^^xsd:float ;
     nidm_qValueFDR: "0.000830722551601523"^^xsd:float .
 
-niiri:8de5a5730461bca9655e8bc03421f590
+niiri:9350f7883a57d93d1d3bf27b2227a68d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0010" ;
     nidm_coordinateVector: "[52,-32,42]"^^xsd:string .
 
-niiri:8bd4848ac7623298803f1a34787fa966 prov:wasDerivedFrom niiri:a09617bcbda951297c2f5a30eb214dc8 .
+niiri:eeb7eca4dd37f5ca956393c13b86f395 prov:wasDerivedFrom niiri:4ceeccbd429ca3c7d49d9b7ebbcbd0c0 .
 
-niiri:8a46b0279756f6415a018c7711b1a4cb
+niiri:4fad84948d108d419b34432aba0aaf97
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0011" ;
-    prov:atLocation niiri:11298449eeae494e6b78c62c62147081 ;
+    prov:atLocation niiri:9443d25369cbea84515f23e7d0f92386 ;
     prov:value "6.24752378463745"^^xsd:float ;
     nidm_equivalentZStatistic: "5.71763687476157"^^xsd:float ;
     nidm_pValueUncorrected: "5.40078304300806e-09"^^xsd:float ;
     nidm_pValueFWER: "0.00120468241369565"^^xsd:float ;
     nidm_qValueFDR: "0.000830722551601523"^^xsd:float .
 
-niiri:11298449eeae494e6b78c62c62147081
+niiri:9443d25369cbea84515f23e7d0f92386
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0011" ;
     nidm_coordinateVector: "[40,-62,50]"^^xsd:string .
 
-niiri:8a46b0279756f6415a018c7711b1a4cb prov:wasDerivedFrom niiri:5093925a984c3130f741f5e59fc218b0 .
+niiri:4fad84948d108d419b34432aba0aaf97 prov:wasDerivedFrom niiri:caaf1d53a3cdfedef4ec795140a8062d .
 
-niiri:508e522a3771bd47c48a85e2503ec95e
+niiri:25794aacdb036e5295f9624245fbac2d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0012" ;
-    prov:atLocation niiri:bc7a498f8663f0f24d67c6c80c21bf98 ;
+    prov:atLocation niiri:e07f914385d7440f95f63702677992f0 ;
     prov:value "5.70337772369385"^^xsd:float ;
     nidm_equivalentZStatistic: "5.28674301747281"^^xsd:float ;
     nidm_pValueUncorrected: "6.22566831420812e-08"^^xsd:float ;
     nidm_pValueFWER: "0.011413186758684"^^xsd:float ;
     nidm_qValueFDR: "0.00350091530962783"^^xsd:float .
 
-niiri:bc7a498f8663f0f24d67c6c80c21bf98
+niiri:e07f914385d7440f95f63702677992f0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0012" ;
     nidm_coordinateVector: "[56,-44,52]"^^xsd:string .
 
-niiri:508e522a3771bd47c48a85e2503ec95e prov:wasDerivedFrom niiri:5093925a984c3130f741f5e59fc218b0 .
+niiri:25794aacdb036e5295f9624245fbac2d prov:wasDerivedFrom niiri:caaf1d53a3cdfedef4ec795140a8062d .
 
-niiri:843fee814dd98b6545f8be55d8dac863
+niiri:cb9ecebff84e7c0bcff30f16d62e415c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0013" ;
-    prov:atLocation niiri:8156244ae431d17d5e84fbc488d4ee87 ;
+    prov:atLocation niiri:d53d6dc777cb961845f7af09a33453e0 ;
     prov:value "5.69516134262085"^^xsd:float ;
     nidm_equivalentZStatistic: "5.28011855642631"^^xsd:float ;
     nidm_pValueUncorrected: "6.45501619933597e-08"^^xsd:float ;
     nidm_pValueFWER: "0.0117816592148946"^^xsd:float ;
     nidm_qValueFDR: "0.00350091530962783"^^xsd:float .
 
-niiri:8156244ae431d17d5e84fbc488d4ee87
+niiri:d53d6dc777cb961845f7af09a33453e0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0013" ;
     nidm_coordinateVector: "[60,-36,54]"^^xsd:string .
 
-niiri:843fee814dd98b6545f8be55d8dac863 prov:wasDerivedFrom niiri:5093925a984c3130f741f5e59fc218b0 .
+niiri:cb9ecebff84e7c0bcff30f16d62e415c prov:wasDerivedFrom niiri:caaf1d53a3cdfedef4ec795140a8062d .
 
-niiri:afb566c89e494d1668c1dfe84e585fce
+niiri:0108e1dedeb535eeacb8a83cdebc4299
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0014" ;
-    prov:atLocation niiri:b9e748b9c817f1ca063fc3c73b314ad0 ;
+    prov:atLocation niiri:0c45c162c51c7e916c4ae63fd56c3aed ;
     prov:value "6.10109901428223"^^xsd:float ;
     nidm_equivalentZStatistic: "5.60320502193174"^^xsd:float ;
     nidm_pValueUncorrected: "1.05212039080982e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00234682813060005"^^xsd:float ;
     nidm_qValueFDR: "0.00104518293275697"^^xsd:float .
 
-niiri:b9e748b9c817f1ca063fc3c73b314ad0
+niiri:0c45c162c51c7e916c4ae63fd56c3aed
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0014" ;
     nidm_coordinateVector: "[32,2,46]"^^xsd:string .
 
-niiri:afb566c89e494d1668c1dfe84e585fce prov:wasDerivedFrom niiri:e14a70de96226faafe4fda4afc1b78d5 .
+niiri:0108e1dedeb535eeacb8a83cdebc4299 prov:wasDerivedFrom niiri:4e4124102f807b660cd900fcbb6a1dad .
 
-niiri:4299a4375397892dfe75cb1a0aa4ecbc
+niiri:a83bcc10e77d0eaa4587d34a0f971292
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0015" ;
-    prov:atLocation niiri:601f78fa9f596cbdc2e60f0f3e73f5fc ;
+    prov:atLocation niiri:bd5f175b844254cd01005a778cafe8ff ;
     prov:value "4.6086859703064"^^xsd:float ;
     nidm_equivalentZStatistic: "4.3736141683061"^^xsd:float ;
     nidm_pValueUncorrected: "6.11031435759912e-06"^^xsd:float ;
     nidm_pValueFWER: "0.453877178455514"^^xsd:float ;
     nidm_qValueFDR: "0.0599714495109201"^^xsd:float .
 
-niiri:601f78fa9f596cbdc2e60f0f3e73f5fc
+niiri:bd5f175b844254cd01005a778cafe8ff
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0015" ;
     nidm_coordinateVector: "[28,4,58]"^^xsd:string .
 
-niiri:4299a4375397892dfe75cb1a0aa4ecbc prov:wasDerivedFrom niiri:e14a70de96226faafe4fda4afc1b78d5 .
+niiri:a83bcc10e77d0eaa4587d34a0f971292 prov:wasDerivedFrom niiri:4e4124102f807b660cd900fcbb6a1dad .
 
-niiri:10eae3e429ecacc5b6e190b25d61ce0b
+niiri:c560dc9de917957ed93bc5ed23e74ca3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0016" ;
-    prov:atLocation niiri:a56f038f8a44eaf3c54322b07b8fb041 ;
+    prov:atLocation niiri:3e99bb8f1bc3edfb1797aa2727ed8adf ;
     prov:value "5.98348569869995"^^xsd:float ;
     nidm_equivalentZStatistic: "5.51047970249337"^^xsd:float ;
     nidm_pValueUncorrected: "1.78928538652201e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00378871596531738"^^xsd:float ;
     nidm_qValueFDR: "0.00136419627856355"^^xsd:float .
 
-niiri:a56f038f8a44eaf3c54322b07b8fb041
+niiri:3e99bb8f1bc3edfb1797aa2727ed8adf
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0016" ;
     nidm_coordinateVector: "[-52,0,38]"^^xsd:string .
 
-niiri:10eae3e429ecacc5b6e190b25d61ce0b prov:wasDerivedFrom niiri:349c921f1331e272395f14c01123038e .
+niiri:c560dc9de917957ed93bc5ed23e74ca3 prov:wasDerivedFrom niiri:8a537453623b3e259868fdc3d34a15c0 .
 
-niiri:569db1fa1f02eabd48742d0c089d7d3b
+niiri:afb5bbe52a67b2392f36dae9544d164a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0017" ;
-    prov:atLocation niiri:74f433f97c7a4b2cc5d1e161dfee67a7 ;
+    prov:atLocation niiri:e0bb2d0e4116aafc8738a07ec9fc9a59 ;
     prov:value "4.98950004577637"^^xsd:float ;
     nidm_equivalentZStatistic: "4.69817956585148"^^xsd:float ;
     nidm_pValueUncorrected: "1.31245304380023e-06"^^xsd:float ;
     nidm_pValueFWER: "0.151048137890434"^^xsd:float ;
     nidm_qValueFDR: "0.0233609510296683"^^xsd:float .
 
-niiri:74f433f97c7a4b2cc5d1e161dfee67a7
+niiri:e0bb2d0e4116aafc8738a07ec9fc9a59
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0017" ;
     nidm_coordinateVector: "[-44,6,28]"^^xsd:string .
 
-niiri:569db1fa1f02eabd48742d0c089d7d3b prov:wasDerivedFrom niiri:349c921f1331e272395f14c01123038e .
+niiri:afb5bbe52a67b2392f36dae9544d164a prov:wasDerivedFrom niiri:8a537453623b3e259868fdc3d34a15c0 .
 
-niiri:ebf667f0ca27e498723bf1deab582795
+niiri:2f7f394faa4711ed3169c6970ab86c8c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0018" ;
-    prov:atLocation niiri:61f5748b29becc6179e42040a27ded00 ;
+    prov:atLocation niiri:9fe79a527627db4bf120eb97627c5ba7 ;
     prov:value "3.52650570869446"^^xsd:float ;
     nidm_equivalentZStatistic: "3.41313019486981"^^xsd:float ;
     nidm_pValueUncorrected: "0.000321106265798399"^^xsd:float ;
     nidm_pValueFWER: "0.999999548134574"^^xsd:float ;
     nidm_qValueFDR: "0.545515072619331"^^xsd:float .
 
-niiri:61f5748b29becc6179e42040a27ded00
+niiri:9fe79a527627db4bf120eb97627c5ba7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0018" ;
     nidm_coordinateVector: "[-56,-6,42]"^^xsd:string .
 
-niiri:ebf667f0ca27e498723bf1deab582795 prov:wasDerivedFrom niiri:349c921f1331e272395f14c01123038e .
+niiri:2f7f394faa4711ed3169c6970ab86c8c prov:wasDerivedFrom niiri:8a537453623b3e259868fdc3d34a15c0 .
 
-niiri:69488ca9d2d42b6d92bd2b949ed627b5
+niiri:60597e96058be6ccc3c820043eb1f0ad
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0019" ;
-    prov:atLocation niiri:626a918ba98dd4e53dad9e1b4c7be71a ;
+    prov:atLocation niiri:9ad31699bbc5f159347fe96fef53bddf ;
     prov:value "5.78093099594116"^^xsd:float ;
     nidm_equivalentZStatistic: "5.34909755317379"^^xsd:float ;
     nidm_pValueUncorrected: "4.41969442155354e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00844151822925698"^^xsd:float ;
     nidm_qValueFDR: "0.00286742427823329"^^xsd:float .
 
-niiri:626a918ba98dd4e53dad9e1b4c7be71a
+niiri:9ad31699bbc5f159347fe96fef53bddf
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0019" ;
     nidm_coordinateVector: "[-34,-2,52]"^^xsd:string .
 
-niiri:69488ca9d2d42b6d92bd2b949ed627b5 prov:wasDerivedFrom niiri:9204e7e7da9650b9d4bc408770a00fdb .
+niiri:60597e96058be6ccc3c820043eb1f0ad prov:wasDerivedFrom niiri:ceaad5cdc25363799f97feba2f347a03 .
 
-niiri:d667ad297d53f529690e2abfb3ac71fc
+niiri:787ff7b095f58a2e09fb3664f762f1c8
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0020" ;
-    prov:atLocation niiri:4f350d59c1f0c58b8f28decf6b73c93b ;
+    prov:atLocation niiri:2f6cbfedd61275c7b99e20bc3e0b4018 ;
     prov:value "5.40964078903198"^^xsd:float ;
     nidm_equivalentZStatistic: "5.04774404642803"^^xsd:float ;
     nidm_pValueUncorrected: "2.23528758724889e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0346958937061391"^^xsd:float ;
     nidm_qValueFDR: "0.00846044059259994"^^xsd:float .
 
-niiri:4f350d59c1f0c58b8f28decf6b73c93b
+niiri:2f6cbfedd61275c7b99e20bc3e0b4018
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0020" ;
     nidm_coordinateVector: "[-54,-46,58]"^^xsd:string .
 
-niiri:d667ad297d53f529690e2abfb3ac71fc prov:wasDerivedFrom niiri:e09b8959852a4e5d12cc0ed7036f61f0 .
+niiri:787ff7b095f58a2e09fb3664f762f1c8 prov:wasDerivedFrom niiri:00cf15c153fb34e5bdc7c627fc153666 .
 
-niiri:fda9b55fc5901fb946545dcd6078b371
+niiri:f4ca1c6a92843304c08668c4cebb90a9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0021" ;
-    prov:atLocation niiri:7b45208ba6aa97addcd922b6cbf3b436 ;
+    prov:atLocation niiri:7701a76f43b9fef7a78168a4da944cb1 ;
     prov:value "5.40141773223877"^^xsd:float ;
     nidm_equivalentZStatistic: "5.04098917180003"^^xsd:float ;
     nidm_pValueUncorrected: "2.31565837394143e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0357643345560115"^^xsd:float ;
     nidm_qValueFDR: "0.0106752417476244"^^xsd:float .
 
-niiri:7b45208ba6aa97addcd922b6cbf3b436
+niiri:7701a76f43b9fef7a78168a4da944cb1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0021" ;
     nidm_coordinateVector: "[-28,-94,2]"^^xsd:string .
 
-niiri:fda9b55fc5901fb946545dcd6078b371 prov:wasDerivedFrom niiri:6f02516841dde7aca88f672df0319963 .
+niiri:f4ca1c6a92843304c08668c4cebb90a9 prov:wasDerivedFrom niiri:9fa05d9e51da6e1bf65e29c91292c1f9 .
 
-niiri:383ba7c1e9d76ef9d7ee73c5ae07841e
+niiri:05f82a99448b178e8b7d8ecb6d85d07b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0022" ;
-    prov:atLocation niiri:137d0f5723227aefac91f2b5a34cff28 ;
+    prov:atLocation niiri:a8fb5389016788e2b146dc701cbdc00c ;
     prov:value "5.31841945648193"^^xsd:float ;
     nidm_equivalentZStatistic: "4.97261482231588"^^xsd:float ;
     nidm_pValueUncorrected: "3.30279114724163e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0484353441449864"^^xsd:float ;
     nidm_qValueFDR: "0.0106752417476244"^^xsd:float .
 
-niiri:137d0f5723227aefac91f2b5a34cff28
+niiri:a8fb5389016788e2b146dc701cbdc00c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0022" ;
     nidm_coordinateVector: "[-62,-38,48]"^^xsd:string .
 
-niiri:383ba7c1e9d76ef9d7ee73c5ae07841e prov:wasDerivedFrom niiri:ff5aee3969c7de59773c94fa04a5a85f .
+niiri:05f82a99448b178e8b7d8ecb6d85d07b prov:wasDerivedFrom niiri:fdf70ff4bf081216be7e467153d2d4d8 .
 
-niiri:ef6681fb7fd348dfcb9472814c0af2e0
+niiri:be00ee78cfab94c36be515c9ca78cb48
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0023" ;
-    prov:atLocation niiri:44e0c656c84cdde51692e18f3512f600 ;
+    prov:atLocation niiri:8da199a5d41709f457ea9104658c0771 ;
     prov:value "4.57099342346191"^^xsd:float ;
     nidm_equivalentZStatistic: "4.34109644800954"^^xsd:float ;
     nidm_pValueUncorrected: "7.08867353027554e-06"^^xsd:float ;
     nidm_pValueFWER: "0.496004086968197"^^xsd:float ;
     nidm_qValueFDR: "0.0635474729952592"^^xsd:float .
 
-niiri:44e0c656c84cdde51692e18f3512f600
+niiri:8da199a5d41709f457ea9104658c0771
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0023" ;
     nidm_coordinateVector: "[-60,-50,48]"^^xsd:string .
 
-niiri:ef6681fb7fd348dfcb9472814c0af2e0 prov:wasDerivedFrom niiri:ff5aee3969c7de59773c94fa04a5a85f .
+niiri:be00ee78cfab94c36be515c9ca78cb48 prov:wasDerivedFrom niiri:fdf70ff4bf081216be7e467153d2d4d8 .
 
-niiri:ce11a63e7102de829a73aea266cc4b64
+niiri:af6e82fac7bbf3d7f1621abbe68ecb05
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0024" ;
-    prov:atLocation niiri:6bd09e245b6f90538ba36c324cac83ab ;
+    prov:atLocation niiri:10b939b5d1d5994f17ba7c7ff8d864c8 ;
     prov:value "5.30699443817139"^^xsd:float ;
     nidm_equivalentZStatistic: "4.96317509467693"^^xsd:float ;
     nidm_pValueUncorrected: "3.46750043123123e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0504786376455083"^^xsd:float ;
     nidm_qValueFDR: "0.0106752417476244"^^xsd:float .
 
-niiri:6bd09e245b6f90538ba36c324cac83ab
+niiri:10b939b5d1d5994f17ba7c7ff8d864c8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0024" ;
     nidm_coordinateVector: "[32,40,16]"^^xsd:string .
 
-niiri:ce11a63e7102de829a73aea266cc4b64 prov:wasDerivedFrom niiri:7cafb1e5ff245f47dacb09ebc1f3d273 .
+niiri:af6e82fac7bbf3d7f1621abbe68ecb05 prov:wasDerivedFrom niiri:bca5fdf4d900bd8486f16dfcd5ab7ade .
 
-niiri:7ab1bfd5aa2d9144300b6d31e5f53038
+niiri:af063a2fc9451b1a0f6d15b4c16c6d93
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0025" ;
-    prov:atLocation niiri:bd6418405e1be506e8f46369f1e2659e ;
+    prov:atLocation niiri:21d15b73a290e3ff6af5dfd0e0823244 ;
     prov:value "4.5497465133667"^^xsd:float ;
     nidm_equivalentZStatistic: "4.32273570618355"^^xsd:float ;
     nidm_pValueUncorrected: "7.7053150754347e-06"^^xsd:float ;
     nidm_pValueFWER: "0.520378392891944"^^xsd:float ;
     nidm_qValueFDR: "0.0649997423676262"^^xsd:float .
 
-niiri:bd6418405e1be506e8f46369f1e2659e
+niiri:21d15b73a290e3ff6af5dfd0e0823244
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0025" ;
     nidm_coordinateVector: "[40,46,12]"^^xsd:string .
 
-niiri:7ab1bfd5aa2d9144300b6d31e5f53038 prov:wasDerivedFrom niiri:7cafb1e5ff245f47dacb09ebc1f3d273 .
+niiri:af063a2fc9451b1a0f6d15b4c16c6d93 prov:wasDerivedFrom niiri:bca5fdf4d900bd8486f16dfcd5ab7ade .
 
-niiri:5a564d2ce1a5327309ee698a83e15c49
+niiri:5ed2c66afda9fc1f8f0e1230a1423370
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0026" ;
-    prov:atLocation niiri:1bd2ac8ac3423d81fb072bc2f95b0599 ;
+    prov:atLocation niiri:a28b17ed80d2b68fdc921f59f0f167eb ;
     prov:value "4.31582498550415"^^xsd:float ;
     nidm_equivalentZStatistic: "4.11913273798974"^^xsd:float ;
     nidm_pValueUncorrected: "1.90150518718513e-05"^^xsd:float ;
     nidm_pValueFWER: "0.788829013385429"^^xsd:float ;
     nidm_qValueFDR: "0.116130094830597"^^xsd:float .
 
-niiri:1bd2ac8ac3423d81fb072bc2f95b0599
+niiri:a28b17ed80d2b68fdc921f59f0f167eb
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0026" ;
     nidm_coordinateVector: "[36,54,6]"^^xsd:string .
 
-niiri:5a564d2ce1a5327309ee698a83e15c49 prov:wasDerivedFrom niiri:7cafb1e5ff245f47dacb09ebc1f3d273 .
+niiri:5ed2c66afda9fc1f8f0e1230a1423370 prov:wasDerivedFrom niiri:bca5fdf4d900bd8486f16dfcd5ab7ade .
 
-niiri:b03e17965d7a204222b0b3a109b619b4
+niiri:4ecf61302a9d659bed84b678acd8b8a3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0027" ;
-    prov:atLocation niiri:1d09c8cd00dd02766f23b87e7d4d07f6 ;
+    prov:atLocation niiri:36fb1e060c03001906e067f973d6addd ;
     prov:value "5.27030229568481"^^xsd:float ;
     nidm_equivalentZStatistic: "4.93281349716267"^^xsd:float ;
     nidm_pValueUncorrected: "4.05267701952816e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0575990926145485"^^xsd:float ;
     nidm_qValueFDR: "0.0110040663565173"^^xsd:float .
 
-niiri:1d09c8cd00dd02766f23b87e7d4d07f6
+niiri:36fb1e060c03001906e067f973d6addd
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0027" ;
     nidm_coordinateVector: "[40,26,48]"^^xsd:string .
 
-niiri:b03e17965d7a204222b0b3a109b619b4 prov:wasDerivedFrom niiri:bccdf03045b0a0de8d422d00c46014f1 .
+niiri:4ecf61302a9d659bed84b678acd8b8a3 prov:wasDerivedFrom niiri:a310e577676878e8eb7499da29ff53b4 .
 
-niiri:5391dbf014e7d50b21918bce0a6e6da6
+niiri:136c9c9df0e52f1962b71b13186923b6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0028" ;
-    prov:atLocation niiri:1fcfb3f247e177e7f3a5d4eae48e70a9 ;
+    prov:atLocation niiri:49d23550974006889f810999f02b6b52 ;
     prov:value "4.93343877792358"^^xsd:float ;
     nidm_equivalentZStatistic: "4.65085575575197"^^xsd:float ;
     nidm_pValueUncorrected: "1.6528024058271e-06"^^xsd:float ;
     nidm_pValueFWER: "0.180887232162623"^^xsd:float ;
     nidm_qValueFDR: "0.0254967087736733"^^xsd:float .
 
-niiri:1fcfb3f247e177e7f3a5d4eae48e70a9
+niiri:49d23550974006889f810999f02b6b52
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0028" ;
     nidm_coordinateVector: "[-58,-30,-18]"^^xsd:string .
 
-niiri:5391dbf014e7d50b21918bce0a6e6da6 prov:wasDerivedFrom niiri:2ecde1198137ba8c84d7f2b8ee573a34 .
+niiri:136c9c9df0e52f1962b71b13186923b6 prov:wasDerivedFrom niiri:4e10b0470621dd6f66d32e5f0d86796f .
 
-niiri:d972e7ca24da18203c2911cfaa636bba
+niiri:f946131984efa63e6aeba7b2a660d9a2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0029" ;
-    prov:atLocation niiri:550e291997b9a924a4f50de8dd44e992 ;
+    prov:atLocation niiri:cf3fb8e35e4c268c2eeb328480decb9c ;
     prov:value "4.76414346694946"^^xsd:float ;
     nidm_equivalentZStatistic: "4.50698548813516"^^xsd:float ;
     nidm_pValueUncorrected: "3.287756441539e-06"^^xsd:float ;
     nidm_pValueFWER: "0.301278778226174"^^xsd:float ;
     nidm_qValueFDR: "0.0396433885053995"^^xsd:float .
 
-niiri:550e291997b9a924a4f50de8dd44e992
+niiri:cf3fb8e35e4c268c2eeb328480decb9c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0029" ;
     nidm_coordinateVector: "[-46,-66,-6]"^^xsd:string .
 
-niiri:d972e7ca24da18203c2911cfaa636bba prov:wasDerivedFrom niiri:f195588e037cf5066c03b040bdd17c5c .
+niiri:f946131984efa63e6aeba7b2a660d9a2 prov:wasDerivedFrom niiri:8d02357e68e2217c76b2789fc556a1e0 .
 
-niiri:509ba4b81e2e1747769f93c7df752feb
+niiri:65cd1425049190819614ec8b724da79c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0030" ;
-    prov:atLocation niiri:238dae6cc3f4dbe99828008d147abf03 ;
+    prov:atLocation niiri:88d00fbb1ce3816c9097d2466e1ade94 ;
     prov:value "3.7637345790863"^^xsd:float ;
     nidm_equivalentZStatistic: "3.62829384243901"^^xsd:float ;
     nidm_pValueUncorrected: "0.000142650218672435"^^xsd:float ;
     nidm_pValueFWER: "0.999605970761399"^^xsd:float ;
     nidm_qValueFDR: "0.34409224637793"^^xsd:float .
 
-niiri:238dae6cc3f4dbe99828008d147abf03
+niiri:88d00fbb1ce3816c9097d2466e1ade94
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0030" ;
     nidm_coordinateVector: "[-54,-64,-8]"^^xsd:string .
 
-niiri:509ba4b81e2e1747769f93c7df752feb prov:wasDerivedFrom niiri:f195588e037cf5066c03b040bdd17c5c .
+niiri:65cd1425049190819614ec8b724da79c prov:wasDerivedFrom niiri:8d02357e68e2217c76b2789fc556a1e0 .
 
-niiri:66bb41c5b59bb5cb8f697e5c97a3d810
+niiri:1038f5b8ec149150369ced9f4ef14d84
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0031" ;
-    prov:atLocation niiri:594b66781a74218782498262f481182a ;
+    prov:atLocation niiri:556ae55aaa299d4d49dc193ab39255bf ;
     prov:value "4.72232866287231"^^xsd:float ;
     nidm_equivalentZStatistic: "4.47122948835043"^^xsd:float ;
     nidm_pValueUncorrected: "3.88855941602095e-06"^^xsd:float ;
     nidm_pValueFWER: "0.338512677882141"^^xsd:float ;
     nidm_qValueFDR: "0.044836631144536"^^xsd:float .
 
-niiri:594b66781a74218782498262f481182a
+niiri:556ae55aaa299d4d49dc193ab39255bf
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0031" ;
     nidm_coordinateVector: "[58,-38,6]"^^xsd:string .
 
-niiri:66bb41c5b59bb5cb8f697e5c97a3d810 prov:wasDerivedFrom niiri:ae3238820d20eca8be6dc34ce2ca54dc .
+niiri:1038f5b8ec149150369ced9f4ef14d84 prov:wasDerivedFrom niiri:4f5f4e9dc219044ae730379a51a53a84 .
 
-niiri:bc68c970f7cc0c0d6665afb53e17d21c
+niiri:ecf27cff24accc7da10b3c89a35e94bd
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0032" ;
-    prov:atLocation niiri:909322dc52bad8d70be56166acfbc671 ;
+    prov:atLocation niiri:38ca5b29b1a44ecc2f165779c9f6945f ;
     prov:value "3.88437390327454"^^xsd:float ;
     nidm_equivalentZStatistic: "3.73675248173504"^^xsd:float ;
     nidm_pValueUncorrected: "9.32061303765552e-05"^^xsd:float ;
     nidm_pValueFWER: "0.996350207228297"^^xsd:float ;
     nidm_qValueFDR: "0.273673640636879"^^xsd:float .
 
-niiri:909322dc52bad8d70be56166acfbc671
+niiri:38ca5b29b1a44ecc2f165779c9f6945f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0032" ;
     nidm_coordinateVector: "[64,-32,-4]"^^xsd:string .
 
-niiri:bc68c970f7cc0c0d6665afb53e17d21c prov:wasDerivedFrom niiri:ae3238820d20eca8be6dc34ce2ca54dc .
+niiri:ecf27cff24accc7da10b3c89a35e94bd prov:wasDerivedFrom niiri:4f5f4e9dc219044ae730379a51a53a84 .
 
-niiri:5d09dd263c7ece698c4b7eefb01f6ca7
+niiri:9d277a53a24699d648dda94e1edb30a0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0033" ;
-    prov:atLocation niiri:42b5e20c2419faf646dd747b914cd4fc ;
+    prov:atLocation niiri:7188d7ddb6523611068b2892e353d78a ;
     prov:value "3.50753784179688"^^xsd:float ;
     nidm_equivalentZStatistic: "3.39582098150001"^^xsd:float ;
     nidm_pValueUncorrected: "0.000342115474631921"^^xsd:float ;
     nidm_pValueFWER: "0.999999778829603"^^xsd:float ;
     nidm_qValueFDR: "0.564856004417035"^^xsd:float .
 
-niiri:42b5e20c2419faf646dd747b914cd4fc
+niiri:7188d7ddb6523611068b2892e353d78a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0033" ;
     nidm_coordinateVector: "[60,-40,-12]"^^xsd:string .
 
-niiri:5d09dd263c7ece698c4b7eefb01f6ca7 prov:wasDerivedFrom niiri:ae3238820d20eca8be6dc34ce2ca54dc .
+niiri:9d277a53a24699d648dda94e1edb30a0 prov:wasDerivedFrom niiri:4f5f4e9dc219044ae730379a51a53a84 .
 
-niiri:45b9069c26a126013fda8da6853dd90c
+niiri:29818f2935a525fc4869ee33b8cc7b28
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0034" ;
-    prov:atLocation niiri:c776509aded558cd3b9be7f9aa30fd6a ;
+    prov:atLocation niiri:d530a8fef909fd9f9de09043bc6a29b8 ;
     prov:value "4.70483255386353"^^xsd:float ;
     nidm_equivalentZStatistic: "4.45624265093732"^^xsd:float ;
     nidm_pValueUncorrected: "4.17043099876224e-06"^^xsd:float ;
     nidm_pValueFWER: "0.354967306449537"^^xsd:float ;
     nidm_qValueFDR: "0.0466228196503302"^^xsd:float .
 
-niiri:c776509aded558cd3b9be7f9aa30fd6a
+niiri:d530a8fef909fd9f9de09043bc6a29b8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0034" ;
     nidm_coordinateVector: "[-36,-74,-14]"^^xsd:string .
 
-niiri:45b9069c26a126013fda8da6853dd90c prov:wasDerivedFrom niiri:5a36931b22b3ff3ae34e9ab8b27bca1e .
+niiri:29818f2935a525fc4869ee33b8cc7b28 prov:wasDerivedFrom niiri:770c988e0434c5ba8e4392759de30eea .
 
-niiri:9b9a5a7e06da367ca321b6ed12583191
+niiri:fecb6f93c50d8f21e158114c7bc5c612
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0035" ;
-    prov:atLocation niiri:ac6152f5696faa63646e0de651766d16 ;
+    prov:atLocation niiri:87b30d0dacfbf3a6baea12b321dbe3ca ;
     prov:value "4.08770418167114"^^xsd:float ;
     nidm_equivalentZStatistic: "3.91804495668"^^xsd:float ;
     nidm_pValueUncorrected: "4.46350297789166e-05"^^xsd:float ;
     nidm_pValueFWER: "0.955724279224547"^^xsd:float ;
     nidm_qValueFDR: "0.186719971332974"^^xsd:float .
 
-niiri:ac6152f5696faa63646e0de651766d16
+niiri:87b30d0dacfbf3a6baea12b321dbe3ca
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0035" ;
     nidm_coordinateVector: "[-36,-68,-20]"^^xsd:string .
 
-niiri:9b9a5a7e06da367ca321b6ed12583191 prov:wasDerivedFrom niiri:5a36931b22b3ff3ae34e9ab8b27bca1e .
+niiri:fecb6f93c50d8f21e158114c7bc5c612 prov:wasDerivedFrom niiri:770c988e0434c5ba8e4392759de30eea .
 
-niiri:ad689fae9bae33e039be5c09c0adf096
+niiri:edde077bec74c6cf6f6e249592b326c1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0036" ;
-    prov:atLocation niiri:e29220741d4935ec2231005723d49c67 ;
+    prov:atLocation niiri:f3774aa2c82de202d63a2de644c906a7 ;
     prov:value "3.71012616157532"^^xsd:float ;
     nidm_equivalentZStatistic: "3.57988831343959"^^xsd:float ;
     nidm_pValueUncorrected: "0.000171870546999631"^^xsd:float ;
     nidm_pValueFWER: "0.999883757236262"^^xsd:float ;
     nidm_qValueFDR: "0.385893135248467"^^xsd:float .
 
-niiri:e29220741d4935ec2231005723d49c67
+niiri:f3774aa2c82de202d63a2de644c906a7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0036" ;
     nidm_coordinateVector: "[-30,-58,-16]"^^xsd:string .
 
-niiri:ad689fae9bae33e039be5c09c0adf096 prov:wasDerivedFrom niiri:5a36931b22b3ff3ae34e9ab8b27bca1e .
+niiri:edde077bec74c6cf6f6e249592b326c1 prov:wasDerivedFrom niiri:770c988e0434c5ba8e4392759de30eea .
 
-niiri:c9b957724aaf9f82d49b8bb95421eec0
+niiri:a96987019566061347adea1fb3ca7702
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0037" ;
-    prov:atLocation niiri:8ef291e4b237ad48e36560e63da4495c ;
+    prov:atLocation niiri:14a79f1b76bb47c7ca62842d674145d2 ;
     prov:value "4.57891654968262"^^xsd:float ;
     nidm_equivalentZStatistic: "4.34793761600864"^^xsd:float ;
     nidm_pValueUncorrected: "6.87118388575936e-06"^^xsd:float ;
     nidm_pValueFWER: "0.487021764768749"^^xsd:float ;
     nidm_qValueFDR: "0.0629240173925056"^^xsd:float .
 
-niiri:8ef291e4b237ad48e36560e63da4495c
+niiri:14a79f1b76bb47c7ca62842d674145d2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0037" ;
     nidm_coordinateVector: "[-60,-16,28]"^^xsd:string .
 
-niiri:c9b957724aaf9f82d49b8bb95421eec0 prov:wasDerivedFrom niiri:6def1f951e1919c60434a8119f03801a .
+niiri:a96987019566061347adea1fb3ca7702 prov:wasDerivedFrom niiri:ce1649f53d38c28c5b0d7cacaaf4f448 .
 
-niiri:180b86e774e9f17cfc45c4446c203b97
+niiri:9bb5d42691cee918ce4d479afc518088
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0038" ;
-    prov:atLocation niiri:e3b63a61d3fdda47494885009dc4d07c ;
+    prov:atLocation niiri:b82ab7eaee85ede4d79638cc7b03af67 ;
     prov:value "4.48185300827026"^^xsd:float ;
     nidm_equivalentZStatistic: "4.26391634421444"^^xsd:float ;
     nidm_pValueUncorrected: "1.00437338077519e-05"^^xsd:float ;
     nidm_pValueFWER: "0.600177833033677"^^xsd:float ;
     nidm_qValueFDR: "0.0894660991036064"^^xsd:float .
 
-niiri:e3b63a61d3fdda47494885009dc4d07c
+niiri:b82ab7eaee85ede4d79638cc7b03af67
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0038" ;
     nidm_coordinateVector: "[18,16,62]"^^xsd:string .
 
-niiri:180b86e774e9f17cfc45c4446c203b97 prov:wasDerivedFrom niiri:f3a4e60499161232255b1ced0a699ecc .
+niiri:9bb5d42691cee918ce4d479afc518088 prov:wasDerivedFrom niiri:11d8aaf31a0f50da63a5edcfdc834eac .
 
-niiri:192c104526b6e954e1bcd32e7eccb4db
+niiri:3ab755e42b6e08f17828f58fe2dd123b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0039" ;
-    prov:atLocation niiri:3b613316773c1bdad9a973b2f3aae4b7 ;
+    prov:atLocation niiri:5f932ae285e704d39f11ceec314ec660 ;
     prov:value "4.37013816833496"^^xsd:float ;
     nidm_equivalentZStatistic: "4.16664310578498"^^xsd:float ;
     nidm_pValueUncorrected: "1.54558935169247e-05"^^xsd:float ;
     nidm_pValueFWER: "0.730405153245217"^^xsd:float ;
     nidm_qValueFDR: "0.101858458171742"^^xsd:float .
 
-niiri:3b613316773c1bdad9a973b2f3aae4b7
+niiri:5f932ae285e704d39f11ceec314ec660
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0039" ;
     nidm_coordinateVector: "[-52,-62,52]"^^xsd:string .
 
-niiri:192c104526b6e954e1bcd32e7eccb4db prov:wasDerivedFrom niiri:7c9ccbac3cd845dfc0c233005757f05f .
+niiri:3ab755e42b6e08f17828f58fe2dd123b prov:wasDerivedFrom niiri:18af84b83a63dcee2acfd1b9003ffe17 .
 
-niiri:9807390605b098701abbf0e61ada1df3
+niiri:86f0d921cd39a0e58bec940eba62746e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0040" ;
-    prov:atLocation niiri:1c77f5b258b84f3b0c9beccdc6b730fb ;
+    prov:atLocation niiri:066a0f8c565a7cecb402e87bb821a838 ;
     prov:value "4.24533367156982"^^xsd:float ;
     nidm_equivalentZStatistic: "4.05725918601008"^^xsd:float ;
     nidm_pValueUncorrected: "2.4825985211363e-05"^^xsd:float ;
     nidm_pValueFWER: "0.855631833511506"^^xsd:float ;
     nidm_qValueFDR: "0.135717263652471"^^xsd:float .
 
-niiri:1c77f5b258b84f3b0c9beccdc6b730fb
+niiri:066a0f8c565a7cecb402e87bb821a838
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0040" ;
     nidm_coordinateVector: "[-18,-60,48]"^^xsd:string .
 
-niiri:9807390605b098701abbf0e61ada1df3 prov:wasDerivedFrom niiri:e89936e52b02ce3aa8a79b72737894c6 .
+niiri:86f0d921cd39a0e58bec940eba62746e prov:wasDerivedFrom niiri:bc47992403400de624fca0326bfeca0a .
 
-niiri:1000fbe292d57558b4be662738bf2153
+niiri:c2069dff2662c758ed500ee4348b7b32
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0041" ;
-    prov:atLocation niiri:5cfa6c776b739dbd5c3f058edb9aaebf ;
+    prov:atLocation niiri:aa8f70fe82ef3aa7629e2e97b230ab16 ;
     prov:value "4.22729349136353"^^xsd:float ;
     nidm_equivalentZStatistic: "4.04138628171284"^^xsd:float ;
     nidm_pValueUncorrected: "2.65680735640483e-05"^^xsd:float ;
     nidm_pValueFWER: "0.870712357794855"^^xsd:float ;
     nidm_qValueFDR: "0.138603763901635"^^xsd:float .
 
-niiri:5cfa6c776b739dbd5c3f058edb9aaebf
+niiri:aa8f70fe82ef3aa7629e2e97b230ab16
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0041" ;
     nidm_coordinateVector: "[-20,-98,22]"^^xsd:string .
 
-niiri:1000fbe292d57558b4be662738bf2153 prov:wasDerivedFrom niiri:18e987f3604a0d6c7d127a9be6b0fb68 .
+niiri:c2069dff2662c758ed500ee4348b7b32 prov:wasDerivedFrom niiri:0c6b532ae8d28e2999918870be27c672 .
 
-niiri:bae87f65b9eeb2d209f8066f91b6c297
+niiri:01af14b9357e03fab37d07283367aa67
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0042" ;
-    prov:atLocation niiri:2e9b9fca51582a9d17298a000969d2e4 ;
+    prov:atLocation niiri:b19e680fa92673699b5d7811f246dc5a ;
     prov:value "4.22599840164185"^^xsd:float ;
     nidm_equivalentZStatistic: "4.04024618213588"^^xsd:float ;
     nidm_pValueUncorrected: "2.66975618669063e-05"^^xsd:float ;
     nidm_pValueFWER: "0.871760516202526"^^xsd:float ;
     nidm_qValueFDR: "0.138603763901635"^^xsd:float .
 
-niiri:2e9b9fca51582a9d17298a000969d2e4
+niiri:b19e680fa92673699b5d7811f246dc5a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0042" ;
     nidm_coordinateVector: "[-36,-74,-34]"^^xsd:string .
 
-niiri:bae87f65b9eeb2d209f8066f91b6c297 prov:wasDerivedFrom niiri:b19fa2f74715b8879a4263e734abff89 .
+niiri:01af14b9357e03fab37d07283367aa67 prov:wasDerivedFrom niiri:58f0b66e88ddd39190a49cc289e1a6a9 .
 
-niiri:f6d338b44225d278f02e33e0da877ab5
+niiri:feb2ebab3443b1487f09e60430381080
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0043" ;
-    prov:atLocation niiri:3daeb8c71524fc3999fa71376db5b18e ;
+    prov:atLocation niiri:30864274adf86d85cec9fa93ad094f06 ;
     prov:value "4.21435213088989"^^xsd:float ;
     nidm_equivalentZStatistic: "4.02999009325983"^^xsd:float ;
     nidm_pValueUncorrected: "2.78896018329755e-05"^^xsd:float ;
     nidm_pValueFWER: "0.880974433980664"^^xsd:float ;
     nidm_qValueFDR: "0.143583628261646"^^xsd:float .
 
-niiri:3daeb8c71524fc3999fa71376db5b18e
+niiri:30864274adf86d85cec9fa93ad094f06
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0043" ;
     nidm_coordinateVector: "[-26,-92,30]"^^xsd:string .
 
-niiri:f6d338b44225d278f02e33e0da877ab5 prov:wasDerivedFrom niiri:0c6a4c5eab9814c8a104ac2ab9ba8e00 .
+niiri:feb2ebab3443b1487f09e60430381080 prov:wasDerivedFrom niiri:6864ea0388f90fdf3d5a0840769fb194 .
 
-niiri:f307201c48340bce70a23de634f9ec3c
+niiri:b20862f472f9d77c1662db6b2eca294f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0044" ;
-    prov:atLocation niiri:83eb7747ee02a020ed521fb9d67b7872 ;
+    prov:atLocation niiri:72a654d54ab595719acda55869b4754f ;
     prov:value "4.20391035079956"^^xsd:float ;
     nidm_equivalentZStatistic: "4.02078923241408"^^xsd:float ;
     nidm_pValueUncorrected: "2.900174224163e-05"^^xsd:float ;
     nidm_pValueFWER: "0.888907080881232"^^xsd:float ;
     nidm_qValueFDR: "0.143583628261646"^^xsd:float .
 
-niiri:83eb7747ee02a020ed521fb9d67b7872
+niiri:72a654d54ab595719acda55869b4754f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0044" ;
     nidm_coordinateVector: "[34,-54,-16]"^^xsd:string .
 
-niiri:f307201c48340bce70a23de634f9ec3c prov:wasDerivedFrom niiri:2c0e11ce65487da45bf7a9358ee57871 .
+niiri:b20862f472f9d77c1662db6b2eca294f prov:wasDerivedFrom niiri:560b390e6daf7bdacebd6f81fc2498ed .
 
-niiri:54ffbced568329bc9f82ee5f4dbc1841
+niiri:fd4266dd0bb219a6a241ff6533c36ff6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0045" ;
-    prov:atLocation niiri:b63300446b864767556af57bde222bf4 ;
+    prov:atLocation niiri:fc644bec2a9708abb95907ff040d5630 ;
     prov:value "4.17404651641846"^^xsd:float ;
     nidm_equivalentZStatistic: "3.99444589181498"^^xsd:float ;
     nidm_pValueUncorrected: "3.24228638075574e-05"^^xsd:float ;
     nidm_pValueFWER: "0.909844421846994"^^xsd:float ;
     nidm_qValueFDR: "0.153735203854581"^^xsd:float .
 
-niiri:b63300446b864767556af57bde222bf4
+niiri:fc644bec2a9708abb95907ff040d5630
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0045" ;
     nidm_coordinateVector: "[-40,-38,44]"^^xsd:string .
 
-niiri:54ffbced568329bc9f82ee5f4dbc1841 prov:wasDerivedFrom niiri:0b550e722b76049b2f7ca0131da7d9c2 .
+niiri:fd4266dd0bb219a6a241ff6533c36ff6 prov:wasDerivedFrom niiri:b02b8c006088cba013305b13d972edc8 .
 
-niiri:c70d2ff92028de2c80d7404c7d274cd3
+niiri:109fbb4d397a1909eb3b295464058f51
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0046" ;
-    prov:atLocation niiri:f8d2684d77f31e59502459d7b548de93 ;
+    prov:atLocation niiri:f06d5ad7743673ee5c44accc1ccd4693 ;
     prov:value "4.12488555908203"^^xsd:float ;
     nidm_equivalentZStatistic: "3.95098834792843"^^xsd:float ;
     nidm_pValueUncorrected: "3.89145570423022e-05"^^xsd:float ;
     nidm_pValueFWER: "0.938594159355111"^^xsd:float ;
     nidm_qValueFDR: "0.172448885449819"^^xsd:float .
 
-niiri:f8d2684d77f31e59502459d7b548de93
+niiri:f06d5ad7743673ee5c44accc1ccd4693
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0046" ;
     nidm_coordinateVector: "[14,-98,4]"^^xsd:string .
 
-niiri:c70d2ff92028de2c80d7404c7d274cd3 prov:wasDerivedFrom niiri:72450de63634a896c274e40a3163e02f .
+niiri:109fbb4d397a1909eb3b295464058f51 prov:wasDerivedFrom niiri:a4e0cdaf05e785d8dd95f23ce74745d2 .
 
-niiri:dfae772dc0866f88082cc01fccdd4633
+niiri:2d19dc148fa248efc7a3df765c6a06cb
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0047" ;
-    prov:atLocation niiri:40253ac0f41ee20d2dbf716aac798f63 ;
+    prov:atLocation niiri:01b946515c1c0572e49c00274feae5bc ;
     prov:value "4.12145137786865"^^xsd:float ;
     nidm_equivalentZStatistic: "3.94794832362008"^^xsd:float ;
     nidm_pValueUncorrected: "3.94119065879606e-05"^^xsd:float ;
     nidm_pValueFWER: "0.940339218142555"^^xsd:float ;
     nidm_qValueFDR: "0.172448885449819"^^xsd:float .
 
-niiri:40253ac0f41ee20d2dbf716aac798f63
+niiri:01b946515c1c0572e49c00274feae5bc
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0047" ;
     nidm_coordinateVector: "[-48,-72,2]"^^xsd:string .
 
-niiri:dfae772dc0866f88082cc01fccdd4633 prov:wasDerivedFrom niiri:cd940e6e9b2162b03485c9d3045fe2cf .
+niiri:2d19dc148fa248efc7a3df765c6a06cb prov:wasDerivedFrom niiri:a57f08ef6a63ebebf16d1533899bc25f .
 
-niiri:763e9a5ddb64d79a4963dd0c08f20ec3
+niiri:13cbba597089b29e46b69027980a685e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0048" ;
-    prov:atLocation niiri:0342deb3954ed20c2903ef704d4f3287 ;
+    prov:atLocation niiri:187d5d28119342c706dc84a629c3f64c ;
     prov:value "4.07333517074585"^^xsd:float ;
     nidm_equivalentZStatistic: "3.9052963692066"^^xsd:float ;
     nidm_pValueUncorrected: "4.70549882543025e-05"^^xsd:float ;
     nidm_pValueFWER: "0.961337330645756"^^xsd:float ;
     nidm_qValueFDR: "0.192831151077206"^^xsd:float .
 
-niiri:0342deb3954ed20c2903ef704d4f3287
+niiri:187d5d28119342c706dc84a629c3f64c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0048" ;
     nidm_coordinateVector: "[20,-66,34]"^^xsd:string .
 
-niiri:763e9a5ddb64d79a4963dd0c08f20ec3 prov:wasDerivedFrom niiri:e32122a83b7d8bb16e3180c78f7eda7c .
+niiri:13cbba597089b29e46b69027980a685e prov:wasDerivedFrom niiri:61ed7bccd640009bb231b2a1982f0622 .
 
-niiri:5e496faaa2325b69842de4796343c369
+niiri:46ae4164bfa8a7fd52ad313b6b95ad52
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0049" ;
-    prov:atLocation niiri:fa54128151b6e9ba93c9743bac5b7810 ;
+    prov:atLocation niiri:95c55eeeed13d264184e830910c60b20 ;
     prov:value "4.05762767791748"^^xsd:float ;
     nidm_equivalentZStatistic: "3.89134919103145"^^xsd:float ;
     nidm_pValueUncorrected: "4.98441713834286e-05"^^xsd:float ;
     nidm_pValueFWER: "0.966867400896655"^^xsd:float ;
     nidm_qValueFDR: "0.199920408224698"^^xsd:float .
 
-niiri:fa54128151b6e9ba93c9743bac5b7810
+niiri:95c55eeeed13d264184e830910c60b20
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0049" ;
     nidm_coordinateVector: "[-46,-56,14]"^^xsd:string .
 
-niiri:5e496faaa2325b69842de4796343c369 prov:wasDerivedFrom niiri:6ae34632238cbeb521e67cef26caf7eb .
+niiri:46ae4164bfa8a7fd52ad313b6b95ad52 prov:wasDerivedFrom niiri:0095bc91a1253454e74d41690d9f6df3 .
 
-niiri:626bc5b24a804a5a21acebd988be2e61
+niiri:6ec3e0f95a4dca384d07f9fba19f7d96
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0050" ;
-    prov:atLocation niiri:06343ebc6fe179c7b610559b432c0030 ;
+    prov:atLocation niiri:0393612c8584550483fc955cb87af40e ;
     prov:value "3.97341108322144"^^xsd:float ;
     nidm_equivalentZStatistic: "3.81637469850314"^^xsd:float ;
     nidm_pValueUncorrected: "6.7713399346081e-05"^^xsd:float ;
     nidm_pValueFWER: "0.987160063394768"^^xsd:float ;
     nidm_qValueFDR: "0.237117251115433"^^xsd:float .
 
-niiri:06343ebc6fe179c7b610559b432c0030
+niiri:0393612c8584550483fc955cb87af40e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0050" ;
     nidm_coordinateVector: "[-50,-50,20]"^^xsd:string .
 
-niiri:626bc5b24a804a5a21acebd988be2e61 prov:wasDerivedFrom niiri:6ae34632238cbeb521e67cef26caf7eb .
+niiri:6ec3e0f95a4dca384d07f9fba19f7d96 prov:wasDerivedFrom niiri:0095bc91a1253454e74d41690d9f6df3 .
 
-niiri:ec00c90a90ca813778eb1e94775cb9d9
+niiri:3f8990df299e6c17b1734919846f4c6f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0051" ;
-    prov:atLocation niiri:ae286cede70d2e06338412f0ca028263 ;
+    prov:atLocation niiri:78a29eee84d8fb0874ce0bc42c8d8c0c ;
     prov:value "4.03719234466553"^^xsd:float ;
     nidm_equivalentZStatistic: "3.87318677164159"^^xsd:float ;
     nidm_pValueUncorrected: "5.37107204765519e-05"^^xsd:float ;
     nidm_pValueFWER: "0.973166168280088"^^xsd:float ;
     nidm_qValueFDR: "0.210147957128937"^^xsd:float .
 
-niiri:ae286cede70d2e06338412f0ca028263
+niiri:78a29eee84d8fb0874ce0bc42c8d8c0c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0051" ;
     nidm_coordinateVector: "[-48,2,50]"^^xsd:string .
 
-niiri:ec00c90a90ca813778eb1e94775cb9d9 prov:wasDerivedFrom niiri:5559b2a8337e94bc2084c45d5600922b .
+niiri:3f8990df299e6c17b1734919846f4c6f prov:wasDerivedFrom niiri:fdd0f25c58dffbc950780afac712f03c .
 
-niiri:a8f71dfdc8ef6d2ac7c90360a6fdf106
+niiri:aa18f0ad742a246e138666daf0480e72
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0052" ;
-    prov:atLocation niiri:c153a603b30ff7cdbc1f03f4334cae80 ;
+    prov:atLocation niiri:0bcb0950fefd4e3b5cbefda9af5fd682 ;
     prov:value "4.0217924118042"^^xsd:float ;
     nidm_equivalentZStatistic: "3.85948683644491"^^xsd:float ;
     nidm_pValueUncorrected: "5.68126885931441e-05"^^xsd:float ;
     nidm_pValueFWER: "0.977286609355005"^^xsd:float ;
     nidm_qValueFDR: "0.217632520436791"^^xsd:float .
 
-niiri:c153a603b30ff7cdbc1f03f4334cae80
+niiri:0bcb0950fefd4e3b5cbefda9af5fd682
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0052" ;
     nidm_coordinateVector: "[-36,-40,-36]"^^xsd:string .
 
-niiri:a8f71dfdc8ef6d2ac7c90360a6fdf106 prov:wasDerivedFrom niiri:853079021e568a419ad6b8ad88952642 .
+niiri:aa18f0ad742a246e138666daf0480e72 prov:wasDerivedFrom niiri:19300df9cc64fa2764a0780af7af6f84 .
 
-niiri:0fe40a31dce9c91b7e238b2efb60f066
+niiri:bcaf0c8e6a688a504f644ea44b72c874
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0053" ;
-    prov:atLocation niiri:d3909b6b2738c4fe53dbbab649c1f79a ;
+    prov:atLocation niiri:c18ca0f70ac22ec9bab26c8c3ac14734 ;
     prov:value "3.97676801681519"^^xsd:float ;
     nidm_equivalentZStatistic: "3.81936952854042"^^xsd:float ;
     nidm_pValueUncorrected: "6.68966021436512e-05"^^xsd:float ;
     nidm_pValueFWER: "0.986609697042008"^^xsd:float ;
     nidm_qValueFDR: "0.237117251115433"^^xsd:float .
 
-niiri:d3909b6b2738c4fe53dbbab649c1f79a
+niiri:c18ca0f70ac22ec9bab26c8c3ac14734
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0053" ;
     nidm_coordinateVector: "[50,-52,60]"^^xsd:string .
 
-niiri:0fe40a31dce9c91b7e238b2efb60f066 prov:wasDerivedFrom niiri:0cf1dc899a75152a30a291b0a2560db3 .
+niiri:bcaf0c8e6a688a504f644ea44b72c874 prov:wasDerivedFrom niiri:5ef4fb1358a9a6249f348a6eb79516e7 .
 
-niiri:84698a1d0ecbfce2248e5a4818536e14
+niiri:32ff477de924235c5522ee862332ff7c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0054" ;
-    prov:atLocation niiri:cd00d2e8ae4225f520d00f40bb2893a7 ;
+    prov:atLocation niiri:6bef910ff6ac94722e287b9d2729d1e1 ;
     prov:value "3.9634416103363"^^xsd:float ;
     nidm_equivalentZStatistic: "3.80747753892992"^^xsd:float ;
     nidm_pValueUncorrected: "7.01957428701494e-05"^^xsd:float ;
     nidm_pValueFWER: "0.988689669381963"^^xsd:float ;
     nidm_qValueFDR: "0.237117251115433"^^xsd:float .
 
-niiri:cd00d2e8ae4225f520d00f40bb2893a7
+niiri:6bef910ff6ac94722e287b9d2729d1e1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0054" ;
     nidm_coordinateVector: "[4,6,32]"^^xsd:string .
 
-niiri:84698a1d0ecbfce2248e5a4818536e14 prov:wasDerivedFrom niiri:678b8fa6b0f9293b49f20d1427d409e0 .
+niiri:32ff477de924235c5522ee862332ff7c prov:wasDerivedFrom niiri:520bd6c8ac4aa6408335f0e0c324688b .
 
-niiri:24a6789ba2036a9952a8413c3b376013
+niiri:f538dc161505199a9d4a9dc200bbfbd1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0055" ;
-    prov:atLocation niiri:be9c0a7a9f305f6267e4cab4122b3985 ;
+    prov:atLocation niiri:af082644064d49a87df191a50e018a1f ;
     prov:value "3.96245408058167"^^xsd:float ;
     nidm_equivalentZStatistic: "3.80659597790245"^^xsd:float ;
     nidm_pValueUncorrected: "7.04463150378309e-05"^^xsd:float ;
     nidm_pValueFWER: "0.988832912076595"^^xsd:float ;
     nidm_qValueFDR: "0.237117251115433"^^xsd:float .
 
-niiri:be9c0a7a9f305f6267e4cab4122b3985
+niiri:af082644064d49a87df191a50e018a1f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0055" ;
     nidm_coordinateVector: "[-50,-48,-16]"^^xsd:string .
 
-niiri:24a6789ba2036a9952a8413c3b376013 prov:wasDerivedFrom niiri:45253dc06118b1b5a6a77ba54c4b1490 .
+niiri:f538dc161505199a9d4a9dc200bbfbd1 prov:wasDerivedFrom niiri:f881e9cbe818d5f8b37dfed6dec527cc .
 
-niiri:0062a939c1eee665c50ee4abd8f63b2f
+niiri:d0d01153923178a42866f6f64e32d01c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0056" ;
-    prov:atLocation niiri:3d14aa99f7ec458fc842e78731256bf0 ;
+    prov:atLocation niiri:6e604072f92df73cd898dcd2f349304a ;
     prov:value "3.95309829711914"^^xsd:float ;
     nidm_equivalentZStatistic: "3.79824190359279"^^xsd:float ;
     nidm_pValueUncorrected: "7.28630328464819e-05"^^xsd:float ;
     nidm_pValueFWER: "0.990119383011277"^^xsd:float ;
     nidm_qValueFDR: "0.243341582944922"^^xsd:float .
 
-niiri:3d14aa99f7ec458fc842e78731256bf0
+niiri:6e604072f92df73cd898dcd2f349304a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0056" ;
     nidm_coordinateVector: "[44,4,48]"^^xsd:string .
 
-niiri:0062a939c1eee665c50ee4abd8f63b2f prov:wasDerivedFrom niiri:a5e4bc181e94cafee69b551c62f10925 .
+niiri:d0d01153923178a42866f6f64e32d01c prov:wasDerivedFrom niiri:4aa4a0455dab2440720331d043f09ec2 .
 
-niiri:aaf1d5898881a1966667867eb1616aae
+niiri:970399f54bebe49057e2e105ecea663c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0057" ;
-    prov:atLocation niiri:cbc5239baf97fef8d1e2c457a4a53cc8 ;
+    prov:atLocation niiri:2deadff2e7be322b63ec9667a75a3e66 ;
     prov:value "3.92427015304565"^^xsd:float ;
     nidm_equivalentZStatistic: "3.77247501519699"^^xsd:float ;
     nidm_pValueUncorrected: "8.08180782938539e-05"^^xsd:float ;
     nidm_pValueFWER: "0.993353008667813"^^xsd:float ;
     nidm_qValueFDR: "0.257401847609111"^^xsd:float .
 
-niiri:cbc5239baf97fef8d1e2c457a4a53cc8
+niiri:2deadff2e7be322b63ec9667a75a3e66
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0057" ;
     nidm_coordinateVector: "[34,12,64]"^^xsd:string .
 
-niiri:aaf1d5898881a1966667867eb1616aae prov:wasDerivedFrom niiri:ce3143388409a30de94c45862dcc1603 .
+niiri:970399f54bebe49057e2e105ecea663c prov:wasDerivedFrom niiri:69ca7568c07230cf3584aaca638281b0 .
 
-niiri:0dc1329f25297e93e8c0460a58d173cc
+niiri:1a51f95440dce51af59c428b51c26851
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0058" ;
-    prov:atLocation niiri:30cbf5888756940aeeb4a89421c50833 ;
+    prov:atLocation niiri:da6ab50c8b91b09b511975b823c28c39 ;
     prov:value "3.9098813533783"^^xsd:float ;
     nidm_equivalentZStatistic: "3.75959988615137"^^xsd:float ;
     nidm_pValueUncorrected: "8.50926599039736e-05"^^xsd:float ;
     nidm_pValueFWER: "0.994607633788328"^^xsd:float ;
     nidm_qValueFDR: "0.264100967145263"^^xsd:float .
 
-niiri:30cbf5888756940aeeb4a89421c50833
+niiri:da6ab50c8b91b09b511975b823c28c39
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0058" ;
     nidm_coordinateVector: "[54,-24,-2]"^^xsd:string .
 
-niiri:0dc1329f25297e93e8c0460a58d173cc prov:wasDerivedFrom niiri:76c08ff817708a0abbb42fa1bb47a0cf .
+niiri:1a51f95440dce51af59c428b51c26851 prov:wasDerivedFrom niiri:350dbc35c571e3a5c09f2cdc4c910d34 .
 
-niiri:1fb4e43da779ff8bd8d2331d2f9864e1
+niiri:87fdac079acb3a60695755078ec9ff23
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0059" ;
-    prov:atLocation niiri:346d98428f4ca87d175e3fee210b0d72 ;
+    prov:atLocation niiri:2b2fc48f07fee7b33d6bccd9c1aaf3e2 ;
     prov:value "3.90759468078613"^^xsd:float ;
     nidm_equivalentZStatistic: "3.75755289319297"^^xsd:float ;
     nidm_pValueUncorrected: "8.57915531067288e-05"^^xsd:float ;
     nidm_pValueFWER: "0.994787688943672"^^xsd:float ;
     nidm_qValueFDR: "0.264100967145263"^^xsd:float .
 
-niiri:346d98428f4ca87d175e3fee210b0d72
+niiri:2b2fc48f07fee7b33d6bccd9c1aaf3e2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0059" ;
     nidm_coordinateVector: "[-14,-98,-4]"^^xsd:string .
 
-niiri:1fb4e43da779ff8bd8d2331d2f9864e1 prov:wasDerivedFrom niiri:47fed6da7f0600bc158182bd59714d25 .
+niiri:87fdac079acb3a60695755078ec9ff23 prov:wasDerivedFrom niiri:5d231bb78e3753cb8f1f83f432b012a4 .
 
-niiri:86d4a5331879dd3c7fadbc94b1f1ae62
+niiri:dc459f0a0e3ee90c5e29e061346c5e6a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0060" ;
-    prov:atLocation niiri:c328279f3a63ea8585497c804b21b951 ;
+    prov:atLocation niiri:3c7c82e3cab9399987475ea5f2e30a60 ;
     prov:value "3.90285301208496"^^xsd:float ;
     nidm_equivalentZStatistic: "3.75330746420074"^^xsd:float ;
     nidm_pValueUncorrected: "8.72582920719012e-05"^^xsd:float ;
     nidm_pValueFWER: "0.99514521861122"^^xsd:float ;
     nidm_qValueFDR: "0.264100967145263"^^xsd:float .
 
-niiri:c328279f3a63ea8585497c804b21b951
+niiri:3c7c82e3cab9399987475ea5f2e30a60
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0060" ;
     nidm_coordinateVector: "[-36,-46,-18]"^^xsd:string .
 
-niiri:86d4a5331879dd3c7fadbc94b1f1ae62 prov:wasDerivedFrom niiri:3aaffeb437aa651f0d21d28a688e78dd .
+niiri:dc459f0a0e3ee90c5e29e061346c5e6a prov:wasDerivedFrom niiri:d962ed566ab823dc017d65a55c96005b .
 
-niiri:05e5020143d70e64995b69f8756df39d
+niiri:f41100c4c035a126bb3e090ac5b96ef2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0061" ;
-    prov:atLocation niiri:ed2bda47df044137ff7c87b426d33de9 ;
+    prov:atLocation niiri:189bf1ada1eef7b44db4d193f2a65962 ;
     prov:value "3.8867518901825"^^xsd:float ;
     nidm_equivalentZStatistic: "3.73888373627584"^^xsd:float ;
     nidm_pValueUncorrected: "9.24195907030523e-05"^^xsd:float ;
     nidm_pValueFWER: "0.996210852184447"^^xsd:float ;
     nidm_qValueFDR: "0.271701156704036"^^xsd:float .
 
-niiri:ed2bda47df044137ff7c87b426d33de9
+niiri:189bf1ada1eef7b44db4d193f2a65962
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0061" ;
     nidm_coordinateVector: "[-50,-46,-32]"^^xsd:string .
 
-niiri:05e5020143d70e64995b69f8756df39d prov:wasDerivedFrom niiri:902f31a0f58308cc0d2941ed3096a18c .
+niiri:f41100c4c035a126bb3e090ac5b96ef2 prov:wasDerivedFrom niiri:5ca18f66be2a0317891dd14ae924d09a .
 
-niiri:44db62c0993869cd21f00cabf2e8af08
+niiri:12d30f83fba50c448c40e1fea8540142
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0062" ;
-    prov:atLocation niiri:40234c37348bd37ac581575825a90b9a ;
+    prov:atLocation niiri:e74e6fef095025d78f7d87d10fe04d0b ;
     prov:value "3.82178378105164"^^xsd:float ;
     nidm_equivalentZStatistic: "3.68056404693028"^^xsd:float ;
     nidm_pValueUncorrected: "0.000116359297336222"^^xsd:float ;
     nidm_pValueFWER: "0.998750111206092"^^xsd:float ;
     nidm_qValueFDR: "0.307505393775956"^^xsd:float .
 
-niiri:40234c37348bd37ac581575825a90b9a
+niiri:e74e6fef095025d78f7d87d10fe04d0b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0062" ;
     nidm_coordinateVector: "[12,52,-12]"^^xsd:string .
 
-niiri:44db62c0993869cd21f00cabf2e8af08 prov:wasDerivedFrom niiri:6fcbec37cf34db5ad09da73b06411a40 .
+niiri:12d30f83fba50c448c40e1fea8540142 prov:wasDerivedFrom niiri:bf714e8e855430179f84817bfe8aa9f4 .
 
-niiri:da102df177c6d704c38aacb85be36982
+niiri:3b77fd4f30cbd966a672c142e10cd1ec
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0063" ;
-    prov:atLocation niiri:062830474981e1d2ba13ceed932a801e ;
+    prov:atLocation niiri:937f76ecbce55de2fa752519e4da8b1e ;
     prov:value "3.81266117095947"^^xsd:float ;
     nidm_equivalentZStatistic: "3.67235967240763"^^xsd:float ;
     nidm_pValueUncorrected: "0.000120160560553639"^^xsd:float ;
     nidm_pValueFWER: "0.998946217488595"^^xsd:float ;
     nidm_qValueFDR: "0.312228840798665"^^xsd:float .
 
-niiri:062830474981e1d2ba13ceed932a801e
+niiri:937f76ecbce55de2fa752519e4da8b1e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0063" ;
     nidm_coordinateVector: "[36,54,20]"^^xsd:string .
 
-niiri:da102df177c6d704c38aacb85be36982 prov:wasDerivedFrom niiri:f7fec6797003228e9250ccd152a5c37f .
+niiri:3b77fd4f30cbd966a672c142e10cd1ec prov:wasDerivedFrom niiri:404e791392df064f45734040de92da30 .
 
-niiri:30a6a9c3a1e992761478114beb6cd83c
+niiri:8636582fe5845fabfeeef03ea097da99
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0064" ;
-    prov:atLocation niiri:691977ec4c5992f167733ac50b857d36 ;
+    prov:atLocation niiri:dea96efaeecd8d7265aff2a6bf2a2ae8 ;
     prov:value "3.80767583847046"^^xsd:float ;
     nidm_equivalentZStatistic: "3.66787455107711"^^xsd:float ;
     nidm_pValueUncorrected: "0.000122287561408974"^^xsd:float ;
     nidm_pValueFWER: "0.999041631710947"^^xsd:float ;
     nidm_qValueFDR: "0.312228840798665"^^xsd:float .
 
-niiri:691977ec4c5992f167733ac50b857d36
+niiri:dea96efaeecd8d7265aff2a6bf2a2ae8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0064" ;
     nidm_coordinateVector: "[22,-80,54]"^^xsd:string .
 
-niiri:30a6a9c3a1e992761478114beb6cd83c prov:wasDerivedFrom niiri:35377dee19e22bb0a24fdb50eccf1b74 .
+niiri:8636582fe5845fabfeeef03ea097da99 prov:wasDerivedFrom niiri:def46784463991aed85ece366ca75ad8 .
 
-niiri:57f5cb1301cb0ec2e5344369714f88fe
+niiri:82603814879a87f0ffb468aa32aadf1d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0065" ;
-    prov:atLocation niiri:8d9aa683ac84ad8c4f7b91ade6acbd91 ;
+    prov:atLocation niiri:c94ea4de157b0c9d29d9fd4d205f5607 ;
     prov:value "3.7885959148407"^^xsd:float ;
     nidm_equivalentZStatistic: "3.65069869844077"^^xsd:float ;
     nidm_pValueUncorrected: "0.000130763947768786"^^xsd:float ;
     nidm_pValueFWER: "0.999340802437346"^^xsd:float ;
     nidm_qValueFDR: "0.325675502417125"^^xsd:float .
 
-niiri:8d9aa683ac84ad8c4f7b91ade6acbd91
+niiri:c94ea4de157b0c9d29d9fd4d205f5607
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0065" ;
     nidm_coordinateVector: "[22,40,26]"^^xsd:string .
 
-niiri:57f5cb1301cb0ec2e5344369714f88fe prov:wasDerivedFrom niiri:662b849d101be496cda3a65d2f69da2b .
+niiri:82603814879a87f0ffb468aa32aadf1d prov:wasDerivedFrom niiri:c2de51d4065404a70c8e75ad7f34a79f .
 
-niiri:e103f97c657699dbaf09a36090171a99
+niiri:ce7014584411a4e6030e1b6874e61edb
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0066" ;
-    prov:atLocation niiri:2052d8263e350348d11ea4187b75e730 ;
+    prov:atLocation niiri:a2ec71c72c91d6abcb527c15c9c3f40d ;
     prov:value "3.78668808937073"^^xsd:float ;
     nidm_equivalentZStatistic: "3.64898036269368"^^xsd:float ;
     nidm_pValueUncorrected: "0.000131641613210109"^^xsd:float ;
     nidm_pValueFWER: "0.999365630484476"^^xsd:float ;
     nidm_qValueFDR: "0.325675502417125"^^xsd:float .
 
-niiri:2052d8263e350348d11ea4187b75e730
+niiri:a2ec71c72c91d6abcb527c15c9c3f40d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0066" ;
     nidm_coordinateVector: "[-22,-74,60]"^^xsd:string .
 
-niiri:e103f97c657699dbaf09a36090171a99 prov:wasDerivedFrom niiri:bb8721fcbfb280a841be169cb5e433b5 .
+niiri:ce7014584411a4e6030e1b6874e61edb prov:wasDerivedFrom niiri:f11cdd5ae11ea581dcd3882d3540354b .
 
-niiri:35bd49a168370574c7f77d091b60b6e8
+niiri:1914d7526225245a6b8afde3e39c1ba6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0067" ;
-    prov:atLocation niiri:23641c588e77eba9190a5aea981daeef ;
+    prov:atLocation niiri:5af3e20e07b7118fe0888052b8cfcab7 ;
     prov:value "3.71480798721313"^^xsd:float ;
     nidm_equivalentZStatistic: "3.58412084932714"^^xsd:float ;
     nidm_pValueUncorrected: "0.000169107736440521"^^xsd:float ;
     nidm_pValueFWER: "0.999869855188705"^^xsd:float ;
     nidm_qValueFDR: "0.383925327139989"^^xsd:float .
 
-niiri:23641c588e77eba9190a5aea981daeef
+niiri:5af3e20e07b7118fe0888052b8cfcab7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0067" ;
     nidm_coordinateVector: "[-34,-84,-2]"^^xsd:string .
 
-niiri:35bd49a168370574c7f77d091b60b6e8 prov:wasDerivedFrom niiri:8b2e8095aa6535f320b2113605db7dba .
+niiri:1914d7526225245a6b8afde3e39c1ba6 prov:wasDerivedFrom niiri:37773f3cd9125252813f9101750c8618 .
 
-niiri:5aebbcf97cbcbee6a9ed3f90454b3328
+niiri:34abe905d1d081ef06aa532dca4df55e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0068" ;
-    prov:atLocation niiri:8f772bf50dbd17f1023835fe30a113e5 ;
+    prov:atLocation niiri:980e6c21a07dfe3b31d1697a47c25f1d ;
     prov:value "3.69408750534058"^^xsd:float ;
     nidm_equivalentZStatistic: "3.56538143418403"^^xsd:float ;
     nidm_pValueUncorrected: "0.000181663694368006"^^xsd:float ;
     nidm_pValueFWER: "0.999921818129803"^^xsd:float ;
     nidm_qValueFDR: "0.399826018660701"^^xsd:float .
 
-niiri:8f772bf50dbd17f1023835fe30a113e5
+niiri:980e6c21a07dfe3b31d1697a47c25f1d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0068" ;
     nidm_coordinateVector: "[50,46,-12]"^^xsd:string .
 
-niiri:5aebbcf97cbcbee6a9ed3f90454b3328 prov:wasDerivedFrom niiri:e7305b9c4bb3949423d41a45d18d3fcf .
+niiri:34abe905d1d081ef06aa532dca4df55e prov:wasDerivedFrom niiri:b9bf3dcf444022a80942813a2e7f252d .
 
-niiri:940a6014aaed122dcf5fd43384f0a5d5
+niiri:7f523ca7243bef20f31c8eb562ee6271
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0069" ;
-    prov:atLocation niiri:f4581185e3edc4e58b1c20a1a91f4dc8 ;
+    prov:atLocation niiri:d62e229f0b52ec9242d7f41c5d3e36bf ;
     prov:value "3.65790581703186"^^xsd:float ;
     nidm_equivalentZStatistic: "3.53261354467296"^^xsd:float ;
     nidm_pValueUncorrected: "0.000205736742878826"^^xsd:float ;
     nidm_pValueFWER: "0.999969815552823"^^xsd:float ;
     nidm_qValueFDR: "0.430567192397012"^^xsd:float .
 
-niiri:f4581185e3edc4e58b1c20a1a91f4dc8
+niiri:d62e229f0b52ec9242d7f41c5d3e36bf
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0069" ;
     nidm_coordinateVector: "[52,-46,-12]"^^xsd:string .
 
-niiri:940a6014aaed122dcf5fd43384f0a5d5 prov:wasDerivedFrom niiri:fe1342908b2c590f0d205c54b090c224 .
+niiri:7f523ca7243bef20f31c8eb562ee6271 prov:wasDerivedFrom niiri:06de03bbb8e40178692ae6ec9dd3f5d5 .
 
-niiri:7c5c6e8d715a000785be71ff81c99299
+niiri:11cc93907e041bf61389cd50514f54ae
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0070" ;
-    prov:atLocation niiri:236353457645394e22d80a2c71e9e9d4 ;
+    prov:atLocation niiri:c9a383c2a53704da619a4a92b0b47a77 ;
     prov:value "3.65459251403809"^^xsd:float ;
     nidm_equivalentZStatistic: "3.52960997534834"^^xsd:float ;
     nidm_pValueUncorrected: "0.000208086348004177"^^xsd:float ;
     nidm_pValueFWER: "0.999972447579615"^^xsd:float ;
     nidm_qValueFDR: "0.431239033859527"^^xsd:float .
 
-niiri:236353457645394e22d80a2c71e9e9d4
+niiri:c9a383c2a53704da619a4a92b0b47a77
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0070" ;
     nidm_coordinateVector: "[54,8,-36]"^^xsd:string .
 
-niiri:7c5c6e8d715a000785be71ff81c99299 prov:wasDerivedFrom niiri:ad067a0d2a64875916d47893c9bf91b0 .
+niiri:11cc93907e041bf61389cd50514f54ae prov:wasDerivedFrom niiri:ae0af12ba47d22765200496a05e3cc2e .
 
-niiri:661a3a0bf3ee22fc68637091b9eb8d21
+niiri:e0c55ebec0ecd249a6a1221b9000af8b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0071" ;
-    prov:atLocation niiri:b8c0b2299ce9f7ee7a75bb8d211f6c46 ;
+    prov:atLocation niiri:6ad9741eec3138fb7501dba131b7c01a ;
     prov:value "3.60870504379272"^^xsd:float ;
     nidm_equivalentZStatistic: "3.48796269267718"^^xsd:float ;
     nidm_pValueUncorrected: "0.000243357993216953"^^xsd:float ;
     nidm_pValueFWER: "0.999992770534091"^^xsd:float ;
     nidm_qValueFDR: "0.475991356580954"^^xsd:float .
 
-niiri:b8c0b2299ce9f7ee7a75bb8d211f6c46
+niiri:6ad9741eec3138fb7501dba131b7c01a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0071" ;
     nidm_coordinateVector: "[40,-52,68]"^^xsd:string .
 
-niiri:661a3a0bf3ee22fc68637091b9eb8d21 prov:wasDerivedFrom niiri:4426798282ac8143b4291fc9731c0d21 .
+niiri:e0c55ebec0ecd249a6a1221b9000af8b prov:wasDerivedFrom niiri:f5ac1b556f82f90ca54e1755f459aeb0 .
 
-niiri:b2b7b7692f5aa26cb11995e3a85e0f60
+niiri:010e57748e944b9a5344c65b7dcca649
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0072" ;
-    prov:atLocation niiri:625b71154320941f351eb8e0610bb4a9 ;
+    prov:atLocation niiri:3c7a921ea450332ded31c7e83f039528 ;
     prov:value "3.60173606872559"^^xsd:float ;
     nidm_equivalentZStatistic: "3.48162963814792"^^xsd:float ;
     nidm_pValueUncorrected: "0.000249186237945009"^^xsd:float ;
     nidm_pValueFWER: "0.999994173508246"^^xsd:float ;
     nidm_qValueFDR: "0.477936808108637"^^xsd:float .
 
-niiri:625b71154320941f351eb8e0610bb4a9
+niiri:3c7a921ea450332ded31c7e83f039528
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0072" ;
     nidm_coordinateVector: "[-14,58,10]"^^xsd:string .
 
-niiri:b2b7b7692f5aa26cb11995e3a85e0f60 prov:wasDerivedFrom niiri:094ca018251a2b17ad5bbde342203d06 .
+niiri:010e57748e944b9a5344c65b7dcca649 prov:wasDerivedFrom niiri:e0f350ef000b2636edd606950fbacdd8 .
 
-niiri:48f37e3e3778678617889255991dd32b
+niiri:7c4a82dba1a9aef0c16e95acba02ea74
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0073" ;
-    prov:atLocation niiri:c0aa3153ab7b9798444ef5a0d2160603 ;
+    prov:atLocation niiri:b64f47ef39dc6d1ee386d9414e21721c ;
     prov:value "3.58989810943604"^^xsd:float ;
     nidm_equivalentZStatistic: "3.47086705539024"^^xsd:float ;
     nidm_pValueUncorrected: "0.000259390388114844"^^xsd:float ;
     nidm_pValueFWER: "0.999995993033212"^^xsd:float ;
     nidm_qValueFDR: "0.486123239113482"^^xsd:float .
 
-niiri:c0aa3153ab7b9798444ef5a0d2160603
+niiri:b64f47ef39dc6d1ee386d9414e21721c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0073" ;
     nidm_coordinateVector: "[-66,-36,22]"^^xsd:string .
 
-niiri:48f37e3e3778678617889255991dd32b prov:wasDerivedFrom niiri:e765876280bde3e4bebecc566c8bd29c .
+niiri:7c4a82dba1a9aef0c16e95acba02ea74 prov:wasDerivedFrom niiri:208e0aa56bc32fd1c4efbe75ea40b1a0 .
 
-niiri:1a64ed947fc053d9e4a3a2232b21f553
+niiri:1ee2a189ddde50048e5bc2471880d25e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0074" ;
-    prov:atLocation niiri:9e25d55ac03149402f6368fbff8cd8f8 ;
+    prov:atLocation niiri:6da0792c18731727d1fd106d98144c77 ;
     prov:value "3.56340670585632"^^xsd:float ;
     nidm_equivalentZStatistic: "3.44676015888715"^^xsd:float ;
     nidm_pValueUncorrected: "0.000283676007278189"^^xsd:float ;
     nidm_pValueFWER: "0.999998329299787"^^xsd:float ;
     nidm_qValueFDR: "0.513357841480064"^^xsd:float .
 
-niiri:9e25d55ac03149402f6368fbff8cd8f8
+niiri:6da0792c18731727d1fd106d98144c77
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0074" ;
     nidm_coordinateVector: "[18,60,12]"^^xsd:string .
 
-niiri:1a64ed947fc053d9e4a3a2232b21f553 prov:wasDerivedFrom niiri:b6238a8e3e93a9273be55294f38a7061 .
+niiri:1ee2a189ddde50048e5bc2471880d25e prov:wasDerivedFrom niiri:6270b7e521adb112773419d81745ba32 .
 
-niiri:e0ebd33047b60463151cb6665224b6f0
+niiri:17365311e977a0f7612d95a39cd6fdc2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0075" ;
-    prov:atLocation niiri:d1815b9f59348c4536edbc8565583355 ;
+    prov:atLocation niiri:3d8fb7e482b175f8eeba0bb983116a40 ;
     prov:value "3.55537104606628"^^xsd:float ;
     nidm_equivalentZStatistic: "3.43944179853069"^^xsd:float ;
     nidm_pValueUncorrected: "0.000291457553818653"^^xsd:float ;
     nidm_pValueFWER: "0.999998731920076"^^xsd:float ;
     nidm_qValueFDR: "0.518882279088377"^^xsd:float .
 
-niiri:d1815b9f59348c4536edbc8565583355
+niiri:3d8fb7e482b175f8eeba0bb983116a40
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0075" ;
     nidm_coordinateVector: "[-64,-34,8]"^^xsd:string .
 
-niiri:e0ebd33047b60463151cb6665224b6f0 prov:wasDerivedFrom niiri:cedb782dada08c65c4916daa0ad6e465 .
+niiri:17365311e977a0f7612d95a39cd6fdc2 prov:wasDerivedFrom niiri:6e8c7efcd65fd269ae1163d977b34228 .
 
-niiri:c1c88dff04830e47aa47afc9c4fac17d
+niiri:1aa22f63d5d63be3e71695c4f2ce2cf2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0076" ;
-    prov:atLocation niiri:82f63ba4bd070f22267f249ea665eeaf ;
+    prov:atLocation niiri:bacf64ffb57e108f35e206bfb1eea36e ;
     prov:value "3.55148839950562"^^xsd:float ;
     nidm_equivalentZStatistic: "3.43590473729199"^^xsd:float ;
     nidm_pValueUncorrected: "0.000295289297083445"^^xsd:float ;
     nidm_pValueFWER: "0.99999889206113"^^xsd:float ;
     nidm_qValueFDR: "0.518882279088377"^^xsd:float .
 
-niiri:82f63ba4bd070f22267f249ea665eeaf
+niiri:bacf64ffb57e108f35e206bfb1eea36e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0076" ;
     nidm_coordinateVector: "[64,-34,16]"^^xsd:string .
 
-niiri:c1c88dff04830e47aa47afc9c4fac17d prov:wasDerivedFrom niiri:47f716a7866282e59c2437414f29fb67 .
+niiri:1aa22f63d5d63be3e71695c4f2ce2cf2 prov:wasDerivedFrom niiri:8bdb7c1cfc0e4c28f73b9ebb2067be4a .
 
-niiri:ff928eaadfedd741182cbded3233112a
+niiri:c6643c3287ba5b3c7c9ae880836c753c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0077" ;
-    prov:atLocation niiri:e8a10ec98b3eed51c1409f98d5b0d591 ;
+    prov:atLocation niiri:50f9cac6df1136e4e7d38b392707df25 ;
     prov:value "3.51380252838135"^^xsd:float ;
     nidm_equivalentZStatistic: "3.40153955037634"^^xsd:float ;
     nidm_pValueUncorrected: "0.000335037159349127"^^xsd:float ;
     nidm_pValueFWER: "0.99999971905221"^^xsd:float ;
     nidm_qValueFDR: "0.559625109906516"^^xsd:float .
 
-niiri:e8a10ec98b3eed51c1409f98d5b0d591
+niiri:50f9cac6df1136e4e7d38b392707df25
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0077" ;
     nidm_coordinateVector: "[48,12,50]"^^xsd:string .
 
-niiri:ff928eaadfedd741182cbded3233112a prov:wasDerivedFrom niiri:e6b8fc7731810aa6f311348e0b1cc140 .
+niiri:c6643c3287ba5b3c7c9ae880836c753c prov:wasDerivedFrom niiri:bb0ea248bef4b3a56f8b7bd4674e079a .
 
-niiri:1408e93ad1851d9792bfacd6962fb96f
+niiri:d0858c2460bb3887c10ea7cc932fda7e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0078" ;
-    prov:atLocation niiri:16a27ce79d9c5118048286ef0e7664b6 ;
+    prov:atLocation niiri:91f4aee1b203764ec626f1b44c205485 ;
     prov:value "3.46123600006104"^^xsd:float ;
     nidm_equivalentZStatistic: "3.353503690367"^^xsd:float ;
     nidm_pValueUncorrected: "0.000398976748636981"^^xsd:float ;
     nidm_pValueFWER: "0.999999965973308"^^xsd:float ;
     nidm_qValueFDR: "0.628488500556802"^^xsd:float .
 
-niiri:16a27ce79d9c5118048286ef0e7664b6
+niiri:91f4aee1b203764ec626f1b44c205485
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0078" ;
     nidm_coordinateVector: "[14,-14,70]"^^xsd:string .
 
-niiri:1408e93ad1851d9792bfacd6962fb96f prov:wasDerivedFrom niiri:9e7a68deeddb09104c97844d6208138a .
+niiri:d0858c2460bb3887c10ea7cc932fda7e prov:wasDerivedFrom niiri:3ba5f3e50f85d1172dccf7cdc87e047a .
 
-niiri:f11f999d153a5c371e14a2eeb7b4d67d
+niiri:ce7fafbed4002da1a8d55bef85886de8
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0079" ;
-    prov:atLocation niiri:7d99e4e09c14e281690ee87ee2ddb1bd ;
+    prov:atLocation niiri:f43bc57e246dba1a18fe143d2e61fabb ;
     prov:value "3.45441365242004"^^xsd:float ;
     nidm_equivalentZStatistic: "3.34726077209469"^^xsd:float ;
     nidm_pValueUncorrected: "0.000408071982705316"^^xsd:float ;
     nidm_pValueFWER: "0.999999974583179"^^xsd:float ;
     nidm_qValueFDR: "0.628488500556802"^^xsd:float .
 
-niiri:7d99e4e09c14e281690ee87ee2ddb1bd
+niiri:f43bc57e246dba1a18fe143d2e61fabb
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0079" ;
     nidm_coordinateVector: "[-38,-54,-42]"^^xsd:string .
 
-niiri:f11f999d153a5c371e14a2eeb7b4d67d prov:wasDerivedFrom niiri:9f7250b2986229e27c73d4ee533b5581 .
+niiri:ce7fafbed4002da1a8d55bef85886de8 prov:wasDerivedFrom niiri:221ffcb9e61912db0c8ea94c83c806f3 .
 
-niiri:d37743c2f9e1a162338e1a5b050c758b
+niiri:703dca43a303429db425b818bc12c6a4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0080" ;
-    prov:atLocation niiri:0b9fd817b3f65dd363c55c7058ed28ad ;
+    prov:atLocation niiri:3c414ad1fd71de414c026f189f78779b ;
     prov:value "3.43550229072571"^^xsd:float ;
     nidm_equivalentZStatistic: "3.32994532400952"^^xsd:float ;
     nidm_pValueUncorrected: "0.000434315195478541"^^xsd:float ;
     nidm_pValueFWER: "0.999999988927098"^^xsd:float ;
     nidm_qValueFDR: "0.654261098812949"^^xsd:float .
 
-niiri:0b9fd817b3f65dd363c55c7058ed28ad
+niiri:3c414ad1fd71de414c026f189f78779b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0080" ;
     nidm_coordinateVector: "[22,44,-16]"^^xsd:string .
 
-niiri:d37743c2f9e1a162338e1a5b050c758b prov:wasDerivedFrom niiri:f895b7fb895eba3b656944c4b6b3efb7 .
+niiri:703dca43a303429db425b818bc12c6a4 prov:wasDerivedFrom niiri:680f2d4ea6ccf9065674d450817a8a71 .
 
-niiri:13e122ce299b2d1e7cf72040e14d82d5
+niiri:43941dd0099dba7340078c94b1f176e4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0081" ;
-    prov:atLocation niiri:0d4a093240dd121e9a286d0f15282a3b ;
+    prov:atLocation niiri:14d4d48691f4187769651ca7e448575f ;
     prov:value "3.43198323249817"^^xsd:float ;
     nidm_equivalentZStatistic: "3.32672157755253"^^xsd:float ;
     nidm_pValueUncorrected: "0.000439370628491198"^^xsd:float ;
     nidm_pValueFWER: "0.999999990548038"^^xsd:float ;
     nidm_qValueFDR: "0.655840530088522"^^xsd:float .
 
-niiri:0d4a093240dd121e9a286d0f15282a3b
+niiri:14d4d48691f4187769651ca7e448575f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0081" ;
     nidm_coordinateVector: "[42,-42,14]"^^xsd:string .
 
-niiri:13e122ce299b2d1e7cf72040e14d82d5 prov:wasDerivedFrom niiri:1a924fb418bec3cd95c0a03c9ae66f54 .
+niiri:43941dd0099dba7340078c94b1f176e4 prov:wasDerivedFrom niiri:cf57b893da54bea9529d4c0bc8ff02f0 .
 
-niiri:c1609883ce93d4f3a7644077172aa74c
+niiri:9a9c1fe4c7f0e8236338ec3ccf5fb8c1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0082" ;
-    prov:atLocation niiri:8135fa25879ec1de7f1702afb81fc631 ;
+    prov:atLocation niiri:e8cd739d9997617595ca094639c0d767 ;
     prov:value "3.40386486053467"^^xsd:float ;
     nidm_equivalentZStatistic: "3.30094422133281"^^xsd:float ;
     nidm_pValueUncorrected: "0.000481800187664638"^^xsd:float ;
     nidm_pValueFWER: "0.999999997442132"^^xsd:float ;
     nidm_qValueFDR: "0.689466168942319"^^xsd:float .
 
-niiri:8135fa25879ec1de7f1702afb81fc631
+niiri:e8cd739d9997617595ca094639c0d767
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0082" ;
     nidm_coordinateVector: "[52,-42,18]"^^xsd:string .
 
-niiri:c1609883ce93d4f3a7644077172aa74c prov:wasDerivedFrom niiri:e8f2997ff1833098ebac8c27365f5882 .
+niiri:9a9c1fe4c7f0e8236338ec3ccf5fb8c1 prov:wasDerivedFrom niiri:06f83c4cb0758a1db3af7b9ac9595bd1 .
 
-niiri:ccb0cbfacba02c3f3c0aebf6cc526afa
+niiri:5aaecc8f07f4c4f973768fbf89a146da
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0083" ;
-    prov:atLocation niiri:4462a75d1ee425538428f9db9a7ebf85 ;
+    prov:atLocation niiri:6d64cee175b474ae9c60ccad84bf5aed ;
     prov:value "3.36533284187317"^^xsd:float ;
     nidm_equivalentZStatistic: "3.26556677338515"^^xsd:float ;
     nidm_pValueUncorrected: "0.000546226226643243"^^xsd:float ;
     nidm_pValueFWER: "0.999999999624169"^^xsd:float ;
     nidm_qValueFDR: "0.751744172496132"^^xsd:float .
 
-niiri:4462a75d1ee425538428f9db9a7ebf85
+niiri:6d64cee175b474ae9c60ccad84bf5aed
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0083" ;
     nidm_coordinateVector: "[44,-48,-26]"^^xsd:string .
 
-niiri:ccb0cbfacba02c3f3c0aebf6cc526afa prov:wasDerivedFrom niiri:af1ebc888c3ec8f9fad9e0c771ed7a78 .
+niiri:5aaecc8f07f4c4f973768fbf89a146da prov:wasDerivedFrom niiri:33c167d8677c415c916bc8b906fd4db4 .
 
-niiri:4110f602cbcf1840e8e4015bf63dc181
+niiri:48bf8ce794db930df930c41d224bdc16
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0084" ;
-    prov:atLocation niiri:154c5a85bf34ecccb8b3e64fe364d7b0 ;
+    prov:atLocation niiri:a186d322a8d32a9dcd3c456718013455 ;
     prov:value "3.3379864692688"^^xsd:float ;
     nidm_equivalentZStatistic: "3.24042202275062"^^xsd:float ;
     nidm_pValueUncorrected: "0.000596764555146345"^^xsd:float ;
     nidm_pValueFWER: "0.999999999912202"^^xsd:float ;
     nidm_qValueFDR: "0.787874793017543"^^xsd:float .
 
-niiri:154c5a85bf34ecccb8b3e64fe364d7b0
+niiri:a186d322a8d32a9dcd3c456718013455
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0084" ;
     nidm_coordinateVector: "[46,-40,44]"^^xsd:string .
 
-niiri:4110f602cbcf1840e8e4015bf63dc181 prov:wasDerivedFrom niiri:93eff452c29120a5015af008a69e2b85 .
+niiri:48bf8ce794db930df930c41d224bdc16 prov:wasDerivedFrom niiri:6f398d8313ba8da3802bd6174fad64a9 .
 
-niiri:7e00fc9195554320e63dd74c7c844f43
+niiri:553299baed01f241bd72ebf115908e51
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0085" ;
-    prov:atLocation niiri:a717960733802b20ec0357c684696cee ;
+    prov:atLocation niiri:089c8164018121709a50c5c000adb8b4 ;
     prov:value "3.33372783660889"^^xsd:float ;
     nidm_equivalentZStatistic: "3.23650348537689"^^xsd:float ;
     nidm_pValueUncorrected: "0.000605018743711327"^^xsd:float ;
     nidm_pValueFWER: "0.999999999930494"^^xsd:float ;
     nidm_qValueFDR: "0.791142662581953"^^xsd:float .
 
-niiri:a717960733802b20ec0357c684696cee
+niiri:089c8164018121709a50c5c000adb8b4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0085" ;
     nidm_coordinateVector: "[16,4,16]"^^xsd:string .
 
-niiri:7e00fc9195554320e63dd74c7c844f43 prov:wasDerivedFrom niiri:eadc69190fdc6d634404fa8f12f510eb .
+niiri:553299baed01f241bd72ebf115908e51 prov:wasDerivedFrom niiri:441c62b804db7724fe069a4683eabbb3 .
 
-niiri:7c518ba27edef4f0933ea4750087fe00
+niiri:6eaf36636b84719dcdad3b87ac63db9d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0086" ;
-    prov:atLocation niiri:cfc0fc18cb48322234eec2b8adf838e3 ;
+    prov:atLocation niiri:48ea271c59c0d27824322ff2afca20a5 ;
     prov:value "3.32532405853271"^^xsd:float ;
     nidm_equivalentZStatistic: "3.22876865896546"^^xsd:float ;
     nidm_pValueUncorrected: "0.000621622108231912"^^xsd:float ;
     nidm_pValueFWER: "0.99999999995642"^^xsd:float ;
     nidm_qValueFDR: "0.802213727911317"^^xsd:float .
 
-niiri:cfc0fc18cb48322234eec2b8adf838e3
+niiri:48ea271c59c0d27824322ff2afca20a5
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0086" ;
     nidm_coordinateVector: "[-54,-32,42]"^^xsd:string .
 
-niiri:7c518ba27edef4f0933ea4750087fe00 prov:wasDerivedFrom niiri:fdf3341a871a270775355dceeb623541 .
+niiri:6eaf36636b84719dcdad3b87ac63db9d prov:wasDerivedFrom niiri:9573a33cf8de1d0d7462efcefe1aa3b3 .
 
-niiri:92dbb4f064c8dffea3d0b3dc7f7936a3
+niiri:e375fd72351a936406457560ff4bf243
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0087" ;
-    prov:atLocation niiri:005cc9e6032d3220d252231334197152 ;
+    prov:atLocation niiri:e8219e816a81544fd1542b7c43739e8d ;
     prov:value "3.3035409450531"^^xsd:float ;
     nidm_equivalentZStatistic: "3.20870610659348"^^xsd:float ;
     nidm_pValueUncorrected: "0.000666668530368786"^^xsd:float ;
     nidm_pValueFWER: "0.999999999987468"^^xsd:float ;
     nidm_qValueFDR: "0.829570299628891"^^xsd:float .
 
-niiri:005cc9e6032d3220d252231334197152
+niiri:e8219e816a81544fd1542b7c43739e8d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0087" ;
     nidm_coordinateVector: "[22,38,10]"^^xsd:string .
 
-niiri:92dbb4f064c8dffea3d0b3dc7f7936a3 prov:wasDerivedFrom niiri:d53a0a4ae6e04c2856dad6f7de113409 .
+niiri:e375fd72351a936406457560ff4bf243 prov:wasDerivedFrom niiri:adc671bb3b8aead7b73b777448e0d974 .
 
-niiri:620973253c62a151921fc9a1c9d5dfa2
+niiri:19a0feb2eced3573854928d35a375bea
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0088" ;
-    prov:atLocation niiri:da864c21a52816da3b0190478e49caae ;
+    prov:atLocation niiri:0865df5da5b73976893b2a73cf860d9d ;
     prov:value "3.29107904434204"^^xsd:float ;
     nidm_equivalentZStatistic: "3.19721985733158"^^xsd:float ;
     nidm_pValueUncorrected: "0.000693795605607228"^^xsd:float ;
     nidm_pValueFWER: "0.999999999994003"^^xsd:float ;
     nidm_qValueFDR: "0.839453948823053"^^xsd:float .
 
-niiri:da864c21a52816da3b0190478e49caae
+niiri:0865df5da5b73976893b2a73cf860d9d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0088" ;
     nidm_coordinateVector: "[30,34,48]"^^xsd:string .
 
-niiri:620973253c62a151921fc9a1c9d5dfa2 prov:wasDerivedFrom niiri:cf7aba36a552e6ca5812f44e1297b2e9 .
+niiri:19a0feb2eced3573854928d35a375bea prov:wasDerivedFrom niiri:e9779649e0e322514fd2b0963b83e9b3 .
 
-niiri:440111cd7e19e50738e336a36656bf0b
+niiri:0e5f9cfe273ad2b56c5d941a8fa1d751
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0089" ;
-    prov:atLocation niiri:4f6e4659ace26929d99204d0904b13df ;
+    prov:atLocation niiri:831e9d6a1c1a2ca8f3a901a82bb321af ;
     prov:value "3.27154183387756"^^xsd:float ;
     nidm_equivalentZStatistic: "3.17919960131803"^^xsd:float ;
     nidm_pValueUncorrected: "0.000738411785119797"^^xsd:float ;
     nidm_pValueFWER: "0.999999999998178"^^xsd:float ;
     nidm_qValueFDR: "0.858755937068456"^^xsd:float .
 
-niiri:4f6e4659ace26929d99204d0904b13df
+niiri:831e9d6a1c1a2ca8f3a901a82bb321af
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0089" ;
     nidm_coordinateVector: "[10,-76,-12]"^^xsd:string .
 
-niiri:440111cd7e19e50738e336a36656bf0b prov:wasDerivedFrom niiri:43852b81a09cf6e877d19e5df6f9977b .
+niiri:0e5f9cfe273ad2b56c5d941a8fa1d751 prov:wasDerivedFrom niiri:41fb45bc18bea4725f44ca167cd99df1 .
 
-niiri:4f84c599f455625d062b8e65b802ab8c
+niiri:9ae75a88cde46be90790ef06a7e29dee
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0090" ;
-    prov:atLocation niiri:f89dda8a627ed3bf3657e54cbacfadcc ;
+    prov:atLocation niiri:8f64ab79b8b00ebd627396d051504046 ;
     prov:value "3.2669575214386"^^xsd:float ;
     nidm_equivalentZStatistic: "3.17496900913942"^^xsd:float ;
     nidm_pValueUncorrected: "0.000749262523860983"^^xsd:float ;
     nidm_pValueFWER: "0.999999999998632"^^xsd:float ;
     nidm_qValueFDR: "0.863075307004762"^^xsd:float .
 
-niiri:f89dda8a627ed3bf3657e54cbacfadcc
+niiri:8f64ab79b8b00ebd627396d051504046
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0090" ;
     nidm_coordinateVector: "[20,32,54]"^^xsd:string .
 
-niiri:4f84c599f455625d062b8e65b802ab8c prov:wasDerivedFrom niiri:a0bcd52b78a9ad004b1f13878095b584 .
+niiri:9ae75a88cde46be90790ef06a7e29dee prov:wasDerivedFrom niiri:eea8668c9a2e77333db7bb9162d0d4ef .
 
-niiri:87aeb61d09b8ed3ecc86948bd241107b
+niiri:7e114fc2dca77ff7f26aca5c69c3b36c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0091" ;
-    prov:atLocation niiri:5f9fca926c517d3aea0593e330aa9bdd ;
+    prov:atLocation niiri:c125b47469686fd33678c1b78d004968 ;
     prov:value "3.26226496696472"^^xsd:float ;
     nidm_equivalentZStatistic: "3.17063765299814"^^xsd:float ;
     nidm_pValueUncorrected: "0.000760523733375762"^^xsd:float ;
     nidm_pValueFWER: "0.999999999998982"^^xsd:float ;
     nidm_qValueFDR: "0.867640730428823"^^xsd:float .
 
-niiri:5f9fca926c517d3aea0593e330aa9bdd
+niiri:c125b47469686fd33678c1b78d004968
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0091" ;
     nidm_coordinateVector: "[-60,-14,10]"^^xsd:string .
 
-niiri:87aeb61d09b8ed3ecc86948bd241107b prov:wasDerivedFrom niiri:315508af939cde7c660dac4093bd5f63 .
+niiri:7e114fc2dca77ff7f26aca5c69c3b36c prov:wasDerivedFrom niiri:dd0835679f1bd959157bd71b4d4ada4a .
 
-niiri:4d68f5ce2e83a0ebec736d32656f74f1
+niiri:65129edf8c444af2b8ae3ebfb73d5a95
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0092" ;
-    prov:atLocation niiri:e003e96d659ec853a8be0de10428a8b0 ;
+    prov:atLocation niiri:c218dfdf71b575e423a61a71046e3254 ;
     prov:value "3.25743293762207"^^xsd:float ;
     nidm_equivalentZStatistic: "3.16617663527645"^^xsd:float ;
     nidm_pValueUncorrected: "0.000772284854291594"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999251"^^xsd:float ;
     nidm_qValueFDR: "0.872516606801204"^^xsd:float .
 
-niiri:e003e96d659ec853a8be0de10428a8b0
+niiri:c218dfdf71b575e423a61a71046e3254
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0092" ;
     nidm_coordinateVector: "[-22,-94,28]"^^xsd:string .
 
-niiri:4d68f5ce2e83a0ebec736d32656f74f1 prov:wasDerivedFrom niiri:415cf023223ce3eb6f3ea193de2e66d0 .
+niiri:65129edf8c444af2b8ae3ebfb73d5a95 prov:wasDerivedFrom niiri:7cdc9365fde87ad8333e6618dc3a8a51 .
 
-niiri:8664244aebf3c8a36b9e9665e962c1ec
+niiri:3d4630be29adc78b6133a798da406017
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0093" ;
-    prov:atLocation niiri:39036215cb38b5650d990b5ece73ad97 ;
+    prov:atLocation niiri:e30ef537b55de5d1df0298565809152d ;
     prov:value "3.25416302680969"^^xsd:float ;
     nidm_equivalentZStatistic: "3.16315726358056"^^xsd:float ;
     nidm_pValueUncorrected: "0.000780339994975288"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999392"^^xsd:float ;
     nidm_qValueFDR: "0.874305136305167"^^xsd:float .
 
-niiri:39036215cb38b5650d990b5ece73ad97
+niiri:e30ef537b55de5d1df0298565809152d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0093" ;
     nidm_coordinateVector: "[-66,-46,8]"^^xsd:string .
 
-niiri:8664244aebf3c8a36b9e9665e962c1ec prov:wasDerivedFrom niiri:688e11a39a0754d2ec0a74d65774433a .
+niiri:3d4630be29adc78b6133a798da406017 prov:wasDerivedFrom niiri:7de4f98c4ea2239ac1a4b37fb8737ebb .
 
-niiri:9b9b2ef57e28b344957456512066c471
+niiri:3399f5c31ecf4ca8aaa4e0dc4d2629cb
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0094" ;
-    prov:atLocation niiri:f9b694a8cf7dc1b99809ac4c60026737 ;
+    prov:atLocation niiri:5ffd97e765bdcd6a40cee30a818bf20b ;
     prov:value "3.24836373329163"^^xsd:float ;
     nidm_equivalentZStatistic: "3.15780125799237"^^xsd:float ;
     nidm_pValueUncorrected: "0.000794819459152607"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999582"^^xsd:float ;
     nidm_qValueFDR: "0.881177035765112"^^xsd:float .
 
-niiri:f9b694a8cf7dc1b99809ac4c60026737
+niiri:5ffd97e765bdcd6a40cee30a818bf20b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0094" ;
     nidm_coordinateVector: "[-68,-34,-8]"^^xsd:string .
 
-niiri:9b9b2ef57e28b344957456512066c471 prov:wasDerivedFrom niiri:7a715e1614e6866276cb5725bccf59a3 .
+niiri:3399f5c31ecf4ca8aaa4e0dc4d2629cb prov:wasDerivedFrom niiri:392bbfa2f02e1783423c67df389a3772 .
 
-niiri:fc68fcdb2d7ea6ecf1b753ff553dab73
+niiri:b0d26737223ecac9b30bc4e6d357903d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0095" ;
-    prov:atLocation niiri:b26f7ba046631013d0386f159502667a ;
+    prov:atLocation niiri:724852999b8744da36a792174695ead8 ;
     prov:value "3.23741388320923"^^xsd:float ;
     nidm_equivalentZStatistic: "3.14768473672474"^^xsd:float ;
     nidm_pValueUncorrected: "0.000822845399445549"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999796"^^xsd:float ;
     nidm_qValueFDR: "0.899808991491498"^^xsd:float .
 
-niiri:b26f7ba046631013d0386f159502667a
+niiri:724852999b8744da36a792174695ead8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0095" ;
     nidm_coordinateVector: "[-16,2,64]"^^xsd:string .
 
-niiri:fc68fcdb2d7ea6ecf1b753ff553dab73 prov:wasDerivedFrom niiri:fcab5dc9b5ee7cb3164b6fcfb041800b .
+niiri:b0d26737223ecac9b30bc4e6d357903d prov:wasDerivedFrom niiri:e08ea74eba6d829dc8f77ccdfebbc2e1 .
 
-niiri:4b9d5324c991dbf9c955d16b6be9e350
+niiri:e2f4bde66682178e0070983ec98c509e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0096" ;
-    prov:atLocation niiri:2f724fbf26dc28087784e44e413cace9 ;
+    prov:atLocation niiri:ba9cc9e29049445b143af1ec4b4403bf ;
     prov:value "3.23679161071777"^^xsd:float ;
     nidm_equivalentZStatistic: "3.14710967833961"^^xsd:float ;
     nidm_pValueUncorrected: "0.000824465484375092"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999804"^^xsd:float ;
     nidm_qValueFDR: "0.899808991491498"^^xsd:float .
 
-niiri:2f724fbf26dc28087784e44e413cace9
+niiri:ba9cc9e29049445b143af1ec4b4403bf
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0096" ;
     nidm_coordinateVector: "[-56,34,-20]"^^xsd:string .
 
-niiri:4b9d5324c991dbf9c955d16b6be9e350 prov:wasDerivedFrom niiri:62711d2ee0c0429ed4fbe29698cac6fd .
+niiri:e2f4bde66682178e0070983ec98c509e prov:wasDerivedFrom niiri:81ce1dbb2b4b3915a17f1002f7600876 .
 
-niiri:86a14c6a5207006da29629c9a675a39b
+niiri:a5e53303ae16c0a4417cd3327ff317ba
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0097" ;
-    prov:atLocation niiri:51322f21443be51e4277c524c474bd84 ;
+    prov:atLocation niiri:9b75309624d284042d8f748c6299b979 ;
     prov:value "3.22331190109253"^^xsd:float ;
     nidm_equivalentZStatistic: "3.13464894829369"^^xsd:float ;
     nidm_pValueUncorrected: "0.000860299398633191"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999921"^^xsd:float ;
     nidm_qValueFDR: "0.917823543835361"^^xsd:float .
 
-niiri:51322f21443be51e4277c524c474bd84
+niiri:9b75309624d284042d8f748c6299b979
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0097" ;
     nidm_coordinateVector: "[42,-86,12]"^^xsd:string .
 
-niiri:86a14c6a5207006da29629c9a675a39b prov:wasDerivedFrom niiri:485ed7c2aeeaf61df445bf323937617d .
+niiri:a5e53303ae16c0a4417cd3327ff317ba prov:wasDerivedFrom niiri:8ab01cc9ec9b9c9144318b6ebf4b61e5 .
 
-niiri:746e32e138528d33390c23c66ccd9226
+niiri:acda002ca084ac39e0dc294ad4a29af7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0098" ;
-    prov:atLocation niiri:e377146f96f9a7ef6738156416ebfa62 ;
+    prov:atLocation niiri:d76d5a8db54f907ce0bcdb7be6430159 ;
     prov:value "3.19609522819519"^^xsd:float ;
     nidm_equivalentZStatistic: "3.10946777700093"^^xsd:float ;
     nidm_pValueUncorrected: "0.000937123635013748"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999988"^^xsd:float ;
     nidm_qValueFDR: "0.958204454708765"^^xsd:float .
 
-niiri:e377146f96f9a7ef6738156416ebfa62
+niiri:d76d5a8db54f907ce0bcdb7be6430159
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0098" ;
     nidm_coordinateVector: "[14,40,20]"^^xsd:string .
 
-niiri:746e32e138528d33390c23c66ccd9226 prov:wasDerivedFrom niiri:78ffd46fab5c7ea256ba49f6155cee5b .
+niiri:acda002ca084ac39e0dc294ad4a29af7 prov:wasDerivedFrom niiri:e00f285b0f3ca710fd516c8d96d4953b .
 
-niiri:9f01d6bb46569d89f6d406f8c1ec9c29
+niiri:1aebec9df0ae7e94b35fcd5f1681e2b8
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0099" ;
-    prov:atLocation niiri:16ab3321bd5f8419971b333165a1c5bb ;
+    prov:atLocation niiri:e3d8e69139ddc1af81e4b6a9cc70c133 ;
     prov:value "3.19474077224731"^^xsd:float ;
     nidm_equivalentZStatistic: "3.10821385730133"^^xsd:float ;
     nidm_pValueUncorrected: "0.000941109068576473"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999989"^^xsd:float ;
     nidm_qValueFDR: "0.958204454708765"^^xsd:float .
 
-niiri:16ab3321bd5f8419971b333165a1c5bb
+niiri:e3d8e69139ddc1af81e4b6a9cc70c133
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0099" ;
     nidm_coordinateVector: "[-44,-42,-36]"^^xsd:string .
 
-niiri:9f01d6bb46569d89f6d406f8c1ec9c29 prov:wasDerivedFrom niiri:1273746a68b63344576d89035c4af958 .
+niiri:1aebec9df0ae7e94b35fcd5f1681e2b8 prov:wasDerivedFrom niiri:b113d084583b1c858c15b076e563ba0c .
 
-niiri:4dab90a4878fc6fe161f501468e5811b
+niiri:e95fde56ae83d5db12a5db6e6b137be0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0100" ;
-    prov:atLocation niiri:c7174cd0ebcbf60604768ef1bba962b1 ;
+    prov:atLocation niiri:81fbc09a7af80e50862290bf64c5c485 ;
     prov:value "3.18584132194519"^^xsd:float ;
     nidm_equivalentZStatistic: "3.0999731910723"^^xsd:float ;
     nidm_pValueUncorrected: "0.000967690796773613"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999994"^^xsd:float ;
     nidm_qValueFDR: "1"^^xsd:float .
 
-niiri:c7174cd0ebcbf60604768ef1bba962b1
+niiri:81fbc09a7af80e50862290bf64c5c485
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0100" ;
     nidm_coordinateVector: "[-16,4,60]"^^xsd:string .
 
-niiri:4dab90a4878fc6fe161f501468e5811b prov:wasDerivedFrom niiri:00d8da85844fdb0d453c7cffeb50aef0 .
+niiri:e95fde56ae83d5db12a5db6e6b137be0 prov:wasDerivedFrom niiri:f9a8bd72695ec56fe97eefd5b04d42d4 .
 

--- a/spmexport/ex_spm_default/nidm.json
+++ b/spmexport/ex_spm_default/nidm.json
@@ -1,0 +1,10522 @@
+{
+  "prefix": {
+    "nidm": "http://purl.org/nidash/nidm#",
+    "niiri": "http://iri.nidash.org/",
+    "spm": "http://purl.org/nidash/spm#",
+    "neurolex": "http://neurolex.org/wiki/",
+    "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/",
+    "dct": "http://purl.org/dc/terms/",
+    "nfo": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#",
+    "dc": "http://purl.org/dc/elements/1.1/",
+    "dctype": "http://purl.org/dc/dcmitype/",
+    "obo": "http://purl.obolibrary.org/obo/",
+    "nidm_NIDMResults": "http://purl.org/nidash/nidm#NIDM_0000027",
+    "nidm_version": "http://purl.org/nidash/nidm#NIDM_0000127",
+    "nidm_spm_results_nidm": "http://purl.org/nidash/nidm#NIDM_0000168",
+    "nidm_softwareVersion": "http://purl.org/nidash/nidm#NIDM_0000122",
+    "nidm_NIDMResultsExport": "http://purl.org/nidash/nidm#NIDM_0000166"
+  },
+  "entity": {
+    "niiri:4e5cde201dcf24532399b37950fbd970": {
+      "prov:type": [
+        {
+        "$": "prov:Bundle",
+        "type": "xsd:QName"
+        },
+        {
+        "$": "nidm_NIDMResults:",
+        "type": "xsd:QName"
+        }
+      ],
+      "prov:label": {
+        "$": "NIDM-Results",
+        "type": "xsd:string"
+      },
+      "nidm_version:": {
+        "$": "1.3.0",
+        "type": "xsd:string"
+      }
+    }
+  },
+  "activity": {
+    "niiri:b4b82a058bfac16201e2b70c727d1328": {
+      "prov:type": {
+        "$": "nidm_NIDMResultsExport:",
+        "type": "xsd:QName"
+      },
+      "prov:label": {
+        "$": "NIDM-Results export",
+        "type": "xsd:string"
+      }
+    }
+  },
+  "agent": {
+    "niiri:50df5922ab028839c3e8faae100dc78f": {
+      "prov:type": [
+        {
+        "$": "nidm_spm_results_nidm:",
+        "type": "xsd:QName"
+        },
+        {
+        "$": "prov:SoftwareAgent",
+        "type": "xsd:QName"
+        }
+      ],
+      "prov:label": {
+        "$": "spm_results_nidm",
+        "type": "xsd:string"
+      },
+      "nidm_softwareVersion:": {
+        "$": "12.7057",
+        "type": "xsd:string"
+      }
+    }
+  },
+  "wasGeneratedBy": {
+    "_:wGB5": {
+      "prov:entity": "niiri:4e5cde201dcf24532399b37950fbd970",
+      "prov:activity": "niiri:b4b82a058bfac16201e2b70c727d1328",
+      "prov:time": "2017-04-19T12:18:02"
+    }
+  },
+  "wasAssociatedWith": {
+    "_:wAW4": {
+      "prov:activity": "niiri:b4b82a058bfac16201e2b70c727d1328",
+      "prov:agent": "niiri:50df5922ab028839c3e8faae100dc78f"
+    }
+  },
+  "bundle": {
+    "niiri:4e5cde201dcf24532399b37950fbd970": {
+    "prefix": {
+        "nidm_softwareVersion": "http://purl.org/nidash/nidm#NIDM_0000122",
+        "nidm_CoordinateSpace": "http://purl.org/nidash/nidm#NIDM_0000016",
+        "nidm_voxelToWorldMapping": "http://purl.org/nidash/nidm#NIDM_0000132",
+        "nidm_voxelUnits": "http://purl.org/nidash/nidm#NIDM_0000133",
+        "nidm_voxelSize": "http://purl.org/nidash/nidm#NIDM_0000131",
+        "nidm_inWorldCoordinateSystem": "http://purl.org/nidash/nidm#NIDM_0000105",
+        "nidm_numberOfDimensions": "http://purl.org/nidash/nidm#NIDM_0000112",
+        "nidm_dimensionsInVoxels": "http://purl.org/nidash/nidm#NIDM_0000090",
+        "nlx_Imaginginstrument": "http://uri.neuinfo.org/nif/nifstd/birnlex_2094",
+        "nlx_Magneticresonanceimagingscanner": "http://uri.neuinfo.org/nif/nifstd/birnlex_2100",
+        "nidm_grandMeanScaling": "http://purl.org/nidash/nidm#NIDM_0000096",
+        "nidm_targetIntensity": "http://purl.org/nidash/nidm#NIDM_0000124",
+        "nidm_hasMRIProtocol": "http://purl.org/nidash/nidm#NIDM_0000172",
+        "nlx_FunctionalMRIprotocol": "http://uri.neuinfo.org/nif/nifstd/birnlex_2250",
+        "nidm_Data": "http://purl.org/nidash/nidm#NIDM_0000169",
+        "spm_DCTDriftModel": "http://purl.org/nidash/spm#SPM_0000002",
+        "spm_SPMsDriftCutoffPeriod": "http://purl.org/nidash/spm#SPM_0000001",
+        "nidm_hasDriftModel": "http://purl.org/nidash/nidm#NIDM_0000088",
+        "nidm_hasHRFBasis": "http://purl.org/nidash/nidm#NIDM_0000102",
+        "spm_SPMsCanonicalHRF": "http://purl.org/nidash/spm#SPM_0000004",
+        "nidm_DesignMatrix": "http://purl.org/nidash/nidm#NIDM_0000019",
+        "nidm_regressorNames": "http://purl.org/nidash/nidm#NIDM_0000021",
+        "nidm_hasErrorDependence": "http://purl.org/nidash/nidm#NIDM_0000100",
+        "obo_Toeplitzcovariancestructure": "http://purl.obolibrary.org/obo/STATO_0000357",
+        "nidm_dependenceMapWiseDependence": "http://purl.org/nidash/nidm#NIDM_0000089",
+        "nidm_ConstantParameter": "http://purl.org/nidash/nidm#NIDM_0000072",
+        "nidm_errorVarianceHomogeneous": "http://purl.org/nidash/nidm#NIDM_0000094",
+        "nidm_varianceMapWiseDependence": "http://purl.org/nidash/nidm#NIDM_0000126",
+        "nidm_IndependentParameter": "http://purl.org/nidash/nidm#NIDM_0000073",
+        "nidm_withEstimationMethod": "http://purl.org/nidash/nidm#NIDM_0000134",
+        "obo_generalizedleastsquaresestimation": "http://purl.obolibrary.org/obo/STATO_0000372",
+        "nidm_ErrorModel": "http://purl.org/nidash/nidm#NIDM_0000023",
+        "nidm_hasErrorDistribution": "http://purl.org/nidash/nidm#NIDM_0000101",
+        "obo_normaldistribution": "http://purl.obolibrary.org/obo/STATO_0000227",
+        "nidm_ModelParametersEstimation": "http://purl.org/nidash/nidm#NIDM_0000056",
+        "nidm_MaskMap": "http://purl.org/nidash/nidm#NIDM_0000054",
+        "nidm_isUserDefined": "http://purl.org/nidash/nidm#NIDM_0000106",
+        "nidm_inCoordinateSpace": "http://purl.org/nidash/nidm#NIDM_0000104",
+        "nidm_GrandMeanMap": "http://purl.org/nidash/nidm#NIDM_0000033",
+        "nidm_maskedMedian": "http://purl.org/nidash/nidm#NIDM_0000107",
+        "nidm_ParameterEstimateMap": "http://purl.org/nidash/nidm#NIDM_0000061",
+        "nidm_ResidualMeanSquaresMap": "http://purl.org/nidash/nidm#NIDM_0000066",
+        "nidm_ReselsPerVoxelMap": "http://purl.org/nidash/nidm#NIDM_0000144",
+        "obo_contrastweightmatrix": "http://purl.obolibrary.org/obo/STATO_0000323",
+        "nidm_statisticType": "http://purl.org/nidash/nidm#NIDM_0000123",
+        "obo_tstatistic": "http://purl.obolibrary.org/obo/STATO_0000176",
+        "nidm_contrastName": "http://purl.org/nidash/nidm#NIDM_0000085",
+        "nidm_ContrastEstimation": "http://purl.org/nidash/nidm#NIDM_0000001",
+        "nidm_StatisticMap": "http://purl.org/nidash/nidm#NIDM_0000076",
+        "nidm_errorDegreesOfFreedom": "http://purl.org/nidash/nidm#NIDM_0000093",
+        "nidm_effectDegreesOfFreedom": "http://purl.org/nidash/nidm#NIDM_0000091",
+        "nidm_ContrastMap": "http://purl.org/nidash/nidm#NIDM_0000002",
+        "nidm_ContrastStandardErrorMap": "http://purl.org/nidash/nidm#NIDM_0000013",
+        "obo_statistic": "http://purl.obolibrary.org/obo/STATO_0000039",
+        "nidm_PValueUncorrected": "http://purl.org/nidash/nidm#NIDM_0000160",
+        "obo_FWERadjustedpvalue": "http://purl.obolibrary.org/obo/OBI_0001265",
+        "nidm_HeightThreshold": "http://purl.org/nidash/nidm#NIDM_0000034",
+        "nidm_equivalentThreshold": "http://purl.org/nidash/nidm#NIDM_0000161",
+        "nidm_ExtentThreshold": "http://purl.org/nidash/nidm#NIDM_0000026",
+        "nidm_clusterSizeInVoxels": "http://purl.org/nidash/nidm#NIDM_0000084",
+        "nidm_clusterSizeInResels": "http://purl.org/nidash/nidm#NIDM_0000156",
+        "nidm_PeakDefinitionCriteria": "http://purl.org/nidash/nidm#NIDM_0000063",
+        "nidm_maxNumberOfPeaksPerCluster": "http://purl.org/nidash/nidm#NIDM_0000108",
+        "nidm_minDistanceBetweenPeaks": "http://purl.org/nidash/nidm#NIDM_0000109",
+        "nidm_ClusterDefinitionCriteria": "http://purl.org/nidash/nidm#NIDM_0000007",
+        "nidm_hasConnectivityCriterion": "http://purl.org/nidash/nidm#NIDM_0000099",
+        "nidm_voxel18connected": "http://purl.org/nidash/nidm#NIDM_0000128",
+        "nidm_Inference": "http://purl.org/nidash/nidm#NIDM_0000049",
+        "nidm_hasAlternativeHypothesis": "http://purl.org/nidash/nidm#NIDM_0000097",
+        "nidm_OneTailedTest": "http://purl.org/nidash/nidm#NIDM_0000060",
+        "nidm_SearchSpaceMaskMap": "http://purl.org/nidash/nidm#NIDM_0000068",
+        "nidm_searchVolumeInVoxels": "http://purl.org/nidash/nidm#NIDM_0000121",
+        "nidm_searchVolumeInUnits": "http://purl.org/nidash/nidm#NIDM_0000136",
+        "nidm_reselSizeInVoxels": "http://purl.org/nidash/nidm#NIDM_0000148",
+        "nidm_searchVolumeInResels": "http://purl.org/nidash/nidm#NIDM_0000149",
+        "spm_searchVolumeReselsGeometry": "http://purl.org/nidash/spm#SPM_0000010",
+        "nidm_noiseFWHMInVoxels": "http://purl.org/nidash/nidm#NIDM_0000159",
+        "nidm_noiseFWHMInUnits": "http://purl.org/nidash/nidm#NIDM_0000157",
+        "nidm_randomFieldStationarity": "http://purl.org/nidash/nidm#NIDM_0000120",
+        "nidm_expectedNumberOfVoxelsPerCluster": "http://purl.org/nidash/nidm#NIDM_0000143",
+        "nidm_expectedNumberOfClusters": "http://purl.org/nidash/nidm#NIDM_0000141",
+        "nidm_heightCriticalThresholdFWE05": "http://purl.org/nidash/nidm#NIDM_0000147",
+        "nidm_heightCriticalThresholdFDR05": "http://purl.org/nidash/nidm#NIDM_0000146",
+        "spm_smallestSignificantClusterSizeInVoxelsFWE05": "http://purl.org/nidash/spm#SPM_0000014",
+        "spm_smallestSignificantClusterSizeInVoxelsFDR05": "http://purl.org/nidash/spm#SPM_0000013",
+        "nidm_ExcursionSetMap": "http://purl.org/nidash/nidm#NIDM_0000025",
+        "nidm_numberOfSupraThresholdClusters": "http://purl.org/nidash/nidm#NIDM_0000111",
+        "nidm_pValue": "http://purl.org/nidash/nidm#NIDM_0000114",
+        "nidm_hasClusterLabelsMap": "http://purl.org/nidash/nidm#NIDM_0000098",
+        "nidm_hasMaximumIntensityProjection": "http://purl.org/nidash/nidm#NIDM_0000138",
+        "nidm_ClusterLabelsMap": "http://purl.org/nidash/nidm#NIDM_0000008",
+        "nidm_SupraThresholdCluster": "http://purl.org/nidash/nidm#NIDM_0000070",
+        "nidm_pValueUncorrected": "http://purl.org/nidash/nidm#NIDM_0000116",
+        "nidm_pValueFWER": "http://purl.org/nidash/nidm#NIDM_0000115",
+        "nidm_qValueFDR": "http://purl.org/nidash/nidm#NIDM_0000119",
+        "nidm_clusterLabelId": "http://purl.org/nidash/nidm#NIDM_0000082",
+        "nidm_Peak": "http://purl.org/nidash/nidm#NIDM_0000062",
+        "nidm_equivalentZStatistic": "http://purl.org/nidash/nidm#NIDM_0000092",
+        "nidm_Coordinate": "http://purl.org/nidash/nidm#NIDM_0000015",
+        "nidm_coordinateVector": "http://purl.org/nidash/nidm#NIDM_0000086"
+    },
+    "entity": {
+        "niiri:b2a98667786a7f2349a2658d9fd2f766": {
+            "prov:type": {
+                "$": "nidm_CoordinateSpace:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Coordinate space 1",
+                "type": "xsd:string"
+            },
+            "nidm_voxelToWorldMapping:": {
+                "$": "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]",
+                "type": "xsd:string"
+            },
+            "nidm_voxelUnits:": {
+                "$": "[\"mm\", \"mm\", \"mm\"]",
+                "type": "xsd:string"
+            },
+            "nidm_voxelSize:": {
+                "$": "[2, 2, 2]",
+                "type": "xsd:string"
+            },
+            "nidm_inWorldCoordinateSystem:": {
+                "$": "nidm_Ixi549CoordinateSystem:",
+                "type": "xsd:string"
+            },
+            "nidm_numberOfDimensions:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_dimensionsInVoxels:": {
+                "$": "[79,95,79]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d8cb12a2013805cec8a0537c545e4c27": {
+            "prov:type": [
+                {
+                "$": "prov:Collection",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Data:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Data",
+                "type": "xsd:string"
+            },
+            "nidm_grandMeanScaling:": {
+                "$": "true",
+                "type": "xsd:boolean"
+            },
+            "nidm_targetIntensity:": {
+                "$": "100",
+                "type": "xsd:float"
+            },
+            "nidm_hasMRIProtocol:": {
+                "$": "nlx_FunctionalMRIprotocol:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:960c1b74729818f390814df5d8a07151": {
+            "prov:type": {
+                "$": "spm_DCTDriftModel:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "SPM's DCT Drift Model",
+                "type": "xsd:string"
+            },
+            "spm_SPMsDriftCutoffPeriod:": {
+                "$": "128",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d44fca7b57060de1677bc74daa15aa89": {
+            "prov:type": {
+                "$": "nidm_DesignMatrix:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "DesignMatrix.csv",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "DesignMatrix.csv",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "text/csv",
+                "type": "xsd:string"
+            },
+            "dc:description": {
+                "$": "niiri:8787c98cac2e7989b33c3fc7a9c9f2fa",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Design Matrix",
+                "type": "xsd:string"
+            },
+            "nidm_regressorNames:": {
+                "$": "[\"Sn(1) to*bf(1)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) constant\"]",
+                "type": "xsd:string"
+            },
+            "nidm_hasDriftModel:": {
+                "$": "niiri:960c1b74729818f390814df5d8a07151",
+                "type": "xsd:string"
+            },
+            "nidm_hasHRFBasis:": {
+                "$": "spm_SPMsCanonicalHRF:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8787c98cac2e7989b33c3fc7a9c9f2fa": {
+            "prov:type": {
+                "$": "dctype:Image",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "DesignMatrix.png",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "DesignMatrix.png",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/png",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ca9137874e81e1af901b6acfc7ff391a": {
+            "prov:type": {
+                "$": "nidm_ErrorModel:",
+                "type": "xsd:QName"
+            },
+            "nidm_hasErrorDistribution:": {
+                "$": "obo_normaldistribution:",
+                "type": "xsd:string"
+            },
+            "nidm_hasErrorDependence:": {
+                "$": "obo_Toeplitzcovariancestructure:",
+                "type": "xsd:string"
+            },
+            "nidm_dependenceMapWiseDependence:": {
+                "$": "nidm_ConstantParameter:",
+                "type": "xsd:string"
+            },
+            "nidm_errorVarianceHomogeneous:": {
+                "$": "true",
+                "type": "xsd:boolean"
+            },
+            "nidm_varianceMapWiseDependence:": {
+                "$": "nidm_IndependentParameter:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:218e9dabb7ce7346a5fc5d0e4d956c0f": {
+            "prov:type": {
+                "$": "nidm_MaskMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "Mask.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nidm_isUserDefined:": {
+                "$": "false",
+                "type": "xsd:boolean"
+            },
+            "nfo:fileName": {
+                "$": "Mask.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Mask",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b2a98667786a7f2349a2658d9fd2f766",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e5b0a4f7beeecbff1514adf4c11f02ab": {
+            "prov:type": {
+                "$": "nidm_MaskMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "mask.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "36929e1f5f4143bd9cc818cd896a25f129961fab208c3a4438555f40444c08347b359142ee8c53ece6e8cca1627f49db0788a1fd3b9e2ecaef61999c6c6c67ac",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b6dedebe44bd4dfcd70f1e56cc87d8e1": {
+            "prov:type": {
+                "$": "nidm_GrandMeanMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "GrandMean.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "GrandMean.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Grand Mean Map",
+                "type": "xsd:string"
+            },
+            "nidm_maskedMedian:": {
+                "$": "111.557487487793",
+                "type": "xsd:float"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b2a98667786a7f2349a2658d9fd2f766",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "512157cc6bff89d9343a09b4068226eb3edd64a8cbcee861f06231767fae6f8d4819921182adebee083a9bf309afd65529ab04a92f0aa6b0038c8098550f6124",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:55bbc45f54dbafed48a1b302258b19a8": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0001.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0001.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 1",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b2a98667786a7f2349a2658d9fd2f766",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a8f1001f03928204508b6ab86da06246": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0001.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3625bdf3e80d5e9a25b486f9360a1378": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0002.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0002.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 2",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b2a98667786a7f2349a2658d9fd2f766",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:91a5ac743cdb91c1d48fca362a3241fc": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0002.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:67cc3fa692b977e0ac54b72dec7e4384": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0003.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0003.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 3",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b2a98667786a7f2349a2658d9fd2f766",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:fe38b6202e69c84f88ece9b51a9a99c3": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0003.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b49762a3483888f79a5d5b06f51a25d1": {
+            "prov:type": {
+                "$": "nidm_ResidualMeanSquaresMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ResidualMeanSquares.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ResidualMeanSquares.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Residual Mean Squares Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b2a98667786a7f2349a2658d9fd2f766",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "991abf563d795a43b1e2eef8643e57023f2e0b090b2031f05f839321fc0643df6f71d423486a1021519b6dc82f6b0f563e19f3fbd50cb16063bed54a0e192d3e",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:685419d4a3159548c52f7aa12e55d28b": {
+            "prov:type": {
+                "$": "nidm_ResidualMeanSquaresMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "ResMS.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "40b28d03fcf9a2f60b11f10d7fb83bf3618b234fb5aedf09df644cb7cbb6aab8c9f468897c1078166d455a3d04a83f4e3bf762cfca0b4ea982d7a4e406849f18",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:982b6bb49828f15a05294a1c58d03b8b": {
+            "prov:type": {
+                "$": "nidm_ReselsPerVoxelMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ReselsPerVoxel.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ReselsPerVoxel.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Resels per Voxel Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b2a98667786a7f2349a2658d9fd2f766",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "1a3f9216e145249ccc0b14b2bc337d6b38b81ad45e32768001fb22b35f0c2c0f3e2bce013b40c85f7dc0fc62723ac761ee7f7e1e6aff128a05f0ba7b8b8202a3",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:cad5e3e80a900432c8b3e58a397f0b76": {
+            "prov:type": {
+                "$": "nidm_ReselsPerVoxelMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "RPV.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "4f76663162857f6b38b2a45a63b15a23b2ca8b338c283b69c1e71f2ea2f43797d045a733cd14e845be9c12f8b8f84d3931c599a08e8f6d77e99fab46ad87ab8f",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f9498d3b2bcc41a724d906ee170c4316": {
+            "prov:type": {
+                "$": "obo_contrastweightmatrix:",
+                "type": "xsd:QName"
+            },
+            "nidm_statisticType:": {
+                "$": "obo_tstatistic:",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast: tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "[1, 0, 0]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e461c8f3ab4826650944bec7b1912e84": {
+            "prov:type": {
+                "$": "nidm_StatisticMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "TStatistic.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "TStatistic.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "T-Statistic Map: tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "nidm_statisticType:": {
+                "$": "obo_tstatistic:",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "nidm_errorDegreesOfFreedom:": {
+                "$": "97.9999999998522",
+                "type": "xsd:float"
+            },
+            "nidm_effectDegreesOfFreedom:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b2a98667786a7f2349a2658d9fd2f766",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "9e1714c2d86a050b38b4e10a4d2d23253a24c5e1d228ae16a9c3be8872739278505ac0729ecab54265a717e3a54f9f782d0ed72eea904e0d482a6072bb817bd4",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:901cc6a5ebd5a3b326b9725834bdddca": {
+            "prov:type": {
+                "$": "nidm_StatisticMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "spmT_0001.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "d288b1b0f117f64502555da13c5398dffa5bf5ff0b58951510e43d5388755bc185798802a92e98a07c7e313c6991066d2908f2a44aa5153ba23433da1335970f",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f9b320bdd9480281306f90d15b0ab8be": {
+            "prov:type": {
+                "$": "nidm_ContrastMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "Contrast.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "Contrast.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast Map: tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b2a98667786a7f2349a2658d9fd2f766",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "fc5e2ad175243ee496db98f9b2e1b235c4c3bae1a8d7122ce461c897b537e40c49dfee5d6cf20f71c6a2bb9b5f0760fcb4ecd8fe2e9428910ef3d60d8f3c56a9",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ed3281c40be1462539e94647abd36a73": {
+            "prov:type": {
+                "$": "nidm_ContrastMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "con_0001.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "d4aa46b3603ba508578e39751262d528cf6d1ed2e722ec46f1cd8194c50591e46b229deb8cb4f72d1b7e0e2640f3e6604be7a335301c5c8357f453e5d0d4daf2",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a8574ab2053ab027cf06dd5d2a5a785a": {
+            "prov:type": {
+                "$": "nidm_ContrastStandardErrorMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ContrastStandardError.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ContrastStandardError.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast Standard Error Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b2a98667786a7f2349a2658d9fd2f766",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "791d48f5d1adb15079a5289271ce0c4b95c56d69bfdb3e5d41b0d24eb538d3075e1cdd15502494b5a5a18c16eaa2153cb4847a996043fa48cdaf26e938a2576d",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:dd97c56b32bf917687b52d95e2b13099": {
+            "prov:type": [
+                {
+                "$": "nidm_HeightThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_PValueUncorrected:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Height Threshold: p<0.001 (unc.)",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "0.000999500158000544",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentThreshold:": [
+                {
+                "$": "niiri:5ca71150749a0c1b73185241479322c6",
+                "type": "xsd:string"
+                },
+                {
+                "$": "niiri:34949c0c34ebc75ccb4b4818296e0a77",
+                "type": "xsd:string"
+                }
+            ]
+        },
+        "niiri:5ca71150749a0c1b73185241479322c6": {
+            "prov:type": [
+                {
+                "$": "nidm_HeightThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_statistic:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Height Threshold: T=3.175486)",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.17548628637284",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:34949c0c34ebc75ccb4b4818296e0a77": {
+            "prov:type": [
+                {
+                "$": "nidm_HeightThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_FWERadjustedpvalue:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Height Threshold: p<1.000000 (FWE)",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "0.999999999999997",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:99724284af9cacae301790c375fe6b15": {
+            "prov:type": [
+                {
+                "$": "nidm_ExtentThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_statistic:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Extent Threshold: k>=0",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "0",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentThreshold:": [
+                {
+                "$": "niiri:e135cf296ac53187ccabf232f6d1faac",
+                "type": "xsd:string"
+                },
+                {
+                "$": "niiri:70f26b0e75559a8ee50b5623efa62ae9",
+                "type": "xsd:string"
+                }
+            ]
+        },
+        "niiri:e135cf296ac53187ccabf232f6d1faac": {
+            "prov:type": [
+                {
+                "$": "nidm_ExtentThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_FWERadjustedpvalue:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Extent Threshold",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:70f26b0e75559a8ee50b5623efa62ae9": {
+            "prov:type": [
+                {
+                "$": "nidm_ExtentThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_PValueUncorrected:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Extent Threshold",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:dfa8c97f4a46388cf4a9bb1364e0d92e": {
+            "prov:type": {
+                "$": "nidm_PeakDefinitionCriteria:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak Definition Criteria",
+                "type": "xsd:string"
+            },
+            "nidm_maxNumberOfPeaksPerCluster:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_minDistanceBetweenPeaks:": {
+                "$": "8",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:5bd0a1af1bb03071db4c49f47a4396a1": {
+            "prov:type": {
+                "$": "nidm_ClusterDefinitionCriteria:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Cluster Connectivity Criterion: 18",
+                "type": "xsd:string"
+            },
+            "nidm_hasConnectivityCriterion:": {
+                "$": "nidm_voxel18connected:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b9b82d6e97f1bad3e6178276b982be04": {
+            "prov:type": {
+                "$": "nidm_SearchSpaceMaskMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "SearchSpaceMask.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "SearchSpaceMask.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Search Space Mask Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b2a98667786a7f2349a2658d9fd2f766",
+                "type": "xsd:string"
+            },
+            "nidm_searchVolumeInVoxels:": {
+                "$": "223057",
+                "type": "xsd:int"
+            },
+            "nidm_searchVolumeInUnits:": {
+                "$": "1784456",
+                "type": "xsd:float"
+            },
+            "nidm_reselSizeInVoxels:": {
+                "$": "65.5786964036542",
+                "type": "xsd:float"
+            },
+            "nidm_searchVolumeInResels:": {
+                "$": "3155.84193266257",
+                "type": "xsd:float"
+            },
+            "spm_searchVolumeReselsGeometry:": {
+                "$": "[6, 97.8140592306853, 965.938819261507, 3155.84193266257]",
+                "type": "xsd:string"
+            },
+            "nidm_noiseFWHMInVoxels:": {
+                "$": "[4.09118640605185, 4.0346308705955, 3.97291894351243]",
+                "type": "xsd:string"
+            },
+            "nidm_noiseFWHMInUnits:": {
+                "$": "[8.18237281210369, 8.069261741191, 7.94583788702486]",
+                "type": "xsd:string"
+            },
+            "nidm_randomFieldStationarity:": {
+                "$": "true",
+                "type": "xsd:boolean"
+            },
+            "nidm_expectedNumberOfVoxelsPerCluster:": {
+                "$": "7.21748994812991",
+                "type": "xsd:float"
+            },
+            "nidm_expectedNumberOfClusters:": {
+                "$": "33.5642173578105",
+                "type": "xsd:float"
+            },
+            "nidm_heightCriticalThresholdFWE05:": {
+                "$": "5.30963135104407",
+                "type": "xsd:float"
+            },
+            "nidm_heightCriticalThresholdFDR05:": {
+                "$": "4.69981384277344",
+                "type": "xsd:float"
+            },
+            "crypto:sha512": {
+                "$": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876",
+                "type": "xsd:string"
+            },
+            "spm_smallestSignificantClusterSizeInVoxelsFWE05:": {
+                "$": "116",
+                "type": "xsd:int"
+            },
+            "spm_smallestSignificantClusterSizeInVoxelsFDR05:": {
+                "$": "61",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:80c10806c0beeee32d27292ced29500f": {
+            "prov:type": {
+                "$": "nidm_ExcursionSetMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ExcursionSet.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ExcursionSet.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Excursion Set Map",
+                "type": "xsd:string"
+            },
+            "nidm_numberOfSupraThresholdClusters:": {
+                "$": "81",
+                "type": "xsd:int"
+            },
+            "nidm_pValue:": {
+                "$": "3.03579383853503e-12",
+                "type": "xsd:float"
+            },
+            "nidm_hasClusterLabelsMap:": {
+                "$": "niiri:e52ca30928761b2a737cfd8aadc61c9a",
+                "type": "xsd:string"
+            },
+            "nidm_hasMaximumIntensityProjection:": {
+                "$": "niiri:a8dea88063f0005998cb2504c3d1c11d",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b2a98667786a7f2349a2658d9fd2f766",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "014dbfd7824bc4040c0b428b073ff43721cf78f5e15bbfe3edf01dad68c62eac0a4e978b1cd38dcae91777937b9f5257fb28329cf8c317223be18fa70c2a2ed6",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e52ca30928761b2a737cfd8aadc61c9a": {
+            "prov:type": {
+                "$": "nidm_ClusterLabelsMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ClusterLabels.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ClusterLabels.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Cluster Labels Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b2a98667786a7f2349a2658d9fd2f766",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "06977d4de4ad0066cd008492aeee125405b5fc4a1c6fe605211b4c16a2eaa09a2793f430dd5dec0d1b5fce0d872b2fa96b8083d6cdbe719e497031b5b9d08256",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a8dea88063f0005998cb2504c3d1c11d": {
+            "prov:type": {
+                "$": "dctype:Image",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "MaximumIntensityProjection.png",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "MaximumIntensityProjection.png",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/png",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:749b77e80ffd0ed4ca77337a7893adc6": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0001",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1804",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "27.5089335246298",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.46511379022666e-21",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "5.93371085041799e-20",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "1",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:e2c6b47be3a342a41d95bfc20852c868": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0002",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "356",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "5.42859220330831",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.6728855149243e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "2.91098190852157e-06",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1.17083954451478e-06",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "2",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:7d345f60b278ac792f989f5862ed9684": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0003",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "5090",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "77.6166694237059",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.51031151932561e-42",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "2.03335233065374e-40",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "3",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:78cf678fc1d8e63075a90d654ff6f858": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0004",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "766",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "11.6806225498151",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.69891112070838e-12",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "5.70226088569825e-11",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "4.58706002591263e-11",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "4",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:d1df03018bbf137ff5ef2da545a3e8bf": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0005",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "54",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.823438143198452",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00980531403246826",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.280434478478115",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.061094648971533",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "5",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:168af8a06bcba9be4ec76231fb932bcd": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0006",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "285",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "4.34592353354738",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.15539697056139e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "2.73725770201239e-05",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "9.4369593516496e-06",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "6",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:3b36a7334ca09a3c238279baec873119": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0007",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "395",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "6.02329752895164",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.70020762554596e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "9.06303145864484e-07",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "4.37433635338446e-07",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "7",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:58bff46dfff701e885b3a3a8403d6869": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0008",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "116",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.7688671224263",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000452977534465859",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0150888416289883",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00366911802917346",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "8",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:2bcab9b8311e435ff15509af340ba45e": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0009",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "19",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.289728235569826",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0997597824989178",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.964858026030202",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.278639392496977",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "9",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:932a73d91444fc459c9b49f8b73b2582": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0010",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "50",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.762442725183751",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0123570633152281",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.339498021136914",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0707678054255747",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "10",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:d974c978eac6eff6a9802fd0358ceab9": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0011",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "447",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "6.81623796314274",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.03851586308171e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "2.02678038352389e-07",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1.22279946227405e-07",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "11",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:e373ddbc76b41aa980c394eaa5c0e960": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0012",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "162",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "2.47031442959535",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.63852466674842e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00222568832297587",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000672150622508277",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "12",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:92a9d73b8902193b0f3316f35cc0dc5b": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0013",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "29",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.442216780606576",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0470937359607303",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.79416170413585",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.190729630640958",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "13",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:be5f1c0a23837aa1ccfc35022807cc1b": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0014",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "38",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.579456471139651",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0257597057294564",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.578781830495109",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.130408510255373",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "14",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:4cb37275d66ab0f22e3ea2174721f6f4": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0015",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "134",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "2.04334650349245",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000208225307159483",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00696455376757865",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00187402776443535",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "15",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:9bf6744a8796b8070ccd764f775a5e39": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0016",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "76",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.1589129422793",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00300279655548563",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0958739715182708",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.022111501908576",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "16",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c8a038b61f85138c6e21eee9f3570ce3": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0017",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "16",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.2439816720588",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.128031320700056",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.986394362860718",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.324079280522016",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "17",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:4cfb37bb6f2ac0c6613c6f7263fc6650": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0018",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "26",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.396470217095551",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0583630672052552",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.858988054642613",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.205539497548942",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "18",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:090f310da60ee22317a7fb037c567897": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0019",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "29",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.442216780606576",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0470937359607303",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.79416170413585",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.190729630640958",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "19",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:363fdfdf14cd35df5666fb3e18b0d8c5": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0020",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "6",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0914931270220502",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.343388487126378",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999990125608014",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.604501360009182",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "20",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:80cfe87c528fca41e72aca65987a69a4": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0021",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "10",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.15248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.22255850848336",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999430072930499",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.487222680733842",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "21",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:e4d6a9f909a852e57111554ebf0b4352": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0022",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "8",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.1219908360294",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.273933067513935",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999898388010158",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.554714461715718",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "22",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:039182fcb99c4f9a98332d4c4fb55e21": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0023",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "49",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.747193870680076",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0131051491528842",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.355876032106543",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0707678054255747",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "23",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:52a34b3a1f2ce2562ef0f4d897e30a2f": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0024",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "21",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.320225944577176",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0850912379420168",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.942502902202007",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.255273713826051",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "24",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f5b45be86dbcd41fe68a83f7d23cef72": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0025",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "9",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.137239690533075",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.24643774370434",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999744295990386",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.511832236924399",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "25",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:6f8473034fe37635ca935744c8d051ba": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0026",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "30",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.457465635110251",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.043916653732793",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.770998817460931",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.190729630640958",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "26",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:72d641147c79cc42de66fcaf250eefff": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0027",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "27",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.411719071599226",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0542875242970965",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.83831709934398",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.199876794002946",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "27",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:0a54f2c3fbd560105040dd395d10cd8e": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0028",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "10",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.15248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.22255850848336",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999430072930499",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.487222680733842",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "28",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:6c719ef53d6799a1aa00e8155fb90aa7": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0029",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "61",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.930180124724177",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00662877418964967",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.199476682033478",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0447442257801353",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "29",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:9abcaf1e1cd8e4fffc65b4dcd102664f": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0030",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "19",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.289728235569826",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0997597824989178",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.964858026030202",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.278639392496977",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "30",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c17192cb7b2dfe5b506d5632ee2f9128": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0031",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "14",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.21348396305145",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.152527900243506",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.994020866354823",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.374386664234061",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "31",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:0cdd87a23d70e882dffa97ccc3f06458": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0032",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "18",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.27447938106615",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.108241900089372",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.973564689982443",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.292253130241304",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "32",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:24c8de1b4ac2f5e9c8b9a7759335fe9d": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0033",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "28",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.426967926102901",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.050541462694511",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.81665481379022",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.194945641821685",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "33",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:9634c37192a257704d16f5f1d880a757": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0034",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "6",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0914931270220502",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.343388487126378",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999990125608014",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.604501360009182",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "34",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:11b95279587654680aac97970c1dca33": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0035",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "21",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.320225944577176",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0850912379420168",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.942502902202007",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.255273713826051",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "35",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:0a1d8340cb8c5e4660accea8890aaead": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0036",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "6",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0914931270220502",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.343388487126378",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999990125608014",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.604501360009182",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "36",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:7e88673ecdc8e0e122c41546194e1107": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0037",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "29",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.442216780606576",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0470937359607303",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.79416170413585",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.190729630640958",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "37",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:9c9e8e71561800d1df10386138b306ed": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0038",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "24",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.365972508088201",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0676477474681771",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.896743975460065",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.228311147705098",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "38",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:7fe6fe573e42bb4d7fda5294f70b254e": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0039",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0609954180147001",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.44232166254071",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999643232106",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.628562362557851",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "39",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:8fa9b6d9acd2c49ac8d56eaee29fc687": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0040",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "12",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.1829862540441",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.183276076907294",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.997869754572677",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.42415320655688",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "40",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:5033df2d3441877c72a35517e4199588": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0041",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "9",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.137239690533075",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.24643774370434",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999744295990386",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.511832236924399",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "41",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:4124e50de0ee3b3d33d8b3570cdaf9c8": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0042",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999997153",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "42",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:4a2fd60e9307d21139c66a8495323c62": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0043",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "21",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.320225944577176",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0850912379420168",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.942502902202007",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.255273713826051",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "43",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:47493d1488caf09ebaff86e6cfddca82": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0044",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "7",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.106741981525725",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.305873808816549",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999965218155016",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.604287280832693",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "44",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f30d659f7dd564a91713174649a7897e": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0045",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "5",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0762442725183751",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.388074947166389",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999997796430203",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.604501360009182",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "45",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:bf5d4132caa2ab59278ac933dbeefdc4": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0046",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "16",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.2439816720588",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.128031320700056",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.986394362860718",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.324079280522016",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "46",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:5063c9c53f326a1d63e57a9ad368aba4": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0047",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "5",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0762442725183751",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.388074947166389",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999997796430203",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.604501360009182",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "47",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f53e11fdc36e62f28a07e009b005603e": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0048",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "5",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0762442725183751",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.388074947166389",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999997796430203",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.604501360009182",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "48",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:ae4cfacdd2f80d4db5489f80321a64c5": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0049",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.598176099264786",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999998092195",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "49",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:4bf515909ab7c79154616841d777e9fa": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0050",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0457465635110251",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.509991966452308",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999963189445",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.688489154710615",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "50",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:9c5ac23579b49a629cb17821a462a039": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0051",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0609954180147001",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.44232166254071",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999643232106",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.628562362557851",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "51",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:0059ec9a6bb7c2d7e6ea96012aa070a4": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0052",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "13",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.198235108547775",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.166999709083906",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.996321368733297",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.39785224811166",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "52",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:3bb3714faa1aae7d02675cad6938ab52": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0053",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "6",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0914931270220502",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.343388487126378",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999990125608014",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.604501360009182",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "53",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:79f4ea32c57ff4bc44bd9693fb4bfb39": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0054",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0457465635110251",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.509991966452308",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999963189445",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.688489154710615",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "54",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:16165a8f8f2fb7e16961bd153e0121b3": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0055",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "5",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0762442725183751",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.388074947166389",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999997796430203",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.604501360009182",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "55",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:120ccd02c2048169aea9fc9ef80dac7e": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0056",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0457465635110251",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.509991966452308",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999963189445",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.688489154710615",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "56",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:8ecb9c4697fe5773d29ea35c29d84ef3": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0057",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.598176099264786",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999998092195",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "57",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:b24de80c3a706246e31d6423b3708450": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0058",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "6",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0914931270220502",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.343388487126378",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999990125608014",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.604501360009182",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "58",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:0f16dde8718dddce4db284b7a40496a8": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0059",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999997153",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "59",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:6618ca3eaa19d5e02557c9a8428828e3": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0060",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0609954180147001",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.44232166254071",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999643232106",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.628562362557851",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "60",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:edcf13cf2a9f550f95f7fa64a9ab86ca": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0061",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.598176099264786",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999998092195",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "61",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:80da85f37d04350ac439bb0dfa06ea5b": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0062",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0609954180147001",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.44232166254071",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999643232106",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.628562362557851",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "62",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:cce62b8bba59fb588c9623468819b0f6": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0063",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0609954180147001",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.44232166254071",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999643232106",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.628562362557851",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "63",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:fe52388c406befa95a7e7abdd9bc5d0d": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0064",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999997153",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "64",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:aaf8a80c3785eabb526fa793c58065c5": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0065",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "5",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0762442725183751",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.388074947166389",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999997796430203",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.604501360009182",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "65",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:66a2dce74584c693a761996e8a52ee2c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0066",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "5",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0762442725183751",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.388074947166389",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999997796430203",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.604501360009182",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "66",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:842dcf5877dd33791cbf64037b0d160d": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0067",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.598176099264786",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999998092195",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "67",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:826c8df2b7140fdd69ec6d944489cb87": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0068",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999997153",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "68",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:a8072ecfcdfd108f310a1bc87c821cf1": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0069",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.598176099264786",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999998092195",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "69",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:71b52ab8126a30a8e2c6e66f6b5da31f": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0070",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999997153",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "70",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:339add5fca2f1335faf3c97a8ad874f4": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0071",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999997153",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "71",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:b822c27c9e4ca42b4196dd89b524730c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0072",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999997153",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "72",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:96419b4c6e6c59ea3a4153112ed9d514": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0073",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999997153",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "73",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:2156904148b8610fa21cc0ac6f11f0a5": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0074",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999997153",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "74",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:bba6fb2b90294edde963661ec3fea027": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0075",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999997153",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "75",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:a428752a112ae62b5d4a764c475ebebb": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0076",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999997153",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "76",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:011ca539a5756d6a56b02867c8dc0da5": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0077",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999997153",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "77",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:cba5fb0d6db1529fec8f4fba47f35ad8": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0078",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999997153",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "78",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:ff8870f1fb72bc18a894385e2e338a1a": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0079",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999997153",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "79",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:0dd915ffcbdf519b3a8e0e342a7a3a15": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0080",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999997153",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "80",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:aa3557b1b3fba9452176860c67262bd9": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0081",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999997153",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723454321471829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "81",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:32978f193454276a89690a074d1f925d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0001",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:55d81a635f7a8d8e2db6359db99ea928",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "7.92007970809937",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "6.94608360738412",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.87783122385099e-12",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "4.18813870695089e-07",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "5.21674435923017e-06",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:55d81a635f7a8d8e2db6359db99ea928": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0001",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[46,16,24]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:34b93bd18a1d6b9d11f9220e9d0c8d8f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0002",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e8b2f11cf4cbe836c4f5539b6b098535",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.31603479385376",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.77079466112137",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.94492849498107e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.000879943865776389",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000830722551601523",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e8b2f11cf4cbe836c4f5539b6b098535": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0002",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[32,24,-4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3898d262fb3baf3f75b22150a9b04a7a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0003",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ac1322201748ec0f5c221256a0fd16af",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.68819808959961",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.27450168515333",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.655864770444e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0121028975026269",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00350091530962783",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ac1322201748ec0f5c221256a0fd16af": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0003",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[18,16,4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:603e9a34a8c2b14d5f22ac5bab31465c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0004",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4d22debd9be5615681ad6502530caa16",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "7.11683940887451",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "6.37404871703245",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "9.20510334623259e-11",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "2.05325778424026e-05",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "9.33757664730496e-05",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4d22debd9be5615681ad6502530caa16": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0004",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[34,-88,-2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d1e8c4e4831c31323bfedc0662522fc6": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0005",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:fd5d0747ba793c53ed9eb8130c1f1499",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.48292255401611",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.8992593141605",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.82568493656277e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.000407231755366277",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000830722551601523",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:fd5d0747ba793c53ed9eb8130c1f1499": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0005",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[42,-72,-10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:58f6ffe36b16b4d86866a57a2e3f0d86": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0006",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:fb04675da6d16642172d2d7cdf72b57e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.2275915145874",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.89738468004472",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.85602978606003e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0670610253017228",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0118363293065346",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:fb04675da6d16642172d2d7cdf72b57e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0006",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[34,-86,12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6f9df5a084be3215b055ddef7915c8ba": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0007",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6ae79521dd4177d878efc76a6f51db6b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.28007745742798",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.74292583422276",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.65272453897825e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00103782272796227",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000830722551601523",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6ae79521dd4177d878efc76a6f51db6b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0007",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[8,18,50]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6cdda123bcee4885c1034564912a97af": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0008",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:684b2a5117bca29995311831b26bfe6e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.15222215652466",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.64328512810061",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.34178537356678e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00186069357054308",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000972721201433817",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:684b2a5117bca29995311831b26bfe6e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0008",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-6,12,52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:463d5476f401e65d9740c56ea881befc": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0009",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:153814c4f143461197c66a523426c9c6",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.98517084121704",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.51181334779297",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.77577724747024e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00376326218366319",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00136419627856355",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:153814c4f143461197c66a523426c9c6": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0009",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[8,32,38]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:291008c3ba8bd66b60306971f236360c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0010",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a2722e3c6e931e50799908c5e74e91c3",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.25127363204956",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.72055271981637",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.30890376104765e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0011841880966994",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000830722551601523",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a2722e3c6e931e50799908c5e74e91c3": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0010",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[52,-32,42]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0dcc549539442c3724ba5d0e1f6e467a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0011",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:3e89abdddd60a7d0574ff07c1016607e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.24752378463745",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.71763687476157",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.40078304300806e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00120468241369565",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000830722551601523",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3e89abdddd60a7d0574ff07c1016607e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0011",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[40,-62,50]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:657157689be2c61689eb1b3f4efc21e6": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0012",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:99bc5ffcd4466f85102d7f98c44118e4",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.70337772369385",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.28674301747281",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.22566831420812e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.011413186758684",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00350091530962783",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:99bc5ffcd4466f85102d7f98c44118e4": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0012",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[56,-44,52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:669694fe0c4b5ec1a6f8a3977df4c580": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0013",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:362ca75eb1ae6d24ff2704daf43214da",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.15371799468994",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.64445580026639",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.285227171001e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00184807786755337",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000972721201433817",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:362ca75eb1ae6d24ff2704daf43214da": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0013",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-28,-94,4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:bc09fd8c13efc94b69b000bed2848f2b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0014",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e988c9d2fc231cbc70e8805189a61b44",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.71480798721313",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.58412084932714",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000169107736440521",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999869855188705",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.383925327139989",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e988c9d2fc231cbc70e8805189a61b44": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0014",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-34,-84,-2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4a8c6a17b71f45dcd261be37cfbbff63": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0015",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:bc786bfc82330377611d0623c983ab4c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.10109901428223",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.60320502193174",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.05212039080982e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00234682813060005",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00104518293275697",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:bc786bfc82330377611d0623c983ab4c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0015",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[32,2,46]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d4bb165ca9721ee62b430b539898419d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0016",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:5ceb4eee142abfc8ef98e23cf45add6b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.6086859703064",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.3736141683061",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.11031435759912e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.453877178455514",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0599714495109201",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:5ceb4eee142abfc8ef98e23cf45add6b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0016",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[28,4,58]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1e8f2a721817f907e33ce3661a849f73": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0017",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:cf61866a953e360975460a1159eb7ecc",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.98793148994446",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.82932508069717",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.42475887594474e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.984644566584946",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.233149120368192",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:cf61866a953e360975460a1159eb7ecc": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0017",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[42,4,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1b716cf23c999bf2aa97632831c920c3": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0018",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:842d653a416be2a0412210b9f86b2f75",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.98348569869995",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.51047970249337",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.78928538652201e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00378871596531738",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00136419627856355",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:842d653a416be2a0412210b9f86b2f75": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0018",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-52,0,38]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:fb67c0bff2a0e2b33b7e98f6e72ecf20": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0019",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a514db27f5969eb25e9b9e72a4d9f19a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.2253565788269",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.89552821543552",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.90210114501011e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0675937275056587",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0118363293065346",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a514db27f5969eb25e9b9e72a4d9f19a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0019",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-60,8,20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:99264e96be684bdfa859b1fd9ef7404f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0020",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d9cc01f2b233cccc98b3ad8ed9f1f720",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.98950004577637",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.69817956585148",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.31245304380023e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.151048137890434",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0233609510296683",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d9cc01f2b233cccc98b3ad8ed9f1f720": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0020",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-44,6,28]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3af87f4c8a485677db1de109851382ce": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0021",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:bf1ac20f2cb36a10c73e16a4eeb39be4",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.78093099594116",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.34909755317379",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.41969442155354e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00844151822925698",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00286742427823329",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:bf1ac20f2cb36a10c73e16a4eeb39be4": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0021",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-34,-2,52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:96137cd609a52308057e3eaad2affaf7": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0022",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:beb35637b378cd19eb529fa6fe9f24a4",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.40964078903198",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.04774404642803",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.23528758724889e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0346958937061391",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00846044059259994",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:beb35637b378cd19eb529fa6fe9f24a4": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0022",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-54,-46,58]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:aaf8bff445839cb9f02a0507509d96c7": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0023",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:76446890b6db0c500548a40b8f8682ba",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.31841945648193",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.97261482231588",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.30279114724163e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0484353441449864",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0106752417476244",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:76446890b6db0c500548a40b8f8682ba": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0023",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-62,-38,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:bb9e9131199389d2fff8def462545512": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0024",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:1a6f397bb7d9d28ef9486bd1bbe04132",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.57099342346191",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.34109644800954",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.08867353027554e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.496004086968197",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0635474729952592",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:1a6f397bb7d9d28ef9486bd1bbe04132": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0024",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-60,-50,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f70c6e8ed2f106b23ce93474c5815a76": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0025",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:00a170f0bfc9c991ef7f484e52ffbd96",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.30699443817139",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.96317509467693",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.46750043123123e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0504786376455083",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0106752417476244",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:00a170f0bfc9c991ef7f484e52ffbd96": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0025",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[32,40,16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:69121dd33164fbc51ac41add220ab8f1": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0026",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:2915dee2e934763f3afa376514c5fc13",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.5497465133667",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.32273570618355",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.7053150754347e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.520378392891944",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0649997423676262",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:2915dee2e934763f3afa376514c5fc13": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0026",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[40,46,12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:389952192f36c8bc6c584ad875df6b35": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0027",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7e19b6c879f069e1c59ced1c8f607cf9",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.31582498550415",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.11913273798974",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.90150518718513e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.788829013385429",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.116130094830597",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7e19b6c879f069e1c59ced1c8f607cf9": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0027",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[36,54,6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:16d663f0f26b3dea4fc4e29533365eeb": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0028",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b0203375b18fa3d7ba036c947ea91f58",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.27030229568481",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.93281349716267",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.05267701952816e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0575990926145485",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0110040663565173",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b0203375b18fa3d7ba036c947ea91f58": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0028",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[40,26,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:194a103256f1c1af23ae04557a658012": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0029",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:18944c45a5c3f4f6c0960eadd37d221d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.93343877792358",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.65085575575197",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.6528024058271e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.180887232162623",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0254967087736733",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:18944c45a5c3f4f6c0960eadd37d221d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0029",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-58,-30,-18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b2215dc88285adf34cfc03ef8a5dcaf1": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0030",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:9566ab35f1332f530ab3aa63f168999d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.76414346694946",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.50698548813516",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.287756441539e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.301278778226174",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0396433885053995",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:9566ab35f1332f530ab3aa63f168999d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0030",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-46,-66,-6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:67a3ff30cb368a2f12ff59805b696982": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0031",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ab09c9a1f4598c0665ad4a53a4beb3c8",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.7637345790863",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.62829384243901",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000142650218672435",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999605970761399",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.34409224637793",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ab09c9a1f4598c0665ad4a53a4beb3c8": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0031",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-54,-64,-8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:bc9137f84fc1f9762b49aad753870257": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0032",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:265b96175bce3138b953075789167720",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.72232866287231",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.47122948835043",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.88855941602095e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.338512677882141",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.044836631144536",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:265b96175bce3138b953075789167720": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0032",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[58,-38,6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:032b9f13b127793861eb7c63ac30ae1b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0033",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:9b7979d59b62e98d7460d92ae0fd5b69",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.98372888565063",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.8255778871433",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.52328381068878e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.985409231324461",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.233731539105478",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:9b7979d59b62e98d7460d92ae0fd5b69": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0033",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[64,-30,-4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0f6fd82788868c60fecefa6c60f52281": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0034",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4f9fe05667da20caedb476e93089a356",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.50753784179688",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.39582098150001",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000342115474631921",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999778829603",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.564856004417035",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4f9fe05667da20caedb476e93089a356": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0034",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[60,-40,-12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e9fcf67ed1b73b63fa0b87828f16d554": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0035",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d7f46e225306f0225e6a2937b1ec4c06",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.70483255386353",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.45624265093732",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.17043099876224e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.354967306449537",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0466228196503302",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d7f46e225306f0225e6a2937b1ec4c06": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0035",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-36,-74,-14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c2b2577f48de89a6cc0be9c94fc55aa8": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0036",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:be9f98153fcd6a17397aa36d2bf4d58a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.08770418167114",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.91804495668",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.46350297789166e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.955724279224547",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.186719971332974",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:be9f98153fcd6a17397aa36d2bf4d58a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0036",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-36,-68,-20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b280d4a0b64592367cef28cf83c1c50a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0037",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7cd7d2893f104d27cbed450c735c9350",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.71012616157532",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.57988831343959",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000171870546999631",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999883757236262",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.385893135248467",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7cd7d2893f104d27cbed450c735c9350": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0037",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-30,-58,-16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0617028bebc10a87084f495d6bea9816": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0038",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6003244d95b3096ffcb5a0152cfd0933",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.59621620178223",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.36286413267216",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.41853365035416e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.467637998233248",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0604181585485856",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6003244d95b3096ffcb5a0152cfd0933": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0038",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[16,-98,6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8f28adfa177b2033e8aac730e9d813c5": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0039",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:48a7698048fc6f6f19a99b0f9a8e75ca",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.57891654968262",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.34793761600864",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.87118388575936e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.487021764768749",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0629240173925056",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:48a7698048fc6f6f19a99b0f9a8e75ca": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0039",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-60,-16,28]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f796d2323c68b364b61ab304f29abf8e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0040",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6fb77fc57ac2e71a37a28ea2ba3920c5",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.37013816833496",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.16664310578498",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.54558935169247e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.730405153245217",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.101858458171742",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6fb77fc57ac2e71a37a28ea2ba3920c5": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0040",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-52,-62,52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5dfc83216f09a2194e4624ad70c56926": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0041",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:bb668322a2477c49c19e0215c96fb605",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.30655717849731",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.11101155082742",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.96964745459161e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.798260223882423",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.118009486872663",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:bb668322a2477c49c19e0215c96fb605": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0041",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-26,-92,32]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:177ec6548b8ab076a0df6d6033e514c2": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0042",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:477ea5657432a192d97ad576b0c8eff4",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.24533367156982",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.05725918601008",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.4825985211363e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.855631833511506",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.135717263652471",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:477ea5657432a192d97ad576b0c8eff4": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0042",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-18,-60,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1d5012af3aa91d2f7de1ec238455128e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0043",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b3517cb478482fae609d9448b489dff3",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.22729349136353",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.04138628171284",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.65680735640483e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.870712357794855",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.138603763901635",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b3517cb478482fae609d9448b489dff3": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0043",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-20,-98,22]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4d9c6e08f557697d937d4fdbfcc226ba": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0044",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:339ce93075072a6674c586ffcd2e7071",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.22599840164185",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.04024618213588",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.66975618669063e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.871760516202526",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.138603763901635",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:339ce93075072a6674c586ffcd2e7071": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0044",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-36,-74,-34]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d8febb8ec85b4a6284d965e1e96f0d42": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0045",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e904483face2f6172191f30b5ae887ce",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.20391035079956",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.02078923241408",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.900174224163e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.888907080881232",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.143583628261646",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e904483face2f6172191f30b5ae887ce": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0045",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[34,-54,-16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:65b361322bcb8dd8d0c9982a75869714": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0046",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4fa3bc1af5d44cdcfedda68c2e03da7b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.18721437454224",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.00606667297511",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.08691144208506e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.900934824371894",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.149373770721144",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4fa3bc1af5d44cdcfedda68c2e03da7b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0046",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[12,-100,20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d600d8085bb73831a72181b797fbb63f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0047",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:44fa7d75ab0e1e4c9901acf92b82d38d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.17404651641846",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.99444589181498",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.24228638075574e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.909844421846994",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.153735203854581",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:44fa7d75ab0e1e4c9901acf92b82d38d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0047",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-40,-38,44]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ded4c30265dfe6755db542029d96c626": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0048",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0971061f8b6c1b553a97b9f5389dce86",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.12145137786865",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.94794832362008",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.94119065879606e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.940339218142555",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.172448885449819",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0971061f8b6c1b553a97b9f5389dce86": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0048",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-48,-72,2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7a194dfabc293f3340bc257f2bdeae5d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0049",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ee77107f2f4a2e971a92ac9a2e392acb",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.07333517074585",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.9052963692066",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.70549882543025e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.961337330645756",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.192831151077206",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ee77107f2f4a2e971a92ac9a2e392acb": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0049",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[20,-66,34]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:777f22c81e3e2fc6331b52dd359fa25e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0050",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:718728dcea773b178c0c2b9d86005a62",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.05762767791748",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.89134919103145",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.98441713834286e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.966867400896655",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.199920408224698",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:718728dcea773b178c0c2b9d86005a62": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0050",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-46,-56,14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:bf28f434cc925cd8ac3e307644c0a142": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0051",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:751a1a8bf69143bd2cb1f4a9e30f273e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.97341108322144",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.81637469850314",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.7713399346081e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.987160063394768",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.237117251115433",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:751a1a8bf69143bd2cb1f4a9e30f273e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0051",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-50,-50,20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0790b31de0dbbcbf3f332d97e57d1b55": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0052",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e2f23bfbe72aad139a81ca5b2ffa8abd",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.03719234466553",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.87318677164159",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.37107204765519e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.973166168280088",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.210147957128937",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e2f23bfbe72aad139a81ca5b2ffa8abd": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0052",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-48,2,50]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:59d06f0b13371b506f9af55d24b5067d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0053",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:1db7da9477f7603e8262d33595ac73df",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.0217924118042",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.85948683644491",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.68126885931441e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.977286609355005",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.217632520436791",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:1db7da9477f7603e8262d33595ac73df": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0053",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-36,-40,-36]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:59b131173ec529026e6491eccefa7ada": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0054",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7af98a598509557bd8993f48cda58395",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.9634416103363",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.80747753892992",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.01957428701494e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.988689669381963",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.237117251115433",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7af98a598509557bd8993f48cda58395": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0054",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[4,6,32]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e9a001b5e220f1405185d99aa83b727f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0055",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:99944e1f658081a155c51941aabefa5f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.96245408058167",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.80659597790245",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.04463150378309e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.988832912076595",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.237117251115433",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:99944e1f658081a155c51941aabefa5f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0055",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-50,-48,-16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6d610ea93d5ad1b8ca06db397254b20a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0056",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a648ad8c9947c2b6d297437cebcf0586",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.92427015304565",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.77247501519699",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.08180782938539e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.993353008667813",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.257401847609111",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a648ad8c9947c2b6d297437cebcf0586": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0056",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[34,12,64]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1c148cb4176155acbe0672cefa9a95c5": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0057",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c4b0615738aa35638b2835835d1d7819",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.9098813533783",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.75959988615137",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.50926599039736e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.994607633788328",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.264100967145263",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c4b0615738aa35638b2835835d1d7819": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0057",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[54,-24,-2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e5dd8e18ee93409839d84e35a139c001": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0058",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0fac8c3499b5602b8c4d3f4c5c36353f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.90759468078613",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.75755289319297",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.57915531067288e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.994787688943672",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.264100967145263",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0fac8c3499b5602b8c4d3f4c5c36353f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0058",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-14,-98,-4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e9643fe2556c8083fc3a5c54aa6831f0": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0059",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c71a141432731c3a83c4fb20d9096844",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.90285301208496",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.75330746420074",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.72582920719012e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99514521861122",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.264100967145263",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c71a141432731c3a83c4fb20d9096844": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0059",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-36,-46,-18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5f418c8024d0ae92d508d9bad7d2d04d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0060",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:9a92eb0b7c3cc5e9caf8918bfa863800",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.8867518901825",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.73888373627584",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "9.24195907030523e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.996210852184447",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.271701156704036",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:9a92eb0b7c3cc5e9caf8918bfa863800": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0060",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-50,-46,-32]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8eab02fbf5295443c2cecf3656cd3d2d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0061",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a9eabe163be93303971a1a577a90ad43",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.86077284812927",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.7155862280194",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000101366555929516",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.997515005942308",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.285012944590861",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a9eabe163be93303971a1a577a90ad43": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0061",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[64,-30,-22]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:98b8c845b0552789d333d70cc497d509": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0062",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:497235ab7af561483668157451b5d000",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.82178378105164",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.68056404693028",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000116359297336222",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.998750111206092",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.307505393775956",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:497235ab7af561483668157451b5d000": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0062",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[12,52,-12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:efa880b12dd83fae6f169908e5aa1b6d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0063",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:633bc6590e9c2c6637b5c66d4c1f6821",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.81266117095947",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.67235967240763",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000120160560553639",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.998946217488595",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.312228840798665",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:633bc6590e9c2c6637b5c66d4c1f6821": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0063",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[36,54,20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a24de0716b7868c15dfd5714da3cd7f5": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0064",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:bb8a6cbf2ee7aef13285cd3e0c1d7119",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.80767583847046",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.66787455107711",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000122287561408974",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999041631710947",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.312228840798665",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:bb8a6cbf2ee7aef13285cd3e0c1d7119": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0064",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[22,-80,54]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b0236ac6504fe7c6d9875b7e3acda5d2": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0065",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:403d8420a1ed6bf11ed2faac9417eb00",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.7885959148407",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.65069869844077",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000130763947768786",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999340802437346",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.325675502417125",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:403d8420a1ed6bf11ed2faac9417eb00": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0065",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[22,40,26]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5b2f95ea874a1f6a91671a4479c9378b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0066",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:913d07b2c660b69689773736cedef910",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.78668808937073",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.64898036269368",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000131641613210109",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999365630484476",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.325675502417125",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:913d07b2c660b69689773736cedef910": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0066",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-22,-74,60]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9bf774e06d17f683fc16cd62139d3371": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0067",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:2ad6b182f9055333dc6e0015fa4f155e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.69408750534058",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.56538143418403",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000181663694368006",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999921818129803",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.399826018660701",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:2ad6b182f9055333dc6e0015fa4f155e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0067",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[50,46,-12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3bc6e9db3abd7587209de9f8eb441a76": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0068",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4d905d145479d69d91038af595094893",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.65790581703186",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.53261354467296",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000205736742878826",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999969815552823",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.430567192397012",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4d905d145479d69d91038af595094893": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0068",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[52,-46,-12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5364de8a0b6714a83fbec79f6028081c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0069",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4a5cdfd710492874c59e711371fd82ab",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.65459251403809",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.52960997534834",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000208086348004177",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999972447579615",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.431239033859527",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4a5cdfd710492874c59e711371fd82ab": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0069",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[54,8,-36]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3634f7fe7105a2e1b8f1882a519825af": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0070",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:50692615fe720fe70b53e64f6fead8a4",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.60173606872559",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.48162963814792",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000249186237945009",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999994173508246",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.477936808108637",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:50692615fe720fe70b53e64f6fead8a4": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0070",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-14,58,10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d594b8cfacb807f125997448b08835a3": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0071",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6bfc99bd843bdcf4e013f217dc98c9a3",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.58989810943604",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.47086705539024",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000259390388114844",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999995993033212",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.486123239113482",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6bfc99bd843bdcf4e013f217dc98c9a3": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0071",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-66,-36,22]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:023cc3012925d0776b89ecf4fe87ab52": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0072",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:fc0d7a41934aa1b2738a3f70b84a927c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.56340670585632",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.44676015888715",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000283676007278189",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999998329299787",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.513357841480064",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:fc0d7a41934aa1b2738a3f70b84a927c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0072",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[18,60,12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2fec8cee976754e3979a50e6ecb659e9": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0073",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:82fc364bc9872056c82c6d3896703c98",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.55537104606628",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.43944179853069",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000291457553818653",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999998731920076",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.518882279088377",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:82fc364bc9872056c82c6d3896703c98": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0073",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-64,-34,8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ead9a2eb3fe810d3e2fe175ba57a770f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0074",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:8b1df836dbd1d79b4e93b815de590aba",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.55148839950562",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.43590473729199",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000295289297083445",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999889206113",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.518882279088377",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:8b1df836dbd1d79b4e93b815de590aba": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0074",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[64,-34,16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b52f0f12bced214c2dfafd7282f27bad": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0075",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:5bef0119303f4bb85383ac9d192f0fe1",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.54216623306274",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.42740966598884",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000304684504620178",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999202607737",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.527734905237698",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:5bef0119303f4bb85383ac9d192f0fe1": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0075",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-58,-32,22]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:bacceffe4d760f806512a8fa62a47caf": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0076",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a0e61cb131cd0271669e7df79a2ed186",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.51380252838135",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.40153955037634",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000335037159349127",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999971905221",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.559625109906516",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a0e61cb131cd0271669e7df79a2ed186": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0076",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[48,12,50]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2a6483578ad30a2fe3721daffa288c28": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0077",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b0a0b798bff91a011585b210275ecaa3",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.46738910675049",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.35913252154752",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000390937814553127",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999955890495",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.612505014136882",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b0a0b798bff91a011585b210275ecaa3": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0077",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[14,-14,72]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5db20ef1a857b0c93873cca6dbbaf653": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0078",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0c2e89b7dd30256e4f516083c49c1398",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.45441365242004",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.34726077209469",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000408071982705316",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999974583179",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.628488500556802",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0c2e89b7dd30256e4f516083c49c1398": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0078",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-38,-54,-42]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0e5b5cad25297838be93e85247842bc4": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0079",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e0b64d5d590b611bc9f1ea430c4ce478",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.43550229072571",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.32994532400952",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000434315195478541",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999988927098",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.654261098812949",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e0b64d5d590b611bc9f1ea430c4ce478": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0079",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[22,44,-16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8f596ef744414c01a33ad6c39029765e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0080",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:41bcac017885a0d5ce419f1cd6147e96",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.43198323249817",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.32672157755253",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000439370628491198",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999990548038",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.655840530088522",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:41bcac017885a0d5ce419f1cd6147e96": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0080",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[42,-42,14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ea5435e2a886068031ebe5de352b9252": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0081",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:979e4f14c98dd53d2ba2316ad891327d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.40964436531067",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.30624524554301",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000472776443704692",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999996632889",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.684032337898302",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:979e4f14c98dd53d2ba2316ad891327d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0081",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-22,-82,0]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6eff0cb119fb17bde1587b506a65b95c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0082",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a04b89d12a0e23c950fc82f4714923df",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.40386486053467",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.30094422133281",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000481800187664638",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999997442132",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.689466168942319",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a04b89d12a0e23c950fc82f4714923df": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0082",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[52,-42,18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:42ba59332aba027b09e0f7fb5b836ccf": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0083",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:efbdb520a93e8c7041418140163a877a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.36533284187317",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.26556677338515",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000546226226643243",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999624169",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.751744172496132",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:efbdb520a93e8c7041418140163a877a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0083",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[44,-48,-26]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:503a860df4608d362f5472437c9aac33": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0084",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:bd9e880b12aa24548b9447799a89b39d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.3379864692688",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.24042202275062",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000596764555146345",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999912202",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.787874793017543",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:bd9e880b12aa24548b9447799a89b39d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0084",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[46,-40,44]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9a50100528de3301f53864b1e2d26813": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0085",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:2a527d6fde4a3e0f1b5549da2bcb4937",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.33372783660889",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.23650348537689",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000605018743711327",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999930494",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.791142662581953",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:2a527d6fde4a3e0f1b5549da2bcb4937": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0085",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[16,4,16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c79bb08a7cc62e4c3bb0bc2ea61487fb": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0086",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d0196efa9c520da7383566a50c9bd6e0",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.32532405853271",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.22876865896546",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000621622108231912",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999995642",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.802213727911317",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d0196efa9c520da7383566a50c9bd6e0": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0086",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-54,-32,42]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:df49da2116399dd93cbe380ad45dc4ba": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0087",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4e6b7532be0436dc269457ac5fbda880",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.31892204284668",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.22287431730178",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000634556128578101",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999996962",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.809612456104087",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4e6b7532be0436dc269457ac5fbda880": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0087",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-16,4,62]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8e179e19b02140d23014ccfa85f27a50": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0088",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:37bb88de70a250d9e55221ba28b52c7c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.3035409450531",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.20870610659348",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000666668530368786",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999987468",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.829570299628891",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:37bb88de70a250d9e55221ba28b52c7c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0088",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[22,38,10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a787086f5cb922314611375f0c56cc32": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0089",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:fe659463fa080cf764c8d49213755e7b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.29107904434204",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.19721985733158",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000693795605607228",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999994003",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.839453948823053",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:fe659463fa080cf764c8d49213755e7b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0089",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[30,34,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a8e3819b8f7d45e8b8dc7d86a80ef681": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0090",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:86dee79597b91333e151e37e0e03522b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.28136968612671",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.18826629952882",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000715643274853739",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999996665",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.851590920517607",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:86dee79597b91333e151e37e0e03522b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0090",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[56,-66,4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:95a3e6c899a63c97c10b2e2a21870587": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0091",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:22f0969feaa27b87063bdc731a8b5ebd",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.27154183387756",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.17919960131803",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000738411785119797",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999998178",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.858755937068456",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:22f0969feaa27b87063bdc731a8b5ebd": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0091",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[10,-76,-12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:47c4c2b62e33d8d5bf68323f3604cbdb": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0092",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6239faf38126e85b2d8d417db1895726",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.2669575214386",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.17496900913942",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000749262523860983",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999998632",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.863075307004762",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6239faf38126e85b2d8d417db1895726": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0092",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[20,32,54]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:259c1693d6155c7a6f30bb08608f1f4f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0093",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a3247e37750de016acf24df9bc60fa49",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.26226496696472",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.17063765299814",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000760523733375762",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999998982",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.867640730428823",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a3247e37750de016acf24df9bc60fa49": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0093",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-60,-14,10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c3c6c3b4bc379cbd3e79cdda209910be": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0094",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:3c4fc33d1b64cfdf812854e59f738d56",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.25743293762207",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.16617663527645",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000772284854291594",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999251",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.872516606801204",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3c4fc33d1b64cfdf812854e59f738d56": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0094",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-22,-94,28]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:af534a3f98f60ec7b7d00384e405199b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0095",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:2499239f2dd610a8d96045353e0f3c47",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.25416302680969",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.16315726358056",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000780339994975288",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999392",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.874305136305167",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:2499239f2dd610a8d96045353e0f3c47": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0095",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-66,-46,8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6101b3c8a7b6e0ec13ee88b3c0076b8f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0096",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b6c31642bad37d7720ecff6c57e5191b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.24836373329163",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.15780125799237",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000794819459152607",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999582",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.881177035765112",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b6c31642bad37d7720ecff6c57e5191b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0096",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-68,-34,-8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f45f9a4f27b514a76b251ca6940d64cc": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0097",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:be17a094497e539d851d03d853f569e8",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.23679161071777",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.14710967833961",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000824465484375092",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999804",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.899808991491498",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:be17a094497e539d851d03d853f569e8": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0097",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-56,34,-20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0775bd867b7640b1610595991372a3a4": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0098",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c4dbdab79f8821a024aad1cbea9bfdc0",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.22478008270264",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.13600649460504",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000856327054624684",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999913",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.917823543835361",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c4dbdab79f8821a024aad1cbea9bfdc0": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0098",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[8,-72,42]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b8c1d7232cf84cc17142cad17a88efd4": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0099",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:5d92f1be38abbce4c3a63c0c46448f74",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.22331190109253",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.13464894829369",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000860299398633191",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999921",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.917823543835361",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:5d92f1be38abbce4c3a63c0c46448f74": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0099",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[42,-86,12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d7f13c4e30c7f05356ed60a5151c02bc": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0100",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6eb2e0f022d96c098a1c921602f59fc8",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.21184372901917",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.12404202893254",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000891924872423622",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999964",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.936836924136013",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6eb2e0f022d96c098a1c921602f59fc8": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0100",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-18,-92,8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:490f1070a7fe465c3b5c6f734cf1749d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0101",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:139066f39e05f69f22d080013a95fbf1",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.19808602333069",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.1113106720378",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000931294345451028",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999986",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.958204454708765",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:139066f39e05f69f22d080013a95fbf1": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0101",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[12,6,18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:738e8e698240388bfd3862aecb89fc27": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0102",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:1a1d537499ae7b8db798494bbd47949b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.19609522819519",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.10946777700093",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000937123635013748",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999988",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.958204454708765",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:1a1d537499ae7b8db798494bbd47949b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0102",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[14,40,20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:cb10f3dde606a9db392eeb31defadb58": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0103",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:34d7cb1b6c22f3bab972ec17b5943913",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.19474077224731",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.10821385730133",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000941109068576473",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999989",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.958204454708765",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:34d7cb1b6c22f3bab972ec17b5943913": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0103",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-44,-42,-36]",
+                "type": "xsd:string"
+            }
+        }
+    },
+    "activity": {
+        "niiri:773a735fbcc316e9f2d58362f2f4d1bc": {
+            "prov:type": {
+                "$": "nidm_ModelParametersEstimation:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Model parameters estimation",
+                "type": "xsd:string"
+            },
+            "nidm_withEstimationMethod:": {
+                "$": "obo_generalizedleastsquaresestimation:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2556ad05de8d46ac8899042750f19e3b": {
+            "prov:type": {
+                "$": "nidm_ContrastEstimation:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Contrast estimation",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:741b8ea52f035ab6ac7f052b1d8660ed": {
+            "prov:type": {
+                "$": "nidm_Inference:",
+                "type": "xsd:QName"
+            },
+            "nidm_hasAlternativeHypothesis:": {
+                "$": "nidm_OneTailedTest:",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Inference",
+                "type": "xsd:string"
+            }
+        }
+    },
+    "agent": {
+        "niiri:eb9874e84de35431b43fa1c2015078a6": {
+            "prov:type": [
+                {
+                "$": "src_SPM:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "prov:SoftwareAgent",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "SPM",
+                "type": "xsd:string"
+            },
+            "nidm_softwareVersion:": {
+                "$": "12.6906",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c1ffd758228d702c4e45a8569d5e3a17": {
+            "prov:type": [
+                {
+                "$": "nlx_Imaginginstrument:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nlx_Magneticresonanceimagingscanner:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "MRI Scanner",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d2fd7c347715d0e29b9dd29e3691672a": {
+            "prov:type": {
+                "$": "prov:Person",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Person",
+                "type": "xsd:string"
+            }
+        }
+    },
+    "wasGeneratedBy": {
+        "_:wGB20": {
+            "prov:entity": "niiri:218e9dabb7ce7346a5fc5d0e4d956c0f",
+            "prov:activity": "niiri:773a735fbcc316e9f2d58362f2f4d1bc"
+        },
+        "_:wGB22": {
+            "prov:entity": "niiri:b6dedebe44bd4dfcd70f1e56cc87d8e1",
+            "prov:activity": "niiri:773a735fbcc316e9f2d58362f2f4d1bc"
+        },
+        "_:wGB26": {
+            "prov:entity": "niiri:55bbc45f54dbafed48a1b302258b19a8",
+            "prov:activity": "niiri:773a735fbcc316e9f2d58362f2f4d1bc"
+        },
+        "_:wGB30": {
+            "prov:entity": "niiri:3625bdf3e80d5e9a25b486f9360a1378",
+            "prov:activity": "niiri:773a735fbcc316e9f2d58362f2f4d1bc"
+        },
+        "_:wGB34": {
+            "prov:entity": "niiri:67cc3fa692b977e0ac54b72dec7e4384",
+            "prov:activity": "niiri:773a735fbcc316e9f2d58362f2f4d1bc"
+        },
+        "_:wGB38": {
+            "prov:entity": "niiri:b49762a3483888f79a5d5b06f51a25d1",
+            "prov:activity": "niiri:773a735fbcc316e9f2d58362f2f4d1bc"
+        },
+        "_:wGB42": {
+            "prov:entity": "niiri:982b6bb49828f15a05294a1c58d03b8b",
+            "prov:activity": "niiri:773a735fbcc316e9f2d58362f2f4d1bc"
+        },
+        "_:wGB56": {
+            "prov:entity": "niiri:e461c8f3ab4826650944bec7b1912e84",
+            "prov:activity": "niiri:2556ad05de8d46ac8899042750f19e3b"
+        },
+        "_:wGB60": {
+            "prov:entity": "niiri:f9b320bdd9480281306f90d15b0ab8be",
+            "prov:activity": "niiri:2556ad05de8d46ac8899042750f19e3b"
+        },
+        "_:wGB62": {
+            "prov:entity": "niiri:a8574ab2053ab027cf06dd5d2a5a785a",
+            "prov:activity": "niiri:2556ad05de8d46ac8899042750f19e3b"
+        },
+        "_:wGB81": {
+            "prov:entity": "niiri:b9b82d6e97f1bad3e6178276b982be04",
+            "prov:activity": "niiri:741b8ea52f035ab6ac7f052b1d8660ed"
+        },
+        "_:wGB85": {
+            "prov:entity": "niiri:80c10806c0beeee32d27292ced29500f",
+            "prov:activity": "niiri:741b8ea52f035ab6ac7f052b1d8660ed"
+        }
+    },
+    "used": {
+        "_:u14": {
+            "prov:activity": "niiri:773a735fbcc316e9f2d58362f2f4d1bc",
+            "prov:entity": "niiri:d44fca7b57060de1677bc74daa15aa89"
+        },
+        "_:u15": {
+            "prov:activity": "niiri:773a735fbcc316e9f2d58362f2f4d1bc",
+            "prov:entity": "niiri:d8cb12a2013805cec8a0537c545e4c27"
+        },
+        "_:u16": {
+            "prov:activity": "niiri:773a735fbcc316e9f2d58362f2f4d1bc",
+            "prov:entity": "niiri:ca9137874e81e1af901b6acfc7ff391a"
+        },
+        "_:u46": {
+            "prov:activity": "niiri:2556ad05de8d46ac8899042750f19e3b",
+            "prov:entity": "niiri:218e9dabb7ce7346a5fc5d0e4d956c0f"
+        },
+        "_:u47": {
+            "prov:activity": "niiri:2556ad05de8d46ac8899042750f19e3b",
+            "prov:entity": "niiri:b49762a3483888f79a5d5b06f51a25d1"
+        },
+        "_:u48": {
+            "prov:activity": "niiri:2556ad05de8d46ac8899042750f19e3b",
+            "prov:entity": "niiri:d44fca7b57060de1677bc74daa15aa89"
+        },
+        "_:u49": {
+            "prov:activity": "niiri:2556ad05de8d46ac8899042750f19e3b",
+            "prov:entity": "niiri:f9498d3b2bcc41a724d906ee170c4316"
+        },
+        "_:u50": {
+            "prov:activity": "niiri:2556ad05de8d46ac8899042750f19e3b",
+            "prov:entity": "niiri:55bbc45f54dbafed48a1b302258b19a8"
+        },
+        "_:u51": {
+            "prov:activity": "niiri:2556ad05de8d46ac8899042750f19e3b",
+            "prov:entity": "niiri:3625bdf3e80d5e9a25b486f9360a1378"
+        },
+        "_:u52": {
+            "prov:activity": "niiri:2556ad05de8d46ac8899042750f19e3b",
+            "prov:entity": "niiri:67cc3fa692b977e0ac54b72dec7e4384"
+        },
+        "_:u73": {
+            "prov:activity": "niiri:741b8ea52f035ab6ac7f052b1d8660ed",
+            "prov:entity": "niiri:dd97c56b32bf917687b52d95e2b13099"
+        },
+        "_:u74": {
+            "prov:activity": "niiri:741b8ea52f035ab6ac7f052b1d8660ed",
+            "prov:entity": "niiri:99724284af9cacae301790c375fe6b15"
+        },
+        "_:u75": {
+            "prov:activity": "niiri:741b8ea52f035ab6ac7f052b1d8660ed",
+            "prov:entity": "niiri:e461c8f3ab4826650944bec7b1912e84"
+        },
+        "_:u76": {
+            "prov:activity": "niiri:741b8ea52f035ab6ac7f052b1d8660ed",
+            "prov:entity": "niiri:982b6bb49828f15a05294a1c58d03b8b"
+        },
+        "_:u77": {
+            "prov:activity": "niiri:741b8ea52f035ab6ac7f052b1d8660ed",
+            "prov:entity": "niiri:218e9dabb7ce7346a5fc5d0e4d956c0f"
+        },
+        "_:u78": {
+            "prov:activity": "niiri:741b8ea52f035ab6ac7f052b1d8660ed",
+            "prov:entity": "niiri:dfa8c97f4a46388cf4a9bb1364e0d92e"
+        },
+        "_:u79": {
+            "prov:activity": "niiri:741b8ea52f035ab6ac7f052b1d8660ed",
+            "prov:entity": "niiri:5bd0a1af1bb03071db4c49f47a4396a1"
+        }
+    },
+    "wasDerivedFrom": {
+        "_:wDF19": {
+            "prov:generatedEntity": "niiri:218e9dabb7ce7346a5fc5d0e4d956c0f",
+            "prov:usedEntity": "niiri:e5b0a4f7beeecbff1514adf4c11f02ab"
+        },
+        "_:wDF25": {
+            "prov:generatedEntity": "niiri:55bbc45f54dbafed48a1b302258b19a8",
+            "prov:usedEntity": "niiri:a8f1001f03928204508b6ab86da06246"
+        },
+        "_:wDF29": {
+            "prov:generatedEntity": "niiri:3625bdf3e80d5e9a25b486f9360a1378",
+            "prov:usedEntity": "niiri:91a5ac743cdb91c1d48fca362a3241fc"
+        },
+        "_:wDF33": {
+            "prov:generatedEntity": "niiri:67cc3fa692b977e0ac54b72dec7e4384",
+            "prov:usedEntity": "niiri:fe38b6202e69c84f88ece9b51a9a99c3"
+        },
+        "_:wDF37": {
+            "prov:generatedEntity": "niiri:b49762a3483888f79a5d5b06f51a25d1",
+            "prov:usedEntity": "niiri:685419d4a3159548c52f7aa12e55d28b"
+        },
+        "_:wDF41": {
+            "prov:generatedEntity": "niiri:982b6bb49828f15a05294a1c58d03b8b",
+            "prov:usedEntity": "niiri:cad5e3e80a900432c8b3e58a397f0b76"
+        },
+        "_:wDF55": {
+            "prov:generatedEntity": "niiri:e461c8f3ab4826650944bec7b1912e84",
+            "prov:usedEntity": "niiri:901cc6a5ebd5a3b326b9725834bdddca"
+        },
+        "_:wDF59": {
+            "prov:generatedEntity": "niiri:f9b320bdd9480281306f90d15b0ab8be",
+            "prov:usedEntity": "niiri:ed3281c40be1462539e94647abd36a73"
+        },
+        "_:wDF87": {
+            "prov:generatedEntity": "niiri:749b77e80ffd0ed4ca77337a7893adc6",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF89": {
+            "prov:generatedEntity": "niiri:e2c6b47be3a342a41d95bfc20852c868",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF91": {
+            "prov:generatedEntity": "niiri:7d345f60b278ac792f989f5862ed9684",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF93": {
+            "prov:generatedEntity": "niiri:78cf678fc1d8e63075a90d654ff6f858",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF95": {
+            "prov:generatedEntity": "niiri:d1df03018bbf137ff5ef2da545a3e8bf",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF97": {
+            "prov:generatedEntity": "niiri:168af8a06bcba9be4ec76231fb932bcd",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF99": {
+            "prov:generatedEntity": "niiri:3b36a7334ca09a3c238279baec873119",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF101": {
+            "prov:generatedEntity": "niiri:58bff46dfff701e885b3a3a8403d6869",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF103": {
+            "prov:generatedEntity": "niiri:2bcab9b8311e435ff15509af340ba45e",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF105": {
+            "prov:generatedEntity": "niiri:932a73d91444fc459c9b49f8b73b2582",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF107": {
+            "prov:generatedEntity": "niiri:d974c978eac6eff6a9802fd0358ceab9",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF109": {
+            "prov:generatedEntity": "niiri:e373ddbc76b41aa980c394eaa5c0e960",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF111": {
+            "prov:generatedEntity": "niiri:92a9d73b8902193b0f3316f35cc0dc5b",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF113": {
+            "prov:generatedEntity": "niiri:be5f1c0a23837aa1ccfc35022807cc1b",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF115": {
+            "prov:generatedEntity": "niiri:4cb37275d66ab0f22e3ea2174721f6f4",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF117": {
+            "prov:generatedEntity": "niiri:9bf6744a8796b8070ccd764f775a5e39",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF119": {
+            "prov:generatedEntity": "niiri:c8a038b61f85138c6e21eee9f3570ce3",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF121": {
+            "prov:generatedEntity": "niiri:4cfb37bb6f2ac0c6613c6f7263fc6650",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF123": {
+            "prov:generatedEntity": "niiri:090f310da60ee22317a7fb037c567897",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF125": {
+            "prov:generatedEntity": "niiri:363fdfdf14cd35df5666fb3e18b0d8c5",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF127": {
+            "prov:generatedEntity": "niiri:80cfe87c528fca41e72aca65987a69a4",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF129": {
+            "prov:generatedEntity": "niiri:e4d6a9f909a852e57111554ebf0b4352",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF131": {
+            "prov:generatedEntity": "niiri:039182fcb99c4f9a98332d4c4fb55e21",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF133": {
+            "prov:generatedEntity": "niiri:52a34b3a1f2ce2562ef0f4d897e30a2f",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF135": {
+            "prov:generatedEntity": "niiri:f5b45be86dbcd41fe68a83f7d23cef72",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF137": {
+            "prov:generatedEntity": "niiri:6f8473034fe37635ca935744c8d051ba",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF139": {
+            "prov:generatedEntity": "niiri:72d641147c79cc42de66fcaf250eefff",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF141": {
+            "prov:generatedEntity": "niiri:0a54f2c3fbd560105040dd395d10cd8e",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF143": {
+            "prov:generatedEntity": "niiri:6c719ef53d6799a1aa00e8155fb90aa7",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF145": {
+            "prov:generatedEntity": "niiri:9abcaf1e1cd8e4fffc65b4dcd102664f",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF147": {
+            "prov:generatedEntity": "niiri:c17192cb7b2dfe5b506d5632ee2f9128",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF149": {
+            "prov:generatedEntity": "niiri:0cdd87a23d70e882dffa97ccc3f06458",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF151": {
+            "prov:generatedEntity": "niiri:24c8de1b4ac2f5e9c8b9a7759335fe9d",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF153": {
+            "prov:generatedEntity": "niiri:9634c37192a257704d16f5f1d880a757",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF155": {
+            "prov:generatedEntity": "niiri:11b95279587654680aac97970c1dca33",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF157": {
+            "prov:generatedEntity": "niiri:0a1d8340cb8c5e4660accea8890aaead",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF159": {
+            "prov:generatedEntity": "niiri:7e88673ecdc8e0e122c41546194e1107",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF161": {
+            "prov:generatedEntity": "niiri:9c9e8e71561800d1df10386138b306ed",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF163": {
+            "prov:generatedEntity": "niiri:7fe6fe573e42bb4d7fda5294f70b254e",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF165": {
+            "prov:generatedEntity": "niiri:8fa9b6d9acd2c49ac8d56eaee29fc687",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF167": {
+            "prov:generatedEntity": "niiri:5033df2d3441877c72a35517e4199588",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF169": {
+            "prov:generatedEntity": "niiri:4124e50de0ee3b3d33d8b3570cdaf9c8",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF171": {
+            "prov:generatedEntity": "niiri:4a2fd60e9307d21139c66a8495323c62",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF173": {
+            "prov:generatedEntity": "niiri:47493d1488caf09ebaff86e6cfddca82",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF175": {
+            "prov:generatedEntity": "niiri:f30d659f7dd564a91713174649a7897e",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF177": {
+            "prov:generatedEntity": "niiri:bf5d4132caa2ab59278ac933dbeefdc4",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF179": {
+            "prov:generatedEntity": "niiri:5063c9c53f326a1d63e57a9ad368aba4",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF181": {
+            "prov:generatedEntity": "niiri:f53e11fdc36e62f28a07e009b005603e",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF183": {
+            "prov:generatedEntity": "niiri:ae4cfacdd2f80d4db5489f80321a64c5",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF185": {
+            "prov:generatedEntity": "niiri:4bf515909ab7c79154616841d777e9fa",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF187": {
+            "prov:generatedEntity": "niiri:9c5ac23579b49a629cb17821a462a039",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF189": {
+            "prov:generatedEntity": "niiri:0059ec9a6bb7c2d7e6ea96012aa070a4",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF191": {
+            "prov:generatedEntity": "niiri:3bb3714faa1aae7d02675cad6938ab52",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF193": {
+            "prov:generatedEntity": "niiri:79f4ea32c57ff4bc44bd9693fb4bfb39",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF195": {
+            "prov:generatedEntity": "niiri:16165a8f8f2fb7e16961bd153e0121b3",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF197": {
+            "prov:generatedEntity": "niiri:120ccd02c2048169aea9fc9ef80dac7e",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF199": {
+            "prov:generatedEntity": "niiri:8ecb9c4697fe5773d29ea35c29d84ef3",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF201": {
+            "prov:generatedEntity": "niiri:b24de80c3a706246e31d6423b3708450",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF203": {
+            "prov:generatedEntity": "niiri:0f16dde8718dddce4db284b7a40496a8",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF205": {
+            "prov:generatedEntity": "niiri:6618ca3eaa19d5e02557c9a8428828e3",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF207": {
+            "prov:generatedEntity": "niiri:edcf13cf2a9f550f95f7fa64a9ab86ca",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF209": {
+            "prov:generatedEntity": "niiri:80da85f37d04350ac439bb0dfa06ea5b",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF211": {
+            "prov:generatedEntity": "niiri:cce62b8bba59fb588c9623468819b0f6",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF213": {
+            "prov:generatedEntity": "niiri:fe52388c406befa95a7e7abdd9bc5d0d",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF215": {
+            "prov:generatedEntity": "niiri:aaf8a80c3785eabb526fa793c58065c5",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF217": {
+            "prov:generatedEntity": "niiri:66a2dce74584c693a761996e8a52ee2c",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF219": {
+            "prov:generatedEntity": "niiri:842dcf5877dd33791cbf64037b0d160d",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF221": {
+            "prov:generatedEntity": "niiri:826c8df2b7140fdd69ec6d944489cb87",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF223": {
+            "prov:generatedEntity": "niiri:a8072ecfcdfd108f310a1bc87c821cf1",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF225": {
+            "prov:generatedEntity": "niiri:71b52ab8126a30a8e2c6e66f6b5da31f",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF227": {
+            "prov:generatedEntity": "niiri:339add5fca2f1335faf3c97a8ad874f4",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF229": {
+            "prov:generatedEntity": "niiri:b822c27c9e4ca42b4196dd89b524730c",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF231": {
+            "prov:generatedEntity": "niiri:96419b4c6e6c59ea3a4153112ed9d514",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF233": {
+            "prov:generatedEntity": "niiri:2156904148b8610fa21cc0ac6f11f0a5",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF235": {
+            "prov:generatedEntity": "niiri:bba6fb2b90294edde963661ec3fea027",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF237": {
+            "prov:generatedEntity": "niiri:a428752a112ae62b5d4a764c475ebebb",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF239": {
+            "prov:generatedEntity": "niiri:011ca539a5756d6a56b02867c8dc0da5",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF241": {
+            "prov:generatedEntity": "niiri:cba5fb0d6db1529fec8f4fba47f35ad8",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF243": {
+            "prov:generatedEntity": "niiri:ff8870f1fb72bc18a894385e2e338a1a",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF245": {
+            "prov:generatedEntity": "niiri:0dd915ffcbdf519b3a8e0e342a7a3a15",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF247": {
+            "prov:generatedEntity": "niiri:aa3557b1b3fba9452176860c67262bd9",
+            "prov:usedEntity": "niiri:80c10806c0beeee32d27292ced29500f"
+        },
+        "_:wDF250": {
+            "prov:generatedEntity": "niiri:32978f193454276a89690a074d1f925d",
+            "prov:usedEntity": "niiri:749b77e80ffd0ed4ca77337a7893adc6"
+        },
+        "_:wDF253": {
+            "prov:generatedEntity": "niiri:34b93bd18a1d6b9d11f9220e9d0c8d8f",
+            "prov:usedEntity": "niiri:749b77e80ffd0ed4ca77337a7893adc6"
+        },
+        "_:wDF256": {
+            "prov:generatedEntity": "niiri:3898d262fb3baf3f75b22150a9b04a7a",
+            "prov:usedEntity": "niiri:749b77e80ffd0ed4ca77337a7893adc6"
+        },
+        "_:wDF259": {
+            "prov:generatedEntity": "niiri:603e9a34a8c2b14d5f22ac5bab31465c",
+            "prov:usedEntity": "niiri:e2c6b47be3a342a41d95bfc20852c868"
+        },
+        "_:wDF262": {
+            "prov:generatedEntity": "niiri:d1e8c4e4831c31323bfedc0662522fc6",
+            "prov:usedEntity": "niiri:e2c6b47be3a342a41d95bfc20852c868"
+        },
+        "_:wDF265": {
+            "prov:generatedEntity": "niiri:58f6ffe36b16b4d86866a57a2e3f0d86",
+            "prov:usedEntity": "niiri:e2c6b47be3a342a41d95bfc20852c868"
+        },
+        "_:wDF268": {
+            "prov:generatedEntity": "niiri:6f9df5a084be3215b055ddef7915c8ba",
+            "prov:usedEntity": "niiri:7d345f60b278ac792f989f5862ed9684"
+        },
+        "_:wDF271": {
+            "prov:generatedEntity": "niiri:6cdda123bcee4885c1034564912a97af",
+            "prov:usedEntity": "niiri:7d345f60b278ac792f989f5862ed9684"
+        },
+        "_:wDF274": {
+            "prov:generatedEntity": "niiri:463d5476f401e65d9740c56ea881befc",
+            "prov:usedEntity": "niiri:7d345f60b278ac792f989f5862ed9684"
+        },
+        "_:wDF277": {
+            "prov:generatedEntity": "niiri:291008c3ba8bd66b60306971f236360c",
+            "prov:usedEntity": "niiri:78cf678fc1d8e63075a90d654ff6f858"
+        },
+        "_:wDF280": {
+            "prov:generatedEntity": "niiri:0dcc549539442c3724ba5d0e1f6e467a",
+            "prov:usedEntity": "niiri:78cf678fc1d8e63075a90d654ff6f858"
+        },
+        "_:wDF283": {
+            "prov:generatedEntity": "niiri:657157689be2c61689eb1b3f4efc21e6",
+            "prov:usedEntity": "niiri:78cf678fc1d8e63075a90d654ff6f858"
+        },
+        "_:wDF286": {
+            "prov:generatedEntity": "niiri:669694fe0c4b5ec1a6f8a3977df4c580",
+            "prov:usedEntity": "niiri:d1df03018bbf137ff5ef2da545a3e8bf"
+        },
+        "_:wDF289": {
+            "prov:generatedEntity": "niiri:bc09fd8c13efc94b69b000bed2848f2b",
+            "prov:usedEntity": "niiri:d1df03018bbf137ff5ef2da545a3e8bf"
+        },
+        "_:wDF292": {
+            "prov:generatedEntity": "niiri:4a8c6a17b71f45dcd261be37cfbbff63",
+            "prov:usedEntity": "niiri:168af8a06bcba9be4ec76231fb932bcd"
+        },
+        "_:wDF295": {
+            "prov:generatedEntity": "niiri:d4bb165ca9721ee62b430b539898419d",
+            "prov:usedEntity": "niiri:168af8a06bcba9be4ec76231fb932bcd"
+        },
+        "_:wDF298": {
+            "prov:generatedEntity": "niiri:1e8f2a721817f907e33ce3661a849f73",
+            "prov:usedEntity": "niiri:168af8a06bcba9be4ec76231fb932bcd"
+        },
+        "_:wDF301": {
+            "prov:generatedEntity": "niiri:1b716cf23c999bf2aa97632831c920c3",
+            "prov:usedEntity": "niiri:3b36a7334ca09a3c238279baec873119"
+        },
+        "_:wDF304": {
+            "prov:generatedEntity": "niiri:fb67c0bff2a0e2b33b7e98f6e72ecf20",
+            "prov:usedEntity": "niiri:3b36a7334ca09a3c238279baec873119"
+        },
+        "_:wDF307": {
+            "prov:generatedEntity": "niiri:99264e96be684bdfa859b1fd9ef7404f",
+            "prov:usedEntity": "niiri:3b36a7334ca09a3c238279baec873119"
+        },
+        "_:wDF310": {
+            "prov:generatedEntity": "niiri:3af87f4c8a485677db1de109851382ce",
+            "prov:usedEntity": "niiri:58bff46dfff701e885b3a3a8403d6869"
+        },
+        "_:wDF313": {
+            "prov:generatedEntity": "niiri:96137cd609a52308057e3eaad2affaf7",
+            "prov:usedEntity": "niiri:2bcab9b8311e435ff15509af340ba45e"
+        },
+        "_:wDF316": {
+            "prov:generatedEntity": "niiri:aaf8bff445839cb9f02a0507509d96c7",
+            "prov:usedEntity": "niiri:932a73d91444fc459c9b49f8b73b2582"
+        },
+        "_:wDF319": {
+            "prov:generatedEntity": "niiri:bb9e9131199389d2fff8def462545512",
+            "prov:usedEntity": "niiri:932a73d91444fc459c9b49f8b73b2582"
+        },
+        "_:wDF322": {
+            "prov:generatedEntity": "niiri:f70c6e8ed2f106b23ce93474c5815a76",
+            "prov:usedEntity": "niiri:d974c978eac6eff6a9802fd0358ceab9"
+        },
+        "_:wDF325": {
+            "prov:generatedEntity": "niiri:69121dd33164fbc51ac41add220ab8f1",
+            "prov:usedEntity": "niiri:d974c978eac6eff6a9802fd0358ceab9"
+        },
+        "_:wDF328": {
+            "prov:generatedEntity": "niiri:389952192f36c8bc6c584ad875df6b35",
+            "prov:usedEntity": "niiri:d974c978eac6eff6a9802fd0358ceab9"
+        },
+        "_:wDF331": {
+            "prov:generatedEntity": "niiri:16d663f0f26b3dea4fc4e29533365eeb",
+            "prov:usedEntity": "niiri:e373ddbc76b41aa980c394eaa5c0e960"
+        },
+        "_:wDF334": {
+            "prov:generatedEntity": "niiri:194a103256f1c1af23ae04557a658012",
+            "prov:usedEntity": "niiri:92a9d73b8902193b0f3316f35cc0dc5b"
+        },
+        "_:wDF337": {
+            "prov:generatedEntity": "niiri:b2215dc88285adf34cfc03ef8a5dcaf1",
+            "prov:usedEntity": "niiri:be5f1c0a23837aa1ccfc35022807cc1b"
+        },
+        "_:wDF340": {
+            "prov:generatedEntity": "niiri:67a3ff30cb368a2f12ff59805b696982",
+            "prov:usedEntity": "niiri:be5f1c0a23837aa1ccfc35022807cc1b"
+        },
+        "_:wDF343": {
+            "prov:generatedEntity": "niiri:bc9137f84fc1f9762b49aad753870257",
+            "prov:usedEntity": "niiri:4cb37275d66ab0f22e3ea2174721f6f4"
+        },
+        "_:wDF346": {
+            "prov:generatedEntity": "niiri:032b9f13b127793861eb7c63ac30ae1b",
+            "prov:usedEntity": "niiri:4cb37275d66ab0f22e3ea2174721f6f4"
+        },
+        "_:wDF349": {
+            "prov:generatedEntity": "niiri:0f6fd82788868c60fecefa6c60f52281",
+            "prov:usedEntity": "niiri:4cb37275d66ab0f22e3ea2174721f6f4"
+        },
+        "_:wDF352": {
+            "prov:generatedEntity": "niiri:e9fcf67ed1b73b63fa0b87828f16d554",
+            "prov:usedEntity": "niiri:9bf6744a8796b8070ccd764f775a5e39"
+        },
+        "_:wDF355": {
+            "prov:generatedEntity": "niiri:c2b2577f48de89a6cc0be9c94fc55aa8",
+            "prov:usedEntity": "niiri:9bf6744a8796b8070ccd764f775a5e39"
+        },
+        "_:wDF358": {
+            "prov:generatedEntity": "niiri:b280d4a0b64592367cef28cf83c1c50a",
+            "prov:usedEntity": "niiri:9bf6744a8796b8070ccd764f775a5e39"
+        },
+        "_:wDF361": {
+            "prov:generatedEntity": "niiri:0617028bebc10a87084f495d6bea9816",
+            "prov:usedEntity": "niiri:c8a038b61f85138c6e21eee9f3570ce3"
+        },
+        "_:wDF364": {
+            "prov:generatedEntity": "niiri:8f28adfa177b2033e8aac730e9d813c5",
+            "prov:usedEntity": "niiri:4cfb37bb6f2ac0c6613c6f7263fc6650"
+        },
+        "_:wDF367": {
+            "prov:generatedEntity": "niiri:f796d2323c68b364b61ab304f29abf8e",
+            "prov:usedEntity": "niiri:090f310da60ee22317a7fb037c567897"
+        },
+        "_:wDF370": {
+            "prov:generatedEntity": "niiri:5dfc83216f09a2194e4624ad70c56926",
+            "prov:usedEntity": "niiri:363fdfdf14cd35df5666fb3e18b0d8c5"
+        },
+        "_:wDF373": {
+            "prov:generatedEntity": "niiri:177ec6548b8ab076a0df6d6033e514c2",
+            "prov:usedEntity": "niiri:80cfe87c528fca41e72aca65987a69a4"
+        },
+        "_:wDF376": {
+            "prov:generatedEntity": "niiri:1d5012af3aa91d2f7de1ec238455128e",
+            "prov:usedEntity": "niiri:e4d6a9f909a852e57111554ebf0b4352"
+        },
+        "_:wDF379": {
+            "prov:generatedEntity": "niiri:4d9c6e08f557697d937d4fdbfcc226ba",
+            "prov:usedEntity": "niiri:039182fcb99c4f9a98332d4c4fb55e21"
+        },
+        "_:wDF382": {
+            "prov:generatedEntity": "niiri:d8febb8ec85b4a6284d965e1e96f0d42",
+            "prov:usedEntity": "niiri:52a34b3a1f2ce2562ef0f4d897e30a2f"
+        },
+        "_:wDF385": {
+            "prov:generatedEntity": "niiri:65b361322bcb8dd8d0c9982a75869714",
+            "prov:usedEntity": "niiri:f5b45be86dbcd41fe68a83f7d23cef72"
+        },
+        "_:wDF388": {
+            "prov:generatedEntity": "niiri:d600d8085bb73831a72181b797fbb63f",
+            "prov:usedEntity": "niiri:6f8473034fe37635ca935744c8d051ba"
+        },
+        "_:wDF391": {
+            "prov:generatedEntity": "niiri:ded4c30265dfe6755db542029d96c626",
+            "prov:usedEntity": "niiri:72d641147c79cc42de66fcaf250eefff"
+        },
+        "_:wDF394": {
+            "prov:generatedEntity": "niiri:7a194dfabc293f3340bc257f2bdeae5d",
+            "prov:usedEntity": "niiri:0a54f2c3fbd560105040dd395d10cd8e"
+        },
+        "_:wDF397": {
+            "prov:generatedEntity": "niiri:777f22c81e3e2fc6331b52dd359fa25e",
+            "prov:usedEntity": "niiri:6c719ef53d6799a1aa00e8155fb90aa7"
+        },
+        "_:wDF400": {
+            "prov:generatedEntity": "niiri:bf28f434cc925cd8ac3e307644c0a142",
+            "prov:usedEntity": "niiri:6c719ef53d6799a1aa00e8155fb90aa7"
+        },
+        "_:wDF403": {
+            "prov:generatedEntity": "niiri:0790b31de0dbbcbf3f332d97e57d1b55",
+            "prov:usedEntity": "niiri:9abcaf1e1cd8e4fffc65b4dcd102664f"
+        },
+        "_:wDF406": {
+            "prov:generatedEntity": "niiri:59d06f0b13371b506f9af55d24b5067d",
+            "prov:usedEntity": "niiri:c17192cb7b2dfe5b506d5632ee2f9128"
+        },
+        "_:wDF409": {
+            "prov:generatedEntity": "niiri:59b131173ec529026e6491eccefa7ada",
+            "prov:usedEntity": "niiri:0cdd87a23d70e882dffa97ccc3f06458"
+        },
+        "_:wDF412": {
+            "prov:generatedEntity": "niiri:e9a001b5e220f1405185d99aa83b727f",
+            "prov:usedEntity": "niiri:24c8de1b4ac2f5e9c8b9a7759335fe9d"
+        },
+        "_:wDF415": {
+            "prov:generatedEntity": "niiri:6d610ea93d5ad1b8ca06db397254b20a",
+            "prov:usedEntity": "niiri:9634c37192a257704d16f5f1d880a757"
+        },
+        "_:wDF418": {
+            "prov:generatedEntity": "niiri:1c148cb4176155acbe0672cefa9a95c5",
+            "prov:usedEntity": "niiri:11b95279587654680aac97970c1dca33"
+        },
+        "_:wDF421": {
+            "prov:generatedEntity": "niiri:e5dd8e18ee93409839d84e35a139c001",
+            "prov:usedEntity": "niiri:0a1d8340cb8c5e4660accea8890aaead"
+        },
+        "_:wDF424": {
+            "prov:generatedEntity": "niiri:e9643fe2556c8083fc3a5c54aa6831f0",
+            "prov:usedEntity": "niiri:7e88673ecdc8e0e122c41546194e1107"
+        },
+        "_:wDF427": {
+            "prov:generatedEntity": "niiri:5f418c8024d0ae92d508d9bad7d2d04d",
+            "prov:usedEntity": "niiri:9c9e8e71561800d1df10386138b306ed"
+        },
+        "_:wDF430": {
+            "prov:generatedEntity": "niiri:8eab02fbf5295443c2cecf3656cd3d2d",
+            "prov:usedEntity": "niiri:7fe6fe573e42bb4d7fda5294f70b254e"
+        },
+        "_:wDF433": {
+            "prov:generatedEntity": "niiri:98b8c845b0552789d333d70cc497d509",
+            "prov:usedEntity": "niiri:8fa9b6d9acd2c49ac8d56eaee29fc687"
+        },
+        "_:wDF436": {
+            "prov:generatedEntity": "niiri:efa880b12dd83fae6f169908e5aa1b6d",
+            "prov:usedEntity": "niiri:5033df2d3441877c72a35517e4199588"
+        },
+        "_:wDF439": {
+            "prov:generatedEntity": "niiri:a24de0716b7868c15dfd5714da3cd7f5",
+            "prov:usedEntity": "niiri:4124e50de0ee3b3d33d8b3570cdaf9c8"
+        },
+        "_:wDF442": {
+            "prov:generatedEntity": "niiri:b0236ac6504fe7c6d9875b7e3acda5d2",
+            "prov:usedEntity": "niiri:4a2fd60e9307d21139c66a8495323c62"
+        },
+        "_:wDF445": {
+            "prov:generatedEntity": "niiri:5b2f95ea874a1f6a91671a4479c9378b",
+            "prov:usedEntity": "niiri:47493d1488caf09ebaff86e6cfddca82"
+        },
+        "_:wDF448": {
+            "prov:generatedEntity": "niiri:9bf774e06d17f683fc16cd62139d3371",
+            "prov:usedEntity": "niiri:f30d659f7dd564a91713174649a7897e"
+        },
+        "_:wDF451": {
+            "prov:generatedEntity": "niiri:3bc6e9db3abd7587209de9f8eb441a76",
+            "prov:usedEntity": "niiri:bf5d4132caa2ab59278ac933dbeefdc4"
+        },
+        "_:wDF454": {
+            "prov:generatedEntity": "niiri:5364de8a0b6714a83fbec79f6028081c",
+            "prov:usedEntity": "niiri:5063c9c53f326a1d63e57a9ad368aba4"
+        },
+        "_:wDF457": {
+            "prov:generatedEntity": "niiri:3634f7fe7105a2e1b8f1882a519825af",
+            "prov:usedEntity": "niiri:f53e11fdc36e62f28a07e009b005603e"
+        },
+        "_:wDF460": {
+            "prov:generatedEntity": "niiri:d594b8cfacb807f125997448b08835a3",
+            "prov:usedEntity": "niiri:ae4cfacdd2f80d4db5489f80321a64c5"
+        },
+        "_:wDF463": {
+            "prov:generatedEntity": "niiri:023cc3012925d0776b89ecf4fe87ab52",
+            "prov:usedEntity": "niiri:4bf515909ab7c79154616841d777e9fa"
+        },
+        "_:wDF466": {
+            "prov:generatedEntity": "niiri:2fec8cee976754e3979a50e6ecb659e9",
+            "prov:usedEntity": "niiri:9c5ac23579b49a629cb17821a462a039"
+        },
+        "_:wDF469": {
+            "prov:generatedEntity": "niiri:ead9a2eb3fe810d3e2fe175ba57a770f",
+            "prov:usedEntity": "niiri:0059ec9a6bb7c2d7e6ea96012aa070a4"
+        },
+        "_:wDF472": {
+            "prov:generatedEntity": "niiri:b52f0f12bced214c2dfafd7282f27bad",
+            "prov:usedEntity": "niiri:3bb3714faa1aae7d02675cad6938ab52"
+        },
+        "_:wDF475": {
+            "prov:generatedEntity": "niiri:bacceffe4d760f806512a8fa62a47caf",
+            "prov:usedEntity": "niiri:79f4ea32c57ff4bc44bd9693fb4bfb39"
+        },
+        "_:wDF478": {
+            "prov:generatedEntity": "niiri:2a6483578ad30a2fe3721daffa288c28",
+            "prov:usedEntity": "niiri:16165a8f8f2fb7e16961bd153e0121b3"
+        },
+        "_:wDF481": {
+            "prov:generatedEntity": "niiri:5db20ef1a857b0c93873cca6dbbaf653",
+            "prov:usedEntity": "niiri:120ccd02c2048169aea9fc9ef80dac7e"
+        },
+        "_:wDF484": {
+            "prov:generatedEntity": "niiri:0e5b5cad25297838be93e85247842bc4",
+            "prov:usedEntity": "niiri:8ecb9c4697fe5773d29ea35c29d84ef3"
+        },
+        "_:wDF487": {
+            "prov:generatedEntity": "niiri:8f596ef744414c01a33ad6c39029765e",
+            "prov:usedEntity": "niiri:b24de80c3a706246e31d6423b3708450"
+        },
+        "_:wDF490": {
+            "prov:generatedEntity": "niiri:ea5435e2a886068031ebe5de352b9252",
+            "prov:usedEntity": "niiri:0f16dde8718dddce4db284b7a40496a8"
+        },
+        "_:wDF493": {
+            "prov:generatedEntity": "niiri:6eff0cb119fb17bde1587b506a65b95c",
+            "prov:usedEntity": "niiri:6618ca3eaa19d5e02557c9a8428828e3"
+        },
+        "_:wDF496": {
+            "prov:generatedEntity": "niiri:42ba59332aba027b09e0f7fb5b836ccf",
+            "prov:usedEntity": "niiri:edcf13cf2a9f550f95f7fa64a9ab86ca"
+        },
+        "_:wDF499": {
+            "prov:generatedEntity": "niiri:503a860df4608d362f5472437c9aac33",
+            "prov:usedEntity": "niiri:80da85f37d04350ac439bb0dfa06ea5b"
+        },
+        "_:wDF502": {
+            "prov:generatedEntity": "niiri:9a50100528de3301f53864b1e2d26813",
+            "prov:usedEntity": "niiri:cce62b8bba59fb588c9623468819b0f6"
+        },
+        "_:wDF505": {
+            "prov:generatedEntity": "niiri:c79bb08a7cc62e4c3bb0bc2ea61487fb",
+            "prov:usedEntity": "niiri:fe52388c406befa95a7e7abdd9bc5d0d"
+        },
+        "_:wDF508": {
+            "prov:generatedEntity": "niiri:df49da2116399dd93cbe380ad45dc4ba",
+            "prov:usedEntity": "niiri:aaf8a80c3785eabb526fa793c58065c5"
+        },
+        "_:wDF511": {
+            "prov:generatedEntity": "niiri:8e179e19b02140d23014ccfa85f27a50",
+            "prov:usedEntity": "niiri:66a2dce74584c693a761996e8a52ee2c"
+        },
+        "_:wDF514": {
+            "prov:generatedEntity": "niiri:a787086f5cb922314611375f0c56cc32",
+            "prov:usedEntity": "niiri:842dcf5877dd33791cbf64037b0d160d"
+        },
+        "_:wDF517": {
+            "prov:generatedEntity": "niiri:a8e3819b8f7d45e8b8dc7d86a80ef681",
+            "prov:usedEntity": "niiri:826c8df2b7140fdd69ec6d944489cb87"
+        },
+        "_:wDF520": {
+            "prov:generatedEntity": "niiri:95a3e6c899a63c97c10b2e2a21870587",
+            "prov:usedEntity": "niiri:a8072ecfcdfd108f310a1bc87c821cf1"
+        },
+        "_:wDF523": {
+            "prov:generatedEntity": "niiri:47c4c2b62e33d8d5bf68323f3604cbdb",
+            "prov:usedEntity": "niiri:71b52ab8126a30a8e2c6e66f6b5da31f"
+        },
+        "_:wDF526": {
+            "prov:generatedEntity": "niiri:259c1693d6155c7a6f30bb08608f1f4f",
+            "prov:usedEntity": "niiri:339add5fca2f1335faf3c97a8ad874f4"
+        },
+        "_:wDF529": {
+            "prov:generatedEntity": "niiri:c3c6c3b4bc379cbd3e79cdda209910be",
+            "prov:usedEntity": "niiri:b822c27c9e4ca42b4196dd89b524730c"
+        },
+        "_:wDF532": {
+            "prov:generatedEntity": "niiri:af534a3f98f60ec7b7d00384e405199b",
+            "prov:usedEntity": "niiri:96419b4c6e6c59ea3a4153112ed9d514"
+        },
+        "_:wDF535": {
+            "prov:generatedEntity": "niiri:6101b3c8a7b6e0ec13ee88b3c0076b8f",
+            "prov:usedEntity": "niiri:2156904148b8610fa21cc0ac6f11f0a5"
+        },
+        "_:wDF538": {
+            "prov:generatedEntity": "niiri:f45f9a4f27b514a76b251ca6940d64cc",
+            "prov:usedEntity": "niiri:bba6fb2b90294edde963661ec3fea027"
+        },
+        "_:wDF541": {
+            "prov:generatedEntity": "niiri:0775bd867b7640b1610595991372a3a4",
+            "prov:usedEntity": "niiri:a428752a112ae62b5d4a764c475ebebb"
+        },
+        "_:wDF544": {
+            "prov:generatedEntity": "niiri:b8c1d7232cf84cc17142cad17a88efd4",
+            "prov:usedEntity": "niiri:011ca539a5756d6a56b02867c8dc0da5"
+        },
+        "_:wDF547": {
+            "prov:generatedEntity": "niiri:d7f13c4e30c7f05356ed60a5151c02bc",
+            "prov:usedEntity": "niiri:cba5fb0d6db1529fec8f4fba47f35ad8"
+        },
+        "_:wDF550": {
+            "prov:generatedEntity": "niiri:490f1070a7fe465c3b5c6f734cf1749d",
+            "prov:usedEntity": "niiri:ff8870f1fb72bc18a894385e2e338a1a"
+        },
+        "_:wDF553": {
+            "prov:generatedEntity": "niiri:738e8e698240388bfd3862aecb89fc27",
+            "prov:usedEntity": "niiri:0dd915ffcbdf519b3a8e0e342a7a3a15"
+        },
+        "_:wDF556": {
+            "prov:generatedEntity": "niiri:cb10f3dde606a9db392eeb31defadb58",
+            "prov:usedEntity": "niiri:aa3557b1b3fba9452176860c67262bd9"
+        }
+    },
+    "wasAttributedTo": {
+        "_:wAT6": {
+            "prov:entity": "niiri:d8cb12a2013805cec8a0537c545e4c27",
+            "prov:agent": "niiri:c1ffd758228d702c4e45a8569d5e3a17"
+        },
+        "_:wAT7": {
+            "prov:entity": "niiri:d8cb12a2013805cec8a0537c545e4c27",
+            "prov:agent": "niiri:d2fd7c347715d0e29b9dd29e3691672a"
+        }
+    },
+    "wasAssociatedWith": {
+        "_:wAW13": {
+            "prov:activity": "niiri:773a735fbcc316e9f2d58362f2f4d1bc",
+            "prov:agent": "niiri:eb9874e84de35431b43fa1c2015078a6"
+        },
+        "_:wAW45": {
+            "prov:activity": "niiri:2556ad05de8d46ac8899042750f19e3b",
+            "prov:agent": "niiri:eb9874e84de35431b43fa1c2015078a6"
+        },
+        "_:wAW72": {
+            "prov:activity": "niiri:741b8ea52f035ab6ac7f052b1d8660ed",
+            "prov:agent": "niiri:eb9874e84de35431b43fa1c2015078a6"
+        }
+    }
+    }
+  }
+}

--- a/spmexport/ex_spm_default/nidm.jsonld
+++ b/spmexport/ex_spm_default/nidm.jsonld
@@ -7,7 +7,7 @@
       "niiri": "http://iri.nidash.org/",
       "spm": "http://purl.org/nidash/spm#",
       "neurolex": "http://neurolex.org/wiki/",
-      "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#",
+      "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/",
       "dct": "http://purl.org/dc/terms/",
       "nfo": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#",
       "dc": "http://purl.org/dc/elements/1.1/",
@@ -22,32 +22,32 @@
   ],
   "@graph": [
     {
-      "@id": "niiri:0230ba1707dc047fb8389b2b1765b59c",
-      "@type": ["prov:Entity","prov:Bundle","nidm_NIDMResults:"],
+      "@id": "niiri:4e5cde201dcf24532399b37950fbd970",
+      "@type": ["prov:Entity","prov:Bundle","nidm_NIDMResults"],
       "rdfs:label": "NIDM-Results",
-      "nidm_version:": {"@type": "xsd:string", "@value": "1.3.0"}
+      "nidm_version": {"@type": "xsd:string", "@value": "1.3.0"}
     },
     {
-      "@id": "niiri:4eb4fb1cc6b0b36b0e9e21f171f8e0ad",
-      "@type": ["prov:Agent","nidm_spm_results_nidm:","prov:SoftwareAgent"],
+      "@id": "niiri:50df5922ab028839c3e8faae100dc78f",
+      "@type": ["prov:Agent","nidm_spm_results_nidm","prov:SoftwareAgent"],
       "rdfs:label": "spm_results_nidm",
-      "nidm_softwareVersion:": {"@type": "xsd:string", "@value": "12.6903"}
+      "nidm_softwareVersion": {"@type": "xsd:string", "@value": "12.7057"}
     },
     {
-      "@id": "niiri:25cb7abdb03032f3423f9b59112037a0",
-      "@type": ["prov:Activity","nidm_NIDMResultsExport:"],
+      "@id": "niiri:b4b82a058bfac16201e2b70c727d1328",
+      "@type": ["prov:Activity","nidm_NIDMResultsExport"],
       "rdfs:label": "NIDM-Results export"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:25cb7abdb03032f3423f9b59112037a0",
-      "agent": "niiri:4eb4fb1cc6b0b36b0e9e21f171f8e0ad"
+      "activity_associated": "niiri:b4b82a058bfac16201e2b70c727d1328",
+      "agent": "niiri:50df5922ab028839c3e8faae100dc78f"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:0230ba1707dc047fb8389b2b1765b59c",
-      "activity": "niiri:25cb7abdb03032f3423f9b59112037a0",
-      "atTime": "2016-12-07T16:08:21"
+      "entity_generated": "niiri:4e5cde201dcf24532399b37950fbd970",
+      "activity": "niiri:b4b82a058bfac16201e2b70c727d1328",
+      "atTime": "2017-04-19T12:18:02"
     }
   ]
 },
@@ -158,572 +158,572 @@
       "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
     }
   ],
-  "@id": "niiri:0230ba1707dc047fb8389b2b1765b59c",
+  "@id": "niiri:4e5cde201dcf24532399b37950fbd970",
   "@graph": [
     {
-      "@id": "niiri:1c85e51e306450f93ae1eea7dc030468",
-      "@type": ["prov:Agent","src_SPM:","prov:SoftwareAgent"],
+      "@id": "niiri:eb9874e84de35431b43fa1c2015078a6",
+      "@type": ["prov:Agent","src_SPM","prov:SoftwareAgent"],
       "rdfs:label": "SPM",
-      "nidm_softwareVersion:": {"@type": "xsd:string", "@value": "12.12.2"}
+      "nidm_softwareVersion": {"@type": "xsd:string", "@value": "12.6906"}
     },
     {
-      "@id": "niiri:50ab6f82bfb155a52f9575700bce87ef",
-      "@type": ["prov:Entity","nidm_CoordinateSpace:"],
+      "@id": "niiri:b2a98667786a7f2349a2658d9fd2f766",
+      "@type": ["prov:Entity","nidm_CoordinateSpace"],
       "rdfs:label": "Coordinate space 1",
-      "nidm_voxelToWorldMapping:": {"@type": "xsd:string", "@value": "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"},
-      "nidm_voxelUnits:": {"@type": "xsd:string", "@value": "[\"mm\", \"mm\", \"mm\"]"},
-      "nidm_voxelSize:": {"@type": "xsd:string", "@value": "[2, 2, 2]"},
-      "nidm_inWorldCoordinateSystem:": {"@id": "nidm_Ixi549CoordinateSystem:"},
-      "nidm_numberOfDimensions:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_dimensionsInVoxels:": {"@type": "xsd:string", "@value": "[79,95,79]"}
+      "nidm_voxelToWorldMapping": {"@type": "xsd:string", "@value": "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"},
+      "nidm_voxelUnits": {"@type": "xsd:string", "@value": "[\"mm\", \"mm\", \"mm\"]"},
+      "nidm_voxelSize": {"@type": "xsd:string", "@value": "[2, 2, 2]"},
+      "nidm_inWorldCoordinateSystem": {"@id": "nidm_Ixi549CoordinateSystem"},
+      "nidm_numberOfDimensions": {"@type": "xsd:int", "@value": "3"},
+      "nidm_dimensionsInVoxels": {"@type": "xsd:string", "@value": "[79,95,79]"}
     },
     {
-      "@id": "niiri:1b2879ef56e59c00fbd3766cb2b27c90",
-      "@type": ["prov:Agent","nlx_Imaginginstrument:","nlx_Magneticresonanceimagingscanner:"],
+      "@id": "niiri:c1ffd758228d702c4e45a8569d5e3a17",
+      "@type": ["prov:Agent","nlx_Imaginginstrument","nlx_Magneticresonanceimagingscanner"],
       "rdfs:label": "MRI Scanner"
     },
     {
-      "@id": "niiri:c2605828d483ca45e828f58004e6f46e",
+      "@id": "niiri:d2fd7c347715d0e29b9dd29e3691672a",
       "@type": ["prov:Agent","prov:Person"],
       "rdfs:label": "Person"
     },
     {
-      "@id": "niiri:9e1284f48529999852e941d1bfb0d208",
-      "@type": ["prov:Entity","prov:Collection","nidm_Data:"],
+      "@id": "niiri:d8cb12a2013805cec8a0537c545e4c27",
+      "@type": ["prov:Entity","prov:Collection","nidm_Data"],
       "rdfs:label": "Data",
-      "nidm_grandMeanScaling:": {"@type": "xsd:boolean", "@value": "true"},
-      "nidm_targetIntensity:": {"@type": "xsd:float", "@value": "100"},
-      "nidm_hasMRIProtocol:": {"@id": "nlx_FunctionalMRIprotocol:"}
+      "nidm_grandMeanScaling": {"@type": "xsd:boolean", "@value": "true"},
+      "nidm_targetIntensity": {"@type": "xsd:float", "@value": "100"},
+      "nidm_hasMRIProtocol": {"@id": "nlx_FunctionalMRIprotocol"}
     },
     {
       "@type": "prov:Attribution",
-      "entity_attributed": "niiri:9e1284f48529999852e941d1bfb0d208",
-      "agent": "niiri:1b2879ef56e59c00fbd3766cb2b27c90"
+      "entity_attributed": "niiri:d8cb12a2013805cec8a0537c545e4c27",
+      "agent": "niiri:c1ffd758228d702c4e45a8569d5e3a17"
     },
     {
       "@type": "prov:Attribution",
-      "entity_attributed": "niiri:9e1284f48529999852e941d1bfb0d208",
-      "agent": "niiri:c2605828d483ca45e828f58004e6f46e"
+      "entity_attributed": "niiri:d8cb12a2013805cec8a0537c545e4c27",
+      "agent": "niiri:d2fd7c347715d0e29b9dd29e3691672a"
     },
     {
-      "@id": "niiri:9a72b9f06e919ffd7b6beea514120c4c",
-      "@type": ["prov:Entity","spm_DCTDriftModel:"],
+      "@id": "niiri:960c1b74729818f390814df5d8a07151",
+      "@type": ["prov:Entity","spm_DCTDriftModel"],
       "rdfs:label": "SPM's DCT Drift Model",
-      "spm_SPMsDriftCutoffPeriod:": {"@type": "xsd:float", "@value": "128"}
+      "spm_SPMsDriftCutoffPeriod": {"@type": "xsd:float", "@value": "128"}
     },
     {
-      "@id": "niiri:26462807ede3305a82102677feba6507",
-      "@type": ["prov:Entity","nidm_DesignMatrix:"],
+      "@id": "niiri:d44fca7b57060de1677bc74daa15aa89",
+      "@type": ["prov:Entity","nidm_DesignMatrix"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "DesignMatrix.csv"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "DesignMatrix.csv"},
       "dct:format": {"@type": "xsd:string", "@value": "text/csv"},
-      "dc:description": {"@id": "niiri:d2863cf18ed3a73f1c9d8cfc639e76a5"},
+      "dc:description": {"@id": "niiri:8787c98cac2e7989b33c3fc7a9c9f2fa"},
       "rdfs:label": "Design Matrix",
-      "nidm_regressorNames:": {"@type": "xsd:string", "@value": "[\"Sn(1) to*bf(1)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) constant\"]"},
-      "nidm_hasDriftModel:": {"@id": "niiri:9a72b9f06e919ffd7b6beea514120c4c"},
-      "nidm_hasHRFBasis:": {"@id": "spm_SPMsCanonicalHRF:"}
+      "nidm_regressorNames": {"@type": "xsd:string", "@value": "[\"Sn(1) to*bf(1)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) constant\"]"},
+      "nidm_hasDriftModel": {"@id": "niiri:960c1b74729818f390814df5d8a07151"},
+      "nidm_hasHRFBasis": {"@id": "spm_SPMsCanonicalHRF"}
     },
     {
-      "@id": "niiri:d2863cf18ed3a73f1c9d8cfc639e76a5",
+      "@id": "niiri:8787c98cac2e7989b33c3fc7a9c9f2fa",
       "@type": ["prov:Entity","dctype:Image"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "DesignMatrix.png"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "DesignMatrix.png"},
       "dct:format": {"@type": "xsd:string", "@value": "image/png"}
     },
     {
-      "@id": "niiri:9f8cfdef5717075200868a7658ae42b2",
-      "@type": ["prov:Entity","nidm_ErrorModel:"],
-      "nidm_hasErrorDistribution:": {"@id": "obo_normaldistribution:"},
-      "nidm_hasErrorDependence:": {"@id": "obo_Toeplitzcovariancestructure:"},
-      "nidm_dependenceMapWiseDependence:": {"@id": "nidm_ConstantParameter:"},
-      "nidm_errorVarianceHomogeneous:": {"@type": "xsd:boolean", "@value": "true"},
-      "nidm_varianceMapWiseDependence:": {"@id": "nidm_IndependentParameter:"}
+      "@id": "niiri:ca9137874e81e1af901b6acfc7ff391a",
+      "@type": ["prov:Entity","nidm_ErrorModel"],
+      "nidm_hasErrorDistribution": {"@id": "obo_normaldistribution"},
+      "nidm_hasErrorDependence": {"@id": "obo_Toeplitzcovariancestructure"},
+      "nidm_dependenceMapWiseDependence": {"@id": "nidm_ConstantParameter"},
+      "nidm_errorVarianceHomogeneous": {"@type": "xsd:boolean", "@value": "true"},
+      "nidm_varianceMapWiseDependence": {"@id": "nidm_IndependentParameter"}
     },
     {
-      "@id": "niiri:01b92aaf71dc95787225c9a92c03368c",
-      "@type": ["prov:Activity","nidm_ModelParametersEstimation:"],
+      "@id": "niiri:773a735fbcc316e9f2d58362f2f4d1bc",
+      "@type": ["prov:Activity","nidm_ModelParametersEstimation"],
       "rdfs:label": "Model parameters estimation",
-      "nidm_withEstimationMethod:": {"@id": "obo_generalizedleastsquaresestimation:"}
+      "nidm_withEstimationMethod": {"@id": "obo_generalizedleastsquaresestimation"}
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:01b92aaf71dc95787225c9a92c03368c",
-      "agent": "niiri:1c85e51e306450f93ae1eea7dc030468"
+      "activity_associated": "niiri:773a735fbcc316e9f2d58362f2f4d1bc",
+      "agent": "niiri:eb9874e84de35431b43fa1c2015078a6"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:01b92aaf71dc95787225c9a92c03368c",
-      "entity": "niiri:26462807ede3305a82102677feba6507"
+      "activity_using": "niiri:773a735fbcc316e9f2d58362f2f4d1bc",
+      "entity": "niiri:d44fca7b57060de1677bc74daa15aa89"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:01b92aaf71dc95787225c9a92c03368c",
-      "entity": "niiri:9e1284f48529999852e941d1bfb0d208"
+      "activity_using": "niiri:773a735fbcc316e9f2d58362f2f4d1bc",
+      "entity": "niiri:d8cb12a2013805cec8a0537c545e4c27"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:01b92aaf71dc95787225c9a92c03368c",
-      "entity": "niiri:9f8cfdef5717075200868a7658ae42b2"
+      "activity_using": "niiri:773a735fbcc316e9f2d58362f2f4d1bc",
+      "entity": "niiri:ca9137874e81e1af901b6acfc7ff391a"
     },
     {
-      "@id": "niiri:10e0a40e6b9f6264450889f5827a282b",
-      "@type": ["prov:Entity","nidm_MaskMap:"],
+      "@id": "niiri:218e9dabb7ce7346a5fc5d0e4d956c0f",
+      "@type": ["prov:Entity","nidm_MaskMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "Mask.nii.gz"},
-      "nidm_isUserDefined:": {"@type": "xsd:boolean", "@value": "false"},
+      "nidm_isUserDefined": {"@type": "xsd:boolean", "@value": "false"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "Mask.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Mask",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:50ab6f82bfb155a52f9575700bce87ef"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b2a98667786a7f2349a2658d9fd2f766"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876"}
     },
     {
-      "@id": "niiri:c50012d9153f74d1edfa6503cad067c3",
-      "@type": ["prov:Entity","nidm_MaskMap:"],
+      "@id": "niiri:e5b0a4f7beeecbff1514adf4c11f02ab",
+      "@type": ["prov:Entity","nidm_MaskMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "mask.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "36929e1f5f4143bd9cc818cd896a25f129961fab208c3a4438555f40444c08347b359142ee8c53ece6e8cca1627f49db0788a1fd3b9e2ecaef61999c6c6c67ac"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:10e0a40e6b9f6264450889f5827a282b",
-      "entity": "niiri:c50012d9153f74d1edfa6503cad067c3"
+      "entity_derived": "niiri:218e9dabb7ce7346a5fc5d0e4d956c0f",
+      "entity": "niiri:e5b0a4f7beeecbff1514adf4c11f02ab"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:10e0a40e6b9f6264450889f5827a282b",
-      "activity": "niiri:01b92aaf71dc95787225c9a92c03368c"
+      "entity_generated": "niiri:218e9dabb7ce7346a5fc5d0e4d956c0f",
+      "activity": "niiri:773a735fbcc316e9f2d58362f2f4d1bc"
     },
     {
-      "@id": "niiri:af22552e6ef04231ab1ba39bdac1b5be",
-      "@type": ["prov:Entity","nidm_GrandMeanMap:"],
+      "@id": "niiri:b6dedebe44bd4dfcd70f1e56cc87d8e1",
+      "@type": ["prov:Entity","nidm_GrandMeanMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "GrandMean.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "GrandMean.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Grand Mean Map",
-      "nidm_maskedMedian:": {"@type": "xsd:float", "@value": "111.557487487793"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:50ab6f82bfb155a52f9575700bce87ef"},
+      "nidm_maskedMedian": {"@type": "xsd:float", "@value": "111.557487487793"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b2a98667786a7f2349a2658d9fd2f766"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "512157cc6bff89d9343a09b4068226eb3edd64a8cbcee861f06231767fae6f8d4819921182adebee083a9bf309afd65529ab04a92f0aa6b0038c8098550f6124"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:af22552e6ef04231ab1ba39bdac1b5be",
-      "activity": "niiri:01b92aaf71dc95787225c9a92c03368c"
+      "entity_generated": "niiri:b6dedebe44bd4dfcd70f1e56cc87d8e1",
+      "activity": "niiri:773a735fbcc316e9f2d58362f2f4d1bc"
     },
     {
-      "@id": "niiri:45a7380cf4b4845a292bd63d0a2ac4ff",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:55bbc45f54dbafed48a1b302258b19a8",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0001.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0001.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 1",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:50ab6f82bfb155a52f9575700bce87ef"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b2a98667786a7f2349a2658d9fd2f766"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd"}
     },
     {
-      "@id": "niiri:7f8756e251d0ce0a7cef8e400ee2a011",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:a8f1001f03928204508b6ab86da06246",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0001.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:45a7380cf4b4845a292bd63d0a2ac4ff",
-      "entity": "niiri:7f8756e251d0ce0a7cef8e400ee2a011"
+      "entity_derived": "niiri:55bbc45f54dbafed48a1b302258b19a8",
+      "entity": "niiri:a8f1001f03928204508b6ab86da06246"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:45a7380cf4b4845a292bd63d0a2ac4ff",
-      "activity": "niiri:01b92aaf71dc95787225c9a92c03368c"
+      "entity_generated": "niiri:55bbc45f54dbafed48a1b302258b19a8",
+      "activity": "niiri:773a735fbcc316e9f2d58362f2f4d1bc"
     },
     {
-      "@id": "niiri:3a7853f4d424f1acc25ad576004c913f",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:3625bdf3e80d5e9a25b486f9360a1378",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0002.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0002.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 2",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:50ab6f82bfb155a52f9575700bce87ef"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b2a98667786a7f2349a2658d9fd2f766"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c"}
     },
     {
-      "@id": "niiri:531d00f731d00fb9d4b49b8fde409299",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:91a5ac743cdb91c1d48fca362a3241fc",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0002.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3a7853f4d424f1acc25ad576004c913f",
-      "entity": "niiri:531d00f731d00fb9d4b49b8fde409299"
+      "entity_derived": "niiri:3625bdf3e80d5e9a25b486f9360a1378",
+      "entity": "niiri:91a5ac743cdb91c1d48fca362a3241fc"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:3a7853f4d424f1acc25ad576004c913f",
-      "activity": "niiri:01b92aaf71dc95787225c9a92c03368c"
+      "entity_generated": "niiri:3625bdf3e80d5e9a25b486f9360a1378",
+      "activity": "niiri:773a735fbcc316e9f2d58362f2f4d1bc"
     },
     {
-      "@id": "niiri:0b91d3ce63a63f2e4aa74029f82aeae9",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:67cc3fa692b977e0ac54b72dec7e4384",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0003.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0003.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 3",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:50ab6f82bfb155a52f9575700bce87ef"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b2a98667786a7f2349a2658d9fd2f766"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373"}
     },
     {
-      "@id": "niiri:e218c62ae4c038a044a29968c0f162f7",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:fe38b6202e69c84f88ece9b51a9a99c3",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0003.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0b91d3ce63a63f2e4aa74029f82aeae9",
-      "entity": "niiri:e218c62ae4c038a044a29968c0f162f7"
+      "entity_derived": "niiri:67cc3fa692b977e0ac54b72dec7e4384",
+      "entity": "niiri:fe38b6202e69c84f88ece9b51a9a99c3"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:0b91d3ce63a63f2e4aa74029f82aeae9",
-      "activity": "niiri:01b92aaf71dc95787225c9a92c03368c"
+      "entity_generated": "niiri:67cc3fa692b977e0ac54b72dec7e4384",
+      "activity": "niiri:773a735fbcc316e9f2d58362f2f4d1bc"
     },
     {
-      "@id": "niiri:d7d297d8f94d7b492b408fb5c96acdd9",
-      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap:"],
+      "@id": "niiri:b49762a3483888f79a5d5b06f51a25d1",
+      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ResidualMeanSquares.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ResidualMeanSquares.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Residual Mean Squares Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:50ab6f82bfb155a52f9575700bce87ef"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b2a98667786a7f2349a2658d9fd2f766"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "991abf563d795a43b1e2eef8643e57023f2e0b090b2031f05f839321fc0643df6f71d423486a1021519b6dc82f6b0f563e19f3fbd50cb16063bed54a0e192d3e"}
     },
     {
-      "@id": "niiri:d0e293879b9e5931f795c43f7edfe497",
-      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap:"],
+      "@id": "niiri:685419d4a3159548c52f7aa12e55d28b",
+      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "ResMS.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "40b28d03fcf9a2f60b11f10d7fb83bf3618b234fb5aedf09df644cb7cbb6aab8c9f468897c1078166d455a3d04a83f4e3bf762cfca0b4ea982d7a4e406849f18"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d7d297d8f94d7b492b408fb5c96acdd9",
-      "entity": "niiri:d0e293879b9e5931f795c43f7edfe497"
+      "entity_derived": "niiri:b49762a3483888f79a5d5b06f51a25d1",
+      "entity": "niiri:685419d4a3159548c52f7aa12e55d28b"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:d7d297d8f94d7b492b408fb5c96acdd9",
-      "activity": "niiri:01b92aaf71dc95787225c9a92c03368c"
+      "entity_generated": "niiri:b49762a3483888f79a5d5b06f51a25d1",
+      "activity": "niiri:773a735fbcc316e9f2d58362f2f4d1bc"
     },
     {
-      "@id": "niiri:2e723257cae1733db839c73ac25f6112",
-      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap:"],
+      "@id": "niiri:982b6bb49828f15a05294a1c58d03b8b",
+      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ReselsPerVoxel.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ReselsPerVoxel.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Resels per Voxel Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:50ab6f82bfb155a52f9575700bce87ef"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b2a98667786a7f2349a2658d9fd2f766"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "1a3f9216e145249ccc0b14b2bc337d6b38b81ad45e32768001fb22b35f0c2c0f3e2bce013b40c85f7dc0fc62723ac761ee7f7e1e6aff128a05f0ba7b8b8202a3"}
     },
     {
-      "@id": "niiri:392b1752b3da836208fac5721f378347",
-      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap:"],
+      "@id": "niiri:cad5e3e80a900432c8b3e58a397f0b76",
+      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "RPV.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "4f76663162857f6b38b2a45a63b15a23b2ca8b338c283b69c1e71f2ea2f43797d045a733cd14e845be9c12f8b8f84d3931c599a08e8f6d77e99fab46ad87ab8f"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2e723257cae1733db839c73ac25f6112",
-      "entity": "niiri:392b1752b3da836208fac5721f378347"
+      "entity_derived": "niiri:982b6bb49828f15a05294a1c58d03b8b",
+      "entity": "niiri:cad5e3e80a900432c8b3e58a397f0b76"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:2e723257cae1733db839c73ac25f6112",
-      "activity": "niiri:01b92aaf71dc95787225c9a92c03368c"
+      "entity_generated": "niiri:982b6bb49828f15a05294a1c58d03b8b",
+      "activity": "niiri:773a735fbcc316e9f2d58362f2f4d1bc"
     },
     {
-      "@id": "niiri:502e44f2fbcf62365e603de5eac7ff92",
-      "@type": ["prov:Entity","obo_contrastweightmatrix:"],
-      "nidm_statisticType:": {"@id": "obo_tstatistic:"},
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
+      "@id": "niiri:f9498d3b2bcc41a724d906ee170c4316",
+      "@type": ["prov:Entity","obo_contrastweightmatrix"],
+      "nidm_statisticType": {"@id": "obo_tstatistic"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
       "rdfs:label": "Contrast: tone counting vs baseline",
       "prov:value": {"@type": "xsd:string", "@value": "[1, 0, 0]"}
     },
     {
-      "@id": "niiri:d7857c352c75e52b917064fe80e4d398",
-      "@type": ["prov:Activity","nidm_ContrastEstimation:"],
+      "@id": "niiri:2556ad05de8d46ac8899042750f19e3b",
+      "@type": ["prov:Activity","nidm_ContrastEstimation"],
       "rdfs:label": "Contrast estimation"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:d7857c352c75e52b917064fe80e4d398",
-      "agent": "niiri:1c85e51e306450f93ae1eea7dc030468"
+      "activity_associated": "niiri:2556ad05de8d46ac8899042750f19e3b",
+      "agent": "niiri:eb9874e84de35431b43fa1c2015078a6"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:d7857c352c75e52b917064fe80e4d398",
-      "entity": "niiri:10e0a40e6b9f6264450889f5827a282b"
+      "activity_using": "niiri:2556ad05de8d46ac8899042750f19e3b",
+      "entity": "niiri:218e9dabb7ce7346a5fc5d0e4d956c0f"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:d7857c352c75e52b917064fe80e4d398",
-      "entity": "niiri:d7d297d8f94d7b492b408fb5c96acdd9"
+      "activity_using": "niiri:2556ad05de8d46ac8899042750f19e3b",
+      "entity": "niiri:b49762a3483888f79a5d5b06f51a25d1"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:d7857c352c75e52b917064fe80e4d398",
-      "entity": "niiri:26462807ede3305a82102677feba6507"
+      "activity_using": "niiri:2556ad05de8d46ac8899042750f19e3b",
+      "entity": "niiri:d44fca7b57060de1677bc74daa15aa89"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:d7857c352c75e52b917064fe80e4d398",
-      "entity": "niiri:502e44f2fbcf62365e603de5eac7ff92"
+      "activity_using": "niiri:2556ad05de8d46ac8899042750f19e3b",
+      "entity": "niiri:f9498d3b2bcc41a724d906ee170c4316"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:d7857c352c75e52b917064fe80e4d398",
-      "entity": "niiri:45a7380cf4b4845a292bd63d0a2ac4ff"
+      "activity_using": "niiri:2556ad05de8d46ac8899042750f19e3b",
+      "entity": "niiri:55bbc45f54dbafed48a1b302258b19a8"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:d7857c352c75e52b917064fe80e4d398",
-      "entity": "niiri:3a7853f4d424f1acc25ad576004c913f"
+      "activity_using": "niiri:2556ad05de8d46ac8899042750f19e3b",
+      "entity": "niiri:3625bdf3e80d5e9a25b486f9360a1378"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:d7857c352c75e52b917064fe80e4d398",
-      "entity": "niiri:0b91d3ce63a63f2e4aa74029f82aeae9"
+      "activity_using": "niiri:2556ad05de8d46ac8899042750f19e3b",
+      "entity": "niiri:67cc3fa692b977e0ac54b72dec7e4384"
     },
     {
-      "@id": "niiri:bad129c64d1cd2ee3998d0e6c519ba45",
-      "@type": ["prov:Entity","nidm_StatisticMap:"],
+      "@id": "niiri:e461c8f3ab4826650944bec7b1912e84",
+      "@type": ["prov:Entity","nidm_StatisticMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "TStatistic.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "TStatistic.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "T-Statistic Map: tone counting vs baseline",
-      "nidm_statisticType:": {"@id": "obo_tstatistic:"},
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
-      "nidm_errorDegreesOfFreedom:": {"@type": "xsd:float", "@value": "97.9999999998522"},
-      "nidm_effectDegreesOfFreedom:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:50ab6f82bfb155a52f9575700bce87ef"},
+      "nidm_statisticType": {"@id": "obo_tstatistic"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
+      "nidm_errorDegreesOfFreedom": {"@type": "xsd:float", "@value": "97.9999999998522"},
+      "nidm_effectDegreesOfFreedom": {"@type": "xsd:float", "@value": "1"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b2a98667786a7f2349a2658d9fd2f766"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "9e1714c2d86a050b38b4e10a4d2d23253a24c5e1d228ae16a9c3be8872739278505ac0729ecab54265a717e3a54f9f782d0ed72eea904e0d482a6072bb817bd4"}
     },
     {
-      "@id": "niiri:37a27475ed991e4ef01f569ba4bef25e",
-      "@type": ["prov:Entity","nidm_StatisticMap:"],
+      "@id": "niiri:901cc6a5ebd5a3b326b9725834bdddca",
+      "@type": ["prov:Entity","nidm_StatisticMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "spmT_0001.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "d288b1b0f117f64502555da13c5398dffa5bf5ff0b58951510e43d5388755bc185798802a92e98a07c7e313c6991066d2908f2a44aa5153ba23433da1335970f"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:bad129c64d1cd2ee3998d0e6c519ba45",
-      "entity": "niiri:37a27475ed991e4ef01f569ba4bef25e"
+      "entity_derived": "niiri:e461c8f3ab4826650944bec7b1912e84",
+      "entity": "niiri:901cc6a5ebd5a3b326b9725834bdddca"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:bad129c64d1cd2ee3998d0e6c519ba45",
-      "activity": "niiri:d7857c352c75e52b917064fe80e4d398"
+      "entity_generated": "niiri:e461c8f3ab4826650944bec7b1912e84",
+      "activity": "niiri:2556ad05de8d46ac8899042750f19e3b"
     },
     {
-      "@id": "niiri:536beda6b1e9d1057f3a5fa328898c89",
-      "@type": ["prov:Entity","nidm_ContrastMap:"],
+      "@id": "niiri:f9b320bdd9480281306f90d15b0ab8be",
+      "@type": ["prov:Entity","nidm_ContrastMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "Contrast.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "Contrast.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Contrast Map: tone counting vs baseline",
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:50ab6f82bfb155a52f9575700bce87ef"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b2a98667786a7f2349a2658d9fd2f766"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "fc5e2ad175243ee496db98f9b2e1b235c4c3bae1a8d7122ce461c897b537e40c49dfee5d6cf20f71c6a2bb9b5f0760fcb4ecd8fe2e9428910ef3d60d8f3c56a9"}
     },
     {
-      "@id": "niiri:4dbb67fcea1b196014de11fa34a7c299",
-      "@type": ["prov:Entity","nidm_ContrastMap:"],
+      "@id": "niiri:ed3281c40be1462539e94647abd36a73",
+      "@type": ["prov:Entity","nidm_ContrastMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "con_0001.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "d4aa46b3603ba508578e39751262d528cf6d1ed2e722ec46f1cd8194c50591e46b229deb8cb4f72d1b7e0e2640f3e6604be7a335301c5c8357f453e5d0d4daf2"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:536beda6b1e9d1057f3a5fa328898c89",
-      "entity": "niiri:4dbb67fcea1b196014de11fa34a7c299"
+      "entity_derived": "niiri:f9b320bdd9480281306f90d15b0ab8be",
+      "entity": "niiri:ed3281c40be1462539e94647abd36a73"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:536beda6b1e9d1057f3a5fa328898c89",
-      "activity": "niiri:d7857c352c75e52b917064fe80e4d398"
+      "entity_generated": "niiri:f9b320bdd9480281306f90d15b0ab8be",
+      "activity": "niiri:2556ad05de8d46ac8899042750f19e3b"
     },
     {
-      "@id": "niiri:f385f3aec2411e329ca4b4d16ae45cc5",
-      "@type": ["prov:Entity","nidm_ContrastStandardErrorMap:"],
+      "@id": "niiri:a8574ab2053ab027cf06dd5d2a5a785a",
+      "@type": ["prov:Entity","nidm_ContrastStandardErrorMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ContrastStandardError.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ContrastStandardError.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Contrast Standard Error Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:50ab6f82bfb155a52f9575700bce87ef"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b2a98667786a7f2349a2658d9fd2f766"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "791d48f5d1adb15079a5289271ce0c4b95c56d69bfdb3e5d41b0d24eb538d3075e1cdd15502494b5a5a18c16eaa2153cb4847a996043fa48cdaf26e938a2576d"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:f385f3aec2411e329ca4b4d16ae45cc5",
-      "activity": "niiri:d7857c352c75e52b917064fe80e4d398"
+      "entity_generated": "niiri:a8574ab2053ab027cf06dd5d2a5a785a",
+      "activity": "niiri:2556ad05de8d46ac8899042750f19e3b"
     },
     {
-      "@id": "niiri:830481ffc845251233d35209faa5e3c4",
-      "@type": ["prov:Entity","nidm_HeightThreshold:","nidm_PValueUncorrected:"],
-      "rdfs:label": "Height Threshold: p<0.001000 (unc.)",
+      "@id": "niiri:dd97c56b32bf917687b52d95e2b13099",
+      "@type": ["prov:Entity","nidm_HeightThreshold","nidm_PValueUncorrected"],
+      "rdfs:label": "Height Threshold: p<0.001 (unc.)",
       "prov:value": {"@type": "xsd:float", "@value": "0.000999500158000544"},
-      "nidm_equivalentThreshold:": [{"@id": "niiri:2b5fce69752ddfce546ae1b20c298b88"},{"@id": "niiri:2c9e1cb5b11d4d9e79f581086360e7e5"}]
+      "nidm_equivalentThreshold": [{"@id": "niiri:5ca71150749a0c1b73185241479322c6"},{"@id": "niiri:34949c0c34ebc75ccb4b4818296e0a77"}]
     },
     {
-      "@id": "niiri:2b5fce69752ddfce546ae1b20c298b88",
-      "@type": ["prov:Entity","nidm_HeightThreshold:","obo_statistic:"],
-      "rdfs:label": "Height Threshold",
+      "@id": "niiri:5ca71150749a0c1b73185241479322c6",
+      "@type": ["prov:Entity","nidm_HeightThreshold","obo_statistic"],
+      "rdfs:label": "Height Threshold: T=3.175486)",
       "prov:value": {"@type": "xsd:float", "@value": "3.17548628637284"}
     },
     {
-      "@id": "niiri:2c9e1cb5b11d4d9e79f581086360e7e5",
-      "@type": ["prov:Entity","nidm_HeightThreshold:","obo_FWERadjustedpvalue:"],
-      "rdfs:label": "Height Threshold",
+      "@id": "niiri:34949c0c34ebc75ccb4b4818296e0a77",
+      "@type": ["prov:Entity","nidm_HeightThreshold","obo_FWERadjustedpvalue"],
+      "rdfs:label": "Height Threshold: p<1.000000 (FWE)",
       "prov:value": {"@type": "xsd:float", "@value": "0.999999999999997"}
     },
     {
-      "@id": "niiri:1c2d9fb88b84d0d10397f2645fc81f7e",
-      "@type": ["prov:Entity","nidm_ExtentThreshold:","obo_statistic:"],
+      "@id": "niiri:99724284af9cacae301790c375fe6b15",
+      "@type": ["prov:Entity","nidm_ExtentThreshold","obo_statistic"],
       "rdfs:label": "Extent Threshold: k>=0",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "0"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0"},
-      "nidm_equivalentThreshold:": [{"@id": "niiri:f8398b5d7778680876cbd0d3b53b21c8"},{"@id": "niiri:a93b85496c625d485e90cec91df388cc"}]
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "0"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0"},
+      "nidm_equivalentThreshold": [{"@id": "niiri:e135cf296ac53187ccabf232f6d1faac"},{"@id": "niiri:70f26b0e75559a8ee50b5623efa62ae9"}]
     },
     {
-      "@id": "niiri:f8398b5d7778680876cbd0d3b53b21c8",
-      "@type": ["prov:Entity","nidm_ExtentThreshold:","obo_FWERadjustedpvalue:"],
+      "@id": "niiri:e135cf296ac53187ccabf232f6d1faac",
+      "@type": ["prov:Entity","nidm_ExtentThreshold","obo_FWERadjustedpvalue"],
       "rdfs:label": "Extent Threshold",
       "prov:value": {"@type": "xsd:float", "@value": "1"}
     },
     {
-      "@id": "niiri:a93b85496c625d485e90cec91df388cc",
-      "@type": ["prov:Entity","nidm_ExtentThreshold:","nidm_PValueUncorrected:"],
+      "@id": "niiri:70f26b0e75559a8ee50b5623efa62ae9",
+      "@type": ["prov:Entity","nidm_ExtentThreshold","nidm_PValueUncorrected"],
       "rdfs:label": "Extent Threshold",
       "prov:value": {"@type": "xsd:float", "@value": "1"}
     },
     {
-      "@id": "niiri:5b869c4f5dab0de2f993363ded227212",
-      "@type": ["prov:Entity","nidm_PeakDefinitionCriteria:"],
+      "@id": "niiri:dfa8c97f4a46388cf4a9bb1364e0d92e",
+      "@type": ["prov:Entity","nidm_PeakDefinitionCriteria"],
       "rdfs:label": "Peak Definition Criteria",
-      "nidm_maxNumberOfPeaksPerCluster:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_minDistanceBetweenPeaks:": {"@type": "xsd:float", "@value": "8"}
+      "nidm_maxNumberOfPeaksPerCluster": {"@type": "xsd:int", "@value": "3"},
+      "nidm_minDistanceBetweenPeaks": {"@type": "xsd:float", "@value": "8"}
     },
     {
-      "@id": "niiri:0ef97cb242016a21e21ce29dbcb35703",
-      "@type": ["prov:Entity","nidm_ClusterDefinitionCriteria:"],
+      "@id": "niiri:5bd0a1af1bb03071db4c49f47a4396a1",
+      "@type": ["prov:Entity","nidm_ClusterDefinitionCriteria"],
       "rdfs:label": "Cluster Connectivity Criterion: 18",
-      "nidm_hasConnectivityCriterion:": {"@id": "nidm_voxel18connected:"}
+      "nidm_hasConnectivityCriterion": {"@id": "nidm_voxel18connected"}
     },
     {
-      "@id": "niiri:87014624fb0cd5fe9b225ba254cc4638",
-      "@type": ["prov:Activity","nidm_Inference:"],
-      "nidm_hasAlternativeHypothesis:": {"@id": "nidm_OneTailedTest:"},
+      "@id": "niiri:741b8ea52f035ab6ac7f052b1d8660ed",
+      "@type": ["prov:Activity","nidm_Inference"],
+      "nidm_hasAlternativeHypothesis": {"@id": "nidm_OneTailedTest"},
       "rdfs:label": "Inference"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:87014624fb0cd5fe9b225ba254cc4638",
-      "agent": "niiri:1c85e51e306450f93ae1eea7dc030468"
+      "activity_associated": "niiri:741b8ea52f035ab6ac7f052b1d8660ed",
+      "agent": "niiri:eb9874e84de35431b43fa1c2015078a6"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:87014624fb0cd5fe9b225ba254cc4638",
-      "entity": "niiri:830481ffc845251233d35209faa5e3c4"
+      "activity_using": "niiri:741b8ea52f035ab6ac7f052b1d8660ed",
+      "entity": "niiri:dd97c56b32bf917687b52d95e2b13099"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:87014624fb0cd5fe9b225ba254cc4638",
-      "entity": "niiri:1c2d9fb88b84d0d10397f2645fc81f7e"
+      "activity_using": "niiri:741b8ea52f035ab6ac7f052b1d8660ed",
+      "entity": "niiri:99724284af9cacae301790c375fe6b15"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:87014624fb0cd5fe9b225ba254cc4638",
-      "entity": "niiri:bad129c64d1cd2ee3998d0e6c519ba45"
+      "activity_using": "niiri:741b8ea52f035ab6ac7f052b1d8660ed",
+      "entity": "niiri:e461c8f3ab4826650944bec7b1912e84"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:87014624fb0cd5fe9b225ba254cc4638",
-      "entity": "niiri:2e723257cae1733db839c73ac25f6112"
+      "activity_using": "niiri:741b8ea52f035ab6ac7f052b1d8660ed",
+      "entity": "niiri:982b6bb49828f15a05294a1c58d03b8b"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:87014624fb0cd5fe9b225ba254cc4638",
-      "entity": "niiri:10e0a40e6b9f6264450889f5827a282b"
+      "activity_using": "niiri:741b8ea52f035ab6ac7f052b1d8660ed",
+      "entity": "niiri:218e9dabb7ce7346a5fc5d0e4d956c0f"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:87014624fb0cd5fe9b225ba254cc4638",
-      "entity": "niiri:5b869c4f5dab0de2f993363ded227212"
+      "activity_using": "niiri:741b8ea52f035ab6ac7f052b1d8660ed",
+      "entity": "niiri:dfa8c97f4a46388cf4a9bb1364e0d92e"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:87014624fb0cd5fe9b225ba254cc4638",
-      "entity": "niiri:0ef97cb242016a21e21ce29dbcb35703"
+      "activity_using": "niiri:741b8ea52f035ab6ac7f052b1d8660ed",
+      "entity": "niiri:5bd0a1af1bb03071db4c49f47a4396a1"
     },
     {
-      "@id": "niiri:0a910bd73739b38d4f925e16066c96ca",
-      "@type": ["prov:Entity","nidm_SearchSpaceMaskMap:"],
+      "@id": "niiri:b9b82d6e97f1bad3e6178276b982be04",
+      "@type": ["prov:Entity","nidm_SearchSpaceMaskMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "SearchSpaceMask.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "SearchSpaceMask.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Search Space Mask Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:50ab6f82bfb155a52f9575700bce87ef"},
-      "nidm_searchVolumeInVoxels:": {"@type": "xsd:int", "@value": "223057"},
-      "nidm_searchVolumeInUnits:": {"@type": "xsd:float", "@value": "1784456"},
-      "nidm_reselSizeInVoxels:": {"@type": "xsd:float", "@value": "65.5786964036542"},
-      "nidm_searchVolumeInResels:": {"@type": "xsd:float", "@value": "3155.84193266257"},
-      "spm_searchVolumeReselsGeometry:": {"@type": "xsd:string", "@value": "[6, 97.8140592306853, 965.938819261507, 3155.84193266257]"},
-      "nidm_noiseFWHMInVoxels:": {"@type": "xsd:string", "@value": "[4.09118640605185, 4.0346308705955, 3.97291894351243]"},
-      "nidm_noiseFWHMInUnits:": {"@type": "xsd:string", "@value": "[8.18237281210369, 8.069261741191, 7.94583788702486]"},
-      "nidm_randomFieldStationarity:": {"@type": "xsd:boolean", "@value": "true"},
-      "nidm_expectedNumberOfVoxelsPerCluster:": {"@type": "xsd:float", "@value": "7.21748994812991"},
-      "nidm_expectedNumberOfClusters:": {"@type": "xsd:float", "@value": "33.5642173578105"},
-      "nidm_heightCriticalThresholdFWE05:": {"@type": "xsd:float", "@value": "5.30963135104407"},
-      "nidm_heightCriticalThresholdFDR05:": {"@type": "xsd:float", "@value": "4.69981384277344"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b2a98667786a7f2349a2658d9fd2f766"},
+      "nidm_searchVolumeInVoxels": {"@type": "xsd:int", "@value": "223057"},
+      "nidm_searchVolumeInUnits": {"@type": "xsd:float", "@value": "1784456"},
+      "nidm_reselSizeInVoxels": {"@type": "xsd:float", "@value": "65.5786964036542"},
+      "nidm_searchVolumeInResels": {"@type": "xsd:float", "@value": "3155.84193266257"},
+      "spm_searchVolumeReselsGeometry": {"@type": "xsd:string", "@value": "[6, 97.8140592306853, 965.938819261507, 3155.84193266257]"},
+      "nidm_noiseFWHMInVoxels": {"@type": "xsd:string", "@value": "[4.09118640605185, 4.0346308705955, 3.97291894351243]"},
+      "nidm_noiseFWHMInUnits": {"@type": "xsd:string", "@value": "[8.18237281210369, 8.069261741191, 7.94583788702486]"},
+      "nidm_randomFieldStationarity": {"@type": "xsd:boolean", "@value": "true"},
+      "nidm_expectedNumberOfVoxelsPerCluster": {"@type": "xsd:float", "@value": "7.21748994812991"},
+      "nidm_expectedNumberOfClusters": {"@type": "xsd:float", "@value": "33.5642173578105"},
+      "nidm_heightCriticalThresholdFWE05": {"@type": "xsd:float", "@value": "5.30963135104407"},
+      "nidm_heightCriticalThresholdFDR05": {"@type": "xsd:float", "@value": "4.69981384277344"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876"},
-      "spm_smallestSignificantClusterSizeInVoxelsFWE05:": {"@type": "xsd:int", "@value": "116"},
-      "spm_smallestSignificantClusterSizeInVoxelsFDR05:": {"@type": "xsd:int", "@value": "61"}
+      "spm_smallestSignificantClusterSizeInVoxelsFWE05": {"@type": "xsd:int", "@value": "116"},
+      "spm_smallestSignificantClusterSizeInVoxelsFDR05": {"@type": "xsd:int", "@value": "61"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:0a910bd73739b38d4f925e16066c96ca",
-      "activity": "niiri:87014624fb0cd5fe9b225ba254cc4638"
+      "entity_generated": "niiri:b9b82d6e97f1bad3e6178276b982be04",
+      "activity": "niiri:741b8ea52f035ab6ac7f052b1d8660ed"
     },
     {
-      "@id": "niiri:086f71113cd77b52e83a7758b427f167",
-      "@type": ["prov:Entity","nidm_ExcursionSetMap:"],
+      "@id": "niiri:80c10806c0beeee32d27292ced29500f",
+      "@type": ["prov:Entity","nidm_ExcursionSetMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ExcursionSet.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ExcursionSet.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Excursion Set Map",
-      "nidm_numberOfSupraThresholdClusters:": {"@type": "xsd:int", "@value": "81"},
-      "nidm_pValue:": {"@type": "xsd:float", "@value": "3.03579383853503e-12"},
-      "nidm_hasClusterLabelsMap:": {"@id": "niiri:13e6b83205b252983ff42d6a042ef554"},
-      "nidm_hasMaximumIntensityProjection:": {"@id": "niiri:09a42f4704a482efe7b956643a762aba"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:50ab6f82bfb155a52f9575700bce87ef"},
+      "nidm_numberOfSupraThresholdClusters": {"@type": "xsd:int", "@value": "81"},
+      "nidm_pValue": {"@type": "xsd:float", "@value": "3.03579383853503e-12"},
+      "nidm_hasClusterLabelsMap": {"@id": "niiri:e52ca30928761b2a737cfd8aadc61c9a"},
+      "nidm_hasMaximumIntensityProjection": {"@id": "niiri:a8dea88063f0005998cb2504c3d1c11d"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b2a98667786a7f2349a2658d9fd2f766"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "014dbfd7824bc4040c0b428b073ff43721cf78f5e15bbfe3edf01dad68c62eac0a4e978b1cd38dcae91777937b9f5257fb28329cf8c317223be18fa70c2a2ed6"}
     },
     {
-      "@id": "niiri:13e6b83205b252983ff42d6a042ef554",
-      "@type": ["prov:Entity","nidm_ClusterLabelsMap:"],
+      "@id": "niiri:e52ca30928761b2a737cfd8aadc61c9a",
+      "@type": ["prov:Entity","nidm_ClusterLabelsMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ClusterLabels.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ClusterLabels.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Cluster Labels Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:50ab6f82bfb155a52f9575700bce87ef"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b2a98667786a7f2349a2658d9fd2f766"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "06977d4de4ad0066cd008492aeee125405b5fc4a1c6fe605211b4c16a2eaa09a2793f430dd5dec0d1b5fce0d872b2fa96b8083d6cdbe719e497031b5b9d08256"}
     },
     {
-      "@id": "niiri:09a42f4704a482efe7b956643a762aba",
+      "@id": "niiri:a8dea88063f0005998cb2504c3d1c11d",
       "@type": ["prov:Entity","dctype:Image"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "MaximumIntensityProjection.png"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "MaximumIntensityProjection.png"},
@@ -731,3570 +731,3570 @@
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:086f71113cd77b52e83a7758b427f167",
-      "activity": "niiri:87014624fb0cd5fe9b225ba254cc4638"
+      "entity_generated": "niiri:80c10806c0beeee32d27292ced29500f",
+      "activity": "niiri:741b8ea52f035ab6ac7f052b1d8660ed"
     },
     {
-      "@id": "niiri:5fc01864c8f0e284bb366e4a9fc5f229",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:749b77e80ffd0ed4ca77337a7893adc6",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0001",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1804"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "27.5089335246298"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.46511379022666e-21"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "5.93371085041799e-20"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "1"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1804"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "27.5089335246298"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.46511379022666e-21"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "5.93371085041799e-20"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "1"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5fc01864c8f0e284bb366e4a9fc5f229",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:749b77e80ffd0ed4ca77337a7893adc6",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:7164f842b38559769512336527f4fe59",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:e2c6b47be3a342a41d95bfc20852c868",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0002",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "356"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "5.42859220330831"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.6728855149243e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "2.91098190852157e-06"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1.17083954451478e-06"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "2"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "356"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "5.42859220330831"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.6728855149243e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "2.91098190852157e-06"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1.17083954451478e-06"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "2"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7164f842b38559769512336527f4fe59",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:e2c6b47be3a342a41d95bfc20852c868",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:b19f0b712285b7e8de902f92c3fede84",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:7d345f60b278ac792f989f5862ed9684",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0003",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "5090"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "77.6166694237059"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.51031151932561e-42"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "2.03335233065374e-40"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "3"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "5090"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "77.6166694237059"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.51031151932561e-42"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "2.03335233065374e-40"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "3"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b19f0b712285b7e8de902f92c3fede84",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:7d345f60b278ac792f989f5862ed9684",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:01758d9126d8fc5ff1b54b4e6edb737b",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:78cf678fc1d8e63075a90d654ff6f858",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0004",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "766"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "11.6806225498151"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.69891112070838e-12"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "5.70226088569825e-11"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "4.58706002591263e-11"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "4"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "766"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "11.6806225498151"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.69891112070838e-12"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "5.70226088569825e-11"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "4.58706002591263e-11"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "4"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:01758d9126d8fc5ff1b54b4e6edb737b",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:78cf678fc1d8e63075a90d654ff6f858",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:ae4dcd02f2fd1098abb0e8a48b888b04",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:d1df03018bbf137ff5ef2da545a3e8bf",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0005",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "54"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.823438143198452"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00980531403246826"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.280434478478115"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.061094648971533"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "5"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "54"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.823438143198452"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00980531403246826"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.280434478478115"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.061094648971533"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "5"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ae4dcd02f2fd1098abb0e8a48b888b04",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:d1df03018bbf137ff5ef2da545a3e8bf",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:5bfdd7920dcd4de97cf8b89a13cd95e8",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:168af8a06bcba9be4ec76231fb932bcd",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0006",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "285"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "4.34592353354738"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.15539697056139e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "2.73725770201239e-05"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "9.4369593516496e-06"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "6"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "285"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "4.34592353354738"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.15539697056139e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "2.73725770201239e-05"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "9.4369593516496e-06"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "6"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5bfdd7920dcd4de97cf8b89a13cd95e8",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:168af8a06bcba9be4ec76231fb932bcd",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:0fee37ce3647eeec66b703b7384f7d51",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:3b36a7334ca09a3c238279baec873119",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0007",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "395"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "6.02329752895164"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.70020762554596e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "9.06303145864484e-07"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "4.37433635338446e-07"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "7"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "395"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "6.02329752895164"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.70020762554596e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "9.06303145864484e-07"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "4.37433635338446e-07"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "7"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0fee37ce3647eeec66b703b7384f7d51",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:3b36a7334ca09a3c238279baec873119",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:f62983c44994abc2d68d9067929a281b",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:58bff46dfff701e885b3a3a8403d6869",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0008",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "116"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.7688671224263"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000452977534465859"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0150888416289883"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00366911802917346"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "8"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "116"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.7688671224263"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000452977534465859"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0150888416289883"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00366911802917346"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "8"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f62983c44994abc2d68d9067929a281b",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:58bff46dfff701e885b3a3a8403d6869",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:702e99e0477ee69dcca3053044008e4e",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:2bcab9b8311e435ff15509af340ba45e",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0009",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "19"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.289728235569826"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0997597824989178"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.964858026030202"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.278639392496977"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "9"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "19"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.289728235569826"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0997597824989178"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.964858026030202"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.278639392496977"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "9"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:702e99e0477ee69dcca3053044008e4e",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:2bcab9b8311e435ff15509af340ba45e",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:4c2901ae6d0b982e4779668839a7a895",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:932a73d91444fc459c9b49f8b73b2582",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0010",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "50"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.762442725183751"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0123570633152281"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.339498021136914"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0707678054255747"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "10"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "50"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.762442725183751"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0123570633152281"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.339498021136914"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0707678054255747"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "10"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4c2901ae6d0b982e4779668839a7a895",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:932a73d91444fc459c9b49f8b73b2582",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:831be1ca287d5764924d7a7e83076a91",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:d974c978eac6eff6a9802fd0358ceab9",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0011",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "447"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "6.81623796314274"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.03851586308171e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "2.02678038352389e-07"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1.22279946227405e-07"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "11"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "447"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "6.81623796314274"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.03851586308171e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "2.02678038352389e-07"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1.22279946227405e-07"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "11"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:831be1ca287d5764924d7a7e83076a91",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:d974c978eac6eff6a9802fd0358ceab9",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:179b7e6f7102d0f73e68205b289425c6",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:e373ddbc76b41aa980c394eaa5c0e960",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0012",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "162"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "2.47031442959535"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.63852466674842e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00222568832297587"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000672150622508277"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "12"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "162"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "2.47031442959535"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.63852466674842e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00222568832297587"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000672150622508277"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "12"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:179b7e6f7102d0f73e68205b289425c6",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:e373ddbc76b41aa980c394eaa5c0e960",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:5d951dbde4c6cfb00e34afc3122af0f4",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:92a9d73b8902193b0f3316f35cc0dc5b",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0013",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "29"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.442216780606576"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0470937359607303"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.79416170413585"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.190729630640958"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "13"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "29"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.442216780606576"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0470937359607303"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.79416170413585"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.190729630640958"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "13"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5d951dbde4c6cfb00e34afc3122af0f4",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:92a9d73b8902193b0f3316f35cc0dc5b",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:9af9c71c19106f542230ad07eb5a764e",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:be5f1c0a23837aa1ccfc35022807cc1b",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0014",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "38"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.579456471139651"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0257597057294564"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.578781830495109"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.130408510255373"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "14"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "38"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.579456471139651"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0257597057294564"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.578781830495109"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.130408510255373"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "14"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9af9c71c19106f542230ad07eb5a764e",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:be5f1c0a23837aa1ccfc35022807cc1b",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:23627cb4952c94ceb6b00ae5c1c4b815",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:4cb37275d66ab0f22e3ea2174721f6f4",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0015",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "134"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "2.04334650349245"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000208225307159483"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00696455376757865"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00187402776443535"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "15"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "134"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "2.04334650349245"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000208225307159483"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00696455376757865"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00187402776443535"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "15"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:23627cb4952c94ceb6b00ae5c1c4b815",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:4cb37275d66ab0f22e3ea2174721f6f4",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:41c35d6e275325f6cc2f0e603bcbf838",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:9bf6744a8796b8070ccd764f775a5e39",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0016",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "76"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.1589129422793"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00300279655548563"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0958739715182708"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.022111501908576"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "16"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "76"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.1589129422793"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00300279655548563"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0958739715182708"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.022111501908576"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "16"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:41c35d6e275325f6cc2f0e603bcbf838",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:9bf6744a8796b8070ccd764f775a5e39",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:7d64ad68122f5c09739782f91cf20691",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c8a038b61f85138c6e21eee9f3570ce3",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0017",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "16"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.2439816720588"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.128031320700056"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.986394362860718"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.324079280522016"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "17"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "16"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.2439816720588"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.128031320700056"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.986394362860718"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.324079280522016"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "17"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7d64ad68122f5c09739782f91cf20691",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:c8a038b61f85138c6e21eee9f3570ce3",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:7a862cf3ff4623a7a92b4abf907392c8",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:4cfb37bb6f2ac0c6613c6f7263fc6650",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0018",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "26"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.396470217095551"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0583630672052552"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.858988054642613"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.205539497548942"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "18"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "26"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.396470217095551"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0583630672052552"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.858988054642613"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.205539497548942"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "18"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7a862cf3ff4623a7a92b4abf907392c8",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:4cfb37bb6f2ac0c6613c6f7263fc6650",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:abfa5ca5d76007e8bc66144c1f88d4ca",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:090f310da60ee22317a7fb037c567897",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0019",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "29"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.442216780606576"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0470937359607303"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.79416170413585"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.190729630640958"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "19"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "29"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.442216780606576"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0470937359607303"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.79416170413585"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.190729630640958"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "19"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:abfa5ca5d76007e8bc66144c1f88d4ca",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:090f310da60ee22317a7fb037c567897",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:dd86dc550acd2473942e6a2580d34577",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:363fdfdf14cd35df5666fb3e18b0d8c5",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0020",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "6"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0914931270220502"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.343388487126378"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999990125608014"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.604501360009182"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "20"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "6"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0914931270220502"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.343388487126378"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999990125608014"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.604501360009182"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "20"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:dd86dc550acd2473942e6a2580d34577",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:363fdfdf14cd35df5666fb3e18b0d8c5",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:024ae749b1d9748c3c6c99db326eed03",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:80cfe87c528fca41e72aca65987a69a4",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0021",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "10"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.15248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.22255850848336"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999430072930499"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.487222680733842"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "21"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "10"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.15248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.22255850848336"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999430072930499"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.487222680733842"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "21"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:024ae749b1d9748c3c6c99db326eed03",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:80cfe87c528fca41e72aca65987a69a4",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:e47686b38499c7d1c62fe38be1293da3",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:e4d6a9f909a852e57111554ebf0b4352",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0022",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "8"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.1219908360294"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.273933067513935"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999898388010158"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.554714461715718"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "22"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "8"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.1219908360294"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.273933067513935"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999898388010158"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.554714461715718"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "22"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e47686b38499c7d1c62fe38be1293da3",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:e4d6a9f909a852e57111554ebf0b4352",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:8186f3cd73bc2bc0b8b1223383efb0d8",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:039182fcb99c4f9a98332d4c4fb55e21",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0023",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "49"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.747193870680076"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0131051491528842"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.355876032106543"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0707678054255747"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "23"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "49"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.747193870680076"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0131051491528842"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.355876032106543"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0707678054255747"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "23"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8186f3cd73bc2bc0b8b1223383efb0d8",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:039182fcb99c4f9a98332d4c4fb55e21",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:c5762aac6b4c6d55a8d8adc67e3b7dcc",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:52a34b3a1f2ce2562ef0f4d897e30a2f",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0024",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "21"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.320225944577176"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0850912379420168"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.942502902202007"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.255273713826051"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "24"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "21"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.320225944577176"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0850912379420168"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.942502902202007"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.255273713826051"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "24"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c5762aac6b4c6d55a8d8adc67e3b7dcc",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:52a34b3a1f2ce2562ef0f4d897e30a2f",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:f5539938a236da748bfc223f58706047",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f5b45be86dbcd41fe68a83f7d23cef72",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0025",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "9"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.137239690533075"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.24643774370434"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999744295990386"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.511832236924399"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "25"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "9"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.137239690533075"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.24643774370434"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999744295990386"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.511832236924399"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "25"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f5539938a236da748bfc223f58706047",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:f5b45be86dbcd41fe68a83f7d23cef72",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:989884d381b2838d468431f65a707824",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:6f8473034fe37635ca935744c8d051ba",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0026",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "30"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.457465635110251"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.043916653732793"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.770998817460931"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.190729630640958"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "26"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "30"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.457465635110251"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.043916653732793"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.770998817460931"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.190729630640958"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "26"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:989884d381b2838d468431f65a707824",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:6f8473034fe37635ca935744c8d051ba",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:38033d63ea964f0e007a1fe6038289e0",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:72d641147c79cc42de66fcaf250eefff",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0027",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "27"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.411719071599226"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0542875242970965"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.83831709934398"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.199876794002946"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "27"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "27"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.411719071599226"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0542875242970965"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.83831709934398"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.199876794002946"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "27"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:38033d63ea964f0e007a1fe6038289e0",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:72d641147c79cc42de66fcaf250eefff",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:099e17d7816e029529107ceb1b6c97e2",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:0a54f2c3fbd560105040dd395d10cd8e",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0028",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "10"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.15248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.22255850848336"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999430072930499"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.487222680733842"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "28"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "10"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.15248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.22255850848336"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999430072930499"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.487222680733842"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "28"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:099e17d7816e029529107ceb1b6c97e2",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:0a54f2c3fbd560105040dd395d10cd8e",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:c5b0621af9bf43fba5521742d45d67b5",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:6c719ef53d6799a1aa00e8155fb90aa7",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0029",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "61"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.930180124724177"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00662877418964967"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.199476682033478"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0447442257801353"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "29"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "61"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.930180124724177"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00662877418964967"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.199476682033478"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0447442257801353"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "29"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c5b0621af9bf43fba5521742d45d67b5",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:6c719ef53d6799a1aa00e8155fb90aa7",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:370f32e6111a54eccb31b0cf49bb202d",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:9abcaf1e1cd8e4fffc65b4dcd102664f",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0030",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "19"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.289728235569826"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0997597824989178"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.964858026030202"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.278639392496977"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "30"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "19"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.289728235569826"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0997597824989178"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.964858026030202"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.278639392496977"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "30"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:370f32e6111a54eccb31b0cf49bb202d",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:9abcaf1e1cd8e4fffc65b4dcd102664f",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:d66810393703f83fa8331fcba04ca628",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c17192cb7b2dfe5b506d5632ee2f9128",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0031",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "14"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.21348396305145"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.152527900243506"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.994020866354823"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.374386664234061"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "31"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "14"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.21348396305145"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.152527900243506"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.994020866354823"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.374386664234061"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "31"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d66810393703f83fa8331fcba04ca628",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:c17192cb7b2dfe5b506d5632ee2f9128",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:71d217841d852b0f36a116432eae4b2d",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:0cdd87a23d70e882dffa97ccc3f06458",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0032",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "18"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.27447938106615"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.108241900089372"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.973564689982443"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.292253130241304"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "32"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "18"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.27447938106615"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.108241900089372"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.973564689982443"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.292253130241304"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "32"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:71d217841d852b0f36a116432eae4b2d",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:0cdd87a23d70e882dffa97ccc3f06458",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:d6d7d4eefe6b670db24c97dc9318b6ce",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:24c8de1b4ac2f5e9c8b9a7759335fe9d",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0033",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "28"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.426967926102901"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.050541462694511"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.81665481379022"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.194945641821685"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "33"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "28"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.426967926102901"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.050541462694511"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.81665481379022"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.194945641821685"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "33"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d6d7d4eefe6b670db24c97dc9318b6ce",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:24c8de1b4ac2f5e9c8b9a7759335fe9d",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:876fcdab3aee2f6373c0e2df60b41a4e",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:9634c37192a257704d16f5f1d880a757",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0034",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "6"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0914931270220502"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.343388487126378"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999990125608014"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.604501360009182"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "34"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "6"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0914931270220502"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.343388487126378"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999990125608014"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.604501360009182"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "34"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:876fcdab3aee2f6373c0e2df60b41a4e",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:9634c37192a257704d16f5f1d880a757",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:542b8b904774372e0a9627db540a47b7",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:11b95279587654680aac97970c1dca33",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0035",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "21"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.320225944577176"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0850912379420168"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.942502902202007"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.255273713826051"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "35"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "21"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.320225944577176"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0850912379420168"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.942502902202007"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.255273713826051"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "35"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:542b8b904774372e0a9627db540a47b7",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:11b95279587654680aac97970c1dca33",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:8bb571ef9ea74d78aa93e3046b5d96de",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:0a1d8340cb8c5e4660accea8890aaead",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0036",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "6"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0914931270220502"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.343388487126378"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999990125608014"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.604501360009182"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "36"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "6"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0914931270220502"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.343388487126378"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999990125608014"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.604501360009182"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "36"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8bb571ef9ea74d78aa93e3046b5d96de",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:0a1d8340cb8c5e4660accea8890aaead",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:b4db133a7dcffc113bdc5cacd1f15c64",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:7e88673ecdc8e0e122c41546194e1107",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0037",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "29"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.442216780606576"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0470937359607303"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.79416170413585"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.190729630640958"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "37"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "29"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.442216780606576"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0470937359607303"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.79416170413585"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.190729630640958"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "37"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b4db133a7dcffc113bdc5cacd1f15c64",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:7e88673ecdc8e0e122c41546194e1107",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:0c00d9725bd14d031e130ad06f956eb2",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:9c9e8e71561800d1df10386138b306ed",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0038",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "24"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.365972508088201"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0676477474681771"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.896743975460065"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.228311147705098"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "38"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "24"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.365972508088201"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0676477474681771"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.896743975460065"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.228311147705098"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "38"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0c00d9725bd14d031e130ad06f956eb2",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:9c9e8e71561800d1df10386138b306ed",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:02839eee4d11ae4489dc6302d4195c9e",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:7fe6fe573e42bb4d7fda5294f70b254e",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0039",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0609954180147001"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.44232166254071"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999643232106"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.628562362557851"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "39"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0609954180147001"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.44232166254071"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999643232106"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.628562362557851"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "39"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:02839eee4d11ae4489dc6302d4195c9e",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:7fe6fe573e42bb4d7fda5294f70b254e",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:5bc68587f226de0a0713847e711c40db",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:8fa9b6d9acd2c49ac8d56eaee29fc687",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0040",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "12"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.1829862540441"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.183276076907294"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.997869754572677"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.42415320655688"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "40"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "12"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.1829862540441"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.183276076907294"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.997869754572677"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.42415320655688"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "40"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5bc68587f226de0a0713847e711c40db",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:8fa9b6d9acd2c49ac8d56eaee29fc687",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:e7802951bd1400071eecd4c74c824fb2",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:5033df2d3441877c72a35517e4199588",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0041",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "9"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.137239690533075"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.24643774370434"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999744295990386"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.511832236924399"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "41"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "9"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.137239690533075"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.24643774370434"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999744295990386"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.511832236924399"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "41"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e7802951bd1400071eecd4c74c824fb2",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:5033df2d3441877c72a35517e4199588",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:fc840fc33c4cab88ad22815e22846638",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:4124e50de0ee3b3d33d8b3570cdaf9c8",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0042",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999997153"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "42"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999997153"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "42"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:fc840fc33c4cab88ad22815e22846638",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:4124e50de0ee3b3d33d8b3570cdaf9c8",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:3efd65f0da924a5bb703dc14f0ae2445",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:4a2fd60e9307d21139c66a8495323c62",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0043",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "21"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.320225944577176"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0850912379420168"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.942502902202007"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.255273713826051"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "43"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "21"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.320225944577176"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0850912379420168"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.942502902202007"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.255273713826051"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "43"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3efd65f0da924a5bb703dc14f0ae2445",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:4a2fd60e9307d21139c66a8495323c62",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:aa3d8d16c81b84fa58af94c6d0a92521",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:47493d1488caf09ebaff86e6cfddca82",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0044",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "7"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.106741981525725"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.305873808816549"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999965218155016"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.604287280832693"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "44"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "7"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.106741981525725"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.305873808816549"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999965218155016"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.604287280832693"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "44"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:aa3d8d16c81b84fa58af94c6d0a92521",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:47493d1488caf09ebaff86e6cfddca82",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:be89147f5a6922a011e2b69c54c91307",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f30d659f7dd564a91713174649a7897e",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0045",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "5"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0762442725183751"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.388074947166389"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999997796430203"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.604501360009182"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "45"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "5"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0762442725183751"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.388074947166389"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999997796430203"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.604501360009182"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "45"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:be89147f5a6922a011e2b69c54c91307",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:f30d659f7dd564a91713174649a7897e",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:27aff9030eda043106c67b4df9bd432f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:bf5d4132caa2ab59278ac933dbeefdc4",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0046",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "16"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.2439816720588"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.128031320700056"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.986394362860718"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.324079280522016"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "46"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "16"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.2439816720588"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.128031320700056"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.986394362860718"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.324079280522016"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "46"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:27aff9030eda043106c67b4df9bd432f",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:bf5d4132caa2ab59278ac933dbeefdc4",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:6015153862c2f18b0399c5979d77b579",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:5063c9c53f326a1d63e57a9ad368aba4",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0047",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "5"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0762442725183751"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.388074947166389"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999997796430203"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.604501360009182"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "47"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "5"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0762442725183751"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.388074947166389"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999997796430203"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.604501360009182"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "47"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6015153862c2f18b0399c5979d77b579",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:5063c9c53f326a1d63e57a9ad368aba4",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:d49cca9c5e9ab92f918362c3052e9a2d",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f53e11fdc36e62f28a07e009b005603e",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0048",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "5"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0762442725183751"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.388074947166389"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999997796430203"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.604501360009182"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "48"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "5"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0762442725183751"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.388074947166389"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999997796430203"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.604501360009182"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "48"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d49cca9c5e9ab92f918362c3052e9a2d",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:f53e11fdc36e62f28a07e009b005603e",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:e35587b2acf9fd9a9fdf0672cc249a3a",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:ae4cfacdd2f80d4db5489f80321a64c5",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0049",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.598176099264786"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999998092195"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "49"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.598176099264786"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999998092195"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "49"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e35587b2acf9fd9a9fdf0672cc249a3a",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:ae4cfacdd2f80d4db5489f80321a64c5",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:98d127e586abf35e62811f986bd3be18",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:4bf515909ab7c79154616841d777e9fa",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0050",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0457465635110251"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.509991966452308"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999963189445"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.688489154710615"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "50"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0457465635110251"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.509991966452308"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999963189445"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.688489154710615"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "50"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:98d127e586abf35e62811f986bd3be18",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:4bf515909ab7c79154616841d777e9fa",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:b2f002bc586117a24bdd5081006f3f23",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:9c5ac23579b49a629cb17821a462a039",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0051",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0609954180147001"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.44232166254071"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999643232106"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.628562362557851"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "51"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0609954180147001"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.44232166254071"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999643232106"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.628562362557851"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "51"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b2f002bc586117a24bdd5081006f3f23",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:9c5ac23579b49a629cb17821a462a039",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:4ce238771ccf766ed28486be0e931e33",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:0059ec9a6bb7c2d7e6ea96012aa070a4",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0052",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "13"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.198235108547775"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.166999709083906"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.996321368733297"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.39785224811166"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "52"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "13"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.198235108547775"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.166999709083906"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.996321368733297"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.39785224811166"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "52"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4ce238771ccf766ed28486be0e931e33",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:0059ec9a6bb7c2d7e6ea96012aa070a4",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:e4b08c3de8b3e30fc520a4a7fb1d0717",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:3bb3714faa1aae7d02675cad6938ab52",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0053",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "6"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0914931270220502"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.343388487126378"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999990125608014"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.604501360009182"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "53"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "6"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0914931270220502"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.343388487126378"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999990125608014"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.604501360009182"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "53"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e4b08c3de8b3e30fc520a4a7fb1d0717",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:3bb3714faa1aae7d02675cad6938ab52",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:f272badd0515e42b4d960d9705968657",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:79f4ea32c57ff4bc44bd9693fb4bfb39",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0054",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0457465635110251"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.509991966452308"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999963189445"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.688489154710615"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "54"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0457465635110251"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.509991966452308"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999963189445"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.688489154710615"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "54"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f272badd0515e42b4d960d9705968657",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:79f4ea32c57ff4bc44bd9693fb4bfb39",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:d1006f0765b2d600f398d4672099ed92",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:16165a8f8f2fb7e16961bd153e0121b3",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0055",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "5"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0762442725183751"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.388074947166389"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999997796430203"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.604501360009182"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "55"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "5"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0762442725183751"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.388074947166389"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999997796430203"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.604501360009182"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "55"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d1006f0765b2d600f398d4672099ed92",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:16165a8f8f2fb7e16961bd153e0121b3",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:b221fbfb15d7f985909dc4575902ee79",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:120ccd02c2048169aea9fc9ef80dac7e",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0056",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0457465635110251"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.509991966452308"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999963189445"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.688489154710615"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "56"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0457465635110251"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.509991966452308"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999963189445"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.688489154710615"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "56"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b221fbfb15d7f985909dc4575902ee79",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:120ccd02c2048169aea9fc9ef80dac7e",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:22518d42d4312d19842a6c5c7116e209",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:8ecb9c4697fe5773d29ea35c29d84ef3",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0057",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.598176099264786"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999998092195"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "57"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.598176099264786"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999998092195"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "57"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:22518d42d4312d19842a6c5c7116e209",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:8ecb9c4697fe5773d29ea35c29d84ef3",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:27f64237a208bdd1b919662a44a25b49",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:b24de80c3a706246e31d6423b3708450",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0058",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "6"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0914931270220502"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.343388487126378"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999990125608014"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.604501360009182"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "58"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "6"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0914931270220502"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.343388487126378"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999990125608014"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.604501360009182"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "58"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:27f64237a208bdd1b919662a44a25b49",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:b24de80c3a706246e31d6423b3708450",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:a5728ac41df0c581754b6db5427b1f05",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:0f16dde8718dddce4db284b7a40496a8",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0059",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999997153"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "59"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999997153"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "59"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a5728ac41df0c581754b6db5427b1f05",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:0f16dde8718dddce4db284b7a40496a8",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:ff4fe7af97fc1af636a6c8d8f050f08f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:6618ca3eaa19d5e02557c9a8428828e3",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0060",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0609954180147001"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.44232166254071"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999643232106"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.628562362557851"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "60"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0609954180147001"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.44232166254071"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999643232106"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.628562362557851"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "60"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ff4fe7af97fc1af636a6c8d8f050f08f",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:6618ca3eaa19d5e02557c9a8428828e3",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:ec5515690308a412deffcb4cf46f2365",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:edcf13cf2a9f550f95f7fa64a9ab86ca",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0061",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.598176099264786"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999998092195"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "61"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.598176099264786"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999998092195"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "61"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ec5515690308a412deffcb4cf46f2365",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:edcf13cf2a9f550f95f7fa64a9ab86ca",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:f74ca8cae4e2c682c3f97b1a640a5f00",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:80da85f37d04350ac439bb0dfa06ea5b",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0062",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0609954180147001"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.44232166254071"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999643232106"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.628562362557851"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "62"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0609954180147001"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.44232166254071"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999643232106"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.628562362557851"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "62"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f74ca8cae4e2c682c3f97b1a640a5f00",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:80da85f37d04350ac439bb0dfa06ea5b",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:2a63ea593120afc6649eda0c102f631d",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:cce62b8bba59fb588c9623468819b0f6",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0063",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0609954180147001"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.44232166254071"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999643232106"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.628562362557851"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "63"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0609954180147001"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.44232166254071"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999643232106"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.628562362557851"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "63"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2a63ea593120afc6649eda0c102f631d",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:cce62b8bba59fb588c9623468819b0f6",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:6f87e962fab6d1220c091e46877922d9",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:fe52388c406befa95a7e7abdd9bc5d0d",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0064",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999997153"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "64"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999997153"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "64"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6f87e962fab6d1220c091e46877922d9",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:fe52388c406befa95a7e7abdd9bc5d0d",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:e86febc59d83b46e7775b7ea6281d7b6",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:aaf8a80c3785eabb526fa793c58065c5",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0065",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "5"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0762442725183751"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.388074947166389"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999997796430203"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.604501360009182"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "65"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "5"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0762442725183751"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.388074947166389"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999997796430203"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.604501360009182"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "65"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e86febc59d83b46e7775b7ea6281d7b6",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:aaf8a80c3785eabb526fa793c58065c5",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:033bb93f5934ac8e2216a6953d84f96b",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:66a2dce74584c693a761996e8a52ee2c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0066",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "5"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0762442725183751"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.388074947166389"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999997796430203"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.604501360009182"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "66"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "5"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0762442725183751"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.388074947166389"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999997796430203"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.604501360009182"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "66"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:033bb93f5934ac8e2216a6953d84f96b",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:66a2dce74584c693a761996e8a52ee2c",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:20e24f503a4809e9cf0241f76eaaf79d",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:842dcf5877dd33791cbf64037b0d160d",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0067",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.598176099264786"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999998092195"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "67"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.598176099264786"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999998092195"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "67"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:20e24f503a4809e9cf0241f76eaaf79d",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:842dcf5877dd33791cbf64037b0d160d",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:80d7fbf81e2055777ba9feeeadecc526",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:826c8df2b7140fdd69ec6d944489cb87",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0068",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999997153"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "68"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999997153"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "68"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:80d7fbf81e2055777ba9feeeadecc526",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:826c8df2b7140fdd69ec6d944489cb87",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:2bd7817009f58b9da9bae43a5b25b68f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:a8072ecfcdfd108f310a1bc87c821cf1",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0069",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.598176099264786"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999998092195"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "69"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.598176099264786"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999998092195"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "69"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2bd7817009f58b9da9bae43a5b25b68f",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:a8072ecfcdfd108f310a1bc87c821cf1",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:15e4c29ced9fec2482ceb9ba6a0a51d1",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:71b52ab8126a30a8e2c6e66f6b5da31f",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0070",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999997153"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "70"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999997153"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "70"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:15e4c29ced9fec2482ceb9ba6a0a51d1",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:71b52ab8126a30a8e2c6e66f6b5da31f",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:42e659c3800a504268b49626856a7c27",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:339add5fca2f1335faf3c97a8ad874f4",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0071",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999997153"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "71"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999997153"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "71"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:42e659c3800a504268b49626856a7c27",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:339add5fca2f1335faf3c97a8ad874f4",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:2cd92c6773d556b9448a0ddb09bd8b31",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:b822c27c9e4ca42b4196dd89b524730c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0072",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999997153"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "72"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999997153"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "72"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2cd92c6773d556b9448a0ddb09bd8b31",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:b822c27c9e4ca42b4196dd89b524730c",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:fbeda8761878a098b300fa81bfca94a3",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:96419b4c6e6c59ea3a4153112ed9d514",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0073",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999997153"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "73"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999997153"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "73"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:fbeda8761878a098b300fa81bfca94a3",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:96419b4c6e6c59ea3a4153112ed9d514",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:ff113369a1aab0598dc0f3d86fc0129b",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:2156904148b8610fa21cc0ac6f11f0a5",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0074",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999997153"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "74"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999997153"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "74"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ff113369a1aab0598dc0f3d86fc0129b",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:2156904148b8610fa21cc0ac6f11f0a5",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:ef6a4c707bf3e80d6954ad82e2705808",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:bba6fb2b90294edde963661ec3fea027",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0075",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999997153"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "75"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999997153"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "75"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ef6a4c707bf3e80d6954ad82e2705808",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:bba6fb2b90294edde963661ec3fea027",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:cb14e2f236a171bf561b547935b40dd9",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:a428752a112ae62b5d4a764c475ebebb",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0076",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999997153"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "76"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999997153"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "76"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cb14e2f236a171bf561b547935b40dd9",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:a428752a112ae62b5d4a764c475ebebb",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:215e12d51ca68faf83b3c157465a4274",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:011ca539a5756d6a56b02867c8dc0da5",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0077",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999997153"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "77"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999997153"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "77"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:215e12d51ca68faf83b3c157465a4274",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:011ca539a5756d6a56b02867c8dc0da5",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:846d054635e491107608bcf6e7db6e7b",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:cba5fb0d6db1529fec8f4fba47f35ad8",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0078",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999997153"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "78"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999997153"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "78"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:846d054635e491107608bcf6e7db6e7b",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:cba5fb0d6db1529fec8f4fba47f35ad8",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:cc3ec71f9506a13ad5812b94c954a6a4",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:ff8870f1fb72bc18a894385e2e338a1a",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0079",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999997153"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "79"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999997153"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "79"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cc3ec71f9506a13ad5812b94c954a6a4",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:ff8870f1fb72bc18a894385e2e338a1a",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:ddbafccf344e9c4433df922b8641380c",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:0dd915ffcbdf519b3a8e0e342a7a3a15",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0080",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999997153"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "80"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999997153"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "80"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ddbafccf344e9c4433df922b8641380c",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:0dd915ffcbdf519b3a8e0e342a7a3a15",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:c89051853f599ba8b9d939c26968a8b9",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:aa3557b1b3fba9452176860c67262bd9",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0081",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999997153"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723454321471829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "81"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999997153"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723454321471829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "81"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c89051853f599ba8b9d939c26968a8b9",
-      "entity": "niiri:086f71113cd77b52e83a7758b427f167"
+      "entity_derived": "niiri:aa3557b1b3fba9452176860c67262bd9",
+      "entity": "niiri:80c10806c0beeee32d27292ced29500f"
     },
     {
-      "@id": "niiri:1efb472cf409fc6990ad7949ea12623b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:32978f193454276a89690a074d1f925d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0001",
-      "prov:atLocation": {"@id": "niiri:e33b3578f5d7f2bd6821d58e98d19ba1"},
+      "prov:atLocation": {"@id": "niiri:55d81a635f7a8d8e2db6359db99ea928"},
       "prov:value": {"@type": "xsd:float", "@value": "7.92007970809937"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "6.94608360738412"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.87783122385099e-12"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "4.18813870695089e-07"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "5.21674435923017e-06"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "6.94608360738412"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.87783122385099e-12"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "4.18813870695089e-07"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "5.21674435923017e-06"}
     },
     {
-      "@id": "niiri:e33b3578f5d7f2bd6821d58e98d19ba1",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:55d81a635f7a8d8e2db6359db99ea928",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0001",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[46,16,24]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[46,16,24]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1efb472cf409fc6990ad7949ea12623b",
-      "entity": "niiri:5fc01864c8f0e284bb366e4a9fc5f229"
+      "entity_derived": "niiri:32978f193454276a89690a074d1f925d",
+      "entity": "niiri:749b77e80ffd0ed4ca77337a7893adc6"
     },
     {
-      "@id": "niiri:1a013dfcb97a9f36ba77ac6137c1edf8",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:34b93bd18a1d6b9d11f9220e9d0c8d8f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0002",
-      "prov:atLocation": {"@id": "niiri:f8d77c57fd14c4f211154bb71e689486"},
+      "prov:atLocation": {"@id": "niiri:e8b2f11cf4cbe836c4f5539b6b098535"},
       "prov:value": {"@type": "xsd:float", "@value": "6.31603479385376"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.77079466112137"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.94492849498107e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.000879943865776389"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000830722551601523"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.77079466112137"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.94492849498107e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.000879943865776389"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000830722551601523"}
     },
     {
-      "@id": "niiri:f8d77c57fd14c4f211154bb71e689486",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e8b2f11cf4cbe836c4f5539b6b098535",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0002",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[32,24,-4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[32,24,-4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1a013dfcb97a9f36ba77ac6137c1edf8",
-      "entity": "niiri:5fc01864c8f0e284bb366e4a9fc5f229"
+      "entity_derived": "niiri:34b93bd18a1d6b9d11f9220e9d0c8d8f",
+      "entity": "niiri:749b77e80ffd0ed4ca77337a7893adc6"
     },
     {
-      "@id": "niiri:caabb17b7e59e93fae5554b48316ee5e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3898d262fb3baf3f75b22150a9b04a7a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0003",
-      "prov:atLocation": {"@id": "niiri:0d71b27c6ee9fe48a05d153c27767e18"},
+      "prov:atLocation": {"@id": "niiri:ac1322201748ec0f5c221256a0fd16af"},
       "prov:value": {"@type": "xsd:float", "@value": "5.68819808959961"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.27450168515333"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.655864770444e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0121028975026269"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00350091530962783"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.27450168515333"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.655864770444e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0121028975026269"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00350091530962783"}
     },
     {
-      "@id": "niiri:0d71b27c6ee9fe48a05d153c27767e18",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ac1322201748ec0f5c221256a0fd16af",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0003",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[18,16,4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[18,16,4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:caabb17b7e59e93fae5554b48316ee5e",
-      "entity": "niiri:5fc01864c8f0e284bb366e4a9fc5f229"
+      "entity_derived": "niiri:3898d262fb3baf3f75b22150a9b04a7a",
+      "entity": "niiri:749b77e80ffd0ed4ca77337a7893adc6"
     },
     {
-      "@id": "niiri:f007a456fb6f4d8cb6bf39a2f9d5e74a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:603e9a34a8c2b14d5f22ac5bab31465c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0004",
-      "prov:atLocation": {"@id": "niiri:c31e51d23633fd58f2f374a962a5dc1c"},
+      "prov:atLocation": {"@id": "niiri:4d22debd9be5615681ad6502530caa16"},
       "prov:value": {"@type": "xsd:float", "@value": "7.11683940887451"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "6.37404871703245"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "9.20510334623259e-11"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "2.05325778424026e-05"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "9.33757664730496e-05"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "6.37404871703245"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "9.20510334623259e-11"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "2.05325778424026e-05"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "9.33757664730496e-05"}
     },
     {
-      "@id": "niiri:c31e51d23633fd58f2f374a962a5dc1c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4d22debd9be5615681ad6502530caa16",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0004",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[34,-88,-2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[34,-88,-2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f007a456fb6f4d8cb6bf39a2f9d5e74a",
-      "entity": "niiri:7164f842b38559769512336527f4fe59"
+      "entity_derived": "niiri:603e9a34a8c2b14d5f22ac5bab31465c",
+      "entity": "niiri:e2c6b47be3a342a41d95bfc20852c868"
     },
     {
-      "@id": "niiri:2fbc8b5c390bb7e049cba0090dd4ff65",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d1e8c4e4831c31323bfedc0662522fc6",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0005",
-      "prov:atLocation": {"@id": "niiri:2c308e506ba4941e91e9702a543dc7b2"},
+      "prov:atLocation": {"@id": "niiri:fd5d0747ba793c53ed9eb8130c1f1499"},
       "prov:value": {"@type": "xsd:float", "@value": "6.48292255401611"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.8992593141605"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.82568493656277e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.000407231755366277"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000830722551601523"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.8992593141605"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.82568493656277e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.000407231755366277"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000830722551601523"}
     },
     {
-      "@id": "niiri:2c308e506ba4941e91e9702a543dc7b2",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:fd5d0747ba793c53ed9eb8130c1f1499",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0005",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[42,-72,-10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[42,-72,-10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2fbc8b5c390bb7e049cba0090dd4ff65",
-      "entity": "niiri:7164f842b38559769512336527f4fe59"
+      "entity_derived": "niiri:d1e8c4e4831c31323bfedc0662522fc6",
+      "entity": "niiri:e2c6b47be3a342a41d95bfc20852c868"
     },
     {
-      "@id": "niiri:c510dbd234cba3682e284dfbe3dfcd07",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:58f6ffe36b16b4d86866a57a2e3f0d86",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0006",
-      "prov:atLocation": {"@id": "niiri:4bb9017fbe8036db5bb4983c1371606a"},
+      "prov:atLocation": {"@id": "niiri:fb04675da6d16642172d2d7cdf72b57e"},
       "prov:value": {"@type": "xsd:float", "@value": "5.2275915145874"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.89738468004472"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.85602978606003e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0670610253017228"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0118363293065346"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.89738468004472"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.85602978606003e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0670610253017228"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0118363293065346"}
     },
     {
-      "@id": "niiri:4bb9017fbe8036db5bb4983c1371606a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:fb04675da6d16642172d2d7cdf72b57e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0006",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[34,-86,12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[34,-86,12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c510dbd234cba3682e284dfbe3dfcd07",
-      "entity": "niiri:7164f842b38559769512336527f4fe59"
+      "entity_derived": "niiri:58f6ffe36b16b4d86866a57a2e3f0d86",
+      "entity": "niiri:e2c6b47be3a342a41d95bfc20852c868"
     },
     {
-      "@id": "niiri:31247a1d059ea149c62b1fe34caf249b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:6f9df5a084be3215b055ddef7915c8ba",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0007",
-      "prov:atLocation": {"@id": "niiri:464aa8a5582a70422e4ad672d0aebc40"},
+      "prov:atLocation": {"@id": "niiri:6ae79521dd4177d878efc76a6f51db6b"},
       "prov:value": {"@type": "xsd:float", "@value": "6.28007745742798"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.74292583422276"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.65272453897825e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00103782272796227"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000830722551601523"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.74292583422276"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.65272453897825e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00103782272796227"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000830722551601523"}
     },
     {
-      "@id": "niiri:464aa8a5582a70422e4ad672d0aebc40",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6ae79521dd4177d878efc76a6f51db6b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0007",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[8,18,50]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[8,18,50]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:31247a1d059ea149c62b1fe34caf249b",
-      "entity": "niiri:b19f0b712285b7e8de902f92c3fede84"
+      "entity_derived": "niiri:6f9df5a084be3215b055ddef7915c8ba",
+      "entity": "niiri:7d345f60b278ac792f989f5862ed9684"
     },
     {
-      "@id": "niiri:77506a7482eddd4edff175b5f79fa109",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:6cdda123bcee4885c1034564912a97af",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0008",
-      "prov:atLocation": {"@id": "niiri:f635cbf5f75164df1bceeb2422223464"},
+      "prov:atLocation": {"@id": "niiri:684b2a5117bca29995311831b26bfe6e"},
       "prov:value": {"@type": "xsd:float", "@value": "6.15222215652466"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.64328512810061"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.34178537356678e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00186069357054308"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000972721201433817"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.64328512810061"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.34178537356678e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00186069357054308"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000972721201433817"}
     },
     {
-      "@id": "niiri:f635cbf5f75164df1bceeb2422223464",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:684b2a5117bca29995311831b26bfe6e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0008",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-6,12,52]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-6,12,52]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:77506a7482eddd4edff175b5f79fa109",
-      "entity": "niiri:b19f0b712285b7e8de902f92c3fede84"
+      "entity_derived": "niiri:6cdda123bcee4885c1034564912a97af",
+      "entity": "niiri:7d345f60b278ac792f989f5862ed9684"
     },
     {
-      "@id": "niiri:6b0edf38814b032e80ab3bf727127995",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:463d5476f401e65d9740c56ea881befc",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0009",
-      "prov:atLocation": {"@id": "niiri:8778369dc9a05966e61a41c53c1e5c65"},
+      "prov:atLocation": {"@id": "niiri:153814c4f143461197c66a523426c9c6"},
       "prov:value": {"@type": "xsd:float", "@value": "5.98517084121704"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.51181334779297"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.77577724747024e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00376326218366319"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00136419627856355"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.51181334779297"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.77577724747024e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00376326218366319"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00136419627856355"}
     },
     {
-      "@id": "niiri:8778369dc9a05966e61a41c53c1e5c65",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:153814c4f143461197c66a523426c9c6",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0009",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[8,32,38]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[8,32,38]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6b0edf38814b032e80ab3bf727127995",
-      "entity": "niiri:b19f0b712285b7e8de902f92c3fede84"
+      "entity_derived": "niiri:463d5476f401e65d9740c56ea881befc",
+      "entity": "niiri:7d345f60b278ac792f989f5862ed9684"
     },
     {
-      "@id": "niiri:a9cdf184f9a4f9933cfb8a1a901241e5",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:291008c3ba8bd66b60306971f236360c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0010",
-      "prov:atLocation": {"@id": "niiri:2cf3e64a20c377876f126c6cc7288ff4"},
+      "prov:atLocation": {"@id": "niiri:a2722e3c6e931e50799908c5e74e91c3"},
       "prov:value": {"@type": "xsd:float", "@value": "6.25127363204956"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.72055271981637"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.30890376104765e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0011841880966994"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000830722551601523"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.72055271981637"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.30890376104765e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0011841880966994"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000830722551601523"}
     },
     {
-      "@id": "niiri:2cf3e64a20c377876f126c6cc7288ff4",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a2722e3c6e931e50799908c5e74e91c3",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0010",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[52,-32,42]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[52,-32,42]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a9cdf184f9a4f9933cfb8a1a901241e5",
-      "entity": "niiri:01758d9126d8fc5ff1b54b4e6edb737b"
+      "entity_derived": "niiri:291008c3ba8bd66b60306971f236360c",
+      "entity": "niiri:78cf678fc1d8e63075a90d654ff6f858"
     },
     {
-      "@id": "niiri:b4893a122d15bd8fe693a1fc342975d7",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0dcc549539442c3724ba5d0e1f6e467a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0011",
-      "prov:atLocation": {"@id": "niiri:4ca8920e1d66c9e2a05d11cb18e77893"},
+      "prov:atLocation": {"@id": "niiri:3e89abdddd60a7d0574ff07c1016607e"},
       "prov:value": {"@type": "xsd:float", "@value": "6.24752378463745"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.71763687476157"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.40078304300806e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00120468241369565"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000830722551601523"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.71763687476157"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.40078304300806e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00120468241369565"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000830722551601523"}
     },
     {
-      "@id": "niiri:4ca8920e1d66c9e2a05d11cb18e77893",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:3e89abdddd60a7d0574ff07c1016607e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0011",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[40,-62,50]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[40,-62,50]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b4893a122d15bd8fe693a1fc342975d7",
-      "entity": "niiri:01758d9126d8fc5ff1b54b4e6edb737b"
+      "entity_derived": "niiri:0dcc549539442c3724ba5d0e1f6e467a",
+      "entity": "niiri:78cf678fc1d8e63075a90d654ff6f858"
     },
     {
-      "@id": "niiri:7f63bfa642f417f9b431f1c5db8cc31d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:657157689be2c61689eb1b3f4efc21e6",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0012",
-      "prov:atLocation": {"@id": "niiri:630905268907463a9b5f1dc56ae3687c"},
+      "prov:atLocation": {"@id": "niiri:99bc5ffcd4466f85102d7f98c44118e4"},
       "prov:value": {"@type": "xsd:float", "@value": "5.70337772369385"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.28674301747281"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.22566831420812e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.011413186758684"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00350091530962783"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.28674301747281"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.22566831420812e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.011413186758684"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00350091530962783"}
     },
     {
-      "@id": "niiri:630905268907463a9b5f1dc56ae3687c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:99bc5ffcd4466f85102d7f98c44118e4",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0012",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[56,-44,52]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[56,-44,52]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7f63bfa642f417f9b431f1c5db8cc31d",
-      "entity": "niiri:01758d9126d8fc5ff1b54b4e6edb737b"
+      "entity_derived": "niiri:657157689be2c61689eb1b3f4efc21e6",
+      "entity": "niiri:78cf678fc1d8e63075a90d654ff6f858"
     },
     {
-      "@id": "niiri:3d450e9e88af5733b43414b19c103157",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:669694fe0c4b5ec1a6f8a3977df4c580",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0013",
-      "prov:atLocation": {"@id": "niiri:edb8bced4f82ed9c8526b8a2708de239"},
+      "prov:atLocation": {"@id": "niiri:362ca75eb1ae6d24ff2704daf43214da"},
       "prov:value": {"@type": "xsd:float", "@value": "6.15371799468994"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.64445580026639"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.285227171001e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00184807786755337"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000972721201433817"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.64445580026639"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.285227171001e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00184807786755337"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000972721201433817"}
     },
     {
-      "@id": "niiri:edb8bced4f82ed9c8526b8a2708de239",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:362ca75eb1ae6d24ff2704daf43214da",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0013",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-28,-94,4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-28,-94,4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3d450e9e88af5733b43414b19c103157",
-      "entity": "niiri:ae4dcd02f2fd1098abb0e8a48b888b04"
+      "entity_derived": "niiri:669694fe0c4b5ec1a6f8a3977df4c580",
+      "entity": "niiri:d1df03018bbf137ff5ef2da545a3e8bf"
     },
     {
-      "@id": "niiri:fff6908e787e946dec45b335368d3f2a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:bc09fd8c13efc94b69b000bed2848f2b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0014",
-      "prov:atLocation": {"@id": "niiri:9c7edae30330492942ed42ec6bc978aa"},
+      "prov:atLocation": {"@id": "niiri:e988c9d2fc231cbc70e8805189a61b44"},
       "prov:value": {"@type": "xsd:float", "@value": "3.71480798721313"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.58412084932714"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000169107736440521"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999869855188705"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.383925327139989"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.58412084932714"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000169107736440521"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999869855188705"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.383925327139989"}
     },
     {
-      "@id": "niiri:9c7edae30330492942ed42ec6bc978aa",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e988c9d2fc231cbc70e8805189a61b44",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0014",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-34,-84,-2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-34,-84,-2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:fff6908e787e946dec45b335368d3f2a",
-      "entity": "niiri:ae4dcd02f2fd1098abb0e8a48b888b04"
+      "entity_derived": "niiri:bc09fd8c13efc94b69b000bed2848f2b",
+      "entity": "niiri:d1df03018bbf137ff5ef2da545a3e8bf"
     },
     {
-      "@id": "niiri:301172f442679d7a1642a8fb8bfb520d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:4a8c6a17b71f45dcd261be37cfbbff63",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0015",
-      "prov:atLocation": {"@id": "niiri:fea04bc2ee41b23b32b70ac824e9cfc6"},
+      "prov:atLocation": {"@id": "niiri:bc786bfc82330377611d0623c983ab4c"},
       "prov:value": {"@type": "xsd:float", "@value": "6.10109901428223"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.60320502193174"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.05212039080982e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00234682813060005"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00104518293275697"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.60320502193174"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.05212039080982e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00234682813060005"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00104518293275697"}
     },
     {
-      "@id": "niiri:fea04bc2ee41b23b32b70ac824e9cfc6",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:bc786bfc82330377611d0623c983ab4c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0015",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[32,2,46]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[32,2,46]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:301172f442679d7a1642a8fb8bfb520d",
-      "entity": "niiri:5bfdd7920dcd4de97cf8b89a13cd95e8"
+      "entity_derived": "niiri:4a8c6a17b71f45dcd261be37cfbbff63",
+      "entity": "niiri:168af8a06bcba9be4ec76231fb932bcd"
     },
     {
-      "@id": "niiri:e5dfa2ecf5e4361e83ba435c82bd2b6d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d4bb165ca9721ee62b430b539898419d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0016",
-      "prov:atLocation": {"@id": "niiri:7ec1912c0a340c768b4a3537eec0dde9"},
+      "prov:atLocation": {"@id": "niiri:5ceb4eee142abfc8ef98e23cf45add6b"},
       "prov:value": {"@type": "xsd:float", "@value": "4.6086859703064"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.3736141683061"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.11031435759912e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.453877178455514"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0599714495109201"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.3736141683061"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.11031435759912e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.453877178455514"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0599714495109201"}
     },
     {
-      "@id": "niiri:7ec1912c0a340c768b4a3537eec0dde9",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:5ceb4eee142abfc8ef98e23cf45add6b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0016",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[28,4,58]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[28,4,58]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e5dfa2ecf5e4361e83ba435c82bd2b6d",
-      "entity": "niiri:5bfdd7920dcd4de97cf8b89a13cd95e8"
+      "entity_derived": "niiri:d4bb165ca9721ee62b430b539898419d",
+      "entity": "niiri:168af8a06bcba9be4ec76231fb932bcd"
     },
     {
-      "@id": "niiri:da447f4ff20e607975dacc5c4abd9827",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:1e8f2a721817f907e33ce3661a849f73",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0017",
-      "prov:atLocation": {"@id": "niiri:7264f9db75e890717b2f0983b90f844d"},
+      "prov:atLocation": {"@id": "niiri:cf61866a953e360975460a1159eb7ecc"},
       "prov:value": {"@type": "xsd:float", "@value": "3.98793148994446"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.82932508069717"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.42475887594474e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.984644566584946"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.233149120368192"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.82932508069717"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.42475887594474e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.984644566584946"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.233149120368192"}
     },
     {
-      "@id": "niiri:7264f9db75e890717b2f0983b90f844d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:cf61866a953e360975460a1159eb7ecc",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0017",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[42,4,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[42,4,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:da447f4ff20e607975dacc5c4abd9827",
-      "entity": "niiri:5bfdd7920dcd4de97cf8b89a13cd95e8"
+      "entity_derived": "niiri:1e8f2a721817f907e33ce3661a849f73",
+      "entity": "niiri:168af8a06bcba9be4ec76231fb932bcd"
     },
     {
-      "@id": "niiri:f916aec7ac31457f1c089e162fb3fe50",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:1b716cf23c999bf2aa97632831c920c3",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0018",
-      "prov:atLocation": {"@id": "niiri:360992cc1632b4ee5094bf297bbfad73"},
+      "prov:atLocation": {"@id": "niiri:842d653a416be2a0412210b9f86b2f75"},
       "prov:value": {"@type": "xsd:float", "@value": "5.98348569869995"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.51047970249337"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.78928538652201e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00378871596531738"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00136419627856355"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.51047970249337"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.78928538652201e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00378871596531738"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00136419627856355"}
     },
     {
-      "@id": "niiri:360992cc1632b4ee5094bf297bbfad73",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:842d653a416be2a0412210b9f86b2f75",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0018",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-52,0,38]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-52,0,38]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f916aec7ac31457f1c089e162fb3fe50",
-      "entity": "niiri:0fee37ce3647eeec66b703b7384f7d51"
+      "entity_derived": "niiri:1b716cf23c999bf2aa97632831c920c3",
+      "entity": "niiri:3b36a7334ca09a3c238279baec873119"
     },
     {
-      "@id": "niiri:9d2cd74bc63a1bba9b5c53e079da06f6",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:fb67c0bff2a0e2b33b7e98f6e72ecf20",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0019",
-      "prov:atLocation": {"@id": "niiri:ebc40334e4681dcc1a51a0d2532bc417"},
+      "prov:atLocation": {"@id": "niiri:a514db27f5969eb25e9b9e72a4d9f19a"},
       "prov:value": {"@type": "xsd:float", "@value": "5.2253565788269"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.89552821543552"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.90210114501011e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0675937275056587"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0118363293065346"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.89552821543552"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.90210114501011e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0675937275056587"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0118363293065346"}
     },
     {
-      "@id": "niiri:ebc40334e4681dcc1a51a0d2532bc417",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a514db27f5969eb25e9b9e72a4d9f19a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0019",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-60,8,20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-60,8,20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9d2cd74bc63a1bba9b5c53e079da06f6",
-      "entity": "niiri:0fee37ce3647eeec66b703b7384f7d51"
+      "entity_derived": "niiri:fb67c0bff2a0e2b33b7e98f6e72ecf20",
+      "entity": "niiri:3b36a7334ca09a3c238279baec873119"
     },
     {
-      "@id": "niiri:2c7a45a34a2bb31c8f7ae615cb9b7bfc",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:99264e96be684bdfa859b1fd9ef7404f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0020",
-      "prov:atLocation": {"@id": "niiri:8e6c11eb7e840e38db5518cb924c5665"},
+      "prov:atLocation": {"@id": "niiri:d9cc01f2b233cccc98b3ad8ed9f1f720"},
       "prov:value": {"@type": "xsd:float", "@value": "4.98950004577637"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.69817956585148"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.31245304380023e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.151048137890434"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0233609510296683"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.69817956585148"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.31245304380023e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.151048137890434"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0233609510296683"}
     },
     {
-      "@id": "niiri:8e6c11eb7e840e38db5518cb924c5665",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d9cc01f2b233cccc98b3ad8ed9f1f720",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0020",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-44,6,28]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-44,6,28]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2c7a45a34a2bb31c8f7ae615cb9b7bfc",
-      "entity": "niiri:0fee37ce3647eeec66b703b7384f7d51"
+      "entity_derived": "niiri:99264e96be684bdfa859b1fd9ef7404f",
+      "entity": "niiri:3b36a7334ca09a3c238279baec873119"
     },
     {
-      "@id": "niiri:7745f80e690ce59f0794072a6e073803",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3af87f4c8a485677db1de109851382ce",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0021",
-      "prov:atLocation": {"@id": "niiri:9f8e7be021921b2c62f8192683f1da25"},
+      "prov:atLocation": {"@id": "niiri:bf1ac20f2cb36a10c73e16a4eeb39be4"},
       "prov:value": {"@type": "xsd:float", "@value": "5.78093099594116"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.34909755317379"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.41969442155354e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00844151822925698"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00286742427823329"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.34909755317379"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.41969442155354e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00844151822925698"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00286742427823329"}
     },
     {
-      "@id": "niiri:9f8e7be021921b2c62f8192683f1da25",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:bf1ac20f2cb36a10c73e16a4eeb39be4",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0021",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-34,-2,52]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-34,-2,52]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7745f80e690ce59f0794072a6e073803",
-      "entity": "niiri:f62983c44994abc2d68d9067929a281b"
+      "entity_derived": "niiri:3af87f4c8a485677db1de109851382ce",
+      "entity": "niiri:58bff46dfff701e885b3a3a8403d6869"
     },
     {
-      "@id": "niiri:c116f777747b7f5b03f844c9119ed2c9",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:96137cd609a52308057e3eaad2affaf7",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0022",
-      "prov:atLocation": {"@id": "niiri:2f5713ae7dc5f30abfd4836de2aac8a4"},
+      "prov:atLocation": {"@id": "niiri:beb35637b378cd19eb529fa6fe9f24a4"},
       "prov:value": {"@type": "xsd:float", "@value": "5.40964078903198"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.04774404642803"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.23528758724889e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0346958937061391"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00846044059259994"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.04774404642803"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.23528758724889e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0346958937061391"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00846044059259994"}
     },
     {
-      "@id": "niiri:2f5713ae7dc5f30abfd4836de2aac8a4",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:beb35637b378cd19eb529fa6fe9f24a4",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0022",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-54,-46,58]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-54,-46,58]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c116f777747b7f5b03f844c9119ed2c9",
-      "entity": "niiri:702e99e0477ee69dcca3053044008e4e"
+      "entity_derived": "niiri:96137cd609a52308057e3eaad2affaf7",
+      "entity": "niiri:2bcab9b8311e435ff15509af340ba45e"
     },
     {
-      "@id": "niiri:a5003d4837d902c0521222a716f5a060",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:aaf8bff445839cb9f02a0507509d96c7",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0023",
-      "prov:atLocation": {"@id": "niiri:d571dcea2d592aadafd121f833113f7b"},
+      "prov:atLocation": {"@id": "niiri:76446890b6db0c500548a40b8f8682ba"},
       "prov:value": {"@type": "xsd:float", "@value": "5.31841945648193"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.97261482231588"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.30279114724163e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0484353441449864"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0106752417476244"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.97261482231588"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.30279114724163e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0484353441449864"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0106752417476244"}
     },
     {
-      "@id": "niiri:d571dcea2d592aadafd121f833113f7b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:76446890b6db0c500548a40b8f8682ba",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0023",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-62,-38,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-62,-38,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a5003d4837d902c0521222a716f5a060",
-      "entity": "niiri:4c2901ae6d0b982e4779668839a7a895"
+      "entity_derived": "niiri:aaf8bff445839cb9f02a0507509d96c7",
+      "entity": "niiri:932a73d91444fc459c9b49f8b73b2582"
     },
     {
-      "@id": "niiri:871397ad34f5c9ba92cd9b39715a44b4",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:bb9e9131199389d2fff8def462545512",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0024",
-      "prov:atLocation": {"@id": "niiri:a2f052657ac606b266b7c78be31e44cd"},
+      "prov:atLocation": {"@id": "niiri:1a6f397bb7d9d28ef9486bd1bbe04132"},
       "prov:value": {"@type": "xsd:float", "@value": "4.57099342346191"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.34109644800954"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.08867353027554e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.496004086968197"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0635474729952592"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.34109644800954"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.08867353027554e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.496004086968197"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0635474729952592"}
     },
     {
-      "@id": "niiri:a2f052657ac606b266b7c78be31e44cd",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:1a6f397bb7d9d28ef9486bd1bbe04132",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0024",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-60,-50,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-60,-50,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:871397ad34f5c9ba92cd9b39715a44b4",
-      "entity": "niiri:4c2901ae6d0b982e4779668839a7a895"
+      "entity_derived": "niiri:bb9e9131199389d2fff8def462545512",
+      "entity": "niiri:932a73d91444fc459c9b49f8b73b2582"
     },
     {
-      "@id": "niiri:24d9574d36d73fd8b94d9c0088b1e9e8",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f70c6e8ed2f106b23ce93474c5815a76",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0025",
-      "prov:atLocation": {"@id": "niiri:1dc734541a2aaaae4bcc4dd8f2dbc9b8"},
+      "prov:atLocation": {"@id": "niiri:00a170f0bfc9c991ef7f484e52ffbd96"},
       "prov:value": {"@type": "xsd:float", "@value": "5.30699443817139"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.96317509467693"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.46750043123123e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0504786376455083"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0106752417476244"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.96317509467693"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.46750043123123e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0504786376455083"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0106752417476244"}
     },
     {
-      "@id": "niiri:1dc734541a2aaaae4bcc4dd8f2dbc9b8",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:00a170f0bfc9c991ef7f484e52ffbd96",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0025",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[32,40,16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[32,40,16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:24d9574d36d73fd8b94d9c0088b1e9e8",
-      "entity": "niiri:831be1ca287d5764924d7a7e83076a91"
+      "entity_derived": "niiri:f70c6e8ed2f106b23ce93474c5815a76",
+      "entity": "niiri:d974c978eac6eff6a9802fd0358ceab9"
     },
     {
-      "@id": "niiri:49040948837005e5e1c996da2811c96e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:69121dd33164fbc51ac41add220ab8f1",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0026",
-      "prov:atLocation": {"@id": "niiri:70f491ce10beca655ae3cfec86c98d5e"},
+      "prov:atLocation": {"@id": "niiri:2915dee2e934763f3afa376514c5fc13"},
       "prov:value": {"@type": "xsd:float", "@value": "4.5497465133667"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.32273570618355"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.7053150754347e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.520378392891944"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0649997423676262"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.32273570618355"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.7053150754347e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.520378392891944"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0649997423676262"}
     },
     {
-      "@id": "niiri:70f491ce10beca655ae3cfec86c98d5e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:2915dee2e934763f3afa376514c5fc13",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0026",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[40,46,12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[40,46,12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:49040948837005e5e1c996da2811c96e",
-      "entity": "niiri:831be1ca287d5764924d7a7e83076a91"
+      "entity_derived": "niiri:69121dd33164fbc51ac41add220ab8f1",
+      "entity": "niiri:d974c978eac6eff6a9802fd0358ceab9"
     },
     {
-      "@id": "niiri:e74a4f85efaad80e360ad16acb297971",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:389952192f36c8bc6c584ad875df6b35",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0027",
-      "prov:atLocation": {"@id": "niiri:f8fb2f2d3fae26ab38553ba1be2db6e6"},
+      "prov:atLocation": {"@id": "niiri:7e19b6c879f069e1c59ced1c8f607cf9"},
       "prov:value": {"@type": "xsd:float", "@value": "4.31582498550415"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.11913273798974"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.90150518718513e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.788829013385429"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.116130094830597"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.11913273798974"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.90150518718513e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.788829013385429"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.116130094830597"}
     },
     {
-      "@id": "niiri:f8fb2f2d3fae26ab38553ba1be2db6e6",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7e19b6c879f069e1c59ced1c8f607cf9",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0027",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[36,54,6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[36,54,6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e74a4f85efaad80e360ad16acb297971",
-      "entity": "niiri:831be1ca287d5764924d7a7e83076a91"
+      "entity_derived": "niiri:389952192f36c8bc6c584ad875df6b35",
+      "entity": "niiri:d974c978eac6eff6a9802fd0358ceab9"
     },
     {
-      "@id": "niiri:543cc2540e2800de5ebf85b0a9f5f7cc",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:16d663f0f26b3dea4fc4e29533365eeb",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0028",
-      "prov:atLocation": {"@id": "niiri:1d1e65f0646e5d0cc3a27edec08b3b48"},
+      "prov:atLocation": {"@id": "niiri:b0203375b18fa3d7ba036c947ea91f58"},
       "prov:value": {"@type": "xsd:float", "@value": "5.27030229568481"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.93281349716267"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.05267701952816e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0575990926145485"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0110040663565173"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.93281349716267"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.05267701952816e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0575990926145485"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0110040663565173"}
     },
     {
-      "@id": "niiri:1d1e65f0646e5d0cc3a27edec08b3b48",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b0203375b18fa3d7ba036c947ea91f58",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0028",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[40,26,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[40,26,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:543cc2540e2800de5ebf85b0a9f5f7cc",
-      "entity": "niiri:179b7e6f7102d0f73e68205b289425c6"
+      "entity_derived": "niiri:16d663f0f26b3dea4fc4e29533365eeb",
+      "entity": "niiri:e373ddbc76b41aa980c394eaa5c0e960"
     },
     {
-      "@id": "niiri:53f7a2df04f0c527945e0fd42e89e1c6",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:194a103256f1c1af23ae04557a658012",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0029",
-      "prov:atLocation": {"@id": "niiri:27a8be7b4f26dd1a9c867598a99529b0"},
+      "prov:atLocation": {"@id": "niiri:18944c45a5c3f4f6c0960eadd37d221d"},
       "prov:value": {"@type": "xsd:float", "@value": "4.93343877792358"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.65085575575197"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.6528024058271e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.180887232162623"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0254967087736733"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.65085575575197"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.6528024058271e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.180887232162623"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0254967087736733"}
     },
     {
-      "@id": "niiri:27a8be7b4f26dd1a9c867598a99529b0",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:18944c45a5c3f4f6c0960eadd37d221d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0029",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-58,-30,-18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-58,-30,-18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:53f7a2df04f0c527945e0fd42e89e1c6",
-      "entity": "niiri:5d951dbde4c6cfb00e34afc3122af0f4"
+      "entity_derived": "niiri:194a103256f1c1af23ae04557a658012",
+      "entity": "niiri:92a9d73b8902193b0f3316f35cc0dc5b"
     },
     {
-      "@id": "niiri:0af3212407d34db161fb65bf59c0014f",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b2215dc88285adf34cfc03ef8a5dcaf1",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0030",
-      "prov:atLocation": {"@id": "niiri:8d82e53b4231d95d1a2d112c5a3f4883"},
+      "prov:atLocation": {"@id": "niiri:9566ab35f1332f530ab3aa63f168999d"},
       "prov:value": {"@type": "xsd:float", "@value": "4.76414346694946"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.50698548813516"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.287756441539e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.301278778226174"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0396433885053995"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.50698548813516"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.287756441539e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.301278778226174"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0396433885053995"}
     },
     {
-      "@id": "niiri:8d82e53b4231d95d1a2d112c5a3f4883",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:9566ab35f1332f530ab3aa63f168999d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0030",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-46,-66,-6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-46,-66,-6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0af3212407d34db161fb65bf59c0014f",
-      "entity": "niiri:9af9c71c19106f542230ad07eb5a764e"
+      "entity_derived": "niiri:b2215dc88285adf34cfc03ef8a5dcaf1",
+      "entity": "niiri:be5f1c0a23837aa1ccfc35022807cc1b"
     },
     {
-      "@id": "niiri:c43efe72a950a8d62d531eb0474f99d4",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:67a3ff30cb368a2f12ff59805b696982",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0031",
-      "prov:atLocation": {"@id": "niiri:f7e99da4046d70bb9fcf699b14116754"},
+      "prov:atLocation": {"@id": "niiri:ab09c9a1f4598c0665ad4a53a4beb3c8"},
       "prov:value": {"@type": "xsd:float", "@value": "3.7637345790863"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.62829384243901"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000142650218672435"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999605970761399"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.34409224637793"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.62829384243901"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000142650218672435"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999605970761399"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.34409224637793"}
     },
     {
-      "@id": "niiri:f7e99da4046d70bb9fcf699b14116754",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ab09c9a1f4598c0665ad4a53a4beb3c8",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0031",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-54,-64,-8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-54,-64,-8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c43efe72a950a8d62d531eb0474f99d4",
-      "entity": "niiri:9af9c71c19106f542230ad07eb5a764e"
+      "entity_derived": "niiri:67a3ff30cb368a2f12ff59805b696982",
+      "entity": "niiri:be5f1c0a23837aa1ccfc35022807cc1b"
     },
     {
-      "@id": "niiri:853ae70c6d90e7c0bfc7fbab4f739762",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:bc9137f84fc1f9762b49aad753870257",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0032",
-      "prov:atLocation": {"@id": "niiri:45106be8847c9468d39eb1bfe48e81e7"},
+      "prov:atLocation": {"@id": "niiri:265b96175bce3138b953075789167720"},
       "prov:value": {"@type": "xsd:float", "@value": "4.72232866287231"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.47122948835043"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.88855941602095e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.338512677882141"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.044836631144536"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.47122948835043"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.88855941602095e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.338512677882141"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.044836631144536"}
     },
     {
-      "@id": "niiri:45106be8847c9468d39eb1bfe48e81e7",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:265b96175bce3138b953075789167720",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0032",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[58,-38,6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[58,-38,6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:853ae70c6d90e7c0bfc7fbab4f739762",
-      "entity": "niiri:23627cb4952c94ceb6b00ae5c1c4b815"
+      "entity_derived": "niiri:bc9137f84fc1f9762b49aad753870257",
+      "entity": "niiri:4cb37275d66ab0f22e3ea2174721f6f4"
     },
     {
-      "@id": "niiri:86f7c7d98eaf7022ea8524b6c58cd91a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:032b9f13b127793861eb7c63ac30ae1b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0033",
-      "prov:atLocation": {"@id": "niiri:a13664931d39e111c2ddb44eaa337587"},
+      "prov:atLocation": {"@id": "niiri:9b7979d59b62e98d7460d92ae0fd5b69"},
       "prov:value": {"@type": "xsd:float", "@value": "3.98372888565063"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.8255778871433"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.52328381068878e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.985409231324461"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.233731539105478"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.8255778871433"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.52328381068878e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.985409231324461"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.233731539105478"}
     },
     {
-      "@id": "niiri:a13664931d39e111c2ddb44eaa337587",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:9b7979d59b62e98d7460d92ae0fd5b69",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0033",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[64,-30,-4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[64,-30,-4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:86f7c7d98eaf7022ea8524b6c58cd91a",
-      "entity": "niiri:23627cb4952c94ceb6b00ae5c1c4b815"
+      "entity_derived": "niiri:032b9f13b127793861eb7c63ac30ae1b",
+      "entity": "niiri:4cb37275d66ab0f22e3ea2174721f6f4"
     },
     {
-      "@id": "niiri:e8f814bd669afcc4ca37cbd7ee04df76",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0f6fd82788868c60fecefa6c60f52281",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0034",
-      "prov:atLocation": {"@id": "niiri:69d8d1576704528c0b41c26f47eb9be5"},
+      "prov:atLocation": {"@id": "niiri:4f9fe05667da20caedb476e93089a356"},
       "prov:value": {"@type": "xsd:float", "@value": "3.50753784179688"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.39582098150001"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000342115474631921"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999778829603"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.564856004417035"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.39582098150001"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000342115474631921"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999778829603"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.564856004417035"}
     },
     {
-      "@id": "niiri:69d8d1576704528c0b41c26f47eb9be5",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4f9fe05667da20caedb476e93089a356",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0034",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[60,-40,-12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[60,-40,-12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e8f814bd669afcc4ca37cbd7ee04df76",
-      "entity": "niiri:23627cb4952c94ceb6b00ae5c1c4b815"
+      "entity_derived": "niiri:0f6fd82788868c60fecefa6c60f52281",
+      "entity": "niiri:4cb37275d66ab0f22e3ea2174721f6f4"
     },
     {
-      "@id": "niiri:7742d27e6cd7a776f3addee6be9da6df",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e9fcf67ed1b73b63fa0b87828f16d554",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0035",
-      "prov:atLocation": {"@id": "niiri:ad385209b5d2f028d38875ee7ed35d42"},
+      "prov:atLocation": {"@id": "niiri:d7f46e225306f0225e6a2937b1ec4c06"},
       "prov:value": {"@type": "xsd:float", "@value": "4.70483255386353"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.45624265093732"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.17043099876224e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.354967306449537"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0466228196503302"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.45624265093732"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.17043099876224e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.354967306449537"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0466228196503302"}
     },
     {
-      "@id": "niiri:ad385209b5d2f028d38875ee7ed35d42",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d7f46e225306f0225e6a2937b1ec4c06",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0035",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-36,-74,-14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-36,-74,-14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7742d27e6cd7a776f3addee6be9da6df",
-      "entity": "niiri:41c35d6e275325f6cc2f0e603bcbf838"
+      "entity_derived": "niiri:e9fcf67ed1b73b63fa0b87828f16d554",
+      "entity": "niiri:9bf6744a8796b8070ccd764f775a5e39"
     },
     {
-      "@id": "niiri:88e096b5026c7bd33eace8c13267d1cc",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c2b2577f48de89a6cc0be9c94fc55aa8",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0036",
-      "prov:atLocation": {"@id": "niiri:2b4e5c510c90a0b786b65a3f07fe5328"},
+      "prov:atLocation": {"@id": "niiri:be9f98153fcd6a17397aa36d2bf4d58a"},
       "prov:value": {"@type": "xsd:float", "@value": "4.08770418167114"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.91804495668"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.46350297789166e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.955724279224547"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.186719971332974"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.91804495668"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.46350297789166e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.955724279224547"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.186719971332974"}
     },
     {
-      "@id": "niiri:2b4e5c510c90a0b786b65a3f07fe5328",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:be9f98153fcd6a17397aa36d2bf4d58a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0036",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-36,-68,-20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-36,-68,-20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:88e096b5026c7bd33eace8c13267d1cc",
-      "entity": "niiri:41c35d6e275325f6cc2f0e603bcbf838"
+      "entity_derived": "niiri:c2b2577f48de89a6cc0be9c94fc55aa8",
+      "entity": "niiri:9bf6744a8796b8070ccd764f775a5e39"
     },
     {
-      "@id": "niiri:dc406b75d329249d3148daf5c3ce8876",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b280d4a0b64592367cef28cf83c1c50a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0037",
-      "prov:atLocation": {"@id": "niiri:09f201fd7b3652a7c2b113ee0bdd8141"},
+      "prov:atLocation": {"@id": "niiri:7cd7d2893f104d27cbed450c735c9350"},
       "prov:value": {"@type": "xsd:float", "@value": "3.71012616157532"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.57988831343959"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000171870546999631"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999883757236262"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.385893135248467"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.57988831343959"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000171870546999631"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999883757236262"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.385893135248467"}
     },
     {
-      "@id": "niiri:09f201fd7b3652a7c2b113ee0bdd8141",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7cd7d2893f104d27cbed450c735c9350",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0037",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-30,-58,-16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-30,-58,-16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:dc406b75d329249d3148daf5c3ce8876",
-      "entity": "niiri:41c35d6e275325f6cc2f0e603bcbf838"
+      "entity_derived": "niiri:b280d4a0b64592367cef28cf83c1c50a",
+      "entity": "niiri:9bf6744a8796b8070ccd764f775a5e39"
     },
     {
-      "@id": "niiri:8755ef265b3457619230538a6ac5496d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0617028bebc10a87084f495d6bea9816",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0038",
-      "prov:atLocation": {"@id": "niiri:4f3a6136c3e6f0a2ad32cc4811bcaca4"},
+      "prov:atLocation": {"@id": "niiri:6003244d95b3096ffcb5a0152cfd0933"},
       "prov:value": {"@type": "xsd:float", "@value": "4.59621620178223"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.36286413267216"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.41853365035416e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.467637998233248"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0604181585485856"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.36286413267216"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.41853365035416e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.467637998233248"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0604181585485856"}
     },
     {
-      "@id": "niiri:4f3a6136c3e6f0a2ad32cc4811bcaca4",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6003244d95b3096ffcb5a0152cfd0933",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0038",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[16,-98,6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[16,-98,6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8755ef265b3457619230538a6ac5496d",
-      "entity": "niiri:7d64ad68122f5c09739782f91cf20691"
+      "entity_derived": "niiri:0617028bebc10a87084f495d6bea9816",
+      "entity": "niiri:c8a038b61f85138c6e21eee9f3570ce3"
     },
     {
-      "@id": "niiri:a3cc4ddd8e840d385cedb96973550274",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:8f28adfa177b2033e8aac730e9d813c5",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0039",
-      "prov:atLocation": {"@id": "niiri:f3e1888fcbf40bbe9c3e8b15a3a3c1a5"},
+      "prov:atLocation": {"@id": "niiri:48a7698048fc6f6f19a99b0f9a8e75ca"},
       "prov:value": {"@type": "xsd:float", "@value": "4.57891654968262"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.34793761600864"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.87118388575936e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.487021764768749"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0629240173925056"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.34793761600864"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.87118388575936e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.487021764768749"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0629240173925056"}
     },
     {
-      "@id": "niiri:f3e1888fcbf40bbe9c3e8b15a3a3c1a5",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:48a7698048fc6f6f19a99b0f9a8e75ca",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0039",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-60,-16,28]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-60,-16,28]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a3cc4ddd8e840d385cedb96973550274",
-      "entity": "niiri:7a862cf3ff4623a7a92b4abf907392c8"
+      "entity_derived": "niiri:8f28adfa177b2033e8aac730e9d813c5",
+      "entity": "niiri:4cfb37bb6f2ac0c6613c6f7263fc6650"
     },
     {
-      "@id": "niiri:63c20abda72662979bb576f613029ad0",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f796d2323c68b364b61ab304f29abf8e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0040",
-      "prov:atLocation": {"@id": "niiri:e65080b7647f61f65312fe5888001d1e"},
+      "prov:atLocation": {"@id": "niiri:6fb77fc57ac2e71a37a28ea2ba3920c5"},
       "prov:value": {"@type": "xsd:float", "@value": "4.37013816833496"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.16664310578498"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.54558935169247e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.730405153245217"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.101858458171742"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.16664310578498"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.54558935169247e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.730405153245217"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.101858458171742"}
     },
     {
-      "@id": "niiri:e65080b7647f61f65312fe5888001d1e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6fb77fc57ac2e71a37a28ea2ba3920c5",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0040",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-52,-62,52]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-52,-62,52]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:63c20abda72662979bb576f613029ad0",
-      "entity": "niiri:abfa5ca5d76007e8bc66144c1f88d4ca"
+      "entity_derived": "niiri:f796d2323c68b364b61ab304f29abf8e",
+      "entity": "niiri:090f310da60ee22317a7fb037c567897"
     },
     {
-      "@id": "niiri:fe2dabd199510e3560209e2f00544a7b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5dfc83216f09a2194e4624ad70c56926",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0041",
-      "prov:atLocation": {"@id": "niiri:e8dadab76e08845e90ab9f6e5bd25c4f"},
+      "prov:atLocation": {"@id": "niiri:bb668322a2477c49c19e0215c96fb605"},
       "prov:value": {"@type": "xsd:float", "@value": "4.30655717849731"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.11101155082742"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.96964745459161e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.798260223882423"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.118009486872663"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.11101155082742"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.96964745459161e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.798260223882423"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.118009486872663"}
     },
     {
-      "@id": "niiri:e8dadab76e08845e90ab9f6e5bd25c4f",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:bb668322a2477c49c19e0215c96fb605",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0041",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-26,-92,32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-26,-92,32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:fe2dabd199510e3560209e2f00544a7b",
-      "entity": "niiri:dd86dc550acd2473942e6a2580d34577"
+      "entity_derived": "niiri:5dfc83216f09a2194e4624ad70c56926",
+      "entity": "niiri:363fdfdf14cd35df5666fb3e18b0d8c5"
     },
     {
-      "@id": "niiri:1eeb0501959cee954028fb613b80be9c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:177ec6548b8ab076a0df6d6033e514c2",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0042",
-      "prov:atLocation": {"@id": "niiri:3a2625c1665f190914d2d20bbf0575ca"},
+      "prov:atLocation": {"@id": "niiri:477ea5657432a192d97ad576b0c8eff4"},
       "prov:value": {"@type": "xsd:float", "@value": "4.24533367156982"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.05725918601008"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.4825985211363e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.855631833511506"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.135717263652471"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.05725918601008"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.4825985211363e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.855631833511506"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.135717263652471"}
     },
     {
-      "@id": "niiri:3a2625c1665f190914d2d20bbf0575ca",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:477ea5657432a192d97ad576b0c8eff4",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0042",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-18,-60,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-18,-60,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1eeb0501959cee954028fb613b80be9c",
-      "entity": "niiri:024ae749b1d9748c3c6c99db326eed03"
+      "entity_derived": "niiri:177ec6548b8ab076a0df6d6033e514c2",
+      "entity": "niiri:80cfe87c528fca41e72aca65987a69a4"
     },
     {
-      "@id": "niiri:9423c4d4f185c3598548ec75ac2ad0ef",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:1d5012af3aa91d2f7de1ec238455128e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0043",
-      "prov:atLocation": {"@id": "niiri:de5c42d49f78704745711ad7136e8c0a"},
+      "prov:atLocation": {"@id": "niiri:b3517cb478482fae609d9448b489dff3"},
       "prov:value": {"@type": "xsd:float", "@value": "4.22729349136353"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.04138628171284"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.65680735640483e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.870712357794855"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.138603763901635"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.04138628171284"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.65680735640483e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.870712357794855"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.138603763901635"}
     },
     {
-      "@id": "niiri:de5c42d49f78704745711ad7136e8c0a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b3517cb478482fae609d9448b489dff3",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0043",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-20,-98,22]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-20,-98,22]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9423c4d4f185c3598548ec75ac2ad0ef",
-      "entity": "niiri:e47686b38499c7d1c62fe38be1293da3"
+      "entity_derived": "niiri:1d5012af3aa91d2f7de1ec238455128e",
+      "entity": "niiri:e4d6a9f909a852e57111554ebf0b4352"
     },
     {
-      "@id": "niiri:246e0bfadf745b48765a08f7dd8adba3",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:4d9c6e08f557697d937d4fdbfcc226ba",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0044",
-      "prov:atLocation": {"@id": "niiri:6871de71c339de8561b5de51dace7c80"},
+      "prov:atLocation": {"@id": "niiri:339ce93075072a6674c586ffcd2e7071"},
       "prov:value": {"@type": "xsd:float", "@value": "4.22599840164185"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.04024618213588"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.66975618669063e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.871760516202526"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.138603763901635"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.04024618213588"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.66975618669063e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.871760516202526"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.138603763901635"}
     },
     {
-      "@id": "niiri:6871de71c339de8561b5de51dace7c80",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:339ce93075072a6674c586ffcd2e7071",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0044",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-36,-74,-34]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-36,-74,-34]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:246e0bfadf745b48765a08f7dd8adba3",
-      "entity": "niiri:8186f3cd73bc2bc0b8b1223383efb0d8"
+      "entity_derived": "niiri:4d9c6e08f557697d937d4fdbfcc226ba",
+      "entity": "niiri:039182fcb99c4f9a98332d4c4fb55e21"
     },
     {
-      "@id": "niiri:38b3c5a759f71cbb194652b1f1fff1fb",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d8febb8ec85b4a6284d965e1e96f0d42",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0045",
-      "prov:atLocation": {"@id": "niiri:2df45033aa2319f6182924390af08a28"},
+      "prov:atLocation": {"@id": "niiri:e904483face2f6172191f30b5ae887ce"},
       "prov:value": {"@type": "xsd:float", "@value": "4.20391035079956"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.02078923241408"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.900174224163e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.888907080881232"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.143583628261646"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.02078923241408"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.900174224163e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.888907080881232"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.143583628261646"}
     },
     {
-      "@id": "niiri:2df45033aa2319f6182924390af08a28",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e904483face2f6172191f30b5ae887ce",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0045",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[34,-54,-16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[34,-54,-16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:38b3c5a759f71cbb194652b1f1fff1fb",
-      "entity": "niiri:c5762aac6b4c6d55a8d8adc67e3b7dcc"
+      "entity_derived": "niiri:d8febb8ec85b4a6284d965e1e96f0d42",
+      "entity": "niiri:52a34b3a1f2ce2562ef0f4d897e30a2f"
     },
     {
-      "@id": "niiri:e641aad8ec4b97845bcdf72cf235b8bd",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:65b361322bcb8dd8d0c9982a75869714",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0046",
-      "prov:atLocation": {"@id": "niiri:7b259b27d8f1c62ac5f903d7dbf942d5"},
+      "prov:atLocation": {"@id": "niiri:4fa3bc1af5d44cdcfedda68c2e03da7b"},
       "prov:value": {"@type": "xsd:float", "@value": "4.18721437454224"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.00606667297511"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.08691144208506e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.900934824371894"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.149373770721144"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.00606667297511"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.08691144208506e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.900934824371894"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.149373770721144"}
     },
     {
-      "@id": "niiri:7b259b27d8f1c62ac5f903d7dbf942d5",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4fa3bc1af5d44cdcfedda68c2e03da7b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0046",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[12,-100,20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[12,-100,20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e641aad8ec4b97845bcdf72cf235b8bd",
-      "entity": "niiri:f5539938a236da748bfc223f58706047"
+      "entity_derived": "niiri:65b361322bcb8dd8d0c9982a75869714",
+      "entity": "niiri:f5b45be86dbcd41fe68a83f7d23cef72"
     },
     {
-      "@id": "niiri:b2097d1c880a6cd73abfa9801ec3eeac",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d600d8085bb73831a72181b797fbb63f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0047",
-      "prov:atLocation": {"@id": "niiri:d4a36341ab8d676b63b319cc11373d11"},
+      "prov:atLocation": {"@id": "niiri:44fa7d75ab0e1e4c9901acf92b82d38d"},
       "prov:value": {"@type": "xsd:float", "@value": "4.17404651641846"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.99444589181498"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.24228638075574e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.909844421846994"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.153735203854581"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.99444589181498"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.24228638075574e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.909844421846994"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.153735203854581"}
     },
     {
-      "@id": "niiri:d4a36341ab8d676b63b319cc11373d11",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:44fa7d75ab0e1e4c9901acf92b82d38d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0047",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-40,-38,44]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-40,-38,44]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b2097d1c880a6cd73abfa9801ec3eeac",
-      "entity": "niiri:989884d381b2838d468431f65a707824"
+      "entity_derived": "niiri:d600d8085bb73831a72181b797fbb63f",
+      "entity": "niiri:6f8473034fe37635ca935744c8d051ba"
     },
     {
-      "@id": "niiri:21ab4717934b57cb495dfc5509d556d0",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ded4c30265dfe6755db542029d96c626",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0048",
-      "prov:atLocation": {"@id": "niiri:e9db66af2e8200c8f6d251567a7e681f"},
+      "prov:atLocation": {"@id": "niiri:0971061f8b6c1b553a97b9f5389dce86"},
       "prov:value": {"@type": "xsd:float", "@value": "4.12145137786865"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.94794832362008"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.94119065879606e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.940339218142555"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.172448885449819"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.94794832362008"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.94119065879606e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.940339218142555"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.172448885449819"}
     },
     {
-      "@id": "niiri:e9db66af2e8200c8f6d251567a7e681f",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0971061f8b6c1b553a97b9f5389dce86",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0048",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-48,-72,2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-48,-72,2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:21ab4717934b57cb495dfc5509d556d0",
-      "entity": "niiri:38033d63ea964f0e007a1fe6038289e0"
+      "entity_derived": "niiri:ded4c30265dfe6755db542029d96c626",
+      "entity": "niiri:72d641147c79cc42de66fcaf250eefff"
     },
     {
-      "@id": "niiri:771ae40e57764e0f94900239c15c9bce",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:7a194dfabc293f3340bc257f2bdeae5d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0049",
-      "prov:atLocation": {"@id": "niiri:907ccfed9a8a91be876fa0e2fa360b8b"},
+      "prov:atLocation": {"@id": "niiri:ee77107f2f4a2e971a92ac9a2e392acb"},
       "prov:value": {"@type": "xsd:float", "@value": "4.07333517074585"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.9052963692066"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.70549882543025e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.961337330645756"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.192831151077206"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.9052963692066"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.70549882543025e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.961337330645756"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.192831151077206"}
     },
     {
-      "@id": "niiri:907ccfed9a8a91be876fa0e2fa360b8b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ee77107f2f4a2e971a92ac9a2e392acb",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0049",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[20,-66,34]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[20,-66,34]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:771ae40e57764e0f94900239c15c9bce",
-      "entity": "niiri:099e17d7816e029529107ceb1b6c97e2"
+      "entity_derived": "niiri:7a194dfabc293f3340bc257f2bdeae5d",
+      "entity": "niiri:0a54f2c3fbd560105040dd395d10cd8e"
     },
     {
-      "@id": "niiri:536c2b389b0bec2a2ec988d17da1f46d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:777f22c81e3e2fc6331b52dd359fa25e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0050",
-      "prov:atLocation": {"@id": "niiri:2cf7c389a7f18e8d2b9fab0c88a40077"},
+      "prov:atLocation": {"@id": "niiri:718728dcea773b178c0c2b9d86005a62"},
       "prov:value": {"@type": "xsd:float", "@value": "4.05762767791748"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.89134919103145"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.98441713834286e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.966867400896655"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.199920408224698"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.89134919103145"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.98441713834286e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.966867400896655"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.199920408224698"}
     },
     {
-      "@id": "niiri:2cf7c389a7f18e8d2b9fab0c88a40077",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:718728dcea773b178c0c2b9d86005a62",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0050",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-46,-56,14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-46,-56,14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:536c2b389b0bec2a2ec988d17da1f46d",
-      "entity": "niiri:c5b0621af9bf43fba5521742d45d67b5"
+      "entity_derived": "niiri:777f22c81e3e2fc6331b52dd359fa25e",
+      "entity": "niiri:6c719ef53d6799a1aa00e8155fb90aa7"
     },
     {
-      "@id": "niiri:e13cd74dc141ed8756972e26fa1c5da5",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:bf28f434cc925cd8ac3e307644c0a142",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0051",
-      "prov:atLocation": {"@id": "niiri:e4207e9d0a4b818d72e2e397e7db12e3"},
+      "prov:atLocation": {"@id": "niiri:751a1a8bf69143bd2cb1f4a9e30f273e"},
       "prov:value": {"@type": "xsd:float", "@value": "3.97341108322144"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.81637469850314"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.7713399346081e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.987160063394768"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.237117251115433"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.81637469850314"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.7713399346081e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.987160063394768"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.237117251115433"}
     },
     {
-      "@id": "niiri:e4207e9d0a4b818d72e2e397e7db12e3",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:751a1a8bf69143bd2cb1f4a9e30f273e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0051",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-50,-50,20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-50,-50,20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e13cd74dc141ed8756972e26fa1c5da5",
-      "entity": "niiri:c5b0621af9bf43fba5521742d45d67b5"
+      "entity_derived": "niiri:bf28f434cc925cd8ac3e307644c0a142",
+      "entity": "niiri:6c719ef53d6799a1aa00e8155fb90aa7"
     },
     {
-      "@id": "niiri:6e1d8e9ba2b442365af4af41172d3d65",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0790b31de0dbbcbf3f332d97e57d1b55",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0052",
-      "prov:atLocation": {"@id": "niiri:8adbdd43a9e57b07e13fc6b9ed46e509"},
+      "prov:atLocation": {"@id": "niiri:e2f23bfbe72aad139a81ca5b2ffa8abd"},
       "prov:value": {"@type": "xsd:float", "@value": "4.03719234466553"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.87318677164159"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.37107204765519e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.973166168280088"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.210147957128937"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.87318677164159"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.37107204765519e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.973166168280088"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.210147957128937"}
     },
     {
-      "@id": "niiri:8adbdd43a9e57b07e13fc6b9ed46e509",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e2f23bfbe72aad139a81ca5b2ffa8abd",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0052",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-48,2,50]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-48,2,50]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6e1d8e9ba2b442365af4af41172d3d65",
-      "entity": "niiri:370f32e6111a54eccb31b0cf49bb202d"
+      "entity_derived": "niiri:0790b31de0dbbcbf3f332d97e57d1b55",
+      "entity": "niiri:9abcaf1e1cd8e4fffc65b4dcd102664f"
     },
     {
-      "@id": "niiri:f19a98ac6894de7c0dd4ce0a9ef72292",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:59d06f0b13371b506f9af55d24b5067d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0053",
-      "prov:atLocation": {"@id": "niiri:aa90bdd0fff52eead175270437b0c471"},
+      "prov:atLocation": {"@id": "niiri:1db7da9477f7603e8262d33595ac73df"},
       "prov:value": {"@type": "xsd:float", "@value": "4.0217924118042"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.85948683644491"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.68126885931441e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.977286609355005"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.217632520436791"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.85948683644491"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.68126885931441e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.977286609355005"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.217632520436791"}
     },
     {
-      "@id": "niiri:aa90bdd0fff52eead175270437b0c471",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:1db7da9477f7603e8262d33595ac73df",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0053",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-36,-40,-36]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-36,-40,-36]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f19a98ac6894de7c0dd4ce0a9ef72292",
-      "entity": "niiri:d66810393703f83fa8331fcba04ca628"
+      "entity_derived": "niiri:59d06f0b13371b506f9af55d24b5067d",
+      "entity": "niiri:c17192cb7b2dfe5b506d5632ee2f9128"
     },
     {
-      "@id": "niiri:259418f8a35163228a4bea0e4b78c346",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:59b131173ec529026e6491eccefa7ada",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0054",
-      "prov:atLocation": {"@id": "niiri:081e69a16c43b2f3c8148d017c8bc2cc"},
+      "prov:atLocation": {"@id": "niiri:7af98a598509557bd8993f48cda58395"},
       "prov:value": {"@type": "xsd:float", "@value": "3.9634416103363"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.80747753892992"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.01957428701494e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.988689669381963"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.237117251115433"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.80747753892992"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.01957428701494e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.988689669381963"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.237117251115433"}
     },
     {
-      "@id": "niiri:081e69a16c43b2f3c8148d017c8bc2cc",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7af98a598509557bd8993f48cda58395",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0054",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[4,6,32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[4,6,32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:259418f8a35163228a4bea0e4b78c346",
-      "entity": "niiri:71d217841d852b0f36a116432eae4b2d"
+      "entity_derived": "niiri:59b131173ec529026e6491eccefa7ada",
+      "entity": "niiri:0cdd87a23d70e882dffa97ccc3f06458"
     },
     {
-      "@id": "niiri:bee381a064a85379200e492537c3d0c2",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e9a001b5e220f1405185d99aa83b727f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0055",
-      "prov:atLocation": {"@id": "niiri:a6518d9b0773370425f7babe131c50f2"},
+      "prov:atLocation": {"@id": "niiri:99944e1f658081a155c51941aabefa5f"},
       "prov:value": {"@type": "xsd:float", "@value": "3.96245408058167"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.80659597790245"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.04463150378309e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.988832912076595"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.237117251115433"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.80659597790245"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.04463150378309e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.988832912076595"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.237117251115433"}
     },
     {
-      "@id": "niiri:a6518d9b0773370425f7babe131c50f2",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:99944e1f658081a155c51941aabefa5f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0055",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-50,-48,-16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-50,-48,-16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:bee381a064a85379200e492537c3d0c2",
-      "entity": "niiri:d6d7d4eefe6b670db24c97dc9318b6ce"
+      "entity_derived": "niiri:e9a001b5e220f1405185d99aa83b727f",
+      "entity": "niiri:24c8de1b4ac2f5e9c8b9a7759335fe9d"
     },
     {
-      "@id": "niiri:c938737f9b90e71a114fca777023c371",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:6d610ea93d5ad1b8ca06db397254b20a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0056",
-      "prov:atLocation": {"@id": "niiri:f171360a13edfee13ea1f53522f55c43"},
+      "prov:atLocation": {"@id": "niiri:a648ad8c9947c2b6d297437cebcf0586"},
       "prov:value": {"@type": "xsd:float", "@value": "3.92427015304565"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.77247501519699"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.08180782938539e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.993353008667813"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.257401847609111"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.77247501519699"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.08180782938539e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.993353008667813"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.257401847609111"}
     },
     {
-      "@id": "niiri:f171360a13edfee13ea1f53522f55c43",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a648ad8c9947c2b6d297437cebcf0586",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0056",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[34,12,64]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[34,12,64]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c938737f9b90e71a114fca777023c371",
-      "entity": "niiri:876fcdab3aee2f6373c0e2df60b41a4e"
+      "entity_derived": "niiri:6d610ea93d5ad1b8ca06db397254b20a",
+      "entity": "niiri:9634c37192a257704d16f5f1d880a757"
     },
     {
-      "@id": "niiri:a5021d18f963dda0808bbbef29086d76",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:1c148cb4176155acbe0672cefa9a95c5",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0057",
-      "prov:atLocation": {"@id": "niiri:2b51af35726a74140ee537f1a898be32"},
+      "prov:atLocation": {"@id": "niiri:c4b0615738aa35638b2835835d1d7819"},
       "prov:value": {"@type": "xsd:float", "@value": "3.9098813533783"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.75959988615137"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.50926599039736e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.994607633788328"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.264100967145263"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.75959988615137"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.50926599039736e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.994607633788328"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.264100967145263"}
     },
     {
-      "@id": "niiri:2b51af35726a74140ee537f1a898be32",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c4b0615738aa35638b2835835d1d7819",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0057",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[54,-24,-2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[54,-24,-2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a5021d18f963dda0808bbbef29086d76",
-      "entity": "niiri:542b8b904774372e0a9627db540a47b7"
+      "entity_derived": "niiri:1c148cb4176155acbe0672cefa9a95c5",
+      "entity": "niiri:11b95279587654680aac97970c1dca33"
     },
     {
-      "@id": "niiri:eb1ad46ae5903dce306f049cef4b329e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e5dd8e18ee93409839d84e35a139c001",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0058",
-      "prov:atLocation": {"@id": "niiri:9ebd31e3d72e007bb65ba5c17a1c6f58"},
+      "prov:atLocation": {"@id": "niiri:0fac8c3499b5602b8c4d3f4c5c36353f"},
       "prov:value": {"@type": "xsd:float", "@value": "3.90759468078613"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.75755289319297"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.57915531067288e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.994787688943672"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.264100967145263"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.75755289319297"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.57915531067288e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.994787688943672"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.264100967145263"}
     },
     {
-      "@id": "niiri:9ebd31e3d72e007bb65ba5c17a1c6f58",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0fac8c3499b5602b8c4d3f4c5c36353f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0058",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-14,-98,-4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-14,-98,-4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:eb1ad46ae5903dce306f049cef4b329e",
-      "entity": "niiri:8bb571ef9ea74d78aa93e3046b5d96de"
+      "entity_derived": "niiri:e5dd8e18ee93409839d84e35a139c001",
+      "entity": "niiri:0a1d8340cb8c5e4660accea8890aaead"
     },
     {
-      "@id": "niiri:8952f96888ae77d615ed079871c0995d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e9643fe2556c8083fc3a5c54aa6831f0",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0059",
-      "prov:atLocation": {"@id": "niiri:99e89ec2c4bcd9b66b74ba72383d98ed"},
+      "prov:atLocation": {"@id": "niiri:c71a141432731c3a83c4fb20d9096844"},
       "prov:value": {"@type": "xsd:float", "@value": "3.90285301208496"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.75330746420074"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.72582920719012e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99514521861122"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.264100967145263"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.75330746420074"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.72582920719012e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99514521861122"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.264100967145263"}
     },
     {
-      "@id": "niiri:99e89ec2c4bcd9b66b74ba72383d98ed",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c71a141432731c3a83c4fb20d9096844",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0059",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-36,-46,-18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-36,-46,-18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8952f96888ae77d615ed079871c0995d",
-      "entity": "niiri:b4db133a7dcffc113bdc5cacd1f15c64"
+      "entity_derived": "niiri:e9643fe2556c8083fc3a5c54aa6831f0",
+      "entity": "niiri:7e88673ecdc8e0e122c41546194e1107"
     },
     {
-      "@id": "niiri:c85e35984aa3e8577a5785e955b273e9",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5f418c8024d0ae92d508d9bad7d2d04d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0060",
-      "prov:atLocation": {"@id": "niiri:f193a012db987a102c72532b175fb3cc"},
+      "prov:atLocation": {"@id": "niiri:9a92eb0b7c3cc5e9caf8918bfa863800"},
       "prov:value": {"@type": "xsd:float", "@value": "3.8867518901825"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.73888373627584"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "9.24195907030523e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.996210852184447"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.271701156704036"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.73888373627584"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "9.24195907030523e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.996210852184447"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.271701156704036"}
     },
     {
-      "@id": "niiri:f193a012db987a102c72532b175fb3cc",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:9a92eb0b7c3cc5e9caf8918bfa863800",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0060",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-50,-46,-32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-50,-46,-32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c85e35984aa3e8577a5785e955b273e9",
-      "entity": "niiri:0c00d9725bd14d031e130ad06f956eb2"
+      "entity_derived": "niiri:5f418c8024d0ae92d508d9bad7d2d04d",
+      "entity": "niiri:9c9e8e71561800d1df10386138b306ed"
     },
     {
-      "@id": "niiri:623b4ff80c62c7660ed2e243f61181ed",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:8eab02fbf5295443c2cecf3656cd3d2d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0061",
-      "prov:atLocation": {"@id": "niiri:3b5fa69f770ab6963ca617948f29b863"},
+      "prov:atLocation": {"@id": "niiri:a9eabe163be93303971a1a577a90ad43"},
       "prov:value": {"@type": "xsd:float", "@value": "3.86077284812927"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.7155862280194"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000101366555929516"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.997515005942308"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.285012944590861"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.7155862280194"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000101366555929516"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.997515005942308"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.285012944590861"}
     },
     {
-      "@id": "niiri:3b5fa69f770ab6963ca617948f29b863",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a9eabe163be93303971a1a577a90ad43",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0061",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[64,-30,-22]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[64,-30,-22]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:623b4ff80c62c7660ed2e243f61181ed",
-      "entity": "niiri:02839eee4d11ae4489dc6302d4195c9e"
+      "entity_derived": "niiri:8eab02fbf5295443c2cecf3656cd3d2d",
+      "entity": "niiri:7fe6fe573e42bb4d7fda5294f70b254e"
     },
     {
-      "@id": "niiri:ca308f414199fdd13201a908cf532b78",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:98b8c845b0552789d333d70cc497d509",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0062",
-      "prov:atLocation": {"@id": "niiri:91e83d57d821ea08a88f8b1d8a4a27e4"},
+      "prov:atLocation": {"@id": "niiri:497235ab7af561483668157451b5d000"},
       "prov:value": {"@type": "xsd:float", "@value": "3.82178378105164"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.68056404693028"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000116359297336222"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.998750111206092"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.307505393775956"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.68056404693028"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000116359297336222"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.998750111206092"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.307505393775956"}
     },
     {
-      "@id": "niiri:91e83d57d821ea08a88f8b1d8a4a27e4",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:497235ab7af561483668157451b5d000",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0062",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[12,52,-12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[12,52,-12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ca308f414199fdd13201a908cf532b78",
-      "entity": "niiri:5bc68587f226de0a0713847e711c40db"
+      "entity_derived": "niiri:98b8c845b0552789d333d70cc497d509",
+      "entity": "niiri:8fa9b6d9acd2c49ac8d56eaee29fc687"
     },
     {
-      "@id": "niiri:eaa2b900f7f40f54804d9ecff0a1c5ab",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:efa880b12dd83fae6f169908e5aa1b6d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0063",
-      "prov:atLocation": {"@id": "niiri:2180fcf8dd79ec32b9a869a37ae99584"},
+      "prov:atLocation": {"@id": "niiri:633bc6590e9c2c6637b5c66d4c1f6821"},
       "prov:value": {"@type": "xsd:float", "@value": "3.81266117095947"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.67235967240763"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000120160560553639"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.998946217488595"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.312228840798665"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.67235967240763"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000120160560553639"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.998946217488595"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.312228840798665"}
     },
     {
-      "@id": "niiri:2180fcf8dd79ec32b9a869a37ae99584",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:633bc6590e9c2c6637b5c66d4c1f6821",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0063",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[36,54,20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[36,54,20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:eaa2b900f7f40f54804d9ecff0a1c5ab",
-      "entity": "niiri:e7802951bd1400071eecd4c74c824fb2"
+      "entity_derived": "niiri:efa880b12dd83fae6f169908e5aa1b6d",
+      "entity": "niiri:5033df2d3441877c72a35517e4199588"
     },
     {
-      "@id": "niiri:1e1c9814736ecd91122cac0122742e5b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a24de0716b7868c15dfd5714da3cd7f5",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0064",
-      "prov:atLocation": {"@id": "niiri:6f1683e067362086652ae2ef7ca96a2a"},
+      "prov:atLocation": {"@id": "niiri:bb8a6cbf2ee7aef13285cd3e0c1d7119"},
       "prov:value": {"@type": "xsd:float", "@value": "3.80767583847046"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.66787455107711"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000122287561408974"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999041631710947"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.312228840798665"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.66787455107711"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000122287561408974"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999041631710947"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.312228840798665"}
     },
     {
-      "@id": "niiri:6f1683e067362086652ae2ef7ca96a2a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:bb8a6cbf2ee7aef13285cd3e0c1d7119",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0064",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[22,-80,54]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[22,-80,54]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1e1c9814736ecd91122cac0122742e5b",
-      "entity": "niiri:fc840fc33c4cab88ad22815e22846638"
+      "entity_derived": "niiri:a24de0716b7868c15dfd5714da3cd7f5",
+      "entity": "niiri:4124e50de0ee3b3d33d8b3570cdaf9c8"
     },
     {
-      "@id": "niiri:dd26664ccd32f67f1d7aa983d4507077",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b0236ac6504fe7c6d9875b7e3acda5d2",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0065",
-      "prov:atLocation": {"@id": "niiri:9523a337ca67b111200abde41b41e4d7"},
+      "prov:atLocation": {"@id": "niiri:403d8420a1ed6bf11ed2faac9417eb00"},
       "prov:value": {"@type": "xsd:float", "@value": "3.7885959148407"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.65069869844077"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000130763947768786"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999340802437346"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.325675502417125"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.65069869844077"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000130763947768786"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999340802437346"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.325675502417125"}
     },
     {
-      "@id": "niiri:9523a337ca67b111200abde41b41e4d7",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:403d8420a1ed6bf11ed2faac9417eb00",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0065",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[22,40,26]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[22,40,26]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:dd26664ccd32f67f1d7aa983d4507077",
-      "entity": "niiri:3efd65f0da924a5bb703dc14f0ae2445"
+      "entity_derived": "niiri:b0236ac6504fe7c6d9875b7e3acda5d2",
+      "entity": "niiri:4a2fd60e9307d21139c66a8495323c62"
     },
     {
-      "@id": "niiri:19a5fa4d22f7cc4ac80f8c5f5a788665",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5b2f95ea874a1f6a91671a4479c9378b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0066",
-      "prov:atLocation": {"@id": "niiri:1fa2852bb07da088bfab685e3c150032"},
+      "prov:atLocation": {"@id": "niiri:913d07b2c660b69689773736cedef910"},
       "prov:value": {"@type": "xsd:float", "@value": "3.78668808937073"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.64898036269368"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000131641613210109"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999365630484476"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.325675502417125"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.64898036269368"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000131641613210109"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999365630484476"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.325675502417125"}
     },
     {
-      "@id": "niiri:1fa2852bb07da088bfab685e3c150032",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:913d07b2c660b69689773736cedef910",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0066",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-22,-74,60]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-22,-74,60]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:19a5fa4d22f7cc4ac80f8c5f5a788665",
-      "entity": "niiri:aa3d8d16c81b84fa58af94c6d0a92521"
+      "entity_derived": "niiri:5b2f95ea874a1f6a91671a4479c9378b",
+      "entity": "niiri:47493d1488caf09ebaff86e6cfddca82"
     },
     {
-      "@id": "niiri:8b1da47bf149d737fe00b50c03b037d1",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:9bf774e06d17f683fc16cd62139d3371",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0067",
-      "prov:atLocation": {"@id": "niiri:f31ae0bd232628899181e950730fca21"},
+      "prov:atLocation": {"@id": "niiri:2ad6b182f9055333dc6e0015fa4f155e"},
       "prov:value": {"@type": "xsd:float", "@value": "3.69408750534058"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.56538143418403"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000181663694368006"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999921818129803"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.399826018660701"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.56538143418403"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000181663694368006"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999921818129803"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.399826018660701"}
     },
     {
-      "@id": "niiri:f31ae0bd232628899181e950730fca21",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:2ad6b182f9055333dc6e0015fa4f155e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0067",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[50,46,-12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[50,46,-12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8b1da47bf149d737fe00b50c03b037d1",
-      "entity": "niiri:be89147f5a6922a011e2b69c54c91307"
+      "entity_derived": "niiri:9bf774e06d17f683fc16cd62139d3371",
+      "entity": "niiri:f30d659f7dd564a91713174649a7897e"
     },
     {
-      "@id": "niiri:d5608ca55a605481514892b1a7c435b3",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3bc6e9db3abd7587209de9f8eb441a76",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0068",
-      "prov:atLocation": {"@id": "niiri:e6835e5b2e9178172588a30347dd19cb"},
+      "prov:atLocation": {"@id": "niiri:4d905d145479d69d91038af595094893"},
       "prov:value": {"@type": "xsd:float", "@value": "3.65790581703186"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.53261354467296"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000205736742878826"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999969815552823"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.430567192397012"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.53261354467296"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000205736742878826"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999969815552823"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.430567192397012"}
     },
     {
-      "@id": "niiri:e6835e5b2e9178172588a30347dd19cb",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4d905d145479d69d91038af595094893",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0068",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[52,-46,-12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[52,-46,-12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d5608ca55a605481514892b1a7c435b3",
-      "entity": "niiri:27aff9030eda043106c67b4df9bd432f"
+      "entity_derived": "niiri:3bc6e9db3abd7587209de9f8eb441a76",
+      "entity": "niiri:bf5d4132caa2ab59278ac933dbeefdc4"
     },
     {
-      "@id": "niiri:7903a62ac51810f7c46fcb9355f157a5",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5364de8a0b6714a83fbec79f6028081c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0069",
-      "prov:atLocation": {"@id": "niiri:a5a0ecbb5e09c10506a89c8aee878bf8"},
+      "prov:atLocation": {"@id": "niiri:4a5cdfd710492874c59e711371fd82ab"},
       "prov:value": {"@type": "xsd:float", "@value": "3.65459251403809"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.52960997534834"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000208086348004177"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999972447579615"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.431239033859527"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.52960997534834"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000208086348004177"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999972447579615"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.431239033859527"}
     },
     {
-      "@id": "niiri:a5a0ecbb5e09c10506a89c8aee878bf8",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4a5cdfd710492874c59e711371fd82ab",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0069",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[54,8,-36]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[54,8,-36]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7903a62ac51810f7c46fcb9355f157a5",
-      "entity": "niiri:6015153862c2f18b0399c5979d77b579"
+      "entity_derived": "niiri:5364de8a0b6714a83fbec79f6028081c",
+      "entity": "niiri:5063c9c53f326a1d63e57a9ad368aba4"
     },
     {
-      "@id": "niiri:be09e1146cef3cb118d3227c20ca8af4",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3634f7fe7105a2e1b8f1882a519825af",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0070",
-      "prov:atLocation": {"@id": "niiri:7cf49e10d22703efdc8154f527a1b2cd"},
+      "prov:atLocation": {"@id": "niiri:50692615fe720fe70b53e64f6fead8a4"},
       "prov:value": {"@type": "xsd:float", "@value": "3.60173606872559"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.48162963814792"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000249186237945009"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999994173508246"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.477936808108637"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.48162963814792"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000249186237945009"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999994173508246"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.477936808108637"}
     },
     {
-      "@id": "niiri:7cf49e10d22703efdc8154f527a1b2cd",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:50692615fe720fe70b53e64f6fead8a4",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0070",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-14,58,10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-14,58,10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:be09e1146cef3cb118d3227c20ca8af4",
-      "entity": "niiri:d49cca9c5e9ab92f918362c3052e9a2d"
+      "entity_derived": "niiri:3634f7fe7105a2e1b8f1882a519825af",
+      "entity": "niiri:f53e11fdc36e62f28a07e009b005603e"
     },
     {
-      "@id": "niiri:7ad11b670fd2baf50c03c3a384f798b5",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d594b8cfacb807f125997448b08835a3",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0071",
-      "prov:atLocation": {"@id": "niiri:33e1cd87a458fe29ab701e484800d410"},
+      "prov:atLocation": {"@id": "niiri:6bfc99bd843bdcf4e013f217dc98c9a3"},
       "prov:value": {"@type": "xsd:float", "@value": "3.58989810943604"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.47086705539024"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000259390388114844"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999995993033212"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.486123239113482"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.47086705539024"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000259390388114844"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999995993033212"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.486123239113482"}
     },
     {
-      "@id": "niiri:33e1cd87a458fe29ab701e484800d410",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6bfc99bd843bdcf4e013f217dc98c9a3",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0071",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-66,-36,22]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-66,-36,22]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7ad11b670fd2baf50c03c3a384f798b5",
-      "entity": "niiri:e35587b2acf9fd9a9fdf0672cc249a3a"
+      "entity_derived": "niiri:d594b8cfacb807f125997448b08835a3",
+      "entity": "niiri:ae4cfacdd2f80d4db5489f80321a64c5"
     },
     {
-      "@id": "niiri:84559a10e4aac67f42e886d101120a11",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:023cc3012925d0776b89ecf4fe87ab52",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0072",
-      "prov:atLocation": {"@id": "niiri:3ebee967c8f95586fe3b050df3264c90"},
+      "prov:atLocation": {"@id": "niiri:fc0d7a41934aa1b2738a3f70b84a927c"},
       "prov:value": {"@type": "xsd:float", "@value": "3.56340670585632"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.44676015888715"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000283676007278189"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999998329299787"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.513357841480064"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.44676015888715"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000283676007278189"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999998329299787"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.513357841480064"}
     },
     {
-      "@id": "niiri:3ebee967c8f95586fe3b050df3264c90",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:fc0d7a41934aa1b2738a3f70b84a927c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0072",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[18,60,12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[18,60,12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:84559a10e4aac67f42e886d101120a11",
-      "entity": "niiri:98d127e586abf35e62811f986bd3be18"
+      "entity_derived": "niiri:023cc3012925d0776b89ecf4fe87ab52",
+      "entity": "niiri:4bf515909ab7c79154616841d777e9fa"
     },
     {
-      "@id": "niiri:2ee348e23bd790da7f54db5a451c1807",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:2fec8cee976754e3979a50e6ecb659e9",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0073",
-      "prov:atLocation": {"@id": "niiri:fcc5fc214e1e7c66ef053f5e0edbd305"},
+      "prov:atLocation": {"@id": "niiri:82fc364bc9872056c82c6d3896703c98"},
       "prov:value": {"@type": "xsd:float", "@value": "3.55537104606628"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.43944179853069"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000291457553818653"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999998731920076"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.518882279088377"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.43944179853069"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000291457553818653"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999998731920076"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.518882279088377"}
     },
     {
-      "@id": "niiri:fcc5fc214e1e7c66ef053f5e0edbd305",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:82fc364bc9872056c82c6d3896703c98",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0073",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-64,-34,8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-64,-34,8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2ee348e23bd790da7f54db5a451c1807",
-      "entity": "niiri:b2f002bc586117a24bdd5081006f3f23"
+      "entity_derived": "niiri:2fec8cee976754e3979a50e6ecb659e9",
+      "entity": "niiri:9c5ac23579b49a629cb17821a462a039"
     },
     {
-      "@id": "niiri:9e7d4b02e214575563f6759eec843914",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ead9a2eb3fe810d3e2fe175ba57a770f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0074",
-      "prov:atLocation": {"@id": "niiri:7051ff9eab1e55a23fe508d8e5ccdb23"},
+      "prov:atLocation": {"@id": "niiri:8b1df836dbd1d79b4e93b815de590aba"},
       "prov:value": {"@type": "xsd:float", "@value": "3.55148839950562"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.43590473729199"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000295289297083445"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999889206113"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.518882279088377"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.43590473729199"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000295289297083445"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999889206113"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.518882279088377"}
     },
     {
-      "@id": "niiri:7051ff9eab1e55a23fe508d8e5ccdb23",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:8b1df836dbd1d79b4e93b815de590aba",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0074",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[64,-34,16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[64,-34,16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9e7d4b02e214575563f6759eec843914",
-      "entity": "niiri:4ce238771ccf766ed28486be0e931e33"
+      "entity_derived": "niiri:ead9a2eb3fe810d3e2fe175ba57a770f",
+      "entity": "niiri:0059ec9a6bb7c2d7e6ea96012aa070a4"
     },
     {
-      "@id": "niiri:0bd2557f6b490ffcb00ea0c712af8f4b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b52f0f12bced214c2dfafd7282f27bad",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0075",
-      "prov:atLocation": {"@id": "niiri:bafb9cad93527bef6220c8e82f0b02d1"},
+      "prov:atLocation": {"@id": "niiri:5bef0119303f4bb85383ac9d192f0fe1"},
       "prov:value": {"@type": "xsd:float", "@value": "3.54216623306274"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.42740966598884"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000304684504620178"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999202607737"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.527734905237698"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.42740966598884"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000304684504620178"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999202607737"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.527734905237698"}
     },
     {
-      "@id": "niiri:bafb9cad93527bef6220c8e82f0b02d1",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:5bef0119303f4bb85383ac9d192f0fe1",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0075",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-58,-32,22]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-58,-32,22]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0bd2557f6b490ffcb00ea0c712af8f4b",
-      "entity": "niiri:e4b08c3de8b3e30fc520a4a7fb1d0717"
+      "entity_derived": "niiri:b52f0f12bced214c2dfafd7282f27bad",
+      "entity": "niiri:3bb3714faa1aae7d02675cad6938ab52"
     },
     {
-      "@id": "niiri:6b31c056a3635633634ee06046d5ac3c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:bacceffe4d760f806512a8fa62a47caf",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0076",
-      "prov:atLocation": {"@id": "niiri:18e0487e0ffe077b7befcaeefe4eb5d1"},
+      "prov:atLocation": {"@id": "niiri:a0e61cb131cd0271669e7df79a2ed186"},
       "prov:value": {"@type": "xsd:float", "@value": "3.51380252838135"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.40153955037634"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000335037159349127"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999971905221"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.559625109906516"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.40153955037634"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000335037159349127"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999971905221"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.559625109906516"}
     },
     {
-      "@id": "niiri:18e0487e0ffe077b7befcaeefe4eb5d1",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a0e61cb131cd0271669e7df79a2ed186",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0076",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[48,12,50]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[48,12,50]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6b31c056a3635633634ee06046d5ac3c",
-      "entity": "niiri:f272badd0515e42b4d960d9705968657"
+      "entity_derived": "niiri:bacceffe4d760f806512a8fa62a47caf",
+      "entity": "niiri:79f4ea32c57ff4bc44bd9693fb4bfb39"
     },
     {
-      "@id": "niiri:abf1fbcf7bcf8cb38ba350a38da40094",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:2a6483578ad30a2fe3721daffa288c28",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0077",
-      "prov:atLocation": {"@id": "niiri:e22391d652de43c047396542ecdc48a9"},
+      "prov:atLocation": {"@id": "niiri:b0a0b798bff91a011585b210275ecaa3"},
       "prov:value": {"@type": "xsd:float", "@value": "3.46738910675049"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.35913252154752"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000390937814553127"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999955890495"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.612505014136882"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.35913252154752"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000390937814553127"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999955890495"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.612505014136882"}
     },
     {
-      "@id": "niiri:e22391d652de43c047396542ecdc48a9",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b0a0b798bff91a011585b210275ecaa3",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0077",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[14,-14,72]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[14,-14,72]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:abf1fbcf7bcf8cb38ba350a38da40094",
-      "entity": "niiri:d1006f0765b2d600f398d4672099ed92"
+      "entity_derived": "niiri:2a6483578ad30a2fe3721daffa288c28",
+      "entity": "niiri:16165a8f8f2fb7e16961bd153e0121b3"
     },
     {
-      "@id": "niiri:68b45bef100bb26837b64f001f207e66",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5db20ef1a857b0c93873cca6dbbaf653",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0078",
-      "prov:atLocation": {"@id": "niiri:6951bddaf8775b4d58f7069ba2908e88"},
+      "prov:atLocation": {"@id": "niiri:0c2e89b7dd30256e4f516083c49c1398"},
       "prov:value": {"@type": "xsd:float", "@value": "3.45441365242004"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.34726077209469"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000408071982705316"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999974583179"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.628488500556802"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.34726077209469"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000408071982705316"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999974583179"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.628488500556802"}
     },
     {
-      "@id": "niiri:6951bddaf8775b4d58f7069ba2908e88",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0c2e89b7dd30256e4f516083c49c1398",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0078",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-38,-54,-42]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-38,-54,-42]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:68b45bef100bb26837b64f001f207e66",
-      "entity": "niiri:b221fbfb15d7f985909dc4575902ee79"
+      "entity_derived": "niiri:5db20ef1a857b0c93873cca6dbbaf653",
+      "entity": "niiri:120ccd02c2048169aea9fc9ef80dac7e"
     },
     {
-      "@id": "niiri:f82b9ff2e622994294df709356b82e8f",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0e5b5cad25297838be93e85247842bc4",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0079",
-      "prov:atLocation": {"@id": "niiri:12468409a278fc8cfed934ff363294a3"},
+      "prov:atLocation": {"@id": "niiri:e0b64d5d590b611bc9f1ea430c4ce478"},
       "prov:value": {"@type": "xsd:float", "@value": "3.43550229072571"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.32994532400952"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000434315195478541"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999988927098"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.654261098812949"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.32994532400952"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000434315195478541"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999988927098"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.654261098812949"}
     },
     {
-      "@id": "niiri:12468409a278fc8cfed934ff363294a3",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e0b64d5d590b611bc9f1ea430c4ce478",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0079",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[22,44,-16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[22,44,-16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f82b9ff2e622994294df709356b82e8f",
-      "entity": "niiri:22518d42d4312d19842a6c5c7116e209"
+      "entity_derived": "niiri:0e5b5cad25297838be93e85247842bc4",
+      "entity": "niiri:8ecb9c4697fe5773d29ea35c29d84ef3"
     },
     {
-      "@id": "niiri:cc557366f8629ace9d550272ed55ee4f",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:8f596ef744414c01a33ad6c39029765e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0080",
-      "prov:atLocation": {"@id": "niiri:080582743d141af59a223b138c253884"},
+      "prov:atLocation": {"@id": "niiri:41bcac017885a0d5ce419f1cd6147e96"},
       "prov:value": {"@type": "xsd:float", "@value": "3.43198323249817"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.32672157755253"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000439370628491198"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999990548038"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.655840530088522"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.32672157755253"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000439370628491198"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999990548038"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.655840530088522"}
     },
     {
-      "@id": "niiri:080582743d141af59a223b138c253884",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:41bcac017885a0d5ce419f1cd6147e96",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0080",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[42,-42,14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[42,-42,14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cc557366f8629ace9d550272ed55ee4f",
-      "entity": "niiri:27f64237a208bdd1b919662a44a25b49"
+      "entity_derived": "niiri:8f596ef744414c01a33ad6c39029765e",
+      "entity": "niiri:b24de80c3a706246e31d6423b3708450"
     },
     {
-      "@id": "niiri:7ec37de0b42c7cf286b0373e02809553",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ea5435e2a886068031ebe5de352b9252",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0081",
-      "prov:atLocation": {"@id": "niiri:780aa496fd956b885f73959a2c05b7a4"},
+      "prov:atLocation": {"@id": "niiri:979e4f14c98dd53d2ba2316ad891327d"},
       "prov:value": {"@type": "xsd:float", "@value": "3.40964436531067"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.30624524554301"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000472776443704692"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999996632889"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.684032337898302"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.30624524554301"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000472776443704692"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999996632889"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.684032337898302"}
     },
     {
-      "@id": "niiri:780aa496fd956b885f73959a2c05b7a4",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:979e4f14c98dd53d2ba2316ad891327d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0081",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-22,-82,0]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-22,-82,0]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7ec37de0b42c7cf286b0373e02809553",
-      "entity": "niiri:a5728ac41df0c581754b6db5427b1f05"
+      "entity_derived": "niiri:ea5435e2a886068031ebe5de352b9252",
+      "entity": "niiri:0f16dde8718dddce4db284b7a40496a8"
     },
     {
-      "@id": "niiri:76886ce075c1debe50a7057c2b3e69d0",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:6eff0cb119fb17bde1587b506a65b95c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0082",
-      "prov:atLocation": {"@id": "niiri:af900c2fc80952034fa7783eccc02891"},
+      "prov:atLocation": {"@id": "niiri:a04b89d12a0e23c950fc82f4714923df"},
       "prov:value": {"@type": "xsd:float", "@value": "3.40386486053467"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.30094422133281"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000481800187664638"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999997442132"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.689466168942319"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.30094422133281"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000481800187664638"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999997442132"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.689466168942319"}
     },
     {
-      "@id": "niiri:af900c2fc80952034fa7783eccc02891",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a04b89d12a0e23c950fc82f4714923df",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0082",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[52,-42,18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[52,-42,18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:76886ce075c1debe50a7057c2b3e69d0",
-      "entity": "niiri:ff4fe7af97fc1af636a6c8d8f050f08f"
+      "entity_derived": "niiri:6eff0cb119fb17bde1587b506a65b95c",
+      "entity": "niiri:6618ca3eaa19d5e02557c9a8428828e3"
     },
     {
-      "@id": "niiri:16bf040c6279d28b8388cb8253d87450",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:42ba59332aba027b09e0f7fb5b836ccf",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0083",
-      "prov:atLocation": {"@id": "niiri:24766e79c67cc0c037cf32322401d526"},
+      "prov:atLocation": {"@id": "niiri:efbdb520a93e8c7041418140163a877a"},
       "prov:value": {"@type": "xsd:float", "@value": "3.36533284187317"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.26556677338515"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000546226226643243"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999624169"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.751744172496132"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.26556677338515"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000546226226643243"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999624169"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.751744172496132"}
     },
     {
-      "@id": "niiri:24766e79c67cc0c037cf32322401d526",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:efbdb520a93e8c7041418140163a877a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0083",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[44,-48,-26]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[44,-48,-26]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:16bf040c6279d28b8388cb8253d87450",
-      "entity": "niiri:ec5515690308a412deffcb4cf46f2365"
+      "entity_derived": "niiri:42ba59332aba027b09e0f7fb5b836ccf",
+      "entity": "niiri:edcf13cf2a9f550f95f7fa64a9ab86ca"
     },
     {
-      "@id": "niiri:b0c0e398ec53716105009e7fa73170ce",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:503a860df4608d362f5472437c9aac33",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0084",
-      "prov:atLocation": {"@id": "niiri:d460156cc32122e28861084b0b0b15e3"},
+      "prov:atLocation": {"@id": "niiri:bd9e880b12aa24548b9447799a89b39d"},
       "prov:value": {"@type": "xsd:float", "@value": "3.3379864692688"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.24042202275062"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000596764555146345"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999912202"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.787874793017543"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.24042202275062"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000596764555146345"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999912202"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.787874793017543"}
     },
     {
-      "@id": "niiri:d460156cc32122e28861084b0b0b15e3",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:bd9e880b12aa24548b9447799a89b39d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0084",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[46,-40,44]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[46,-40,44]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b0c0e398ec53716105009e7fa73170ce",
-      "entity": "niiri:f74ca8cae4e2c682c3f97b1a640a5f00"
+      "entity_derived": "niiri:503a860df4608d362f5472437c9aac33",
+      "entity": "niiri:80da85f37d04350ac439bb0dfa06ea5b"
     },
     {
-      "@id": "niiri:19ad6f2b4ff101153b33f0be29b51fe5",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:9a50100528de3301f53864b1e2d26813",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0085",
-      "prov:atLocation": {"@id": "niiri:6fa898d927f461d92b4563dda70d874d"},
+      "prov:atLocation": {"@id": "niiri:2a527d6fde4a3e0f1b5549da2bcb4937"},
       "prov:value": {"@type": "xsd:float", "@value": "3.33372783660889"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.23650348537689"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000605018743711327"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999930494"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.791142662581953"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.23650348537689"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000605018743711327"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999930494"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.791142662581953"}
     },
     {
-      "@id": "niiri:6fa898d927f461d92b4563dda70d874d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:2a527d6fde4a3e0f1b5549da2bcb4937",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0085",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[16,4,16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[16,4,16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:19ad6f2b4ff101153b33f0be29b51fe5",
-      "entity": "niiri:2a63ea593120afc6649eda0c102f631d"
+      "entity_derived": "niiri:9a50100528de3301f53864b1e2d26813",
+      "entity": "niiri:cce62b8bba59fb588c9623468819b0f6"
     },
     {
-      "@id": "niiri:9917257ea5164857a1baa41404e6e936",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c79bb08a7cc62e4c3bb0bc2ea61487fb",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0086",
-      "prov:atLocation": {"@id": "niiri:656be12fa4ec04f7713f80d1dd720ed4"},
+      "prov:atLocation": {"@id": "niiri:d0196efa9c520da7383566a50c9bd6e0"},
       "prov:value": {"@type": "xsd:float", "@value": "3.32532405853271"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.22876865896546"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000621622108231912"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999995642"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.802213727911317"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.22876865896546"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000621622108231912"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999995642"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.802213727911317"}
     },
     {
-      "@id": "niiri:656be12fa4ec04f7713f80d1dd720ed4",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d0196efa9c520da7383566a50c9bd6e0",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0086",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-54,-32,42]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-54,-32,42]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9917257ea5164857a1baa41404e6e936",
-      "entity": "niiri:6f87e962fab6d1220c091e46877922d9"
+      "entity_derived": "niiri:c79bb08a7cc62e4c3bb0bc2ea61487fb",
+      "entity": "niiri:fe52388c406befa95a7e7abdd9bc5d0d"
     },
     {
-      "@id": "niiri:cf833657eb3598d1a9b7977360d4fd1c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:df49da2116399dd93cbe380ad45dc4ba",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0087",
-      "prov:atLocation": {"@id": "niiri:13038ca4507903488f6e26dc43d88933"},
+      "prov:atLocation": {"@id": "niiri:4e6b7532be0436dc269457ac5fbda880"},
       "prov:value": {"@type": "xsd:float", "@value": "3.31892204284668"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.22287431730178"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000634556128578101"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999996962"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.809612456104087"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.22287431730178"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000634556128578101"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999996962"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.809612456104087"}
     },
     {
-      "@id": "niiri:13038ca4507903488f6e26dc43d88933",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4e6b7532be0436dc269457ac5fbda880",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0087",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-16,4,62]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-16,4,62]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cf833657eb3598d1a9b7977360d4fd1c",
-      "entity": "niiri:e86febc59d83b46e7775b7ea6281d7b6"
+      "entity_derived": "niiri:df49da2116399dd93cbe380ad45dc4ba",
+      "entity": "niiri:aaf8a80c3785eabb526fa793c58065c5"
     },
     {
-      "@id": "niiri:d56d26d4324078f3777c84e26c5b7470",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:8e179e19b02140d23014ccfa85f27a50",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0088",
-      "prov:atLocation": {"@id": "niiri:cfb225497f83f359afc32fd25d314738"},
+      "prov:atLocation": {"@id": "niiri:37bb88de70a250d9e55221ba28b52c7c"},
       "prov:value": {"@type": "xsd:float", "@value": "3.3035409450531"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.20870610659348"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000666668530368786"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999987468"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.829570299628891"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.20870610659348"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000666668530368786"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999987468"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.829570299628891"}
     },
     {
-      "@id": "niiri:cfb225497f83f359afc32fd25d314738",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:37bb88de70a250d9e55221ba28b52c7c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0088",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[22,38,10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[22,38,10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d56d26d4324078f3777c84e26c5b7470",
-      "entity": "niiri:033bb93f5934ac8e2216a6953d84f96b"
+      "entity_derived": "niiri:8e179e19b02140d23014ccfa85f27a50",
+      "entity": "niiri:66a2dce74584c693a761996e8a52ee2c"
     },
     {
-      "@id": "niiri:9ff6226009f8434164bdf61861afdbc7",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a787086f5cb922314611375f0c56cc32",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0089",
-      "prov:atLocation": {"@id": "niiri:7dd9ba427ca2a6599b105d721b7d20b1"},
+      "prov:atLocation": {"@id": "niiri:fe659463fa080cf764c8d49213755e7b"},
       "prov:value": {"@type": "xsd:float", "@value": "3.29107904434204"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.19721985733158"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000693795605607228"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999994003"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.839453948823053"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.19721985733158"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000693795605607228"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999994003"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.839453948823053"}
     },
     {
-      "@id": "niiri:7dd9ba427ca2a6599b105d721b7d20b1",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:fe659463fa080cf764c8d49213755e7b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0089",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[30,34,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[30,34,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9ff6226009f8434164bdf61861afdbc7",
-      "entity": "niiri:20e24f503a4809e9cf0241f76eaaf79d"
+      "entity_derived": "niiri:a787086f5cb922314611375f0c56cc32",
+      "entity": "niiri:842dcf5877dd33791cbf64037b0d160d"
     },
     {
-      "@id": "niiri:e3296ae004d313fabc717af9627a0a06",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a8e3819b8f7d45e8b8dc7d86a80ef681",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0090",
-      "prov:atLocation": {"@id": "niiri:938bbc435ec79f3ce60320a00e5284ff"},
+      "prov:atLocation": {"@id": "niiri:86dee79597b91333e151e37e0e03522b"},
       "prov:value": {"@type": "xsd:float", "@value": "3.28136968612671"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.18826629952882"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000715643274853739"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999996665"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.851590920517607"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.18826629952882"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000715643274853739"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999996665"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.851590920517607"}
     },
     {
-      "@id": "niiri:938bbc435ec79f3ce60320a00e5284ff",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:86dee79597b91333e151e37e0e03522b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0090",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[56,-66,4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[56,-66,4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e3296ae004d313fabc717af9627a0a06",
-      "entity": "niiri:80d7fbf81e2055777ba9feeeadecc526"
+      "entity_derived": "niiri:a8e3819b8f7d45e8b8dc7d86a80ef681",
+      "entity": "niiri:826c8df2b7140fdd69ec6d944489cb87"
     },
     {
-      "@id": "niiri:aeaaeba1bcffc0ef70031392484d9f0a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:95a3e6c899a63c97c10b2e2a21870587",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0091",
-      "prov:atLocation": {"@id": "niiri:df7b9525c8b178320f407adbe92e8a48"},
+      "prov:atLocation": {"@id": "niiri:22f0969feaa27b87063bdc731a8b5ebd"},
       "prov:value": {"@type": "xsd:float", "@value": "3.27154183387756"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.17919960131803"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000738411785119797"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999998178"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.858755937068456"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.17919960131803"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000738411785119797"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999998178"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.858755937068456"}
     },
     {
-      "@id": "niiri:df7b9525c8b178320f407adbe92e8a48",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:22f0969feaa27b87063bdc731a8b5ebd",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0091",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[10,-76,-12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[10,-76,-12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:aeaaeba1bcffc0ef70031392484d9f0a",
-      "entity": "niiri:2bd7817009f58b9da9bae43a5b25b68f"
+      "entity_derived": "niiri:95a3e6c899a63c97c10b2e2a21870587",
+      "entity": "niiri:a8072ecfcdfd108f310a1bc87c821cf1"
     },
     {
-      "@id": "niiri:8f754514998b454dca87e7abb9f76440",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:47c4c2b62e33d8d5bf68323f3604cbdb",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0092",
-      "prov:atLocation": {"@id": "niiri:d024f9aef6c9b9669ab3f984895a5c4c"},
+      "prov:atLocation": {"@id": "niiri:6239faf38126e85b2d8d417db1895726"},
       "prov:value": {"@type": "xsd:float", "@value": "3.2669575214386"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.17496900913942"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000749262523860983"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999998632"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.863075307004762"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.17496900913942"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000749262523860983"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999998632"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.863075307004762"}
     },
     {
-      "@id": "niiri:d024f9aef6c9b9669ab3f984895a5c4c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6239faf38126e85b2d8d417db1895726",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0092",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[20,32,54]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[20,32,54]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8f754514998b454dca87e7abb9f76440",
-      "entity": "niiri:15e4c29ced9fec2482ceb9ba6a0a51d1"
+      "entity_derived": "niiri:47c4c2b62e33d8d5bf68323f3604cbdb",
+      "entity": "niiri:71b52ab8126a30a8e2c6e66f6b5da31f"
     },
     {
-      "@id": "niiri:e8586dbf89a93015d3002e70da4faca6",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:259c1693d6155c7a6f30bb08608f1f4f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0093",
-      "prov:atLocation": {"@id": "niiri:4b920376d9e3f432ce36972dc1012e4c"},
+      "prov:atLocation": {"@id": "niiri:a3247e37750de016acf24df9bc60fa49"},
       "prov:value": {"@type": "xsd:float", "@value": "3.26226496696472"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.17063765299814"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000760523733375762"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999998982"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.867640730428823"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.17063765299814"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000760523733375762"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999998982"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.867640730428823"}
     },
     {
-      "@id": "niiri:4b920376d9e3f432ce36972dc1012e4c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a3247e37750de016acf24df9bc60fa49",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0093",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-60,-14,10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-60,-14,10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e8586dbf89a93015d3002e70da4faca6",
-      "entity": "niiri:42e659c3800a504268b49626856a7c27"
+      "entity_derived": "niiri:259c1693d6155c7a6f30bb08608f1f4f",
+      "entity": "niiri:339add5fca2f1335faf3c97a8ad874f4"
     },
     {
-      "@id": "niiri:047e6e1f775a8a5f58aa4b7d3e812581",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c3c6c3b4bc379cbd3e79cdda209910be",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0094",
-      "prov:atLocation": {"@id": "niiri:68872dd188b97e9ea0f7546461438010"},
+      "prov:atLocation": {"@id": "niiri:3c4fc33d1b64cfdf812854e59f738d56"},
       "prov:value": {"@type": "xsd:float", "@value": "3.25743293762207"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.16617663527645"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000772284854291594"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999251"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.872516606801204"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.16617663527645"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000772284854291594"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999251"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.872516606801204"}
     },
     {
-      "@id": "niiri:68872dd188b97e9ea0f7546461438010",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:3c4fc33d1b64cfdf812854e59f738d56",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0094",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-22,-94,28]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-22,-94,28]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:047e6e1f775a8a5f58aa4b7d3e812581",
-      "entity": "niiri:2cd92c6773d556b9448a0ddb09bd8b31"
+      "entity_derived": "niiri:c3c6c3b4bc379cbd3e79cdda209910be",
+      "entity": "niiri:b822c27c9e4ca42b4196dd89b524730c"
     },
     {
-      "@id": "niiri:6a750b566ecd46c30ce3664eda825e53",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:af534a3f98f60ec7b7d00384e405199b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0095",
-      "prov:atLocation": {"@id": "niiri:659ab3aeaaa1689a6222dcb767bb247f"},
+      "prov:atLocation": {"@id": "niiri:2499239f2dd610a8d96045353e0f3c47"},
       "prov:value": {"@type": "xsd:float", "@value": "3.25416302680969"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.16315726358056"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000780339994975288"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999392"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.874305136305167"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.16315726358056"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000780339994975288"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999392"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.874305136305167"}
     },
     {
-      "@id": "niiri:659ab3aeaaa1689a6222dcb767bb247f",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:2499239f2dd610a8d96045353e0f3c47",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0095",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-66,-46,8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-66,-46,8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6a750b566ecd46c30ce3664eda825e53",
-      "entity": "niiri:fbeda8761878a098b300fa81bfca94a3"
+      "entity_derived": "niiri:af534a3f98f60ec7b7d00384e405199b",
+      "entity": "niiri:96419b4c6e6c59ea3a4153112ed9d514"
     },
     {
-      "@id": "niiri:bd323934a92c157b5ad4685430864ac0",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:6101b3c8a7b6e0ec13ee88b3c0076b8f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0096",
-      "prov:atLocation": {"@id": "niiri:1388e7efb9d1146ae68c05848ce1f875"},
+      "prov:atLocation": {"@id": "niiri:b6c31642bad37d7720ecff6c57e5191b"},
       "prov:value": {"@type": "xsd:float", "@value": "3.24836373329163"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.15780125799237"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000794819459152607"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999582"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.881177035765112"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.15780125799237"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000794819459152607"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999582"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.881177035765112"}
     },
     {
-      "@id": "niiri:1388e7efb9d1146ae68c05848ce1f875",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b6c31642bad37d7720ecff6c57e5191b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0096",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-68,-34,-8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-68,-34,-8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:bd323934a92c157b5ad4685430864ac0",
-      "entity": "niiri:ff113369a1aab0598dc0f3d86fc0129b"
+      "entity_derived": "niiri:6101b3c8a7b6e0ec13ee88b3c0076b8f",
+      "entity": "niiri:2156904148b8610fa21cc0ac6f11f0a5"
     },
     {
-      "@id": "niiri:fd4eeef784922ab3c1279b04181425cf",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f45f9a4f27b514a76b251ca6940d64cc",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0097",
-      "prov:atLocation": {"@id": "niiri:15f297ad956e513ea8bd0168cd8276df"},
+      "prov:atLocation": {"@id": "niiri:be17a094497e539d851d03d853f569e8"},
       "prov:value": {"@type": "xsd:float", "@value": "3.23679161071777"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.14710967833961"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000824465484375092"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999804"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.899808991491498"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.14710967833961"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000824465484375092"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999804"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.899808991491498"}
     },
     {
-      "@id": "niiri:15f297ad956e513ea8bd0168cd8276df",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:be17a094497e539d851d03d853f569e8",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0097",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-56,34,-20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-56,34,-20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:fd4eeef784922ab3c1279b04181425cf",
-      "entity": "niiri:ef6a4c707bf3e80d6954ad82e2705808"
+      "entity_derived": "niiri:f45f9a4f27b514a76b251ca6940d64cc",
+      "entity": "niiri:bba6fb2b90294edde963661ec3fea027"
     },
     {
-      "@id": "niiri:3b4f28f7e1e4a0092736a83729825138",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0775bd867b7640b1610595991372a3a4",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0098",
-      "prov:atLocation": {"@id": "niiri:165578ad640128bc70e890636626df8c"},
+      "prov:atLocation": {"@id": "niiri:c4dbdab79f8821a024aad1cbea9bfdc0"},
       "prov:value": {"@type": "xsd:float", "@value": "3.22478008270264"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.13600649460504"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000856327054624684"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999913"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.917823543835361"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.13600649460504"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000856327054624684"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999913"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.917823543835361"}
     },
     {
-      "@id": "niiri:165578ad640128bc70e890636626df8c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c4dbdab79f8821a024aad1cbea9bfdc0",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0098",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[8,-72,42]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[8,-72,42]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3b4f28f7e1e4a0092736a83729825138",
-      "entity": "niiri:cb14e2f236a171bf561b547935b40dd9"
+      "entity_derived": "niiri:0775bd867b7640b1610595991372a3a4",
+      "entity": "niiri:a428752a112ae62b5d4a764c475ebebb"
     },
     {
-      "@id": "niiri:5da82e3f5bf83184ccf6b908e46cc0a0",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b8c1d7232cf84cc17142cad17a88efd4",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0099",
-      "prov:atLocation": {"@id": "niiri:91aafb76f5392ceffa689f067b201ad2"},
+      "prov:atLocation": {"@id": "niiri:5d92f1be38abbce4c3a63c0c46448f74"},
       "prov:value": {"@type": "xsd:float", "@value": "3.22331190109253"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.13464894829369"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000860299398633191"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999921"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.917823543835361"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.13464894829369"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000860299398633191"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999921"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.917823543835361"}
     },
     {
-      "@id": "niiri:91aafb76f5392ceffa689f067b201ad2",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:5d92f1be38abbce4c3a63c0c46448f74",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0099",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[42,-86,12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[42,-86,12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5da82e3f5bf83184ccf6b908e46cc0a0",
-      "entity": "niiri:215e12d51ca68faf83b3c157465a4274"
+      "entity_derived": "niiri:b8c1d7232cf84cc17142cad17a88efd4",
+      "entity": "niiri:011ca539a5756d6a56b02867c8dc0da5"
     },
     {
-      "@id": "niiri:40ba61e7a6c7ea4c170c7ce06bd578ae",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d7f13c4e30c7f05356ed60a5151c02bc",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0100",
-      "prov:atLocation": {"@id": "niiri:c4b90588653fee15f2d09b041423e8b5"},
+      "prov:atLocation": {"@id": "niiri:6eb2e0f022d96c098a1c921602f59fc8"},
       "prov:value": {"@type": "xsd:float", "@value": "3.21184372901917"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.12404202893254"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000891924872423622"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999964"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.936836924136013"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.12404202893254"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000891924872423622"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999964"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.936836924136013"}
     },
     {
-      "@id": "niiri:c4b90588653fee15f2d09b041423e8b5",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6eb2e0f022d96c098a1c921602f59fc8",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0100",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-18,-92,8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-18,-92,8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:40ba61e7a6c7ea4c170c7ce06bd578ae",
-      "entity": "niiri:846d054635e491107608bcf6e7db6e7b"
+      "entity_derived": "niiri:d7f13c4e30c7f05356ed60a5151c02bc",
+      "entity": "niiri:cba5fb0d6db1529fec8f4fba47f35ad8"
     },
     {
-      "@id": "niiri:eb7824ce74a09e1ba49d7c665b7e6354",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:490f1070a7fe465c3b5c6f734cf1749d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0101",
-      "prov:atLocation": {"@id": "niiri:c78717f72e65e6b5b17d12d4232790f4"},
+      "prov:atLocation": {"@id": "niiri:139066f39e05f69f22d080013a95fbf1"},
       "prov:value": {"@type": "xsd:float", "@value": "3.19808602333069"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.1113106720378"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000931294345451028"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999986"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.958204454708765"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.1113106720378"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000931294345451028"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999986"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.958204454708765"}
     },
     {
-      "@id": "niiri:c78717f72e65e6b5b17d12d4232790f4",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:139066f39e05f69f22d080013a95fbf1",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0101",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[12,6,18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[12,6,18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:eb7824ce74a09e1ba49d7c665b7e6354",
-      "entity": "niiri:cc3ec71f9506a13ad5812b94c954a6a4"
+      "entity_derived": "niiri:490f1070a7fe465c3b5c6f734cf1749d",
+      "entity": "niiri:ff8870f1fb72bc18a894385e2e338a1a"
     },
     {
-      "@id": "niiri:7d3f6e43708b4bd0ebb482485824b220",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:738e8e698240388bfd3862aecb89fc27",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0102",
-      "prov:atLocation": {"@id": "niiri:54f861e2561b9c0b9304a6eea7150801"},
+      "prov:atLocation": {"@id": "niiri:1a1d537499ae7b8db798494bbd47949b"},
       "prov:value": {"@type": "xsd:float", "@value": "3.19609522819519"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.10946777700093"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000937123635013748"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999988"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.958204454708765"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.10946777700093"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000937123635013748"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999988"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.958204454708765"}
     },
     {
-      "@id": "niiri:54f861e2561b9c0b9304a6eea7150801",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:1a1d537499ae7b8db798494bbd47949b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0102",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[14,40,20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[14,40,20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7d3f6e43708b4bd0ebb482485824b220",
-      "entity": "niiri:ddbafccf344e9c4433df922b8641380c"
+      "entity_derived": "niiri:738e8e698240388bfd3862aecb89fc27",
+      "entity": "niiri:0dd915ffcbdf519b3a8e0e342a7a3a15"
     },
     {
-      "@id": "niiri:fd49df5bffcb3bce9fae882c7b391b13",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:cb10f3dde606a9db392eeb31defadb58",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0103",
-      "prov:atLocation": {"@id": "niiri:bc9a02d4964eac08c5b10095266979e6"},
+      "prov:atLocation": {"@id": "niiri:34d7cb1b6c22f3bab972ec17b5943913"},
       "prov:value": {"@type": "xsd:float", "@value": "3.19474077224731"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.10821385730133"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000941109068576473"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999989"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.958204454708765"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.10821385730133"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000941109068576473"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999989"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.958204454708765"}
     },
     {
-      "@id": "niiri:bc9a02d4964eac08c5b10095266979e6",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:34d7cb1b6c22f3bab972ec17b5943913",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0103",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-44,-42,-36]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-44,-42,-36]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:fd49df5bffcb3bce9fae882c7b391b13",
-      "entity": "niiri:c89051853f599ba8b9d939c26968a8b9"
+      "entity_derived": "niiri:cb10f3dde606a9db392eeb31defadb58",
+      "entity": "niiri:aa3557b1b3fba9452176860c67262bd9"
     }
   ]
 }

--- a/spmexport/ex_spm_default/nidm.ttl
+++ b/spmexport/ex_spm_default/nidm.ttl
@@ -4,7 +4,7 @@
 @prefix niiri: <http://iri.nidash.org/> .
 @prefix spm: <http://purl.org/nidash/spm#> .
 @prefix neurolex: <http://neurolex.org/wiki/> .
-@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#> .
+@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
@@ -17,27 +17,27 @@
 @prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-niiri:0230ba1707dc047fb8389b2b1765b59c
+niiri:4e5cde201dcf24532399b37950fbd970
   a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
   rdfs:label "NIDM-Results" ;
   nidm_version: "1.3.0"^^xsd:string .
 
-niiri:4eb4fb1cc6b0b36b0e9e21f171f8e0ad
+niiri:50df5922ab028839c3e8faae100dc78f
   a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
   rdfs:label "spm_results_nidm" ;
-  nidm_softwareVersion: "12.6903"^^xsd:string .
+  nidm_softwareVersion: "12.7057"^^xsd:string .
 
-niiri:25cb7abdb03032f3423f9b59112037a0
+niiri:b4b82a058bfac16201e2b70c727d1328
   a prov:Activity, nidm_NIDMResultsExport: ; 
   rdfs:label "NIDM-Results export" .
 
-niiri:25cb7abdb03032f3423f9b59112037a0 prov:wasAssociatedWith niiri:4eb4fb1cc6b0b36b0e9e21f171f8e0ad .
+niiri:b4b82a058bfac16201e2b70c727d1328 prov:wasAssociatedWith niiri:50df5922ab028839c3e8faae100dc78f .
 
 _:blank5 a prov:Generation .
 
-niiri:0230ba1707dc047fb8389b2b1765b59c prov:qualifiedGeneration _:blank5 .
+niiri:4e5cde201dcf24532399b37950fbd970 prov:qualifiedGeneration _:blank5 .
 
-_:blank5 prov:atTime "2016-12-07T16:08:21"^^xsd:dateTime .
+_:blank5 prov:atTime "2017-04-19T12:18:02"^^xsd:dateTime .
 
 @prefix nidm_Ixi549CoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000050> .
 @prefix src_SPM: <http://scicrunch.org/resolver/SCR_007037> .
@@ -142,12 +142,12 @@ _:blank5 prov:atTime "2016-12-07T16:08:21"^^xsd:dateTime .
 @prefix nidm_Coordinate: <http://purl.org/nidash/nidm#NIDM_0000015> .
 @prefix nidm_coordinateVector: <http://purl.org/nidash/nidm#NIDM_0000086> .
 
-niiri:1c85e51e306450f93ae1eea7dc030468
+niiri:eb9874e84de35431b43fa1c2015078a6
     a prov:Agent, src_SPM:, prov:SoftwareAgent ; 
     rdfs:label "SPM" ;
-    nidm_softwareVersion: "12.12.2"^^xsd:string .
+    nidm_softwareVersion: "12.6906"^^xsd:string .
 
-niiri:50ab6f82bfb155a52f9575700bce87ef
+niiri:b2a98667786a7f2349a2658d9fd2f766
     a prov:Entity, nidm_CoordinateSpace: ; 
     rdfs:label "Coordinate space 1" ;
     nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
@@ -157,48 +157,48 @@ niiri:50ab6f82bfb155a52f9575700bce87ef
     nidm_numberOfDimensions: "3"^^xsd:int ;
     nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
 
-niiri:1b2879ef56e59c00fbd3766cb2b27c90
+niiri:c1ffd758228d702c4e45a8569d5e3a17
     a prov:Agent, nlx_Imaginginstrument:, nlx_Magneticresonanceimagingscanner: ; 
     rdfs:label "MRI Scanner" .
 
-niiri:c2605828d483ca45e828f58004e6f46e
+niiri:d2fd7c347715d0e29b9dd29e3691672a
     a prov:Agent, prov:Person ; 
     rdfs:label "Person" .
 
-niiri:9e1284f48529999852e941d1bfb0d208
+niiri:d8cb12a2013805cec8a0537c545e4c27
     a prov:Entity, prov:Collection, nidm_Data: ; 
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "true"^^xsd:boolean ;
     nidm_targetIntensity: "100"^^xsd:float ;
     nidm_hasMRIProtocol: nlx_FunctionalMRIprotocol: .
 
-niiri:9e1284f48529999852e941d1bfb0d208 prov:wasAttributedTo niiri:1b2879ef56e59c00fbd3766cb2b27c90 .
+niiri:d8cb12a2013805cec8a0537c545e4c27 prov:wasAttributedTo niiri:c1ffd758228d702c4e45a8569d5e3a17 .
 
-niiri:9e1284f48529999852e941d1bfb0d208 prov:wasAttributedTo niiri:c2605828d483ca45e828f58004e6f46e .
+niiri:d8cb12a2013805cec8a0537c545e4c27 prov:wasAttributedTo niiri:d2fd7c347715d0e29b9dd29e3691672a .
 
-niiri:9a72b9f06e919ffd7b6beea514120c4c
+niiri:960c1b74729818f390814df5d8a07151
     a prov:Entity, spm_DCTDriftModel: ; 
     rdfs:label "SPM's DCT Drift Model" ;
     spm_SPMsDriftCutoffPeriod: "128"^^xsd:float .
 
-niiri:26462807ede3305a82102677feba6507
+niiri:d44fca7b57060de1677bc74daa15aa89
     a prov:Entity, nidm_DesignMatrix: ; 
     prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.csv"^^xsd:string ;
     dct:format "text/csv"^^xsd:string ;
-    dc:description niiri:d2863cf18ed3a73f1c9d8cfc639e76a5 ;
+    dc:description niiri:8787c98cac2e7989b33c3fc7a9c9f2fa ;
     rdfs:label "Design Matrix" ;
     nidm_regressorNames: "[\"Sn(1) to*bf(1)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) constant\"]"^^xsd:string ;
-    nidm_hasDriftModel: niiri:9a72b9f06e919ffd7b6beea514120c4c ;
+    nidm_hasDriftModel: niiri:960c1b74729818f390814df5d8a07151 ;
     nidm_hasHRFBasis: spm_SPMsCanonicalHRF: .
 
-niiri:d2863cf18ed3a73f1c9d8cfc639e76a5
+niiri:8787c98cac2e7989b33c3fc7a9c9f2fa
     a prov:Entity, dctype:Image ; 
     prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:9f8cfdef5717075200868a7658ae42b2
+niiri:ca9137874e81e1af901b6acfc7ff391a
     a prov:Entity, nidm_ErrorModel: ; 
     nidm_hasErrorDistribution: obo_normaldistribution: ;
     nidm_hasErrorDependence: obo_Toeplitzcovariancestructure: ;
@@ -206,174 +206,174 @@ niiri:9f8cfdef5717075200868a7658ae42b2
     nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
     nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
 
-niiri:01b92aaf71dc95787225c9a92c03368c
+niiri:773a735fbcc316e9f2d58362f2f4d1bc
     a prov:Activity, nidm_ModelParametersEstimation: ; 
     rdfs:label "Model parameters estimation" ;
     nidm_withEstimationMethod: obo_generalizedleastsquaresestimation: .
 
-niiri:01b92aaf71dc95787225c9a92c03368c prov:wasAssociatedWith niiri:1c85e51e306450f93ae1eea7dc030468 .
+niiri:773a735fbcc316e9f2d58362f2f4d1bc prov:wasAssociatedWith niiri:eb9874e84de35431b43fa1c2015078a6 .
 
-niiri:01b92aaf71dc95787225c9a92c03368c prov:used niiri:26462807ede3305a82102677feba6507 .
+niiri:773a735fbcc316e9f2d58362f2f4d1bc prov:used niiri:d44fca7b57060de1677bc74daa15aa89 .
 
-niiri:01b92aaf71dc95787225c9a92c03368c prov:used niiri:9e1284f48529999852e941d1bfb0d208 .
+niiri:773a735fbcc316e9f2d58362f2f4d1bc prov:used niiri:d8cb12a2013805cec8a0537c545e4c27 .
 
-niiri:01b92aaf71dc95787225c9a92c03368c prov:used niiri:9f8cfdef5717075200868a7658ae42b2 .
+niiri:773a735fbcc316e9f2d58362f2f4d1bc prov:used niiri:ca9137874e81e1af901b6acfc7ff391a .
 
-niiri:10e0a40e6b9f6264450889f5827a282b
+niiri:218e9dabb7ce7346a5fc5d0e4d956c0f
     a prov:Entity, nidm_MaskMap: ; 
     prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
     nidm_isUserDefined: "false"^^xsd:boolean ;
     nfo:fileName "Mask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Mask" ;
-    nidm_inCoordinateSpace: niiri:50ab6f82bfb155a52f9575700bce87ef ;
+    nidm_inCoordinateSpace: niiri:b2a98667786a7f2349a2658d9fd2f766 ;
     crypto:sha512 "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876"^^xsd:string .
 
-niiri:c50012d9153f74d1edfa6503cad067c3
+niiri:e5b0a4f7beeecbff1514adf4c11f02ab
     a prov:Entity, nidm_MaskMap: ; 
     nfo:fileName "mask.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "36929e1f5f4143bd9cc818cd896a25f129961fab208c3a4438555f40444c08347b359142ee8c53ece6e8cca1627f49db0788a1fd3b9e2ecaef61999c6c6c67ac"^^xsd:string .
 
-niiri:10e0a40e6b9f6264450889f5827a282b prov:wasDerivedFrom niiri:c50012d9153f74d1edfa6503cad067c3 .
+niiri:218e9dabb7ce7346a5fc5d0e4d956c0f prov:wasDerivedFrom niiri:e5b0a4f7beeecbff1514adf4c11f02ab .
 
-niiri:10e0a40e6b9f6264450889f5827a282b prov:wasGeneratedBy niiri:01b92aaf71dc95787225c9a92c03368c .
+niiri:218e9dabb7ce7346a5fc5d0e4d956c0f prov:wasGeneratedBy niiri:773a735fbcc316e9f2d58362f2f4d1bc .
 
-niiri:af22552e6ef04231ab1ba39bdac1b5be
+niiri:b6dedebe44bd4dfcd70f1e56cc87d8e1
     a prov:Entity, nidm_GrandMeanMap: ; 
     prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
     nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Grand Mean Map" ;
     nidm_maskedMedian: "111.557487487793"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:50ab6f82bfb155a52f9575700bce87ef ;
+    nidm_inCoordinateSpace: niiri:b2a98667786a7f2349a2658d9fd2f766 ;
     crypto:sha512 "512157cc6bff89d9343a09b4068226eb3edd64a8cbcee861f06231767fae6f8d4819921182adebee083a9bf309afd65529ab04a92f0aa6b0038c8098550f6124"^^xsd:string .
 
-niiri:af22552e6ef04231ab1ba39bdac1b5be prov:wasGeneratedBy niiri:01b92aaf71dc95787225c9a92c03368c .
+niiri:b6dedebe44bd4dfcd70f1e56cc87d8e1 prov:wasGeneratedBy niiri:773a735fbcc316e9f2d58362f2f4d1bc .
 
-niiri:45a7380cf4b4845a292bd63d0a2ac4ff
+niiri:55bbc45f54dbafed48a1b302258b19a8
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0001.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0001.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 1" ;
-    nidm_inCoordinateSpace: niiri:50ab6f82bfb155a52f9575700bce87ef ;
+    nidm_inCoordinateSpace: niiri:b2a98667786a7f2349a2658d9fd2f766 ;
     crypto:sha512 "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd"^^xsd:string .
 
-niiri:7f8756e251d0ce0a7cef8e400ee2a011
+niiri:a8f1001f03928204508b6ab86da06246
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd"^^xsd:string .
 
-niiri:45a7380cf4b4845a292bd63d0a2ac4ff prov:wasDerivedFrom niiri:7f8756e251d0ce0a7cef8e400ee2a011 .
+niiri:55bbc45f54dbafed48a1b302258b19a8 prov:wasDerivedFrom niiri:a8f1001f03928204508b6ab86da06246 .
 
-niiri:45a7380cf4b4845a292bd63d0a2ac4ff prov:wasGeneratedBy niiri:01b92aaf71dc95787225c9a92c03368c .
+niiri:55bbc45f54dbafed48a1b302258b19a8 prov:wasGeneratedBy niiri:773a735fbcc316e9f2d58362f2f4d1bc .
 
-niiri:3a7853f4d424f1acc25ad576004c913f
+niiri:3625bdf3e80d5e9a25b486f9360a1378
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0002.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0002.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 2" ;
-    nidm_inCoordinateSpace: niiri:50ab6f82bfb155a52f9575700bce87ef ;
+    nidm_inCoordinateSpace: niiri:b2a98667786a7f2349a2658d9fd2f766 ;
     crypto:sha512 "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c"^^xsd:string .
 
-niiri:531d00f731d00fb9d4b49b8fde409299
+niiri:91a5ac743cdb91c1d48fca362a3241fc
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0002.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c"^^xsd:string .
 
-niiri:3a7853f4d424f1acc25ad576004c913f prov:wasDerivedFrom niiri:531d00f731d00fb9d4b49b8fde409299 .
+niiri:3625bdf3e80d5e9a25b486f9360a1378 prov:wasDerivedFrom niiri:91a5ac743cdb91c1d48fca362a3241fc .
 
-niiri:3a7853f4d424f1acc25ad576004c913f prov:wasGeneratedBy niiri:01b92aaf71dc95787225c9a92c03368c .
+niiri:3625bdf3e80d5e9a25b486f9360a1378 prov:wasGeneratedBy niiri:773a735fbcc316e9f2d58362f2f4d1bc .
 
-niiri:0b91d3ce63a63f2e4aa74029f82aeae9
+niiri:67cc3fa692b977e0ac54b72dec7e4384
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0003.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0003.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 3" ;
-    nidm_inCoordinateSpace: niiri:50ab6f82bfb155a52f9575700bce87ef ;
+    nidm_inCoordinateSpace: niiri:b2a98667786a7f2349a2658d9fd2f766 ;
     crypto:sha512 "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373"^^xsd:string .
 
-niiri:e218c62ae4c038a044a29968c0f162f7
+niiri:fe38b6202e69c84f88ece9b51a9a99c3
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0003.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373"^^xsd:string .
 
-niiri:0b91d3ce63a63f2e4aa74029f82aeae9 prov:wasDerivedFrom niiri:e218c62ae4c038a044a29968c0f162f7 .
+niiri:67cc3fa692b977e0ac54b72dec7e4384 prov:wasDerivedFrom niiri:fe38b6202e69c84f88ece9b51a9a99c3 .
 
-niiri:0b91d3ce63a63f2e4aa74029f82aeae9 prov:wasGeneratedBy niiri:01b92aaf71dc95787225c9a92c03368c .
+niiri:67cc3fa692b977e0ac54b72dec7e4384 prov:wasGeneratedBy niiri:773a735fbcc316e9f2d58362f2f4d1bc .
 
-niiri:d7d297d8f94d7b492b408fb5c96acdd9
+niiri:b49762a3483888f79a5d5b06f51a25d1
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Residual Mean Squares Map" ;
-    nidm_inCoordinateSpace: niiri:50ab6f82bfb155a52f9575700bce87ef ;
+    nidm_inCoordinateSpace: niiri:b2a98667786a7f2349a2658d9fd2f766 ;
     crypto:sha512 "991abf563d795a43b1e2eef8643e57023f2e0b090b2031f05f839321fc0643df6f71d423486a1021519b6dc82f6b0f563e19f3fbd50cb16063bed54a0e192d3e"^^xsd:string .
 
-niiri:d0e293879b9e5931f795c43f7edfe497
+niiri:685419d4a3159548c52f7aa12e55d28b
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     nfo:fileName "ResMS.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "40b28d03fcf9a2f60b11f10d7fb83bf3618b234fb5aedf09df644cb7cbb6aab8c9f468897c1078166d455a3d04a83f4e3bf762cfca0b4ea982d7a4e406849f18"^^xsd:string .
 
-niiri:d7d297d8f94d7b492b408fb5c96acdd9 prov:wasDerivedFrom niiri:d0e293879b9e5931f795c43f7edfe497 .
+niiri:b49762a3483888f79a5d5b06f51a25d1 prov:wasDerivedFrom niiri:685419d4a3159548c52f7aa12e55d28b .
 
-niiri:d7d297d8f94d7b492b408fb5c96acdd9 prov:wasGeneratedBy niiri:01b92aaf71dc95787225c9a92c03368c .
+niiri:b49762a3483888f79a5d5b06f51a25d1 prov:wasGeneratedBy niiri:773a735fbcc316e9f2d58362f2f4d1bc .
 
-niiri:2e723257cae1733db839c73ac25f6112
+niiri:982b6bb49828f15a05294a1c58d03b8b
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Resels per Voxel Map" ;
-    nidm_inCoordinateSpace: niiri:50ab6f82bfb155a52f9575700bce87ef ;
+    nidm_inCoordinateSpace: niiri:b2a98667786a7f2349a2658d9fd2f766 ;
     crypto:sha512 "1a3f9216e145249ccc0b14b2bc337d6b38b81ad45e32768001fb22b35f0c2c0f3e2bce013b40c85f7dc0fc62723ac761ee7f7e1e6aff128a05f0ba7b8b8202a3"^^xsd:string .
 
-niiri:392b1752b3da836208fac5721f378347
+niiri:cad5e3e80a900432c8b3e58a397f0b76
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     nfo:fileName "RPV.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "4f76663162857f6b38b2a45a63b15a23b2ca8b338c283b69c1e71f2ea2f43797d045a733cd14e845be9c12f8b8f84d3931c599a08e8f6d77e99fab46ad87ab8f"^^xsd:string .
 
-niiri:2e723257cae1733db839c73ac25f6112 prov:wasDerivedFrom niiri:392b1752b3da836208fac5721f378347 .
+niiri:982b6bb49828f15a05294a1c58d03b8b prov:wasDerivedFrom niiri:cad5e3e80a900432c8b3e58a397f0b76 .
 
-niiri:2e723257cae1733db839c73ac25f6112 prov:wasGeneratedBy niiri:01b92aaf71dc95787225c9a92c03368c .
+niiri:982b6bb49828f15a05294a1c58d03b8b prov:wasGeneratedBy niiri:773a735fbcc316e9f2d58362f2f4d1bc .
 
-niiri:502e44f2fbcf62365e603de5eac7ff92
+niiri:f9498d3b2bcc41a724d906ee170c4316
     a prov:Entity, obo_contrastweightmatrix: ; 
     nidm_statisticType: obo_tstatistic: ;
     nidm_contrastName: "tone counting vs baseline"^^xsd:string ;
     rdfs:label "Contrast: tone counting vs baseline" ;
     prov:value "[1, 0, 0]"^^xsd:string .
 
-niiri:d7857c352c75e52b917064fe80e4d398
+niiri:2556ad05de8d46ac8899042750f19e3b
     a prov:Activity, nidm_ContrastEstimation: ; 
     rdfs:label "Contrast estimation" .
 
-niiri:d7857c352c75e52b917064fe80e4d398 prov:wasAssociatedWith niiri:1c85e51e306450f93ae1eea7dc030468 .
+niiri:2556ad05de8d46ac8899042750f19e3b prov:wasAssociatedWith niiri:eb9874e84de35431b43fa1c2015078a6 .
 
-niiri:d7857c352c75e52b917064fe80e4d398 prov:used niiri:10e0a40e6b9f6264450889f5827a282b .
+niiri:2556ad05de8d46ac8899042750f19e3b prov:used niiri:218e9dabb7ce7346a5fc5d0e4d956c0f .
 
-niiri:d7857c352c75e52b917064fe80e4d398 prov:used niiri:d7d297d8f94d7b492b408fb5c96acdd9 .
+niiri:2556ad05de8d46ac8899042750f19e3b prov:used niiri:b49762a3483888f79a5d5b06f51a25d1 .
 
-niiri:d7857c352c75e52b917064fe80e4d398 prov:used niiri:26462807ede3305a82102677feba6507 .
+niiri:2556ad05de8d46ac8899042750f19e3b prov:used niiri:d44fca7b57060de1677bc74daa15aa89 .
 
-niiri:d7857c352c75e52b917064fe80e4d398 prov:used niiri:502e44f2fbcf62365e603de5eac7ff92 .
+niiri:2556ad05de8d46ac8899042750f19e3b prov:used niiri:f9498d3b2bcc41a724d906ee170c4316 .
 
-niiri:d7857c352c75e52b917064fe80e4d398 prov:used niiri:45a7380cf4b4845a292bd63d0a2ac4ff .
+niiri:2556ad05de8d46ac8899042750f19e3b prov:used niiri:55bbc45f54dbafed48a1b302258b19a8 .
 
-niiri:d7857c352c75e52b917064fe80e4d398 prov:used niiri:3a7853f4d424f1acc25ad576004c913f .
+niiri:2556ad05de8d46ac8899042750f19e3b prov:used niiri:3625bdf3e80d5e9a25b486f9360a1378 .
 
-niiri:d7857c352c75e52b917064fe80e4d398 prov:used niiri:0b91d3ce63a63f2e4aa74029f82aeae9 .
+niiri:2556ad05de8d46ac8899042750f19e3b prov:used niiri:67cc3fa692b977e0ac54b72dec7e4384 .
 
-niiri:bad129c64d1cd2ee3998d0e6c519ba45
+niiri:e461c8f3ab4826650944bec7b1912e84
     a prov:Entity, nidm_StatisticMap: ; 
     prov:atLocation "TStatistic.nii.gz"^^xsd:anyURI ;
     nfo:fileName "TStatistic.nii.gz"^^xsd:string ;
@@ -383,124 +383,124 @@ niiri:bad129c64d1cd2ee3998d0e6c519ba45
     nidm_contrastName: "tone counting vs baseline"^^xsd:string ;
     nidm_errorDegreesOfFreedom: "97.9999999998522"^^xsd:float ;
     nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:50ab6f82bfb155a52f9575700bce87ef ;
+    nidm_inCoordinateSpace: niiri:b2a98667786a7f2349a2658d9fd2f766 ;
     crypto:sha512 "9e1714c2d86a050b38b4e10a4d2d23253a24c5e1d228ae16a9c3be8872739278505ac0729ecab54265a717e3a54f9f782d0ed72eea904e0d482a6072bb817bd4"^^xsd:string .
 
-niiri:37a27475ed991e4ef01f569ba4bef25e
+niiri:901cc6a5ebd5a3b326b9725834bdddca
     a prov:Entity, nidm_StatisticMap: ; 
     nfo:fileName "spmT_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "d288b1b0f117f64502555da13c5398dffa5bf5ff0b58951510e43d5388755bc185798802a92e98a07c7e313c6991066d2908f2a44aa5153ba23433da1335970f"^^xsd:string .
 
-niiri:bad129c64d1cd2ee3998d0e6c519ba45 prov:wasDerivedFrom niiri:37a27475ed991e4ef01f569ba4bef25e .
+niiri:e461c8f3ab4826650944bec7b1912e84 prov:wasDerivedFrom niiri:901cc6a5ebd5a3b326b9725834bdddca .
 
-niiri:bad129c64d1cd2ee3998d0e6c519ba45 prov:wasGeneratedBy niiri:d7857c352c75e52b917064fe80e4d398 .
+niiri:e461c8f3ab4826650944bec7b1912e84 prov:wasGeneratedBy niiri:2556ad05de8d46ac8899042750f19e3b .
 
-niiri:536beda6b1e9d1057f3a5fa328898c89
+niiri:f9b320bdd9480281306f90d15b0ab8be
     a prov:Entity, nidm_ContrastMap: ; 
     prov:atLocation "Contrast.nii.gz"^^xsd:anyURI ;
     nfo:fileName "Contrast.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Map: tone counting vs baseline" ;
     nidm_contrastName: "tone counting vs baseline"^^xsd:string ;
-    nidm_inCoordinateSpace: niiri:50ab6f82bfb155a52f9575700bce87ef ;
+    nidm_inCoordinateSpace: niiri:b2a98667786a7f2349a2658d9fd2f766 ;
     crypto:sha512 "fc5e2ad175243ee496db98f9b2e1b235c4c3bae1a8d7122ce461c897b537e40c49dfee5d6cf20f71c6a2bb9b5f0760fcb4ecd8fe2e9428910ef3d60d8f3c56a9"^^xsd:string .
 
-niiri:4dbb67fcea1b196014de11fa34a7c299
+niiri:ed3281c40be1462539e94647abd36a73
     a prov:Entity, nidm_ContrastMap: ; 
     nfo:fileName "con_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "d4aa46b3603ba508578e39751262d528cf6d1ed2e722ec46f1cd8194c50591e46b229deb8cb4f72d1b7e0e2640f3e6604be7a335301c5c8357f453e5d0d4daf2"^^xsd:string .
 
-niiri:536beda6b1e9d1057f3a5fa328898c89 prov:wasDerivedFrom niiri:4dbb67fcea1b196014de11fa34a7c299 .
+niiri:f9b320bdd9480281306f90d15b0ab8be prov:wasDerivedFrom niiri:ed3281c40be1462539e94647abd36a73 .
 
-niiri:536beda6b1e9d1057f3a5fa328898c89 prov:wasGeneratedBy niiri:d7857c352c75e52b917064fe80e4d398 .
+niiri:f9b320bdd9480281306f90d15b0ab8be prov:wasGeneratedBy niiri:2556ad05de8d46ac8899042750f19e3b .
 
-niiri:f385f3aec2411e329ca4b4d16ae45cc5
+niiri:a8574ab2053ab027cf06dd5d2a5a785a
     a prov:Entity, nidm_ContrastStandardErrorMap: ; 
     prov:atLocation "ContrastStandardError.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ContrastStandardError.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Standard Error Map" ;
-    nidm_inCoordinateSpace: niiri:50ab6f82bfb155a52f9575700bce87ef ;
+    nidm_inCoordinateSpace: niiri:b2a98667786a7f2349a2658d9fd2f766 ;
     crypto:sha512 "791d48f5d1adb15079a5289271ce0c4b95c56d69bfdb3e5d41b0d24eb538d3075e1cdd15502494b5a5a18c16eaa2153cb4847a996043fa48cdaf26e938a2576d"^^xsd:string .
 
-niiri:f385f3aec2411e329ca4b4d16ae45cc5 prov:wasGeneratedBy niiri:d7857c352c75e52b917064fe80e4d398 .
+niiri:a8574ab2053ab027cf06dd5d2a5a785a prov:wasGeneratedBy niiri:2556ad05de8d46ac8899042750f19e3b .
 
-niiri:830481ffc845251233d35209faa5e3c4
+niiri:dd97c56b32bf917687b52d95e2b13099
     a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
-    rdfs:label "Height Threshold: p<0.001000 (unc.)" ;
+    rdfs:label "Height Threshold: p<0.001 (unc.)" ;
     prov:value "0.000999500158000544"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:2b5fce69752ddfce546ae1b20c298b88 ;
-    nidm_equivalentThreshold: niiri:2c9e1cb5b11d4d9e79f581086360e7e5 .
+    nidm_equivalentThreshold: niiri:5ca71150749a0c1b73185241479322c6 ;
+    nidm_equivalentThreshold: niiri:34949c0c34ebc75ccb4b4818296e0a77 .
 
-niiri:2b5fce69752ddfce546ae1b20c298b88
+niiri:5ca71150749a0c1b73185241479322c6
     a prov:Entity, nidm_HeightThreshold:, obo_statistic: ; 
-    rdfs:label "Height Threshold" ;
+    rdfs:label "Height Threshold: T=3.175486)" ;
     prov:value "3.17548628637284"^^xsd:float .
 
-niiri:2c9e1cb5b11d4d9e79f581086360e7e5
+niiri:34949c0c34ebc75ccb4b4818296e0a77
     a prov:Entity, nidm_HeightThreshold:, obo_FWERadjustedpvalue: ; 
-    rdfs:label "Height Threshold" ;
+    rdfs:label "Height Threshold: p<1.000000 (FWE)" ;
     prov:value "0.999999999999997"^^xsd:float .
 
-niiri:1c2d9fb88b84d0d10397f2645fc81f7e
+niiri:99724284af9cacae301790c375fe6b15
     a prov:Entity, nidm_ExtentThreshold:, obo_statistic: ; 
     rdfs:label "Extent Threshold: k>=0" ;
     nidm_clusterSizeInVoxels: "0"^^xsd:int ;
     nidm_clusterSizeInResels: "0"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:f8398b5d7778680876cbd0d3b53b21c8 ;
-    nidm_equivalentThreshold: niiri:a93b85496c625d485e90cec91df388cc .
+    nidm_equivalentThreshold: niiri:e135cf296ac53187ccabf232f6d1faac ;
+    nidm_equivalentThreshold: niiri:70f26b0e75559a8ee50b5623efa62ae9 .
 
-niiri:f8398b5d7778680876cbd0d3b53b21c8
+niiri:e135cf296ac53187ccabf232f6d1faac
     a prov:Entity, nidm_ExtentThreshold:, obo_FWERadjustedpvalue: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:a93b85496c625d485e90cec91df388cc
+niiri:70f26b0e75559a8ee50b5623efa62ae9
     a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:5b869c4f5dab0de2f993363ded227212
+niiri:dfa8c97f4a46388cf4a9bb1364e0d92e
     a prov:Entity, nidm_PeakDefinitionCriteria: ; 
     rdfs:label "Peak Definition Criteria" ;
     nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
     nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
 
-niiri:0ef97cb242016a21e21ce29dbcb35703
+niiri:5bd0a1af1bb03071db4c49f47a4396a1
     a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
     rdfs:label "Cluster Connectivity Criterion: 18" ;
     nidm_hasConnectivityCriterion: nidm_voxel18connected: .
 
-niiri:87014624fb0cd5fe9b225ba254cc4638
+niiri:741b8ea52f035ab6ac7f052b1d8660ed
     a prov:Activity, nidm_Inference: ; 
     nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
     rdfs:label "Inference" .
 
-niiri:87014624fb0cd5fe9b225ba254cc4638 prov:wasAssociatedWith niiri:1c85e51e306450f93ae1eea7dc030468 .
+niiri:741b8ea52f035ab6ac7f052b1d8660ed prov:wasAssociatedWith niiri:eb9874e84de35431b43fa1c2015078a6 .
 
-niiri:87014624fb0cd5fe9b225ba254cc4638 prov:used niiri:830481ffc845251233d35209faa5e3c4 .
+niiri:741b8ea52f035ab6ac7f052b1d8660ed prov:used niiri:dd97c56b32bf917687b52d95e2b13099 .
 
-niiri:87014624fb0cd5fe9b225ba254cc4638 prov:used niiri:1c2d9fb88b84d0d10397f2645fc81f7e .
+niiri:741b8ea52f035ab6ac7f052b1d8660ed prov:used niiri:99724284af9cacae301790c375fe6b15 .
 
-niiri:87014624fb0cd5fe9b225ba254cc4638 prov:used niiri:bad129c64d1cd2ee3998d0e6c519ba45 .
+niiri:741b8ea52f035ab6ac7f052b1d8660ed prov:used niiri:e461c8f3ab4826650944bec7b1912e84 .
 
-niiri:87014624fb0cd5fe9b225ba254cc4638 prov:used niiri:2e723257cae1733db839c73ac25f6112 .
+niiri:741b8ea52f035ab6ac7f052b1d8660ed prov:used niiri:982b6bb49828f15a05294a1c58d03b8b .
 
-niiri:87014624fb0cd5fe9b225ba254cc4638 prov:used niiri:10e0a40e6b9f6264450889f5827a282b .
+niiri:741b8ea52f035ab6ac7f052b1d8660ed prov:used niiri:218e9dabb7ce7346a5fc5d0e4d956c0f .
 
-niiri:87014624fb0cd5fe9b225ba254cc4638 prov:used niiri:5b869c4f5dab0de2f993363ded227212 .
+niiri:741b8ea52f035ab6ac7f052b1d8660ed prov:used niiri:dfa8c97f4a46388cf4a9bb1364e0d92e .
 
-niiri:87014624fb0cd5fe9b225ba254cc4638 prov:used niiri:0ef97cb242016a21e21ce29dbcb35703 .
+niiri:741b8ea52f035ab6ac7f052b1d8660ed prov:used niiri:5bd0a1af1bb03071db4c49f47a4396a1 .
 
-niiri:0a910bd73739b38d4f925e16066c96ca
+niiri:b9b82d6e97f1bad3e6178276b982be04
     a prov:Entity, nidm_SearchSpaceMaskMap: ; 
     prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
     nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Search Space Mask Map" ;
-    nidm_inCoordinateSpace: niiri:50ab6f82bfb155a52f9575700bce87ef ;
+    nidm_inCoordinateSpace: niiri:b2a98667786a7f2349a2658d9fd2f766 ;
     nidm_searchVolumeInVoxels: "223057"^^xsd:int ;
     nidm_searchVolumeInUnits: "1784456"^^xsd:float ;
     nidm_reselSizeInVoxels: "65.5786964036542"^^xsd:float ;
@@ -517,9 +517,9 @@ niiri:0a910bd73739b38d4f925e16066c96ca
     spm_smallestSignificantClusterSizeInVoxelsFWE05: "116"^^xsd:int ;
     spm_smallestSignificantClusterSizeInVoxelsFDR05: "61"^^xsd:int .
 
-niiri:0a910bd73739b38d4f925e16066c96ca prov:wasGeneratedBy niiri:87014624fb0cd5fe9b225ba254cc4638 .
+niiri:b9b82d6e97f1bad3e6178276b982be04 prov:wasGeneratedBy niiri:741b8ea52f035ab6ac7f052b1d8660ed .
 
-niiri:086f71113cd77b52e83a7758b427f167
+niiri:80c10806c0beeee32d27292ced29500f
     a prov:Entity, nidm_ExcursionSetMap: ; 
     prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
@@ -527,29 +527,29 @@ niiri:086f71113cd77b52e83a7758b427f167
     rdfs:label "Excursion Set Map" ;
     nidm_numberOfSupraThresholdClusters: "81"^^xsd:int ;
     nidm_pValue: "3.03579383853503e-12"^^xsd:float ;
-    nidm_hasClusterLabelsMap: niiri:13e6b83205b252983ff42d6a042ef554 ;
-    nidm_hasMaximumIntensityProjection: niiri:09a42f4704a482efe7b956643a762aba ;
-    nidm_inCoordinateSpace: niiri:50ab6f82bfb155a52f9575700bce87ef ;
+    nidm_hasClusterLabelsMap: niiri:e52ca30928761b2a737cfd8aadc61c9a ;
+    nidm_hasMaximumIntensityProjection: niiri:a8dea88063f0005998cb2504c3d1c11d ;
+    nidm_inCoordinateSpace: niiri:b2a98667786a7f2349a2658d9fd2f766 ;
     crypto:sha512 "014dbfd7824bc4040c0b428b073ff43721cf78f5e15bbfe3edf01dad68c62eac0a4e978b1cd38dcae91777937b9f5257fb28329cf8c317223be18fa70c2a2ed6"^^xsd:string .
 
-niiri:13e6b83205b252983ff42d6a042ef554
+niiri:e52ca30928761b2a737cfd8aadc61c9a
     a prov:Entity, nidm_ClusterLabelsMap: ; 
     prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Cluster Labels Map" ;
-    nidm_inCoordinateSpace: niiri:50ab6f82bfb155a52f9575700bce87ef ;
+    nidm_inCoordinateSpace: niiri:b2a98667786a7f2349a2658d9fd2f766 ;
     crypto:sha512 "06977d4de4ad0066cd008492aeee125405b5fc4a1c6fe605211b4c16a2eaa09a2793f430dd5dec0d1b5fce0d872b2fa96b8083d6cdbe719e497031b5b9d08256"^^xsd:string .
 
-niiri:09a42f4704a482efe7b956643a762aba
+niiri:a8dea88063f0005998cb2504c3d1c11d
     a prov:Entity, dctype:Image ; 
     prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
     nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:086f71113cd77b52e83a7758b427f167 prov:wasGeneratedBy niiri:87014624fb0cd5fe9b225ba254cc4638 .
+niiri:80c10806c0beeee32d27292ced29500f prov:wasGeneratedBy niiri:741b8ea52f035ab6ac7f052b1d8660ed .
 
-niiri:5fc01864c8f0e284bb366e4a9fc5f229
+niiri:749b77e80ffd0ed4ca77337a7893adc6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0001" ;
     nidm_clusterSizeInVoxels: "1804"^^xsd:int ;
@@ -559,9 +559,9 @@ niiri:5fc01864c8f0e284bb366e4a9fc5f229
     nidm_qValueFDR: "5.93371085041799e-20"^^xsd:float ;
     nidm_clusterLabelId: "1"^^xsd:int .
 
-niiri:5fc01864c8f0e284bb366e4a9fc5f229 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:749b77e80ffd0ed4ca77337a7893adc6 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:7164f842b38559769512336527f4fe59
+niiri:e2c6b47be3a342a41d95bfc20852c868
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0002" ;
     nidm_clusterSizeInVoxels: "356"^^xsd:int ;
@@ -571,9 +571,9 @@ niiri:7164f842b38559769512336527f4fe59
     nidm_qValueFDR: "1.17083954451478e-06"^^xsd:float ;
     nidm_clusterLabelId: "2"^^xsd:int .
 
-niiri:7164f842b38559769512336527f4fe59 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:e2c6b47be3a342a41d95bfc20852c868 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:b19f0b712285b7e8de902f92c3fede84
+niiri:7d345f60b278ac792f989f5862ed9684
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0003" ;
     nidm_clusterSizeInVoxels: "5090"^^xsd:int ;
@@ -583,9 +583,9 @@ niiri:b19f0b712285b7e8de902f92c3fede84
     nidm_qValueFDR: "2.03335233065374e-40"^^xsd:float ;
     nidm_clusterLabelId: "3"^^xsd:int .
 
-niiri:b19f0b712285b7e8de902f92c3fede84 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:7d345f60b278ac792f989f5862ed9684 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:01758d9126d8fc5ff1b54b4e6edb737b
+niiri:78cf678fc1d8e63075a90d654ff6f858
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0004" ;
     nidm_clusterSizeInVoxels: "766"^^xsd:int ;
@@ -595,9 +595,9 @@ niiri:01758d9126d8fc5ff1b54b4e6edb737b
     nidm_qValueFDR: "4.58706002591263e-11"^^xsd:float ;
     nidm_clusterLabelId: "4"^^xsd:int .
 
-niiri:01758d9126d8fc5ff1b54b4e6edb737b prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:78cf678fc1d8e63075a90d654ff6f858 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:ae4dcd02f2fd1098abb0e8a48b888b04
+niiri:d1df03018bbf137ff5ef2da545a3e8bf
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0005" ;
     nidm_clusterSizeInVoxels: "54"^^xsd:int ;
@@ -607,9 +607,9 @@ niiri:ae4dcd02f2fd1098abb0e8a48b888b04
     nidm_qValueFDR: "0.061094648971533"^^xsd:float ;
     nidm_clusterLabelId: "5"^^xsd:int .
 
-niiri:ae4dcd02f2fd1098abb0e8a48b888b04 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:d1df03018bbf137ff5ef2da545a3e8bf prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:5bfdd7920dcd4de97cf8b89a13cd95e8
+niiri:168af8a06bcba9be4ec76231fb932bcd
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0006" ;
     nidm_clusterSizeInVoxels: "285"^^xsd:int ;
@@ -619,9 +619,9 @@ niiri:5bfdd7920dcd4de97cf8b89a13cd95e8
     nidm_qValueFDR: "9.4369593516496e-06"^^xsd:float ;
     nidm_clusterLabelId: "6"^^xsd:int .
 
-niiri:5bfdd7920dcd4de97cf8b89a13cd95e8 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:168af8a06bcba9be4ec76231fb932bcd prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:0fee37ce3647eeec66b703b7384f7d51
+niiri:3b36a7334ca09a3c238279baec873119
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0007" ;
     nidm_clusterSizeInVoxels: "395"^^xsd:int ;
@@ -631,9 +631,9 @@ niiri:0fee37ce3647eeec66b703b7384f7d51
     nidm_qValueFDR: "4.37433635338446e-07"^^xsd:float ;
     nidm_clusterLabelId: "7"^^xsd:int .
 
-niiri:0fee37ce3647eeec66b703b7384f7d51 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:3b36a7334ca09a3c238279baec873119 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:f62983c44994abc2d68d9067929a281b
+niiri:58bff46dfff701e885b3a3a8403d6869
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0008" ;
     nidm_clusterSizeInVoxels: "116"^^xsd:int ;
@@ -643,9 +643,9 @@ niiri:f62983c44994abc2d68d9067929a281b
     nidm_qValueFDR: "0.00366911802917346"^^xsd:float ;
     nidm_clusterLabelId: "8"^^xsd:int .
 
-niiri:f62983c44994abc2d68d9067929a281b prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:58bff46dfff701e885b3a3a8403d6869 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:702e99e0477ee69dcca3053044008e4e
+niiri:2bcab9b8311e435ff15509af340ba45e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0009" ;
     nidm_clusterSizeInVoxels: "19"^^xsd:int ;
@@ -655,9 +655,9 @@ niiri:702e99e0477ee69dcca3053044008e4e
     nidm_qValueFDR: "0.278639392496977"^^xsd:float ;
     nidm_clusterLabelId: "9"^^xsd:int .
 
-niiri:702e99e0477ee69dcca3053044008e4e prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:2bcab9b8311e435ff15509af340ba45e prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:4c2901ae6d0b982e4779668839a7a895
+niiri:932a73d91444fc459c9b49f8b73b2582
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0010" ;
     nidm_clusterSizeInVoxels: "50"^^xsd:int ;
@@ -667,9 +667,9 @@ niiri:4c2901ae6d0b982e4779668839a7a895
     nidm_qValueFDR: "0.0707678054255747"^^xsd:float ;
     nidm_clusterLabelId: "10"^^xsd:int .
 
-niiri:4c2901ae6d0b982e4779668839a7a895 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:932a73d91444fc459c9b49f8b73b2582 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:831be1ca287d5764924d7a7e83076a91
+niiri:d974c978eac6eff6a9802fd0358ceab9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0011" ;
     nidm_clusterSizeInVoxels: "447"^^xsd:int ;
@@ -679,9 +679,9 @@ niiri:831be1ca287d5764924d7a7e83076a91
     nidm_qValueFDR: "1.22279946227405e-07"^^xsd:float ;
     nidm_clusterLabelId: "11"^^xsd:int .
 
-niiri:831be1ca287d5764924d7a7e83076a91 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:d974c978eac6eff6a9802fd0358ceab9 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:179b7e6f7102d0f73e68205b289425c6
+niiri:e373ddbc76b41aa980c394eaa5c0e960
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0012" ;
     nidm_clusterSizeInVoxels: "162"^^xsd:int ;
@@ -691,9 +691,9 @@ niiri:179b7e6f7102d0f73e68205b289425c6
     nidm_qValueFDR: "0.000672150622508277"^^xsd:float ;
     nidm_clusterLabelId: "12"^^xsd:int .
 
-niiri:179b7e6f7102d0f73e68205b289425c6 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:e373ddbc76b41aa980c394eaa5c0e960 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:5d951dbde4c6cfb00e34afc3122af0f4
+niiri:92a9d73b8902193b0f3316f35cc0dc5b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0013" ;
     nidm_clusterSizeInVoxels: "29"^^xsd:int ;
@@ -703,9 +703,9 @@ niiri:5d951dbde4c6cfb00e34afc3122af0f4
     nidm_qValueFDR: "0.190729630640958"^^xsd:float ;
     nidm_clusterLabelId: "13"^^xsd:int .
 
-niiri:5d951dbde4c6cfb00e34afc3122af0f4 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:92a9d73b8902193b0f3316f35cc0dc5b prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:9af9c71c19106f542230ad07eb5a764e
+niiri:be5f1c0a23837aa1ccfc35022807cc1b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0014" ;
     nidm_clusterSizeInVoxels: "38"^^xsd:int ;
@@ -715,9 +715,9 @@ niiri:9af9c71c19106f542230ad07eb5a764e
     nidm_qValueFDR: "0.130408510255373"^^xsd:float ;
     nidm_clusterLabelId: "14"^^xsd:int .
 
-niiri:9af9c71c19106f542230ad07eb5a764e prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:be5f1c0a23837aa1ccfc35022807cc1b prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:23627cb4952c94ceb6b00ae5c1c4b815
+niiri:4cb37275d66ab0f22e3ea2174721f6f4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0015" ;
     nidm_clusterSizeInVoxels: "134"^^xsd:int ;
@@ -727,9 +727,9 @@ niiri:23627cb4952c94ceb6b00ae5c1c4b815
     nidm_qValueFDR: "0.00187402776443535"^^xsd:float ;
     nidm_clusterLabelId: "15"^^xsd:int .
 
-niiri:23627cb4952c94ceb6b00ae5c1c4b815 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:4cb37275d66ab0f22e3ea2174721f6f4 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:41c35d6e275325f6cc2f0e603bcbf838
+niiri:9bf6744a8796b8070ccd764f775a5e39
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0016" ;
     nidm_clusterSizeInVoxels: "76"^^xsd:int ;
@@ -739,9 +739,9 @@ niiri:41c35d6e275325f6cc2f0e603bcbf838
     nidm_qValueFDR: "0.022111501908576"^^xsd:float ;
     nidm_clusterLabelId: "16"^^xsd:int .
 
-niiri:41c35d6e275325f6cc2f0e603bcbf838 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:9bf6744a8796b8070ccd764f775a5e39 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:7d64ad68122f5c09739782f91cf20691
+niiri:c8a038b61f85138c6e21eee9f3570ce3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0017" ;
     nidm_clusterSizeInVoxels: "16"^^xsd:int ;
@@ -751,9 +751,9 @@ niiri:7d64ad68122f5c09739782f91cf20691
     nidm_qValueFDR: "0.324079280522016"^^xsd:float ;
     nidm_clusterLabelId: "17"^^xsd:int .
 
-niiri:7d64ad68122f5c09739782f91cf20691 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:c8a038b61f85138c6e21eee9f3570ce3 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:7a862cf3ff4623a7a92b4abf907392c8
+niiri:4cfb37bb6f2ac0c6613c6f7263fc6650
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0018" ;
     nidm_clusterSizeInVoxels: "26"^^xsd:int ;
@@ -763,9 +763,9 @@ niiri:7a862cf3ff4623a7a92b4abf907392c8
     nidm_qValueFDR: "0.205539497548942"^^xsd:float ;
     nidm_clusterLabelId: "18"^^xsd:int .
 
-niiri:7a862cf3ff4623a7a92b4abf907392c8 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:4cfb37bb6f2ac0c6613c6f7263fc6650 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:abfa5ca5d76007e8bc66144c1f88d4ca
+niiri:090f310da60ee22317a7fb037c567897
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0019" ;
     nidm_clusterSizeInVoxels: "29"^^xsd:int ;
@@ -775,9 +775,9 @@ niiri:abfa5ca5d76007e8bc66144c1f88d4ca
     nidm_qValueFDR: "0.190729630640958"^^xsd:float ;
     nidm_clusterLabelId: "19"^^xsd:int .
 
-niiri:abfa5ca5d76007e8bc66144c1f88d4ca prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:090f310da60ee22317a7fb037c567897 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:dd86dc550acd2473942e6a2580d34577
+niiri:363fdfdf14cd35df5666fb3e18b0d8c5
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0020" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -787,9 +787,9 @@ niiri:dd86dc550acd2473942e6a2580d34577
     nidm_qValueFDR: "0.604501360009182"^^xsd:float ;
     nidm_clusterLabelId: "20"^^xsd:int .
 
-niiri:dd86dc550acd2473942e6a2580d34577 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:363fdfdf14cd35df5666fb3e18b0d8c5 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:024ae749b1d9748c3c6c99db326eed03
+niiri:80cfe87c528fca41e72aca65987a69a4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0021" ;
     nidm_clusterSizeInVoxels: "10"^^xsd:int ;
@@ -799,9 +799,9 @@ niiri:024ae749b1d9748c3c6c99db326eed03
     nidm_qValueFDR: "0.487222680733842"^^xsd:float ;
     nidm_clusterLabelId: "21"^^xsd:int .
 
-niiri:024ae749b1d9748c3c6c99db326eed03 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:80cfe87c528fca41e72aca65987a69a4 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:e47686b38499c7d1c62fe38be1293da3
+niiri:e4d6a9f909a852e57111554ebf0b4352
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0022" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -811,9 +811,9 @@ niiri:e47686b38499c7d1c62fe38be1293da3
     nidm_qValueFDR: "0.554714461715718"^^xsd:float ;
     nidm_clusterLabelId: "22"^^xsd:int .
 
-niiri:e47686b38499c7d1c62fe38be1293da3 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:e4d6a9f909a852e57111554ebf0b4352 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:8186f3cd73bc2bc0b8b1223383efb0d8
+niiri:039182fcb99c4f9a98332d4c4fb55e21
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0023" ;
     nidm_clusterSizeInVoxels: "49"^^xsd:int ;
@@ -823,9 +823,9 @@ niiri:8186f3cd73bc2bc0b8b1223383efb0d8
     nidm_qValueFDR: "0.0707678054255747"^^xsd:float ;
     nidm_clusterLabelId: "23"^^xsd:int .
 
-niiri:8186f3cd73bc2bc0b8b1223383efb0d8 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:039182fcb99c4f9a98332d4c4fb55e21 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:c5762aac6b4c6d55a8d8adc67e3b7dcc
+niiri:52a34b3a1f2ce2562ef0f4d897e30a2f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0024" ;
     nidm_clusterSizeInVoxels: "21"^^xsd:int ;
@@ -835,9 +835,9 @@ niiri:c5762aac6b4c6d55a8d8adc67e3b7dcc
     nidm_qValueFDR: "0.255273713826051"^^xsd:float ;
     nidm_clusterLabelId: "24"^^xsd:int .
 
-niiri:c5762aac6b4c6d55a8d8adc67e3b7dcc prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:52a34b3a1f2ce2562ef0f4d897e30a2f prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:f5539938a236da748bfc223f58706047
+niiri:f5b45be86dbcd41fe68a83f7d23cef72
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0025" ;
     nidm_clusterSizeInVoxels: "9"^^xsd:int ;
@@ -847,9 +847,9 @@ niiri:f5539938a236da748bfc223f58706047
     nidm_qValueFDR: "0.511832236924399"^^xsd:float ;
     nidm_clusterLabelId: "25"^^xsd:int .
 
-niiri:f5539938a236da748bfc223f58706047 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:f5b45be86dbcd41fe68a83f7d23cef72 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:989884d381b2838d468431f65a707824
+niiri:6f8473034fe37635ca935744c8d051ba
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0026" ;
     nidm_clusterSizeInVoxels: "30"^^xsd:int ;
@@ -859,9 +859,9 @@ niiri:989884d381b2838d468431f65a707824
     nidm_qValueFDR: "0.190729630640958"^^xsd:float ;
     nidm_clusterLabelId: "26"^^xsd:int .
 
-niiri:989884d381b2838d468431f65a707824 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:6f8473034fe37635ca935744c8d051ba prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:38033d63ea964f0e007a1fe6038289e0
+niiri:72d641147c79cc42de66fcaf250eefff
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0027" ;
     nidm_clusterSizeInVoxels: "27"^^xsd:int ;
@@ -871,9 +871,9 @@ niiri:38033d63ea964f0e007a1fe6038289e0
     nidm_qValueFDR: "0.199876794002946"^^xsd:float ;
     nidm_clusterLabelId: "27"^^xsd:int .
 
-niiri:38033d63ea964f0e007a1fe6038289e0 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:72d641147c79cc42de66fcaf250eefff prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:099e17d7816e029529107ceb1b6c97e2
+niiri:0a54f2c3fbd560105040dd395d10cd8e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0028" ;
     nidm_clusterSizeInVoxels: "10"^^xsd:int ;
@@ -883,9 +883,9 @@ niiri:099e17d7816e029529107ceb1b6c97e2
     nidm_qValueFDR: "0.487222680733842"^^xsd:float ;
     nidm_clusterLabelId: "28"^^xsd:int .
 
-niiri:099e17d7816e029529107ceb1b6c97e2 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:0a54f2c3fbd560105040dd395d10cd8e prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:c5b0621af9bf43fba5521742d45d67b5
+niiri:6c719ef53d6799a1aa00e8155fb90aa7
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0029" ;
     nidm_clusterSizeInVoxels: "61"^^xsd:int ;
@@ -895,9 +895,9 @@ niiri:c5b0621af9bf43fba5521742d45d67b5
     nidm_qValueFDR: "0.0447442257801353"^^xsd:float ;
     nidm_clusterLabelId: "29"^^xsd:int .
 
-niiri:c5b0621af9bf43fba5521742d45d67b5 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:6c719ef53d6799a1aa00e8155fb90aa7 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:370f32e6111a54eccb31b0cf49bb202d
+niiri:9abcaf1e1cd8e4fffc65b4dcd102664f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0030" ;
     nidm_clusterSizeInVoxels: "19"^^xsd:int ;
@@ -907,9 +907,9 @@ niiri:370f32e6111a54eccb31b0cf49bb202d
     nidm_qValueFDR: "0.278639392496977"^^xsd:float ;
     nidm_clusterLabelId: "30"^^xsd:int .
 
-niiri:370f32e6111a54eccb31b0cf49bb202d prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:9abcaf1e1cd8e4fffc65b4dcd102664f prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:d66810393703f83fa8331fcba04ca628
+niiri:c17192cb7b2dfe5b506d5632ee2f9128
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0031" ;
     nidm_clusterSizeInVoxels: "14"^^xsd:int ;
@@ -919,9 +919,9 @@ niiri:d66810393703f83fa8331fcba04ca628
     nidm_qValueFDR: "0.374386664234061"^^xsd:float ;
     nidm_clusterLabelId: "31"^^xsd:int .
 
-niiri:d66810393703f83fa8331fcba04ca628 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:c17192cb7b2dfe5b506d5632ee2f9128 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:71d217841d852b0f36a116432eae4b2d
+niiri:0cdd87a23d70e882dffa97ccc3f06458
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0032" ;
     nidm_clusterSizeInVoxels: "18"^^xsd:int ;
@@ -931,9 +931,9 @@ niiri:71d217841d852b0f36a116432eae4b2d
     nidm_qValueFDR: "0.292253130241304"^^xsd:float ;
     nidm_clusterLabelId: "32"^^xsd:int .
 
-niiri:71d217841d852b0f36a116432eae4b2d prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:0cdd87a23d70e882dffa97ccc3f06458 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:d6d7d4eefe6b670db24c97dc9318b6ce
+niiri:24c8de1b4ac2f5e9c8b9a7759335fe9d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0033" ;
     nidm_clusterSizeInVoxels: "28"^^xsd:int ;
@@ -943,9 +943,9 @@ niiri:d6d7d4eefe6b670db24c97dc9318b6ce
     nidm_qValueFDR: "0.194945641821685"^^xsd:float ;
     nidm_clusterLabelId: "33"^^xsd:int .
 
-niiri:d6d7d4eefe6b670db24c97dc9318b6ce prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:24c8de1b4ac2f5e9c8b9a7759335fe9d prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:876fcdab3aee2f6373c0e2df60b41a4e
+niiri:9634c37192a257704d16f5f1d880a757
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0034" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -955,9 +955,9 @@ niiri:876fcdab3aee2f6373c0e2df60b41a4e
     nidm_qValueFDR: "0.604501360009182"^^xsd:float ;
     nidm_clusterLabelId: "34"^^xsd:int .
 
-niiri:876fcdab3aee2f6373c0e2df60b41a4e prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:9634c37192a257704d16f5f1d880a757 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:542b8b904774372e0a9627db540a47b7
+niiri:11b95279587654680aac97970c1dca33
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0035" ;
     nidm_clusterSizeInVoxels: "21"^^xsd:int ;
@@ -967,9 +967,9 @@ niiri:542b8b904774372e0a9627db540a47b7
     nidm_qValueFDR: "0.255273713826051"^^xsd:float ;
     nidm_clusterLabelId: "35"^^xsd:int .
 
-niiri:542b8b904774372e0a9627db540a47b7 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:11b95279587654680aac97970c1dca33 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:8bb571ef9ea74d78aa93e3046b5d96de
+niiri:0a1d8340cb8c5e4660accea8890aaead
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0036" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -979,9 +979,9 @@ niiri:8bb571ef9ea74d78aa93e3046b5d96de
     nidm_qValueFDR: "0.604501360009182"^^xsd:float ;
     nidm_clusterLabelId: "36"^^xsd:int .
 
-niiri:8bb571ef9ea74d78aa93e3046b5d96de prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:0a1d8340cb8c5e4660accea8890aaead prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:b4db133a7dcffc113bdc5cacd1f15c64
+niiri:7e88673ecdc8e0e122c41546194e1107
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0037" ;
     nidm_clusterSizeInVoxels: "29"^^xsd:int ;
@@ -991,9 +991,9 @@ niiri:b4db133a7dcffc113bdc5cacd1f15c64
     nidm_qValueFDR: "0.190729630640958"^^xsd:float ;
     nidm_clusterLabelId: "37"^^xsd:int .
 
-niiri:b4db133a7dcffc113bdc5cacd1f15c64 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:7e88673ecdc8e0e122c41546194e1107 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:0c00d9725bd14d031e130ad06f956eb2
+niiri:9c9e8e71561800d1df10386138b306ed
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0038" ;
     nidm_clusterSizeInVoxels: "24"^^xsd:int ;
@@ -1003,9 +1003,9 @@ niiri:0c00d9725bd14d031e130ad06f956eb2
     nidm_qValueFDR: "0.228311147705098"^^xsd:float ;
     nidm_clusterLabelId: "38"^^xsd:int .
 
-niiri:0c00d9725bd14d031e130ad06f956eb2 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:9c9e8e71561800d1df10386138b306ed prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:02839eee4d11ae4489dc6302d4195c9e
+niiri:7fe6fe573e42bb4d7fda5294f70b254e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0039" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1015,9 +1015,9 @@ niiri:02839eee4d11ae4489dc6302d4195c9e
     nidm_qValueFDR: "0.628562362557851"^^xsd:float ;
     nidm_clusterLabelId: "39"^^xsd:int .
 
-niiri:02839eee4d11ae4489dc6302d4195c9e prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:7fe6fe573e42bb4d7fda5294f70b254e prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:5bc68587f226de0a0713847e711c40db
+niiri:8fa9b6d9acd2c49ac8d56eaee29fc687
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0040" ;
     nidm_clusterSizeInVoxels: "12"^^xsd:int ;
@@ -1027,9 +1027,9 @@ niiri:5bc68587f226de0a0713847e711c40db
     nidm_qValueFDR: "0.42415320655688"^^xsd:float ;
     nidm_clusterLabelId: "40"^^xsd:int .
 
-niiri:5bc68587f226de0a0713847e711c40db prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:8fa9b6d9acd2c49ac8d56eaee29fc687 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:e7802951bd1400071eecd4c74c824fb2
+niiri:5033df2d3441877c72a35517e4199588
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0041" ;
     nidm_clusterSizeInVoxels: "9"^^xsd:int ;
@@ -1039,9 +1039,9 @@ niiri:e7802951bd1400071eecd4c74c824fb2
     nidm_qValueFDR: "0.511832236924399"^^xsd:float ;
     nidm_clusterLabelId: "41"^^xsd:int .
 
-niiri:e7802951bd1400071eecd4c74c824fb2 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:5033df2d3441877c72a35517e4199588 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:fc840fc33c4cab88ad22815e22846638
+niiri:4124e50de0ee3b3d33d8b3570cdaf9c8
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0042" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1051,9 +1051,9 @@ niiri:fc840fc33c4cab88ad22815e22846638
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "42"^^xsd:int .
 
-niiri:fc840fc33c4cab88ad22815e22846638 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:4124e50de0ee3b3d33d8b3570cdaf9c8 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:3efd65f0da924a5bb703dc14f0ae2445
+niiri:4a2fd60e9307d21139c66a8495323c62
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0043" ;
     nidm_clusterSizeInVoxels: "21"^^xsd:int ;
@@ -1063,9 +1063,9 @@ niiri:3efd65f0da924a5bb703dc14f0ae2445
     nidm_qValueFDR: "0.255273713826051"^^xsd:float ;
     nidm_clusterLabelId: "43"^^xsd:int .
 
-niiri:3efd65f0da924a5bb703dc14f0ae2445 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:4a2fd60e9307d21139c66a8495323c62 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:aa3d8d16c81b84fa58af94c6d0a92521
+niiri:47493d1488caf09ebaff86e6cfddca82
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0044" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -1075,9 +1075,9 @@ niiri:aa3d8d16c81b84fa58af94c6d0a92521
     nidm_qValueFDR: "0.604287280832693"^^xsd:float ;
     nidm_clusterLabelId: "44"^^xsd:int .
 
-niiri:aa3d8d16c81b84fa58af94c6d0a92521 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:47493d1488caf09ebaff86e6cfddca82 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:be89147f5a6922a011e2b69c54c91307
+niiri:f30d659f7dd564a91713174649a7897e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0045" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -1087,9 +1087,9 @@ niiri:be89147f5a6922a011e2b69c54c91307
     nidm_qValueFDR: "0.604501360009182"^^xsd:float ;
     nidm_clusterLabelId: "45"^^xsd:int .
 
-niiri:be89147f5a6922a011e2b69c54c91307 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:f30d659f7dd564a91713174649a7897e prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:27aff9030eda043106c67b4df9bd432f
+niiri:bf5d4132caa2ab59278ac933dbeefdc4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0046" ;
     nidm_clusterSizeInVoxels: "16"^^xsd:int ;
@@ -1099,9 +1099,9 @@ niiri:27aff9030eda043106c67b4df9bd432f
     nidm_qValueFDR: "0.324079280522016"^^xsd:float ;
     nidm_clusterLabelId: "46"^^xsd:int .
 
-niiri:27aff9030eda043106c67b4df9bd432f prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:bf5d4132caa2ab59278ac933dbeefdc4 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:6015153862c2f18b0399c5979d77b579
+niiri:5063c9c53f326a1d63e57a9ad368aba4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0047" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -1111,9 +1111,9 @@ niiri:6015153862c2f18b0399c5979d77b579
     nidm_qValueFDR: "0.604501360009182"^^xsd:float ;
     nidm_clusterLabelId: "47"^^xsd:int .
 
-niiri:6015153862c2f18b0399c5979d77b579 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:5063c9c53f326a1d63e57a9ad368aba4 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:d49cca9c5e9ab92f918362c3052e9a2d
+niiri:f53e11fdc36e62f28a07e009b005603e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0048" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -1123,9 +1123,9 @@ niiri:d49cca9c5e9ab92f918362c3052e9a2d
     nidm_qValueFDR: "0.604501360009182"^^xsd:float ;
     nidm_clusterLabelId: "48"^^xsd:int .
 
-niiri:d49cca9c5e9ab92f918362c3052e9a2d prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:f53e11fdc36e62f28a07e009b005603e prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:e35587b2acf9fd9a9fdf0672cc249a3a
+niiri:ae4cfacdd2f80d4db5489f80321a64c5
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0049" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1135,9 +1135,9 @@ niiri:e35587b2acf9fd9a9fdf0672cc249a3a
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "49"^^xsd:int .
 
-niiri:e35587b2acf9fd9a9fdf0672cc249a3a prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:ae4cfacdd2f80d4db5489f80321a64c5 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:98d127e586abf35e62811f986bd3be18
+niiri:4bf515909ab7c79154616841d777e9fa
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0050" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1147,9 +1147,9 @@ niiri:98d127e586abf35e62811f986bd3be18
     nidm_qValueFDR: "0.688489154710615"^^xsd:float ;
     nidm_clusterLabelId: "50"^^xsd:int .
 
-niiri:98d127e586abf35e62811f986bd3be18 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:4bf515909ab7c79154616841d777e9fa prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:b2f002bc586117a24bdd5081006f3f23
+niiri:9c5ac23579b49a629cb17821a462a039
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0051" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1159,9 +1159,9 @@ niiri:b2f002bc586117a24bdd5081006f3f23
     nidm_qValueFDR: "0.628562362557851"^^xsd:float ;
     nidm_clusterLabelId: "51"^^xsd:int .
 
-niiri:b2f002bc586117a24bdd5081006f3f23 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:9c5ac23579b49a629cb17821a462a039 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:4ce238771ccf766ed28486be0e931e33
+niiri:0059ec9a6bb7c2d7e6ea96012aa070a4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0052" ;
     nidm_clusterSizeInVoxels: "13"^^xsd:int ;
@@ -1171,9 +1171,9 @@ niiri:4ce238771ccf766ed28486be0e931e33
     nidm_qValueFDR: "0.39785224811166"^^xsd:float ;
     nidm_clusterLabelId: "52"^^xsd:int .
 
-niiri:4ce238771ccf766ed28486be0e931e33 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:0059ec9a6bb7c2d7e6ea96012aa070a4 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:e4b08c3de8b3e30fc520a4a7fb1d0717
+niiri:3bb3714faa1aae7d02675cad6938ab52
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0053" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -1183,9 +1183,9 @@ niiri:e4b08c3de8b3e30fc520a4a7fb1d0717
     nidm_qValueFDR: "0.604501360009182"^^xsd:float ;
     nidm_clusterLabelId: "53"^^xsd:int .
 
-niiri:e4b08c3de8b3e30fc520a4a7fb1d0717 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:3bb3714faa1aae7d02675cad6938ab52 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:f272badd0515e42b4d960d9705968657
+niiri:79f4ea32c57ff4bc44bd9693fb4bfb39
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0054" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1195,9 +1195,9 @@ niiri:f272badd0515e42b4d960d9705968657
     nidm_qValueFDR: "0.688489154710615"^^xsd:float ;
     nidm_clusterLabelId: "54"^^xsd:int .
 
-niiri:f272badd0515e42b4d960d9705968657 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:79f4ea32c57ff4bc44bd9693fb4bfb39 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:d1006f0765b2d600f398d4672099ed92
+niiri:16165a8f8f2fb7e16961bd153e0121b3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0055" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -1207,9 +1207,9 @@ niiri:d1006f0765b2d600f398d4672099ed92
     nidm_qValueFDR: "0.604501360009182"^^xsd:float ;
     nidm_clusterLabelId: "55"^^xsd:int .
 
-niiri:d1006f0765b2d600f398d4672099ed92 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:16165a8f8f2fb7e16961bd153e0121b3 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:b221fbfb15d7f985909dc4575902ee79
+niiri:120ccd02c2048169aea9fc9ef80dac7e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0056" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1219,9 +1219,9 @@ niiri:b221fbfb15d7f985909dc4575902ee79
     nidm_qValueFDR: "0.688489154710615"^^xsd:float ;
     nidm_clusterLabelId: "56"^^xsd:int .
 
-niiri:b221fbfb15d7f985909dc4575902ee79 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:120ccd02c2048169aea9fc9ef80dac7e prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:22518d42d4312d19842a6c5c7116e209
+niiri:8ecb9c4697fe5773d29ea35c29d84ef3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0057" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1231,9 +1231,9 @@ niiri:22518d42d4312d19842a6c5c7116e209
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "57"^^xsd:int .
 
-niiri:22518d42d4312d19842a6c5c7116e209 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:8ecb9c4697fe5773d29ea35c29d84ef3 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:27f64237a208bdd1b919662a44a25b49
+niiri:b24de80c3a706246e31d6423b3708450
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0058" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -1243,9 +1243,9 @@ niiri:27f64237a208bdd1b919662a44a25b49
     nidm_qValueFDR: "0.604501360009182"^^xsd:float ;
     nidm_clusterLabelId: "58"^^xsd:int .
 
-niiri:27f64237a208bdd1b919662a44a25b49 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:b24de80c3a706246e31d6423b3708450 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:a5728ac41df0c581754b6db5427b1f05
+niiri:0f16dde8718dddce4db284b7a40496a8
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0059" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1255,9 +1255,9 @@ niiri:a5728ac41df0c581754b6db5427b1f05
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "59"^^xsd:int .
 
-niiri:a5728ac41df0c581754b6db5427b1f05 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:0f16dde8718dddce4db284b7a40496a8 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:ff4fe7af97fc1af636a6c8d8f050f08f
+niiri:6618ca3eaa19d5e02557c9a8428828e3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0060" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1267,9 +1267,9 @@ niiri:ff4fe7af97fc1af636a6c8d8f050f08f
     nidm_qValueFDR: "0.628562362557851"^^xsd:float ;
     nidm_clusterLabelId: "60"^^xsd:int .
 
-niiri:ff4fe7af97fc1af636a6c8d8f050f08f prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:6618ca3eaa19d5e02557c9a8428828e3 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:ec5515690308a412deffcb4cf46f2365
+niiri:edcf13cf2a9f550f95f7fa64a9ab86ca
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0061" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1279,9 +1279,9 @@ niiri:ec5515690308a412deffcb4cf46f2365
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "61"^^xsd:int .
 
-niiri:ec5515690308a412deffcb4cf46f2365 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:edcf13cf2a9f550f95f7fa64a9ab86ca prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:f74ca8cae4e2c682c3f97b1a640a5f00
+niiri:80da85f37d04350ac439bb0dfa06ea5b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0062" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1291,9 +1291,9 @@ niiri:f74ca8cae4e2c682c3f97b1a640a5f00
     nidm_qValueFDR: "0.628562362557851"^^xsd:float ;
     nidm_clusterLabelId: "62"^^xsd:int .
 
-niiri:f74ca8cae4e2c682c3f97b1a640a5f00 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:80da85f37d04350ac439bb0dfa06ea5b prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:2a63ea593120afc6649eda0c102f631d
+niiri:cce62b8bba59fb588c9623468819b0f6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0063" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1303,9 +1303,9 @@ niiri:2a63ea593120afc6649eda0c102f631d
     nidm_qValueFDR: "0.628562362557851"^^xsd:float ;
     nidm_clusterLabelId: "63"^^xsd:int .
 
-niiri:2a63ea593120afc6649eda0c102f631d prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:cce62b8bba59fb588c9623468819b0f6 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:6f87e962fab6d1220c091e46877922d9
+niiri:fe52388c406befa95a7e7abdd9bc5d0d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0064" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1315,9 +1315,9 @@ niiri:6f87e962fab6d1220c091e46877922d9
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "64"^^xsd:int .
 
-niiri:6f87e962fab6d1220c091e46877922d9 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:fe52388c406befa95a7e7abdd9bc5d0d prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:e86febc59d83b46e7775b7ea6281d7b6
+niiri:aaf8a80c3785eabb526fa793c58065c5
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0065" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -1327,9 +1327,9 @@ niiri:e86febc59d83b46e7775b7ea6281d7b6
     nidm_qValueFDR: "0.604501360009182"^^xsd:float ;
     nidm_clusterLabelId: "65"^^xsd:int .
 
-niiri:e86febc59d83b46e7775b7ea6281d7b6 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:aaf8a80c3785eabb526fa793c58065c5 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:033bb93f5934ac8e2216a6953d84f96b
+niiri:66a2dce74584c693a761996e8a52ee2c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0066" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -1339,9 +1339,9 @@ niiri:033bb93f5934ac8e2216a6953d84f96b
     nidm_qValueFDR: "0.604501360009182"^^xsd:float ;
     nidm_clusterLabelId: "66"^^xsd:int .
 
-niiri:033bb93f5934ac8e2216a6953d84f96b prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:66a2dce74584c693a761996e8a52ee2c prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:20e24f503a4809e9cf0241f76eaaf79d
+niiri:842dcf5877dd33791cbf64037b0d160d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0067" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1351,9 +1351,9 @@ niiri:20e24f503a4809e9cf0241f76eaaf79d
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "67"^^xsd:int .
 
-niiri:20e24f503a4809e9cf0241f76eaaf79d prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:842dcf5877dd33791cbf64037b0d160d prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:80d7fbf81e2055777ba9feeeadecc526
+niiri:826c8df2b7140fdd69ec6d944489cb87
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0068" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1363,9 +1363,9 @@ niiri:80d7fbf81e2055777ba9feeeadecc526
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "68"^^xsd:int .
 
-niiri:80d7fbf81e2055777ba9feeeadecc526 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:826c8df2b7140fdd69ec6d944489cb87 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:2bd7817009f58b9da9bae43a5b25b68f
+niiri:a8072ecfcdfd108f310a1bc87c821cf1
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0069" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1375,9 +1375,9 @@ niiri:2bd7817009f58b9da9bae43a5b25b68f
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "69"^^xsd:int .
 
-niiri:2bd7817009f58b9da9bae43a5b25b68f prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:a8072ecfcdfd108f310a1bc87c821cf1 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:15e4c29ced9fec2482ceb9ba6a0a51d1
+niiri:71b52ab8126a30a8e2c6e66f6b5da31f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0070" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1387,9 +1387,9 @@ niiri:15e4c29ced9fec2482ceb9ba6a0a51d1
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "70"^^xsd:int .
 
-niiri:15e4c29ced9fec2482ceb9ba6a0a51d1 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:71b52ab8126a30a8e2c6e66f6b5da31f prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:42e659c3800a504268b49626856a7c27
+niiri:339add5fca2f1335faf3c97a8ad874f4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0071" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1399,9 +1399,9 @@ niiri:42e659c3800a504268b49626856a7c27
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "71"^^xsd:int .
 
-niiri:42e659c3800a504268b49626856a7c27 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:339add5fca2f1335faf3c97a8ad874f4 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:2cd92c6773d556b9448a0ddb09bd8b31
+niiri:b822c27c9e4ca42b4196dd89b524730c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0072" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1411,9 +1411,9 @@ niiri:2cd92c6773d556b9448a0ddb09bd8b31
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "72"^^xsd:int .
 
-niiri:2cd92c6773d556b9448a0ddb09bd8b31 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:b822c27c9e4ca42b4196dd89b524730c prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:fbeda8761878a098b300fa81bfca94a3
+niiri:96419b4c6e6c59ea3a4153112ed9d514
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0073" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1423,9 +1423,9 @@ niiri:fbeda8761878a098b300fa81bfca94a3
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "73"^^xsd:int .
 
-niiri:fbeda8761878a098b300fa81bfca94a3 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:96419b4c6e6c59ea3a4153112ed9d514 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:ff113369a1aab0598dc0f3d86fc0129b
+niiri:2156904148b8610fa21cc0ac6f11f0a5
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0074" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1435,9 +1435,9 @@ niiri:ff113369a1aab0598dc0f3d86fc0129b
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "74"^^xsd:int .
 
-niiri:ff113369a1aab0598dc0f3d86fc0129b prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:2156904148b8610fa21cc0ac6f11f0a5 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:ef6a4c707bf3e80d6954ad82e2705808
+niiri:bba6fb2b90294edde963661ec3fea027
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0075" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1447,9 +1447,9 @@ niiri:ef6a4c707bf3e80d6954ad82e2705808
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "75"^^xsd:int .
 
-niiri:ef6a4c707bf3e80d6954ad82e2705808 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:bba6fb2b90294edde963661ec3fea027 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:cb14e2f236a171bf561b547935b40dd9
+niiri:a428752a112ae62b5d4a764c475ebebb
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0076" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1459,9 +1459,9 @@ niiri:cb14e2f236a171bf561b547935b40dd9
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "76"^^xsd:int .
 
-niiri:cb14e2f236a171bf561b547935b40dd9 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:a428752a112ae62b5d4a764c475ebebb prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:215e12d51ca68faf83b3c157465a4274
+niiri:011ca539a5756d6a56b02867c8dc0da5
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0077" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1471,9 +1471,9 @@ niiri:215e12d51ca68faf83b3c157465a4274
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "77"^^xsd:int .
 
-niiri:215e12d51ca68faf83b3c157465a4274 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:011ca539a5756d6a56b02867c8dc0da5 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:846d054635e491107608bcf6e7db6e7b
+niiri:cba5fb0d6db1529fec8f4fba47f35ad8
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0078" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1483,9 +1483,9 @@ niiri:846d054635e491107608bcf6e7db6e7b
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "78"^^xsd:int .
 
-niiri:846d054635e491107608bcf6e7db6e7b prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:cba5fb0d6db1529fec8f4fba47f35ad8 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:cc3ec71f9506a13ad5812b94c954a6a4
+niiri:ff8870f1fb72bc18a894385e2e338a1a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0079" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1495,9 +1495,9 @@ niiri:cc3ec71f9506a13ad5812b94c954a6a4
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "79"^^xsd:int .
 
-niiri:cc3ec71f9506a13ad5812b94c954a6a4 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:ff8870f1fb72bc18a894385e2e338a1a prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:ddbafccf344e9c4433df922b8641380c
+niiri:0dd915ffcbdf519b3a8e0e342a7a3a15
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0080" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1507,9 +1507,9 @@ niiri:ddbafccf344e9c4433df922b8641380c
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "80"^^xsd:int .
 
-niiri:ddbafccf344e9c4433df922b8641380c prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:0dd915ffcbdf519b3a8e0e342a7a3a15 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:c89051853f599ba8b9d939c26968a8b9
+niiri:aa3557b1b3fba9452176860c67262bd9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0081" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1519,1756 +1519,1756 @@ niiri:c89051853f599ba8b9d939c26968a8b9
     nidm_qValueFDR: "0.723454321471829"^^xsd:float ;
     nidm_clusterLabelId: "81"^^xsd:int .
 
-niiri:c89051853f599ba8b9d939c26968a8b9 prov:wasDerivedFrom niiri:086f71113cd77b52e83a7758b427f167 .
+niiri:aa3557b1b3fba9452176860c67262bd9 prov:wasDerivedFrom niiri:80c10806c0beeee32d27292ced29500f .
 
-niiri:1efb472cf409fc6990ad7949ea12623b
+niiri:32978f193454276a89690a074d1f925d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0001" ;
-    prov:atLocation niiri:e33b3578f5d7f2bd6821d58e98d19ba1 ;
+    prov:atLocation niiri:55d81a635f7a8d8e2db6359db99ea928 ;
     prov:value "7.92007970809937"^^xsd:float ;
     nidm_equivalentZStatistic: "6.94608360738412"^^xsd:float ;
     nidm_pValueUncorrected: "1.87783122385099e-12"^^xsd:float ;
     nidm_pValueFWER: "4.18813870695089e-07"^^xsd:float ;
     nidm_qValueFDR: "5.21674435923017e-06"^^xsd:float .
 
-niiri:e33b3578f5d7f2bd6821d58e98d19ba1
+niiri:55d81a635f7a8d8e2db6359db99ea928
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0001" ;
     nidm_coordinateVector: "[46,16,24]"^^xsd:string .
 
-niiri:1efb472cf409fc6990ad7949ea12623b prov:wasDerivedFrom niiri:5fc01864c8f0e284bb366e4a9fc5f229 .
+niiri:32978f193454276a89690a074d1f925d prov:wasDerivedFrom niiri:749b77e80ffd0ed4ca77337a7893adc6 .
 
-niiri:1a013dfcb97a9f36ba77ac6137c1edf8
+niiri:34b93bd18a1d6b9d11f9220e9d0c8d8f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0002" ;
-    prov:atLocation niiri:f8d77c57fd14c4f211154bb71e689486 ;
+    prov:atLocation niiri:e8b2f11cf4cbe836c4f5539b6b098535 ;
     prov:value "6.31603479385376"^^xsd:float ;
     nidm_equivalentZStatistic: "5.77079466112137"^^xsd:float ;
     nidm_pValueUncorrected: "3.94492849498107e-09"^^xsd:float ;
     nidm_pValueFWER: "0.000879943865776389"^^xsd:float ;
     nidm_qValueFDR: "0.000830722551601523"^^xsd:float .
 
-niiri:f8d77c57fd14c4f211154bb71e689486
+niiri:e8b2f11cf4cbe836c4f5539b6b098535
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0002" ;
     nidm_coordinateVector: "[32,24,-4]"^^xsd:string .
 
-niiri:1a013dfcb97a9f36ba77ac6137c1edf8 prov:wasDerivedFrom niiri:5fc01864c8f0e284bb366e4a9fc5f229 .
+niiri:34b93bd18a1d6b9d11f9220e9d0c8d8f prov:wasDerivedFrom niiri:749b77e80ffd0ed4ca77337a7893adc6 .
 
-niiri:caabb17b7e59e93fae5554b48316ee5e
+niiri:3898d262fb3baf3f75b22150a9b04a7a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0003" ;
-    prov:atLocation niiri:0d71b27c6ee9fe48a05d153c27767e18 ;
+    prov:atLocation niiri:ac1322201748ec0f5c221256a0fd16af ;
     prov:value "5.68819808959961"^^xsd:float ;
     nidm_equivalentZStatistic: "5.27450168515333"^^xsd:float ;
     nidm_pValueUncorrected: "6.655864770444e-08"^^xsd:float ;
     nidm_pValueFWER: "0.0121028975026269"^^xsd:float ;
     nidm_qValueFDR: "0.00350091530962783"^^xsd:float .
 
-niiri:0d71b27c6ee9fe48a05d153c27767e18
+niiri:ac1322201748ec0f5c221256a0fd16af
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0003" ;
     nidm_coordinateVector: "[18,16,4]"^^xsd:string .
 
-niiri:caabb17b7e59e93fae5554b48316ee5e prov:wasDerivedFrom niiri:5fc01864c8f0e284bb366e4a9fc5f229 .
+niiri:3898d262fb3baf3f75b22150a9b04a7a prov:wasDerivedFrom niiri:749b77e80ffd0ed4ca77337a7893adc6 .
 
-niiri:f007a456fb6f4d8cb6bf39a2f9d5e74a
+niiri:603e9a34a8c2b14d5f22ac5bab31465c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0004" ;
-    prov:atLocation niiri:c31e51d23633fd58f2f374a962a5dc1c ;
+    prov:atLocation niiri:4d22debd9be5615681ad6502530caa16 ;
     prov:value "7.11683940887451"^^xsd:float ;
     nidm_equivalentZStatistic: "6.37404871703245"^^xsd:float ;
     nidm_pValueUncorrected: "9.20510334623259e-11"^^xsd:float ;
     nidm_pValueFWER: "2.05325778424026e-05"^^xsd:float ;
     nidm_qValueFDR: "9.33757664730496e-05"^^xsd:float .
 
-niiri:c31e51d23633fd58f2f374a962a5dc1c
+niiri:4d22debd9be5615681ad6502530caa16
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0004" ;
     nidm_coordinateVector: "[34,-88,-2]"^^xsd:string .
 
-niiri:f007a456fb6f4d8cb6bf39a2f9d5e74a prov:wasDerivedFrom niiri:7164f842b38559769512336527f4fe59 .
+niiri:603e9a34a8c2b14d5f22ac5bab31465c prov:wasDerivedFrom niiri:e2c6b47be3a342a41d95bfc20852c868 .
 
-niiri:2fbc8b5c390bb7e049cba0090dd4ff65
+niiri:d1e8c4e4831c31323bfedc0662522fc6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0005" ;
-    prov:atLocation niiri:2c308e506ba4941e91e9702a543dc7b2 ;
+    prov:atLocation niiri:fd5d0747ba793c53ed9eb8130c1f1499 ;
     prov:value "6.48292255401611"^^xsd:float ;
     nidm_equivalentZStatistic: "5.8992593141605"^^xsd:float ;
     nidm_pValueUncorrected: "1.82568493656277e-09"^^xsd:float ;
     nidm_pValueFWER: "0.000407231755366277"^^xsd:float ;
     nidm_qValueFDR: "0.000830722551601523"^^xsd:float .
 
-niiri:2c308e506ba4941e91e9702a543dc7b2
+niiri:fd5d0747ba793c53ed9eb8130c1f1499
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0005" ;
     nidm_coordinateVector: "[42,-72,-10]"^^xsd:string .
 
-niiri:2fbc8b5c390bb7e049cba0090dd4ff65 prov:wasDerivedFrom niiri:7164f842b38559769512336527f4fe59 .
+niiri:d1e8c4e4831c31323bfedc0662522fc6 prov:wasDerivedFrom niiri:e2c6b47be3a342a41d95bfc20852c868 .
 
-niiri:c510dbd234cba3682e284dfbe3dfcd07
+niiri:58f6ffe36b16b4d86866a57a2e3f0d86
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0006" ;
-    prov:atLocation niiri:4bb9017fbe8036db5bb4983c1371606a ;
+    prov:atLocation niiri:fb04675da6d16642172d2d7cdf72b57e ;
     prov:value "5.2275915145874"^^xsd:float ;
     nidm_equivalentZStatistic: "4.89738468004472"^^xsd:float ;
     nidm_pValueUncorrected: "4.85602978606003e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0670610253017228"^^xsd:float ;
     nidm_qValueFDR: "0.0118363293065346"^^xsd:float .
 
-niiri:4bb9017fbe8036db5bb4983c1371606a
+niiri:fb04675da6d16642172d2d7cdf72b57e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0006" ;
     nidm_coordinateVector: "[34,-86,12]"^^xsd:string .
 
-niiri:c510dbd234cba3682e284dfbe3dfcd07 prov:wasDerivedFrom niiri:7164f842b38559769512336527f4fe59 .
+niiri:58f6ffe36b16b4d86866a57a2e3f0d86 prov:wasDerivedFrom niiri:e2c6b47be3a342a41d95bfc20852c868 .
 
-niiri:31247a1d059ea149c62b1fe34caf249b
+niiri:6f9df5a084be3215b055ddef7915c8ba
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0007" ;
-    prov:atLocation niiri:464aa8a5582a70422e4ad672d0aebc40 ;
+    prov:atLocation niiri:6ae79521dd4177d878efc76a6f51db6b ;
     prov:value "6.28007745742798"^^xsd:float ;
     nidm_equivalentZStatistic: "5.74292583422276"^^xsd:float ;
     nidm_pValueUncorrected: "4.65272453897825e-09"^^xsd:float ;
     nidm_pValueFWER: "0.00103782272796227"^^xsd:float ;
     nidm_qValueFDR: "0.000830722551601523"^^xsd:float .
 
-niiri:464aa8a5582a70422e4ad672d0aebc40
+niiri:6ae79521dd4177d878efc76a6f51db6b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0007" ;
     nidm_coordinateVector: "[8,18,50]"^^xsd:string .
 
-niiri:31247a1d059ea149c62b1fe34caf249b prov:wasDerivedFrom niiri:b19f0b712285b7e8de902f92c3fede84 .
+niiri:6f9df5a084be3215b055ddef7915c8ba prov:wasDerivedFrom niiri:7d345f60b278ac792f989f5862ed9684 .
 
-niiri:77506a7482eddd4edff175b5f79fa109
+niiri:6cdda123bcee4885c1034564912a97af
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0008" ;
-    prov:atLocation niiri:f635cbf5f75164df1bceeb2422223464 ;
+    prov:atLocation niiri:684b2a5117bca29995311831b26bfe6e ;
     prov:value "6.15222215652466"^^xsd:float ;
     nidm_equivalentZStatistic: "5.64328512810061"^^xsd:float ;
     nidm_pValueUncorrected: "8.34178537356678e-09"^^xsd:float ;
     nidm_pValueFWER: "0.00186069357054308"^^xsd:float ;
     nidm_qValueFDR: "0.000972721201433817"^^xsd:float .
 
-niiri:f635cbf5f75164df1bceeb2422223464
+niiri:684b2a5117bca29995311831b26bfe6e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0008" ;
     nidm_coordinateVector: "[-6,12,52]"^^xsd:string .
 
-niiri:77506a7482eddd4edff175b5f79fa109 prov:wasDerivedFrom niiri:b19f0b712285b7e8de902f92c3fede84 .
+niiri:6cdda123bcee4885c1034564912a97af prov:wasDerivedFrom niiri:7d345f60b278ac792f989f5862ed9684 .
 
-niiri:6b0edf38814b032e80ab3bf727127995
+niiri:463d5476f401e65d9740c56ea881befc
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0009" ;
-    prov:atLocation niiri:8778369dc9a05966e61a41c53c1e5c65 ;
+    prov:atLocation niiri:153814c4f143461197c66a523426c9c6 ;
     prov:value "5.98517084121704"^^xsd:float ;
     nidm_equivalentZStatistic: "5.51181334779297"^^xsd:float ;
     nidm_pValueUncorrected: "1.77577724747024e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00376326218366319"^^xsd:float ;
     nidm_qValueFDR: "0.00136419627856355"^^xsd:float .
 
-niiri:8778369dc9a05966e61a41c53c1e5c65
+niiri:153814c4f143461197c66a523426c9c6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0009" ;
     nidm_coordinateVector: "[8,32,38]"^^xsd:string .
 
-niiri:6b0edf38814b032e80ab3bf727127995 prov:wasDerivedFrom niiri:b19f0b712285b7e8de902f92c3fede84 .
+niiri:463d5476f401e65d9740c56ea881befc prov:wasDerivedFrom niiri:7d345f60b278ac792f989f5862ed9684 .
 
-niiri:a9cdf184f9a4f9933cfb8a1a901241e5
+niiri:291008c3ba8bd66b60306971f236360c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0010" ;
-    prov:atLocation niiri:2cf3e64a20c377876f126c6cc7288ff4 ;
+    prov:atLocation niiri:a2722e3c6e931e50799908c5e74e91c3 ;
     prov:value "6.25127363204956"^^xsd:float ;
     nidm_equivalentZStatistic: "5.72055271981637"^^xsd:float ;
     nidm_pValueUncorrected: "5.30890376104765e-09"^^xsd:float ;
     nidm_pValueFWER: "0.0011841880966994"^^xsd:float ;
     nidm_qValueFDR: "0.000830722551601523"^^xsd:float .
 
-niiri:2cf3e64a20c377876f126c6cc7288ff4
+niiri:a2722e3c6e931e50799908c5e74e91c3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0010" ;
     nidm_coordinateVector: "[52,-32,42]"^^xsd:string .
 
-niiri:a9cdf184f9a4f9933cfb8a1a901241e5 prov:wasDerivedFrom niiri:01758d9126d8fc5ff1b54b4e6edb737b .
+niiri:291008c3ba8bd66b60306971f236360c prov:wasDerivedFrom niiri:78cf678fc1d8e63075a90d654ff6f858 .
 
-niiri:b4893a122d15bd8fe693a1fc342975d7
+niiri:0dcc549539442c3724ba5d0e1f6e467a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0011" ;
-    prov:atLocation niiri:4ca8920e1d66c9e2a05d11cb18e77893 ;
+    prov:atLocation niiri:3e89abdddd60a7d0574ff07c1016607e ;
     prov:value "6.24752378463745"^^xsd:float ;
     nidm_equivalentZStatistic: "5.71763687476157"^^xsd:float ;
     nidm_pValueUncorrected: "5.40078304300806e-09"^^xsd:float ;
     nidm_pValueFWER: "0.00120468241369565"^^xsd:float ;
     nidm_qValueFDR: "0.000830722551601523"^^xsd:float .
 
-niiri:4ca8920e1d66c9e2a05d11cb18e77893
+niiri:3e89abdddd60a7d0574ff07c1016607e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0011" ;
     nidm_coordinateVector: "[40,-62,50]"^^xsd:string .
 
-niiri:b4893a122d15bd8fe693a1fc342975d7 prov:wasDerivedFrom niiri:01758d9126d8fc5ff1b54b4e6edb737b .
+niiri:0dcc549539442c3724ba5d0e1f6e467a prov:wasDerivedFrom niiri:78cf678fc1d8e63075a90d654ff6f858 .
 
-niiri:7f63bfa642f417f9b431f1c5db8cc31d
+niiri:657157689be2c61689eb1b3f4efc21e6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0012" ;
-    prov:atLocation niiri:630905268907463a9b5f1dc56ae3687c ;
+    prov:atLocation niiri:99bc5ffcd4466f85102d7f98c44118e4 ;
     prov:value "5.70337772369385"^^xsd:float ;
     nidm_equivalentZStatistic: "5.28674301747281"^^xsd:float ;
     nidm_pValueUncorrected: "6.22566831420812e-08"^^xsd:float ;
     nidm_pValueFWER: "0.011413186758684"^^xsd:float ;
     nidm_qValueFDR: "0.00350091530962783"^^xsd:float .
 
-niiri:630905268907463a9b5f1dc56ae3687c
+niiri:99bc5ffcd4466f85102d7f98c44118e4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0012" ;
     nidm_coordinateVector: "[56,-44,52]"^^xsd:string .
 
-niiri:7f63bfa642f417f9b431f1c5db8cc31d prov:wasDerivedFrom niiri:01758d9126d8fc5ff1b54b4e6edb737b .
+niiri:657157689be2c61689eb1b3f4efc21e6 prov:wasDerivedFrom niiri:78cf678fc1d8e63075a90d654ff6f858 .
 
-niiri:3d450e9e88af5733b43414b19c103157
+niiri:669694fe0c4b5ec1a6f8a3977df4c580
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0013" ;
-    prov:atLocation niiri:edb8bced4f82ed9c8526b8a2708de239 ;
+    prov:atLocation niiri:362ca75eb1ae6d24ff2704daf43214da ;
     prov:value "6.15371799468994"^^xsd:float ;
     nidm_equivalentZStatistic: "5.64445580026639"^^xsd:float ;
     nidm_pValueUncorrected: "8.285227171001e-09"^^xsd:float ;
     nidm_pValueFWER: "0.00184807786755337"^^xsd:float ;
     nidm_qValueFDR: "0.000972721201433817"^^xsd:float .
 
-niiri:edb8bced4f82ed9c8526b8a2708de239
+niiri:362ca75eb1ae6d24ff2704daf43214da
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0013" ;
     nidm_coordinateVector: "[-28,-94,4]"^^xsd:string .
 
-niiri:3d450e9e88af5733b43414b19c103157 prov:wasDerivedFrom niiri:ae4dcd02f2fd1098abb0e8a48b888b04 .
+niiri:669694fe0c4b5ec1a6f8a3977df4c580 prov:wasDerivedFrom niiri:d1df03018bbf137ff5ef2da545a3e8bf .
 
-niiri:fff6908e787e946dec45b335368d3f2a
+niiri:bc09fd8c13efc94b69b000bed2848f2b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0014" ;
-    prov:atLocation niiri:9c7edae30330492942ed42ec6bc978aa ;
+    prov:atLocation niiri:e988c9d2fc231cbc70e8805189a61b44 ;
     prov:value "3.71480798721313"^^xsd:float ;
     nidm_equivalentZStatistic: "3.58412084932714"^^xsd:float ;
     nidm_pValueUncorrected: "0.000169107736440521"^^xsd:float ;
     nidm_pValueFWER: "0.999869855188705"^^xsd:float ;
     nidm_qValueFDR: "0.383925327139989"^^xsd:float .
 
-niiri:9c7edae30330492942ed42ec6bc978aa
+niiri:e988c9d2fc231cbc70e8805189a61b44
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0014" ;
     nidm_coordinateVector: "[-34,-84,-2]"^^xsd:string .
 
-niiri:fff6908e787e946dec45b335368d3f2a prov:wasDerivedFrom niiri:ae4dcd02f2fd1098abb0e8a48b888b04 .
+niiri:bc09fd8c13efc94b69b000bed2848f2b prov:wasDerivedFrom niiri:d1df03018bbf137ff5ef2da545a3e8bf .
 
-niiri:301172f442679d7a1642a8fb8bfb520d
+niiri:4a8c6a17b71f45dcd261be37cfbbff63
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0015" ;
-    prov:atLocation niiri:fea04bc2ee41b23b32b70ac824e9cfc6 ;
+    prov:atLocation niiri:bc786bfc82330377611d0623c983ab4c ;
     prov:value "6.10109901428223"^^xsd:float ;
     nidm_equivalentZStatistic: "5.60320502193174"^^xsd:float ;
     nidm_pValueUncorrected: "1.05212039080982e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00234682813060005"^^xsd:float ;
     nidm_qValueFDR: "0.00104518293275697"^^xsd:float .
 
-niiri:fea04bc2ee41b23b32b70ac824e9cfc6
+niiri:bc786bfc82330377611d0623c983ab4c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0015" ;
     nidm_coordinateVector: "[32,2,46]"^^xsd:string .
 
-niiri:301172f442679d7a1642a8fb8bfb520d prov:wasDerivedFrom niiri:5bfdd7920dcd4de97cf8b89a13cd95e8 .
+niiri:4a8c6a17b71f45dcd261be37cfbbff63 prov:wasDerivedFrom niiri:168af8a06bcba9be4ec76231fb932bcd .
 
-niiri:e5dfa2ecf5e4361e83ba435c82bd2b6d
+niiri:d4bb165ca9721ee62b430b539898419d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0016" ;
-    prov:atLocation niiri:7ec1912c0a340c768b4a3537eec0dde9 ;
+    prov:atLocation niiri:5ceb4eee142abfc8ef98e23cf45add6b ;
     prov:value "4.6086859703064"^^xsd:float ;
     nidm_equivalentZStatistic: "4.3736141683061"^^xsd:float ;
     nidm_pValueUncorrected: "6.11031435759912e-06"^^xsd:float ;
     nidm_pValueFWER: "0.453877178455514"^^xsd:float ;
     nidm_qValueFDR: "0.0599714495109201"^^xsd:float .
 
-niiri:7ec1912c0a340c768b4a3537eec0dde9
+niiri:5ceb4eee142abfc8ef98e23cf45add6b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0016" ;
     nidm_coordinateVector: "[28,4,58]"^^xsd:string .
 
-niiri:e5dfa2ecf5e4361e83ba435c82bd2b6d prov:wasDerivedFrom niiri:5bfdd7920dcd4de97cf8b89a13cd95e8 .
+niiri:d4bb165ca9721ee62b430b539898419d prov:wasDerivedFrom niiri:168af8a06bcba9be4ec76231fb932bcd .
 
-niiri:da447f4ff20e607975dacc5c4abd9827
+niiri:1e8f2a721817f907e33ce3661a849f73
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0017" ;
-    prov:atLocation niiri:7264f9db75e890717b2f0983b90f844d ;
+    prov:atLocation niiri:cf61866a953e360975460a1159eb7ecc ;
     prov:value "3.98793148994446"^^xsd:float ;
     nidm_equivalentZStatistic: "3.82932508069717"^^xsd:float ;
     nidm_pValueUncorrected: "6.42475887594474e-05"^^xsd:float ;
     nidm_pValueFWER: "0.984644566584946"^^xsd:float ;
     nidm_qValueFDR: "0.233149120368192"^^xsd:float .
 
-niiri:7264f9db75e890717b2f0983b90f844d
+niiri:cf61866a953e360975460a1159eb7ecc
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0017" ;
     nidm_coordinateVector: "[42,4,48]"^^xsd:string .
 
-niiri:da447f4ff20e607975dacc5c4abd9827 prov:wasDerivedFrom niiri:5bfdd7920dcd4de97cf8b89a13cd95e8 .
+niiri:1e8f2a721817f907e33ce3661a849f73 prov:wasDerivedFrom niiri:168af8a06bcba9be4ec76231fb932bcd .
 
-niiri:f916aec7ac31457f1c089e162fb3fe50
+niiri:1b716cf23c999bf2aa97632831c920c3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0018" ;
-    prov:atLocation niiri:360992cc1632b4ee5094bf297bbfad73 ;
+    prov:atLocation niiri:842d653a416be2a0412210b9f86b2f75 ;
     prov:value "5.98348569869995"^^xsd:float ;
     nidm_equivalentZStatistic: "5.51047970249337"^^xsd:float ;
     nidm_pValueUncorrected: "1.78928538652201e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00378871596531738"^^xsd:float ;
     nidm_qValueFDR: "0.00136419627856355"^^xsd:float .
 
-niiri:360992cc1632b4ee5094bf297bbfad73
+niiri:842d653a416be2a0412210b9f86b2f75
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0018" ;
     nidm_coordinateVector: "[-52,0,38]"^^xsd:string .
 
-niiri:f916aec7ac31457f1c089e162fb3fe50 prov:wasDerivedFrom niiri:0fee37ce3647eeec66b703b7384f7d51 .
+niiri:1b716cf23c999bf2aa97632831c920c3 prov:wasDerivedFrom niiri:3b36a7334ca09a3c238279baec873119 .
 
-niiri:9d2cd74bc63a1bba9b5c53e079da06f6
+niiri:fb67c0bff2a0e2b33b7e98f6e72ecf20
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0019" ;
-    prov:atLocation niiri:ebc40334e4681dcc1a51a0d2532bc417 ;
+    prov:atLocation niiri:a514db27f5969eb25e9b9e72a4d9f19a ;
     prov:value "5.2253565788269"^^xsd:float ;
     nidm_equivalentZStatistic: "4.89552821543552"^^xsd:float ;
     nidm_pValueUncorrected: "4.90210114501011e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0675937275056587"^^xsd:float ;
     nidm_qValueFDR: "0.0118363293065346"^^xsd:float .
 
-niiri:ebc40334e4681dcc1a51a0d2532bc417
+niiri:a514db27f5969eb25e9b9e72a4d9f19a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0019" ;
     nidm_coordinateVector: "[-60,8,20]"^^xsd:string .
 
-niiri:9d2cd74bc63a1bba9b5c53e079da06f6 prov:wasDerivedFrom niiri:0fee37ce3647eeec66b703b7384f7d51 .
+niiri:fb67c0bff2a0e2b33b7e98f6e72ecf20 prov:wasDerivedFrom niiri:3b36a7334ca09a3c238279baec873119 .
 
-niiri:2c7a45a34a2bb31c8f7ae615cb9b7bfc
+niiri:99264e96be684bdfa859b1fd9ef7404f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0020" ;
-    prov:atLocation niiri:8e6c11eb7e840e38db5518cb924c5665 ;
+    prov:atLocation niiri:d9cc01f2b233cccc98b3ad8ed9f1f720 ;
     prov:value "4.98950004577637"^^xsd:float ;
     nidm_equivalentZStatistic: "4.69817956585148"^^xsd:float ;
     nidm_pValueUncorrected: "1.31245304380023e-06"^^xsd:float ;
     nidm_pValueFWER: "0.151048137890434"^^xsd:float ;
     nidm_qValueFDR: "0.0233609510296683"^^xsd:float .
 
-niiri:8e6c11eb7e840e38db5518cb924c5665
+niiri:d9cc01f2b233cccc98b3ad8ed9f1f720
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0020" ;
     nidm_coordinateVector: "[-44,6,28]"^^xsd:string .
 
-niiri:2c7a45a34a2bb31c8f7ae615cb9b7bfc prov:wasDerivedFrom niiri:0fee37ce3647eeec66b703b7384f7d51 .
+niiri:99264e96be684bdfa859b1fd9ef7404f prov:wasDerivedFrom niiri:3b36a7334ca09a3c238279baec873119 .
 
-niiri:7745f80e690ce59f0794072a6e073803
+niiri:3af87f4c8a485677db1de109851382ce
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0021" ;
-    prov:atLocation niiri:9f8e7be021921b2c62f8192683f1da25 ;
+    prov:atLocation niiri:bf1ac20f2cb36a10c73e16a4eeb39be4 ;
     prov:value "5.78093099594116"^^xsd:float ;
     nidm_equivalentZStatistic: "5.34909755317379"^^xsd:float ;
     nidm_pValueUncorrected: "4.41969442155354e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00844151822925698"^^xsd:float ;
     nidm_qValueFDR: "0.00286742427823329"^^xsd:float .
 
-niiri:9f8e7be021921b2c62f8192683f1da25
+niiri:bf1ac20f2cb36a10c73e16a4eeb39be4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0021" ;
     nidm_coordinateVector: "[-34,-2,52]"^^xsd:string .
 
-niiri:7745f80e690ce59f0794072a6e073803 prov:wasDerivedFrom niiri:f62983c44994abc2d68d9067929a281b .
+niiri:3af87f4c8a485677db1de109851382ce prov:wasDerivedFrom niiri:58bff46dfff701e885b3a3a8403d6869 .
 
-niiri:c116f777747b7f5b03f844c9119ed2c9
+niiri:96137cd609a52308057e3eaad2affaf7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0022" ;
-    prov:atLocation niiri:2f5713ae7dc5f30abfd4836de2aac8a4 ;
+    prov:atLocation niiri:beb35637b378cd19eb529fa6fe9f24a4 ;
     prov:value "5.40964078903198"^^xsd:float ;
     nidm_equivalentZStatistic: "5.04774404642803"^^xsd:float ;
     nidm_pValueUncorrected: "2.23528758724889e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0346958937061391"^^xsd:float ;
     nidm_qValueFDR: "0.00846044059259994"^^xsd:float .
 
-niiri:2f5713ae7dc5f30abfd4836de2aac8a4
+niiri:beb35637b378cd19eb529fa6fe9f24a4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0022" ;
     nidm_coordinateVector: "[-54,-46,58]"^^xsd:string .
 
-niiri:c116f777747b7f5b03f844c9119ed2c9 prov:wasDerivedFrom niiri:702e99e0477ee69dcca3053044008e4e .
+niiri:96137cd609a52308057e3eaad2affaf7 prov:wasDerivedFrom niiri:2bcab9b8311e435ff15509af340ba45e .
 
-niiri:a5003d4837d902c0521222a716f5a060
+niiri:aaf8bff445839cb9f02a0507509d96c7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0023" ;
-    prov:atLocation niiri:d571dcea2d592aadafd121f833113f7b ;
+    prov:atLocation niiri:76446890b6db0c500548a40b8f8682ba ;
     prov:value "5.31841945648193"^^xsd:float ;
     nidm_equivalentZStatistic: "4.97261482231588"^^xsd:float ;
     nidm_pValueUncorrected: "3.30279114724163e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0484353441449864"^^xsd:float ;
     nidm_qValueFDR: "0.0106752417476244"^^xsd:float .
 
-niiri:d571dcea2d592aadafd121f833113f7b
+niiri:76446890b6db0c500548a40b8f8682ba
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0023" ;
     nidm_coordinateVector: "[-62,-38,48]"^^xsd:string .
 
-niiri:a5003d4837d902c0521222a716f5a060 prov:wasDerivedFrom niiri:4c2901ae6d0b982e4779668839a7a895 .
+niiri:aaf8bff445839cb9f02a0507509d96c7 prov:wasDerivedFrom niiri:932a73d91444fc459c9b49f8b73b2582 .
 
-niiri:871397ad34f5c9ba92cd9b39715a44b4
+niiri:bb9e9131199389d2fff8def462545512
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0024" ;
-    prov:atLocation niiri:a2f052657ac606b266b7c78be31e44cd ;
+    prov:atLocation niiri:1a6f397bb7d9d28ef9486bd1bbe04132 ;
     prov:value "4.57099342346191"^^xsd:float ;
     nidm_equivalentZStatistic: "4.34109644800954"^^xsd:float ;
     nidm_pValueUncorrected: "7.08867353027554e-06"^^xsd:float ;
     nidm_pValueFWER: "0.496004086968197"^^xsd:float ;
     nidm_qValueFDR: "0.0635474729952592"^^xsd:float .
 
-niiri:a2f052657ac606b266b7c78be31e44cd
+niiri:1a6f397bb7d9d28ef9486bd1bbe04132
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0024" ;
     nidm_coordinateVector: "[-60,-50,48]"^^xsd:string .
 
-niiri:871397ad34f5c9ba92cd9b39715a44b4 prov:wasDerivedFrom niiri:4c2901ae6d0b982e4779668839a7a895 .
+niiri:bb9e9131199389d2fff8def462545512 prov:wasDerivedFrom niiri:932a73d91444fc459c9b49f8b73b2582 .
 
-niiri:24d9574d36d73fd8b94d9c0088b1e9e8
+niiri:f70c6e8ed2f106b23ce93474c5815a76
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0025" ;
-    prov:atLocation niiri:1dc734541a2aaaae4bcc4dd8f2dbc9b8 ;
+    prov:atLocation niiri:00a170f0bfc9c991ef7f484e52ffbd96 ;
     prov:value "5.30699443817139"^^xsd:float ;
     nidm_equivalentZStatistic: "4.96317509467693"^^xsd:float ;
     nidm_pValueUncorrected: "3.46750043123123e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0504786376455083"^^xsd:float ;
     nidm_qValueFDR: "0.0106752417476244"^^xsd:float .
 
-niiri:1dc734541a2aaaae4bcc4dd8f2dbc9b8
+niiri:00a170f0bfc9c991ef7f484e52ffbd96
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0025" ;
     nidm_coordinateVector: "[32,40,16]"^^xsd:string .
 
-niiri:24d9574d36d73fd8b94d9c0088b1e9e8 prov:wasDerivedFrom niiri:831be1ca287d5764924d7a7e83076a91 .
+niiri:f70c6e8ed2f106b23ce93474c5815a76 prov:wasDerivedFrom niiri:d974c978eac6eff6a9802fd0358ceab9 .
 
-niiri:49040948837005e5e1c996da2811c96e
+niiri:69121dd33164fbc51ac41add220ab8f1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0026" ;
-    prov:atLocation niiri:70f491ce10beca655ae3cfec86c98d5e ;
+    prov:atLocation niiri:2915dee2e934763f3afa376514c5fc13 ;
     prov:value "4.5497465133667"^^xsd:float ;
     nidm_equivalentZStatistic: "4.32273570618355"^^xsd:float ;
     nidm_pValueUncorrected: "7.7053150754347e-06"^^xsd:float ;
     nidm_pValueFWER: "0.520378392891944"^^xsd:float ;
     nidm_qValueFDR: "0.0649997423676262"^^xsd:float .
 
-niiri:70f491ce10beca655ae3cfec86c98d5e
+niiri:2915dee2e934763f3afa376514c5fc13
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0026" ;
     nidm_coordinateVector: "[40,46,12]"^^xsd:string .
 
-niiri:49040948837005e5e1c996da2811c96e prov:wasDerivedFrom niiri:831be1ca287d5764924d7a7e83076a91 .
+niiri:69121dd33164fbc51ac41add220ab8f1 prov:wasDerivedFrom niiri:d974c978eac6eff6a9802fd0358ceab9 .
 
-niiri:e74a4f85efaad80e360ad16acb297971
+niiri:389952192f36c8bc6c584ad875df6b35
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0027" ;
-    prov:atLocation niiri:f8fb2f2d3fae26ab38553ba1be2db6e6 ;
+    prov:atLocation niiri:7e19b6c879f069e1c59ced1c8f607cf9 ;
     prov:value "4.31582498550415"^^xsd:float ;
     nidm_equivalentZStatistic: "4.11913273798974"^^xsd:float ;
     nidm_pValueUncorrected: "1.90150518718513e-05"^^xsd:float ;
     nidm_pValueFWER: "0.788829013385429"^^xsd:float ;
     nidm_qValueFDR: "0.116130094830597"^^xsd:float .
 
-niiri:f8fb2f2d3fae26ab38553ba1be2db6e6
+niiri:7e19b6c879f069e1c59ced1c8f607cf9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0027" ;
     nidm_coordinateVector: "[36,54,6]"^^xsd:string .
 
-niiri:e74a4f85efaad80e360ad16acb297971 prov:wasDerivedFrom niiri:831be1ca287d5764924d7a7e83076a91 .
+niiri:389952192f36c8bc6c584ad875df6b35 prov:wasDerivedFrom niiri:d974c978eac6eff6a9802fd0358ceab9 .
 
-niiri:543cc2540e2800de5ebf85b0a9f5f7cc
+niiri:16d663f0f26b3dea4fc4e29533365eeb
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0028" ;
-    prov:atLocation niiri:1d1e65f0646e5d0cc3a27edec08b3b48 ;
+    prov:atLocation niiri:b0203375b18fa3d7ba036c947ea91f58 ;
     prov:value "5.27030229568481"^^xsd:float ;
     nidm_equivalentZStatistic: "4.93281349716267"^^xsd:float ;
     nidm_pValueUncorrected: "4.05267701952816e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0575990926145485"^^xsd:float ;
     nidm_qValueFDR: "0.0110040663565173"^^xsd:float .
 
-niiri:1d1e65f0646e5d0cc3a27edec08b3b48
+niiri:b0203375b18fa3d7ba036c947ea91f58
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0028" ;
     nidm_coordinateVector: "[40,26,48]"^^xsd:string .
 
-niiri:543cc2540e2800de5ebf85b0a9f5f7cc prov:wasDerivedFrom niiri:179b7e6f7102d0f73e68205b289425c6 .
+niiri:16d663f0f26b3dea4fc4e29533365eeb prov:wasDerivedFrom niiri:e373ddbc76b41aa980c394eaa5c0e960 .
 
-niiri:53f7a2df04f0c527945e0fd42e89e1c6
+niiri:194a103256f1c1af23ae04557a658012
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0029" ;
-    prov:atLocation niiri:27a8be7b4f26dd1a9c867598a99529b0 ;
+    prov:atLocation niiri:18944c45a5c3f4f6c0960eadd37d221d ;
     prov:value "4.93343877792358"^^xsd:float ;
     nidm_equivalentZStatistic: "4.65085575575197"^^xsd:float ;
     nidm_pValueUncorrected: "1.6528024058271e-06"^^xsd:float ;
     nidm_pValueFWER: "0.180887232162623"^^xsd:float ;
     nidm_qValueFDR: "0.0254967087736733"^^xsd:float .
 
-niiri:27a8be7b4f26dd1a9c867598a99529b0
+niiri:18944c45a5c3f4f6c0960eadd37d221d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0029" ;
     nidm_coordinateVector: "[-58,-30,-18]"^^xsd:string .
 
-niiri:53f7a2df04f0c527945e0fd42e89e1c6 prov:wasDerivedFrom niiri:5d951dbde4c6cfb00e34afc3122af0f4 .
+niiri:194a103256f1c1af23ae04557a658012 prov:wasDerivedFrom niiri:92a9d73b8902193b0f3316f35cc0dc5b .
 
-niiri:0af3212407d34db161fb65bf59c0014f
+niiri:b2215dc88285adf34cfc03ef8a5dcaf1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0030" ;
-    prov:atLocation niiri:8d82e53b4231d95d1a2d112c5a3f4883 ;
+    prov:atLocation niiri:9566ab35f1332f530ab3aa63f168999d ;
     prov:value "4.76414346694946"^^xsd:float ;
     nidm_equivalentZStatistic: "4.50698548813516"^^xsd:float ;
     nidm_pValueUncorrected: "3.287756441539e-06"^^xsd:float ;
     nidm_pValueFWER: "0.301278778226174"^^xsd:float ;
     nidm_qValueFDR: "0.0396433885053995"^^xsd:float .
 
-niiri:8d82e53b4231d95d1a2d112c5a3f4883
+niiri:9566ab35f1332f530ab3aa63f168999d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0030" ;
     nidm_coordinateVector: "[-46,-66,-6]"^^xsd:string .
 
-niiri:0af3212407d34db161fb65bf59c0014f prov:wasDerivedFrom niiri:9af9c71c19106f542230ad07eb5a764e .
+niiri:b2215dc88285adf34cfc03ef8a5dcaf1 prov:wasDerivedFrom niiri:be5f1c0a23837aa1ccfc35022807cc1b .
 
-niiri:c43efe72a950a8d62d531eb0474f99d4
+niiri:67a3ff30cb368a2f12ff59805b696982
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0031" ;
-    prov:atLocation niiri:f7e99da4046d70bb9fcf699b14116754 ;
+    prov:atLocation niiri:ab09c9a1f4598c0665ad4a53a4beb3c8 ;
     prov:value "3.7637345790863"^^xsd:float ;
     nidm_equivalentZStatistic: "3.62829384243901"^^xsd:float ;
     nidm_pValueUncorrected: "0.000142650218672435"^^xsd:float ;
     nidm_pValueFWER: "0.999605970761399"^^xsd:float ;
     nidm_qValueFDR: "0.34409224637793"^^xsd:float .
 
-niiri:f7e99da4046d70bb9fcf699b14116754
+niiri:ab09c9a1f4598c0665ad4a53a4beb3c8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0031" ;
     nidm_coordinateVector: "[-54,-64,-8]"^^xsd:string .
 
-niiri:c43efe72a950a8d62d531eb0474f99d4 prov:wasDerivedFrom niiri:9af9c71c19106f542230ad07eb5a764e .
+niiri:67a3ff30cb368a2f12ff59805b696982 prov:wasDerivedFrom niiri:be5f1c0a23837aa1ccfc35022807cc1b .
 
-niiri:853ae70c6d90e7c0bfc7fbab4f739762
+niiri:bc9137f84fc1f9762b49aad753870257
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0032" ;
-    prov:atLocation niiri:45106be8847c9468d39eb1bfe48e81e7 ;
+    prov:atLocation niiri:265b96175bce3138b953075789167720 ;
     prov:value "4.72232866287231"^^xsd:float ;
     nidm_equivalentZStatistic: "4.47122948835043"^^xsd:float ;
     nidm_pValueUncorrected: "3.88855941602095e-06"^^xsd:float ;
     nidm_pValueFWER: "0.338512677882141"^^xsd:float ;
     nidm_qValueFDR: "0.044836631144536"^^xsd:float .
 
-niiri:45106be8847c9468d39eb1bfe48e81e7
+niiri:265b96175bce3138b953075789167720
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0032" ;
     nidm_coordinateVector: "[58,-38,6]"^^xsd:string .
 
-niiri:853ae70c6d90e7c0bfc7fbab4f739762 prov:wasDerivedFrom niiri:23627cb4952c94ceb6b00ae5c1c4b815 .
+niiri:bc9137f84fc1f9762b49aad753870257 prov:wasDerivedFrom niiri:4cb37275d66ab0f22e3ea2174721f6f4 .
 
-niiri:86f7c7d98eaf7022ea8524b6c58cd91a
+niiri:032b9f13b127793861eb7c63ac30ae1b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0033" ;
-    prov:atLocation niiri:a13664931d39e111c2ddb44eaa337587 ;
+    prov:atLocation niiri:9b7979d59b62e98d7460d92ae0fd5b69 ;
     prov:value "3.98372888565063"^^xsd:float ;
     nidm_equivalentZStatistic: "3.8255778871433"^^xsd:float ;
     nidm_pValueUncorrected: "6.52328381068878e-05"^^xsd:float ;
     nidm_pValueFWER: "0.985409231324461"^^xsd:float ;
     nidm_qValueFDR: "0.233731539105478"^^xsd:float .
 
-niiri:a13664931d39e111c2ddb44eaa337587
+niiri:9b7979d59b62e98d7460d92ae0fd5b69
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0033" ;
     nidm_coordinateVector: "[64,-30,-4]"^^xsd:string .
 
-niiri:86f7c7d98eaf7022ea8524b6c58cd91a prov:wasDerivedFrom niiri:23627cb4952c94ceb6b00ae5c1c4b815 .
+niiri:032b9f13b127793861eb7c63ac30ae1b prov:wasDerivedFrom niiri:4cb37275d66ab0f22e3ea2174721f6f4 .
 
-niiri:e8f814bd669afcc4ca37cbd7ee04df76
+niiri:0f6fd82788868c60fecefa6c60f52281
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0034" ;
-    prov:atLocation niiri:69d8d1576704528c0b41c26f47eb9be5 ;
+    prov:atLocation niiri:4f9fe05667da20caedb476e93089a356 ;
     prov:value "3.50753784179688"^^xsd:float ;
     nidm_equivalentZStatistic: "3.39582098150001"^^xsd:float ;
     nidm_pValueUncorrected: "0.000342115474631921"^^xsd:float ;
     nidm_pValueFWER: "0.999999778829603"^^xsd:float ;
     nidm_qValueFDR: "0.564856004417035"^^xsd:float .
 
-niiri:69d8d1576704528c0b41c26f47eb9be5
+niiri:4f9fe05667da20caedb476e93089a356
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0034" ;
     nidm_coordinateVector: "[60,-40,-12]"^^xsd:string .
 
-niiri:e8f814bd669afcc4ca37cbd7ee04df76 prov:wasDerivedFrom niiri:23627cb4952c94ceb6b00ae5c1c4b815 .
+niiri:0f6fd82788868c60fecefa6c60f52281 prov:wasDerivedFrom niiri:4cb37275d66ab0f22e3ea2174721f6f4 .
 
-niiri:7742d27e6cd7a776f3addee6be9da6df
+niiri:e9fcf67ed1b73b63fa0b87828f16d554
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0035" ;
-    prov:atLocation niiri:ad385209b5d2f028d38875ee7ed35d42 ;
+    prov:atLocation niiri:d7f46e225306f0225e6a2937b1ec4c06 ;
     prov:value "4.70483255386353"^^xsd:float ;
     nidm_equivalentZStatistic: "4.45624265093732"^^xsd:float ;
     nidm_pValueUncorrected: "4.17043099876224e-06"^^xsd:float ;
     nidm_pValueFWER: "0.354967306449537"^^xsd:float ;
     nidm_qValueFDR: "0.0466228196503302"^^xsd:float .
 
-niiri:ad385209b5d2f028d38875ee7ed35d42
+niiri:d7f46e225306f0225e6a2937b1ec4c06
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0035" ;
     nidm_coordinateVector: "[-36,-74,-14]"^^xsd:string .
 
-niiri:7742d27e6cd7a776f3addee6be9da6df prov:wasDerivedFrom niiri:41c35d6e275325f6cc2f0e603bcbf838 .
+niiri:e9fcf67ed1b73b63fa0b87828f16d554 prov:wasDerivedFrom niiri:9bf6744a8796b8070ccd764f775a5e39 .
 
-niiri:88e096b5026c7bd33eace8c13267d1cc
+niiri:c2b2577f48de89a6cc0be9c94fc55aa8
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0036" ;
-    prov:atLocation niiri:2b4e5c510c90a0b786b65a3f07fe5328 ;
+    prov:atLocation niiri:be9f98153fcd6a17397aa36d2bf4d58a ;
     prov:value "4.08770418167114"^^xsd:float ;
     nidm_equivalentZStatistic: "3.91804495668"^^xsd:float ;
     nidm_pValueUncorrected: "4.46350297789166e-05"^^xsd:float ;
     nidm_pValueFWER: "0.955724279224547"^^xsd:float ;
     nidm_qValueFDR: "0.186719971332974"^^xsd:float .
 
-niiri:2b4e5c510c90a0b786b65a3f07fe5328
+niiri:be9f98153fcd6a17397aa36d2bf4d58a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0036" ;
     nidm_coordinateVector: "[-36,-68,-20]"^^xsd:string .
 
-niiri:88e096b5026c7bd33eace8c13267d1cc prov:wasDerivedFrom niiri:41c35d6e275325f6cc2f0e603bcbf838 .
+niiri:c2b2577f48de89a6cc0be9c94fc55aa8 prov:wasDerivedFrom niiri:9bf6744a8796b8070ccd764f775a5e39 .
 
-niiri:dc406b75d329249d3148daf5c3ce8876
+niiri:b280d4a0b64592367cef28cf83c1c50a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0037" ;
-    prov:atLocation niiri:09f201fd7b3652a7c2b113ee0bdd8141 ;
+    prov:atLocation niiri:7cd7d2893f104d27cbed450c735c9350 ;
     prov:value "3.71012616157532"^^xsd:float ;
     nidm_equivalentZStatistic: "3.57988831343959"^^xsd:float ;
     nidm_pValueUncorrected: "0.000171870546999631"^^xsd:float ;
     nidm_pValueFWER: "0.999883757236262"^^xsd:float ;
     nidm_qValueFDR: "0.385893135248467"^^xsd:float .
 
-niiri:09f201fd7b3652a7c2b113ee0bdd8141
+niiri:7cd7d2893f104d27cbed450c735c9350
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0037" ;
     nidm_coordinateVector: "[-30,-58,-16]"^^xsd:string .
 
-niiri:dc406b75d329249d3148daf5c3ce8876 prov:wasDerivedFrom niiri:41c35d6e275325f6cc2f0e603bcbf838 .
+niiri:b280d4a0b64592367cef28cf83c1c50a prov:wasDerivedFrom niiri:9bf6744a8796b8070ccd764f775a5e39 .
 
-niiri:8755ef265b3457619230538a6ac5496d
+niiri:0617028bebc10a87084f495d6bea9816
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0038" ;
-    prov:atLocation niiri:4f3a6136c3e6f0a2ad32cc4811bcaca4 ;
+    prov:atLocation niiri:6003244d95b3096ffcb5a0152cfd0933 ;
     prov:value "4.59621620178223"^^xsd:float ;
     nidm_equivalentZStatistic: "4.36286413267216"^^xsd:float ;
     nidm_pValueUncorrected: "6.41853365035416e-06"^^xsd:float ;
     nidm_pValueFWER: "0.467637998233248"^^xsd:float ;
     nidm_qValueFDR: "0.0604181585485856"^^xsd:float .
 
-niiri:4f3a6136c3e6f0a2ad32cc4811bcaca4
+niiri:6003244d95b3096ffcb5a0152cfd0933
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0038" ;
     nidm_coordinateVector: "[16,-98,6]"^^xsd:string .
 
-niiri:8755ef265b3457619230538a6ac5496d prov:wasDerivedFrom niiri:7d64ad68122f5c09739782f91cf20691 .
+niiri:0617028bebc10a87084f495d6bea9816 prov:wasDerivedFrom niiri:c8a038b61f85138c6e21eee9f3570ce3 .
 
-niiri:a3cc4ddd8e840d385cedb96973550274
+niiri:8f28adfa177b2033e8aac730e9d813c5
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0039" ;
-    prov:atLocation niiri:f3e1888fcbf40bbe9c3e8b15a3a3c1a5 ;
+    prov:atLocation niiri:48a7698048fc6f6f19a99b0f9a8e75ca ;
     prov:value "4.57891654968262"^^xsd:float ;
     nidm_equivalentZStatistic: "4.34793761600864"^^xsd:float ;
     nidm_pValueUncorrected: "6.87118388575936e-06"^^xsd:float ;
     nidm_pValueFWER: "0.487021764768749"^^xsd:float ;
     nidm_qValueFDR: "0.0629240173925056"^^xsd:float .
 
-niiri:f3e1888fcbf40bbe9c3e8b15a3a3c1a5
+niiri:48a7698048fc6f6f19a99b0f9a8e75ca
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0039" ;
     nidm_coordinateVector: "[-60,-16,28]"^^xsd:string .
 
-niiri:a3cc4ddd8e840d385cedb96973550274 prov:wasDerivedFrom niiri:7a862cf3ff4623a7a92b4abf907392c8 .
+niiri:8f28adfa177b2033e8aac730e9d813c5 prov:wasDerivedFrom niiri:4cfb37bb6f2ac0c6613c6f7263fc6650 .
 
-niiri:63c20abda72662979bb576f613029ad0
+niiri:f796d2323c68b364b61ab304f29abf8e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0040" ;
-    prov:atLocation niiri:e65080b7647f61f65312fe5888001d1e ;
+    prov:atLocation niiri:6fb77fc57ac2e71a37a28ea2ba3920c5 ;
     prov:value "4.37013816833496"^^xsd:float ;
     nidm_equivalentZStatistic: "4.16664310578498"^^xsd:float ;
     nidm_pValueUncorrected: "1.54558935169247e-05"^^xsd:float ;
     nidm_pValueFWER: "0.730405153245217"^^xsd:float ;
     nidm_qValueFDR: "0.101858458171742"^^xsd:float .
 
-niiri:e65080b7647f61f65312fe5888001d1e
+niiri:6fb77fc57ac2e71a37a28ea2ba3920c5
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0040" ;
     nidm_coordinateVector: "[-52,-62,52]"^^xsd:string .
 
-niiri:63c20abda72662979bb576f613029ad0 prov:wasDerivedFrom niiri:abfa5ca5d76007e8bc66144c1f88d4ca .
+niiri:f796d2323c68b364b61ab304f29abf8e prov:wasDerivedFrom niiri:090f310da60ee22317a7fb037c567897 .
 
-niiri:fe2dabd199510e3560209e2f00544a7b
+niiri:5dfc83216f09a2194e4624ad70c56926
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0041" ;
-    prov:atLocation niiri:e8dadab76e08845e90ab9f6e5bd25c4f ;
+    prov:atLocation niiri:bb668322a2477c49c19e0215c96fb605 ;
     prov:value "4.30655717849731"^^xsd:float ;
     nidm_equivalentZStatistic: "4.11101155082742"^^xsd:float ;
     nidm_pValueUncorrected: "1.96964745459161e-05"^^xsd:float ;
     nidm_pValueFWER: "0.798260223882423"^^xsd:float ;
     nidm_qValueFDR: "0.118009486872663"^^xsd:float .
 
-niiri:e8dadab76e08845e90ab9f6e5bd25c4f
+niiri:bb668322a2477c49c19e0215c96fb605
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0041" ;
     nidm_coordinateVector: "[-26,-92,32]"^^xsd:string .
 
-niiri:fe2dabd199510e3560209e2f00544a7b prov:wasDerivedFrom niiri:dd86dc550acd2473942e6a2580d34577 .
+niiri:5dfc83216f09a2194e4624ad70c56926 prov:wasDerivedFrom niiri:363fdfdf14cd35df5666fb3e18b0d8c5 .
 
-niiri:1eeb0501959cee954028fb613b80be9c
+niiri:177ec6548b8ab076a0df6d6033e514c2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0042" ;
-    prov:atLocation niiri:3a2625c1665f190914d2d20bbf0575ca ;
+    prov:atLocation niiri:477ea5657432a192d97ad576b0c8eff4 ;
     prov:value "4.24533367156982"^^xsd:float ;
     nidm_equivalentZStatistic: "4.05725918601008"^^xsd:float ;
     nidm_pValueUncorrected: "2.4825985211363e-05"^^xsd:float ;
     nidm_pValueFWER: "0.855631833511506"^^xsd:float ;
     nidm_qValueFDR: "0.135717263652471"^^xsd:float .
 
-niiri:3a2625c1665f190914d2d20bbf0575ca
+niiri:477ea5657432a192d97ad576b0c8eff4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0042" ;
     nidm_coordinateVector: "[-18,-60,48]"^^xsd:string .
 
-niiri:1eeb0501959cee954028fb613b80be9c prov:wasDerivedFrom niiri:024ae749b1d9748c3c6c99db326eed03 .
+niiri:177ec6548b8ab076a0df6d6033e514c2 prov:wasDerivedFrom niiri:80cfe87c528fca41e72aca65987a69a4 .
 
-niiri:9423c4d4f185c3598548ec75ac2ad0ef
+niiri:1d5012af3aa91d2f7de1ec238455128e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0043" ;
-    prov:atLocation niiri:de5c42d49f78704745711ad7136e8c0a ;
+    prov:atLocation niiri:b3517cb478482fae609d9448b489dff3 ;
     prov:value "4.22729349136353"^^xsd:float ;
     nidm_equivalentZStatistic: "4.04138628171284"^^xsd:float ;
     nidm_pValueUncorrected: "2.65680735640483e-05"^^xsd:float ;
     nidm_pValueFWER: "0.870712357794855"^^xsd:float ;
     nidm_qValueFDR: "0.138603763901635"^^xsd:float .
 
-niiri:de5c42d49f78704745711ad7136e8c0a
+niiri:b3517cb478482fae609d9448b489dff3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0043" ;
     nidm_coordinateVector: "[-20,-98,22]"^^xsd:string .
 
-niiri:9423c4d4f185c3598548ec75ac2ad0ef prov:wasDerivedFrom niiri:e47686b38499c7d1c62fe38be1293da3 .
+niiri:1d5012af3aa91d2f7de1ec238455128e prov:wasDerivedFrom niiri:e4d6a9f909a852e57111554ebf0b4352 .
 
-niiri:246e0bfadf745b48765a08f7dd8adba3
+niiri:4d9c6e08f557697d937d4fdbfcc226ba
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0044" ;
-    prov:atLocation niiri:6871de71c339de8561b5de51dace7c80 ;
+    prov:atLocation niiri:339ce93075072a6674c586ffcd2e7071 ;
     prov:value "4.22599840164185"^^xsd:float ;
     nidm_equivalentZStatistic: "4.04024618213588"^^xsd:float ;
     nidm_pValueUncorrected: "2.66975618669063e-05"^^xsd:float ;
     nidm_pValueFWER: "0.871760516202526"^^xsd:float ;
     nidm_qValueFDR: "0.138603763901635"^^xsd:float .
 
-niiri:6871de71c339de8561b5de51dace7c80
+niiri:339ce93075072a6674c586ffcd2e7071
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0044" ;
     nidm_coordinateVector: "[-36,-74,-34]"^^xsd:string .
 
-niiri:246e0bfadf745b48765a08f7dd8adba3 prov:wasDerivedFrom niiri:8186f3cd73bc2bc0b8b1223383efb0d8 .
+niiri:4d9c6e08f557697d937d4fdbfcc226ba prov:wasDerivedFrom niiri:039182fcb99c4f9a98332d4c4fb55e21 .
 
-niiri:38b3c5a759f71cbb194652b1f1fff1fb
+niiri:d8febb8ec85b4a6284d965e1e96f0d42
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0045" ;
-    prov:atLocation niiri:2df45033aa2319f6182924390af08a28 ;
+    prov:atLocation niiri:e904483face2f6172191f30b5ae887ce ;
     prov:value "4.20391035079956"^^xsd:float ;
     nidm_equivalentZStatistic: "4.02078923241408"^^xsd:float ;
     nidm_pValueUncorrected: "2.900174224163e-05"^^xsd:float ;
     nidm_pValueFWER: "0.888907080881232"^^xsd:float ;
     nidm_qValueFDR: "0.143583628261646"^^xsd:float .
 
-niiri:2df45033aa2319f6182924390af08a28
+niiri:e904483face2f6172191f30b5ae887ce
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0045" ;
     nidm_coordinateVector: "[34,-54,-16]"^^xsd:string .
 
-niiri:38b3c5a759f71cbb194652b1f1fff1fb prov:wasDerivedFrom niiri:c5762aac6b4c6d55a8d8adc67e3b7dcc .
+niiri:d8febb8ec85b4a6284d965e1e96f0d42 prov:wasDerivedFrom niiri:52a34b3a1f2ce2562ef0f4d897e30a2f .
 
-niiri:e641aad8ec4b97845bcdf72cf235b8bd
+niiri:65b361322bcb8dd8d0c9982a75869714
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0046" ;
-    prov:atLocation niiri:7b259b27d8f1c62ac5f903d7dbf942d5 ;
+    prov:atLocation niiri:4fa3bc1af5d44cdcfedda68c2e03da7b ;
     prov:value "4.18721437454224"^^xsd:float ;
     nidm_equivalentZStatistic: "4.00606667297511"^^xsd:float ;
     nidm_pValueUncorrected: "3.08691144208506e-05"^^xsd:float ;
     nidm_pValueFWER: "0.900934824371894"^^xsd:float ;
     nidm_qValueFDR: "0.149373770721144"^^xsd:float .
 
-niiri:7b259b27d8f1c62ac5f903d7dbf942d5
+niiri:4fa3bc1af5d44cdcfedda68c2e03da7b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0046" ;
     nidm_coordinateVector: "[12,-100,20]"^^xsd:string .
 
-niiri:e641aad8ec4b97845bcdf72cf235b8bd prov:wasDerivedFrom niiri:f5539938a236da748bfc223f58706047 .
+niiri:65b361322bcb8dd8d0c9982a75869714 prov:wasDerivedFrom niiri:f5b45be86dbcd41fe68a83f7d23cef72 .
 
-niiri:b2097d1c880a6cd73abfa9801ec3eeac
+niiri:d600d8085bb73831a72181b797fbb63f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0047" ;
-    prov:atLocation niiri:d4a36341ab8d676b63b319cc11373d11 ;
+    prov:atLocation niiri:44fa7d75ab0e1e4c9901acf92b82d38d ;
     prov:value "4.17404651641846"^^xsd:float ;
     nidm_equivalentZStatistic: "3.99444589181498"^^xsd:float ;
     nidm_pValueUncorrected: "3.24228638075574e-05"^^xsd:float ;
     nidm_pValueFWER: "0.909844421846994"^^xsd:float ;
     nidm_qValueFDR: "0.153735203854581"^^xsd:float .
 
-niiri:d4a36341ab8d676b63b319cc11373d11
+niiri:44fa7d75ab0e1e4c9901acf92b82d38d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0047" ;
     nidm_coordinateVector: "[-40,-38,44]"^^xsd:string .
 
-niiri:b2097d1c880a6cd73abfa9801ec3eeac prov:wasDerivedFrom niiri:989884d381b2838d468431f65a707824 .
+niiri:d600d8085bb73831a72181b797fbb63f prov:wasDerivedFrom niiri:6f8473034fe37635ca935744c8d051ba .
 
-niiri:21ab4717934b57cb495dfc5509d556d0
+niiri:ded4c30265dfe6755db542029d96c626
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0048" ;
-    prov:atLocation niiri:e9db66af2e8200c8f6d251567a7e681f ;
+    prov:atLocation niiri:0971061f8b6c1b553a97b9f5389dce86 ;
     prov:value "4.12145137786865"^^xsd:float ;
     nidm_equivalentZStatistic: "3.94794832362008"^^xsd:float ;
     nidm_pValueUncorrected: "3.94119065879606e-05"^^xsd:float ;
     nidm_pValueFWER: "0.940339218142555"^^xsd:float ;
     nidm_qValueFDR: "0.172448885449819"^^xsd:float .
 
-niiri:e9db66af2e8200c8f6d251567a7e681f
+niiri:0971061f8b6c1b553a97b9f5389dce86
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0048" ;
     nidm_coordinateVector: "[-48,-72,2]"^^xsd:string .
 
-niiri:21ab4717934b57cb495dfc5509d556d0 prov:wasDerivedFrom niiri:38033d63ea964f0e007a1fe6038289e0 .
+niiri:ded4c30265dfe6755db542029d96c626 prov:wasDerivedFrom niiri:72d641147c79cc42de66fcaf250eefff .
 
-niiri:771ae40e57764e0f94900239c15c9bce
+niiri:7a194dfabc293f3340bc257f2bdeae5d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0049" ;
-    prov:atLocation niiri:907ccfed9a8a91be876fa0e2fa360b8b ;
+    prov:atLocation niiri:ee77107f2f4a2e971a92ac9a2e392acb ;
     prov:value "4.07333517074585"^^xsd:float ;
     nidm_equivalentZStatistic: "3.9052963692066"^^xsd:float ;
     nidm_pValueUncorrected: "4.70549882543025e-05"^^xsd:float ;
     nidm_pValueFWER: "0.961337330645756"^^xsd:float ;
     nidm_qValueFDR: "0.192831151077206"^^xsd:float .
 
-niiri:907ccfed9a8a91be876fa0e2fa360b8b
+niiri:ee77107f2f4a2e971a92ac9a2e392acb
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0049" ;
     nidm_coordinateVector: "[20,-66,34]"^^xsd:string .
 
-niiri:771ae40e57764e0f94900239c15c9bce prov:wasDerivedFrom niiri:099e17d7816e029529107ceb1b6c97e2 .
+niiri:7a194dfabc293f3340bc257f2bdeae5d prov:wasDerivedFrom niiri:0a54f2c3fbd560105040dd395d10cd8e .
 
-niiri:536c2b389b0bec2a2ec988d17da1f46d
+niiri:777f22c81e3e2fc6331b52dd359fa25e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0050" ;
-    prov:atLocation niiri:2cf7c389a7f18e8d2b9fab0c88a40077 ;
+    prov:atLocation niiri:718728dcea773b178c0c2b9d86005a62 ;
     prov:value "4.05762767791748"^^xsd:float ;
     nidm_equivalentZStatistic: "3.89134919103145"^^xsd:float ;
     nidm_pValueUncorrected: "4.98441713834286e-05"^^xsd:float ;
     nidm_pValueFWER: "0.966867400896655"^^xsd:float ;
     nidm_qValueFDR: "0.199920408224698"^^xsd:float .
 
-niiri:2cf7c389a7f18e8d2b9fab0c88a40077
+niiri:718728dcea773b178c0c2b9d86005a62
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0050" ;
     nidm_coordinateVector: "[-46,-56,14]"^^xsd:string .
 
-niiri:536c2b389b0bec2a2ec988d17da1f46d prov:wasDerivedFrom niiri:c5b0621af9bf43fba5521742d45d67b5 .
+niiri:777f22c81e3e2fc6331b52dd359fa25e prov:wasDerivedFrom niiri:6c719ef53d6799a1aa00e8155fb90aa7 .
 
-niiri:e13cd74dc141ed8756972e26fa1c5da5
+niiri:bf28f434cc925cd8ac3e307644c0a142
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0051" ;
-    prov:atLocation niiri:e4207e9d0a4b818d72e2e397e7db12e3 ;
+    prov:atLocation niiri:751a1a8bf69143bd2cb1f4a9e30f273e ;
     prov:value "3.97341108322144"^^xsd:float ;
     nidm_equivalentZStatistic: "3.81637469850314"^^xsd:float ;
     nidm_pValueUncorrected: "6.7713399346081e-05"^^xsd:float ;
     nidm_pValueFWER: "0.987160063394768"^^xsd:float ;
     nidm_qValueFDR: "0.237117251115433"^^xsd:float .
 
-niiri:e4207e9d0a4b818d72e2e397e7db12e3
+niiri:751a1a8bf69143bd2cb1f4a9e30f273e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0051" ;
     nidm_coordinateVector: "[-50,-50,20]"^^xsd:string .
 
-niiri:e13cd74dc141ed8756972e26fa1c5da5 prov:wasDerivedFrom niiri:c5b0621af9bf43fba5521742d45d67b5 .
+niiri:bf28f434cc925cd8ac3e307644c0a142 prov:wasDerivedFrom niiri:6c719ef53d6799a1aa00e8155fb90aa7 .
 
-niiri:6e1d8e9ba2b442365af4af41172d3d65
+niiri:0790b31de0dbbcbf3f332d97e57d1b55
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0052" ;
-    prov:atLocation niiri:8adbdd43a9e57b07e13fc6b9ed46e509 ;
+    prov:atLocation niiri:e2f23bfbe72aad139a81ca5b2ffa8abd ;
     prov:value "4.03719234466553"^^xsd:float ;
     nidm_equivalentZStatistic: "3.87318677164159"^^xsd:float ;
     nidm_pValueUncorrected: "5.37107204765519e-05"^^xsd:float ;
     nidm_pValueFWER: "0.973166168280088"^^xsd:float ;
     nidm_qValueFDR: "0.210147957128937"^^xsd:float .
 
-niiri:8adbdd43a9e57b07e13fc6b9ed46e509
+niiri:e2f23bfbe72aad139a81ca5b2ffa8abd
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0052" ;
     nidm_coordinateVector: "[-48,2,50]"^^xsd:string .
 
-niiri:6e1d8e9ba2b442365af4af41172d3d65 prov:wasDerivedFrom niiri:370f32e6111a54eccb31b0cf49bb202d .
+niiri:0790b31de0dbbcbf3f332d97e57d1b55 prov:wasDerivedFrom niiri:9abcaf1e1cd8e4fffc65b4dcd102664f .
 
-niiri:f19a98ac6894de7c0dd4ce0a9ef72292
+niiri:59d06f0b13371b506f9af55d24b5067d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0053" ;
-    prov:atLocation niiri:aa90bdd0fff52eead175270437b0c471 ;
+    prov:atLocation niiri:1db7da9477f7603e8262d33595ac73df ;
     prov:value "4.0217924118042"^^xsd:float ;
     nidm_equivalentZStatistic: "3.85948683644491"^^xsd:float ;
     nidm_pValueUncorrected: "5.68126885931441e-05"^^xsd:float ;
     nidm_pValueFWER: "0.977286609355005"^^xsd:float ;
     nidm_qValueFDR: "0.217632520436791"^^xsd:float .
 
-niiri:aa90bdd0fff52eead175270437b0c471
+niiri:1db7da9477f7603e8262d33595ac73df
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0053" ;
     nidm_coordinateVector: "[-36,-40,-36]"^^xsd:string .
 
-niiri:f19a98ac6894de7c0dd4ce0a9ef72292 prov:wasDerivedFrom niiri:d66810393703f83fa8331fcba04ca628 .
+niiri:59d06f0b13371b506f9af55d24b5067d prov:wasDerivedFrom niiri:c17192cb7b2dfe5b506d5632ee2f9128 .
 
-niiri:259418f8a35163228a4bea0e4b78c346
+niiri:59b131173ec529026e6491eccefa7ada
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0054" ;
-    prov:atLocation niiri:081e69a16c43b2f3c8148d017c8bc2cc ;
+    prov:atLocation niiri:7af98a598509557bd8993f48cda58395 ;
     prov:value "3.9634416103363"^^xsd:float ;
     nidm_equivalentZStatistic: "3.80747753892992"^^xsd:float ;
     nidm_pValueUncorrected: "7.01957428701494e-05"^^xsd:float ;
     nidm_pValueFWER: "0.988689669381963"^^xsd:float ;
     nidm_qValueFDR: "0.237117251115433"^^xsd:float .
 
-niiri:081e69a16c43b2f3c8148d017c8bc2cc
+niiri:7af98a598509557bd8993f48cda58395
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0054" ;
     nidm_coordinateVector: "[4,6,32]"^^xsd:string .
 
-niiri:259418f8a35163228a4bea0e4b78c346 prov:wasDerivedFrom niiri:71d217841d852b0f36a116432eae4b2d .
+niiri:59b131173ec529026e6491eccefa7ada prov:wasDerivedFrom niiri:0cdd87a23d70e882dffa97ccc3f06458 .
 
-niiri:bee381a064a85379200e492537c3d0c2
+niiri:e9a001b5e220f1405185d99aa83b727f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0055" ;
-    prov:atLocation niiri:a6518d9b0773370425f7babe131c50f2 ;
+    prov:atLocation niiri:99944e1f658081a155c51941aabefa5f ;
     prov:value "3.96245408058167"^^xsd:float ;
     nidm_equivalentZStatistic: "3.80659597790245"^^xsd:float ;
     nidm_pValueUncorrected: "7.04463150378309e-05"^^xsd:float ;
     nidm_pValueFWER: "0.988832912076595"^^xsd:float ;
     nidm_qValueFDR: "0.237117251115433"^^xsd:float .
 
-niiri:a6518d9b0773370425f7babe131c50f2
+niiri:99944e1f658081a155c51941aabefa5f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0055" ;
     nidm_coordinateVector: "[-50,-48,-16]"^^xsd:string .
 
-niiri:bee381a064a85379200e492537c3d0c2 prov:wasDerivedFrom niiri:d6d7d4eefe6b670db24c97dc9318b6ce .
+niiri:e9a001b5e220f1405185d99aa83b727f prov:wasDerivedFrom niiri:24c8de1b4ac2f5e9c8b9a7759335fe9d .
 
-niiri:c938737f9b90e71a114fca777023c371
+niiri:6d610ea93d5ad1b8ca06db397254b20a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0056" ;
-    prov:atLocation niiri:f171360a13edfee13ea1f53522f55c43 ;
+    prov:atLocation niiri:a648ad8c9947c2b6d297437cebcf0586 ;
     prov:value "3.92427015304565"^^xsd:float ;
     nidm_equivalentZStatistic: "3.77247501519699"^^xsd:float ;
     nidm_pValueUncorrected: "8.08180782938539e-05"^^xsd:float ;
     nidm_pValueFWER: "0.993353008667813"^^xsd:float ;
     nidm_qValueFDR: "0.257401847609111"^^xsd:float .
 
-niiri:f171360a13edfee13ea1f53522f55c43
+niiri:a648ad8c9947c2b6d297437cebcf0586
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0056" ;
     nidm_coordinateVector: "[34,12,64]"^^xsd:string .
 
-niiri:c938737f9b90e71a114fca777023c371 prov:wasDerivedFrom niiri:876fcdab3aee2f6373c0e2df60b41a4e .
+niiri:6d610ea93d5ad1b8ca06db397254b20a prov:wasDerivedFrom niiri:9634c37192a257704d16f5f1d880a757 .
 
-niiri:a5021d18f963dda0808bbbef29086d76
+niiri:1c148cb4176155acbe0672cefa9a95c5
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0057" ;
-    prov:atLocation niiri:2b51af35726a74140ee537f1a898be32 ;
+    prov:atLocation niiri:c4b0615738aa35638b2835835d1d7819 ;
     prov:value "3.9098813533783"^^xsd:float ;
     nidm_equivalentZStatistic: "3.75959988615137"^^xsd:float ;
     nidm_pValueUncorrected: "8.50926599039736e-05"^^xsd:float ;
     nidm_pValueFWER: "0.994607633788328"^^xsd:float ;
     nidm_qValueFDR: "0.264100967145263"^^xsd:float .
 
-niiri:2b51af35726a74140ee537f1a898be32
+niiri:c4b0615738aa35638b2835835d1d7819
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0057" ;
     nidm_coordinateVector: "[54,-24,-2]"^^xsd:string .
 
-niiri:a5021d18f963dda0808bbbef29086d76 prov:wasDerivedFrom niiri:542b8b904774372e0a9627db540a47b7 .
+niiri:1c148cb4176155acbe0672cefa9a95c5 prov:wasDerivedFrom niiri:11b95279587654680aac97970c1dca33 .
 
-niiri:eb1ad46ae5903dce306f049cef4b329e
+niiri:e5dd8e18ee93409839d84e35a139c001
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0058" ;
-    prov:atLocation niiri:9ebd31e3d72e007bb65ba5c17a1c6f58 ;
+    prov:atLocation niiri:0fac8c3499b5602b8c4d3f4c5c36353f ;
     prov:value "3.90759468078613"^^xsd:float ;
     nidm_equivalentZStatistic: "3.75755289319297"^^xsd:float ;
     nidm_pValueUncorrected: "8.57915531067288e-05"^^xsd:float ;
     nidm_pValueFWER: "0.994787688943672"^^xsd:float ;
     nidm_qValueFDR: "0.264100967145263"^^xsd:float .
 
-niiri:9ebd31e3d72e007bb65ba5c17a1c6f58
+niiri:0fac8c3499b5602b8c4d3f4c5c36353f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0058" ;
     nidm_coordinateVector: "[-14,-98,-4]"^^xsd:string .
 
-niiri:eb1ad46ae5903dce306f049cef4b329e prov:wasDerivedFrom niiri:8bb571ef9ea74d78aa93e3046b5d96de .
+niiri:e5dd8e18ee93409839d84e35a139c001 prov:wasDerivedFrom niiri:0a1d8340cb8c5e4660accea8890aaead .
 
-niiri:8952f96888ae77d615ed079871c0995d
+niiri:e9643fe2556c8083fc3a5c54aa6831f0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0059" ;
-    prov:atLocation niiri:99e89ec2c4bcd9b66b74ba72383d98ed ;
+    prov:atLocation niiri:c71a141432731c3a83c4fb20d9096844 ;
     prov:value "3.90285301208496"^^xsd:float ;
     nidm_equivalentZStatistic: "3.75330746420074"^^xsd:float ;
     nidm_pValueUncorrected: "8.72582920719012e-05"^^xsd:float ;
     nidm_pValueFWER: "0.99514521861122"^^xsd:float ;
     nidm_qValueFDR: "0.264100967145263"^^xsd:float .
 
-niiri:99e89ec2c4bcd9b66b74ba72383d98ed
+niiri:c71a141432731c3a83c4fb20d9096844
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0059" ;
     nidm_coordinateVector: "[-36,-46,-18]"^^xsd:string .
 
-niiri:8952f96888ae77d615ed079871c0995d prov:wasDerivedFrom niiri:b4db133a7dcffc113bdc5cacd1f15c64 .
+niiri:e9643fe2556c8083fc3a5c54aa6831f0 prov:wasDerivedFrom niiri:7e88673ecdc8e0e122c41546194e1107 .
 
-niiri:c85e35984aa3e8577a5785e955b273e9
+niiri:5f418c8024d0ae92d508d9bad7d2d04d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0060" ;
-    prov:atLocation niiri:f193a012db987a102c72532b175fb3cc ;
+    prov:atLocation niiri:9a92eb0b7c3cc5e9caf8918bfa863800 ;
     prov:value "3.8867518901825"^^xsd:float ;
     nidm_equivalentZStatistic: "3.73888373627584"^^xsd:float ;
     nidm_pValueUncorrected: "9.24195907030523e-05"^^xsd:float ;
     nidm_pValueFWER: "0.996210852184447"^^xsd:float ;
     nidm_qValueFDR: "0.271701156704036"^^xsd:float .
 
-niiri:f193a012db987a102c72532b175fb3cc
+niiri:9a92eb0b7c3cc5e9caf8918bfa863800
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0060" ;
     nidm_coordinateVector: "[-50,-46,-32]"^^xsd:string .
 
-niiri:c85e35984aa3e8577a5785e955b273e9 prov:wasDerivedFrom niiri:0c00d9725bd14d031e130ad06f956eb2 .
+niiri:5f418c8024d0ae92d508d9bad7d2d04d prov:wasDerivedFrom niiri:9c9e8e71561800d1df10386138b306ed .
 
-niiri:623b4ff80c62c7660ed2e243f61181ed
+niiri:8eab02fbf5295443c2cecf3656cd3d2d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0061" ;
-    prov:atLocation niiri:3b5fa69f770ab6963ca617948f29b863 ;
+    prov:atLocation niiri:a9eabe163be93303971a1a577a90ad43 ;
     prov:value "3.86077284812927"^^xsd:float ;
     nidm_equivalentZStatistic: "3.7155862280194"^^xsd:float ;
     nidm_pValueUncorrected: "0.000101366555929516"^^xsd:float ;
     nidm_pValueFWER: "0.997515005942308"^^xsd:float ;
     nidm_qValueFDR: "0.285012944590861"^^xsd:float .
 
-niiri:3b5fa69f770ab6963ca617948f29b863
+niiri:a9eabe163be93303971a1a577a90ad43
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0061" ;
     nidm_coordinateVector: "[64,-30,-22]"^^xsd:string .
 
-niiri:623b4ff80c62c7660ed2e243f61181ed prov:wasDerivedFrom niiri:02839eee4d11ae4489dc6302d4195c9e .
+niiri:8eab02fbf5295443c2cecf3656cd3d2d prov:wasDerivedFrom niiri:7fe6fe573e42bb4d7fda5294f70b254e .
 
-niiri:ca308f414199fdd13201a908cf532b78
+niiri:98b8c845b0552789d333d70cc497d509
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0062" ;
-    prov:atLocation niiri:91e83d57d821ea08a88f8b1d8a4a27e4 ;
+    prov:atLocation niiri:497235ab7af561483668157451b5d000 ;
     prov:value "3.82178378105164"^^xsd:float ;
     nidm_equivalentZStatistic: "3.68056404693028"^^xsd:float ;
     nidm_pValueUncorrected: "0.000116359297336222"^^xsd:float ;
     nidm_pValueFWER: "0.998750111206092"^^xsd:float ;
     nidm_qValueFDR: "0.307505393775956"^^xsd:float .
 
-niiri:91e83d57d821ea08a88f8b1d8a4a27e4
+niiri:497235ab7af561483668157451b5d000
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0062" ;
     nidm_coordinateVector: "[12,52,-12]"^^xsd:string .
 
-niiri:ca308f414199fdd13201a908cf532b78 prov:wasDerivedFrom niiri:5bc68587f226de0a0713847e711c40db .
+niiri:98b8c845b0552789d333d70cc497d509 prov:wasDerivedFrom niiri:8fa9b6d9acd2c49ac8d56eaee29fc687 .
 
-niiri:eaa2b900f7f40f54804d9ecff0a1c5ab
+niiri:efa880b12dd83fae6f169908e5aa1b6d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0063" ;
-    prov:atLocation niiri:2180fcf8dd79ec32b9a869a37ae99584 ;
+    prov:atLocation niiri:633bc6590e9c2c6637b5c66d4c1f6821 ;
     prov:value "3.81266117095947"^^xsd:float ;
     nidm_equivalentZStatistic: "3.67235967240763"^^xsd:float ;
     nidm_pValueUncorrected: "0.000120160560553639"^^xsd:float ;
     nidm_pValueFWER: "0.998946217488595"^^xsd:float ;
     nidm_qValueFDR: "0.312228840798665"^^xsd:float .
 
-niiri:2180fcf8dd79ec32b9a869a37ae99584
+niiri:633bc6590e9c2c6637b5c66d4c1f6821
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0063" ;
     nidm_coordinateVector: "[36,54,20]"^^xsd:string .
 
-niiri:eaa2b900f7f40f54804d9ecff0a1c5ab prov:wasDerivedFrom niiri:e7802951bd1400071eecd4c74c824fb2 .
+niiri:efa880b12dd83fae6f169908e5aa1b6d prov:wasDerivedFrom niiri:5033df2d3441877c72a35517e4199588 .
 
-niiri:1e1c9814736ecd91122cac0122742e5b
+niiri:a24de0716b7868c15dfd5714da3cd7f5
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0064" ;
-    prov:atLocation niiri:6f1683e067362086652ae2ef7ca96a2a ;
+    prov:atLocation niiri:bb8a6cbf2ee7aef13285cd3e0c1d7119 ;
     prov:value "3.80767583847046"^^xsd:float ;
     nidm_equivalentZStatistic: "3.66787455107711"^^xsd:float ;
     nidm_pValueUncorrected: "0.000122287561408974"^^xsd:float ;
     nidm_pValueFWER: "0.999041631710947"^^xsd:float ;
     nidm_qValueFDR: "0.312228840798665"^^xsd:float .
 
-niiri:6f1683e067362086652ae2ef7ca96a2a
+niiri:bb8a6cbf2ee7aef13285cd3e0c1d7119
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0064" ;
     nidm_coordinateVector: "[22,-80,54]"^^xsd:string .
 
-niiri:1e1c9814736ecd91122cac0122742e5b prov:wasDerivedFrom niiri:fc840fc33c4cab88ad22815e22846638 .
+niiri:a24de0716b7868c15dfd5714da3cd7f5 prov:wasDerivedFrom niiri:4124e50de0ee3b3d33d8b3570cdaf9c8 .
 
-niiri:dd26664ccd32f67f1d7aa983d4507077
+niiri:b0236ac6504fe7c6d9875b7e3acda5d2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0065" ;
-    prov:atLocation niiri:9523a337ca67b111200abde41b41e4d7 ;
+    prov:atLocation niiri:403d8420a1ed6bf11ed2faac9417eb00 ;
     prov:value "3.7885959148407"^^xsd:float ;
     nidm_equivalentZStatistic: "3.65069869844077"^^xsd:float ;
     nidm_pValueUncorrected: "0.000130763947768786"^^xsd:float ;
     nidm_pValueFWER: "0.999340802437346"^^xsd:float ;
     nidm_qValueFDR: "0.325675502417125"^^xsd:float .
 
-niiri:9523a337ca67b111200abde41b41e4d7
+niiri:403d8420a1ed6bf11ed2faac9417eb00
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0065" ;
     nidm_coordinateVector: "[22,40,26]"^^xsd:string .
 
-niiri:dd26664ccd32f67f1d7aa983d4507077 prov:wasDerivedFrom niiri:3efd65f0da924a5bb703dc14f0ae2445 .
+niiri:b0236ac6504fe7c6d9875b7e3acda5d2 prov:wasDerivedFrom niiri:4a2fd60e9307d21139c66a8495323c62 .
 
-niiri:19a5fa4d22f7cc4ac80f8c5f5a788665
+niiri:5b2f95ea874a1f6a91671a4479c9378b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0066" ;
-    prov:atLocation niiri:1fa2852bb07da088bfab685e3c150032 ;
+    prov:atLocation niiri:913d07b2c660b69689773736cedef910 ;
     prov:value "3.78668808937073"^^xsd:float ;
     nidm_equivalentZStatistic: "3.64898036269368"^^xsd:float ;
     nidm_pValueUncorrected: "0.000131641613210109"^^xsd:float ;
     nidm_pValueFWER: "0.999365630484476"^^xsd:float ;
     nidm_qValueFDR: "0.325675502417125"^^xsd:float .
 
-niiri:1fa2852bb07da088bfab685e3c150032
+niiri:913d07b2c660b69689773736cedef910
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0066" ;
     nidm_coordinateVector: "[-22,-74,60]"^^xsd:string .
 
-niiri:19a5fa4d22f7cc4ac80f8c5f5a788665 prov:wasDerivedFrom niiri:aa3d8d16c81b84fa58af94c6d0a92521 .
+niiri:5b2f95ea874a1f6a91671a4479c9378b prov:wasDerivedFrom niiri:47493d1488caf09ebaff86e6cfddca82 .
 
-niiri:8b1da47bf149d737fe00b50c03b037d1
+niiri:9bf774e06d17f683fc16cd62139d3371
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0067" ;
-    prov:atLocation niiri:f31ae0bd232628899181e950730fca21 ;
+    prov:atLocation niiri:2ad6b182f9055333dc6e0015fa4f155e ;
     prov:value "3.69408750534058"^^xsd:float ;
     nidm_equivalentZStatistic: "3.56538143418403"^^xsd:float ;
     nidm_pValueUncorrected: "0.000181663694368006"^^xsd:float ;
     nidm_pValueFWER: "0.999921818129803"^^xsd:float ;
     nidm_qValueFDR: "0.399826018660701"^^xsd:float .
 
-niiri:f31ae0bd232628899181e950730fca21
+niiri:2ad6b182f9055333dc6e0015fa4f155e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0067" ;
     nidm_coordinateVector: "[50,46,-12]"^^xsd:string .
 
-niiri:8b1da47bf149d737fe00b50c03b037d1 prov:wasDerivedFrom niiri:be89147f5a6922a011e2b69c54c91307 .
+niiri:9bf774e06d17f683fc16cd62139d3371 prov:wasDerivedFrom niiri:f30d659f7dd564a91713174649a7897e .
 
-niiri:d5608ca55a605481514892b1a7c435b3
+niiri:3bc6e9db3abd7587209de9f8eb441a76
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0068" ;
-    prov:atLocation niiri:e6835e5b2e9178172588a30347dd19cb ;
+    prov:atLocation niiri:4d905d145479d69d91038af595094893 ;
     prov:value "3.65790581703186"^^xsd:float ;
     nidm_equivalentZStatistic: "3.53261354467296"^^xsd:float ;
     nidm_pValueUncorrected: "0.000205736742878826"^^xsd:float ;
     nidm_pValueFWER: "0.999969815552823"^^xsd:float ;
     nidm_qValueFDR: "0.430567192397012"^^xsd:float .
 
-niiri:e6835e5b2e9178172588a30347dd19cb
+niiri:4d905d145479d69d91038af595094893
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0068" ;
     nidm_coordinateVector: "[52,-46,-12]"^^xsd:string .
 
-niiri:d5608ca55a605481514892b1a7c435b3 prov:wasDerivedFrom niiri:27aff9030eda043106c67b4df9bd432f .
+niiri:3bc6e9db3abd7587209de9f8eb441a76 prov:wasDerivedFrom niiri:bf5d4132caa2ab59278ac933dbeefdc4 .
 
-niiri:7903a62ac51810f7c46fcb9355f157a5
+niiri:5364de8a0b6714a83fbec79f6028081c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0069" ;
-    prov:atLocation niiri:a5a0ecbb5e09c10506a89c8aee878bf8 ;
+    prov:atLocation niiri:4a5cdfd710492874c59e711371fd82ab ;
     prov:value "3.65459251403809"^^xsd:float ;
     nidm_equivalentZStatistic: "3.52960997534834"^^xsd:float ;
     nidm_pValueUncorrected: "0.000208086348004177"^^xsd:float ;
     nidm_pValueFWER: "0.999972447579615"^^xsd:float ;
     nidm_qValueFDR: "0.431239033859527"^^xsd:float .
 
-niiri:a5a0ecbb5e09c10506a89c8aee878bf8
+niiri:4a5cdfd710492874c59e711371fd82ab
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0069" ;
     nidm_coordinateVector: "[54,8,-36]"^^xsd:string .
 
-niiri:7903a62ac51810f7c46fcb9355f157a5 prov:wasDerivedFrom niiri:6015153862c2f18b0399c5979d77b579 .
+niiri:5364de8a0b6714a83fbec79f6028081c prov:wasDerivedFrom niiri:5063c9c53f326a1d63e57a9ad368aba4 .
 
-niiri:be09e1146cef3cb118d3227c20ca8af4
+niiri:3634f7fe7105a2e1b8f1882a519825af
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0070" ;
-    prov:atLocation niiri:7cf49e10d22703efdc8154f527a1b2cd ;
+    prov:atLocation niiri:50692615fe720fe70b53e64f6fead8a4 ;
     prov:value "3.60173606872559"^^xsd:float ;
     nidm_equivalentZStatistic: "3.48162963814792"^^xsd:float ;
     nidm_pValueUncorrected: "0.000249186237945009"^^xsd:float ;
     nidm_pValueFWER: "0.999994173508246"^^xsd:float ;
     nidm_qValueFDR: "0.477936808108637"^^xsd:float .
 
-niiri:7cf49e10d22703efdc8154f527a1b2cd
+niiri:50692615fe720fe70b53e64f6fead8a4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0070" ;
     nidm_coordinateVector: "[-14,58,10]"^^xsd:string .
 
-niiri:be09e1146cef3cb118d3227c20ca8af4 prov:wasDerivedFrom niiri:d49cca9c5e9ab92f918362c3052e9a2d .
+niiri:3634f7fe7105a2e1b8f1882a519825af prov:wasDerivedFrom niiri:f53e11fdc36e62f28a07e009b005603e .
 
-niiri:7ad11b670fd2baf50c03c3a384f798b5
+niiri:d594b8cfacb807f125997448b08835a3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0071" ;
-    prov:atLocation niiri:33e1cd87a458fe29ab701e484800d410 ;
+    prov:atLocation niiri:6bfc99bd843bdcf4e013f217dc98c9a3 ;
     prov:value "3.58989810943604"^^xsd:float ;
     nidm_equivalentZStatistic: "3.47086705539024"^^xsd:float ;
     nidm_pValueUncorrected: "0.000259390388114844"^^xsd:float ;
     nidm_pValueFWER: "0.999995993033212"^^xsd:float ;
     nidm_qValueFDR: "0.486123239113482"^^xsd:float .
 
-niiri:33e1cd87a458fe29ab701e484800d410
+niiri:6bfc99bd843bdcf4e013f217dc98c9a3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0071" ;
     nidm_coordinateVector: "[-66,-36,22]"^^xsd:string .
 
-niiri:7ad11b670fd2baf50c03c3a384f798b5 prov:wasDerivedFrom niiri:e35587b2acf9fd9a9fdf0672cc249a3a .
+niiri:d594b8cfacb807f125997448b08835a3 prov:wasDerivedFrom niiri:ae4cfacdd2f80d4db5489f80321a64c5 .
 
-niiri:84559a10e4aac67f42e886d101120a11
+niiri:023cc3012925d0776b89ecf4fe87ab52
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0072" ;
-    prov:atLocation niiri:3ebee967c8f95586fe3b050df3264c90 ;
+    prov:atLocation niiri:fc0d7a41934aa1b2738a3f70b84a927c ;
     prov:value "3.56340670585632"^^xsd:float ;
     nidm_equivalentZStatistic: "3.44676015888715"^^xsd:float ;
     nidm_pValueUncorrected: "0.000283676007278189"^^xsd:float ;
     nidm_pValueFWER: "0.999998329299787"^^xsd:float ;
     nidm_qValueFDR: "0.513357841480064"^^xsd:float .
 
-niiri:3ebee967c8f95586fe3b050df3264c90
+niiri:fc0d7a41934aa1b2738a3f70b84a927c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0072" ;
     nidm_coordinateVector: "[18,60,12]"^^xsd:string .
 
-niiri:84559a10e4aac67f42e886d101120a11 prov:wasDerivedFrom niiri:98d127e586abf35e62811f986bd3be18 .
+niiri:023cc3012925d0776b89ecf4fe87ab52 prov:wasDerivedFrom niiri:4bf515909ab7c79154616841d777e9fa .
 
-niiri:2ee348e23bd790da7f54db5a451c1807
+niiri:2fec8cee976754e3979a50e6ecb659e9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0073" ;
-    prov:atLocation niiri:fcc5fc214e1e7c66ef053f5e0edbd305 ;
+    prov:atLocation niiri:82fc364bc9872056c82c6d3896703c98 ;
     prov:value "3.55537104606628"^^xsd:float ;
     nidm_equivalentZStatistic: "3.43944179853069"^^xsd:float ;
     nidm_pValueUncorrected: "0.000291457553818653"^^xsd:float ;
     nidm_pValueFWER: "0.999998731920076"^^xsd:float ;
     nidm_qValueFDR: "0.518882279088377"^^xsd:float .
 
-niiri:fcc5fc214e1e7c66ef053f5e0edbd305
+niiri:82fc364bc9872056c82c6d3896703c98
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0073" ;
     nidm_coordinateVector: "[-64,-34,8]"^^xsd:string .
 
-niiri:2ee348e23bd790da7f54db5a451c1807 prov:wasDerivedFrom niiri:b2f002bc586117a24bdd5081006f3f23 .
+niiri:2fec8cee976754e3979a50e6ecb659e9 prov:wasDerivedFrom niiri:9c5ac23579b49a629cb17821a462a039 .
 
-niiri:9e7d4b02e214575563f6759eec843914
+niiri:ead9a2eb3fe810d3e2fe175ba57a770f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0074" ;
-    prov:atLocation niiri:7051ff9eab1e55a23fe508d8e5ccdb23 ;
+    prov:atLocation niiri:8b1df836dbd1d79b4e93b815de590aba ;
     prov:value "3.55148839950562"^^xsd:float ;
     nidm_equivalentZStatistic: "3.43590473729199"^^xsd:float ;
     nidm_pValueUncorrected: "0.000295289297083445"^^xsd:float ;
     nidm_pValueFWER: "0.99999889206113"^^xsd:float ;
     nidm_qValueFDR: "0.518882279088377"^^xsd:float .
 
-niiri:7051ff9eab1e55a23fe508d8e5ccdb23
+niiri:8b1df836dbd1d79b4e93b815de590aba
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0074" ;
     nidm_coordinateVector: "[64,-34,16]"^^xsd:string .
 
-niiri:9e7d4b02e214575563f6759eec843914 prov:wasDerivedFrom niiri:4ce238771ccf766ed28486be0e931e33 .
+niiri:ead9a2eb3fe810d3e2fe175ba57a770f prov:wasDerivedFrom niiri:0059ec9a6bb7c2d7e6ea96012aa070a4 .
 
-niiri:0bd2557f6b490ffcb00ea0c712af8f4b
+niiri:b52f0f12bced214c2dfafd7282f27bad
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0075" ;
-    prov:atLocation niiri:bafb9cad93527bef6220c8e82f0b02d1 ;
+    prov:atLocation niiri:5bef0119303f4bb85383ac9d192f0fe1 ;
     prov:value "3.54216623306274"^^xsd:float ;
     nidm_equivalentZStatistic: "3.42740966598884"^^xsd:float ;
     nidm_pValueUncorrected: "0.000304684504620178"^^xsd:float ;
     nidm_pValueFWER: "0.999999202607737"^^xsd:float ;
     nidm_qValueFDR: "0.527734905237698"^^xsd:float .
 
-niiri:bafb9cad93527bef6220c8e82f0b02d1
+niiri:5bef0119303f4bb85383ac9d192f0fe1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0075" ;
     nidm_coordinateVector: "[-58,-32,22]"^^xsd:string .
 
-niiri:0bd2557f6b490ffcb00ea0c712af8f4b prov:wasDerivedFrom niiri:e4b08c3de8b3e30fc520a4a7fb1d0717 .
+niiri:b52f0f12bced214c2dfafd7282f27bad prov:wasDerivedFrom niiri:3bb3714faa1aae7d02675cad6938ab52 .
 
-niiri:6b31c056a3635633634ee06046d5ac3c
+niiri:bacceffe4d760f806512a8fa62a47caf
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0076" ;
-    prov:atLocation niiri:18e0487e0ffe077b7befcaeefe4eb5d1 ;
+    prov:atLocation niiri:a0e61cb131cd0271669e7df79a2ed186 ;
     prov:value "3.51380252838135"^^xsd:float ;
     nidm_equivalentZStatistic: "3.40153955037634"^^xsd:float ;
     nidm_pValueUncorrected: "0.000335037159349127"^^xsd:float ;
     nidm_pValueFWER: "0.99999971905221"^^xsd:float ;
     nidm_qValueFDR: "0.559625109906516"^^xsd:float .
 
-niiri:18e0487e0ffe077b7befcaeefe4eb5d1
+niiri:a0e61cb131cd0271669e7df79a2ed186
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0076" ;
     nidm_coordinateVector: "[48,12,50]"^^xsd:string .
 
-niiri:6b31c056a3635633634ee06046d5ac3c prov:wasDerivedFrom niiri:f272badd0515e42b4d960d9705968657 .
+niiri:bacceffe4d760f806512a8fa62a47caf prov:wasDerivedFrom niiri:79f4ea32c57ff4bc44bd9693fb4bfb39 .
 
-niiri:abf1fbcf7bcf8cb38ba350a38da40094
+niiri:2a6483578ad30a2fe3721daffa288c28
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0077" ;
-    prov:atLocation niiri:e22391d652de43c047396542ecdc48a9 ;
+    prov:atLocation niiri:b0a0b798bff91a011585b210275ecaa3 ;
     prov:value "3.46738910675049"^^xsd:float ;
     nidm_equivalentZStatistic: "3.35913252154752"^^xsd:float ;
     nidm_pValueUncorrected: "0.000390937814553127"^^xsd:float ;
     nidm_pValueFWER: "0.999999955890495"^^xsd:float ;
     nidm_qValueFDR: "0.612505014136882"^^xsd:float .
 
-niiri:e22391d652de43c047396542ecdc48a9
+niiri:b0a0b798bff91a011585b210275ecaa3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0077" ;
     nidm_coordinateVector: "[14,-14,72]"^^xsd:string .
 
-niiri:abf1fbcf7bcf8cb38ba350a38da40094 prov:wasDerivedFrom niiri:d1006f0765b2d600f398d4672099ed92 .
+niiri:2a6483578ad30a2fe3721daffa288c28 prov:wasDerivedFrom niiri:16165a8f8f2fb7e16961bd153e0121b3 .
 
-niiri:68b45bef100bb26837b64f001f207e66
+niiri:5db20ef1a857b0c93873cca6dbbaf653
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0078" ;
-    prov:atLocation niiri:6951bddaf8775b4d58f7069ba2908e88 ;
+    prov:atLocation niiri:0c2e89b7dd30256e4f516083c49c1398 ;
     prov:value "3.45441365242004"^^xsd:float ;
     nidm_equivalentZStatistic: "3.34726077209469"^^xsd:float ;
     nidm_pValueUncorrected: "0.000408071982705316"^^xsd:float ;
     nidm_pValueFWER: "0.999999974583179"^^xsd:float ;
     nidm_qValueFDR: "0.628488500556802"^^xsd:float .
 
-niiri:6951bddaf8775b4d58f7069ba2908e88
+niiri:0c2e89b7dd30256e4f516083c49c1398
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0078" ;
     nidm_coordinateVector: "[-38,-54,-42]"^^xsd:string .
 
-niiri:68b45bef100bb26837b64f001f207e66 prov:wasDerivedFrom niiri:b221fbfb15d7f985909dc4575902ee79 .
+niiri:5db20ef1a857b0c93873cca6dbbaf653 prov:wasDerivedFrom niiri:120ccd02c2048169aea9fc9ef80dac7e .
 
-niiri:f82b9ff2e622994294df709356b82e8f
+niiri:0e5b5cad25297838be93e85247842bc4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0079" ;
-    prov:atLocation niiri:12468409a278fc8cfed934ff363294a3 ;
+    prov:atLocation niiri:e0b64d5d590b611bc9f1ea430c4ce478 ;
     prov:value "3.43550229072571"^^xsd:float ;
     nidm_equivalentZStatistic: "3.32994532400952"^^xsd:float ;
     nidm_pValueUncorrected: "0.000434315195478541"^^xsd:float ;
     nidm_pValueFWER: "0.999999988927098"^^xsd:float ;
     nidm_qValueFDR: "0.654261098812949"^^xsd:float .
 
-niiri:12468409a278fc8cfed934ff363294a3
+niiri:e0b64d5d590b611bc9f1ea430c4ce478
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0079" ;
     nidm_coordinateVector: "[22,44,-16]"^^xsd:string .
 
-niiri:f82b9ff2e622994294df709356b82e8f prov:wasDerivedFrom niiri:22518d42d4312d19842a6c5c7116e209 .
+niiri:0e5b5cad25297838be93e85247842bc4 prov:wasDerivedFrom niiri:8ecb9c4697fe5773d29ea35c29d84ef3 .
 
-niiri:cc557366f8629ace9d550272ed55ee4f
+niiri:8f596ef744414c01a33ad6c39029765e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0080" ;
-    prov:atLocation niiri:080582743d141af59a223b138c253884 ;
+    prov:atLocation niiri:41bcac017885a0d5ce419f1cd6147e96 ;
     prov:value "3.43198323249817"^^xsd:float ;
     nidm_equivalentZStatistic: "3.32672157755253"^^xsd:float ;
     nidm_pValueUncorrected: "0.000439370628491198"^^xsd:float ;
     nidm_pValueFWER: "0.999999990548038"^^xsd:float ;
     nidm_qValueFDR: "0.655840530088522"^^xsd:float .
 
-niiri:080582743d141af59a223b138c253884
+niiri:41bcac017885a0d5ce419f1cd6147e96
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0080" ;
     nidm_coordinateVector: "[42,-42,14]"^^xsd:string .
 
-niiri:cc557366f8629ace9d550272ed55ee4f prov:wasDerivedFrom niiri:27f64237a208bdd1b919662a44a25b49 .
+niiri:8f596ef744414c01a33ad6c39029765e prov:wasDerivedFrom niiri:b24de80c3a706246e31d6423b3708450 .
 
-niiri:7ec37de0b42c7cf286b0373e02809553
+niiri:ea5435e2a886068031ebe5de352b9252
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0081" ;
-    prov:atLocation niiri:780aa496fd956b885f73959a2c05b7a4 ;
+    prov:atLocation niiri:979e4f14c98dd53d2ba2316ad891327d ;
     prov:value "3.40964436531067"^^xsd:float ;
     nidm_equivalentZStatistic: "3.30624524554301"^^xsd:float ;
     nidm_pValueUncorrected: "0.000472776443704692"^^xsd:float ;
     nidm_pValueFWER: "0.999999996632889"^^xsd:float ;
     nidm_qValueFDR: "0.684032337898302"^^xsd:float .
 
-niiri:780aa496fd956b885f73959a2c05b7a4
+niiri:979e4f14c98dd53d2ba2316ad891327d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0081" ;
     nidm_coordinateVector: "[-22,-82,0]"^^xsd:string .
 
-niiri:7ec37de0b42c7cf286b0373e02809553 prov:wasDerivedFrom niiri:a5728ac41df0c581754b6db5427b1f05 .
+niiri:ea5435e2a886068031ebe5de352b9252 prov:wasDerivedFrom niiri:0f16dde8718dddce4db284b7a40496a8 .
 
-niiri:76886ce075c1debe50a7057c2b3e69d0
+niiri:6eff0cb119fb17bde1587b506a65b95c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0082" ;
-    prov:atLocation niiri:af900c2fc80952034fa7783eccc02891 ;
+    prov:atLocation niiri:a04b89d12a0e23c950fc82f4714923df ;
     prov:value "3.40386486053467"^^xsd:float ;
     nidm_equivalentZStatistic: "3.30094422133281"^^xsd:float ;
     nidm_pValueUncorrected: "0.000481800187664638"^^xsd:float ;
     nidm_pValueFWER: "0.999999997442132"^^xsd:float ;
     nidm_qValueFDR: "0.689466168942319"^^xsd:float .
 
-niiri:af900c2fc80952034fa7783eccc02891
+niiri:a04b89d12a0e23c950fc82f4714923df
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0082" ;
     nidm_coordinateVector: "[52,-42,18]"^^xsd:string .
 
-niiri:76886ce075c1debe50a7057c2b3e69d0 prov:wasDerivedFrom niiri:ff4fe7af97fc1af636a6c8d8f050f08f .
+niiri:6eff0cb119fb17bde1587b506a65b95c prov:wasDerivedFrom niiri:6618ca3eaa19d5e02557c9a8428828e3 .
 
-niiri:16bf040c6279d28b8388cb8253d87450
+niiri:42ba59332aba027b09e0f7fb5b836ccf
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0083" ;
-    prov:atLocation niiri:24766e79c67cc0c037cf32322401d526 ;
+    prov:atLocation niiri:efbdb520a93e8c7041418140163a877a ;
     prov:value "3.36533284187317"^^xsd:float ;
     nidm_equivalentZStatistic: "3.26556677338515"^^xsd:float ;
     nidm_pValueUncorrected: "0.000546226226643243"^^xsd:float ;
     nidm_pValueFWER: "0.999999999624169"^^xsd:float ;
     nidm_qValueFDR: "0.751744172496132"^^xsd:float .
 
-niiri:24766e79c67cc0c037cf32322401d526
+niiri:efbdb520a93e8c7041418140163a877a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0083" ;
     nidm_coordinateVector: "[44,-48,-26]"^^xsd:string .
 
-niiri:16bf040c6279d28b8388cb8253d87450 prov:wasDerivedFrom niiri:ec5515690308a412deffcb4cf46f2365 .
+niiri:42ba59332aba027b09e0f7fb5b836ccf prov:wasDerivedFrom niiri:edcf13cf2a9f550f95f7fa64a9ab86ca .
 
-niiri:b0c0e398ec53716105009e7fa73170ce
+niiri:503a860df4608d362f5472437c9aac33
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0084" ;
-    prov:atLocation niiri:d460156cc32122e28861084b0b0b15e3 ;
+    prov:atLocation niiri:bd9e880b12aa24548b9447799a89b39d ;
     prov:value "3.3379864692688"^^xsd:float ;
     nidm_equivalentZStatistic: "3.24042202275062"^^xsd:float ;
     nidm_pValueUncorrected: "0.000596764555146345"^^xsd:float ;
     nidm_pValueFWER: "0.999999999912202"^^xsd:float ;
     nidm_qValueFDR: "0.787874793017543"^^xsd:float .
 
-niiri:d460156cc32122e28861084b0b0b15e3
+niiri:bd9e880b12aa24548b9447799a89b39d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0084" ;
     nidm_coordinateVector: "[46,-40,44]"^^xsd:string .
 
-niiri:b0c0e398ec53716105009e7fa73170ce prov:wasDerivedFrom niiri:f74ca8cae4e2c682c3f97b1a640a5f00 .
+niiri:503a860df4608d362f5472437c9aac33 prov:wasDerivedFrom niiri:80da85f37d04350ac439bb0dfa06ea5b .
 
-niiri:19ad6f2b4ff101153b33f0be29b51fe5
+niiri:9a50100528de3301f53864b1e2d26813
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0085" ;
-    prov:atLocation niiri:6fa898d927f461d92b4563dda70d874d ;
+    prov:atLocation niiri:2a527d6fde4a3e0f1b5549da2bcb4937 ;
     prov:value "3.33372783660889"^^xsd:float ;
     nidm_equivalentZStatistic: "3.23650348537689"^^xsd:float ;
     nidm_pValueUncorrected: "0.000605018743711327"^^xsd:float ;
     nidm_pValueFWER: "0.999999999930494"^^xsd:float ;
     nidm_qValueFDR: "0.791142662581953"^^xsd:float .
 
-niiri:6fa898d927f461d92b4563dda70d874d
+niiri:2a527d6fde4a3e0f1b5549da2bcb4937
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0085" ;
     nidm_coordinateVector: "[16,4,16]"^^xsd:string .
 
-niiri:19ad6f2b4ff101153b33f0be29b51fe5 prov:wasDerivedFrom niiri:2a63ea593120afc6649eda0c102f631d .
+niiri:9a50100528de3301f53864b1e2d26813 prov:wasDerivedFrom niiri:cce62b8bba59fb588c9623468819b0f6 .
 
-niiri:9917257ea5164857a1baa41404e6e936
+niiri:c79bb08a7cc62e4c3bb0bc2ea61487fb
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0086" ;
-    prov:atLocation niiri:656be12fa4ec04f7713f80d1dd720ed4 ;
+    prov:atLocation niiri:d0196efa9c520da7383566a50c9bd6e0 ;
     prov:value "3.32532405853271"^^xsd:float ;
     nidm_equivalentZStatistic: "3.22876865896546"^^xsd:float ;
     nidm_pValueUncorrected: "0.000621622108231912"^^xsd:float ;
     nidm_pValueFWER: "0.99999999995642"^^xsd:float ;
     nidm_qValueFDR: "0.802213727911317"^^xsd:float .
 
-niiri:656be12fa4ec04f7713f80d1dd720ed4
+niiri:d0196efa9c520da7383566a50c9bd6e0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0086" ;
     nidm_coordinateVector: "[-54,-32,42]"^^xsd:string .
 
-niiri:9917257ea5164857a1baa41404e6e936 prov:wasDerivedFrom niiri:6f87e962fab6d1220c091e46877922d9 .
+niiri:c79bb08a7cc62e4c3bb0bc2ea61487fb prov:wasDerivedFrom niiri:fe52388c406befa95a7e7abdd9bc5d0d .
 
-niiri:cf833657eb3598d1a9b7977360d4fd1c
+niiri:df49da2116399dd93cbe380ad45dc4ba
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0087" ;
-    prov:atLocation niiri:13038ca4507903488f6e26dc43d88933 ;
+    prov:atLocation niiri:4e6b7532be0436dc269457ac5fbda880 ;
     prov:value "3.31892204284668"^^xsd:float ;
     nidm_equivalentZStatistic: "3.22287431730178"^^xsd:float ;
     nidm_pValueUncorrected: "0.000634556128578101"^^xsd:float ;
     nidm_pValueFWER: "0.99999999996962"^^xsd:float ;
     nidm_qValueFDR: "0.809612456104087"^^xsd:float .
 
-niiri:13038ca4507903488f6e26dc43d88933
+niiri:4e6b7532be0436dc269457ac5fbda880
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0087" ;
     nidm_coordinateVector: "[-16,4,62]"^^xsd:string .
 
-niiri:cf833657eb3598d1a9b7977360d4fd1c prov:wasDerivedFrom niiri:e86febc59d83b46e7775b7ea6281d7b6 .
+niiri:df49da2116399dd93cbe380ad45dc4ba prov:wasDerivedFrom niiri:aaf8a80c3785eabb526fa793c58065c5 .
 
-niiri:d56d26d4324078f3777c84e26c5b7470
+niiri:8e179e19b02140d23014ccfa85f27a50
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0088" ;
-    prov:atLocation niiri:cfb225497f83f359afc32fd25d314738 ;
+    prov:atLocation niiri:37bb88de70a250d9e55221ba28b52c7c ;
     prov:value "3.3035409450531"^^xsd:float ;
     nidm_equivalentZStatistic: "3.20870610659348"^^xsd:float ;
     nidm_pValueUncorrected: "0.000666668530368786"^^xsd:float ;
     nidm_pValueFWER: "0.999999999987468"^^xsd:float ;
     nidm_qValueFDR: "0.829570299628891"^^xsd:float .
 
-niiri:cfb225497f83f359afc32fd25d314738
+niiri:37bb88de70a250d9e55221ba28b52c7c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0088" ;
     nidm_coordinateVector: "[22,38,10]"^^xsd:string .
 
-niiri:d56d26d4324078f3777c84e26c5b7470 prov:wasDerivedFrom niiri:033bb93f5934ac8e2216a6953d84f96b .
+niiri:8e179e19b02140d23014ccfa85f27a50 prov:wasDerivedFrom niiri:66a2dce74584c693a761996e8a52ee2c .
 
-niiri:9ff6226009f8434164bdf61861afdbc7
+niiri:a787086f5cb922314611375f0c56cc32
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0089" ;
-    prov:atLocation niiri:7dd9ba427ca2a6599b105d721b7d20b1 ;
+    prov:atLocation niiri:fe659463fa080cf764c8d49213755e7b ;
     prov:value "3.29107904434204"^^xsd:float ;
     nidm_equivalentZStatistic: "3.19721985733158"^^xsd:float ;
     nidm_pValueUncorrected: "0.000693795605607228"^^xsd:float ;
     nidm_pValueFWER: "0.999999999994003"^^xsd:float ;
     nidm_qValueFDR: "0.839453948823053"^^xsd:float .
 
-niiri:7dd9ba427ca2a6599b105d721b7d20b1
+niiri:fe659463fa080cf764c8d49213755e7b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0089" ;
     nidm_coordinateVector: "[30,34,48]"^^xsd:string .
 
-niiri:9ff6226009f8434164bdf61861afdbc7 prov:wasDerivedFrom niiri:20e24f503a4809e9cf0241f76eaaf79d .
+niiri:a787086f5cb922314611375f0c56cc32 prov:wasDerivedFrom niiri:842dcf5877dd33791cbf64037b0d160d .
 
-niiri:e3296ae004d313fabc717af9627a0a06
+niiri:a8e3819b8f7d45e8b8dc7d86a80ef681
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0090" ;
-    prov:atLocation niiri:938bbc435ec79f3ce60320a00e5284ff ;
+    prov:atLocation niiri:86dee79597b91333e151e37e0e03522b ;
     prov:value "3.28136968612671"^^xsd:float ;
     nidm_equivalentZStatistic: "3.18826629952882"^^xsd:float ;
     nidm_pValueUncorrected: "0.000715643274853739"^^xsd:float ;
     nidm_pValueFWER: "0.999999999996665"^^xsd:float ;
     nidm_qValueFDR: "0.851590920517607"^^xsd:float .
 
-niiri:938bbc435ec79f3ce60320a00e5284ff
+niiri:86dee79597b91333e151e37e0e03522b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0090" ;
     nidm_coordinateVector: "[56,-66,4]"^^xsd:string .
 
-niiri:e3296ae004d313fabc717af9627a0a06 prov:wasDerivedFrom niiri:80d7fbf81e2055777ba9feeeadecc526 .
+niiri:a8e3819b8f7d45e8b8dc7d86a80ef681 prov:wasDerivedFrom niiri:826c8df2b7140fdd69ec6d944489cb87 .
 
-niiri:aeaaeba1bcffc0ef70031392484d9f0a
+niiri:95a3e6c899a63c97c10b2e2a21870587
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0091" ;
-    prov:atLocation niiri:df7b9525c8b178320f407adbe92e8a48 ;
+    prov:atLocation niiri:22f0969feaa27b87063bdc731a8b5ebd ;
     prov:value "3.27154183387756"^^xsd:float ;
     nidm_equivalentZStatistic: "3.17919960131803"^^xsd:float ;
     nidm_pValueUncorrected: "0.000738411785119797"^^xsd:float ;
     nidm_pValueFWER: "0.999999999998178"^^xsd:float ;
     nidm_qValueFDR: "0.858755937068456"^^xsd:float .
 
-niiri:df7b9525c8b178320f407adbe92e8a48
+niiri:22f0969feaa27b87063bdc731a8b5ebd
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0091" ;
     nidm_coordinateVector: "[10,-76,-12]"^^xsd:string .
 
-niiri:aeaaeba1bcffc0ef70031392484d9f0a prov:wasDerivedFrom niiri:2bd7817009f58b9da9bae43a5b25b68f .
+niiri:95a3e6c899a63c97c10b2e2a21870587 prov:wasDerivedFrom niiri:a8072ecfcdfd108f310a1bc87c821cf1 .
 
-niiri:8f754514998b454dca87e7abb9f76440
+niiri:47c4c2b62e33d8d5bf68323f3604cbdb
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0092" ;
-    prov:atLocation niiri:d024f9aef6c9b9669ab3f984895a5c4c ;
+    prov:atLocation niiri:6239faf38126e85b2d8d417db1895726 ;
     prov:value "3.2669575214386"^^xsd:float ;
     nidm_equivalentZStatistic: "3.17496900913942"^^xsd:float ;
     nidm_pValueUncorrected: "0.000749262523860983"^^xsd:float ;
     nidm_pValueFWER: "0.999999999998632"^^xsd:float ;
     nidm_qValueFDR: "0.863075307004762"^^xsd:float .
 
-niiri:d024f9aef6c9b9669ab3f984895a5c4c
+niiri:6239faf38126e85b2d8d417db1895726
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0092" ;
     nidm_coordinateVector: "[20,32,54]"^^xsd:string .
 
-niiri:8f754514998b454dca87e7abb9f76440 prov:wasDerivedFrom niiri:15e4c29ced9fec2482ceb9ba6a0a51d1 .
+niiri:47c4c2b62e33d8d5bf68323f3604cbdb prov:wasDerivedFrom niiri:71b52ab8126a30a8e2c6e66f6b5da31f .
 
-niiri:e8586dbf89a93015d3002e70da4faca6
+niiri:259c1693d6155c7a6f30bb08608f1f4f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0093" ;
-    prov:atLocation niiri:4b920376d9e3f432ce36972dc1012e4c ;
+    prov:atLocation niiri:a3247e37750de016acf24df9bc60fa49 ;
     prov:value "3.26226496696472"^^xsd:float ;
     nidm_equivalentZStatistic: "3.17063765299814"^^xsd:float ;
     nidm_pValueUncorrected: "0.000760523733375762"^^xsd:float ;
     nidm_pValueFWER: "0.999999999998982"^^xsd:float ;
     nidm_qValueFDR: "0.867640730428823"^^xsd:float .
 
-niiri:4b920376d9e3f432ce36972dc1012e4c
+niiri:a3247e37750de016acf24df9bc60fa49
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0093" ;
     nidm_coordinateVector: "[-60,-14,10]"^^xsd:string .
 
-niiri:e8586dbf89a93015d3002e70da4faca6 prov:wasDerivedFrom niiri:42e659c3800a504268b49626856a7c27 .
+niiri:259c1693d6155c7a6f30bb08608f1f4f prov:wasDerivedFrom niiri:339add5fca2f1335faf3c97a8ad874f4 .
 
-niiri:047e6e1f775a8a5f58aa4b7d3e812581
+niiri:c3c6c3b4bc379cbd3e79cdda209910be
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0094" ;
-    prov:atLocation niiri:68872dd188b97e9ea0f7546461438010 ;
+    prov:atLocation niiri:3c4fc33d1b64cfdf812854e59f738d56 ;
     prov:value "3.25743293762207"^^xsd:float ;
     nidm_equivalentZStatistic: "3.16617663527645"^^xsd:float ;
     nidm_pValueUncorrected: "0.000772284854291594"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999251"^^xsd:float ;
     nidm_qValueFDR: "0.872516606801204"^^xsd:float .
 
-niiri:68872dd188b97e9ea0f7546461438010
+niiri:3c4fc33d1b64cfdf812854e59f738d56
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0094" ;
     nidm_coordinateVector: "[-22,-94,28]"^^xsd:string .
 
-niiri:047e6e1f775a8a5f58aa4b7d3e812581 prov:wasDerivedFrom niiri:2cd92c6773d556b9448a0ddb09bd8b31 .
+niiri:c3c6c3b4bc379cbd3e79cdda209910be prov:wasDerivedFrom niiri:b822c27c9e4ca42b4196dd89b524730c .
 
-niiri:6a750b566ecd46c30ce3664eda825e53
+niiri:af534a3f98f60ec7b7d00384e405199b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0095" ;
-    prov:atLocation niiri:659ab3aeaaa1689a6222dcb767bb247f ;
+    prov:atLocation niiri:2499239f2dd610a8d96045353e0f3c47 ;
     prov:value "3.25416302680969"^^xsd:float ;
     nidm_equivalentZStatistic: "3.16315726358056"^^xsd:float ;
     nidm_pValueUncorrected: "0.000780339994975288"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999392"^^xsd:float ;
     nidm_qValueFDR: "0.874305136305167"^^xsd:float .
 
-niiri:659ab3aeaaa1689a6222dcb767bb247f
+niiri:2499239f2dd610a8d96045353e0f3c47
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0095" ;
     nidm_coordinateVector: "[-66,-46,8]"^^xsd:string .
 
-niiri:6a750b566ecd46c30ce3664eda825e53 prov:wasDerivedFrom niiri:fbeda8761878a098b300fa81bfca94a3 .
+niiri:af534a3f98f60ec7b7d00384e405199b prov:wasDerivedFrom niiri:96419b4c6e6c59ea3a4153112ed9d514 .
 
-niiri:bd323934a92c157b5ad4685430864ac0
+niiri:6101b3c8a7b6e0ec13ee88b3c0076b8f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0096" ;
-    prov:atLocation niiri:1388e7efb9d1146ae68c05848ce1f875 ;
+    prov:atLocation niiri:b6c31642bad37d7720ecff6c57e5191b ;
     prov:value "3.24836373329163"^^xsd:float ;
     nidm_equivalentZStatistic: "3.15780125799237"^^xsd:float ;
     nidm_pValueUncorrected: "0.000794819459152607"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999582"^^xsd:float ;
     nidm_qValueFDR: "0.881177035765112"^^xsd:float .
 
-niiri:1388e7efb9d1146ae68c05848ce1f875
+niiri:b6c31642bad37d7720ecff6c57e5191b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0096" ;
     nidm_coordinateVector: "[-68,-34,-8]"^^xsd:string .
 
-niiri:bd323934a92c157b5ad4685430864ac0 prov:wasDerivedFrom niiri:ff113369a1aab0598dc0f3d86fc0129b .
+niiri:6101b3c8a7b6e0ec13ee88b3c0076b8f prov:wasDerivedFrom niiri:2156904148b8610fa21cc0ac6f11f0a5 .
 
-niiri:fd4eeef784922ab3c1279b04181425cf
+niiri:f45f9a4f27b514a76b251ca6940d64cc
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0097" ;
-    prov:atLocation niiri:15f297ad956e513ea8bd0168cd8276df ;
+    prov:atLocation niiri:be17a094497e539d851d03d853f569e8 ;
     prov:value "3.23679161071777"^^xsd:float ;
     nidm_equivalentZStatistic: "3.14710967833961"^^xsd:float ;
     nidm_pValueUncorrected: "0.000824465484375092"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999804"^^xsd:float ;
     nidm_qValueFDR: "0.899808991491498"^^xsd:float .
 
-niiri:15f297ad956e513ea8bd0168cd8276df
+niiri:be17a094497e539d851d03d853f569e8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0097" ;
     nidm_coordinateVector: "[-56,34,-20]"^^xsd:string .
 
-niiri:fd4eeef784922ab3c1279b04181425cf prov:wasDerivedFrom niiri:ef6a4c707bf3e80d6954ad82e2705808 .
+niiri:f45f9a4f27b514a76b251ca6940d64cc prov:wasDerivedFrom niiri:bba6fb2b90294edde963661ec3fea027 .
 
-niiri:3b4f28f7e1e4a0092736a83729825138
+niiri:0775bd867b7640b1610595991372a3a4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0098" ;
-    prov:atLocation niiri:165578ad640128bc70e890636626df8c ;
+    prov:atLocation niiri:c4dbdab79f8821a024aad1cbea9bfdc0 ;
     prov:value "3.22478008270264"^^xsd:float ;
     nidm_equivalentZStatistic: "3.13600649460504"^^xsd:float ;
     nidm_pValueUncorrected: "0.000856327054624684"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999913"^^xsd:float ;
     nidm_qValueFDR: "0.917823543835361"^^xsd:float .
 
-niiri:165578ad640128bc70e890636626df8c
+niiri:c4dbdab79f8821a024aad1cbea9bfdc0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0098" ;
     nidm_coordinateVector: "[8,-72,42]"^^xsd:string .
 
-niiri:3b4f28f7e1e4a0092736a83729825138 prov:wasDerivedFrom niiri:cb14e2f236a171bf561b547935b40dd9 .
+niiri:0775bd867b7640b1610595991372a3a4 prov:wasDerivedFrom niiri:a428752a112ae62b5d4a764c475ebebb .
 
-niiri:5da82e3f5bf83184ccf6b908e46cc0a0
+niiri:b8c1d7232cf84cc17142cad17a88efd4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0099" ;
-    prov:atLocation niiri:91aafb76f5392ceffa689f067b201ad2 ;
+    prov:atLocation niiri:5d92f1be38abbce4c3a63c0c46448f74 ;
     prov:value "3.22331190109253"^^xsd:float ;
     nidm_equivalentZStatistic: "3.13464894829369"^^xsd:float ;
     nidm_pValueUncorrected: "0.000860299398633191"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999921"^^xsd:float ;
     nidm_qValueFDR: "0.917823543835361"^^xsd:float .
 
-niiri:91aafb76f5392ceffa689f067b201ad2
+niiri:5d92f1be38abbce4c3a63c0c46448f74
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0099" ;
     nidm_coordinateVector: "[42,-86,12]"^^xsd:string .
 
-niiri:5da82e3f5bf83184ccf6b908e46cc0a0 prov:wasDerivedFrom niiri:215e12d51ca68faf83b3c157465a4274 .
+niiri:b8c1d7232cf84cc17142cad17a88efd4 prov:wasDerivedFrom niiri:011ca539a5756d6a56b02867c8dc0da5 .
 
-niiri:40ba61e7a6c7ea4c170c7ce06bd578ae
+niiri:d7f13c4e30c7f05356ed60a5151c02bc
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0100" ;
-    prov:atLocation niiri:c4b90588653fee15f2d09b041423e8b5 ;
+    prov:atLocation niiri:6eb2e0f022d96c098a1c921602f59fc8 ;
     prov:value "3.21184372901917"^^xsd:float ;
     nidm_equivalentZStatistic: "3.12404202893254"^^xsd:float ;
     nidm_pValueUncorrected: "0.000891924872423622"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999964"^^xsd:float ;
     nidm_qValueFDR: "0.936836924136013"^^xsd:float .
 
-niiri:c4b90588653fee15f2d09b041423e8b5
+niiri:6eb2e0f022d96c098a1c921602f59fc8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0100" ;
     nidm_coordinateVector: "[-18,-92,8]"^^xsd:string .
 
-niiri:40ba61e7a6c7ea4c170c7ce06bd578ae prov:wasDerivedFrom niiri:846d054635e491107608bcf6e7db6e7b .
+niiri:d7f13c4e30c7f05356ed60a5151c02bc prov:wasDerivedFrom niiri:cba5fb0d6db1529fec8f4fba47f35ad8 .
 
-niiri:eb7824ce74a09e1ba49d7c665b7e6354
+niiri:490f1070a7fe465c3b5c6f734cf1749d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0101" ;
-    prov:atLocation niiri:c78717f72e65e6b5b17d12d4232790f4 ;
+    prov:atLocation niiri:139066f39e05f69f22d080013a95fbf1 ;
     prov:value "3.19808602333069"^^xsd:float ;
     nidm_equivalentZStatistic: "3.1113106720378"^^xsd:float ;
     nidm_pValueUncorrected: "0.000931294345451028"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999986"^^xsd:float ;
     nidm_qValueFDR: "0.958204454708765"^^xsd:float .
 
-niiri:c78717f72e65e6b5b17d12d4232790f4
+niiri:139066f39e05f69f22d080013a95fbf1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0101" ;
     nidm_coordinateVector: "[12,6,18]"^^xsd:string .
 
-niiri:eb7824ce74a09e1ba49d7c665b7e6354 prov:wasDerivedFrom niiri:cc3ec71f9506a13ad5812b94c954a6a4 .
+niiri:490f1070a7fe465c3b5c6f734cf1749d prov:wasDerivedFrom niiri:ff8870f1fb72bc18a894385e2e338a1a .
 
-niiri:7d3f6e43708b4bd0ebb482485824b220
+niiri:738e8e698240388bfd3862aecb89fc27
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0102" ;
-    prov:atLocation niiri:54f861e2561b9c0b9304a6eea7150801 ;
+    prov:atLocation niiri:1a1d537499ae7b8db798494bbd47949b ;
     prov:value "3.19609522819519"^^xsd:float ;
     nidm_equivalentZStatistic: "3.10946777700093"^^xsd:float ;
     nidm_pValueUncorrected: "0.000937123635013748"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999988"^^xsd:float ;
     nidm_qValueFDR: "0.958204454708765"^^xsd:float .
 
-niiri:54f861e2561b9c0b9304a6eea7150801
+niiri:1a1d537499ae7b8db798494bbd47949b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0102" ;
     nidm_coordinateVector: "[14,40,20]"^^xsd:string .
 
-niiri:7d3f6e43708b4bd0ebb482485824b220 prov:wasDerivedFrom niiri:ddbafccf344e9c4433df922b8641380c .
+niiri:738e8e698240388bfd3862aecb89fc27 prov:wasDerivedFrom niiri:0dd915ffcbdf519b3a8e0e342a7a3a15 .
 
-niiri:fd49df5bffcb3bce9fae882c7b391b13
+niiri:cb10f3dde606a9db392eeb31defadb58
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0103" ;
-    prov:atLocation niiri:bc9a02d4964eac08c5b10095266979e6 ;
+    prov:atLocation niiri:34d7cb1b6c22f3bab972ec17b5943913 ;
     prov:value "3.19474077224731"^^xsd:float ;
     nidm_equivalentZStatistic: "3.10821385730133"^^xsd:float ;
     nidm_pValueUncorrected: "0.000941109068576473"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999989"^^xsd:float ;
     nidm_qValueFDR: "0.958204454708765"^^xsd:float .
 
-niiri:bc9a02d4964eac08c5b10095266979e6
+niiri:34d7cb1b6c22f3bab972ec17b5943913
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0103" ;
     nidm_coordinateVector: "[-44,-42,-36]"^^xsd:string .
 
-niiri:fd49df5bffcb3bce9fae882c7b391b13 prov:wasDerivedFrom niiri:c89051853f599ba8b9d939c26968a8b9 .
+niiri:cb10f3dde606a9db392eeb31defadb58 prov:wasDerivedFrom niiri:aa3557b1b3fba9452176860c67262bd9 .
 

--- a/spmexport/ex_spm_full_example001/nidm.json
+++ b/spmexport/ex_spm_full_example001/nidm.json
@@ -1,0 +1,2122 @@
+{
+  "prefix": {
+    "nidm": "http://purl.org/nidash/nidm#",
+    "niiri": "http://iri.nidash.org/",
+    "spm": "http://purl.org/nidash/spm#",
+    "neurolex": "http://neurolex.org/wiki/",
+    "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/",
+    "dct": "http://purl.org/dc/terms/",
+    "nfo": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#",
+    "dc": "http://purl.org/dc/elements/1.1/",
+    "dctype": "http://purl.org/dc/dcmitype/",
+    "obo": "http://purl.obolibrary.org/obo/",
+    "nidm_NIDMResults": "http://purl.org/nidash/nidm#NIDM_0000027",
+    "nidm_version": "http://purl.org/nidash/nidm#NIDM_0000127",
+    "nidm_spm_results_nidm": "http://purl.org/nidash/nidm#NIDM_0000168",
+    "nidm_softwareVersion": "http://purl.org/nidash/nidm#NIDM_0000122",
+    "nidm_NIDMResultsExport": "http://purl.org/nidash/nidm#NIDM_0000166"
+  },
+  "entity": {
+    "niiri:e6d0f6a78cb1543128178c286ffb18bd": {
+      "prov:type": [
+        {
+        "$": "prov:Bundle",
+        "type": "xsd:QName"
+        },
+        {
+        "$": "nidm_NIDMResults:",
+        "type": "xsd:QName"
+        }
+      ],
+      "prov:label": {
+        "$": "NIDM-Results",
+        "type": "xsd:string"
+      },
+      "nidm_version:": {
+        "$": "1.3.0",
+        "type": "xsd:string"
+      }
+    }
+  },
+  "activity": {
+    "niiri:4c804d9f1544750b14cad90f7ca97316": {
+      "prov:type": {
+        "$": "nidm_NIDMResultsExport:",
+        "type": "xsd:QName"
+      },
+      "prov:label": {
+        "$": "NIDM-Results export",
+        "type": "xsd:string"
+      }
+    }
+  },
+  "agent": {
+    "niiri:7e0c67dffe4faa56a4221c32e8fd8f48": {
+      "prov:type": [
+        {
+        "$": "nidm_spm_results_nidm:",
+        "type": "xsd:QName"
+        },
+        {
+        "$": "prov:SoftwareAgent",
+        "type": "xsd:QName"
+        }
+      ],
+      "prov:label": {
+        "$": "spm_results_nidm",
+        "type": "xsd:string"
+      },
+      "nidm_softwareVersion:": {
+        "$": "12.7057",
+        "type": "xsd:string"
+      }
+    }
+  },
+  "wasGeneratedBy": {
+    "_:wGB5": {
+      "prov:entity": "niiri:e6d0f6a78cb1543128178c286ffb18bd",
+      "prov:activity": "niiri:4c804d9f1544750b14cad90f7ca97316",
+      "prov:time": "2017-04-19T12:18:07"
+    }
+  },
+  "wasAssociatedWith": {
+    "_:wAW4": {
+      "prov:activity": "niiri:4c804d9f1544750b14cad90f7ca97316",
+      "prov:agent": "niiri:7e0c67dffe4faa56a4221c32e8fd8f48"
+    }
+  },
+  "bundle": {
+    "niiri:e6d0f6a78cb1543128178c286ffb18bd": {
+    "prefix": {
+        "nidm_softwareVersion": "http://purl.org/nidash/nidm#NIDM_0000122",
+        "nidm_CoordinateSpace": "http://purl.org/nidash/nidm#NIDM_0000016",
+        "nidm_voxelToWorldMapping": "http://purl.org/nidash/nidm#NIDM_0000132",
+        "nidm_voxelUnits": "http://purl.org/nidash/nidm#NIDM_0000133",
+        "nidm_voxelSize": "http://purl.org/nidash/nidm#NIDM_0000131",
+        "nidm_inWorldCoordinateSystem": "http://purl.org/nidash/nidm#NIDM_0000105",
+        "nidm_numberOfDimensions": "http://purl.org/nidash/nidm#NIDM_0000112",
+        "nidm_dimensionsInVoxels": "http://purl.org/nidash/nidm#NIDM_0000090",
+        "nlx_Imaginginstrument": "http://uri.neuinfo.org/nif/nifstd/birnlex_2094",
+        "nlx_Magneticresonanceimagingscanner": "http://uri.neuinfo.org/nif/nifstd/birnlex_2100",
+        "nidm_grandMeanScaling": "http://purl.org/nidash/nidm#NIDM_0000096",
+        "nidm_targetIntensity": "http://purl.org/nidash/nidm#NIDM_0000124",
+        "nidm_hasMRIProtocol": "http://purl.org/nidash/nidm#NIDM_0000172",
+        "nlx_FunctionalMRIprotocol": "http://uri.neuinfo.org/nif/nifstd/birnlex_2250",
+        "nidm_Data": "http://purl.org/nidash/nidm#NIDM_0000169",
+        "spm_DCTDriftModel": "http://purl.org/nidash/spm#SPM_0000002",
+        "spm_SPMsDriftCutoffPeriod": "http://purl.org/nidash/spm#SPM_0000001",
+        "nidm_hasDriftModel": "http://purl.org/nidash/nidm#NIDM_0000088",
+        "nidm_hasHRFBasis": "http://purl.org/nidash/nidm#NIDM_0000102",
+        "spm_SPMsCanonicalHRF": "http://purl.org/nidash/spm#SPM_0000004",
+        "nidm_DesignMatrix": "http://purl.org/nidash/nidm#NIDM_0000019",
+        "nidm_regressorNames": "http://purl.org/nidash/nidm#NIDM_0000021",
+        "nidm_hasErrorDependence": "http://purl.org/nidash/nidm#NIDM_0000100",
+        "obo_Toeplitzcovariancestructure": "http://purl.obolibrary.org/obo/STATO_0000357",
+        "nidm_dependenceMapWiseDependence": "http://purl.org/nidash/nidm#NIDM_0000089",
+        "nidm_ConstantParameter": "http://purl.org/nidash/nidm#NIDM_0000072",
+        "nidm_errorVarianceHomogeneous": "http://purl.org/nidash/nidm#NIDM_0000094",
+        "nidm_varianceMapWiseDependence": "http://purl.org/nidash/nidm#NIDM_0000126",
+        "nidm_IndependentParameter": "http://purl.org/nidash/nidm#NIDM_0000073",
+        "nidm_withEstimationMethod": "http://purl.org/nidash/nidm#NIDM_0000134",
+        "obo_generalizedleastsquaresestimation": "http://purl.obolibrary.org/obo/STATO_0000372",
+        "nidm_ErrorModel": "http://purl.org/nidash/nidm#NIDM_0000023",
+        "nidm_hasErrorDistribution": "http://purl.org/nidash/nidm#NIDM_0000101",
+        "obo_normaldistribution": "http://purl.obolibrary.org/obo/STATO_0000227",
+        "nidm_ModelParametersEstimation": "http://purl.org/nidash/nidm#NIDM_0000056",
+        "nidm_MaskMap": "http://purl.org/nidash/nidm#NIDM_0000054",
+        "nidm_isUserDefined": "http://purl.org/nidash/nidm#NIDM_0000106",
+        "nidm_inCoordinateSpace": "http://purl.org/nidash/nidm#NIDM_0000104",
+        "nidm_GrandMeanMap": "http://purl.org/nidash/nidm#NIDM_0000033",
+        "nidm_maskedMedian": "http://purl.org/nidash/nidm#NIDM_0000107",
+        "nidm_ParameterEstimateMap": "http://purl.org/nidash/nidm#NIDM_0000061",
+        "nidm_ResidualMeanSquaresMap": "http://purl.org/nidash/nidm#NIDM_0000066",
+        "nidm_ReselsPerVoxelMap": "http://purl.org/nidash/nidm#NIDM_0000144",
+        "obo_contrastweightmatrix": "http://purl.obolibrary.org/obo/STATO_0000323",
+        "nidm_statisticType": "http://purl.org/nidash/nidm#NIDM_0000123",
+        "obo_tstatistic": "http://purl.obolibrary.org/obo/STATO_0000176",
+        "nidm_contrastName": "http://purl.org/nidash/nidm#NIDM_0000085",
+        "nidm_ContrastEstimation": "http://purl.org/nidash/nidm#NIDM_0000001",
+        "nidm_StatisticMap": "http://purl.org/nidash/nidm#NIDM_0000076",
+        "nidm_errorDegreesOfFreedom": "http://purl.org/nidash/nidm#NIDM_0000093",
+        "nidm_effectDegreesOfFreedom": "http://purl.org/nidash/nidm#NIDM_0000091",
+        "nidm_ContrastMap": "http://purl.org/nidash/nidm#NIDM_0000002",
+        "nidm_ContrastStandardErrorMap": "http://purl.org/nidash/nidm#NIDM_0000013",
+        "obo_statistic": "http://purl.obolibrary.org/obo/STATO_0000039",
+        "nidm_PValueUncorrected": "http://purl.org/nidash/nidm#NIDM_0000160",
+        "obo_FWERadjustedpvalue": "http://purl.obolibrary.org/obo/OBI_0001265",
+        "nidm_HeightThreshold": "http://purl.org/nidash/nidm#NIDM_0000034",
+        "nidm_equivalentThreshold": "http://purl.org/nidash/nidm#NIDM_0000161",
+        "nidm_ExtentThreshold": "http://purl.org/nidash/nidm#NIDM_0000026",
+        "nidm_clusterSizeInVoxels": "http://purl.org/nidash/nidm#NIDM_0000084",
+        "nidm_clusterSizeInResels": "http://purl.org/nidash/nidm#NIDM_0000156",
+        "nidm_PeakDefinitionCriteria": "http://purl.org/nidash/nidm#NIDM_0000063",
+        "nidm_maxNumberOfPeaksPerCluster": "http://purl.org/nidash/nidm#NIDM_0000108",
+        "nidm_minDistanceBetweenPeaks": "http://purl.org/nidash/nidm#NIDM_0000109",
+        "nidm_ClusterDefinitionCriteria": "http://purl.org/nidash/nidm#NIDM_0000007",
+        "nidm_hasConnectivityCriterion": "http://purl.org/nidash/nidm#NIDM_0000099",
+        "nidm_voxel18connected": "http://purl.org/nidash/nidm#NIDM_0000128",
+        "nidm_Inference": "http://purl.org/nidash/nidm#NIDM_0000049",
+        "nidm_hasAlternativeHypothesis": "http://purl.org/nidash/nidm#NIDM_0000097",
+        "nidm_OneTailedTest": "http://purl.org/nidash/nidm#NIDM_0000060",
+        "nidm_SearchSpaceMaskMap": "http://purl.org/nidash/nidm#NIDM_0000068",
+        "nidm_searchVolumeInVoxels": "http://purl.org/nidash/nidm#NIDM_0000121",
+        "nidm_searchVolumeInUnits": "http://purl.org/nidash/nidm#NIDM_0000136",
+        "nidm_reselSizeInVoxels": "http://purl.org/nidash/nidm#NIDM_0000148",
+        "nidm_searchVolumeInResels": "http://purl.org/nidash/nidm#NIDM_0000149",
+        "spm_searchVolumeReselsGeometry": "http://purl.org/nidash/spm#SPM_0000010",
+        "nidm_noiseFWHMInVoxels": "http://purl.org/nidash/nidm#NIDM_0000159",
+        "nidm_noiseFWHMInUnits": "http://purl.org/nidash/nidm#NIDM_0000157",
+        "nidm_randomFieldStationarity": "http://purl.org/nidash/nidm#NIDM_0000120",
+        "nidm_expectedNumberOfVoxelsPerCluster": "http://purl.org/nidash/nidm#NIDM_0000143",
+        "nidm_expectedNumberOfClusters": "http://purl.org/nidash/nidm#NIDM_0000141",
+        "nidm_heightCriticalThresholdFWE05": "http://purl.org/nidash/nidm#NIDM_0000147",
+        "nidm_heightCriticalThresholdFDR05": "http://purl.org/nidash/nidm#NIDM_0000146",
+        "spm_smallestSignificantClusterSizeInVoxelsFWE05": "http://purl.org/nidash/spm#SPM_0000014",
+        "spm_smallestSignificantClusterSizeInVoxelsFDR05": "http://purl.org/nidash/spm#SPM_0000013",
+        "nidm_ExcursionSetMap": "http://purl.org/nidash/nidm#NIDM_0000025",
+        "nidm_numberOfSupraThresholdClusters": "http://purl.org/nidash/nidm#NIDM_0000111",
+        "nidm_pValue": "http://purl.org/nidash/nidm#NIDM_0000114",
+        "nidm_hasClusterLabelsMap": "http://purl.org/nidash/nidm#NIDM_0000098",
+        "nidm_hasMaximumIntensityProjection": "http://purl.org/nidash/nidm#NIDM_0000138",
+        "nidm_ClusterLabelsMap": "http://purl.org/nidash/nidm#NIDM_0000008",
+        "nidm_SupraThresholdCluster": "http://purl.org/nidash/nidm#NIDM_0000070",
+        "nidm_pValueUncorrected": "http://purl.org/nidash/nidm#NIDM_0000116",
+        "nidm_pValueFWER": "http://purl.org/nidash/nidm#NIDM_0000115",
+        "nidm_qValueFDR": "http://purl.org/nidash/nidm#NIDM_0000119",
+        "nidm_clusterLabelId": "http://purl.org/nidash/nidm#NIDM_0000082",
+        "nidm_Peak": "http://purl.org/nidash/nidm#NIDM_0000062",
+        "nidm_equivalentZStatistic": "http://purl.org/nidash/nidm#NIDM_0000092",
+        "nidm_Coordinate": "http://purl.org/nidash/nidm#NIDM_0000015",
+        "nidm_coordinateVector": "http://purl.org/nidash/nidm#NIDM_0000086"
+    },
+    "entity": {
+        "niiri:73f10b52c50aa13993a9f597d9e88831": {
+            "prov:type": {
+                "$": "nidm_CoordinateSpace:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Coordinate space 1",
+                "type": "xsd:string"
+            },
+            "nidm_voxelToWorldMapping:": {
+                "$": "[[-3, 0, 0, 78],[0, 3, 0, -112],[0, 0, 3, -70],[0, 0, 0, 1]]",
+                "type": "xsd:string"
+            },
+            "nidm_voxelUnits:": {
+                "$": "[\"mm\", \"mm\", \"mm\"]",
+                "type": "xsd:string"
+            },
+            "nidm_voxelSize:": {
+                "$": "[3, 3, 3]",
+                "type": "xsd:string"
+            },
+            "nidm_inWorldCoordinateSystem:": {
+                "$": "nidm_Ixi549CoordinateSystem:",
+                "type": "xsd:string"
+            },
+            "nidm_numberOfDimensions:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_dimensionsInVoxels:": {
+                "$": "[53,63,52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1f414ea8a897406413eb2b2efd3d7fb0": {
+            "prov:type": [
+                {
+                "$": "prov:Collection",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Data:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Data",
+                "type": "xsd:string"
+            },
+            "nidm_grandMeanScaling:": {
+                "$": "true",
+                "type": "xsd:boolean"
+            },
+            "nidm_targetIntensity:": {
+                "$": "100",
+                "type": "xsd:float"
+            },
+            "nidm_hasMRIProtocol:": {
+                "$": "nlx_FunctionalMRIprotocol:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:db32db85d971573a6ea64a25cb199cef": {
+            "prov:type": {
+                "$": "spm_DCTDriftModel:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "SPM's DCT Drift Model",
+                "type": "xsd:string"
+            },
+            "spm_SPMsDriftCutoffPeriod:": {
+                "$": "128",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:fe11dc043a6c1e969d626e42eb4b8f47": {
+            "prov:type": {
+                "$": "nidm_DesignMatrix:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "DesignMatrix.csv",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "DesignMatrix.csv",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "text/csv",
+                "type": "xsd:string"
+            },
+            "dc:description": {
+                "$": "niiri:a93cd2d7f08b2c61577d0b847f57fef6",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Design Matrix",
+                "type": "xsd:string"
+            },
+            "nidm_regressorNames:": {
+                "$": "[\"Sn(1) active*bf(1)\", \"Sn(1) constant\"]",
+                "type": "xsd:string"
+            },
+            "nidm_hasDriftModel:": {
+                "$": "niiri:db32db85d971573a6ea64a25cb199cef",
+                "type": "xsd:string"
+            },
+            "nidm_hasHRFBasis:": {
+                "$": "spm_SPMsCanonicalHRF:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a93cd2d7f08b2c61577d0b847f57fef6": {
+            "prov:type": {
+                "$": "dctype:Image",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "DesignMatrix.png",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "DesignMatrix.png",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/png",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ff5c473a8265e68dcc2fc87339f3f003": {
+            "prov:type": {
+                "$": "nidm_ErrorModel:",
+                "type": "xsd:QName"
+            },
+            "nidm_hasErrorDistribution:": {
+                "$": "obo_normaldistribution:",
+                "type": "xsd:string"
+            },
+            "nidm_hasErrorDependence:": {
+                "$": "obo_Toeplitzcovariancestructure:",
+                "type": "xsd:string"
+            },
+            "nidm_dependenceMapWiseDependence:": {
+                "$": "nidm_ConstantParameter:",
+                "type": "xsd:string"
+            },
+            "nidm_errorVarianceHomogeneous:": {
+                "$": "true",
+                "type": "xsd:boolean"
+            },
+            "nidm_varianceMapWiseDependence:": {
+                "$": "nidm_IndependentParameter:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:dfeb3a541e545f7225c8a300f30f9db2": {
+            "prov:type": {
+                "$": "nidm_MaskMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "Mask.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nidm_isUserDefined:": {
+                "$": "false",
+                "type": "xsd:boolean"
+            },
+            "nfo:fileName": {
+                "$": "Mask.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Mask",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:73f10b52c50aa13993a9f597d9e88831",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "932fd9f0d55e9822748f4a9b35a0a7f0fe442f3e061e2eda48c2617a2938df50ea84deca8de0725641a0105b712a80a0c8931df9bdf3bef788b1041379d00875",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:aac954ca0b079b63bea50212e7bee7ba": {
+            "prov:type": {
+                "$": "nidm_MaskMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "mask.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "fbc254cab29db5532feccce554ec9d3c845197eca9013ec9f0efd5d8d56e3aa008ccee4038fb3651d30447fa0f316938b07c3ad961b623458dcd9b46968a8e11",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8435b87aba3543459a1877c94a7e8585": {
+            "prov:type": {
+                "$": "nidm_GrandMeanMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "GrandMean.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "GrandMean.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Grand Mean Map",
+                "type": "xsd:string"
+            },
+            "nidm_maskedMedian:": {
+                "$": "132.008995056152",
+                "type": "xsd:float"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:73f10b52c50aa13993a9f597d9e88831",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "4d3528031bce4a9c1b994b8124e6e0eddb9df90b49c84787652ed94df8c14c04ec92100a2d8ea86a8df24ba44617aca7457ddcb2f42253fc17e33296a1aea1cb",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:bfa48106876dd53a099a744977604cb9": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0001.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0001.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 1",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:73f10b52c50aa13993a9f597d9e88831",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "fab2573099693215bac756bc796fbc983524473dec5c1b2d66fb83694c17412731df7f574094cb6c4a77994af7be11ed9aa545090fbe8ec6565a5c3c3dae8f0f",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:84bf7182b1084033459773520496afba": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0001.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "fab2573099693215bac756bc796fbc983524473dec5c1b2d66fb83694c17412731df7f574094cb6c4a77994af7be11ed9aa545090fbe8ec6565a5c3c3dae8f0f",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:67a2055bd991bd22b5c0f8dbe2a9c324": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0002.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0002.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 2",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:73f10b52c50aa13993a9f597d9e88831",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "3f72b788762d9ab2c7ddb5e4d446872694ee42fc8897fe5317b54efb7924f784da6499065db897a49595d8763d1893ad65ad102b0c88f2e72e2d028173343008",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a29b3712891a7c91662d78dcf924770e": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0002.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "3f72b788762d9ab2c7ddb5e4d446872694ee42fc8897fe5317b54efb7924f784da6499065db897a49595d8763d1893ad65ad102b0c88f2e72e2d028173343008",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f0e51dd36c2dde61a8716db91b41826b": {
+            "prov:type": {
+                "$": "nidm_ResidualMeanSquaresMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ResidualMeanSquares.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ResidualMeanSquares.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Residual Mean Squares Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:73f10b52c50aa13993a9f597d9e88831",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "84cd0e608b8763307a1166b88761291e552838d85b58334a69a286060f6489a3b0929a940c3ccac883803455118787ea32e0bb5a6d236a5d6e9e8b6a9f918a6b",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:61f53db486ef78ea9054e7c459c5d1a1": {
+            "prov:type": {
+                "$": "nidm_ResidualMeanSquaresMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "ResMS.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "1635e0ae420cac1b5989fbc753b95f504dd957ff2986367fc4cd13ff35c44b4ee60994a9cdcab93a7d247fc5a8decb7578fa4c553b0ac905af8c7041db9b4acd",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:63385fd67b9326e0111faaab4107d5ed": {
+            "prov:type": {
+                "$": "nidm_ReselsPerVoxelMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ReselsPerVoxel.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ReselsPerVoxel.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Resels per Voxel Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:73f10b52c50aa13993a9f597d9e88831",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "2025dc6c33708b80708c2eba3215fb1149df236fb558a8e8f8f6cf34595fb54734fe5e436db3e192a424d99699dd7feb2f4a9020ceae8e7bcbd881b17825256a",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5995ef582e48e154eb1cca107d569d57": {
+            "prov:type": {
+                "$": "nidm_ReselsPerVoxelMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "RPV.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "963283cdde607c40e4640c27453867bd0d70133b6d61482933862487c0f4a5acdb2e338a12a2605ee044b1aa47b5717f0c520b90ed3c49b5227f0483bd48512d",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ad993e5ce29359b726f88b74782271d5": {
+            "prov:type": {
+                "$": "obo_contrastweightmatrix:",
+                "type": "xsd:QName"
+            },
+            "nidm_statisticType:": {
+                "$": "obo_tstatistic:",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "passive listening > rest",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast: passive listening > rest",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "[1, 0]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:888e17582e5ef7a041d17c7887c474e9": {
+            "prov:type": {
+                "$": "nidm_StatisticMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "TStatistic.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "TStatistic.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "T-Statistic Map: passive listening > rest",
+                "type": "xsd:string"
+            },
+            "nidm_statisticType:": {
+                "$": "obo_tstatistic:",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "passive listening > rest",
+                "type": "xsd:string"
+            },
+            "nidm_errorDegreesOfFreedom:": {
+                "$": "83.9999999999599",
+                "type": "xsd:float"
+            },
+            "nidm_effectDegreesOfFreedom:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:73f10b52c50aa13993a9f597d9e88831",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "799e9bbf8c15b35c0098bca468846bf2cd895a3366382b5ceaa953f1e9e576955341a7c86e13e6fe9359da4ff1496a609f55ce9ecff8da2e461365372f2506d6",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2b0c1f2512d0af899ea7a06f8b4dd084": {
+            "prov:type": {
+                "$": "nidm_StatisticMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "spmT_0001.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "55951f31f0ede7e88eca5cd4793df3f630aba21bc90fb81e3695db060c7d4c0b0ccf0b51fd8958c32ea3253d3122e9b31a54262bf910f8b5b646054ceb9a5825",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d8ec29b24e8671e380233ea9903cdbd2": {
+            "prov:type": {
+                "$": "nidm_ContrastMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "Contrast.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "Contrast.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast Map: passive listening > rest",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "passive listening > rest",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:73f10b52c50aa13993a9f597d9e88831",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "f0720b732aaf19c2ec42d0469f8308beb3aa978baf65c7dce6476a0d8e5b2f38c4fa9609f045a536678440feebce9a047e3bd6d59fdb8fb64baae058690bbda2",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a9e27a34caba1fd226510284df275d61": {
+            "prov:type": {
+                "$": "nidm_ContrastMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "con_0001.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "277dd1da13d391c33c172fb8c71060008cc66e173de6362eb857b0055b41e9bae57911f7ec4b45659905103b1139ebf3da0c2d04cf105bbce0cdc3004b643c22",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7d5475358da5e5e3fa6b0096d3322086": {
+            "prov:type": {
+                "$": "nidm_ContrastStandardErrorMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ContrastStandardError.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ContrastStandardError.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast Standard Error Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:73f10b52c50aa13993a9f597d9e88831",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "f4e3616579fe8b0812469409b1501e391bb17ca6e364f37d622b37fa9014cf1dd89befece07e73cf5bca5b3116f55ac4496751ca990db85e8377001a4be941b2",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:862fba010ccafbd94fca48544924ba80": {
+            "prov:type": [
+                {
+                "$": "nidm_HeightThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_FWERadjustedpvalue:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Height Threshold: p<0.050000 (FWE)",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "0.0499999999999976",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentThreshold:": [
+                {
+                "$": "niiri:c57807f0245de6c859bb9e20aeeba886",
+                "type": "xsd:string"
+                },
+                {
+                "$": "niiri:e31ef4cef3ce8c113074abc8ce03f836",
+                "type": "xsd:string"
+                }
+            ]
+        },
+        "niiri:c57807f0245de6c859bb9e20aeeba886": {
+            "prov:type": [
+                {
+                "$": "nidm_HeightThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_statistic:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Height Threshold: T=4.852417)",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.85241745689539",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e31ef4cef3ce8c113074abc8ce03f836": {
+            "prov:type": [
+                {
+                "$": "nidm_HeightThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_PValueUncorrected:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Height Threshold: p<0.000003 (unc.)",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.7772578456986e-06",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:2fc9252193ebe1e0c873e2913da2ce6d": {
+            "prov:type": [
+                {
+                "$": "nidm_ExtentThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_statistic:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Extent Threshold: k>=0",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "0",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentThreshold:": [
+                {
+                "$": "niiri:c7a17a77e954fd65195df87a97677960",
+                "type": "xsd:string"
+                },
+                {
+                "$": "niiri:6ed89a2da946cac0366979695a5e6c6a",
+                "type": "xsd:string"
+                }
+            ]
+        },
+        "niiri:c7a17a77e954fd65195df87a97677960": {
+            "prov:type": [
+                {
+                "$": "nidm_ExtentThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_FWERadjustedpvalue:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Extent Threshold",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6ed89a2da946cac0366979695a5e6c6a": {
+            "prov:type": [
+                {
+                "$": "nidm_ExtentThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_PValueUncorrected:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Extent Threshold",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:bc857ecd2ddb63a671ab7c93208e389e": {
+            "prov:type": {
+                "$": "nidm_PeakDefinitionCriteria:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak Definition Criteria",
+                "type": "xsd:string"
+            },
+            "nidm_maxNumberOfPeaksPerCluster:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_minDistanceBetweenPeaks:": {
+                "$": "8",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:41bb616145da910a5db5521ca68d87d5": {
+            "prov:type": {
+                "$": "nidm_ClusterDefinitionCriteria:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Cluster Connectivity Criterion: 18",
+                "type": "xsd:string"
+            },
+            "nidm_hasConnectivityCriterion:": {
+                "$": "nidm_voxel18connected:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0955e8a851b6e4bb57177bb79d663a90": {
+            "prov:type": {
+                "$": "nidm_SearchSpaceMaskMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "SearchSpaceMask.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "SearchSpaceMask.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Search Space Mask Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:73f10b52c50aa13993a9f597d9e88831",
+                "type": "xsd:string"
+            },
+            "nidm_searchVolumeInVoxels:": {
+                "$": "69306",
+                "type": "xsd:int"
+            },
+            "nidm_searchVolumeInUnits:": {
+                "$": "1871262",
+                "type": "xsd:float"
+            },
+            "nidm_reselSizeInVoxels:": {
+                "$": "132.907586178202",
+                "type": "xsd:float"
+            },
+            "nidm_searchVolumeInResels:": {
+                "$": "467.07642343881",
+                "type": "xsd:float"
+            },
+            "spm_searchVolumeReselsGeometry:": {
+                "$": "[7, 42.96312274763, 269.40914815306, 467.07642343881]",
+                "type": "xsd:string"
+            },
+            "nidm_noiseFWHMInVoxels:": {
+                "$": "[5.41278985910694, 5.43638957240286, 4.51666658877481]",
+                "type": "xsd:string"
+            },
+            "nidm_noiseFWHMInUnits:": {
+                "$": "[16.2383695773208, 16.3091687172086, 13.5499997663244]",
+                "type": "xsd:string"
+            },
+            "nidm_randomFieldStationarity:": {
+                "$": "true",
+                "type": "xsd:boolean"
+            },
+            "nidm_expectedNumberOfVoxelsPerCluster:": {
+                "$": "4.02834655908613",
+                "type": "xsd:float"
+            },
+            "nidm_expectedNumberOfClusters:": {
+                "$": "0.0512932943875478",
+                "type": "xsd:float"
+            },
+            "nidm_heightCriticalThresholdFWE05:": {
+                "$": "4.85241745689539",
+                "type": "xsd:float"
+            },
+            "nidm_heightCriticalThresholdFDR05:": {
+                "$": "5.7639536857605",
+                "type": "xsd:float"
+            },
+            "crypto:sha512": {
+                "$": "932fd9f0d55e9822748f4a9b35a0a7f0fe442f3e061e2eda48c2617a2938df50ea84deca8de0725641a0105b712a80a0c8931df9bdf3bef788b1041379d00875",
+                "type": "xsd:string"
+            },
+            "spm_smallestSignificantClusterSizeInVoxelsFWE05:": {
+                "$": "12",
+                "type": "xsd:int"
+            },
+            "spm_smallestSignificantClusterSizeInVoxelsFDR05:": {
+                "$": "29",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:1ce7383d07b62dfc72f11d00c27a9fa5": {
+            "prov:type": {
+                "$": "nidm_ExcursionSetMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ExcursionSet.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ExcursionSet.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Excursion Set Map",
+                "type": "xsd:string"
+            },
+            "nidm_numberOfSupraThresholdClusters:": {
+                "$": "5",
+                "type": "xsd:int"
+            },
+            "nidm_pValue:": {
+                "$": "2.83510681597932e-09",
+                "type": "xsd:float"
+            },
+            "nidm_hasClusterLabelsMap:": {
+                "$": "niiri:f3cce8b8925dba2ba5a72db44eb47dbf",
+                "type": "xsd:string"
+            },
+            "nidm_hasMaximumIntensityProjection:": {
+                "$": "niiri:c5d717db4ccc4350e7c44ba38c293f7d",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:73f10b52c50aa13993a9f597d9e88831",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "d96b82761c299a66978893cab6034f3f8aed25d0a135636b0ffe79f4cf11becce86ba261f7aeb43717f5d0e47ad0b14cfb0402786251e3f2c507890c83b27652",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f3cce8b8925dba2ba5a72db44eb47dbf": {
+            "prov:type": {
+                "$": "nidm_ClusterLabelsMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ClusterLabels.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ClusterLabels.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Cluster Labels Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:73f10b52c50aa13993a9f597d9e88831",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "a132bb284da461fd9e20eb2986373a9171c90a342c1e694297bc02f5674a311a560b7ff34bdf045dc191d4afff8c690a373db6408c1fe93f7c25e23707ce65c3",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c5d717db4ccc4350e7c44ba38c293f7d": {
+            "prov:type": {
+                "$": "dctype:Image",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "MaximumIntensityProjection.png",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "MaximumIntensityProjection.png",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/png",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:02e9a33d08e23de77904e468485cf047": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0001",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "839",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "6.31265696809113",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.55896824480477e-19",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1.77948412240239e-18",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "1",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:d1701492186c7811850274355c9a5da3": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0002",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "695",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "5.22919736927692",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.34280282632073e-17",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1.33570070658018e-16",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "2",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:88442be7736ad5eec0053052bd6e0179": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0003",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "37",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.278388924695318",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00497953247554004",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.000255384009130943",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00829922079256674",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "3",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:98d0b221eadccb2110d30e7f996a11e7": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0004",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "29",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.218196724761195",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0110257032104773",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.000565384750377596",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0137821290130967",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "4",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:1a862c5b84ba646d826413c480f4d010": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0005",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "12",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0902882999011843",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0818393184514307",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00418900977248904",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0818393184514307",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "5",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:ca8b66656ab798a1f5a045766f5d41de": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0001",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a8598038ca4a8b33b2dfe04f95b6c161",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "17.5207633972168",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "INF",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.44089209850063e-16",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1.19156591713838e-11",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a8598038ca4a8b33b2dfe04f95b6c161": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0001",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-60,-25,11]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:414ba670c5dcea4f3bd8bc915e88466a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0002",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:5acdd0ceb3ce5a5c9c75a1a17d22ca5f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "13.0321407318115",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "INF",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.44089209850063e-16",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1.19156591713838e-11",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:5acdd0ceb3ce5a5c9c75a1a17d22ca5f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0002",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-42,-31,11]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:aa8942e5b5f535f75dd2e80da17f1546": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0003",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e6c5a00711416271b141558c1bd92e4b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "10.2856016159058",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "INF",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.44089209850063e-16",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "7.69451169446711e-12",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "6.84121260274992e-10",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e6c5a00711416271b141558c1bd92e4b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0003",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-66,-31,-1]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:90126f11793e8554f08eb9473d5ae15c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0004",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0cc8e87d27467eefcceb101b56a19c68",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "13.5425577163696",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "INF",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.44089209850063e-16",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1.19156591713838e-11",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0cc8e87d27467eefcceb101b56a19c68": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0004",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[63,-13,-4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6e9b5798a110211eece6cd9bf78afa51": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0005",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:1b918485e2cbed73d8ac005a27a82891",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "12.4728717803955",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "INF",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.44089209850063e-16",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1.19156591713838e-11",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:1b918485e2cbed73d8ac005a27a82891": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0005",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[60,-22,11]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:13169f43d43dcd28f4ac0a37a5dfa9b0": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0006",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:37f49ee5dac306c833b0b6456603dd74",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "9.72103404998779",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "INF",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.22124532708767e-15",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "6.9250605250204e-11",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "6.52169693024352e-09",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:37f49ee5dac306c833b0b6456603dd74": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0006",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[57,-40,5]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:819979d305d01b9553c2bfc1398b4de8": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0007",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c19b896ff31dce4bf576fe98821aba9c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.55745935440063",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.87574033699266",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.10478867668229e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "9.17574302586877e-05",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00257605396646668",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c19b896ff31dce4bf576fe98821aba9c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0007",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[36,-28,-13]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9f9f4589c34e65f926a7491d59f7ae39": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0008",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:16adab65d227da691d1b032641f99620",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.19558477401733",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.60645028016544",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.0325913235576e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.000382453907303626",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00949154522981781",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:16adab65d227da691d1b032641f99620": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0008",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-33,-31,-16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:da9faeb078561ebedea50e462541e026": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0009",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:9658e1ec0692c07fb609a32b3b3e4074",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.27320194244385",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.88682085490477",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.12386299833523e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0119099090973821",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.251554254717758",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:9658e1ec0692c07fb609a32b3b3e4074": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0009",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[45,-40,32]",
+                "type": "xsd:string"
+            }
+        }
+    },
+    "activity": {
+        "niiri:2d8e016d2b75897ce56e33b9a1544133": {
+            "prov:type": {
+                "$": "nidm_ModelParametersEstimation:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Model parameters estimation",
+                "type": "xsd:string"
+            },
+            "nidm_withEstimationMethod:": {
+                "$": "obo_generalizedleastsquaresestimation:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7a7c5806a1c15500776e7dedfe9f2000": {
+            "prov:type": {
+                "$": "nidm_ContrastEstimation:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Contrast estimation",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7b79810a033a150be8ea7667379a6e2c": {
+            "prov:type": {
+                "$": "nidm_Inference:",
+                "type": "xsd:QName"
+            },
+            "nidm_hasAlternativeHypothesis:": {
+                "$": "nidm_OneTailedTest:",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Inference",
+                "type": "xsd:string"
+            }
+        }
+    },
+    "agent": {
+        "niiri:aaaa36fcdc37bd70a89714f4c1960753": {
+            "prov:type": [
+                {
+                "$": "src_SPM:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "prov:SoftwareAgent",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "SPM",
+                "type": "xsd:string"
+            },
+            "nidm_softwareVersion:": {
+                "$": "12.6906",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:37399a6aa2ebbc88c58d24169b06a31d": {
+            "prov:type": [
+                {
+                "$": "nlx_Imaginginstrument:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nlx_Magneticresonanceimagingscanner:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "MRI Scanner",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:deb0b682f2b130535875fcdc150f94a0": {
+            "prov:type": {
+                "$": "prov:Person",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Person",
+                "type": "xsd:string"
+            }
+        }
+    },
+    "wasGeneratedBy": {
+        "_:wGB20": {
+            "prov:entity": "niiri:dfeb3a541e545f7225c8a300f30f9db2",
+            "prov:activity": "niiri:2d8e016d2b75897ce56e33b9a1544133"
+        },
+        "_:wGB22": {
+            "prov:entity": "niiri:8435b87aba3543459a1877c94a7e8585",
+            "prov:activity": "niiri:2d8e016d2b75897ce56e33b9a1544133"
+        },
+        "_:wGB26": {
+            "prov:entity": "niiri:bfa48106876dd53a099a744977604cb9",
+            "prov:activity": "niiri:2d8e016d2b75897ce56e33b9a1544133"
+        },
+        "_:wGB30": {
+            "prov:entity": "niiri:67a2055bd991bd22b5c0f8dbe2a9c324",
+            "prov:activity": "niiri:2d8e016d2b75897ce56e33b9a1544133"
+        },
+        "_:wGB34": {
+            "prov:entity": "niiri:f0e51dd36c2dde61a8716db91b41826b",
+            "prov:activity": "niiri:2d8e016d2b75897ce56e33b9a1544133"
+        },
+        "_:wGB38": {
+            "prov:entity": "niiri:63385fd67b9326e0111faaab4107d5ed",
+            "prov:activity": "niiri:2d8e016d2b75897ce56e33b9a1544133"
+        },
+        "_:wGB51": {
+            "prov:entity": "niiri:888e17582e5ef7a041d17c7887c474e9",
+            "prov:activity": "niiri:7a7c5806a1c15500776e7dedfe9f2000"
+        },
+        "_:wGB55": {
+            "prov:entity": "niiri:d8ec29b24e8671e380233ea9903cdbd2",
+            "prov:activity": "niiri:7a7c5806a1c15500776e7dedfe9f2000"
+        },
+        "_:wGB57": {
+            "prov:entity": "niiri:7d5475358da5e5e3fa6b0096d3322086",
+            "prov:activity": "niiri:7a7c5806a1c15500776e7dedfe9f2000"
+        },
+        "_:wGB76": {
+            "prov:entity": "niiri:0955e8a851b6e4bb57177bb79d663a90",
+            "prov:activity": "niiri:7b79810a033a150be8ea7667379a6e2c"
+        },
+        "_:wGB80": {
+            "prov:entity": "niiri:1ce7383d07b62dfc72f11d00c27a9fa5",
+            "prov:activity": "niiri:7b79810a033a150be8ea7667379a6e2c"
+        }
+    },
+    "used": {
+        "_:u14": {
+            "prov:activity": "niiri:2d8e016d2b75897ce56e33b9a1544133",
+            "prov:entity": "niiri:fe11dc043a6c1e969d626e42eb4b8f47"
+        },
+        "_:u15": {
+            "prov:activity": "niiri:2d8e016d2b75897ce56e33b9a1544133",
+            "prov:entity": "niiri:1f414ea8a897406413eb2b2efd3d7fb0"
+        },
+        "_:u16": {
+            "prov:activity": "niiri:2d8e016d2b75897ce56e33b9a1544133",
+            "prov:entity": "niiri:ff5c473a8265e68dcc2fc87339f3f003"
+        },
+        "_:u42": {
+            "prov:activity": "niiri:7a7c5806a1c15500776e7dedfe9f2000",
+            "prov:entity": "niiri:dfeb3a541e545f7225c8a300f30f9db2"
+        },
+        "_:u43": {
+            "prov:activity": "niiri:7a7c5806a1c15500776e7dedfe9f2000",
+            "prov:entity": "niiri:f0e51dd36c2dde61a8716db91b41826b"
+        },
+        "_:u44": {
+            "prov:activity": "niiri:7a7c5806a1c15500776e7dedfe9f2000",
+            "prov:entity": "niiri:fe11dc043a6c1e969d626e42eb4b8f47"
+        },
+        "_:u45": {
+            "prov:activity": "niiri:7a7c5806a1c15500776e7dedfe9f2000",
+            "prov:entity": "niiri:ad993e5ce29359b726f88b74782271d5"
+        },
+        "_:u46": {
+            "prov:activity": "niiri:7a7c5806a1c15500776e7dedfe9f2000",
+            "prov:entity": "niiri:bfa48106876dd53a099a744977604cb9"
+        },
+        "_:u47": {
+            "prov:activity": "niiri:7a7c5806a1c15500776e7dedfe9f2000",
+            "prov:entity": "niiri:67a2055bd991bd22b5c0f8dbe2a9c324"
+        },
+        "_:u68": {
+            "prov:activity": "niiri:7b79810a033a150be8ea7667379a6e2c",
+            "prov:entity": "niiri:862fba010ccafbd94fca48544924ba80"
+        },
+        "_:u69": {
+            "prov:activity": "niiri:7b79810a033a150be8ea7667379a6e2c",
+            "prov:entity": "niiri:2fc9252193ebe1e0c873e2913da2ce6d"
+        },
+        "_:u70": {
+            "prov:activity": "niiri:7b79810a033a150be8ea7667379a6e2c",
+            "prov:entity": "niiri:888e17582e5ef7a041d17c7887c474e9"
+        },
+        "_:u71": {
+            "prov:activity": "niiri:7b79810a033a150be8ea7667379a6e2c",
+            "prov:entity": "niiri:63385fd67b9326e0111faaab4107d5ed"
+        },
+        "_:u72": {
+            "prov:activity": "niiri:7b79810a033a150be8ea7667379a6e2c",
+            "prov:entity": "niiri:dfeb3a541e545f7225c8a300f30f9db2"
+        },
+        "_:u73": {
+            "prov:activity": "niiri:7b79810a033a150be8ea7667379a6e2c",
+            "prov:entity": "niiri:bc857ecd2ddb63a671ab7c93208e389e"
+        },
+        "_:u74": {
+            "prov:activity": "niiri:7b79810a033a150be8ea7667379a6e2c",
+            "prov:entity": "niiri:41bb616145da910a5db5521ca68d87d5"
+        }
+    },
+    "wasDerivedFrom": {
+        "_:wDF19": {
+            "prov:generatedEntity": "niiri:dfeb3a541e545f7225c8a300f30f9db2",
+            "prov:usedEntity": "niiri:aac954ca0b079b63bea50212e7bee7ba"
+        },
+        "_:wDF25": {
+            "prov:generatedEntity": "niiri:bfa48106876dd53a099a744977604cb9",
+            "prov:usedEntity": "niiri:84bf7182b1084033459773520496afba"
+        },
+        "_:wDF29": {
+            "prov:generatedEntity": "niiri:67a2055bd991bd22b5c0f8dbe2a9c324",
+            "prov:usedEntity": "niiri:a29b3712891a7c91662d78dcf924770e"
+        },
+        "_:wDF33": {
+            "prov:generatedEntity": "niiri:f0e51dd36c2dde61a8716db91b41826b",
+            "prov:usedEntity": "niiri:61f53db486ef78ea9054e7c459c5d1a1"
+        },
+        "_:wDF37": {
+            "prov:generatedEntity": "niiri:63385fd67b9326e0111faaab4107d5ed",
+            "prov:usedEntity": "niiri:5995ef582e48e154eb1cca107d569d57"
+        },
+        "_:wDF50": {
+            "prov:generatedEntity": "niiri:888e17582e5ef7a041d17c7887c474e9",
+            "prov:usedEntity": "niiri:2b0c1f2512d0af899ea7a06f8b4dd084"
+        },
+        "_:wDF54": {
+            "prov:generatedEntity": "niiri:d8ec29b24e8671e380233ea9903cdbd2",
+            "prov:usedEntity": "niiri:a9e27a34caba1fd226510284df275d61"
+        },
+        "_:wDF82": {
+            "prov:generatedEntity": "niiri:02e9a33d08e23de77904e468485cf047",
+            "prov:usedEntity": "niiri:1ce7383d07b62dfc72f11d00c27a9fa5"
+        },
+        "_:wDF84": {
+            "prov:generatedEntity": "niiri:d1701492186c7811850274355c9a5da3",
+            "prov:usedEntity": "niiri:1ce7383d07b62dfc72f11d00c27a9fa5"
+        },
+        "_:wDF86": {
+            "prov:generatedEntity": "niiri:88442be7736ad5eec0053052bd6e0179",
+            "prov:usedEntity": "niiri:1ce7383d07b62dfc72f11d00c27a9fa5"
+        },
+        "_:wDF88": {
+            "prov:generatedEntity": "niiri:98d0b221eadccb2110d30e7f996a11e7",
+            "prov:usedEntity": "niiri:1ce7383d07b62dfc72f11d00c27a9fa5"
+        },
+        "_:wDF90": {
+            "prov:generatedEntity": "niiri:1a862c5b84ba646d826413c480f4d010",
+            "prov:usedEntity": "niiri:1ce7383d07b62dfc72f11d00c27a9fa5"
+        },
+        "_:wDF93": {
+            "prov:generatedEntity": "niiri:ca8b66656ab798a1f5a045766f5d41de",
+            "prov:usedEntity": "niiri:02e9a33d08e23de77904e468485cf047"
+        },
+        "_:wDF96": {
+            "prov:generatedEntity": "niiri:414ba670c5dcea4f3bd8bc915e88466a",
+            "prov:usedEntity": "niiri:02e9a33d08e23de77904e468485cf047"
+        },
+        "_:wDF99": {
+            "prov:generatedEntity": "niiri:aa8942e5b5f535f75dd2e80da17f1546",
+            "prov:usedEntity": "niiri:02e9a33d08e23de77904e468485cf047"
+        },
+        "_:wDF102": {
+            "prov:generatedEntity": "niiri:90126f11793e8554f08eb9473d5ae15c",
+            "prov:usedEntity": "niiri:d1701492186c7811850274355c9a5da3"
+        },
+        "_:wDF105": {
+            "prov:generatedEntity": "niiri:6e9b5798a110211eece6cd9bf78afa51",
+            "prov:usedEntity": "niiri:d1701492186c7811850274355c9a5da3"
+        },
+        "_:wDF108": {
+            "prov:generatedEntity": "niiri:13169f43d43dcd28f4ac0a37a5dfa9b0",
+            "prov:usedEntity": "niiri:d1701492186c7811850274355c9a5da3"
+        },
+        "_:wDF111": {
+            "prov:generatedEntity": "niiri:819979d305d01b9553c2bfc1398b4de8",
+            "prov:usedEntity": "niiri:88442be7736ad5eec0053052bd6e0179"
+        },
+        "_:wDF114": {
+            "prov:generatedEntity": "niiri:9f9f4589c34e65f926a7491d59f7ae39",
+            "prov:usedEntity": "niiri:98d0b221eadccb2110d30e7f996a11e7"
+        },
+        "_:wDF117": {
+            "prov:generatedEntity": "niiri:da9faeb078561ebedea50e462541e026",
+            "prov:usedEntity": "niiri:1a862c5b84ba646d826413c480f4d010"
+        }
+    },
+    "wasAttributedTo": {
+        "_:wAT6": {
+            "prov:entity": "niiri:1f414ea8a897406413eb2b2efd3d7fb0",
+            "prov:agent": "niiri:37399a6aa2ebbc88c58d24169b06a31d"
+        },
+        "_:wAT7": {
+            "prov:entity": "niiri:1f414ea8a897406413eb2b2efd3d7fb0",
+            "prov:agent": "niiri:deb0b682f2b130535875fcdc150f94a0"
+        }
+    },
+    "wasAssociatedWith": {
+        "_:wAW13": {
+            "prov:activity": "niiri:2d8e016d2b75897ce56e33b9a1544133",
+            "prov:agent": "niiri:aaaa36fcdc37bd70a89714f4c1960753"
+        },
+        "_:wAW41": {
+            "prov:activity": "niiri:7a7c5806a1c15500776e7dedfe9f2000",
+            "prov:agent": "niiri:aaaa36fcdc37bd70a89714f4c1960753"
+        },
+        "_:wAW67": {
+            "prov:activity": "niiri:7b79810a033a150be8ea7667379a6e2c",
+            "prov:agent": "niiri:aaaa36fcdc37bd70a89714f4c1960753"
+        }
+    }
+    }
+  }
+}

--- a/spmexport/ex_spm_full_example001/nidm.jsonld
+++ b/spmexport/ex_spm_full_example001/nidm.jsonld
@@ -7,7 +7,7 @@
       "niiri": "http://iri.nidash.org/",
       "spm": "http://purl.org/nidash/spm#",
       "neurolex": "http://neurolex.org/wiki/",
-      "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#",
+      "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/",
       "dct": "http://purl.org/dc/terms/",
       "nfo": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#",
       "dc": "http://purl.org/dc/elements/1.1/",
@@ -22,32 +22,32 @@
   ],
   "@graph": [
     {
-      "@id": "niiri:ffde54b8300d0af851eff95e567bab5e",
-      "@type": ["prov:Entity","prov:Bundle","nidm_NIDMResults:"],
+      "@id": "niiri:e6d0f6a78cb1543128178c286ffb18bd",
+      "@type": ["prov:Entity","prov:Bundle","nidm_NIDMResults"],
       "rdfs:label": "NIDM-Results",
-      "nidm_version:": {"@type": "xsd:string", "@value": "1.3.0"}
+      "nidm_version": {"@type": "xsd:string", "@value": "1.3.0"}
     },
     {
-      "@id": "niiri:d6d9b4d58e2e51d60f74ddb191b6a539",
-      "@type": ["prov:Agent","nidm_spm_results_nidm:","prov:SoftwareAgent"],
+      "@id": "niiri:7e0c67dffe4faa56a4221c32e8fd8f48",
+      "@type": ["prov:Agent","nidm_spm_results_nidm","prov:SoftwareAgent"],
       "rdfs:label": "spm_results_nidm",
-      "nidm_softwareVersion:": {"@type": "xsd:string", "@value": "12.6903"}
+      "nidm_softwareVersion": {"@type": "xsd:string", "@value": "12.7057"}
     },
     {
-      "@id": "niiri:9c7d0b07a7251a00c9fd3e2b61c62efc",
-      "@type": ["prov:Activity","nidm_NIDMResultsExport:"],
+      "@id": "niiri:4c804d9f1544750b14cad90f7ca97316",
+      "@type": ["prov:Activity","nidm_NIDMResultsExport"],
       "rdfs:label": "NIDM-Results export"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:9c7d0b07a7251a00c9fd3e2b61c62efc",
-      "agent": "niiri:d6d9b4d58e2e51d60f74ddb191b6a539"
+      "activity_associated": "niiri:4c804d9f1544750b14cad90f7ca97316",
+      "agent": "niiri:7e0c67dffe4faa56a4221c32e8fd8f48"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:ffde54b8300d0af851eff95e567bab5e",
-      "activity": "niiri:9c7d0b07a7251a00c9fd3e2b61c62efc",
-      "atTime": "2016-12-07T16:08:27"
+      "entity_generated": "niiri:e6d0f6a78cb1543128178c286ffb18bd",
+      "activity": "niiri:4c804d9f1544750b14cad90f7ca97316",
+      "atTime": "2017-04-19T12:18:07"
     }
   ]
 },
@@ -158,540 +158,540 @@
       "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
     }
   ],
-  "@id": "niiri:ffde54b8300d0af851eff95e567bab5e",
+  "@id": "niiri:e6d0f6a78cb1543128178c286ffb18bd",
   "@graph": [
     {
-      "@id": "niiri:91a414225d56ee8a5a96d24be371a382",
-      "@type": ["prov:Agent","src_SPM:","prov:SoftwareAgent"],
+      "@id": "niiri:aaaa36fcdc37bd70a89714f4c1960753",
+      "@type": ["prov:Agent","src_SPM","prov:SoftwareAgent"],
       "rdfs:label": "SPM",
-      "nidm_softwareVersion:": {"@type": "xsd:string", "@value": "12.12.2"}
+      "nidm_softwareVersion": {"@type": "xsd:string", "@value": "12.6906"}
     },
     {
-      "@id": "niiri:f4860b5b14f96d2ce160d4f47ba40b97",
-      "@type": ["prov:Entity","nidm_CoordinateSpace:"],
+      "@id": "niiri:73f10b52c50aa13993a9f597d9e88831",
+      "@type": ["prov:Entity","nidm_CoordinateSpace"],
       "rdfs:label": "Coordinate space 1",
-      "nidm_voxelToWorldMapping:": {"@type": "xsd:string", "@value": "[[-3, 0, 0, 78],[0, 3, 0, -112],[0, 0, 3, -70],[0, 0, 0, 1]]"},
-      "nidm_voxelUnits:": {"@type": "xsd:string", "@value": "[\"mm\", \"mm\", \"mm\"]"},
-      "nidm_voxelSize:": {"@type": "xsd:string", "@value": "[3, 3, 3]"},
-      "nidm_inWorldCoordinateSystem:": {"@id": "nidm_Ixi549CoordinateSystem:"},
-      "nidm_numberOfDimensions:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_dimensionsInVoxels:": {"@type": "xsd:string", "@value": "[53,63,52]"}
+      "nidm_voxelToWorldMapping": {"@type": "xsd:string", "@value": "[[-3, 0, 0, 78],[0, 3, 0, -112],[0, 0, 3, -70],[0, 0, 0, 1]]"},
+      "nidm_voxelUnits": {"@type": "xsd:string", "@value": "[\"mm\", \"mm\", \"mm\"]"},
+      "nidm_voxelSize": {"@type": "xsd:string", "@value": "[3, 3, 3]"},
+      "nidm_inWorldCoordinateSystem": {"@id": "nidm_Ixi549CoordinateSystem"},
+      "nidm_numberOfDimensions": {"@type": "xsd:int", "@value": "3"},
+      "nidm_dimensionsInVoxels": {"@type": "xsd:string", "@value": "[53,63,52]"}
     },
     {
-      "@id": "niiri:ad09a5645f9232d32623e075e5fd845d",
-      "@type": ["prov:Agent","nlx_Imaginginstrument:","nlx_Magneticresonanceimagingscanner:"],
+      "@id": "niiri:37399a6aa2ebbc88c58d24169b06a31d",
+      "@type": ["prov:Agent","nlx_Imaginginstrument","nlx_Magneticresonanceimagingscanner"],
       "rdfs:label": "MRI Scanner"
     },
     {
-      "@id": "niiri:4d99b53691398a27947be76a2687857b",
+      "@id": "niiri:deb0b682f2b130535875fcdc150f94a0",
       "@type": ["prov:Agent","prov:Person"],
       "rdfs:label": "Person"
     },
     {
-      "@id": "niiri:09be76d412b7de63274a1bd3e8c8bd62",
-      "@type": ["prov:Entity","prov:Collection","nidm_Data:"],
+      "@id": "niiri:1f414ea8a897406413eb2b2efd3d7fb0",
+      "@type": ["prov:Entity","prov:Collection","nidm_Data"],
       "rdfs:label": "Data",
-      "nidm_grandMeanScaling:": {"@type": "xsd:boolean", "@value": "true"},
-      "nidm_targetIntensity:": {"@type": "xsd:float", "@value": "100"},
-      "nidm_hasMRIProtocol:": {"@id": "nlx_FunctionalMRIprotocol:"}
+      "nidm_grandMeanScaling": {"@type": "xsd:boolean", "@value": "true"},
+      "nidm_targetIntensity": {"@type": "xsd:float", "@value": "100"},
+      "nidm_hasMRIProtocol": {"@id": "nlx_FunctionalMRIprotocol"}
     },
     {
       "@type": "prov:Attribution",
-      "entity_attributed": "niiri:09be76d412b7de63274a1bd3e8c8bd62",
-      "agent": "niiri:ad09a5645f9232d32623e075e5fd845d"
+      "entity_attributed": "niiri:1f414ea8a897406413eb2b2efd3d7fb0",
+      "agent": "niiri:37399a6aa2ebbc88c58d24169b06a31d"
     },
     {
       "@type": "prov:Attribution",
-      "entity_attributed": "niiri:09be76d412b7de63274a1bd3e8c8bd62",
-      "agent": "niiri:4d99b53691398a27947be76a2687857b"
+      "entity_attributed": "niiri:1f414ea8a897406413eb2b2efd3d7fb0",
+      "agent": "niiri:deb0b682f2b130535875fcdc150f94a0"
     },
     {
-      "@id": "niiri:8db91aafdad4f4190a299a572b5e4e49",
-      "@type": ["prov:Entity","spm_DCTDriftModel:"],
+      "@id": "niiri:db32db85d971573a6ea64a25cb199cef",
+      "@type": ["prov:Entity","spm_DCTDriftModel"],
       "rdfs:label": "SPM's DCT Drift Model",
-      "spm_SPMsDriftCutoffPeriod:": {"@type": "xsd:float", "@value": "128"}
+      "spm_SPMsDriftCutoffPeriod": {"@type": "xsd:float", "@value": "128"}
     },
     {
-      "@id": "niiri:e53ee904c37499e500e163c748ba8db1",
-      "@type": ["prov:Entity","nidm_DesignMatrix:"],
+      "@id": "niiri:fe11dc043a6c1e969d626e42eb4b8f47",
+      "@type": ["prov:Entity","nidm_DesignMatrix"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "DesignMatrix.csv"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "DesignMatrix.csv"},
       "dct:format": {"@type": "xsd:string", "@value": "text/csv"},
-      "dc:description": {"@id": "niiri:ab37a0380e21d30c5ef5804b8147308a"},
+      "dc:description": {"@id": "niiri:a93cd2d7f08b2c61577d0b847f57fef6"},
       "rdfs:label": "Design Matrix",
-      "nidm_regressorNames:": {"@type": "xsd:string", "@value": "[\"Sn(1) active*bf(1)\", \"Sn(1) constant\"]"},
-      "nidm_hasDriftModel:": {"@id": "niiri:8db91aafdad4f4190a299a572b5e4e49"},
-      "nidm_hasHRFBasis:": {"@id": "spm_SPMsCanonicalHRF:"}
+      "nidm_regressorNames": {"@type": "xsd:string", "@value": "[\"Sn(1) active*bf(1)\", \"Sn(1) constant\"]"},
+      "nidm_hasDriftModel": {"@id": "niiri:db32db85d971573a6ea64a25cb199cef"},
+      "nidm_hasHRFBasis": {"@id": "spm_SPMsCanonicalHRF"}
     },
     {
-      "@id": "niiri:ab37a0380e21d30c5ef5804b8147308a",
+      "@id": "niiri:a93cd2d7f08b2c61577d0b847f57fef6",
       "@type": ["prov:Entity","dctype:Image"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "DesignMatrix.png"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "DesignMatrix.png"},
       "dct:format": {"@type": "xsd:string", "@value": "image/png"}
     },
     {
-      "@id": "niiri:447b4d5466b5e7ae9fe0aca95e48378b",
-      "@type": ["prov:Entity","nidm_ErrorModel:"],
-      "nidm_hasErrorDistribution:": {"@id": "obo_normaldistribution:"},
-      "nidm_hasErrorDependence:": {"@id": "obo_Toeplitzcovariancestructure:"},
-      "nidm_dependenceMapWiseDependence:": {"@id": "nidm_ConstantParameter:"},
-      "nidm_errorVarianceHomogeneous:": {"@type": "xsd:boolean", "@value": "true"},
-      "nidm_varianceMapWiseDependence:": {"@id": "nidm_IndependentParameter:"}
+      "@id": "niiri:ff5c473a8265e68dcc2fc87339f3f003",
+      "@type": ["prov:Entity","nidm_ErrorModel"],
+      "nidm_hasErrorDistribution": {"@id": "obo_normaldistribution"},
+      "nidm_hasErrorDependence": {"@id": "obo_Toeplitzcovariancestructure"},
+      "nidm_dependenceMapWiseDependence": {"@id": "nidm_ConstantParameter"},
+      "nidm_errorVarianceHomogeneous": {"@type": "xsd:boolean", "@value": "true"},
+      "nidm_varianceMapWiseDependence": {"@id": "nidm_IndependentParameter"}
     },
     {
-      "@id": "niiri:aeba0c609d9e6e9f75d5a6250c59deda",
-      "@type": ["prov:Activity","nidm_ModelParametersEstimation:"],
+      "@id": "niiri:2d8e016d2b75897ce56e33b9a1544133",
+      "@type": ["prov:Activity","nidm_ModelParametersEstimation"],
       "rdfs:label": "Model parameters estimation",
-      "nidm_withEstimationMethod:": {"@id": "obo_generalizedleastsquaresestimation:"}
+      "nidm_withEstimationMethod": {"@id": "obo_generalizedleastsquaresestimation"}
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:aeba0c609d9e6e9f75d5a6250c59deda",
-      "agent": "niiri:91a414225d56ee8a5a96d24be371a382"
+      "activity_associated": "niiri:2d8e016d2b75897ce56e33b9a1544133",
+      "agent": "niiri:aaaa36fcdc37bd70a89714f4c1960753"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:aeba0c609d9e6e9f75d5a6250c59deda",
-      "entity": "niiri:e53ee904c37499e500e163c748ba8db1"
+      "activity_using": "niiri:2d8e016d2b75897ce56e33b9a1544133",
+      "entity": "niiri:fe11dc043a6c1e969d626e42eb4b8f47"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:aeba0c609d9e6e9f75d5a6250c59deda",
-      "entity": "niiri:09be76d412b7de63274a1bd3e8c8bd62"
+      "activity_using": "niiri:2d8e016d2b75897ce56e33b9a1544133",
+      "entity": "niiri:1f414ea8a897406413eb2b2efd3d7fb0"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:aeba0c609d9e6e9f75d5a6250c59deda",
-      "entity": "niiri:447b4d5466b5e7ae9fe0aca95e48378b"
+      "activity_using": "niiri:2d8e016d2b75897ce56e33b9a1544133",
+      "entity": "niiri:ff5c473a8265e68dcc2fc87339f3f003"
     },
     {
-      "@id": "niiri:4c26c48a8db02504e3f8b95c708cb7b5",
-      "@type": ["prov:Entity","nidm_MaskMap:"],
+      "@id": "niiri:dfeb3a541e545f7225c8a300f30f9db2",
+      "@type": ["prov:Entity","nidm_MaskMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "Mask.nii.gz"},
-      "nidm_isUserDefined:": {"@type": "xsd:boolean", "@value": "false"},
+      "nidm_isUserDefined": {"@type": "xsd:boolean", "@value": "false"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "Mask.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Mask",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:f4860b5b14f96d2ce160d4f47ba40b97"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:73f10b52c50aa13993a9f597d9e88831"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "932fd9f0d55e9822748f4a9b35a0a7f0fe442f3e061e2eda48c2617a2938df50ea84deca8de0725641a0105b712a80a0c8931df9bdf3bef788b1041379d00875"}
     },
     {
-      "@id": "niiri:9aef6a76e2de217324ca7ef6a830ac62",
-      "@type": ["prov:Entity","nidm_MaskMap:"],
+      "@id": "niiri:aac954ca0b079b63bea50212e7bee7ba",
+      "@type": ["prov:Entity","nidm_MaskMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "mask.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "fbc254cab29db5532feccce554ec9d3c845197eca9013ec9f0efd5d8d56e3aa008ccee4038fb3651d30447fa0f316938b07c3ad961b623458dcd9b46968a8e11"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4c26c48a8db02504e3f8b95c708cb7b5",
-      "entity": "niiri:9aef6a76e2de217324ca7ef6a830ac62"
+      "entity_derived": "niiri:dfeb3a541e545f7225c8a300f30f9db2",
+      "entity": "niiri:aac954ca0b079b63bea50212e7bee7ba"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:4c26c48a8db02504e3f8b95c708cb7b5",
-      "activity": "niiri:aeba0c609d9e6e9f75d5a6250c59deda"
+      "entity_generated": "niiri:dfeb3a541e545f7225c8a300f30f9db2",
+      "activity": "niiri:2d8e016d2b75897ce56e33b9a1544133"
     },
     {
-      "@id": "niiri:8cf64dafadf6551f3bf05b0dc44322de",
-      "@type": ["prov:Entity","nidm_GrandMeanMap:"],
+      "@id": "niiri:8435b87aba3543459a1877c94a7e8585",
+      "@type": ["prov:Entity","nidm_GrandMeanMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "GrandMean.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "GrandMean.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Grand Mean Map",
-      "nidm_maskedMedian:": {"@type": "xsd:float", "@value": "132.008995056152"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:f4860b5b14f96d2ce160d4f47ba40b97"},
+      "nidm_maskedMedian": {"@type": "xsd:float", "@value": "132.008995056152"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:73f10b52c50aa13993a9f597d9e88831"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "4d3528031bce4a9c1b994b8124e6e0eddb9df90b49c84787652ed94df8c14c04ec92100a2d8ea86a8df24ba44617aca7457ddcb2f42253fc17e33296a1aea1cb"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:8cf64dafadf6551f3bf05b0dc44322de",
-      "activity": "niiri:aeba0c609d9e6e9f75d5a6250c59deda"
+      "entity_generated": "niiri:8435b87aba3543459a1877c94a7e8585",
+      "activity": "niiri:2d8e016d2b75897ce56e33b9a1544133"
     },
     {
-      "@id": "niiri:00309ec2bfb4094676ce58191425e6b9",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:bfa48106876dd53a099a744977604cb9",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0001.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0001.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 1",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:f4860b5b14f96d2ce160d4f47ba40b97"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:73f10b52c50aa13993a9f597d9e88831"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "fab2573099693215bac756bc796fbc983524473dec5c1b2d66fb83694c17412731df7f574094cb6c4a77994af7be11ed9aa545090fbe8ec6565a5c3c3dae8f0f"}
     },
     {
-      "@id": "niiri:c71ec16606bcd54085e667b73221c2a0",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:84bf7182b1084033459773520496afba",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0001.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "fab2573099693215bac756bc796fbc983524473dec5c1b2d66fb83694c17412731df7f574094cb6c4a77994af7be11ed9aa545090fbe8ec6565a5c3c3dae8f0f"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:00309ec2bfb4094676ce58191425e6b9",
-      "entity": "niiri:c71ec16606bcd54085e667b73221c2a0"
+      "entity_derived": "niiri:bfa48106876dd53a099a744977604cb9",
+      "entity": "niiri:84bf7182b1084033459773520496afba"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:00309ec2bfb4094676ce58191425e6b9",
-      "activity": "niiri:aeba0c609d9e6e9f75d5a6250c59deda"
+      "entity_generated": "niiri:bfa48106876dd53a099a744977604cb9",
+      "activity": "niiri:2d8e016d2b75897ce56e33b9a1544133"
     },
     {
-      "@id": "niiri:9e52aea97aeda2494ea801a4937e0ba6",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:67a2055bd991bd22b5c0f8dbe2a9c324",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0002.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0002.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 2",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:f4860b5b14f96d2ce160d4f47ba40b97"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:73f10b52c50aa13993a9f597d9e88831"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "3f72b788762d9ab2c7ddb5e4d446872694ee42fc8897fe5317b54efb7924f784da6499065db897a49595d8763d1893ad65ad102b0c88f2e72e2d028173343008"}
     },
     {
-      "@id": "niiri:e229e8ee225828662ff356a392f960e7",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:a29b3712891a7c91662d78dcf924770e",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0002.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "3f72b788762d9ab2c7ddb5e4d446872694ee42fc8897fe5317b54efb7924f784da6499065db897a49595d8763d1893ad65ad102b0c88f2e72e2d028173343008"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9e52aea97aeda2494ea801a4937e0ba6",
-      "entity": "niiri:e229e8ee225828662ff356a392f960e7"
+      "entity_derived": "niiri:67a2055bd991bd22b5c0f8dbe2a9c324",
+      "entity": "niiri:a29b3712891a7c91662d78dcf924770e"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:9e52aea97aeda2494ea801a4937e0ba6",
-      "activity": "niiri:aeba0c609d9e6e9f75d5a6250c59deda"
+      "entity_generated": "niiri:67a2055bd991bd22b5c0f8dbe2a9c324",
+      "activity": "niiri:2d8e016d2b75897ce56e33b9a1544133"
     },
     {
-      "@id": "niiri:af19cb5b7657fd7b739ef1e05ce15178",
-      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap:"],
+      "@id": "niiri:f0e51dd36c2dde61a8716db91b41826b",
+      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ResidualMeanSquares.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ResidualMeanSquares.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Residual Mean Squares Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:f4860b5b14f96d2ce160d4f47ba40b97"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:73f10b52c50aa13993a9f597d9e88831"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "84cd0e608b8763307a1166b88761291e552838d85b58334a69a286060f6489a3b0929a940c3ccac883803455118787ea32e0bb5a6d236a5d6e9e8b6a9f918a6b"}
     },
     {
-      "@id": "niiri:e606b95cd2ce9841559f80aaa06126c4",
-      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap:"],
+      "@id": "niiri:61f53db486ef78ea9054e7c459c5d1a1",
+      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "ResMS.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "1635e0ae420cac1b5989fbc753b95f504dd957ff2986367fc4cd13ff35c44b4ee60994a9cdcab93a7d247fc5a8decb7578fa4c553b0ac905af8c7041db9b4acd"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:af19cb5b7657fd7b739ef1e05ce15178",
-      "entity": "niiri:e606b95cd2ce9841559f80aaa06126c4"
+      "entity_derived": "niiri:f0e51dd36c2dde61a8716db91b41826b",
+      "entity": "niiri:61f53db486ef78ea9054e7c459c5d1a1"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:af19cb5b7657fd7b739ef1e05ce15178",
-      "activity": "niiri:aeba0c609d9e6e9f75d5a6250c59deda"
+      "entity_generated": "niiri:f0e51dd36c2dde61a8716db91b41826b",
+      "activity": "niiri:2d8e016d2b75897ce56e33b9a1544133"
     },
     {
-      "@id": "niiri:7b982ea4b4037a72101c144d50c0dae6",
-      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap:"],
+      "@id": "niiri:63385fd67b9326e0111faaab4107d5ed",
+      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ReselsPerVoxel.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ReselsPerVoxel.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Resels per Voxel Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:f4860b5b14f96d2ce160d4f47ba40b97"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:73f10b52c50aa13993a9f597d9e88831"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "2025dc6c33708b80708c2eba3215fb1149df236fb558a8e8f8f6cf34595fb54734fe5e436db3e192a424d99699dd7feb2f4a9020ceae8e7bcbd881b17825256a"}
     },
     {
-      "@id": "niiri:d738c59976e05c9ec1d1d60028dcccd8",
-      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap:"],
+      "@id": "niiri:5995ef582e48e154eb1cca107d569d57",
+      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "RPV.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "963283cdde607c40e4640c27453867bd0d70133b6d61482933862487c0f4a5acdb2e338a12a2605ee044b1aa47b5717f0c520b90ed3c49b5227f0483bd48512d"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7b982ea4b4037a72101c144d50c0dae6",
-      "entity": "niiri:d738c59976e05c9ec1d1d60028dcccd8"
+      "entity_derived": "niiri:63385fd67b9326e0111faaab4107d5ed",
+      "entity": "niiri:5995ef582e48e154eb1cca107d569d57"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:7b982ea4b4037a72101c144d50c0dae6",
-      "activity": "niiri:aeba0c609d9e6e9f75d5a6250c59deda"
+      "entity_generated": "niiri:63385fd67b9326e0111faaab4107d5ed",
+      "activity": "niiri:2d8e016d2b75897ce56e33b9a1544133"
     },
     {
-      "@id": "niiri:2d38c668d8a022e60dd72b97785669c6",
-      "@type": ["prov:Entity","obo_contrastweightmatrix:"],
-      "nidm_statisticType:": {"@id": "obo_tstatistic:"},
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "passive listening > rest"},
+      "@id": "niiri:ad993e5ce29359b726f88b74782271d5",
+      "@type": ["prov:Entity","obo_contrastweightmatrix"],
+      "nidm_statisticType": {"@id": "obo_tstatistic"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "passive listening > rest"},
       "rdfs:label": "Contrast: passive listening > rest",
       "prov:value": {"@type": "xsd:string", "@value": "[1, 0]"}
     },
     {
-      "@id": "niiri:765840b904374bbb0560fd61db425925",
-      "@type": ["prov:Activity","nidm_ContrastEstimation:"],
+      "@id": "niiri:7a7c5806a1c15500776e7dedfe9f2000",
+      "@type": ["prov:Activity","nidm_ContrastEstimation"],
       "rdfs:label": "Contrast estimation"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:765840b904374bbb0560fd61db425925",
-      "agent": "niiri:91a414225d56ee8a5a96d24be371a382"
+      "activity_associated": "niiri:7a7c5806a1c15500776e7dedfe9f2000",
+      "agent": "niiri:aaaa36fcdc37bd70a89714f4c1960753"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:765840b904374bbb0560fd61db425925",
-      "entity": "niiri:4c26c48a8db02504e3f8b95c708cb7b5"
+      "activity_using": "niiri:7a7c5806a1c15500776e7dedfe9f2000",
+      "entity": "niiri:dfeb3a541e545f7225c8a300f30f9db2"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:765840b904374bbb0560fd61db425925",
-      "entity": "niiri:af19cb5b7657fd7b739ef1e05ce15178"
+      "activity_using": "niiri:7a7c5806a1c15500776e7dedfe9f2000",
+      "entity": "niiri:f0e51dd36c2dde61a8716db91b41826b"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:765840b904374bbb0560fd61db425925",
-      "entity": "niiri:e53ee904c37499e500e163c748ba8db1"
+      "activity_using": "niiri:7a7c5806a1c15500776e7dedfe9f2000",
+      "entity": "niiri:fe11dc043a6c1e969d626e42eb4b8f47"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:765840b904374bbb0560fd61db425925",
-      "entity": "niiri:2d38c668d8a022e60dd72b97785669c6"
+      "activity_using": "niiri:7a7c5806a1c15500776e7dedfe9f2000",
+      "entity": "niiri:ad993e5ce29359b726f88b74782271d5"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:765840b904374bbb0560fd61db425925",
-      "entity": "niiri:00309ec2bfb4094676ce58191425e6b9"
+      "activity_using": "niiri:7a7c5806a1c15500776e7dedfe9f2000",
+      "entity": "niiri:bfa48106876dd53a099a744977604cb9"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:765840b904374bbb0560fd61db425925",
-      "entity": "niiri:9e52aea97aeda2494ea801a4937e0ba6"
+      "activity_using": "niiri:7a7c5806a1c15500776e7dedfe9f2000",
+      "entity": "niiri:67a2055bd991bd22b5c0f8dbe2a9c324"
     },
     {
-      "@id": "niiri:bf4fbf8c16ddbcfff6524a516718fd32",
-      "@type": ["prov:Entity","nidm_StatisticMap:"],
+      "@id": "niiri:888e17582e5ef7a041d17c7887c474e9",
+      "@type": ["prov:Entity","nidm_StatisticMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "TStatistic.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "TStatistic.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "T-Statistic Map: passive listening > rest",
-      "nidm_statisticType:": {"@id": "obo_tstatistic:"},
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "passive listening > rest"},
-      "nidm_errorDegreesOfFreedom:": {"@type": "xsd:float", "@value": "83.9999999999599"},
-      "nidm_effectDegreesOfFreedom:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:f4860b5b14f96d2ce160d4f47ba40b97"},
+      "nidm_statisticType": {"@id": "obo_tstatistic"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "passive listening > rest"},
+      "nidm_errorDegreesOfFreedom": {"@type": "xsd:float", "@value": "83.9999999999599"},
+      "nidm_effectDegreesOfFreedom": {"@type": "xsd:float", "@value": "1"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:73f10b52c50aa13993a9f597d9e88831"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "799e9bbf8c15b35c0098bca468846bf2cd895a3366382b5ceaa953f1e9e576955341a7c86e13e6fe9359da4ff1496a609f55ce9ecff8da2e461365372f2506d6"}
     },
     {
-      "@id": "niiri:b99915ef6f24d3803a3d2f842980a246",
-      "@type": ["prov:Entity","nidm_StatisticMap:"],
+      "@id": "niiri:2b0c1f2512d0af899ea7a06f8b4dd084",
+      "@type": ["prov:Entity","nidm_StatisticMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "spmT_0001.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "55951f31f0ede7e88eca5cd4793df3f630aba21bc90fb81e3695db060c7d4c0b0ccf0b51fd8958c32ea3253d3122e9b31a54262bf910f8b5b646054ceb9a5825"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:bf4fbf8c16ddbcfff6524a516718fd32",
-      "entity": "niiri:b99915ef6f24d3803a3d2f842980a246"
+      "entity_derived": "niiri:888e17582e5ef7a041d17c7887c474e9",
+      "entity": "niiri:2b0c1f2512d0af899ea7a06f8b4dd084"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:bf4fbf8c16ddbcfff6524a516718fd32",
-      "activity": "niiri:765840b904374bbb0560fd61db425925"
+      "entity_generated": "niiri:888e17582e5ef7a041d17c7887c474e9",
+      "activity": "niiri:7a7c5806a1c15500776e7dedfe9f2000"
     },
     {
-      "@id": "niiri:b912512c4c30505c2e80260a987a41a6",
-      "@type": ["prov:Entity","nidm_ContrastMap:"],
+      "@id": "niiri:d8ec29b24e8671e380233ea9903cdbd2",
+      "@type": ["prov:Entity","nidm_ContrastMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "Contrast.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "Contrast.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Contrast Map: passive listening > rest",
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "passive listening > rest"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:f4860b5b14f96d2ce160d4f47ba40b97"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "passive listening > rest"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:73f10b52c50aa13993a9f597d9e88831"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "f0720b732aaf19c2ec42d0469f8308beb3aa978baf65c7dce6476a0d8e5b2f38c4fa9609f045a536678440feebce9a047e3bd6d59fdb8fb64baae058690bbda2"}
     },
     {
-      "@id": "niiri:cc5a92ad94752699bc8ba18c668c7ba7",
-      "@type": ["prov:Entity","nidm_ContrastMap:"],
+      "@id": "niiri:a9e27a34caba1fd226510284df275d61",
+      "@type": ["prov:Entity","nidm_ContrastMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "con_0001.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "277dd1da13d391c33c172fb8c71060008cc66e173de6362eb857b0055b41e9bae57911f7ec4b45659905103b1139ebf3da0c2d04cf105bbce0cdc3004b643c22"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b912512c4c30505c2e80260a987a41a6",
-      "entity": "niiri:cc5a92ad94752699bc8ba18c668c7ba7"
+      "entity_derived": "niiri:d8ec29b24e8671e380233ea9903cdbd2",
+      "entity": "niiri:a9e27a34caba1fd226510284df275d61"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:b912512c4c30505c2e80260a987a41a6",
-      "activity": "niiri:765840b904374bbb0560fd61db425925"
+      "entity_generated": "niiri:d8ec29b24e8671e380233ea9903cdbd2",
+      "activity": "niiri:7a7c5806a1c15500776e7dedfe9f2000"
     },
     {
-      "@id": "niiri:72105fa17b9aa34e09eba22a09d99f63",
-      "@type": ["prov:Entity","nidm_ContrastStandardErrorMap:"],
+      "@id": "niiri:7d5475358da5e5e3fa6b0096d3322086",
+      "@type": ["prov:Entity","nidm_ContrastStandardErrorMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ContrastStandardError.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ContrastStandardError.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Contrast Standard Error Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:f4860b5b14f96d2ce160d4f47ba40b97"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:73f10b52c50aa13993a9f597d9e88831"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "f4e3616579fe8b0812469409b1501e391bb17ca6e364f37d622b37fa9014cf1dd89befece07e73cf5bca5b3116f55ac4496751ca990db85e8377001a4be941b2"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:72105fa17b9aa34e09eba22a09d99f63",
-      "activity": "niiri:765840b904374bbb0560fd61db425925"
+      "entity_generated": "niiri:7d5475358da5e5e3fa6b0096d3322086",
+      "activity": "niiri:7a7c5806a1c15500776e7dedfe9f2000"
     },
     {
-      "@id": "niiri:82a94267a053e0c842a0e8b1ab5355a3",
-      "@type": ["prov:Entity","nidm_HeightThreshold:","obo_FWERadjustedpvalue:"],
+      "@id": "niiri:862fba010ccafbd94fca48544924ba80",
+      "@type": ["prov:Entity","nidm_HeightThreshold","obo_FWERadjustedpvalue"],
       "rdfs:label": "Height Threshold: p<0.050000 (FWE)",
       "prov:value": {"@type": "xsd:float", "@value": "0.0499999999999976"},
-      "nidm_equivalentThreshold:": [{"@id": "niiri:6936ed0873167edae7ab54416766c0ac"},{"@id": "niiri:3b109031ab420fb3a67037eff0629025"}]
+      "nidm_equivalentThreshold": [{"@id": "niiri:c57807f0245de6c859bb9e20aeeba886"},{"@id": "niiri:e31ef4cef3ce8c113074abc8ce03f836"}]
     },
     {
-      "@id": "niiri:6936ed0873167edae7ab54416766c0ac",
-      "@type": ["prov:Entity","nidm_HeightThreshold:","obo_statistic:"],
-      "rdfs:label": "Height Threshold",
+      "@id": "niiri:c57807f0245de6c859bb9e20aeeba886",
+      "@type": ["prov:Entity","nidm_HeightThreshold","obo_statistic"],
+      "rdfs:label": "Height Threshold: T=4.852417)",
       "prov:value": {"@type": "xsd:float", "@value": "4.85241745689539"}
     },
     {
-      "@id": "niiri:3b109031ab420fb3a67037eff0629025",
-      "@type": ["prov:Entity","nidm_HeightThreshold:","nidm_PValueUncorrected:"],
-      "rdfs:label": "Height Threshold",
+      "@id": "niiri:e31ef4cef3ce8c113074abc8ce03f836",
+      "@type": ["prov:Entity","nidm_HeightThreshold","nidm_PValueUncorrected"],
+      "rdfs:label": "Height Threshold: p<0.000003 (unc.)",
       "prov:value": {"@type": "xsd:float", "@value": "2.7772578456986e-06"}
     },
     {
-      "@id": "niiri:b0acf2cbe9cb30883ac9c52f546bb5a3",
-      "@type": ["prov:Entity","nidm_ExtentThreshold:","obo_statistic:"],
+      "@id": "niiri:2fc9252193ebe1e0c873e2913da2ce6d",
+      "@type": ["prov:Entity","nidm_ExtentThreshold","obo_statistic"],
       "rdfs:label": "Extent Threshold: k>=0",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "0"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0"},
-      "nidm_equivalentThreshold:": [{"@id": "niiri:cd0b4ed6cc186b3beb093cdc7f52a75e"},{"@id": "niiri:880a34828ebe2c327806878605f253dc"}]
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "0"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0"},
+      "nidm_equivalentThreshold": [{"@id": "niiri:c7a17a77e954fd65195df87a97677960"},{"@id": "niiri:6ed89a2da946cac0366979695a5e6c6a"}]
     },
     {
-      "@id": "niiri:cd0b4ed6cc186b3beb093cdc7f52a75e",
-      "@type": ["prov:Entity","nidm_ExtentThreshold:","obo_FWERadjustedpvalue:"],
+      "@id": "niiri:c7a17a77e954fd65195df87a97677960",
+      "@type": ["prov:Entity","nidm_ExtentThreshold","obo_FWERadjustedpvalue"],
       "rdfs:label": "Extent Threshold",
       "prov:value": {"@type": "xsd:float", "@value": "1"}
     },
     {
-      "@id": "niiri:880a34828ebe2c327806878605f253dc",
-      "@type": ["prov:Entity","nidm_ExtentThreshold:","nidm_PValueUncorrected:"],
+      "@id": "niiri:6ed89a2da946cac0366979695a5e6c6a",
+      "@type": ["prov:Entity","nidm_ExtentThreshold","nidm_PValueUncorrected"],
       "rdfs:label": "Extent Threshold",
       "prov:value": {"@type": "xsd:float", "@value": "1"}
     },
     {
-      "@id": "niiri:2d2e22f9a7307597b34ea8d5c607fa53",
-      "@type": ["prov:Entity","nidm_PeakDefinitionCriteria:"],
+      "@id": "niiri:bc857ecd2ddb63a671ab7c93208e389e",
+      "@type": ["prov:Entity","nidm_PeakDefinitionCriteria"],
       "rdfs:label": "Peak Definition Criteria",
-      "nidm_maxNumberOfPeaksPerCluster:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_minDistanceBetweenPeaks:": {"@type": "xsd:float", "@value": "8"}
+      "nidm_maxNumberOfPeaksPerCluster": {"@type": "xsd:int", "@value": "3"},
+      "nidm_minDistanceBetweenPeaks": {"@type": "xsd:float", "@value": "8"}
     },
     {
-      "@id": "niiri:350cec9bc40b76c4e0d77370cf05b127",
-      "@type": ["prov:Entity","nidm_ClusterDefinitionCriteria:"],
+      "@id": "niiri:41bb616145da910a5db5521ca68d87d5",
+      "@type": ["prov:Entity","nidm_ClusterDefinitionCriteria"],
       "rdfs:label": "Cluster Connectivity Criterion: 18",
-      "nidm_hasConnectivityCriterion:": {"@id": "nidm_voxel18connected:"}
+      "nidm_hasConnectivityCriterion": {"@id": "nidm_voxel18connected"}
     },
     {
-      "@id": "niiri:9c1ea8c988e02a01a2bdc6bedff814d4",
-      "@type": ["prov:Activity","nidm_Inference:"],
-      "nidm_hasAlternativeHypothesis:": {"@id": "nidm_OneTailedTest:"},
+      "@id": "niiri:7b79810a033a150be8ea7667379a6e2c",
+      "@type": ["prov:Activity","nidm_Inference"],
+      "nidm_hasAlternativeHypothesis": {"@id": "nidm_OneTailedTest"},
       "rdfs:label": "Inference"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:9c1ea8c988e02a01a2bdc6bedff814d4",
-      "agent": "niiri:91a414225d56ee8a5a96d24be371a382"
+      "activity_associated": "niiri:7b79810a033a150be8ea7667379a6e2c",
+      "agent": "niiri:aaaa36fcdc37bd70a89714f4c1960753"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:9c1ea8c988e02a01a2bdc6bedff814d4",
-      "entity": "niiri:82a94267a053e0c842a0e8b1ab5355a3"
+      "activity_using": "niiri:7b79810a033a150be8ea7667379a6e2c",
+      "entity": "niiri:862fba010ccafbd94fca48544924ba80"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:9c1ea8c988e02a01a2bdc6bedff814d4",
-      "entity": "niiri:b0acf2cbe9cb30883ac9c52f546bb5a3"
+      "activity_using": "niiri:7b79810a033a150be8ea7667379a6e2c",
+      "entity": "niiri:2fc9252193ebe1e0c873e2913da2ce6d"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:9c1ea8c988e02a01a2bdc6bedff814d4",
-      "entity": "niiri:bf4fbf8c16ddbcfff6524a516718fd32"
+      "activity_using": "niiri:7b79810a033a150be8ea7667379a6e2c",
+      "entity": "niiri:888e17582e5ef7a041d17c7887c474e9"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:9c1ea8c988e02a01a2bdc6bedff814d4",
-      "entity": "niiri:7b982ea4b4037a72101c144d50c0dae6"
+      "activity_using": "niiri:7b79810a033a150be8ea7667379a6e2c",
+      "entity": "niiri:63385fd67b9326e0111faaab4107d5ed"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:9c1ea8c988e02a01a2bdc6bedff814d4",
-      "entity": "niiri:4c26c48a8db02504e3f8b95c708cb7b5"
+      "activity_using": "niiri:7b79810a033a150be8ea7667379a6e2c",
+      "entity": "niiri:dfeb3a541e545f7225c8a300f30f9db2"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:9c1ea8c988e02a01a2bdc6bedff814d4",
-      "entity": "niiri:2d2e22f9a7307597b34ea8d5c607fa53"
+      "activity_using": "niiri:7b79810a033a150be8ea7667379a6e2c",
+      "entity": "niiri:bc857ecd2ddb63a671ab7c93208e389e"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:9c1ea8c988e02a01a2bdc6bedff814d4",
-      "entity": "niiri:350cec9bc40b76c4e0d77370cf05b127"
+      "activity_using": "niiri:7b79810a033a150be8ea7667379a6e2c",
+      "entity": "niiri:41bb616145da910a5db5521ca68d87d5"
     },
     {
-      "@id": "niiri:22c31b26fb7ba72523a54bccbfb5c807",
-      "@type": ["prov:Entity","nidm_SearchSpaceMaskMap:"],
+      "@id": "niiri:0955e8a851b6e4bb57177bb79d663a90",
+      "@type": ["prov:Entity","nidm_SearchSpaceMaskMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "SearchSpaceMask.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "SearchSpaceMask.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Search Space Mask Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:f4860b5b14f96d2ce160d4f47ba40b97"},
-      "nidm_searchVolumeInVoxels:": {"@type": "xsd:int", "@value": "69306"},
-      "nidm_searchVolumeInUnits:": {"@type": "xsd:float", "@value": "1871262"},
-      "nidm_reselSizeInVoxels:": {"@type": "xsd:float", "@value": "132.907586178202"},
-      "nidm_searchVolumeInResels:": {"@type": "xsd:float", "@value": "467.07642343881"},
-      "spm_searchVolumeReselsGeometry:": {"@type": "xsd:string", "@value": "[7, 42.96312274763, 269.40914815306, 467.07642343881]"},
-      "nidm_noiseFWHMInVoxels:": {"@type": "xsd:string", "@value": "[5.41278985910694, 5.43638957240286, 4.51666658877481]"},
-      "nidm_noiseFWHMInUnits:": {"@type": "xsd:string", "@value": "[16.2383695773208, 16.3091687172086, 13.5499997663244]"},
-      "nidm_randomFieldStationarity:": {"@type": "xsd:boolean", "@value": "true"},
-      "nidm_expectedNumberOfVoxelsPerCluster:": {"@type": "xsd:float", "@value": "4.02834655908613"},
-      "nidm_expectedNumberOfClusters:": {"@type": "xsd:float", "@value": "0.0512932943875478"},
-      "nidm_heightCriticalThresholdFWE05:": {"@type": "xsd:float", "@value": "4.85241745689539"},
-      "nidm_heightCriticalThresholdFDR05:": {"@type": "xsd:float", "@value": "5.7639536857605"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:73f10b52c50aa13993a9f597d9e88831"},
+      "nidm_searchVolumeInVoxels": {"@type": "xsd:int", "@value": "69306"},
+      "nidm_searchVolumeInUnits": {"@type": "xsd:float", "@value": "1871262"},
+      "nidm_reselSizeInVoxels": {"@type": "xsd:float", "@value": "132.907586178202"},
+      "nidm_searchVolumeInResels": {"@type": "xsd:float", "@value": "467.07642343881"},
+      "spm_searchVolumeReselsGeometry": {"@type": "xsd:string", "@value": "[7, 42.96312274763, 269.40914815306, 467.07642343881]"},
+      "nidm_noiseFWHMInVoxels": {"@type": "xsd:string", "@value": "[5.41278985910694, 5.43638957240286, 4.51666658877481]"},
+      "nidm_noiseFWHMInUnits": {"@type": "xsd:string", "@value": "[16.2383695773208, 16.3091687172086, 13.5499997663244]"},
+      "nidm_randomFieldStationarity": {"@type": "xsd:boolean", "@value": "true"},
+      "nidm_expectedNumberOfVoxelsPerCluster": {"@type": "xsd:float", "@value": "4.02834655908613"},
+      "nidm_expectedNumberOfClusters": {"@type": "xsd:float", "@value": "0.0512932943875478"},
+      "nidm_heightCriticalThresholdFWE05": {"@type": "xsd:float", "@value": "4.85241745689539"},
+      "nidm_heightCriticalThresholdFDR05": {"@type": "xsd:float", "@value": "5.7639536857605"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "932fd9f0d55e9822748f4a9b35a0a7f0fe442f3e061e2eda48c2617a2938df50ea84deca8de0725641a0105b712a80a0c8931df9bdf3bef788b1041379d00875"},
-      "spm_smallestSignificantClusterSizeInVoxelsFWE05:": {"@type": "xsd:int", "@value": "12"},
-      "spm_smallestSignificantClusterSizeInVoxelsFDR05:": {"@type": "xsd:int", "@value": "29"}
+      "spm_smallestSignificantClusterSizeInVoxelsFWE05": {"@type": "xsd:int", "@value": "12"},
+      "spm_smallestSignificantClusterSizeInVoxelsFDR05": {"@type": "xsd:int", "@value": "29"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:22c31b26fb7ba72523a54bccbfb5c807",
-      "activity": "niiri:9c1ea8c988e02a01a2bdc6bedff814d4"
+      "entity_generated": "niiri:0955e8a851b6e4bb57177bb79d663a90",
+      "activity": "niiri:7b79810a033a150be8ea7667379a6e2c"
     },
     {
-      "@id": "niiri:adb0c6a13e1b5f7e48c16fe815355303",
-      "@type": ["prov:Entity","nidm_ExcursionSetMap:"],
+      "@id": "niiri:1ce7383d07b62dfc72f11d00c27a9fa5",
+      "@type": ["prov:Entity","nidm_ExcursionSetMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ExcursionSet.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ExcursionSet.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Excursion Set Map",
-      "nidm_numberOfSupraThresholdClusters:": {"@type": "xsd:int", "@value": "5"},
-      "nidm_pValue:": {"@type": "xsd:float", "@value": "2.83510681597932e-09"},
-      "nidm_hasClusterLabelsMap:": {"@id": "niiri:78ec48d576e7260ada9f4fea44ced392"},
-      "nidm_hasMaximumIntensityProjection:": {"@id": "niiri:b129452d0f62781da97d8128e5bd23f9"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:f4860b5b14f96d2ce160d4f47ba40b97"},
+      "nidm_numberOfSupraThresholdClusters": {"@type": "xsd:int", "@value": "5"},
+      "nidm_pValue": {"@type": "xsd:float", "@value": "2.83510681597932e-09"},
+      "nidm_hasClusterLabelsMap": {"@id": "niiri:f3cce8b8925dba2ba5a72db44eb47dbf"},
+      "nidm_hasMaximumIntensityProjection": {"@id": "niiri:c5d717db4ccc4350e7c44ba38c293f7d"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:73f10b52c50aa13993a9f597d9e88831"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "d96b82761c299a66978893cab6034f3f8aed25d0a135636b0ffe79f4cf11becce86ba261f7aeb43717f5d0e47ad0b14cfb0402786251e3f2c507890c83b27652"}
     },
     {
-      "@id": "niiri:78ec48d576e7260ada9f4fea44ced392",
-      "@type": ["prov:Entity","nidm_ClusterLabelsMap:"],
+      "@id": "niiri:f3cce8b8925dba2ba5a72db44eb47dbf",
+      "@type": ["prov:Entity","nidm_ClusterLabelsMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ClusterLabels.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ClusterLabels.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Cluster Labels Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:f4860b5b14f96d2ce160d4f47ba40b97"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:73f10b52c50aa13993a9f597d9e88831"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "a132bb284da461fd9e20eb2986373a9171c90a342c1e694297bc02f5674a311a560b7ff34bdf045dc191d4afff8c690a373db6408c1fe93f7c25e23707ce65c3"}
     },
     {
-      "@id": "niiri:b129452d0f62781da97d8128e5bd23f9",
+      "@id": "niiri:c5d717db4ccc4350e7c44ba38c293f7d",
       "@type": ["prov:Entity","dctype:Image"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "MaximumIntensityProjection.png"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "MaximumIntensityProjection.png"},
@@ -699,286 +699,286 @@
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:adb0c6a13e1b5f7e48c16fe815355303",
-      "activity": "niiri:9c1ea8c988e02a01a2bdc6bedff814d4"
+      "entity_generated": "niiri:1ce7383d07b62dfc72f11d00c27a9fa5",
+      "activity": "niiri:7b79810a033a150be8ea7667379a6e2c"
     },
     {
-      "@id": "niiri:0ba96e7ae029d539c3491c1f21ff5e62",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:02e9a33d08e23de77904e468485cf047",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0001",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "839"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "6.31265696809113"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.55896824480477e-19"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1.77948412240239e-18"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "1"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "839"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "6.31265696809113"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.55896824480477e-19"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1.77948412240239e-18"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "1"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0ba96e7ae029d539c3491c1f21ff5e62",
-      "entity": "niiri:adb0c6a13e1b5f7e48c16fe815355303"
+      "entity_derived": "niiri:02e9a33d08e23de77904e468485cf047",
+      "entity": "niiri:1ce7383d07b62dfc72f11d00c27a9fa5"
     },
     {
-      "@id": "niiri:62ecedbdd808eaaf2a2754cec2853a7c",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:d1701492186c7811850274355c9a5da3",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0002",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "695"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "5.22919736927692"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.34280282632073e-17"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1.33570070658018e-16"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "2"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "695"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "5.22919736927692"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.34280282632073e-17"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1.33570070658018e-16"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "2"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:62ecedbdd808eaaf2a2754cec2853a7c",
-      "entity": "niiri:adb0c6a13e1b5f7e48c16fe815355303"
+      "entity_derived": "niiri:d1701492186c7811850274355c9a5da3",
+      "entity": "niiri:1ce7383d07b62dfc72f11d00c27a9fa5"
     },
     {
-      "@id": "niiri:b6305d8cf589e221d76467505f479d49",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:88442be7736ad5eec0053052bd6e0179",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0003",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "37"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.278388924695318"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00497953247554004"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.000255384009130943"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00829922079256674"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "3"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "37"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.278388924695318"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00497953247554004"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.000255384009130943"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00829922079256674"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "3"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b6305d8cf589e221d76467505f479d49",
-      "entity": "niiri:adb0c6a13e1b5f7e48c16fe815355303"
+      "entity_derived": "niiri:88442be7736ad5eec0053052bd6e0179",
+      "entity": "niiri:1ce7383d07b62dfc72f11d00c27a9fa5"
     },
     {
-      "@id": "niiri:73900d08903efa68fe450ec1e137a1cb",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:98d0b221eadccb2110d30e7f996a11e7",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0004",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "29"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.218196724761195"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0110257032104773"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.000565384750377596"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0137821290130967"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "4"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "29"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.218196724761195"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0110257032104773"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.000565384750377596"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0137821290130967"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "4"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:73900d08903efa68fe450ec1e137a1cb",
-      "entity": "niiri:adb0c6a13e1b5f7e48c16fe815355303"
+      "entity_derived": "niiri:98d0b221eadccb2110d30e7f996a11e7",
+      "entity": "niiri:1ce7383d07b62dfc72f11d00c27a9fa5"
     },
     {
-      "@id": "niiri:8db5593450e9ad94172a123dc9881fc1",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:1a862c5b84ba646d826413c480f4d010",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0005",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "12"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0902882999011843"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0818393184514307"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00418900977248904"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0818393184514307"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "5"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "12"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0902882999011843"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0818393184514307"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00418900977248904"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0818393184514307"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "5"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8db5593450e9ad94172a123dc9881fc1",
-      "entity": "niiri:adb0c6a13e1b5f7e48c16fe815355303"
+      "entity_derived": "niiri:1a862c5b84ba646d826413c480f4d010",
+      "entity": "niiri:1ce7383d07b62dfc72f11d00c27a9fa5"
     },
     {
-      "@id": "niiri:f25790188e0a938fda159ab70b6bb952",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ca8b66656ab798a1f5a045766f5d41de",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0001",
-      "prov:atLocation": {"@id": "niiri:67eba1ea2930c57af65969243c4ed205"},
+      "prov:atLocation": {"@id": "niiri:a8598038ca4a8b33b2dfe04f95b6c161"},
       "prov:value": {"@type": "xsd:float", "@value": "17.5207633972168"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "INF"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.44089209850063e-16"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1.19156591713838e-11"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "INF"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.44089209850063e-16"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1.19156591713838e-11"}
     },
     {
-      "@id": "niiri:67eba1ea2930c57af65969243c4ed205",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a8598038ca4a8b33b2dfe04f95b6c161",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0001",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-60,-25,11]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-60,-25,11]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f25790188e0a938fda159ab70b6bb952",
-      "entity": "niiri:0ba96e7ae029d539c3491c1f21ff5e62"
+      "entity_derived": "niiri:ca8b66656ab798a1f5a045766f5d41de",
+      "entity": "niiri:02e9a33d08e23de77904e468485cf047"
     },
     {
-      "@id": "niiri:7e4a23c23029a7d7847d9d000f2be1a8",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:414ba670c5dcea4f3bd8bc915e88466a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0002",
-      "prov:atLocation": {"@id": "niiri:86ed510de31f5f9a7c7c0311851d1019"},
+      "prov:atLocation": {"@id": "niiri:5acdd0ceb3ce5a5c9c75a1a17d22ca5f"},
       "prov:value": {"@type": "xsd:float", "@value": "13.0321407318115"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "INF"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.44089209850063e-16"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1.19156591713838e-11"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "INF"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.44089209850063e-16"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1.19156591713838e-11"}
     },
     {
-      "@id": "niiri:86ed510de31f5f9a7c7c0311851d1019",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:5acdd0ceb3ce5a5c9c75a1a17d22ca5f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0002",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-42,-31,11]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-42,-31,11]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7e4a23c23029a7d7847d9d000f2be1a8",
-      "entity": "niiri:0ba96e7ae029d539c3491c1f21ff5e62"
+      "entity_derived": "niiri:414ba670c5dcea4f3bd8bc915e88466a",
+      "entity": "niiri:02e9a33d08e23de77904e468485cf047"
     },
     {
-      "@id": "niiri:b52136167b47ed42b1d06069b8ca8620",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:aa8942e5b5f535f75dd2e80da17f1546",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0003",
-      "prov:atLocation": {"@id": "niiri:db3e3c348eeb68bef67f5fc08c4b6fb0"},
+      "prov:atLocation": {"@id": "niiri:e6c5a00711416271b141558c1bd92e4b"},
       "prov:value": {"@type": "xsd:float", "@value": "10.2856016159058"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "INF"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.44089209850063e-16"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "7.69451169446711e-12"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "6.84121260274992e-10"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "INF"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.44089209850063e-16"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "7.69451169446711e-12"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "6.84121260274992e-10"}
     },
     {
-      "@id": "niiri:db3e3c348eeb68bef67f5fc08c4b6fb0",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e6c5a00711416271b141558c1bd92e4b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0003",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-66,-31,-1]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-66,-31,-1]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b52136167b47ed42b1d06069b8ca8620",
-      "entity": "niiri:0ba96e7ae029d539c3491c1f21ff5e62"
+      "entity_derived": "niiri:aa8942e5b5f535f75dd2e80da17f1546",
+      "entity": "niiri:02e9a33d08e23de77904e468485cf047"
     },
     {
-      "@id": "niiri:b0902e75c679c437569ac7dbc81ebab1",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:90126f11793e8554f08eb9473d5ae15c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0004",
-      "prov:atLocation": {"@id": "niiri:664666406985e4f667bc660d3e10f00a"},
+      "prov:atLocation": {"@id": "niiri:0cc8e87d27467eefcceb101b56a19c68"},
       "prov:value": {"@type": "xsd:float", "@value": "13.5425577163696"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "INF"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.44089209850063e-16"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1.19156591713838e-11"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "INF"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.44089209850063e-16"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1.19156591713838e-11"}
     },
     {
-      "@id": "niiri:664666406985e4f667bc660d3e10f00a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0cc8e87d27467eefcceb101b56a19c68",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0004",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[63,-13,-4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[63,-13,-4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b0902e75c679c437569ac7dbc81ebab1",
-      "entity": "niiri:62ecedbdd808eaaf2a2754cec2853a7c"
+      "entity_derived": "niiri:90126f11793e8554f08eb9473d5ae15c",
+      "entity": "niiri:d1701492186c7811850274355c9a5da3"
     },
     {
-      "@id": "niiri:ae108645e2dfe81017b4dab76141964b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:6e9b5798a110211eece6cd9bf78afa51",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0005",
-      "prov:atLocation": {"@id": "niiri:0238bc39184b3f1d80e96d21d7b2ba50"},
+      "prov:atLocation": {"@id": "niiri:1b918485e2cbed73d8ac005a27a82891"},
       "prov:value": {"@type": "xsd:float", "@value": "12.4728717803955"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "INF"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.44089209850063e-16"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1.19156591713838e-11"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "INF"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.44089209850063e-16"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1.19156591713838e-11"}
     },
     {
-      "@id": "niiri:0238bc39184b3f1d80e96d21d7b2ba50",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:1b918485e2cbed73d8ac005a27a82891",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0005",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[60,-22,11]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[60,-22,11]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ae108645e2dfe81017b4dab76141964b",
-      "entity": "niiri:62ecedbdd808eaaf2a2754cec2853a7c"
+      "entity_derived": "niiri:6e9b5798a110211eece6cd9bf78afa51",
+      "entity": "niiri:d1701492186c7811850274355c9a5da3"
     },
     {
-      "@id": "niiri:469bd2f450f1dd64463b3659c97a2b52",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:13169f43d43dcd28f4ac0a37a5dfa9b0",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0006",
-      "prov:atLocation": {"@id": "niiri:33d2e1928e071d40c56595b7e30700df"},
+      "prov:atLocation": {"@id": "niiri:37f49ee5dac306c833b0b6456603dd74"},
       "prov:value": {"@type": "xsd:float", "@value": "9.72103404998779"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "INF"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.22124532708767e-15"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "6.9250605250204e-11"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "6.52169693024352e-09"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "INF"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.22124532708767e-15"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "6.9250605250204e-11"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "6.52169693024352e-09"}
     },
     {
-      "@id": "niiri:33d2e1928e071d40c56595b7e30700df",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:37f49ee5dac306c833b0b6456603dd74",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0006",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[57,-40,5]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[57,-40,5]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:469bd2f450f1dd64463b3659c97a2b52",
-      "entity": "niiri:62ecedbdd808eaaf2a2754cec2853a7c"
+      "entity_derived": "niiri:13169f43d43dcd28f4ac0a37a5dfa9b0",
+      "entity": "niiri:d1701492186c7811850274355c9a5da3"
     },
     {
-      "@id": "niiri:91669712ee5babe4f83a178cbe509a73",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:819979d305d01b9553c2bfc1398b4de8",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0007",
-      "prov:atLocation": {"@id": "niiri:53f9b5bc77b97eafbecb860028aa265c"},
+      "prov:atLocation": {"@id": "niiri:c19b896ff31dce4bf576fe98821aba9c"},
       "prov:value": {"@type": "xsd:float", "@value": "6.55745935440063"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.87574033699266"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.10478867668229e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "9.17574302586877e-05"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00257605396646668"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.87574033699266"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.10478867668229e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "9.17574302586877e-05"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00257605396646668"}
     },
     {
-      "@id": "niiri:53f9b5bc77b97eafbecb860028aa265c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c19b896ff31dce4bf576fe98821aba9c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0007",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[36,-28,-13]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[36,-28,-13]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:91669712ee5babe4f83a178cbe509a73",
-      "entity": "niiri:b6305d8cf589e221d76467505f479d49"
+      "entity_derived": "niiri:819979d305d01b9553c2bfc1398b4de8",
+      "entity": "niiri:88442be7736ad5eec0053052bd6e0179"
     },
     {
-      "@id": "niiri:0d705a0752ec3881d2ba0cf183c825d4",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:9f9f4589c34e65f926a7491d59f7ae39",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0008",
-      "prov:atLocation": {"@id": "niiri:2a2c8ea727a0e3663fd038ef2962a71b"},
+      "prov:atLocation": {"@id": "niiri:16adab65d227da691d1b032641f99620"},
       "prov:value": {"@type": "xsd:float", "@value": "6.19558477401733"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.60645028016544"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.0325913235576e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.000382453907303626"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00949154522981781"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.60645028016544"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.0325913235576e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.000382453907303626"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00949154522981781"}
     },
     {
-      "@id": "niiri:2a2c8ea727a0e3663fd038ef2962a71b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:16adab65d227da691d1b032641f99620",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0008",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-33,-31,-16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-33,-31,-16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0d705a0752ec3881d2ba0cf183c825d4",
-      "entity": "niiri:73900d08903efa68fe450ec1e137a1cb"
+      "entity_derived": "niiri:9f9f4589c34e65f926a7491d59f7ae39",
+      "entity": "niiri:98d0b221eadccb2110d30e7f996a11e7"
     },
     {
-      "@id": "niiri:3cd641e21261259d690f9d09d4a620c9",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:da9faeb078561ebedea50e462541e026",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0009",
-      "prov:atLocation": {"@id": "niiri:a3a6c876397c4457f4aa472116513bdf"},
+      "prov:atLocation": {"@id": "niiri:9658e1ec0692c07fb609a32b3b3e4074"},
       "prov:value": {"@type": "xsd:float", "@value": "5.27320194244385"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.88682085490477"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.12386299833523e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0119099090973821"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.251554254717758"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.88682085490477"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.12386299833523e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0119099090973821"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.251554254717758"}
     },
     {
-      "@id": "niiri:a3a6c876397c4457f4aa472116513bdf",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:9658e1ec0692c07fb609a32b3b3e4074",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0009",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[45,-40,32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[45,-40,32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3cd641e21261259d690f9d09d4a620c9",
-      "entity": "niiri:8db5593450e9ad94172a123dc9881fc1"
+      "entity_derived": "niiri:da9faeb078561ebedea50e462541e026",
+      "entity": "niiri:1a862c5b84ba646d826413c480f4d010"
     }
   ]
 }

--- a/spmexport/ex_spm_full_example001/nidm.ttl
+++ b/spmexport/ex_spm_full_example001/nidm.ttl
@@ -4,7 +4,7 @@
 @prefix niiri: <http://iri.nidash.org/> .
 @prefix spm: <http://purl.org/nidash/spm#> .
 @prefix neurolex: <http://neurolex.org/wiki/> .
-@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#> .
+@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
@@ -17,27 +17,27 @@
 @prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-niiri:ffde54b8300d0af851eff95e567bab5e
+niiri:e6d0f6a78cb1543128178c286ffb18bd
   a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
   rdfs:label "NIDM-Results" ;
   nidm_version: "1.3.0"^^xsd:string .
 
-niiri:d6d9b4d58e2e51d60f74ddb191b6a539
+niiri:7e0c67dffe4faa56a4221c32e8fd8f48
   a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
   rdfs:label "spm_results_nidm" ;
-  nidm_softwareVersion: "12.6903"^^xsd:string .
+  nidm_softwareVersion: "12.7057"^^xsd:string .
 
-niiri:9c7d0b07a7251a00c9fd3e2b61c62efc
+niiri:4c804d9f1544750b14cad90f7ca97316
   a prov:Activity, nidm_NIDMResultsExport: ; 
   rdfs:label "NIDM-Results export" .
 
-niiri:9c7d0b07a7251a00c9fd3e2b61c62efc prov:wasAssociatedWith niiri:d6d9b4d58e2e51d60f74ddb191b6a539 .
+niiri:4c804d9f1544750b14cad90f7ca97316 prov:wasAssociatedWith niiri:7e0c67dffe4faa56a4221c32e8fd8f48 .
 
 _:blank5 a prov:Generation .
 
-niiri:ffde54b8300d0af851eff95e567bab5e prov:qualifiedGeneration _:blank5 .
+niiri:e6d0f6a78cb1543128178c286ffb18bd prov:qualifiedGeneration _:blank5 .
 
-_:blank5 prov:atTime "2016-12-07T16:08:27"^^xsd:dateTime .
+_:blank5 prov:atTime "2017-04-19T12:18:07"^^xsd:dateTime .
 
 @prefix nidm_Ixi549CoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000050> .
 @prefix src_SPM: <http://scicrunch.org/resolver/SCR_007037> .
@@ -142,12 +142,12 @@ _:blank5 prov:atTime "2016-12-07T16:08:27"^^xsd:dateTime .
 @prefix nidm_Coordinate: <http://purl.org/nidash/nidm#NIDM_0000015> .
 @prefix nidm_coordinateVector: <http://purl.org/nidash/nidm#NIDM_0000086> .
 
-niiri:91a414225d56ee8a5a96d24be371a382
+niiri:aaaa36fcdc37bd70a89714f4c1960753
     a prov:Agent, src_SPM:, prov:SoftwareAgent ; 
     rdfs:label "SPM" ;
-    nidm_softwareVersion: "12.12.2"^^xsd:string .
+    nidm_softwareVersion: "12.6906"^^xsd:string .
 
-niiri:f4860b5b14f96d2ce160d4f47ba40b97
+niiri:73f10b52c50aa13993a9f597d9e88831
     a prov:Entity, nidm_CoordinateSpace: ; 
     rdfs:label "Coordinate space 1" ;
     nidm_voxelToWorldMapping: "[[-3, 0, 0, 78],[0, 3, 0, -112],[0, 0, 3, -70],[0, 0, 0, 1]]"^^xsd:string ;
@@ -157,48 +157,48 @@ niiri:f4860b5b14f96d2ce160d4f47ba40b97
     nidm_numberOfDimensions: "3"^^xsd:int ;
     nidm_dimensionsInVoxels: "[53,63,52]"^^xsd:string .
 
-niiri:ad09a5645f9232d32623e075e5fd845d
+niiri:37399a6aa2ebbc88c58d24169b06a31d
     a prov:Agent, nlx_Imaginginstrument:, nlx_Magneticresonanceimagingscanner: ; 
     rdfs:label "MRI Scanner" .
 
-niiri:4d99b53691398a27947be76a2687857b
+niiri:deb0b682f2b130535875fcdc150f94a0
     a prov:Agent, prov:Person ; 
     rdfs:label "Person" .
 
-niiri:09be76d412b7de63274a1bd3e8c8bd62
+niiri:1f414ea8a897406413eb2b2efd3d7fb0
     a prov:Entity, prov:Collection, nidm_Data: ; 
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "true"^^xsd:boolean ;
     nidm_targetIntensity: "100"^^xsd:float ;
     nidm_hasMRIProtocol: nlx_FunctionalMRIprotocol: .
 
-niiri:09be76d412b7de63274a1bd3e8c8bd62 prov:wasAttributedTo niiri:ad09a5645f9232d32623e075e5fd845d .
+niiri:1f414ea8a897406413eb2b2efd3d7fb0 prov:wasAttributedTo niiri:37399a6aa2ebbc88c58d24169b06a31d .
 
-niiri:09be76d412b7de63274a1bd3e8c8bd62 prov:wasAttributedTo niiri:4d99b53691398a27947be76a2687857b .
+niiri:1f414ea8a897406413eb2b2efd3d7fb0 prov:wasAttributedTo niiri:deb0b682f2b130535875fcdc150f94a0 .
 
-niiri:8db91aafdad4f4190a299a572b5e4e49
+niiri:db32db85d971573a6ea64a25cb199cef
     a prov:Entity, spm_DCTDriftModel: ; 
     rdfs:label "SPM's DCT Drift Model" ;
     spm_SPMsDriftCutoffPeriod: "128"^^xsd:float .
 
-niiri:e53ee904c37499e500e163c748ba8db1
+niiri:fe11dc043a6c1e969d626e42eb4b8f47
     a prov:Entity, nidm_DesignMatrix: ; 
     prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.csv"^^xsd:string ;
     dct:format "text/csv"^^xsd:string ;
-    dc:description niiri:ab37a0380e21d30c5ef5804b8147308a ;
+    dc:description niiri:a93cd2d7f08b2c61577d0b847f57fef6 ;
     rdfs:label "Design Matrix" ;
     nidm_regressorNames: "[\"Sn(1) active*bf(1)\", \"Sn(1) constant\"]"^^xsd:string ;
-    nidm_hasDriftModel: niiri:8db91aafdad4f4190a299a572b5e4e49 ;
+    nidm_hasDriftModel: niiri:db32db85d971573a6ea64a25cb199cef ;
     nidm_hasHRFBasis: spm_SPMsCanonicalHRF: .
 
-niiri:ab37a0380e21d30c5ef5804b8147308a
+niiri:a93cd2d7f08b2c61577d0b847f57fef6
     a prov:Entity, dctype:Image ; 
     prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:447b4d5466b5e7ae9fe0aca95e48378b
+niiri:ff5c473a8265e68dcc2fc87339f3f003
     a prov:Entity, nidm_ErrorModel: ; 
     nidm_hasErrorDistribution: obo_normaldistribution: ;
     nidm_hasErrorDependence: obo_Toeplitzcovariancestructure: ;
@@ -206,153 +206,153 @@ niiri:447b4d5466b5e7ae9fe0aca95e48378b
     nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
     nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
 
-niiri:aeba0c609d9e6e9f75d5a6250c59deda
+niiri:2d8e016d2b75897ce56e33b9a1544133
     a prov:Activity, nidm_ModelParametersEstimation: ; 
     rdfs:label "Model parameters estimation" ;
     nidm_withEstimationMethod: obo_generalizedleastsquaresestimation: .
 
-niiri:aeba0c609d9e6e9f75d5a6250c59deda prov:wasAssociatedWith niiri:91a414225d56ee8a5a96d24be371a382 .
+niiri:2d8e016d2b75897ce56e33b9a1544133 prov:wasAssociatedWith niiri:aaaa36fcdc37bd70a89714f4c1960753 .
 
-niiri:aeba0c609d9e6e9f75d5a6250c59deda prov:used niiri:e53ee904c37499e500e163c748ba8db1 .
+niiri:2d8e016d2b75897ce56e33b9a1544133 prov:used niiri:fe11dc043a6c1e969d626e42eb4b8f47 .
 
-niiri:aeba0c609d9e6e9f75d5a6250c59deda prov:used niiri:09be76d412b7de63274a1bd3e8c8bd62 .
+niiri:2d8e016d2b75897ce56e33b9a1544133 prov:used niiri:1f414ea8a897406413eb2b2efd3d7fb0 .
 
-niiri:aeba0c609d9e6e9f75d5a6250c59deda prov:used niiri:447b4d5466b5e7ae9fe0aca95e48378b .
+niiri:2d8e016d2b75897ce56e33b9a1544133 prov:used niiri:ff5c473a8265e68dcc2fc87339f3f003 .
 
-niiri:4c26c48a8db02504e3f8b95c708cb7b5
+niiri:dfeb3a541e545f7225c8a300f30f9db2
     a prov:Entity, nidm_MaskMap: ; 
     prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
     nidm_isUserDefined: "false"^^xsd:boolean ;
     nfo:fileName "Mask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Mask" ;
-    nidm_inCoordinateSpace: niiri:f4860b5b14f96d2ce160d4f47ba40b97 ;
+    nidm_inCoordinateSpace: niiri:73f10b52c50aa13993a9f597d9e88831 ;
     crypto:sha512 "932fd9f0d55e9822748f4a9b35a0a7f0fe442f3e061e2eda48c2617a2938df50ea84deca8de0725641a0105b712a80a0c8931df9bdf3bef788b1041379d00875"^^xsd:string .
 
-niiri:9aef6a76e2de217324ca7ef6a830ac62
+niiri:aac954ca0b079b63bea50212e7bee7ba
     a prov:Entity, nidm_MaskMap: ; 
     nfo:fileName "mask.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "fbc254cab29db5532feccce554ec9d3c845197eca9013ec9f0efd5d8d56e3aa008ccee4038fb3651d30447fa0f316938b07c3ad961b623458dcd9b46968a8e11"^^xsd:string .
 
-niiri:4c26c48a8db02504e3f8b95c708cb7b5 prov:wasDerivedFrom niiri:9aef6a76e2de217324ca7ef6a830ac62 .
+niiri:dfeb3a541e545f7225c8a300f30f9db2 prov:wasDerivedFrom niiri:aac954ca0b079b63bea50212e7bee7ba .
 
-niiri:4c26c48a8db02504e3f8b95c708cb7b5 prov:wasGeneratedBy niiri:aeba0c609d9e6e9f75d5a6250c59deda .
+niiri:dfeb3a541e545f7225c8a300f30f9db2 prov:wasGeneratedBy niiri:2d8e016d2b75897ce56e33b9a1544133 .
 
-niiri:8cf64dafadf6551f3bf05b0dc44322de
+niiri:8435b87aba3543459a1877c94a7e8585
     a prov:Entity, nidm_GrandMeanMap: ; 
     prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
     nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Grand Mean Map" ;
     nidm_maskedMedian: "132.008995056152"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:f4860b5b14f96d2ce160d4f47ba40b97 ;
+    nidm_inCoordinateSpace: niiri:73f10b52c50aa13993a9f597d9e88831 ;
     crypto:sha512 "4d3528031bce4a9c1b994b8124e6e0eddb9df90b49c84787652ed94df8c14c04ec92100a2d8ea86a8df24ba44617aca7457ddcb2f42253fc17e33296a1aea1cb"^^xsd:string .
 
-niiri:8cf64dafadf6551f3bf05b0dc44322de prov:wasGeneratedBy niiri:aeba0c609d9e6e9f75d5a6250c59deda .
+niiri:8435b87aba3543459a1877c94a7e8585 prov:wasGeneratedBy niiri:2d8e016d2b75897ce56e33b9a1544133 .
 
-niiri:00309ec2bfb4094676ce58191425e6b9
+niiri:bfa48106876dd53a099a744977604cb9
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0001.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0001.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 1" ;
-    nidm_inCoordinateSpace: niiri:f4860b5b14f96d2ce160d4f47ba40b97 ;
+    nidm_inCoordinateSpace: niiri:73f10b52c50aa13993a9f597d9e88831 ;
     crypto:sha512 "fab2573099693215bac756bc796fbc983524473dec5c1b2d66fb83694c17412731df7f574094cb6c4a77994af7be11ed9aa545090fbe8ec6565a5c3c3dae8f0f"^^xsd:string .
 
-niiri:c71ec16606bcd54085e667b73221c2a0
+niiri:84bf7182b1084033459773520496afba
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "fab2573099693215bac756bc796fbc983524473dec5c1b2d66fb83694c17412731df7f574094cb6c4a77994af7be11ed9aa545090fbe8ec6565a5c3c3dae8f0f"^^xsd:string .
 
-niiri:00309ec2bfb4094676ce58191425e6b9 prov:wasDerivedFrom niiri:c71ec16606bcd54085e667b73221c2a0 .
+niiri:bfa48106876dd53a099a744977604cb9 prov:wasDerivedFrom niiri:84bf7182b1084033459773520496afba .
 
-niiri:00309ec2bfb4094676ce58191425e6b9 prov:wasGeneratedBy niiri:aeba0c609d9e6e9f75d5a6250c59deda .
+niiri:bfa48106876dd53a099a744977604cb9 prov:wasGeneratedBy niiri:2d8e016d2b75897ce56e33b9a1544133 .
 
-niiri:9e52aea97aeda2494ea801a4937e0ba6
+niiri:67a2055bd991bd22b5c0f8dbe2a9c324
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0002.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0002.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 2" ;
-    nidm_inCoordinateSpace: niiri:f4860b5b14f96d2ce160d4f47ba40b97 ;
+    nidm_inCoordinateSpace: niiri:73f10b52c50aa13993a9f597d9e88831 ;
     crypto:sha512 "3f72b788762d9ab2c7ddb5e4d446872694ee42fc8897fe5317b54efb7924f784da6499065db897a49595d8763d1893ad65ad102b0c88f2e72e2d028173343008"^^xsd:string .
 
-niiri:e229e8ee225828662ff356a392f960e7
+niiri:a29b3712891a7c91662d78dcf924770e
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0002.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "3f72b788762d9ab2c7ddb5e4d446872694ee42fc8897fe5317b54efb7924f784da6499065db897a49595d8763d1893ad65ad102b0c88f2e72e2d028173343008"^^xsd:string .
 
-niiri:9e52aea97aeda2494ea801a4937e0ba6 prov:wasDerivedFrom niiri:e229e8ee225828662ff356a392f960e7 .
+niiri:67a2055bd991bd22b5c0f8dbe2a9c324 prov:wasDerivedFrom niiri:a29b3712891a7c91662d78dcf924770e .
 
-niiri:9e52aea97aeda2494ea801a4937e0ba6 prov:wasGeneratedBy niiri:aeba0c609d9e6e9f75d5a6250c59deda .
+niiri:67a2055bd991bd22b5c0f8dbe2a9c324 prov:wasGeneratedBy niiri:2d8e016d2b75897ce56e33b9a1544133 .
 
-niiri:af19cb5b7657fd7b739ef1e05ce15178
+niiri:f0e51dd36c2dde61a8716db91b41826b
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Residual Mean Squares Map" ;
-    nidm_inCoordinateSpace: niiri:f4860b5b14f96d2ce160d4f47ba40b97 ;
+    nidm_inCoordinateSpace: niiri:73f10b52c50aa13993a9f597d9e88831 ;
     crypto:sha512 "84cd0e608b8763307a1166b88761291e552838d85b58334a69a286060f6489a3b0929a940c3ccac883803455118787ea32e0bb5a6d236a5d6e9e8b6a9f918a6b"^^xsd:string .
 
-niiri:e606b95cd2ce9841559f80aaa06126c4
+niiri:61f53db486ef78ea9054e7c459c5d1a1
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     nfo:fileName "ResMS.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "1635e0ae420cac1b5989fbc753b95f504dd957ff2986367fc4cd13ff35c44b4ee60994a9cdcab93a7d247fc5a8decb7578fa4c553b0ac905af8c7041db9b4acd"^^xsd:string .
 
-niiri:af19cb5b7657fd7b739ef1e05ce15178 prov:wasDerivedFrom niiri:e606b95cd2ce9841559f80aaa06126c4 .
+niiri:f0e51dd36c2dde61a8716db91b41826b prov:wasDerivedFrom niiri:61f53db486ef78ea9054e7c459c5d1a1 .
 
-niiri:af19cb5b7657fd7b739ef1e05ce15178 prov:wasGeneratedBy niiri:aeba0c609d9e6e9f75d5a6250c59deda .
+niiri:f0e51dd36c2dde61a8716db91b41826b prov:wasGeneratedBy niiri:2d8e016d2b75897ce56e33b9a1544133 .
 
-niiri:7b982ea4b4037a72101c144d50c0dae6
+niiri:63385fd67b9326e0111faaab4107d5ed
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Resels per Voxel Map" ;
-    nidm_inCoordinateSpace: niiri:f4860b5b14f96d2ce160d4f47ba40b97 ;
+    nidm_inCoordinateSpace: niiri:73f10b52c50aa13993a9f597d9e88831 ;
     crypto:sha512 "2025dc6c33708b80708c2eba3215fb1149df236fb558a8e8f8f6cf34595fb54734fe5e436db3e192a424d99699dd7feb2f4a9020ceae8e7bcbd881b17825256a"^^xsd:string .
 
-niiri:d738c59976e05c9ec1d1d60028dcccd8
+niiri:5995ef582e48e154eb1cca107d569d57
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     nfo:fileName "RPV.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "963283cdde607c40e4640c27453867bd0d70133b6d61482933862487c0f4a5acdb2e338a12a2605ee044b1aa47b5717f0c520b90ed3c49b5227f0483bd48512d"^^xsd:string .
 
-niiri:7b982ea4b4037a72101c144d50c0dae6 prov:wasDerivedFrom niiri:d738c59976e05c9ec1d1d60028dcccd8 .
+niiri:63385fd67b9326e0111faaab4107d5ed prov:wasDerivedFrom niiri:5995ef582e48e154eb1cca107d569d57 .
 
-niiri:7b982ea4b4037a72101c144d50c0dae6 prov:wasGeneratedBy niiri:aeba0c609d9e6e9f75d5a6250c59deda .
+niiri:63385fd67b9326e0111faaab4107d5ed prov:wasGeneratedBy niiri:2d8e016d2b75897ce56e33b9a1544133 .
 
-niiri:2d38c668d8a022e60dd72b97785669c6
+niiri:ad993e5ce29359b726f88b74782271d5
     a prov:Entity, obo_contrastweightmatrix: ; 
     nidm_statisticType: obo_tstatistic: ;
     nidm_contrastName: "passive listening > rest"^^xsd:string ;
     rdfs:label "Contrast: passive listening > rest" ;
     prov:value "[1, 0]"^^xsd:string .
 
-niiri:765840b904374bbb0560fd61db425925
+niiri:7a7c5806a1c15500776e7dedfe9f2000
     a prov:Activity, nidm_ContrastEstimation: ; 
     rdfs:label "Contrast estimation" .
 
-niiri:765840b904374bbb0560fd61db425925 prov:wasAssociatedWith niiri:91a414225d56ee8a5a96d24be371a382 .
+niiri:7a7c5806a1c15500776e7dedfe9f2000 prov:wasAssociatedWith niiri:aaaa36fcdc37bd70a89714f4c1960753 .
 
-niiri:765840b904374bbb0560fd61db425925 prov:used niiri:4c26c48a8db02504e3f8b95c708cb7b5 .
+niiri:7a7c5806a1c15500776e7dedfe9f2000 prov:used niiri:dfeb3a541e545f7225c8a300f30f9db2 .
 
-niiri:765840b904374bbb0560fd61db425925 prov:used niiri:af19cb5b7657fd7b739ef1e05ce15178 .
+niiri:7a7c5806a1c15500776e7dedfe9f2000 prov:used niiri:f0e51dd36c2dde61a8716db91b41826b .
 
-niiri:765840b904374bbb0560fd61db425925 prov:used niiri:e53ee904c37499e500e163c748ba8db1 .
+niiri:7a7c5806a1c15500776e7dedfe9f2000 prov:used niiri:fe11dc043a6c1e969d626e42eb4b8f47 .
 
-niiri:765840b904374bbb0560fd61db425925 prov:used niiri:2d38c668d8a022e60dd72b97785669c6 .
+niiri:7a7c5806a1c15500776e7dedfe9f2000 prov:used niiri:ad993e5ce29359b726f88b74782271d5 .
 
-niiri:765840b904374bbb0560fd61db425925 prov:used niiri:00309ec2bfb4094676ce58191425e6b9 .
+niiri:7a7c5806a1c15500776e7dedfe9f2000 prov:used niiri:bfa48106876dd53a099a744977604cb9 .
 
-niiri:765840b904374bbb0560fd61db425925 prov:used niiri:9e52aea97aeda2494ea801a4937e0ba6 .
+niiri:7a7c5806a1c15500776e7dedfe9f2000 prov:used niiri:67a2055bd991bd22b5c0f8dbe2a9c324 .
 
-niiri:bf4fbf8c16ddbcfff6524a516718fd32
+niiri:888e17582e5ef7a041d17c7887c474e9
     a prov:Entity, nidm_StatisticMap: ; 
     prov:atLocation "TStatistic.nii.gz"^^xsd:anyURI ;
     nfo:fileName "TStatistic.nii.gz"^^xsd:string ;
@@ -362,124 +362,124 @@ niiri:bf4fbf8c16ddbcfff6524a516718fd32
     nidm_contrastName: "passive listening > rest"^^xsd:string ;
     nidm_errorDegreesOfFreedom: "83.9999999999599"^^xsd:float ;
     nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:f4860b5b14f96d2ce160d4f47ba40b97 ;
+    nidm_inCoordinateSpace: niiri:73f10b52c50aa13993a9f597d9e88831 ;
     crypto:sha512 "799e9bbf8c15b35c0098bca468846bf2cd895a3366382b5ceaa953f1e9e576955341a7c86e13e6fe9359da4ff1496a609f55ce9ecff8da2e461365372f2506d6"^^xsd:string .
 
-niiri:b99915ef6f24d3803a3d2f842980a246
+niiri:2b0c1f2512d0af899ea7a06f8b4dd084
     a prov:Entity, nidm_StatisticMap: ; 
     nfo:fileName "spmT_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "55951f31f0ede7e88eca5cd4793df3f630aba21bc90fb81e3695db060c7d4c0b0ccf0b51fd8958c32ea3253d3122e9b31a54262bf910f8b5b646054ceb9a5825"^^xsd:string .
 
-niiri:bf4fbf8c16ddbcfff6524a516718fd32 prov:wasDerivedFrom niiri:b99915ef6f24d3803a3d2f842980a246 .
+niiri:888e17582e5ef7a041d17c7887c474e9 prov:wasDerivedFrom niiri:2b0c1f2512d0af899ea7a06f8b4dd084 .
 
-niiri:bf4fbf8c16ddbcfff6524a516718fd32 prov:wasGeneratedBy niiri:765840b904374bbb0560fd61db425925 .
+niiri:888e17582e5ef7a041d17c7887c474e9 prov:wasGeneratedBy niiri:7a7c5806a1c15500776e7dedfe9f2000 .
 
-niiri:b912512c4c30505c2e80260a987a41a6
+niiri:d8ec29b24e8671e380233ea9903cdbd2
     a prov:Entity, nidm_ContrastMap: ; 
     prov:atLocation "Contrast.nii.gz"^^xsd:anyURI ;
     nfo:fileName "Contrast.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Map: passive listening > rest" ;
     nidm_contrastName: "passive listening > rest"^^xsd:string ;
-    nidm_inCoordinateSpace: niiri:f4860b5b14f96d2ce160d4f47ba40b97 ;
+    nidm_inCoordinateSpace: niiri:73f10b52c50aa13993a9f597d9e88831 ;
     crypto:sha512 "f0720b732aaf19c2ec42d0469f8308beb3aa978baf65c7dce6476a0d8e5b2f38c4fa9609f045a536678440feebce9a047e3bd6d59fdb8fb64baae058690bbda2"^^xsd:string .
 
-niiri:cc5a92ad94752699bc8ba18c668c7ba7
+niiri:a9e27a34caba1fd226510284df275d61
     a prov:Entity, nidm_ContrastMap: ; 
     nfo:fileName "con_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "277dd1da13d391c33c172fb8c71060008cc66e173de6362eb857b0055b41e9bae57911f7ec4b45659905103b1139ebf3da0c2d04cf105bbce0cdc3004b643c22"^^xsd:string .
 
-niiri:b912512c4c30505c2e80260a987a41a6 prov:wasDerivedFrom niiri:cc5a92ad94752699bc8ba18c668c7ba7 .
+niiri:d8ec29b24e8671e380233ea9903cdbd2 prov:wasDerivedFrom niiri:a9e27a34caba1fd226510284df275d61 .
 
-niiri:b912512c4c30505c2e80260a987a41a6 prov:wasGeneratedBy niiri:765840b904374bbb0560fd61db425925 .
+niiri:d8ec29b24e8671e380233ea9903cdbd2 prov:wasGeneratedBy niiri:7a7c5806a1c15500776e7dedfe9f2000 .
 
-niiri:72105fa17b9aa34e09eba22a09d99f63
+niiri:7d5475358da5e5e3fa6b0096d3322086
     a prov:Entity, nidm_ContrastStandardErrorMap: ; 
     prov:atLocation "ContrastStandardError.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ContrastStandardError.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Standard Error Map" ;
-    nidm_inCoordinateSpace: niiri:f4860b5b14f96d2ce160d4f47ba40b97 ;
+    nidm_inCoordinateSpace: niiri:73f10b52c50aa13993a9f597d9e88831 ;
     crypto:sha512 "f4e3616579fe8b0812469409b1501e391bb17ca6e364f37d622b37fa9014cf1dd89befece07e73cf5bca5b3116f55ac4496751ca990db85e8377001a4be941b2"^^xsd:string .
 
-niiri:72105fa17b9aa34e09eba22a09d99f63 prov:wasGeneratedBy niiri:765840b904374bbb0560fd61db425925 .
+niiri:7d5475358da5e5e3fa6b0096d3322086 prov:wasGeneratedBy niiri:7a7c5806a1c15500776e7dedfe9f2000 .
 
-niiri:82a94267a053e0c842a0e8b1ab5355a3
+niiri:862fba010ccafbd94fca48544924ba80
     a prov:Entity, nidm_HeightThreshold:, obo_FWERadjustedpvalue: ; 
     rdfs:label "Height Threshold: p<0.050000 (FWE)" ;
     prov:value "0.0499999999999976"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:6936ed0873167edae7ab54416766c0ac ;
-    nidm_equivalentThreshold: niiri:3b109031ab420fb3a67037eff0629025 .
+    nidm_equivalentThreshold: niiri:c57807f0245de6c859bb9e20aeeba886 ;
+    nidm_equivalentThreshold: niiri:e31ef4cef3ce8c113074abc8ce03f836 .
 
-niiri:6936ed0873167edae7ab54416766c0ac
+niiri:c57807f0245de6c859bb9e20aeeba886
     a prov:Entity, nidm_HeightThreshold:, obo_statistic: ; 
-    rdfs:label "Height Threshold" ;
+    rdfs:label "Height Threshold: T=4.852417)" ;
     prov:value "4.85241745689539"^^xsd:float .
 
-niiri:3b109031ab420fb3a67037eff0629025
+niiri:e31ef4cef3ce8c113074abc8ce03f836
     a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
-    rdfs:label "Height Threshold" ;
+    rdfs:label "Height Threshold: p<0.000003 (unc.)" ;
     prov:value "2.7772578456986e-06"^^xsd:float .
 
-niiri:b0acf2cbe9cb30883ac9c52f546bb5a3
+niiri:2fc9252193ebe1e0c873e2913da2ce6d
     a prov:Entity, nidm_ExtentThreshold:, obo_statistic: ; 
     rdfs:label "Extent Threshold: k>=0" ;
     nidm_clusterSizeInVoxels: "0"^^xsd:int ;
     nidm_clusterSizeInResels: "0"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:cd0b4ed6cc186b3beb093cdc7f52a75e ;
-    nidm_equivalentThreshold: niiri:880a34828ebe2c327806878605f253dc .
+    nidm_equivalentThreshold: niiri:c7a17a77e954fd65195df87a97677960 ;
+    nidm_equivalentThreshold: niiri:6ed89a2da946cac0366979695a5e6c6a .
 
-niiri:cd0b4ed6cc186b3beb093cdc7f52a75e
+niiri:c7a17a77e954fd65195df87a97677960
     a prov:Entity, nidm_ExtentThreshold:, obo_FWERadjustedpvalue: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:880a34828ebe2c327806878605f253dc
+niiri:6ed89a2da946cac0366979695a5e6c6a
     a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:2d2e22f9a7307597b34ea8d5c607fa53
+niiri:bc857ecd2ddb63a671ab7c93208e389e
     a prov:Entity, nidm_PeakDefinitionCriteria: ; 
     rdfs:label "Peak Definition Criteria" ;
     nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
     nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
 
-niiri:350cec9bc40b76c4e0d77370cf05b127
+niiri:41bb616145da910a5db5521ca68d87d5
     a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
     rdfs:label "Cluster Connectivity Criterion: 18" ;
     nidm_hasConnectivityCriterion: nidm_voxel18connected: .
 
-niiri:9c1ea8c988e02a01a2bdc6bedff814d4
+niiri:7b79810a033a150be8ea7667379a6e2c
     a prov:Activity, nidm_Inference: ; 
     nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
     rdfs:label "Inference" .
 
-niiri:9c1ea8c988e02a01a2bdc6bedff814d4 prov:wasAssociatedWith niiri:91a414225d56ee8a5a96d24be371a382 .
+niiri:7b79810a033a150be8ea7667379a6e2c prov:wasAssociatedWith niiri:aaaa36fcdc37bd70a89714f4c1960753 .
 
-niiri:9c1ea8c988e02a01a2bdc6bedff814d4 prov:used niiri:82a94267a053e0c842a0e8b1ab5355a3 .
+niiri:7b79810a033a150be8ea7667379a6e2c prov:used niiri:862fba010ccafbd94fca48544924ba80 .
 
-niiri:9c1ea8c988e02a01a2bdc6bedff814d4 prov:used niiri:b0acf2cbe9cb30883ac9c52f546bb5a3 .
+niiri:7b79810a033a150be8ea7667379a6e2c prov:used niiri:2fc9252193ebe1e0c873e2913da2ce6d .
 
-niiri:9c1ea8c988e02a01a2bdc6bedff814d4 prov:used niiri:bf4fbf8c16ddbcfff6524a516718fd32 .
+niiri:7b79810a033a150be8ea7667379a6e2c prov:used niiri:888e17582e5ef7a041d17c7887c474e9 .
 
-niiri:9c1ea8c988e02a01a2bdc6bedff814d4 prov:used niiri:7b982ea4b4037a72101c144d50c0dae6 .
+niiri:7b79810a033a150be8ea7667379a6e2c prov:used niiri:63385fd67b9326e0111faaab4107d5ed .
 
-niiri:9c1ea8c988e02a01a2bdc6bedff814d4 prov:used niiri:4c26c48a8db02504e3f8b95c708cb7b5 .
+niiri:7b79810a033a150be8ea7667379a6e2c prov:used niiri:dfeb3a541e545f7225c8a300f30f9db2 .
 
-niiri:9c1ea8c988e02a01a2bdc6bedff814d4 prov:used niiri:2d2e22f9a7307597b34ea8d5c607fa53 .
+niiri:7b79810a033a150be8ea7667379a6e2c prov:used niiri:bc857ecd2ddb63a671ab7c93208e389e .
 
-niiri:9c1ea8c988e02a01a2bdc6bedff814d4 prov:used niiri:350cec9bc40b76c4e0d77370cf05b127 .
+niiri:7b79810a033a150be8ea7667379a6e2c prov:used niiri:41bb616145da910a5db5521ca68d87d5 .
 
-niiri:22c31b26fb7ba72523a54bccbfb5c807
+niiri:0955e8a851b6e4bb57177bb79d663a90
     a prov:Entity, nidm_SearchSpaceMaskMap: ; 
     prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
     nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Search Space Mask Map" ;
-    nidm_inCoordinateSpace: niiri:f4860b5b14f96d2ce160d4f47ba40b97 ;
+    nidm_inCoordinateSpace: niiri:73f10b52c50aa13993a9f597d9e88831 ;
     nidm_searchVolumeInVoxels: "69306"^^xsd:int ;
     nidm_searchVolumeInUnits: "1871262"^^xsd:float ;
     nidm_reselSizeInVoxels: "132.907586178202"^^xsd:float ;
@@ -496,9 +496,9 @@ niiri:22c31b26fb7ba72523a54bccbfb5c807
     spm_smallestSignificantClusterSizeInVoxelsFWE05: "12"^^xsd:int ;
     spm_smallestSignificantClusterSizeInVoxelsFDR05: "29"^^xsd:int .
 
-niiri:22c31b26fb7ba72523a54bccbfb5c807 prov:wasGeneratedBy niiri:9c1ea8c988e02a01a2bdc6bedff814d4 .
+niiri:0955e8a851b6e4bb57177bb79d663a90 prov:wasGeneratedBy niiri:7b79810a033a150be8ea7667379a6e2c .
 
-niiri:adb0c6a13e1b5f7e48c16fe815355303
+niiri:1ce7383d07b62dfc72f11d00c27a9fa5
     a prov:Entity, nidm_ExcursionSetMap: ; 
     prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
@@ -506,29 +506,29 @@ niiri:adb0c6a13e1b5f7e48c16fe815355303
     rdfs:label "Excursion Set Map" ;
     nidm_numberOfSupraThresholdClusters: "5"^^xsd:int ;
     nidm_pValue: "2.83510681597932e-09"^^xsd:float ;
-    nidm_hasClusterLabelsMap: niiri:78ec48d576e7260ada9f4fea44ced392 ;
-    nidm_hasMaximumIntensityProjection: niiri:b129452d0f62781da97d8128e5bd23f9 ;
-    nidm_inCoordinateSpace: niiri:f4860b5b14f96d2ce160d4f47ba40b97 ;
+    nidm_hasClusterLabelsMap: niiri:f3cce8b8925dba2ba5a72db44eb47dbf ;
+    nidm_hasMaximumIntensityProjection: niiri:c5d717db4ccc4350e7c44ba38c293f7d ;
+    nidm_inCoordinateSpace: niiri:73f10b52c50aa13993a9f597d9e88831 ;
     crypto:sha512 "d96b82761c299a66978893cab6034f3f8aed25d0a135636b0ffe79f4cf11becce86ba261f7aeb43717f5d0e47ad0b14cfb0402786251e3f2c507890c83b27652"^^xsd:string .
 
-niiri:78ec48d576e7260ada9f4fea44ced392
+niiri:f3cce8b8925dba2ba5a72db44eb47dbf
     a prov:Entity, nidm_ClusterLabelsMap: ; 
     prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Cluster Labels Map" ;
-    nidm_inCoordinateSpace: niiri:f4860b5b14f96d2ce160d4f47ba40b97 ;
+    nidm_inCoordinateSpace: niiri:73f10b52c50aa13993a9f597d9e88831 ;
     crypto:sha512 "a132bb284da461fd9e20eb2986373a9171c90a342c1e694297bc02f5674a311a560b7ff34bdf045dc191d4afff8c690a373db6408c1fe93f7c25e23707ce65c3"^^xsd:string .
 
-niiri:b129452d0f62781da97d8128e5bd23f9
+niiri:c5d717db4ccc4350e7c44ba38c293f7d
     a prov:Entity, dctype:Image ; 
     prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
     nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:adb0c6a13e1b5f7e48c16fe815355303 prov:wasGeneratedBy niiri:9c1ea8c988e02a01a2bdc6bedff814d4 .
+niiri:1ce7383d07b62dfc72f11d00c27a9fa5 prov:wasGeneratedBy niiri:7b79810a033a150be8ea7667379a6e2c .
 
-niiri:0ba96e7ae029d539c3491c1f21ff5e62
+niiri:02e9a33d08e23de77904e468485cf047
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0001" ;
     nidm_clusterSizeInVoxels: "839"^^xsd:int ;
@@ -538,9 +538,9 @@ niiri:0ba96e7ae029d539c3491c1f21ff5e62
     nidm_qValueFDR: "1.77948412240239e-18"^^xsd:float ;
     nidm_clusterLabelId: "1"^^xsd:int .
 
-niiri:0ba96e7ae029d539c3491c1f21ff5e62 prov:wasDerivedFrom niiri:adb0c6a13e1b5f7e48c16fe815355303 .
+niiri:02e9a33d08e23de77904e468485cf047 prov:wasDerivedFrom niiri:1ce7383d07b62dfc72f11d00c27a9fa5 .
 
-niiri:62ecedbdd808eaaf2a2754cec2853a7c
+niiri:d1701492186c7811850274355c9a5da3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0002" ;
     nidm_clusterSizeInVoxels: "695"^^xsd:int ;
@@ -550,9 +550,9 @@ niiri:62ecedbdd808eaaf2a2754cec2853a7c
     nidm_qValueFDR: "1.33570070658018e-16"^^xsd:float ;
     nidm_clusterLabelId: "2"^^xsd:int .
 
-niiri:62ecedbdd808eaaf2a2754cec2853a7c prov:wasDerivedFrom niiri:adb0c6a13e1b5f7e48c16fe815355303 .
+niiri:d1701492186c7811850274355c9a5da3 prov:wasDerivedFrom niiri:1ce7383d07b62dfc72f11d00c27a9fa5 .
 
-niiri:b6305d8cf589e221d76467505f479d49
+niiri:88442be7736ad5eec0053052bd6e0179
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0003" ;
     nidm_clusterSizeInVoxels: "37"^^xsd:int ;
@@ -562,9 +562,9 @@ niiri:b6305d8cf589e221d76467505f479d49
     nidm_qValueFDR: "0.00829922079256674"^^xsd:float ;
     nidm_clusterLabelId: "3"^^xsd:int .
 
-niiri:b6305d8cf589e221d76467505f479d49 prov:wasDerivedFrom niiri:adb0c6a13e1b5f7e48c16fe815355303 .
+niiri:88442be7736ad5eec0053052bd6e0179 prov:wasDerivedFrom niiri:1ce7383d07b62dfc72f11d00c27a9fa5 .
 
-niiri:73900d08903efa68fe450ec1e137a1cb
+niiri:98d0b221eadccb2110d30e7f996a11e7
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0004" ;
     nidm_clusterSizeInVoxels: "29"^^xsd:int ;
@@ -574,9 +574,9 @@ niiri:73900d08903efa68fe450ec1e137a1cb
     nidm_qValueFDR: "0.0137821290130967"^^xsd:float ;
     nidm_clusterLabelId: "4"^^xsd:int .
 
-niiri:73900d08903efa68fe450ec1e137a1cb prov:wasDerivedFrom niiri:adb0c6a13e1b5f7e48c16fe815355303 .
+niiri:98d0b221eadccb2110d30e7f996a11e7 prov:wasDerivedFrom niiri:1ce7383d07b62dfc72f11d00c27a9fa5 .
 
-niiri:8db5593450e9ad94172a123dc9881fc1
+niiri:1a862c5b84ba646d826413c480f4d010
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0005" ;
     nidm_clusterSizeInVoxels: "12"^^xsd:int ;
@@ -586,158 +586,158 @@ niiri:8db5593450e9ad94172a123dc9881fc1
     nidm_qValueFDR: "0.0818393184514307"^^xsd:float ;
     nidm_clusterLabelId: "5"^^xsd:int .
 
-niiri:8db5593450e9ad94172a123dc9881fc1 prov:wasDerivedFrom niiri:adb0c6a13e1b5f7e48c16fe815355303 .
+niiri:1a862c5b84ba646d826413c480f4d010 prov:wasDerivedFrom niiri:1ce7383d07b62dfc72f11d00c27a9fa5 .
 
-niiri:f25790188e0a938fda159ab70b6bb952
+niiri:ca8b66656ab798a1f5a045766f5d41de
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0001" ;
-    prov:atLocation niiri:67eba1ea2930c57af65969243c4ed205 ;
+    prov:atLocation niiri:a8598038ca4a8b33b2dfe04f95b6c161 ;
     prov:value "17.5207633972168"^^xsd:float ;
     nidm_equivalentZStatistic: "INF"^^xsd:float ;
     nidm_pValueUncorrected: "4.44089209850063e-16"^^xsd:float ;
     nidm_pValueFWER: "0"^^xsd:float ;
     nidm_qValueFDR: "1.19156591713838e-11"^^xsd:float .
 
-niiri:67eba1ea2930c57af65969243c4ed205
+niiri:a8598038ca4a8b33b2dfe04f95b6c161
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0001" ;
     nidm_coordinateVector: "[-60,-25,11]"^^xsd:string .
 
-niiri:f25790188e0a938fda159ab70b6bb952 prov:wasDerivedFrom niiri:0ba96e7ae029d539c3491c1f21ff5e62 .
+niiri:ca8b66656ab798a1f5a045766f5d41de prov:wasDerivedFrom niiri:02e9a33d08e23de77904e468485cf047 .
 
-niiri:7e4a23c23029a7d7847d9d000f2be1a8
+niiri:414ba670c5dcea4f3bd8bc915e88466a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0002" ;
-    prov:atLocation niiri:86ed510de31f5f9a7c7c0311851d1019 ;
+    prov:atLocation niiri:5acdd0ceb3ce5a5c9c75a1a17d22ca5f ;
     prov:value "13.0321407318115"^^xsd:float ;
     nidm_equivalentZStatistic: "INF"^^xsd:float ;
     nidm_pValueUncorrected: "4.44089209850063e-16"^^xsd:float ;
     nidm_pValueFWER: "0"^^xsd:float ;
     nidm_qValueFDR: "1.19156591713838e-11"^^xsd:float .
 
-niiri:86ed510de31f5f9a7c7c0311851d1019
+niiri:5acdd0ceb3ce5a5c9c75a1a17d22ca5f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0002" ;
     nidm_coordinateVector: "[-42,-31,11]"^^xsd:string .
 
-niiri:7e4a23c23029a7d7847d9d000f2be1a8 prov:wasDerivedFrom niiri:0ba96e7ae029d539c3491c1f21ff5e62 .
+niiri:414ba670c5dcea4f3bd8bc915e88466a prov:wasDerivedFrom niiri:02e9a33d08e23de77904e468485cf047 .
 
-niiri:b52136167b47ed42b1d06069b8ca8620
+niiri:aa8942e5b5f535f75dd2e80da17f1546
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0003" ;
-    prov:atLocation niiri:db3e3c348eeb68bef67f5fc08c4b6fb0 ;
+    prov:atLocation niiri:e6c5a00711416271b141558c1bd92e4b ;
     prov:value "10.2856016159058"^^xsd:float ;
     nidm_equivalentZStatistic: "INF"^^xsd:float ;
     nidm_pValueUncorrected: "4.44089209850063e-16"^^xsd:float ;
     nidm_pValueFWER: "7.69451169446711e-12"^^xsd:float ;
     nidm_qValueFDR: "6.84121260274992e-10"^^xsd:float .
 
-niiri:db3e3c348eeb68bef67f5fc08c4b6fb0
+niiri:e6c5a00711416271b141558c1bd92e4b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0003" ;
     nidm_coordinateVector: "[-66,-31,-1]"^^xsd:string .
 
-niiri:b52136167b47ed42b1d06069b8ca8620 prov:wasDerivedFrom niiri:0ba96e7ae029d539c3491c1f21ff5e62 .
+niiri:aa8942e5b5f535f75dd2e80da17f1546 prov:wasDerivedFrom niiri:02e9a33d08e23de77904e468485cf047 .
 
-niiri:b0902e75c679c437569ac7dbc81ebab1
+niiri:90126f11793e8554f08eb9473d5ae15c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0004" ;
-    prov:atLocation niiri:664666406985e4f667bc660d3e10f00a ;
+    prov:atLocation niiri:0cc8e87d27467eefcceb101b56a19c68 ;
     prov:value "13.5425577163696"^^xsd:float ;
     nidm_equivalentZStatistic: "INF"^^xsd:float ;
     nidm_pValueUncorrected: "4.44089209850063e-16"^^xsd:float ;
     nidm_pValueFWER: "0"^^xsd:float ;
     nidm_qValueFDR: "1.19156591713838e-11"^^xsd:float .
 
-niiri:664666406985e4f667bc660d3e10f00a
+niiri:0cc8e87d27467eefcceb101b56a19c68
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0004" ;
     nidm_coordinateVector: "[63,-13,-4]"^^xsd:string .
 
-niiri:b0902e75c679c437569ac7dbc81ebab1 prov:wasDerivedFrom niiri:62ecedbdd808eaaf2a2754cec2853a7c .
+niiri:90126f11793e8554f08eb9473d5ae15c prov:wasDerivedFrom niiri:d1701492186c7811850274355c9a5da3 .
 
-niiri:ae108645e2dfe81017b4dab76141964b
+niiri:6e9b5798a110211eece6cd9bf78afa51
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0005" ;
-    prov:atLocation niiri:0238bc39184b3f1d80e96d21d7b2ba50 ;
+    prov:atLocation niiri:1b918485e2cbed73d8ac005a27a82891 ;
     prov:value "12.4728717803955"^^xsd:float ;
     nidm_equivalentZStatistic: "INF"^^xsd:float ;
     nidm_pValueUncorrected: "4.44089209850063e-16"^^xsd:float ;
     nidm_pValueFWER: "0"^^xsd:float ;
     nidm_qValueFDR: "1.19156591713838e-11"^^xsd:float .
 
-niiri:0238bc39184b3f1d80e96d21d7b2ba50
+niiri:1b918485e2cbed73d8ac005a27a82891
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0005" ;
     nidm_coordinateVector: "[60,-22,11]"^^xsd:string .
 
-niiri:ae108645e2dfe81017b4dab76141964b prov:wasDerivedFrom niiri:62ecedbdd808eaaf2a2754cec2853a7c .
+niiri:6e9b5798a110211eece6cd9bf78afa51 prov:wasDerivedFrom niiri:d1701492186c7811850274355c9a5da3 .
 
-niiri:469bd2f450f1dd64463b3659c97a2b52
+niiri:13169f43d43dcd28f4ac0a37a5dfa9b0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0006" ;
-    prov:atLocation niiri:33d2e1928e071d40c56595b7e30700df ;
+    prov:atLocation niiri:37f49ee5dac306c833b0b6456603dd74 ;
     prov:value "9.72103404998779"^^xsd:float ;
     nidm_equivalentZStatistic: "INF"^^xsd:float ;
     nidm_pValueUncorrected: "1.22124532708767e-15"^^xsd:float ;
     nidm_pValueFWER: "6.9250605250204e-11"^^xsd:float ;
     nidm_qValueFDR: "6.52169693024352e-09"^^xsd:float .
 
-niiri:33d2e1928e071d40c56595b7e30700df
+niiri:37f49ee5dac306c833b0b6456603dd74
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0006" ;
     nidm_coordinateVector: "[57,-40,5]"^^xsd:string .
 
-niiri:469bd2f450f1dd64463b3659c97a2b52 prov:wasDerivedFrom niiri:62ecedbdd808eaaf2a2754cec2853a7c .
+niiri:13169f43d43dcd28f4ac0a37a5dfa9b0 prov:wasDerivedFrom niiri:d1701492186c7811850274355c9a5da3 .
 
-niiri:91669712ee5babe4f83a178cbe509a73
+niiri:819979d305d01b9553c2bfc1398b4de8
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0007" ;
-    prov:atLocation niiri:53f9b5bc77b97eafbecb860028aa265c ;
+    prov:atLocation niiri:c19b896ff31dce4bf576fe98821aba9c ;
     prov:value "6.55745935440063"^^xsd:float ;
     nidm_equivalentZStatistic: "5.87574033699266"^^xsd:float ;
     nidm_pValueUncorrected: "2.10478867668229e-09"^^xsd:float ;
     nidm_pValueFWER: "9.17574302586877e-05"^^xsd:float ;
     nidm_qValueFDR: "0.00257605396646668"^^xsd:float .
 
-niiri:53f9b5bc77b97eafbecb860028aa265c
+niiri:c19b896ff31dce4bf576fe98821aba9c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0007" ;
     nidm_coordinateVector: "[36,-28,-13]"^^xsd:string .
 
-niiri:91669712ee5babe4f83a178cbe509a73 prov:wasDerivedFrom niiri:b6305d8cf589e221d76467505f479d49 .
+niiri:819979d305d01b9553c2bfc1398b4de8 prov:wasDerivedFrom niiri:88442be7736ad5eec0053052bd6e0179 .
 
-niiri:0d705a0752ec3881d2ba0cf183c825d4
+niiri:9f9f4589c34e65f926a7491d59f7ae39
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0008" ;
-    prov:atLocation niiri:2a2c8ea727a0e3663fd038ef2962a71b ;
+    prov:atLocation niiri:16adab65d227da691d1b032641f99620 ;
     prov:value "6.19558477401733"^^xsd:float ;
     nidm_equivalentZStatistic: "5.60645028016544"^^xsd:float ;
     nidm_pValueUncorrected: "1.0325913235576e-08"^^xsd:float ;
     nidm_pValueFWER: "0.000382453907303626"^^xsd:float ;
     nidm_qValueFDR: "0.00949154522981781"^^xsd:float .
 
-niiri:2a2c8ea727a0e3663fd038ef2962a71b
+niiri:16adab65d227da691d1b032641f99620
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0008" ;
     nidm_coordinateVector: "[-33,-31,-16]"^^xsd:string .
 
-niiri:0d705a0752ec3881d2ba0cf183c825d4 prov:wasDerivedFrom niiri:73900d08903efa68fe450ec1e137a1cb .
+niiri:9f9f4589c34e65f926a7491d59f7ae39 prov:wasDerivedFrom niiri:98d0b221eadccb2110d30e7f996a11e7 .
 
-niiri:3cd641e21261259d690f9d09d4a620c9
+niiri:da9faeb078561ebedea50e462541e026
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0009" ;
-    prov:atLocation niiri:a3a6c876397c4457f4aa472116513bdf ;
+    prov:atLocation niiri:9658e1ec0692c07fb609a32b3b3e4074 ;
     prov:value "5.27320194244385"^^xsd:float ;
     nidm_equivalentZStatistic: "4.88682085490477"^^xsd:float ;
     nidm_pValueUncorrected: "5.12386299833523e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0119099090973821"^^xsd:float ;
     nidm_qValueFDR: "0.251554254717758"^^xsd:float .
 
-niiri:a3a6c876397c4457f4aa472116513bdf
+niiri:9658e1ec0692c07fb609a32b3b3e4074
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0009" ;
     nidm_coordinateVector: "[45,-40,32]"^^xsd:string .
 
-niiri:3cd641e21261259d690f9d09d4a620c9 prov:wasDerivedFrom niiri:8db5593450e9ad94172a123dc9881fc1 .
+niiri:da9faeb078561ebedea50e462541e026 prov:wasDerivedFrom niiri:1a862c5b84ba646d826413c480f4d010 .
 

--- a/spmexport/ex_spm_group_ols/nidm.json
+++ b/spmexport/ex_spm_group_ols/nidm.json
@@ -1,0 +1,3057 @@
+{
+  "prefix": {
+    "nidm": "http://purl.org/nidash/nidm#",
+    "niiri": "http://iri.nidash.org/",
+    "spm": "http://purl.org/nidash/spm#",
+    "neurolex": "http://neurolex.org/wiki/",
+    "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/",
+    "dct": "http://purl.org/dc/terms/",
+    "nfo": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#",
+    "dc": "http://purl.org/dc/elements/1.1/",
+    "dctype": "http://purl.org/dc/dcmitype/",
+    "obo": "http://purl.obolibrary.org/obo/",
+    "nidm_NIDMResults": "http://purl.org/nidash/nidm#NIDM_0000027",
+    "nidm_version": "http://purl.org/nidash/nidm#NIDM_0000127",
+    "nidm_spm_results_nidm": "http://purl.org/nidash/nidm#NIDM_0000168",
+    "nidm_softwareVersion": "http://purl.org/nidash/nidm#NIDM_0000122",
+    "nidm_NIDMResultsExport": "http://purl.org/nidash/nidm#NIDM_0000166"
+  },
+  "entity": {
+    "niiri:68ee16fec71e89a7b58245aa1b686dfb": {
+      "prov:type": [
+        {
+        "$": "prov:Bundle",
+        "type": "xsd:QName"
+        },
+        {
+        "$": "nidm_NIDMResults:",
+        "type": "xsd:QName"
+        }
+      ],
+      "prov:label": {
+        "$": "NIDM-Results",
+        "type": "xsd:string"
+      },
+      "nidm_version:": {
+        "$": "1.3.0",
+        "type": "xsd:string"
+      }
+    }
+  },
+  "activity": {
+    "niiri:67662d8460b62a35fcf8b5cc394aa18c": {
+      "prov:type": {
+        "$": "nidm_NIDMResultsExport:",
+        "type": "xsd:QName"
+      },
+      "prov:label": {
+        "$": "NIDM-Results export",
+        "type": "xsd:string"
+      }
+    }
+  },
+  "agent": {
+    "niiri:4d435dbb932d842eb0f29f9f295f4d39": {
+      "prov:type": [
+        {
+        "$": "nidm_spm_results_nidm:",
+        "type": "xsd:QName"
+        },
+        {
+        "$": "prov:SoftwareAgent",
+        "type": "xsd:QName"
+        }
+      ],
+      "prov:label": {
+        "$": "spm_results_nidm",
+        "type": "xsd:string"
+      },
+      "nidm_softwareVersion:": {
+        "$": "12.7057",
+        "type": "xsd:string"
+      }
+    }
+  },
+  "wasGeneratedBy": {
+    "_:wGB5": {
+      "prov:entity": "niiri:68ee16fec71e89a7b58245aa1b686dfb",
+      "prov:activity": "niiri:67662d8460b62a35fcf8b5cc394aa18c",
+      "prov:time": "2017-04-19T12:18:11"
+    }
+  },
+  "wasAssociatedWith": {
+    "_:wAW4": {
+      "prov:activity": "niiri:67662d8460b62a35fcf8b5cc394aa18c",
+      "prov:agent": "niiri:4d435dbb932d842eb0f29f9f295f4d39"
+    }
+  },
+  "bundle": {
+    "niiri:68ee16fec71e89a7b58245aa1b686dfb": {
+    "prefix": {
+        "nidm_softwareVersion": "http://purl.org/nidash/nidm#NIDM_0000122",
+        "nidm_CoordinateSpace": "http://purl.org/nidash/nidm#NIDM_0000016",
+        "nidm_voxelToWorldMapping": "http://purl.org/nidash/nidm#NIDM_0000132",
+        "nidm_voxelUnits": "http://purl.org/nidash/nidm#NIDM_0000133",
+        "nidm_voxelSize": "http://purl.org/nidash/nidm#NIDM_0000131",
+        "nidm_inWorldCoordinateSystem": "http://purl.org/nidash/nidm#NIDM_0000105",
+        "nidm_numberOfDimensions": "http://purl.org/nidash/nidm#NIDM_0000112",
+        "nidm_dimensionsInVoxels": "http://purl.org/nidash/nidm#NIDM_0000090",
+        "nlx_Imaginginstrument": "http://uri.neuinfo.org/nif/nifstd/birnlex_2094",
+        "nlx_Magneticresonanceimagingscanner": "http://uri.neuinfo.org/nif/nifstd/birnlex_2100",
+        "obo_studygrouppopulation": "http://purl.obolibrary.org/obo/STATO_0000193",
+        "nidm_groupName": "http://purl.org/nidash/nidm#NIDM_0000170",
+        "nidm_numberOfSubjects": "http://purl.org/nidash/nidm#NIDM_0000171",
+        "nidm_grandMeanScaling": "http://purl.org/nidash/nidm#NIDM_0000096",
+        "nidm_hasMRIProtocol": "http://purl.org/nidash/nidm#NIDM_0000172",
+        "nlx_FunctionalMRIprotocol": "http://uri.neuinfo.org/nif/nifstd/birnlex_2250",
+        "nidm_Data": "http://purl.org/nidash/nidm#NIDM_0000169",
+        "nidm_DesignMatrix": "http://purl.org/nidash/nidm#NIDM_0000019",
+        "nidm_regressorNames": "http://purl.org/nidash/nidm#NIDM_0000021",
+        "nidm_hasErrorDependence": "http://purl.org/nidash/nidm#NIDM_0000100",
+        "nidm_IndependentError": "http://purl.org/nidash/nidm#NIDM_0000048",
+        "nidm_errorVarianceHomogeneous": "http://purl.org/nidash/nidm#NIDM_0000094",
+        "nidm_varianceMapWiseDependence": "http://purl.org/nidash/nidm#NIDM_0000126",
+        "nidm_IndependentParameter": "http://purl.org/nidash/nidm#NIDM_0000073",
+        "nidm_withEstimationMethod": "http://purl.org/nidash/nidm#NIDM_0000134",
+        "obo_ordinaryleastsquaresestimation": "http://purl.obolibrary.org/obo/STATO_0000370",
+        "nidm_ErrorModel": "http://purl.org/nidash/nidm#NIDM_0000023",
+        "nidm_hasErrorDistribution": "http://purl.org/nidash/nidm#NIDM_0000101",
+        "obo_normaldistribution": "http://purl.obolibrary.org/obo/STATO_0000227",
+        "nidm_ModelParametersEstimation": "http://purl.org/nidash/nidm#NIDM_0000056",
+        "nidm_MaskMap": "http://purl.org/nidash/nidm#NIDM_0000054",
+        "nidm_isUserDefined": "http://purl.org/nidash/nidm#NIDM_0000106",
+        "nidm_inCoordinateSpace": "http://purl.org/nidash/nidm#NIDM_0000104",
+        "nidm_GrandMeanMap": "http://purl.org/nidash/nidm#NIDM_0000033",
+        "nidm_maskedMedian": "http://purl.org/nidash/nidm#NIDM_0000107",
+        "nidm_ParameterEstimateMap": "http://purl.org/nidash/nidm#NIDM_0000061",
+        "nidm_ResidualMeanSquaresMap": "http://purl.org/nidash/nidm#NIDM_0000066",
+        "nidm_ReselsPerVoxelMap": "http://purl.org/nidash/nidm#NIDM_0000144",
+        "obo_contrastweightmatrix": "http://purl.obolibrary.org/obo/STATO_0000323",
+        "nidm_statisticType": "http://purl.org/nidash/nidm#NIDM_0000123",
+        "obo_tstatistic": "http://purl.obolibrary.org/obo/STATO_0000176",
+        "nidm_contrastName": "http://purl.org/nidash/nidm#NIDM_0000085",
+        "nidm_ContrastEstimation": "http://purl.org/nidash/nidm#NIDM_0000001",
+        "nidm_StatisticMap": "http://purl.org/nidash/nidm#NIDM_0000076",
+        "nidm_errorDegreesOfFreedom": "http://purl.org/nidash/nidm#NIDM_0000093",
+        "nidm_effectDegreesOfFreedom": "http://purl.org/nidash/nidm#NIDM_0000091",
+        "nidm_ContrastMap": "http://purl.org/nidash/nidm#NIDM_0000002",
+        "nidm_ContrastStandardErrorMap": "http://purl.org/nidash/nidm#NIDM_0000013",
+        "obo_statistic": "http://purl.obolibrary.org/obo/STATO_0000039",
+        "nidm_PValueUncorrected": "http://purl.org/nidash/nidm#NIDM_0000160",
+        "obo_FWERadjustedpvalue": "http://purl.obolibrary.org/obo/OBI_0001265",
+        "nidm_HeightThreshold": "http://purl.org/nidash/nidm#NIDM_0000034",
+        "nidm_equivalentThreshold": "http://purl.org/nidash/nidm#NIDM_0000161",
+        "nidm_ExtentThreshold": "http://purl.org/nidash/nidm#NIDM_0000026",
+        "nidm_clusterSizeInVoxels": "http://purl.org/nidash/nidm#NIDM_0000084",
+        "nidm_clusterSizeInResels": "http://purl.org/nidash/nidm#NIDM_0000156",
+        "nidm_PeakDefinitionCriteria": "http://purl.org/nidash/nidm#NIDM_0000063",
+        "nidm_maxNumberOfPeaksPerCluster": "http://purl.org/nidash/nidm#NIDM_0000108",
+        "nidm_minDistanceBetweenPeaks": "http://purl.org/nidash/nidm#NIDM_0000109",
+        "nidm_ClusterDefinitionCriteria": "http://purl.org/nidash/nidm#NIDM_0000007",
+        "nidm_hasConnectivityCriterion": "http://purl.org/nidash/nidm#NIDM_0000099",
+        "nidm_voxel18connected": "http://purl.org/nidash/nidm#NIDM_0000128",
+        "nidm_Inference": "http://purl.org/nidash/nidm#NIDM_0000049",
+        "nidm_hasAlternativeHypothesis": "http://purl.org/nidash/nidm#NIDM_0000097",
+        "nidm_OneTailedTest": "http://purl.org/nidash/nidm#NIDM_0000060",
+        "nidm_SearchSpaceMaskMap": "http://purl.org/nidash/nidm#NIDM_0000068",
+        "nidm_searchVolumeInVoxels": "http://purl.org/nidash/nidm#NIDM_0000121",
+        "nidm_searchVolumeInUnits": "http://purl.org/nidash/nidm#NIDM_0000136",
+        "nidm_reselSizeInVoxels": "http://purl.org/nidash/nidm#NIDM_0000148",
+        "nidm_searchVolumeInResels": "http://purl.org/nidash/nidm#NIDM_0000149",
+        "spm_searchVolumeReselsGeometry": "http://purl.org/nidash/spm#SPM_0000010",
+        "nidm_noiseFWHMInVoxels": "http://purl.org/nidash/nidm#NIDM_0000159",
+        "nidm_noiseFWHMInUnits": "http://purl.org/nidash/nidm#NIDM_0000157",
+        "nidm_randomFieldStationarity": "http://purl.org/nidash/nidm#NIDM_0000120",
+        "nidm_expectedNumberOfVoxelsPerCluster": "http://purl.org/nidash/nidm#NIDM_0000143",
+        "nidm_expectedNumberOfClusters": "http://purl.org/nidash/nidm#NIDM_0000141",
+        "nidm_heightCriticalThresholdFWE05": "http://purl.org/nidash/nidm#NIDM_0000147",
+        "nidm_heightCriticalThresholdFDR05": "http://purl.org/nidash/nidm#NIDM_0000146",
+        "spm_smallestSignificantClusterSizeInVoxelsFWE05": "http://purl.org/nidash/spm#SPM_0000014",
+        "spm_smallestSignificantClusterSizeInVoxelsFDR05": "http://purl.org/nidash/spm#SPM_0000013",
+        "nidm_ExcursionSetMap": "http://purl.org/nidash/nidm#NIDM_0000025",
+        "nidm_numberOfSupraThresholdClusters": "http://purl.org/nidash/nidm#NIDM_0000111",
+        "nidm_pValue": "http://purl.org/nidash/nidm#NIDM_0000114",
+        "nidm_hasClusterLabelsMap": "http://purl.org/nidash/nidm#NIDM_0000098",
+        "nidm_hasMaximumIntensityProjection": "http://purl.org/nidash/nidm#NIDM_0000138",
+        "nidm_ClusterLabelsMap": "http://purl.org/nidash/nidm#NIDM_0000008",
+        "nidm_SupraThresholdCluster": "http://purl.org/nidash/nidm#NIDM_0000070",
+        "nidm_pValueUncorrected": "http://purl.org/nidash/nidm#NIDM_0000116",
+        "nidm_pValueFWER": "http://purl.org/nidash/nidm#NIDM_0000115",
+        "nidm_qValueFDR": "http://purl.org/nidash/nidm#NIDM_0000119",
+        "nidm_clusterLabelId": "http://purl.org/nidash/nidm#NIDM_0000082",
+        "nidm_Peak": "http://purl.org/nidash/nidm#NIDM_0000062",
+        "nidm_equivalentZStatistic": "http://purl.org/nidash/nidm#NIDM_0000092",
+        "nidm_Coordinate": "http://purl.org/nidash/nidm#NIDM_0000015",
+        "nidm_coordinateVector": "http://purl.org/nidash/nidm#NIDM_0000086"
+    },
+    "entity": {
+        "niiri:5e472b9e1804aecf84d34427aeac5d36": {
+            "prov:type": {
+                "$": "nidm_CoordinateSpace:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Coordinate space 1",
+                "type": "xsd:string"
+            },
+            "nidm_voxelToWorldMapping:": {
+                "$": "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]",
+                "type": "xsd:string"
+            },
+            "nidm_voxelUnits:": {
+                "$": "[\"mm\", \"mm\", \"mm\"]",
+                "type": "xsd:string"
+            },
+            "nidm_voxelSize:": {
+                "$": "[2, 2, 2]",
+                "type": "xsd:string"
+            },
+            "nidm_inWorldCoordinateSystem:": {
+                "$": "nidm_Ixi549CoordinateSystem:",
+                "type": "xsd:string"
+            },
+            "nidm_numberOfDimensions:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_dimensionsInVoxels:": {
+                "$": "[79,95,79]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ca46b04d477ee0f0e6f16c372a1a4976": {
+            "prov:type": [
+                {
+                "$": "prov:Collection",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Data:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Data",
+                "type": "xsd:string"
+            },
+            "nidm_grandMeanScaling:": {
+                "$": "false",
+                "type": "xsd:boolean"
+            },
+            "nidm_hasMRIProtocol:": {
+                "$": "nlx_FunctionalMRIprotocol:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5974cc100f3ec5600037861f2b9ed1de": {
+            "prov:type": {
+                "$": "nidm_DesignMatrix:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "DesignMatrix.csv",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "DesignMatrix.csv",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "text/csv",
+                "type": "xsd:string"
+            },
+            "dc:description": {
+                "$": "niiri:153b70474f3c5edca79e4bf57a7ee204",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Design Matrix",
+                "type": "xsd:string"
+            },
+            "nidm_regressorNames:": {
+                "$": "[\"mean\"]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:153b70474f3c5edca79e4bf57a7ee204": {
+            "prov:type": {
+                "$": "dctype:Image",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "DesignMatrix.png",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "DesignMatrix.png",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/png",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7cf52921ad5716e824bef8a127efb7bc": {
+            "prov:type": {
+                "$": "nidm_ErrorModel:",
+                "type": "xsd:QName"
+            },
+            "nidm_hasErrorDistribution:": {
+                "$": "obo_normaldistribution:",
+                "type": "xsd:string"
+            },
+            "nidm_hasErrorDependence:": {
+                "$": "nidm_IndependentError:",
+                "type": "xsd:string"
+            },
+            "nidm_errorVarianceHomogeneous:": {
+                "$": "true",
+                "type": "xsd:boolean"
+            },
+            "nidm_varianceMapWiseDependence:": {
+                "$": "nidm_IndependentParameter:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:134717e80ac83bc17cf1e5f4b6a0dab8": {
+            "prov:type": {
+                "$": "nidm_MaskMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "Mask.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nidm_isUserDefined:": {
+                "$": "false",
+                "type": "xsd:boolean"
+            },
+            "nfo:fileName": {
+                "$": "Mask.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Mask",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:5e472b9e1804aecf84d34427aeac5d36",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "71153b4ca7e1136cf9ae9cb56eaf6a4ed494bad08a1cfa0659e8e211a36425aaf865c3def12dea06c5595662761b891c87ec7b8fa0b8b75cd31247be9418bf24",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4efbab6889ea73c471c6ec4da367d19d": {
+            "prov:type": {
+                "$": "nidm_MaskMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "mask.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "e33feb3fddb2a3ee6d91e0b84ce0050a83414df67559e07679326fab2c31494df0a1db2d693027786c839b356626159d9158e4e9766b2bf46be4d32678f356fd",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b1aa0fbd676b8d41f017be6bdbd31cd3": {
+            "prov:type": {
+                "$": "nidm_GrandMeanMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "GrandMean.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "GrandMean.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Grand Mean Map",
+                "type": "xsd:string"
+            },
+            "nidm_maskedMedian:": {
+                "$": "-0.0577427912503481",
+                "type": "xsd:float"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:5e472b9e1804aecf84d34427aeac5d36",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "f35910a69f57ca530caf395eff6a18f7c8b9715206695cbe6852d4a235128edd4cfecd11f613eb3b9a1ffc9b471d3018bb14472c92453bcd9fc5afe8715c78ca",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2c7195286f0c7c5d7c26fed41636166c": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0001.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0001.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 1",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:5e472b9e1804aecf84d34427aeac5d36",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "7ec9d8c6e184528ab65f3f51dd1622acede31fc2cf3b7f26c4f5769401eee3b887248e8dc51868dfb21fc8e5890cf911194796857ea0bd33db8a24d95faaf1ac",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e0f5b0a00cdf4664ae1696f06275d443": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0001.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "7ec9d8c6e184528ab65f3f51dd1622acede31fc2cf3b7f26c4f5769401eee3b887248e8dc51868dfb21fc8e5890cf911194796857ea0bd33db8a24d95faaf1ac",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:da51626f7a852710359834961cdfa1cc": {
+            "prov:type": {
+                "$": "nidm_ResidualMeanSquaresMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ResidualMeanSquares.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ResidualMeanSquares.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Residual Mean Squares Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:5e472b9e1804aecf84d34427aeac5d36",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "e15461ad432e63ccb4bb2534e12cc51f5c2e7562130472a6859c850f10bc34b0401f39d357a71eb3d1bd5e764a07ca78103bac52b8d6e2e5229386e51308d013",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:40534953fad6a4d97f2c2c4210f5f310": {
+            "prov:type": {
+                "$": "nidm_ResidualMeanSquaresMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "ResMS.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "8fabf9aad5778af79b9ec78de959ac3a5ede3631deeece4528020a0e5b00f3994b2ac5f8805f0dd462adbc4fc7c2775f9b2bab0a2264f50888ff4f114a467338",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:999b4c344889226d33a1a3db629bbcdd": {
+            "prov:type": {
+                "$": "nidm_ReselsPerVoxelMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ReselsPerVoxel.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ReselsPerVoxel.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Resels per Voxel Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:5e472b9e1804aecf84d34427aeac5d36",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "3568d150737aa60112c469cdd700c1339bcb6fbde9b14fbef1b22f6d05141dcd37fc0fc6cddcd98b4d27c9a2d068b832cf694f57519eebc157c37258ad601538",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f3e33ccbd90b2b0c093f458966ab7ef8": {
+            "prov:type": {
+                "$": "nidm_ReselsPerVoxelMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "RPV.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "0ac129143989c790068562a225d8df623a032492270793e9b2a1355c70788ff86279a4debd4c65a9b0c03050b4ba6bbcb88da37a90cdc2dbe470dd618897221b",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a2ce89d6c8d1b7721b0b3ac2a3bad8d8": {
+            "prov:type": {
+                "$": "obo_contrastweightmatrix:",
+                "type": "xsd:QName"
+            },
+            "nidm_statisticType:": {
+                "$": "obo_tstatistic:",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "con-01",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast: con-01",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:65cbca637492fc41602a48854f923270": {
+            "prov:type": {
+                "$": "nidm_StatisticMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "TStatistic.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "TStatistic.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "T-Statistic Map: con-01",
+                "type": "xsd:string"
+            },
+            "nidm_statisticType:": {
+                "$": "obo_tstatistic:",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "con-01",
+                "type": "xsd:string"
+            },
+            "nidm_errorDegreesOfFreedom:": {
+                "$": "13",
+                "type": "xsd:float"
+            },
+            "nidm_effectDegreesOfFreedom:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:5e472b9e1804aecf84d34427aeac5d36",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "b24254216e083a99fcc6d21cb954729c942dc636b49a3961a99c531c8007923031769bae46e5e583ef872f71e62fa3b956257dc2dc7f0b6de7cef6a807d56e91",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:72875077d4eb68692b3e042d5fcac6e9": {
+            "prov:type": {
+                "$": "nidm_StatisticMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "spmT_0001.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "fd01b639babd7881fb50aa553d869683c4b04075260bb67a2d4cdbb406b2b7a0c4bf3a23b5486e9a29d6bcf688e1dd39e1568f830189ce9f3bc250e1f285d768",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:231e885f1374dda1f44a60ed150f55b6": {
+            "prov:type": {
+                "$": "nidm_ContrastMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "Contrast.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "Contrast.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast Map: con-01",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "con-01",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:5e472b9e1804aecf84d34427aeac5d36",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "d73b0fa1856ac6fec8e0fc2c48e858ea1495c7dc6ae1636839cc3e255c2123f2b1e492e6a9c50366b07bfd888c93ea231730f75e28b96d06f846da63da671fd3",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:32d6df109b21d06d7baebdfbabfa9dea": {
+            "prov:type": {
+                "$": "nidm_ContrastMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "con_0001.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "7fbc36bda26c3089c7a092a58c999815b7f4927960270de331bc8934cd23f8c453ad9860e38a845feb63da5f3eac9a478c9eafb33e11cccf596b4ac6b066b35a",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:cd389673c942f3b5e85cbab2a17173b7": {
+            "prov:type": {
+                "$": "nidm_ContrastStandardErrorMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ContrastStandardError.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ContrastStandardError.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast Standard Error Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:5e472b9e1804aecf84d34427aeac5d36",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "7384d50a91b0a096f7ea0027c6681baa90886c59d0bc79806fb2f2005560ca8d2ebef145c1b2286b836fbc556cbef2dead4543d716df39e7b839f992d1f6845f",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e5b5f613b43832e8ca36c5fcd5e197c7": {
+            "prov:type": [
+                {
+                "$": "nidm_HeightThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_PValueUncorrected:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Height Threshold: p<0.001 (unc.)",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "0.000999500181305457",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentThreshold:": [
+                {
+                "$": "niiri:1376b409e19b9dd72fe143831aaa2dad",
+                "type": "xsd:string"
+                },
+                {
+                "$": "niiri:9922364e4e71a98f84cc4bc8276b602f",
+                "type": "xsd:string"
+                }
+            ]
+        },
+        "niiri:1376b409e19b9dd72fe143831aaa2dad": {
+            "prov:type": [
+                {
+                "$": "nidm_HeightThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_statistic:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Height Threshold: T=3.851982)",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.85198238341593",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:9922364e4e71a98f84cc4bc8276b602f": {
+            "prov:type": [
+                {
+                "$": "nidm_HeightThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_FWERadjustedpvalue:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Height Threshold: p<1.000000 (FWE)",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "0.999999998275662",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:9244bb6be2f1484bfb4b5d9df64a143c": {
+            "prov:type": [
+                {
+                "$": "nidm_ExtentThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_statistic:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Extent Threshold: k>=120",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "120",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.878540888502834",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentThreshold:": [
+                {
+                "$": "niiri:920d4d286122d33e6d29abf2133f50e0",
+                "type": "xsd:string"
+                },
+                {
+                "$": "niiri:1b1374f5b2ef8094433e27fa63f6ef2b",
+                "type": "xsd:string"
+                }
+            ]
+        },
+        "niiri:920d4d286122d33e6d29abf2133f50e0": {
+            "prov:type": [
+                {
+                "$": "nidm_ExtentThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_FWERadjustedpvalue:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Extent Threshold",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "0.0208526820077359",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:1b1374f5b2ef8094433e27fa63f6ef2b": {
+            "prov:type": [
+                {
+                "$": "nidm_ExtentThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_PValueUncorrected:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Extent Threshold",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "0.00104434177016124",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:41e52a5a5544a76853bcc91eb3fecb2f": {
+            "prov:type": {
+                "$": "nidm_PeakDefinitionCriteria:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak Definition Criteria",
+                "type": "xsd:string"
+            },
+            "nidm_maxNumberOfPeaksPerCluster:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_minDistanceBetweenPeaks:": {
+                "$": "8",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ba3936fa8577eac03c9623a5f5eb4c81": {
+            "prov:type": {
+                "$": "nidm_ClusterDefinitionCriteria:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Cluster Connectivity Criterion: 18",
+                "type": "xsd:string"
+            },
+            "nidm_hasConnectivityCriterion:": {
+                "$": "nidm_voxel18connected:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b960c3349651945d424e517bd1730a7d": {
+            "prov:type": {
+                "$": "nidm_SearchSpaceMaskMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "SearchSpaceMask.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "SearchSpaceMask.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Search Space Mask Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:5e472b9e1804aecf84d34427aeac5d36",
+                "type": "xsd:string"
+            },
+            "nidm_searchVolumeInVoxels:": {
+                "$": "160902",
+                "type": "xsd:int"
+            },
+            "nidm_searchVolumeInUnits:": {
+                "$": "1287216",
+                "type": "xsd:float"
+            },
+            "nidm_reselSizeInVoxels:": {
+                "$": "136.59011386994",
+                "type": "xsd:float"
+            },
+            "nidm_searchVolumeInResels:": {
+                "$": "1080.61261403256",
+                "type": "xsd:float"
+            },
+            "spm_searchVolumeReselsGeometry:": {
+                "$": "[1, 52.0358980508664, 491.877854544175, 1080.61261403256]",
+                "type": "xsd:string"
+            },
+            "nidm_noiseFWHMInVoxels:": {
+                "$": "[5.14810180713795, 5.07365604355584, 5.22939103936007]",
+                "type": "xsd:string"
+            },
+            "nidm_noiseFWHMInUnits:": {
+                "$": "[10.2962036142759, 10.1473120871117, 10.4587820787201]",
+                "type": "xsd:string"
+            },
+            "nidm_randomFieldStationarity:": {
+                "$": "true",
+                "type": "xsd:boolean"
+            },
+            "nidm_expectedNumberOfVoxelsPerCluster:": {
+                "$": "8.86985588130192",
+                "type": "xsd:float"
+            },
+            "nidm_expectedNumberOfClusters:": {
+                "$": "0.0210731697413967",
+                "type": "xsd:float"
+            },
+            "nidm_heightCriticalThresholdFWE05:": {
+                "$": "8.97488021321025",
+                "type": "xsd:float"
+            },
+            "nidm_heightCriticalThresholdFDR05:": {
+                "$": "Inf",
+                "type": "xsd:float"
+            },
+            "crypto:sha512": {
+                "$": "71153b4ca7e1136cf9ae9cb56eaf6a4ed494bad08a1cfa0659e8e211a36425aaf865c3def12dea06c5595662761b891c87ec7b8fa0b8b75cd31247be9418bf24",
+                "type": "xsd:string"
+            },
+            "spm_smallestSignificantClusterSizeInVoxelsFWE05:": {
+                "$": "120",
+                "type": "xsd:int"
+            },
+            "spm_smallestSignificantClusterSizeInVoxelsFDR05:": {
+                "$": "53",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:64e1c232f0bbae773bd50d725f8f456a": {
+            "prov:type": {
+                "$": "nidm_ExcursionSetMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ExcursionSet.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ExcursionSet.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Excursion Set Map",
+                "type": "xsd:string"
+            },
+            "nidm_numberOfSupraThresholdClusters:": {
+                "$": "9",
+                "type": "xsd:int"
+            },
+            "nidm_pValue:": {
+                "$": "0",
+                "type": "xsd:float"
+            },
+            "nidm_hasClusterLabelsMap:": {
+                "$": "niiri:e020f1e9f1a50dffcbb63594f2caca52",
+                "type": "xsd:string"
+            },
+            "nidm_hasMaximumIntensityProjection:": {
+                "$": "niiri:5f5a4e2d87d4741192c9fedabca572eb",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:5e472b9e1804aecf84d34427aeac5d36",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "2f4011618fe1b59df15513558d716959952362e45f285e1685f6561e4815c19ebf6f1d9cb237b9bdc186055b9b99b9cbd8fd0e0904eee92e35018e4066e212cf",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e020f1e9f1a50dffcbb63594f2caca52": {
+            "prov:type": {
+                "$": "nidm_ClusterLabelsMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ClusterLabels.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ClusterLabels.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Cluster Labels Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:5e472b9e1804aecf84d34427aeac5d36",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "ce4207d9dc614d3ee94a6068b0f5eeb2f118041ba7a3e02687ec19998e43d7eb059246440f46bda14dfb709d4b45eab1077195b2b82ee2dedbed19a12c1f7ccc",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5f5a4e2d87d4741192c9fedabca572eb": {
+            "prov:type": {
+                "$": "dctype:Image",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "MaximumIntensityProjection.png",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "MaximumIntensityProjection.png",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/png",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e3191f42f3f3f4c93e35287c26019f98": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0001",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "565",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "4.13646335003418",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.2210454645763e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "8.51740362683984e-08",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1.30852409401865e-07",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "1",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:d496925af8b0958a04278695c2116f14": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0002",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "201",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.47155598824225",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.24261969297565e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00125886915138074",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000550348915075722",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "2",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:784e20ceac3fc89851575215e2b045a6": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0003",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "130",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.951752629211403",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000716872301655276",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0143612318077091",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00277788016891419",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "3",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:2d8cf2f1c8b135c47e4c992ddddc4603": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0004",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "197",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.44227129195882",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.1012763235577e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00143189941009247",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000550348915075722",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "4",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:145e279f67ab0593ed7aad160ef6ec96": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0005",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "344",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "2.51848388037479",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "9.63976506362912e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1.94513362937743e-05",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1.49416358486251e-05",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "5",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:0cf7fbb104195b08838b495de979f17d": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0006",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "168",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.22995724390397",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000185860057406901",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00374333898481427",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000960276963268989",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "6",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:3fb8d8c50e07f46ff52730667b4ff904": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0007",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "120",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.878540888502834",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00104434177016124",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0208526820077359",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00359717720833317",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "7",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:24ed53e97502545f0497cc97644535d2": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0008",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "182",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.33245368089596",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000116063491953819",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00233923791601987",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000719593650113681",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "8",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:ee68048e8a0744dfd236a85d10e1b80c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0009",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "144",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.0542490662034",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000430078992400458",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00864076784172119",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00190463553777346",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "9",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:ff91629a343c2e8f75793ca5bf4f5456": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0001",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:71861dca5fb2a8a0c5cc60b4795ea2bd",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "9.0197868347168",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.99532807659738",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.93679147334025e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0472535690597315",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.227081208121146",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:71861dca5fb2a8a0c5cc60b4795ea2bd": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0001",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-10,18,42]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c49fbca986b7d0a96d37718d1c0d3be1": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0002",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6ebc4745b212479bf3dbc66f61355303",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "7.42846012115479",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.56538453536696",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.49289781906192e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.28406310634998",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.227081208121146",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6ebc4745b212479bf3dbc66f61355303": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0002",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-2,8,66]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:bc90e98330ecd77c0c61eb4ee20896c0": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0003",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0e7af240702d72adc90cf039012896f6",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.63349199295044",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.93987516059906",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.07620106994688e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.913665566475084",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.365315662158339",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0e7af240702d72adc90cf039012896f6": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0003",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[8,2,66]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1d495ddd1ccf932950c1251a78ced9c4": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0004",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0f0000559de1833e3cc048c853eaef14",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "7.85747480392456",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.6908256972469",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.36052353338911e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.193292933875985",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.227081208121146",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0f0000559de1833e3cc048c853eaef14": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0004",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-42,-4,28]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:84fe5bdeb23007afdd8dfc54f4030c78": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0005",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7c5bb491b25180b0b7561de85c20c240",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.96076774597168",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.65180690060166",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000130200830341765",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.995586804119546",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.508465170731449",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7c5bb491b25180b0b7561de85c20c240": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0005",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-54,4,18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:18cc6e4de0c9e565941028f84899f9aa": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0006",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b8e5d6bbccfb83b99e33609e89895e33",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.68419551849365",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.52268507469106",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000213599326911451",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999471213589401",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.58440570253383",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b8e5d6bbccfb83b99e33609e89895e33": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0006",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-54,6,30]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2b5fa07d66fa075513a31a38dbaa7bd9": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0007",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:5bc970458ceef44ab45ea1e7e7a0635d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "7.27484846115112",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.51851280417867",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.11377539996549e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.324805789402179",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.227081208121146",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:5bc970458ceef44ab45ea1e7e7a0635d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0007",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-46,-4,54]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f458ed28668e8278b72dffade3f56b36": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0008",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d721095be503b1e0f64a2410036a2eaa",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.94224119186401",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.41321599194522",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.09231481560235e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.429119375951011",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.25175924600333",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d721095be503b1e0f64a2410036a2eaa": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0008",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-42,16,10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d9eeac8bb3ecc01f8076b9144f8408a1": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0009",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b9cce062e2feece03ec35b7263ae63a8",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.10717391967773",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.1231772056634",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.86840997530302e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.757824284509807",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.365315662158339",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b9cce062e2feece03ec35b7263ae63a8": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0009",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-34,12,12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e0b762eecb88a3831f1461fcb76acb5e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0010",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7a964994e6526b0666437d95f24abc7c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.91090297698975",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.62901638790644",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000142251590777853",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.996834489281486",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.511946776631986",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7a964994e6526b0666437d95f24abc7c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0010",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-32,14,20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5c4ec650d1179cc0393ce006684df798": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0011",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ad512c918e7340c95eaef8dfde49052a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.90986013412476",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.40267439233253",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.34622897296888e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.440428166820351",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.25175924600333",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ad512c918e7340c95eaef8dfde49052a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0011",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[58,-34,14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:cc7d961cd89c1dd7f8fca1be56c252c2": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0012",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c6311ce077927bd49736a0687796e269",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.82773351669312",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.01684833891347",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.94908276274874e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.858380226002374",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.365315662158339",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c6311ce077927bd49736a0687796e269": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0012",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[66,-38,14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5859c0686be12782603570a07ee67698": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0013",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:9cfe2df9dc6783d6c43a1b8829beb4a8",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.4896821975708",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.88117893748276",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.1975659703607e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.944904699668246",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.386351702418292",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:9cfe2df9dc6783d6c43a1b8829beb4a8": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0013",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[52,-38,6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2e8112ff496740fe656336a508456db6": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0014",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7b8b224d0de6e706a8496c51b9ec92c7",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.21367645263672",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.1624012348651",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.57459182630326e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.715339849593062",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.365315662158339",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7b8b224d0de6e706a8496c51b9ec92c7": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0014",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[8,16,42]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:091092eab6f1574d657d804507dd0192": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0015",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a90f5e73e0da209b7207b1ef41a327b8",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.72438669204712",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.97621777576085",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.50100040308332e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.889577859110148",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.365315662158339",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a90f5e73e0da209b7207b1ef41a327b8": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0015",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[12,18,34]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9a9072a8cc791001f985c339f649ecbc": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0016",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e75ec0ab2114018af91503adf58ab0b0",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.03207159042358",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.09509363345907",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.10998901504222e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.786707462460714",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.365315662158339",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e75ec0ab2114018af91503adf58ab0b0": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0016",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[56,-2,46]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f06598e58370f70e2f5ce0b47e641909": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0017",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0a466a7d36f0e502b275608c297d8bac",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.45615816116333",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.4110394440129",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000323578644043643",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999950103431029",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.701250666193361",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0a466a7d36f0e502b275608c297d8bac": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0017",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[42,0,40]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:cf9e0ce6702a4bc5d75621bb529bb51e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0018",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:2459537b6faed4755f3485553ad12087",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.44447803497314",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.40518918809107",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00033059115403522",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999956572496893",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.701250666193361",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:2459537b6faed4755f3485553ad12087": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0018",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[48,2,52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1d42f9fcfbb48e74a501c76e58311ef7": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0019",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:fbda836c00cc56183550c787012b6eeb",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.99733877182007",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.08198490016656",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.23263492938885e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.799672548097648",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.365315662158339",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:fbda836c00cc56183550c787012b6eeb": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0019",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[52,4,20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2b939bebe4432404eecd773b1a8fa021": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0020",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:8e59c08d21c91e4bd2386b0d3a271df7",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.96960115432739",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.07146072717137",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.33596199642472e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.809821953269947",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.365315662158339",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:8e59c08d21c91e4bd2386b0d3a271df7": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0020",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[48,14,2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d194d8bbb0450258cbb3e2c7b63d052b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0021",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6e46e05c89f606b54b383ab231bc4f7f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.32198143005371",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.81081315671811",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.92552142741443e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.970746077807219",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.416365388604658",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6e46e05c89f606b54b383ab231bc4f7f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0021",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[56,12,16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:373fb030ca503554429e0d448b03ac03": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0022",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:8aa50282813e2f149237738250f246d4",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.69392824172974",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.96410360090528",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.68361273354045e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.898012948452735",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.365315662158339",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:8aa50282813e2f149237738250f246d4": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0022",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-50,-44,10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:88e91db80e4f84543f912f20187894b6": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0023",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0212c0dd8121cea00a8dbedcf8cd7e3c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.6067042350769",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.9290539558673",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.26403524200758e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.920131147013454",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.365315662158339",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0212c0dd8121cea00a8dbedcf8cd7e3c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0023",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-44,-42,18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f11f4cdd0aa465dd12a0072b11116c2c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0024",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7287fc447fabd0245cc28ac2cf7afc62",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.39031887054443",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.37789039899343",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000365220936835664",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999977761191736",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.701250666193361",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7287fc447fabd0245cc28ac2cf7afc62": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0024",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-46,-40,28]",
+                "type": "xsd:string"
+            }
+        }
+    },
+    "activity": {
+        "niiri:b74ede46a6fca129f8c8f17e297de5f1": {
+            "prov:type": {
+                "$": "nidm_ModelParametersEstimation:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Model parameters estimation",
+                "type": "xsd:string"
+            },
+            "nidm_withEstimationMethod:": {
+                "$": "obo_ordinaryleastsquaresestimation:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:137adca045c6b01b9508719af960a129": {
+            "prov:type": {
+                "$": "nidm_ContrastEstimation:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Contrast estimation",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e134b356fffdbdf572967bdab3709e2c": {
+            "prov:type": {
+                "$": "nidm_Inference:",
+                "type": "xsd:QName"
+            },
+            "nidm_hasAlternativeHypothesis:": {
+                "$": "nidm_OneTailedTest:",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Inference",
+                "type": "xsd:string"
+            }
+        }
+    },
+    "agent": {
+        "niiri:94ecae7951d21985687dcb4bf72d88bc": {
+            "prov:type": [
+                {
+                "$": "src_SPM:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "prov:SoftwareAgent",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "SPM",
+                "type": "xsd:string"
+            },
+            "nidm_softwareVersion:": {
+                "$": "12.6906",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c9a2b27e508148967a08a3beda024191": {
+            "prov:type": [
+                {
+                "$": "nlx_Imaginginstrument:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nlx_Magneticresonanceimagingscanner:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "MRI Scanner",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:985a4448969a1b0854e49bb2dbdeab6c": {
+            "prov:type": {
+                "$": "obo_studygrouppopulation:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Group: Control",
+                "type": "xsd:string"
+            },
+            "nidm_groupName:": {
+                "$": "Control",
+                "type": "xsd:string"
+            },
+            "nidm_numberOfSubjects:": {
+                "$": "14",
+                "type": "xsd:int"
+            }
+        }
+    },
+    "wasGeneratedBy": {
+        "_:wGB19": {
+            "prov:entity": "niiri:134717e80ac83bc17cf1e5f4b6a0dab8",
+            "prov:activity": "niiri:b74ede46a6fca129f8c8f17e297de5f1"
+        },
+        "_:wGB21": {
+            "prov:entity": "niiri:b1aa0fbd676b8d41f017be6bdbd31cd3",
+            "prov:activity": "niiri:b74ede46a6fca129f8c8f17e297de5f1"
+        },
+        "_:wGB25": {
+            "prov:entity": "niiri:2c7195286f0c7c5d7c26fed41636166c",
+            "prov:activity": "niiri:b74ede46a6fca129f8c8f17e297de5f1"
+        },
+        "_:wGB29": {
+            "prov:entity": "niiri:da51626f7a852710359834961cdfa1cc",
+            "prov:activity": "niiri:b74ede46a6fca129f8c8f17e297de5f1"
+        },
+        "_:wGB33": {
+            "prov:entity": "niiri:999b4c344889226d33a1a3db629bbcdd",
+            "prov:activity": "niiri:b74ede46a6fca129f8c8f17e297de5f1"
+        },
+        "_:wGB45": {
+            "prov:entity": "niiri:65cbca637492fc41602a48854f923270",
+            "prov:activity": "niiri:137adca045c6b01b9508719af960a129"
+        },
+        "_:wGB49": {
+            "prov:entity": "niiri:231e885f1374dda1f44a60ed150f55b6",
+            "prov:activity": "niiri:137adca045c6b01b9508719af960a129"
+        },
+        "_:wGB51": {
+            "prov:entity": "niiri:cd389673c942f3b5e85cbab2a17173b7",
+            "prov:activity": "niiri:137adca045c6b01b9508719af960a129"
+        },
+        "_:wGB70": {
+            "prov:entity": "niiri:b960c3349651945d424e517bd1730a7d",
+            "prov:activity": "niiri:e134b356fffdbdf572967bdab3709e2c"
+        },
+        "_:wGB74": {
+            "prov:entity": "niiri:64e1c232f0bbae773bd50d725f8f456a",
+            "prov:activity": "niiri:e134b356fffdbdf572967bdab3709e2c"
+        }
+    },
+    "used": {
+        "_:u13": {
+            "prov:activity": "niiri:b74ede46a6fca129f8c8f17e297de5f1",
+            "prov:entity": "niiri:5974cc100f3ec5600037861f2b9ed1de"
+        },
+        "_:u14": {
+            "prov:activity": "niiri:b74ede46a6fca129f8c8f17e297de5f1",
+            "prov:entity": "niiri:ca46b04d477ee0f0e6f16c372a1a4976"
+        },
+        "_:u15": {
+            "prov:activity": "niiri:b74ede46a6fca129f8c8f17e297de5f1",
+            "prov:entity": "niiri:7cf52921ad5716e824bef8a127efb7bc"
+        },
+        "_:u37": {
+            "prov:activity": "niiri:137adca045c6b01b9508719af960a129",
+            "prov:entity": "niiri:134717e80ac83bc17cf1e5f4b6a0dab8"
+        },
+        "_:u38": {
+            "prov:activity": "niiri:137adca045c6b01b9508719af960a129",
+            "prov:entity": "niiri:da51626f7a852710359834961cdfa1cc"
+        },
+        "_:u39": {
+            "prov:activity": "niiri:137adca045c6b01b9508719af960a129",
+            "prov:entity": "niiri:5974cc100f3ec5600037861f2b9ed1de"
+        },
+        "_:u40": {
+            "prov:activity": "niiri:137adca045c6b01b9508719af960a129",
+            "prov:entity": "niiri:a2ce89d6c8d1b7721b0b3ac2a3bad8d8"
+        },
+        "_:u41": {
+            "prov:activity": "niiri:137adca045c6b01b9508719af960a129",
+            "prov:entity": "niiri:2c7195286f0c7c5d7c26fed41636166c"
+        },
+        "_:u62": {
+            "prov:activity": "niiri:e134b356fffdbdf572967bdab3709e2c",
+            "prov:entity": "niiri:e5b5f613b43832e8ca36c5fcd5e197c7"
+        },
+        "_:u63": {
+            "prov:activity": "niiri:e134b356fffdbdf572967bdab3709e2c",
+            "prov:entity": "niiri:9244bb6be2f1484bfb4b5d9df64a143c"
+        },
+        "_:u64": {
+            "prov:activity": "niiri:e134b356fffdbdf572967bdab3709e2c",
+            "prov:entity": "niiri:65cbca637492fc41602a48854f923270"
+        },
+        "_:u65": {
+            "prov:activity": "niiri:e134b356fffdbdf572967bdab3709e2c",
+            "prov:entity": "niiri:999b4c344889226d33a1a3db629bbcdd"
+        },
+        "_:u66": {
+            "prov:activity": "niiri:e134b356fffdbdf572967bdab3709e2c",
+            "prov:entity": "niiri:134717e80ac83bc17cf1e5f4b6a0dab8"
+        },
+        "_:u67": {
+            "prov:activity": "niiri:e134b356fffdbdf572967bdab3709e2c",
+            "prov:entity": "niiri:41e52a5a5544a76853bcc91eb3fecb2f"
+        },
+        "_:u68": {
+            "prov:activity": "niiri:e134b356fffdbdf572967bdab3709e2c",
+            "prov:entity": "niiri:ba3936fa8577eac03c9623a5f5eb4c81"
+        }
+    },
+    "wasDerivedFrom": {
+        "_:wDF18": {
+            "prov:generatedEntity": "niiri:134717e80ac83bc17cf1e5f4b6a0dab8",
+            "prov:usedEntity": "niiri:4efbab6889ea73c471c6ec4da367d19d"
+        },
+        "_:wDF24": {
+            "prov:generatedEntity": "niiri:2c7195286f0c7c5d7c26fed41636166c",
+            "prov:usedEntity": "niiri:e0f5b0a00cdf4664ae1696f06275d443"
+        },
+        "_:wDF28": {
+            "prov:generatedEntity": "niiri:da51626f7a852710359834961cdfa1cc",
+            "prov:usedEntity": "niiri:40534953fad6a4d97f2c2c4210f5f310"
+        },
+        "_:wDF32": {
+            "prov:generatedEntity": "niiri:999b4c344889226d33a1a3db629bbcdd",
+            "prov:usedEntity": "niiri:f3e33ccbd90b2b0c093f458966ab7ef8"
+        },
+        "_:wDF44": {
+            "prov:generatedEntity": "niiri:65cbca637492fc41602a48854f923270",
+            "prov:usedEntity": "niiri:72875077d4eb68692b3e042d5fcac6e9"
+        },
+        "_:wDF48": {
+            "prov:generatedEntity": "niiri:231e885f1374dda1f44a60ed150f55b6",
+            "prov:usedEntity": "niiri:32d6df109b21d06d7baebdfbabfa9dea"
+        },
+        "_:wDF76": {
+            "prov:generatedEntity": "niiri:e3191f42f3f3f4c93e35287c26019f98",
+            "prov:usedEntity": "niiri:64e1c232f0bbae773bd50d725f8f456a"
+        },
+        "_:wDF78": {
+            "prov:generatedEntity": "niiri:d496925af8b0958a04278695c2116f14",
+            "prov:usedEntity": "niiri:64e1c232f0bbae773bd50d725f8f456a"
+        },
+        "_:wDF80": {
+            "prov:generatedEntity": "niiri:784e20ceac3fc89851575215e2b045a6",
+            "prov:usedEntity": "niiri:64e1c232f0bbae773bd50d725f8f456a"
+        },
+        "_:wDF82": {
+            "prov:generatedEntity": "niiri:2d8cf2f1c8b135c47e4c992ddddc4603",
+            "prov:usedEntity": "niiri:64e1c232f0bbae773bd50d725f8f456a"
+        },
+        "_:wDF84": {
+            "prov:generatedEntity": "niiri:145e279f67ab0593ed7aad160ef6ec96",
+            "prov:usedEntity": "niiri:64e1c232f0bbae773bd50d725f8f456a"
+        },
+        "_:wDF86": {
+            "prov:generatedEntity": "niiri:0cf7fbb104195b08838b495de979f17d",
+            "prov:usedEntity": "niiri:64e1c232f0bbae773bd50d725f8f456a"
+        },
+        "_:wDF88": {
+            "prov:generatedEntity": "niiri:3fb8d8c50e07f46ff52730667b4ff904",
+            "prov:usedEntity": "niiri:64e1c232f0bbae773bd50d725f8f456a"
+        },
+        "_:wDF90": {
+            "prov:generatedEntity": "niiri:24ed53e97502545f0497cc97644535d2",
+            "prov:usedEntity": "niiri:64e1c232f0bbae773bd50d725f8f456a"
+        },
+        "_:wDF92": {
+            "prov:generatedEntity": "niiri:ee68048e8a0744dfd236a85d10e1b80c",
+            "prov:usedEntity": "niiri:64e1c232f0bbae773bd50d725f8f456a"
+        },
+        "_:wDF95": {
+            "prov:generatedEntity": "niiri:ff91629a343c2e8f75793ca5bf4f5456",
+            "prov:usedEntity": "niiri:e3191f42f3f3f4c93e35287c26019f98"
+        },
+        "_:wDF98": {
+            "prov:generatedEntity": "niiri:c49fbca986b7d0a96d37718d1c0d3be1",
+            "prov:usedEntity": "niiri:e3191f42f3f3f4c93e35287c26019f98"
+        },
+        "_:wDF101": {
+            "prov:generatedEntity": "niiri:bc90e98330ecd77c0c61eb4ee20896c0",
+            "prov:usedEntity": "niiri:e3191f42f3f3f4c93e35287c26019f98"
+        },
+        "_:wDF104": {
+            "prov:generatedEntity": "niiri:1d495ddd1ccf932950c1251a78ced9c4",
+            "prov:usedEntity": "niiri:d496925af8b0958a04278695c2116f14"
+        },
+        "_:wDF107": {
+            "prov:generatedEntity": "niiri:84fe5bdeb23007afdd8dfc54f4030c78",
+            "prov:usedEntity": "niiri:d496925af8b0958a04278695c2116f14"
+        },
+        "_:wDF110": {
+            "prov:generatedEntity": "niiri:18cc6e4de0c9e565941028f84899f9aa",
+            "prov:usedEntity": "niiri:d496925af8b0958a04278695c2116f14"
+        },
+        "_:wDF113": {
+            "prov:generatedEntity": "niiri:2b5fa07d66fa075513a31a38dbaa7bd9",
+            "prov:usedEntity": "niiri:784e20ceac3fc89851575215e2b045a6"
+        },
+        "_:wDF116": {
+            "prov:generatedEntity": "niiri:f458ed28668e8278b72dffade3f56b36",
+            "prov:usedEntity": "niiri:2d8cf2f1c8b135c47e4c992ddddc4603"
+        },
+        "_:wDF119": {
+            "prov:generatedEntity": "niiri:d9eeac8bb3ecc01f8076b9144f8408a1",
+            "prov:usedEntity": "niiri:2d8cf2f1c8b135c47e4c992ddddc4603"
+        },
+        "_:wDF122": {
+            "prov:generatedEntity": "niiri:e0b762eecb88a3831f1461fcb76acb5e",
+            "prov:usedEntity": "niiri:2d8cf2f1c8b135c47e4c992ddddc4603"
+        },
+        "_:wDF125": {
+            "prov:generatedEntity": "niiri:5c4ec650d1179cc0393ce006684df798",
+            "prov:usedEntity": "niiri:145e279f67ab0593ed7aad160ef6ec96"
+        },
+        "_:wDF128": {
+            "prov:generatedEntity": "niiri:cc7d961cd89c1dd7f8fca1be56c252c2",
+            "prov:usedEntity": "niiri:145e279f67ab0593ed7aad160ef6ec96"
+        },
+        "_:wDF131": {
+            "prov:generatedEntity": "niiri:5859c0686be12782603570a07ee67698",
+            "prov:usedEntity": "niiri:145e279f67ab0593ed7aad160ef6ec96"
+        },
+        "_:wDF134": {
+            "prov:generatedEntity": "niiri:2e8112ff496740fe656336a508456db6",
+            "prov:usedEntity": "niiri:0cf7fbb104195b08838b495de979f17d"
+        },
+        "_:wDF137": {
+            "prov:generatedEntity": "niiri:091092eab6f1574d657d804507dd0192",
+            "prov:usedEntity": "niiri:0cf7fbb104195b08838b495de979f17d"
+        },
+        "_:wDF140": {
+            "prov:generatedEntity": "niiri:9a9072a8cc791001f985c339f649ecbc",
+            "prov:usedEntity": "niiri:3fb8d8c50e07f46ff52730667b4ff904"
+        },
+        "_:wDF143": {
+            "prov:generatedEntity": "niiri:f06598e58370f70e2f5ce0b47e641909",
+            "prov:usedEntity": "niiri:3fb8d8c50e07f46ff52730667b4ff904"
+        },
+        "_:wDF146": {
+            "prov:generatedEntity": "niiri:cf9e0ce6702a4bc5d75621bb529bb51e",
+            "prov:usedEntity": "niiri:3fb8d8c50e07f46ff52730667b4ff904"
+        },
+        "_:wDF149": {
+            "prov:generatedEntity": "niiri:1d42f9fcfbb48e74a501c76e58311ef7",
+            "prov:usedEntity": "niiri:24ed53e97502545f0497cc97644535d2"
+        },
+        "_:wDF152": {
+            "prov:generatedEntity": "niiri:2b939bebe4432404eecd773b1a8fa021",
+            "prov:usedEntity": "niiri:24ed53e97502545f0497cc97644535d2"
+        },
+        "_:wDF155": {
+            "prov:generatedEntity": "niiri:d194d8bbb0450258cbb3e2c7b63d052b",
+            "prov:usedEntity": "niiri:24ed53e97502545f0497cc97644535d2"
+        },
+        "_:wDF158": {
+            "prov:generatedEntity": "niiri:373fb030ca503554429e0d448b03ac03",
+            "prov:usedEntity": "niiri:ee68048e8a0744dfd236a85d10e1b80c"
+        },
+        "_:wDF161": {
+            "prov:generatedEntity": "niiri:88e91db80e4f84543f912f20187894b6",
+            "prov:usedEntity": "niiri:ee68048e8a0744dfd236a85d10e1b80c"
+        },
+        "_:wDF164": {
+            "prov:generatedEntity": "niiri:f11f4cdd0aa465dd12a0072b11116c2c",
+            "prov:usedEntity": "niiri:ee68048e8a0744dfd236a85d10e1b80c"
+        }
+    },
+    "wasAttributedTo": {
+        "_:wAT6": {
+            "prov:entity": "niiri:ca46b04d477ee0f0e6f16c372a1a4976",
+            "prov:agent": "niiri:c9a2b27e508148967a08a3beda024191"
+        },
+        "_:wAT7": {
+            "prov:entity": "niiri:ca46b04d477ee0f0e6f16c372a1a4976",
+            "prov:agent": "niiri:985a4448969a1b0854e49bb2dbdeab6c"
+        }
+    },
+    "wasAssociatedWith": {
+        "_:wAW12": {
+            "prov:activity": "niiri:b74ede46a6fca129f8c8f17e297de5f1",
+            "prov:agent": "niiri:94ecae7951d21985687dcb4bf72d88bc"
+        },
+        "_:wAW36": {
+            "prov:activity": "niiri:137adca045c6b01b9508719af960a129",
+            "prov:agent": "niiri:94ecae7951d21985687dcb4bf72d88bc"
+        },
+        "_:wAW61": {
+            "prov:activity": "niiri:e134b356fffdbdf572967bdab3709e2c",
+            "prov:agent": "niiri:94ecae7951d21985687dcb4bf72d88bc"
+        }
+    }
+    }
+  }
+}

--- a/spmexport/ex_spm_group_ols/nidm.jsonld
+++ b/spmexport/ex_spm_group_ols/nidm.jsonld
@@ -7,7 +7,7 @@
       "niiri": "http://iri.nidash.org/",
       "spm": "http://purl.org/nidash/spm#",
       "neurolex": "http://neurolex.org/wiki/",
-      "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#",
+      "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/",
       "dct": "http://purl.org/dc/terms/",
       "nfo": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#",
       "dc": "http://purl.org/dc/elements/1.1/",
@@ -22,32 +22,32 @@
   ],
   "@graph": [
     {
-      "@id": "niiri:5bfe8d0b2f440c31510a8db7a990bd46",
-      "@type": ["prov:Entity","prov:Bundle","nidm_NIDMResults:"],
+      "@id": "niiri:68ee16fec71e89a7b58245aa1b686dfb",
+      "@type": ["prov:Entity","prov:Bundle","nidm_NIDMResults"],
       "rdfs:label": "NIDM-Results",
-      "nidm_version:": {"@type": "xsd:string", "@value": "1.3.0"}
+      "nidm_version": {"@type": "xsd:string", "@value": "1.3.0"}
     },
     {
-      "@id": "niiri:8dd211f8135c6832c544f144057e23b1",
-      "@type": ["prov:Agent","nidm_spm_results_nidm:","prov:SoftwareAgent"],
+      "@id": "niiri:4d435dbb932d842eb0f29f9f295f4d39",
+      "@type": ["prov:Agent","nidm_spm_results_nidm","prov:SoftwareAgent"],
       "rdfs:label": "spm_results_nidm",
-      "nidm_softwareVersion:": {"@type": "xsd:string", "@value": "12.6903"}
+      "nidm_softwareVersion": {"@type": "xsd:string", "@value": "12.7057"}
     },
     {
-      "@id": "niiri:3141b03efd8fff437c763916b82a53fe",
-      "@type": ["prov:Activity","nidm_NIDMResultsExport:"],
+      "@id": "niiri:67662d8460b62a35fcf8b5cc394aa18c",
+      "@type": ["prov:Activity","nidm_NIDMResultsExport"],
       "rdfs:label": "NIDM-Results export"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:3141b03efd8fff437c763916b82a53fe",
-      "agent": "niiri:8dd211f8135c6832c544f144057e23b1"
+      "activity_associated": "niiri:67662d8460b62a35fcf8b5cc394aa18c",
+      "agent": "niiri:4d435dbb932d842eb0f29f9f295f4d39"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:5bfe8d0b2f440c31510a8db7a990bd46",
-      "activity": "niiri:3141b03efd8fff437c763916b82a53fe",
-      "atTime": "2016-12-07T16:08:32"
+      "entity_generated": "niiri:68ee16fec71e89a7b58245aa1b686dfb",
+      "activity": "niiri:67662d8460b62a35fcf8b5cc394aa18c",
+      "atTime": "2017-04-19T12:18:11"
     }
   ]
 },
@@ -153,500 +153,500 @@
       "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
     }
   ],
-  "@id": "niiri:5bfe8d0b2f440c31510a8db7a990bd46",
+  "@id": "niiri:68ee16fec71e89a7b58245aa1b686dfb",
   "@graph": [
     {
-      "@id": "niiri:582e74d3d47d395484eb9750c00b6034",
-      "@type": ["prov:Agent","src_SPM:","prov:SoftwareAgent"],
+      "@id": "niiri:94ecae7951d21985687dcb4bf72d88bc",
+      "@type": ["prov:Agent","src_SPM","prov:SoftwareAgent"],
       "rdfs:label": "SPM",
-      "nidm_softwareVersion:": {"@type": "xsd:string", "@value": "12.12.2"}
+      "nidm_softwareVersion": {"@type": "xsd:string", "@value": "12.6906"}
     },
     {
-      "@id": "niiri:9ea612def84c2b00a28fde8461621f3d",
-      "@type": ["prov:Entity","nidm_CoordinateSpace:"],
+      "@id": "niiri:5e472b9e1804aecf84d34427aeac5d36",
+      "@type": ["prov:Entity","nidm_CoordinateSpace"],
       "rdfs:label": "Coordinate space 1",
-      "nidm_voxelToWorldMapping:": {"@type": "xsd:string", "@value": "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"},
-      "nidm_voxelUnits:": {"@type": "xsd:string", "@value": "[\"mm\", \"mm\", \"mm\"]"},
-      "nidm_voxelSize:": {"@type": "xsd:string", "@value": "[2, 2, 2]"},
-      "nidm_inWorldCoordinateSystem:": {"@id": "nidm_Ixi549CoordinateSystem:"},
-      "nidm_numberOfDimensions:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_dimensionsInVoxels:": {"@type": "xsd:string", "@value": "[79,95,79]"}
+      "nidm_voxelToWorldMapping": {"@type": "xsd:string", "@value": "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"},
+      "nidm_voxelUnits": {"@type": "xsd:string", "@value": "[\"mm\", \"mm\", \"mm\"]"},
+      "nidm_voxelSize": {"@type": "xsd:string", "@value": "[2, 2, 2]"},
+      "nidm_inWorldCoordinateSystem": {"@id": "nidm_Ixi549CoordinateSystem"},
+      "nidm_numberOfDimensions": {"@type": "xsd:int", "@value": "3"},
+      "nidm_dimensionsInVoxels": {"@type": "xsd:string", "@value": "[79,95,79]"}
     },
     {
-      "@id": "niiri:6473cb489e3dbb8be338e0ecde88fb03",
-      "@type": ["prov:Agent","nlx_Imaginginstrument:","nlx_Magneticresonanceimagingscanner:"],
+      "@id": "niiri:c9a2b27e508148967a08a3beda024191",
+      "@type": ["prov:Agent","nlx_Imaginginstrument","nlx_Magneticresonanceimagingscanner"],
       "rdfs:label": "MRI Scanner"
     },
     {
-      "@id": "niiri:25cb37de070b85d1a0c288c2a24891e1",
-      "@type": ["prov:Agent","obo_studygrouppopulation:"],
+      "@id": "niiri:985a4448969a1b0854e49bb2dbdeab6c",
+      "@type": ["prov:Agent","obo_studygrouppopulation"],
       "rdfs:label": "Group: Control",
-      "nidm_groupName:": {"@type": "xsd:string", "@value": "Control"},
-      "nidm_numberOfSubjects:": {"@type": "xsd:int", "@value": "14"}
+      "nidm_groupName": {"@type": "xsd:string", "@value": "Control"},
+      "nidm_numberOfSubjects": {"@type": "xsd:int", "@value": "14"}
     },
     {
-      "@id": "niiri:88e00486db13f79e1d42aee523efe408",
-      "@type": ["prov:Entity","prov:Collection","nidm_Data:"],
+      "@id": "niiri:ca46b04d477ee0f0e6f16c372a1a4976",
+      "@type": ["prov:Entity","prov:Collection","nidm_Data"],
       "rdfs:label": "Data",
-      "nidm_grandMeanScaling:": {"@type": "xsd:boolean", "@value": "false"},
-      "nidm_hasMRIProtocol:": {"@id": "nlx_FunctionalMRIprotocol:"}
+      "nidm_grandMeanScaling": {"@type": "xsd:boolean", "@value": "false"},
+      "nidm_hasMRIProtocol": {"@id": "nlx_FunctionalMRIprotocol"}
     },
     {
       "@type": "prov:Attribution",
-      "entity_attributed": "niiri:88e00486db13f79e1d42aee523efe408",
-      "agent": "niiri:6473cb489e3dbb8be338e0ecde88fb03"
+      "entity_attributed": "niiri:ca46b04d477ee0f0e6f16c372a1a4976",
+      "agent": "niiri:c9a2b27e508148967a08a3beda024191"
     },
     {
       "@type": "prov:Attribution",
-      "entity_attributed": "niiri:88e00486db13f79e1d42aee523efe408",
-      "agent": "niiri:25cb37de070b85d1a0c288c2a24891e1"
+      "entity_attributed": "niiri:ca46b04d477ee0f0e6f16c372a1a4976",
+      "agent": "niiri:985a4448969a1b0854e49bb2dbdeab6c"
     },
     {
-      "@id": "niiri:0486a876a984f0a75a383ff571c65763",
-      "@type": ["prov:Entity","nidm_DesignMatrix:"],
+      "@id": "niiri:5974cc100f3ec5600037861f2b9ed1de",
+      "@type": ["prov:Entity","nidm_DesignMatrix"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "DesignMatrix.csv"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "DesignMatrix.csv"},
       "dct:format": {"@type": "xsd:string", "@value": "text/csv"},
-      "dc:description": {"@id": "niiri:4c7773760fe7e378c9809d4eb3b4285c"},
+      "dc:description": {"@id": "niiri:153b70474f3c5edca79e4bf57a7ee204"},
       "rdfs:label": "Design Matrix",
-      "nidm_regressorNames:": {"@type": "xsd:string", "@value": "[\"mean\"]"}
+      "nidm_regressorNames": {"@type": "xsd:string", "@value": "[\"mean\"]"}
     },
     {
-      "@id": "niiri:4c7773760fe7e378c9809d4eb3b4285c",
+      "@id": "niiri:153b70474f3c5edca79e4bf57a7ee204",
       "@type": ["prov:Entity","dctype:Image"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "DesignMatrix.png"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "DesignMatrix.png"},
       "dct:format": {"@type": "xsd:string", "@value": "image/png"}
     },
     {
-      "@id": "niiri:98c11fdf4a008d0bb72923f6033452b6",
-      "@type": ["prov:Entity","nidm_ErrorModel:"],
-      "nidm_hasErrorDistribution:": {"@id": "obo_normaldistribution:"},
-      "nidm_hasErrorDependence:": {"@id": "nidm_IndependentError:"},
-      "nidm_errorVarianceHomogeneous:": {"@type": "xsd:boolean", "@value": "true"},
-      "nidm_varianceMapWiseDependence:": {"@id": "nidm_IndependentParameter:"}
+      "@id": "niiri:7cf52921ad5716e824bef8a127efb7bc",
+      "@type": ["prov:Entity","nidm_ErrorModel"],
+      "nidm_hasErrorDistribution": {"@id": "obo_normaldistribution"},
+      "nidm_hasErrorDependence": {"@id": "nidm_IndependentError"},
+      "nidm_errorVarianceHomogeneous": {"@type": "xsd:boolean", "@value": "true"},
+      "nidm_varianceMapWiseDependence": {"@id": "nidm_IndependentParameter"}
     },
     {
-      "@id": "niiri:6991af1c3ba97b3a4470769a6f1f7a1e",
-      "@type": ["prov:Activity","nidm_ModelParametersEstimation:"],
+      "@id": "niiri:b74ede46a6fca129f8c8f17e297de5f1",
+      "@type": ["prov:Activity","nidm_ModelParametersEstimation"],
       "rdfs:label": "Model parameters estimation",
-      "nidm_withEstimationMethod:": {"@id": "obo_ordinaryleastsquaresestimation:"}
+      "nidm_withEstimationMethod": {"@id": "obo_ordinaryleastsquaresestimation"}
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:6991af1c3ba97b3a4470769a6f1f7a1e",
-      "agent": "niiri:582e74d3d47d395484eb9750c00b6034"
+      "activity_associated": "niiri:b74ede46a6fca129f8c8f17e297de5f1",
+      "agent": "niiri:94ecae7951d21985687dcb4bf72d88bc"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:6991af1c3ba97b3a4470769a6f1f7a1e",
-      "entity": "niiri:0486a876a984f0a75a383ff571c65763"
+      "activity_using": "niiri:b74ede46a6fca129f8c8f17e297de5f1",
+      "entity": "niiri:5974cc100f3ec5600037861f2b9ed1de"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:6991af1c3ba97b3a4470769a6f1f7a1e",
-      "entity": "niiri:88e00486db13f79e1d42aee523efe408"
+      "activity_using": "niiri:b74ede46a6fca129f8c8f17e297de5f1",
+      "entity": "niiri:ca46b04d477ee0f0e6f16c372a1a4976"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:6991af1c3ba97b3a4470769a6f1f7a1e",
-      "entity": "niiri:98c11fdf4a008d0bb72923f6033452b6"
+      "activity_using": "niiri:b74ede46a6fca129f8c8f17e297de5f1",
+      "entity": "niiri:7cf52921ad5716e824bef8a127efb7bc"
     },
     {
-      "@id": "niiri:5f0d397b9923b8ec17c86160f22ed3bd",
-      "@type": ["prov:Entity","nidm_MaskMap:"],
+      "@id": "niiri:134717e80ac83bc17cf1e5f4b6a0dab8",
+      "@type": ["prov:Entity","nidm_MaskMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "Mask.nii.gz"},
-      "nidm_isUserDefined:": {"@type": "xsd:boolean", "@value": "false"},
+      "nidm_isUserDefined": {"@type": "xsd:boolean", "@value": "false"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "Mask.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Mask",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:9ea612def84c2b00a28fde8461621f3d"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:5e472b9e1804aecf84d34427aeac5d36"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "71153b4ca7e1136cf9ae9cb56eaf6a4ed494bad08a1cfa0659e8e211a36425aaf865c3def12dea06c5595662761b891c87ec7b8fa0b8b75cd31247be9418bf24"}
     },
     {
-      "@id": "niiri:a7746fa9e94e3bd7d0314c8638421507",
-      "@type": ["prov:Entity","nidm_MaskMap:"],
+      "@id": "niiri:4efbab6889ea73c471c6ec4da367d19d",
+      "@type": ["prov:Entity","nidm_MaskMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "mask.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "e33feb3fddb2a3ee6d91e0b84ce0050a83414df67559e07679326fab2c31494df0a1db2d693027786c839b356626159d9158e4e9766b2bf46be4d32678f356fd"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5f0d397b9923b8ec17c86160f22ed3bd",
-      "entity": "niiri:a7746fa9e94e3bd7d0314c8638421507"
+      "entity_derived": "niiri:134717e80ac83bc17cf1e5f4b6a0dab8",
+      "entity": "niiri:4efbab6889ea73c471c6ec4da367d19d"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:5f0d397b9923b8ec17c86160f22ed3bd",
-      "activity": "niiri:6991af1c3ba97b3a4470769a6f1f7a1e"
+      "entity_generated": "niiri:134717e80ac83bc17cf1e5f4b6a0dab8",
+      "activity": "niiri:b74ede46a6fca129f8c8f17e297de5f1"
     },
     {
-      "@id": "niiri:07cbaf4796e0fb7cb545a8900d2a7073",
-      "@type": ["prov:Entity","nidm_GrandMeanMap:"],
+      "@id": "niiri:b1aa0fbd676b8d41f017be6bdbd31cd3",
+      "@type": ["prov:Entity","nidm_GrandMeanMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "GrandMean.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "GrandMean.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Grand Mean Map",
-      "nidm_maskedMedian:": {"@type": "xsd:float", "@value": "-0.0577427912503481"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:9ea612def84c2b00a28fde8461621f3d"},
+      "nidm_maskedMedian": {"@type": "xsd:float", "@value": "-0.0577427912503481"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:5e472b9e1804aecf84d34427aeac5d36"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "f35910a69f57ca530caf395eff6a18f7c8b9715206695cbe6852d4a235128edd4cfecd11f613eb3b9a1ffc9b471d3018bb14472c92453bcd9fc5afe8715c78ca"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:07cbaf4796e0fb7cb545a8900d2a7073",
-      "activity": "niiri:6991af1c3ba97b3a4470769a6f1f7a1e"
+      "entity_generated": "niiri:b1aa0fbd676b8d41f017be6bdbd31cd3",
+      "activity": "niiri:b74ede46a6fca129f8c8f17e297de5f1"
     },
     {
-      "@id": "niiri:95e672dbad1f46daac797ad2f195f98e",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:2c7195286f0c7c5d7c26fed41636166c",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0001.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0001.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 1",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:9ea612def84c2b00a28fde8461621f3d"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:5e472b9e1804aecf84d34427aeac5d36"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "7ec9d8c6e184528ab65f3f51dd1622acede31fc2cf3b7f26c4f5769401eee3b887248e8dc51868dfb21fc8e5890cf911194796857ea0bd33db8a24d95faaf1ac"}
     },
     {
-      "@id": "niiri:b5883b67a019ff8d4f45ac8adcd4661a",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:e0f5b0a00cdf4664ae1696f06275d443",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0001.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "7ec9d8c6e184528ab65f3f51dd1622acede31fc2cf3b7f26c4f5769401eee3b887248e8dc51868dfb21fc8e5890cf911194796857ea0bd33db8a24d95faaf1ac"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:95e672dbad1f46daac797ad2f195f98e",
-      "entity": "niiri:b5883b67a019ff8d4f45ac8adcd4661a"
+      "entity_derived": "niiri:2c7195286f0c7c5d7c26fed41636166c",
+      "entity": "niiri:e0f5b0a00cdf4664ae1696f06275d443"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:95e672dbad1f46daac797ad2f195f98e",
-      "activity": "niiri:6991af1c3ba97b3a4470769a6f1f7a1e"
+      "entity_generated": "niiri:2c7195286f0c7c5d7c26fed41636166c",
+      "activity": "niiri:b74ede46a6fca129f8c8f17e297de5f1"
     },
     {
-      "@id": "niiri:78a8fec86dd3b4499bf6d06c20deabff",
-      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap:"],
+      "@id": "niiri:da51626f7a852710359834961cdfa1cc",
+      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ResidualMeanSquares.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ResidualMeanSquares.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Residual Mean Squares Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:9ea612def84c2b00a28fde8461621f3d"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:5e472b9e1804aecf84d34427aeac5d36"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "e15461ad432e63ccb4bb2534e12cc51f5c2e7562130472a6859c850f10bc34b0401f39d357a71eb3d1bd5e764a07ca78103bac52b8d6e2e5229386e51308d013"}
     },
     {
-      "@id": "niiri:c3317aed9d01bf247defeb1eee02f614",
-      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap:"],
+      "@id": "niiri:40534953fad6a4d97f2c2c4210f5f310",
+      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "ResMS.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "8fabf9aad5778af79b9ec78de959ac3a5ede3631deeece4528020a0e5b00f3994b2ac5f8805f0dd462adbc4fc7c2775f9b2bab0a2264f50888ff4f114a467338"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:78a8fec86dd3b4499bf6d06c20deabff",
-      "entity": "niiri:c3317aed9d01bf247defeb1eee02f614"
+      "entity_derived": "niiri:da51626f7a852710359834961cdfa1cc",
+      "entity": "niiri:40534953fad6a4d97f2c2c4210f5f310"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:78a8fec86dd3b4499bf6d06c20deabff",
-      "activity": "niiri:6991af1c3ba97b3a4470769a6f1f7a1e"
+      "entity_generated": "niiri:da51626f7a852710359834961cdfa1cc",
+      "activity": "niiri:b74ede46a6fca129f8c8f17e297de5f1"
     },
     {
-      "@id": "niiri:711c7cbfc366f93b909c1e1c576a04e9",
-      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap:"],
+      "@id": "niiri:999b4c344889226d33a1a3db629bbcdd",
+      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ReselsPerVoxel.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ReselsPerVoxel.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Resels per Voxel Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:9ea612def84c2b00a28fde8461621f3d"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:5e472b9e1804aecf84d34427aeac5d36"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "3568d150737aa60112c469cdd700c1339bcb6fbde9b14fbef1b22f6d05141dcd37fc0fc6cddcd98b4d27c9a2d068b832cf694f57519eebc157c37258ad601538"}
     },
     {
-      "@id": "niiri:dd26ef029ad27502fd0726f4d36b2952",
-      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap:"],
+      "@id": "niiri:f3e33ccbd90b2b0c093f458966ab7ef8",
+      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "RPV.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "0ac129143989c790068562a225d8df623a032492270793e9b2a1355c70788ff86279a4debd4c65a9b0c03050b4ba6bbcb88da37a90cdc2dbe470dd618897221b"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:711c7cbfc366f93b909c1e1c576a04e9",
-      "entity": "niiri:dd26ef029ad27502fd0726f4d36b2952"
+      "entity_derived": "niiri:999b4c344889226d33a1a3db629bbcdd",
+      "entity": "niiri:f3e33ccbd90b2b0c093f458966ab7ef8"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:711c7cbfc366f93b909c1e1c576a04e9",
-      "activity": "niiri:6991af1c3ba97b3a4470769a6f1f7a1e"
+      "entity_generated": "niiri:999b4c344889226d33a1a3db629bbcdd",
+      "activity": "niiri:b74ede46a6fca129f8c8f17e297de5f1"
     },
     {
-      "@id": "niiri:6298c9c6b11157fd62e0360b3766a33e",
-      "@type": ["prov:Entity","obo_contrastweightmatrix:"],
-      "nidm_statisticType:": {"@id": "obo_tstatistic:"},
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "con-01"},
+      "@id": "niiri:a2ce89d6c8d1b7721b0b3ac2a3bad8d8",
+      "@type": ["prov:Entity","obo_contrastweightmatrix"],
+      "nidm_statisticType": {"@id": "obo_tstatistic"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "con-01"},
       "rdfs:label": "Contrast: con-01",
       "prov:value": {"@type": "xsd:string", "@value": "1"}
     },
     {
-      "@id": "niiri:185937d0b35e3eadd33255ce74b4aafe",
-      "@type": ["prov:Activity","nidm_ContrastEstimation:"],
+      "@id": "niiri:137adca045c6b01b9508719af960a129",
+      "@type": ["prov:Activity","nidm_ContrastEstimation"],
       "rdfs:label": "Contrast estimation"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:185937d0b35e3eadd33255ce74b4aafe",
-      "agent": "niiri:582e74d3d47d395484eb9750c00b6034"
+      "activity_associated": "niiri:137adca045c6b01b9508719af960a129",
+      "agent": "niiri:94ecae7951d21985687dcb4bf72d88bc"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:185937d0b35e3eadd33255ce74b4aafe",
-      "entity": "niiri:5f0d397b9923b8ec17c86160f22ed3bd"
+      "activity_using": "niiri:137adca045c6b01b9508719af960a129",
+      "entity": "niiri:134717e80ac83bc17cf1e5f4b6a0dab8"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:185937d0b35e3eadd33255ce74b4aafe",
-      "entity": "niiri:78a8fec86dd3b4499bf6d06c20deabff"
+      "activity_using": "niiri:137adca045c6b01b9508719af960a129",
+      "entity": "niiri:da51626f7a852710359834961cdfa1cc"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:185937d0b35e3eadd33255ce74b4aafe",
-      "entity": "niiri:0486a876a984f0a75a383ff571c65763"
+      "activity_using": "niiri:137adca045c6b01b9508719af960a129",
+      "entity": "niiri:5974cc100f3ec5600037861f2b9ed1de"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:185937d0b35e3eadd33255ce74b4aafe",
-      "entity": "niiri:6298c9c6b11157fd62e0360b3766a33e"
+      "activity_using": "niiri:137adca045c6b01b9508719af960a129",
+      "entity": "niiri:a2ce89d6c8d1b7721b0b3ac2a3bad8d8"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:185937d0b35e3eadd33255ce74b4aafe",
-      "entity": "niiri:95e672dbad1f46daac797ad2f195f98e"
+      "activity_using": "niiri:137adca045c6b01b9508719af960a129",
+      "entity": "niiri:2c7195286f0c7c5d7c26fed41636166c"
     },
     {
-      "@id": "niiri:af22bee20fc4bfa20ae2f0da89d98f26",
-      "@type": ["prov:Entity","nidm_StatisticMap:"],
+      "@id": "niiri:65cbca637492fc41602a48854f923270",
+      "@type": ["prov:Entity","nidm_StatisticMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "TStatistic.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "TStatistic.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "T-Statistic Map: con-01",
-      "nidm_statisticType:": {"@id": "obo_tstatistic:"},
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "con-01"},
-      "nidm_errorDegreesOfFreedom:": {"@type": "xsd:float", "@value": "13"},
-      "nidm_effectDegreesOfFreedom:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:9ea612def84c2b00a28fde8461621f3d"},
+      "nidm_statisticType": {"@id": "obo_tstatistic"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "con-01"},
+      "nidm_errorDegreesOfFreedom": {"@type": "xsd:float", "@value": "13"},
+      "nidm_effectDegreesOfFreedom": {"@type": "xsd:float", "@value": "1"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:5e472b9e1804aecf84d34427aeac5d36"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "b24254216e083a99fcc6d21cb954729c942dc636b49a3961a99c531c8007923031769bae46e5e583ef872f71e62fa3b956257dc2dc7f0b6de7cef6a807d56e91"}
     },
     {
-      "@id": "niiri:fec832466afc3287c89d1c72ecafce1c",
-      "@type": ["prov:Entity","nidm_StatisticMap:"],
+      "@id": "niiri:72875077d4eb68692b3e042d5fcac6e9",
+      "@type": ["prov:Entity","nidm_StatisticMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "spmT_0001.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "fd01b639babd7881fb50aa553d869683c4b04075260bb67a2d4cdbb406b2b7a0c4bf3a23b5486e9a29d6bcf688e1dd39e1568f830189ce9f3bc250e1f285d768"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:af22bee20fc4bfa20ae2f0da89d98f26",
-      "entity": "niiri:fec832466afc3287c89d1c72ecafce1c"
+      "entity_derived": "niiri:65cbca637492fc41602a48854f923270",
+      "entity": "niiri:72875077d4eb68692b3e042d5fcac6e9"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:af22bee20fc4bfa20ae2f0da89d98f26",
-      "activity": "niiri:185937d0b35e3eadd33255ce74b4aafe"
+      "entity_generated": "niiri:65cbca637492fc41602a48854f923270",
+      "activity": "niiri:137adca045c6b01b9508719af960a129"
     },
     {
-      "@id": "niiri:8e9cb88aaaf6e3cfd6ece5d543736f4b",
-      "@type": ["prov:Entity","nidm_ContrastMap:"],
+      "@id": "niiri:231e885f1374dda1f44a60ed150f55b6",
+      "@type": ["prov:Entity","nidm_ContrastMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "Contrast.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "Contrast.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Contrast Map: con-01",
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "con-01"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:9ea612def84c2b00a28fde8461621f3d"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "con-01"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:5e472b9e1804aecf84d34427aeac5d36"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "d73b0fa1856ac6fec8e0fc2c48e858ea1495c7dc6ae1636839cc3e255c2123f2b1e492e6a9c50366b07bfd888c93ea231730f75e28b96d06f846da63da671fd3"}
     },
     {
-      "@id": "niiri:deb03302f5b765ccba5306efe257fedf",
-      "@type": ["prov:Entity","nidm_ContrastMap:"],
+      "@id": "niiri:32d6df109b21d06d7baebdfbabfa9dea",
+      "@type": ["prov:Entity","nidm_ContrastMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "con_0001.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "7fbc36bda26c3089c7a092a58c999815b7f4927960270de331bc8934cd23f8c453ad9860e38a845feb63da5f3eac9a478c9eafb33e11cccf596b4ac6b066b35a"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8e9cb88aaaf6e3cfd6ece5d543736f4b",
-      "entity": "niiri:deb03302f5b765ccba5306efe257fedf"
+      "entity_derived": "niiri:231e885f1374dda1f44a60ed150f55b6",
+      "entity": "niiri:32d6df109b21d06d7baebdfbabfa9dea"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:8e9cb88aaaf6e3cfd6ece5d543736f4b",
-      "activity": "niiri:185937d0b35e3eadd33255ce74b4aafe"
+      "entity_generated": "niiri:231e885f1374dda1f44a60ed150f55b6",
+      "activity": "niiri:137adca045c6b01b9508719af960a129"
     },
     {
-      "@id": "niiri:3fa980b5ccd4dfd017bbef0c5e6423f8",
-      "@type": ["prov:Entity","nidm_ContrastStandardErrorMap:"],
+      "@id": "niiri:cd389673c942f3b5e85cbab2a17173b7",
+      "@type": ["prov:Entity","nidm_ContrastStandardErrorMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ContrastStandardError.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ContrastStandardError.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Contrast Standard Error Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:9ea612def84c2b00a28fde8461621f3d"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:5e472b9e1804aecf84d34427aeac5d36"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "7384d50a91b0a096f7ea0027c6681baa90886c59d0bc79806fb2f2005560ca8d2ebef145c1b2286b836fbc556cbef2dead4543d716df39e7b839f992d1f6845f"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:3fa980b5ccd4dfd017bbef0c5e6423f8",
-      "activity": "niiri:185937d0b35e3eadd33255ce74b4aafe"
+      "entity_generated": "niiri:cd389673c942f3b5e85cbab2a17173b7",
+      "activity": "niiri:137adca045c6b01b9508719af960a129"
     },
     {
-      "@id": "niiri:662e79109731fe9b76e0ad3f17301b55",
-      "@type": ["prov:Entity","nidm_HeightThreshold:","nidm_PValueUncorrected:"],
-      "rdfs:label": "Height Threshold: p<0.001000 (unc.)",
+      "@id": "niiri:e5b5f613b43832e8ca36c5fcd5e197c7",
+      "@type": ["prov:Entity","nidm_HeightThreshold","nidm_PValueUncorrected"],
+      "rdfs:label": "Height Threshold: p<0.001 (unc.)",
       "prov:value": {"@type": "xsd:float", "@value": "0.000999500181305457"},
-      "nidm_equivalentThreshold:": [{"@id": "niiri:443ee848bf8d71e2ac13a2d0cefc8cae"},{"@id": "niiri:bdc6ce774917f3c530b0e48d4f6918f3"}]
+      "nidm_equivalentThreshold": [{"@id": "niiri:1376b409e19b9dd72fe143831aaa2dad"},{"@id": "niiri:9922364e4e71a98f84cc4bc8276b602f"}]
     },
     {
-      "@id": "niiri:443ee848bf8d71e2ac13a2d0cefc8cae",
-      "@type": ["prov:Entity","nidm_HeightThreshold:","obo_statistic:"],
-      "rdfs:label": "Height Threshold",
+      "@id": "niiri:1376b409e19b9dd72fe143831aaa2dad",
+      "@type": ["prov:Entity","nidm_HeightThreshold","obo_statistic"],
+      "rdfs:label": "Height Threshold: T=3.851982)",
       "prov:value": {"@type": "xsd:float", "@value": "3.85198238341593"}
     },
     {
-      "@id": "niiri:bdc6ce774917f3c530b0e48d4f6918f3",
-      "@type": ["prov:Entity","nidm_HeightThreshold:","obo_FWERadjustedpvalue:"],
-      "rdfs:label": "Height Threshold",
+      "@id": "niiri:9922364e4e71a98f84cc4bc8276b602f",
+      "@type": ["prov:Entity","nidm_HeightThreshold","obo_FWERadjustedpvalue"],
+      "rdfs:label": "Height Threshold: p<1.000000 (FWE)",
       "prov:value": {"@type": "xsd:float", "@value": "0.999999998275662"}
     },
     {
-      "@id": "niiri:758a317dc145a95aca39aa6587220d24",
-      "@type": ["prov:Entity","nidm_ExtentThreshold:","obo_statistic:"],
+      "@id": "niiri:9244bb6be2f1484bfb4b5d9df64a143c",
+      "@type": ["prov:Entity","nidm_ExtentThreshold","obo_statistic"],
       "rdfs:label": "Extent Threshold: k>=120",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "120"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.878540888502834"},
-      "nidm_equivalentThreshold:": [{"@id": "niiri:e28c8f066d8dda2a777f3c99fe22642b"},{"@id": "niiri:6253986dbb01e4d929b5f54e9fa4e65c"}]
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "120"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.878540888502834"},
+      "nidm_equivalentThreshold": [{"@id": "niiri:920d4d286122d33e6d29abf2133f50e0"},{"@id": "niiri:1b1374f5b2ef8094433e27fa63f6ef2b"}]
     },
     {
-      "@id": "niiri:e28c8f066d8dda2a777f3c99fe22642b",
-      "@type": ["prov:Entity","nidm_ExtentThreshold:","obo_FWERadjustedpvalue:"],
+      "@id": "niiri:920d4d286122d33e6d29abf2133f50e0",
+      "@type": ["prov:Entity","nidm_ExtentThreshold","obo_FWERadjustedpvalue"],
       "rdfs:label": "Extent Threshold",
       "prov:value": {"@type": "xsd:float", "@value": "0.0208526820077359"}
     },
     {
-      "@id": "niiri:6253986dbb01e4d929b5f54e9fa4e65c",
-      "@type": ["prov:Entity","nidm_ExtentThreshold:","nidm_PValueUncorrected:"],
+      "@id": "niiri:1b1374f5b2ef8094433e27fa63f6ef2b",
+      "@type": ["prov:Entity","nidm_ExtentThreshold","nidm_PValueUncorrected"],
       "rdfs:label": "Extent Threshold",
       "prov:value": {"@type": "xsd:float", "@value": "0.00104434177016124"}
     },
     {
-      "@id": "niiri:5409762af19920f26ce664b4d8f61c97",
-      "@type": ["prov:Entity","nidm_PeakDefinitionCriteria:"],
+      "@id": "niiri:41e52a5a5544a76853bcc91eb3fecb2f",
+      "@type": ["prov:Entity","nidm_PeakDefinitionCriteria"],
       "rdfs:label": "Peak Definition Criteria",
-      "nidm_maxNumberOfPeaksPerCluster:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_minDistanceBetweenPeaks:": {"@type": "xsd:float", "@value": "8"}
+      "nidm_maxNumberOfPeaksPerCluster": {"@type": "xsd:int", "@value": "3"},
+      "nidm_minDistanceBetweenPeaks": {"@type": "xsd:float", "@value": "8"}
     },
     {
-      "@id": "niiri:cacee6ad5d2cb227da01f933db8e6d23",
-      "@type": ["prov:Entity","nidm_ClusterDefinitionCriteria:"],
+      "@id": "niiri:ba3936fa8577eac03c9623a5f5eb4c81",
+      "@type": ["prov:Entity","nidm_ClusterDefinitionCriteria"],
       "rdfs:label": "Cluster Connectivity Criterion: 18",
-      "nidm_hasConnectivityCriterion:": {"@id": "nidm_voxel18connected:"}
+      "nidm_hasConnectivityCriterion": {"@id": "nidm_voxel18connected"}
     },
     {
-      "@id": "niiri:4baf3ca1d021e1606e0c84df3af4f006",
-      "@type": ["prov:Activity","nidm_Inference:"],
-      "nidm_hasAlternativeHypothesis:": {"@id": "nidm_OneTailedTest:"},
+      "@id": "niiri:e134b356fffdbdf572967bdab3709e2c",
+      "@type": ["prov:Activity","nidm_Inference"],
+      "nidm_hasAlternativeHypothesis": {"@id": "nidm_OneTailedTest"},
       "rdfs:label": "Inference"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:4baf3ca1d021e1606e0c84df3af4f006",
-      "agent": "niiri:582e74d3d47d395484eb9750c00b6034"
+      "activity_associated": "niiri:e134b356fffdbdf572967bdab3709e2c",
+      "agent": "niiri:94ecae7951d21985687dcb4bf72d88bc"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:4baf3ca1d021e1606e0c84df3af4f006",
-      "entity": "niiri:662e79109731fe9b76e0ad3f17301b55"
+      "activity_using": "niiri:e134b356fffdbdf572967bdab3709e2c",
+      "entity": "niiri:e5b5f613b43832e8ca36c5fcd5e197c7"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:4baf3ca1d021e1606e0c84df3af4f006",
-      "entity": "niiri:758a317dc145a95aca39aa6587220d24"
+      "activity_using": "niiri:e134b356fffdbdf572967bdab3709e2c",
+      "entity": "niiri:9244bb6be2f1484bfb4b5d9df64a143c"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:4baf3ca1d021e1606e0c84df3af4f006",
-      "entity": "niiri:af22bee20fc4bfa20ae2f0da89d98f26"
+      "activity_using": "niiri:e134b356fffdbdf572967bdab3709e2c",
+      "entity": "niiri:65cbca637492fc41602a48854f923270"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:4baf3ca1d021e1606e0c84df3af4f006",
-      "entity": "niiri:711c7cbfc366f93b909c1e1c576a04e9"
+      "activity_using": "niiri:e134b356fffdbdf572967bdab3709e2c",
+      "entity": "niiri:999b4c344889226d33a1a3db629bbcdd"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:4baf3ca1d021e1606e0c84df3af4f006",
-      "entity": "niiri:5f0d397b9923b8ec17c86160f22ed3bd"
+      "activity_using": "niiri:e134b356fffdbdf572967bdab3709e2c",
+      "entity": "niiri:134717e80ac83bc17cf1e5f4b6a0dab8"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:4baf3ca1d021e1606e0c84df3af4f006",
-      "entity": "niiri:5409762af19920f26ce664b4d8f61c97"
+      "activity_using": "niiri:e134b356fffdbdf572967bdab3709e2c",
+      "entity": "niiri:41e52a5a5544a76853bcc91eb3fecb2f"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:4baf3ca1d021e1606e0c84df3af4f006",
-      "entity": "niiri:cacee6ad5d2cb227da01f933db8e6d23"
+      "activity_using": "niiri:e134b356fffdbdf572967bdab3709e2c",
+      "entity": "niiri:ba3936fa8577eac03c9623a5f5eb4c81"
     },
     {
-      "@id": "niiri:a25a4329015a4066066702835b14f949",
-      "@type": ["prov:Entity","nidm_SearchSpaceMaskMap:"],
+      "@id": "niiri:b960c3349651945d424e517bd1730a7d",
+      "@type": ["prov:Entity","nidm_SearchSpaceMaskMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "SearchSpaceMask.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "SearchSpaceMask.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Search Space Mask Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:9ea612def84c2b00a28fde8461621f3d"},
-      "nidm_searchVolumeInVoxels:": {"@type": "xsd:int", "@value": "160902"},
-      "nidm_searchVolumeInUnits:": {"@type": "xsd:float", "@value": "1287216"},
-      "nidm_reselSizeInVoxels:": {"@type": "xsd:float", "@value": "136.59011386994"},
-      "nidm_searchVolumeInResels:": {"@type": "xsd:float", "@value": "1080.61261403256"},
-      "spm_searchVolumeReselsGeometry:": {"@type": "xsd:string", "@value": "[1, 52.0358980508664, 491.877854544175, 1080.61261403256]"},
-      "nidm_noiseFWHMInVoxels:": {"@type": "xsd:string", "@value": "[5.14810180713795, 5.07365604355584, 5.22939103936007]"},
-      "nidm_noiseFWHMInUnits:": {"@type": "xsd:string", "@value": "[10.2962036142759, 10.1473120871117, 10.4587820787201]"},
-      "nidm_randomFieldStationarity:": {"@type": "xsd:boolean", "@value": "true"},
-      "nidm_expectedNumberOfVoxelsPerCluster:": {"@type": "xsd:float", "@value": "8.86985588130192"},
-      "nidm_expectedNumberOfClusters:": {"@type": "xsd:float", "@value": "0.0210731697413967"},
-      "nidm_heightCriticalThresholdFWE05:": {"@type": "xsd:float", "@value": "8.97488021321025"},
-      "nidm_heightCriticalThresholdFDR05:": {"@type": "xsd:float", "@value": "Inf"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:5e472b9e1804aecf84d34427aeac5d36"},
+      "nidm_searchVolumeInVoxels": {"@type": "xsd:int", "@value": "160902"},
+      "nidm_searchVolumeInUnits": {"@type": "xsd:float", "@value": "1287216"},
+      "nidm_reselSizeInVoxels": {"@type": "xsd:float", "@value": "136.59011386994"},
+      "nidm_searchVolumeInResels": {"@type": "xsd:float", "@value": "1080.61261403256"},
+      "spm_searchVolumeReselsGeometry": {"@type": "xsd:string", "@value": "[1, 52.0358980508664, 491.877854544175, 1080.61261403256]"},
+      "nidm_noiseFWHMInVoxels": {"@type": "xsd:string", "@value": "[5.14810180713795, 5.07365604355584, 5.22939103936007]"},
+      "nidm_noiseFWHMInUnits": {"@type": "xsd:string", "@value": "[10.2962036142759, 10.1473120871117, 10.4587820787201]"},
+      "nidm_randomFieldStationarity": {"@type": "xsd:boolean", "@value": "true"},
+      "nidm_expectedNumberOfVoxelsPerCluster": {"@type": "xsd:float", "@value": "8.86985588130192"},
+      "nidm_expectedNumberOfClusters": {"@type": "xsd:float", "@value": "0.0210731697413967"},
+      "nidm_heightCriticalThresholdFWE05": {"@type": "xsd:float", "@value": "8.97488021321025"},
+      "nidm_heightCriticalThresholdFDR05": {"@type": "xsd:float", "@value": "Inf"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "71153b4ca7e1136cf9ae9cb56eaf6a4ed494bad08a1cfa0659e8e211a36425aaf865c3def12dea06c5595662761b891c87ec7b8fa0b8b75cd31247be9418bf24"},
-      "spm_smallestSignificantClusterSizeInVoxelsFWE05:": {"@type": "xsd:int", "@value": "120"},
-      "spm_smallestSignificantClusterSizeInVoxelsFDR05:": {"@type": "xsd:int", "@value": "53"}
+      "spm_smallestSignificantClusterSizeInVoxelsFWE05": {"@type": "xsd:int", "@value": "120"},
+      "spm_smallestSignificantClusterSizeInVoxelsFDR05": {"@type": "xsd:int", "@value": "53"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:a25a4329015a4066066702835b14f949",
-      "activity": "niiri:4baf3ca1d021e1606e0c84df3af4f006"
+      "entity_generated": "niiri:b960c3349651945d424e517bd1730a7d",
+      "activity": "niiri:e134b356fffdbdf572967bdab3709e2c"
     },
     {
-      "@id": "niiri:f798f10a54c653caef26b5a29e8fc1a1",
-      "@type": ["prov:Entity","nidm_ExcursionSetMap:"],
+      "@id": "niiri:64e1c232f0bbae773bd50d725f8f456a",
+      "@type": ["prov:Entity","nidm_ExcursionSetMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ExcursionSet.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ExcursionSet.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Excursion Set Map",
-      "nidm_numberOfSupraThresholdClusters:": {"@type": "xsd:int", "@value": "9"},
-      "nidm_pValue:": {"@type": "xsd:float", "@value": "0"},
-      "nidm_hasClusterLabelsMap:": {"@id": "niiri:776dadec09b8573e7625e36647d7e361"},
-      "nidm_hasMaximumIntensityProjection:": {"@id": "niiri:d488f806941c7d95209f82e23fd351e7"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:9ea612def84c2b00a28fde8461621f3d"},
+      "nidm_numberOfSupraThresholdClusters": {"@type": "xsd:int", "@value": "9"},
+      "nidm_pValue": {"@type": "xsd:float", "@value": "0"},
+      "nidm_hasClusterLabelsMap": {"@id": "niiri:e020f1e9f1a50dffcbb63594f2caca52"},
+      "nidm_hasMaximumIntensityProjection": {"@id": "niiri:5f5a4e2d87d4741192c9fedabca572eb"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:5e472b9e1804aecf84d34427aeac5d36"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "2f4011618fe1b59df15513558d716959952362e45f285e1685f6561e4815c19ebf6f1d9cb237b9bdc186055b9b99b9cbd8fd0e0904eee92e35018e4066e212cf"}
     },
     {
-      "@id": "niiri:776dadec09b8573e7625e36647d7e361",
-      "@type": ["prov:Entity","nidm_ClusterLabelsMap:"],
+      "@id": "niiri:e020f1e9f1a50dffcbb63594f2caca52",
+      "@type": ["prov:Entity","nidm_ClusterLabelsMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ClusterLabels.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ClusterLabels.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Cluster Labels Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:9ea612def84c2b00a28fde8461621f3d"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:5e472b9e1804aecf84d34427aeac5d36"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "ce4207d9dc614d3ee94a6068b0f5eeb2f118041ba7a3e02687ec19998e43d7eb059246440f46bda14dfb709d4b45eab1077195b2b82ee2dedbed19a12c1f7ccc"}
     },
     {
-      "@id": "niiri:d488f806941c7d95209f82e23fd351e7",
+      "@id": "niiri:5f5a4e2d87d4741192c9fedabca572eb",
       "@type": ["prov:Entity","dctype:Image"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "MaximumIntensityProjection.png"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "MaximumIntensityProjection.png"},
@@ -654,680 +654,680 @@
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:f798f10a54c653caef26b5a29e8fc1a1",
-      "activity": "niiri:4baf3ca1d021e1606e0c84df3af4f006"
+      "entity_generated": "niiri:64e1c232f0bbae773bd50d725f8f456a",
+      "activity": "niiri:e134b356fffdbdf572967bdab3709e2c"
     },
     {
-      "@id": "niiri:819bbce44c4139b90c18376738398b7a",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:e3191f42f3f3f4c93e35287c26019f98",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0001",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "565"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "4.13646335003418"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.2210454645763e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "8.51740362683984e-08"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1.30852409401865e-07"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "1"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "565"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "4.13646335003418"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.2210454645763e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "8.51740362683984e-08"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1.30852409401865e-07"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "1"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:819bbce44c4139b90c18376738398b7a",
-      "entity": "niiri:f798f10a54c653caef26b5a29e8fc1a1"
+      "entity_derived": "niiri:e3191f42f3f3f4c93e35287c26019f98",
+      "entity": "niiri:64e1c232f0bbae773bd50d725f8f456a"
     },
     {
-      "@id": "niiri:b8ed575a90fea174c22e252eeae426ab",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:d496925af8b0958a04278695c2116f14",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0002",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "201"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.47155598824225"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.24261969297565e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00125886915138074"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000550348915075722"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "2"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "201"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.47155598824225"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.24261969297565e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00125886915138074"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000550348915075722"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "2"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b8ed575a90fea174c22e252eeae426ab",
-      "entity": "niiri:f798f10a54c653caef26b5a29e8fc1a1"
+      "entity_derived": "niiri:d496925af8b0958a04278695c2116f14",
+      "entity": "niiri:64e1c232f0bbae773bd50d725f8f456a"
     },
     {
-      "@id": "niiri:389bda8aa0474cc3a6c1ccbbd257d3aa",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:784e20ceac3fc89851575215e2b045a6",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0003",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "130"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.951752629211403"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000716872301655276"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0143612318077091"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00277788016891419"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "3"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "130"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.951752629211403"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000716872301655276"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0143612318077091"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00277788016891419"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "3"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:389bda8aa0474cc3a6c1ccbbd257d3aa",
-      "entity": "niiri:f798f10a54c653caef26b5a29e8fc1a1"
+      "entity_derived": "niiri:784e20ceac3fc89851575215e2b045a6",
+      "entity": "niiri:64e1c232f0bbae773bd50d725f8f456a"
     },
     {
-      "@id": "niiri:f38df95463ef91d161217362dadf93bc",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:2d8cf2f1c8b135c47e4c992ddddc4603",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0004",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "197"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.44227129195882"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.1012763235577e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00143189941009247"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000550348915075722"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "4"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "197"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.44227129195882"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.1012763235577e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00143189941009247"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000550348915075722"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "4"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f38df95463ef91d161217362dadf93bc",
-      "entity": "niiri:f798f10a54c653caef26b5a29e8fc1a1"
+      "entity_derived": "niiri:2d8cf2f1c8b135c47e4c992ddddc4603",
+      "entity": "niiri:64e1c232f0bbae773bd50d725f8f456a"
     },
     {
-      "@id": "niiri:2c7b298047315ad1d67ac222bd8224bf",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:145e279f67ab0593ed7aad160ef6ec96",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0005",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "344"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "2.51848388037479"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "9.63976506362912e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1.94513362937743e-05"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1.49416358486251e-05"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "5"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "344"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "2.51848388037479"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "9.63976506362912e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1.94513362937743e-05"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1.49416358486251e-05"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "5"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2c7b298047315ad1d67ac222bd8224bf",
-      "entity": "niiri:f798f10a54c653caef26b5a29e8fc1a1"
+      "entity_derived": "niiri:145e279f67ab0593ed7aad160ef6ec96",
+      "entity": "niiri:64e1c232f0bbae773bd50d725f8f456a"
     },
     {
-      "@id": "niiri:b1faa7f7b978858ed6eb410ca05d8b3d",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:0cf7fbb104195b08838b495de979f17d",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0006",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "168"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.22995724390397"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000185860057406901"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00374333898481427"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000960276963268989"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "6"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "168"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.22995724390397"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000185860057406901"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00374333898481427"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000960276963268989"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "6"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b1faa7f7b978858ed6eb410ca05d8b3d",
-      "entity": "niiri:f798f10a54c653caef26b5a29e8fc1a1"
+      "entity_derived": "niiri:0cf7fbb104195b08838b495de979f17d",
+      "entity": "niiri:64e1c232f0bbae773bd50d725f8f456a"
     },
     {
-      "@id": "niiri:8d1d785aced1bd1fe4b02bf63b8bc4c4",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:3fb8d8c50e07f46ff52730667b4ff904",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0007",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "120"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.878540888502834"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00104434177016124"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0208526820077359"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00359717720833317"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "7"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "120"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.878540888502834"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00104434177016124"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0208526820077359"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00359717720833317"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "7"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8d1d785aced1bd1fe4b02bf63b8bc4c4",
-      "entity": "niiri:f798f10a54c653caef26b5a29e8fc1a1"
+      "entity_derived": "niiri:3fb8d8c50e07f46ff52730667b4ff904",
+      "entity": "niiri:64e1c232f0bbae773bd50d725f8f456a"
     },
     {
-      "@id": "niiri:4a24406f20a447cd18e19bcea9c901b1",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:24ed53e97502545f0497cc97644535d2",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0008",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "182"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.33245368089596"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000116063491953819"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00233923791601987"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000719593650113681"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "8"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "182"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.33245368089596"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000116063491953819"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00233923791601987"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000719593650113681"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "8"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4a24406f20a447cd18e19bcea9c901b1",
-      "entity": "niiri:f798f10a54c653caef26b5a29e8fc1a1"
+      "entity_derived": "niiri:24ed53e97502545f0497cc97644535d2",
+      "entity": "niiri:64e1c232f0bbae773bd50d725f8f456a"
     },
     {
-      "@id": "niiri:0df7f5664a49553001462c97fe08a90e",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:ee68048e8a0744dfd236a85d10e1b80c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0009",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "144"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.0542490662034"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000430078992400458"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00864076784172119"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00190463553777346"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "9"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "144"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.0542490662034"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000430078992400458"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00864076784172119"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00190463553777346"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "9"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0df7f5664a49553001462c97fe08a90e",
-      "entity": "niiri:f798f10a54c653caef26b5a29e8fc1a1"
+      "entity_derived": "niiri:ee68048e8a0744dfd236a85d10e1b80c",
+      "entity": "niiri:64e1c232f0bbae773bd50d725f8f456a"
     },
     {
-      "@id": "niiri:086f61ec7a73359b6e6267997b89f1bb",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ff91629a343c2e8f75793ca5bf4f5456",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0001",
-      "prov:atLocation": {"@id": "niiri:49ebfb89929355725856c4ec88d5dfb3"},
+      "prov:atLocation": {"@id": "niiri:71861dca5fb2a8a0c5cc60b4795ea2bd"},
       "prov:value": {"@type": "xsd:float", "@value": "9.0197868347168"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.99532807659738"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.93679147334025e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0472535690597315"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.227081208121146"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.99532807659738"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.93679147334025e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0472535690597315"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.227081208121146"}
     },
     {
-      "@id": "niiri:49ebfb89929355725856c4ec88d5dfb3",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:71861dca5fb2a8a0c5cc60b4795ea2bd",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0001",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-10,18,42]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-10,18,42]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:086f61ec7a73359b6e6267997b89f1bb",
-      "entity": "niiri:819bbce44c4139b90c18376738398b7a"
+      "entity_derived": "niiri:ff91629a343c2e8f75793ca5bf4f5456",
+      "entity": "niiri:e3191f42f3f3f4c93e35287c26019f98"
     },
     {
-      "@id": "niiri:943f8b7d581fc2fe91ca352e90047fe3",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c49fbca986b7d0a96d37718d1c0d3be1",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0002",
-      "prov:atLocation": {"@id": "niiri:481898ea7fc75b4defb526252bbfbc7d"},
+      "prov:atLocation": {"@id": "niiri:6ebc4745b212479bf3dbc66f61355303"},
       "prov:value": {"@type": "xsd:float", "@value": "7.42846012115479"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.56538453536696"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.49289781906192e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.28406310634998"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.227081208121146"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.56538453536696"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.49289781906192e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.28406310634998"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.227081208121146"}
     },
     {
-      "@id": "niiri:481898ea7fc75b4defb526252bbfbc7d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6ebc4745b212479bf3dbc66f61355303",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0002",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-2,8,66]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-2,8,66]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:943f8b7d581fc2fe91ca352e90047fe3",
-      "entity": "niiri:819bbce44c4139b90c18376738398b7a"
+      "entity_derived": "niiri:c49fbca986b7d0a96d37718d1c0d3be1",
+      "entity": "niiri:e3191f42f3f3f4c93e35287c26019f98"
     },
     {
-      "@id": "niiri:5975bfef0764abc5022af943b2707a09",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:bc90e98330ecd77c0c61eb4ee20896c0",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0003",
-      "prov:atLocation": {"@id": "niiri:c91ee784d0f316ca96004840703df487"},
+      "prov:atLocation": {"@id": "niiri:0e7af240702d72adc90cf039012896f6"},
       "prov:value": {"@type": "xsd:float", "@value": "5.63349199295044"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.93987516059906"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.07620106994688e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.913665566475084"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.365315662158339"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.93987516059906"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.07620106994688e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.913665566475084"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.365315662158339"}
     },
     {
-      "@id": "niiri:c91ee784d0f316ca96004840703df487",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0e7af240702d72adc90cf039012896f6",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0003",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[8,2,66]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[8,2,66]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5975bfef0764abc5022af943b2707a09",
-      "entity": "niiri:819bbce44c4139b90c18376738398b7a"
+      "entity_derived": "niiri:bc90e98330ecd77c0c61eb4ee20896c0",
+      "entity": "niiri:e3191f42f3f3f4c93e35287c26019f98"
     },
     {
-      "@id": "niiri:f61f477dd0190930988f10ec2ccc3953",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:1d495ddd1ccf932950c1251a78ced9c4",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0004",
-      "prov:atLocation": {"@id": "niiri:88c238030228ae5516f1bcbf1b5503b1"},
+      "prov:atLocation": {"@id": "niiri:0f0000559de1833e3cc048c853eaef14"},
       "prov:value": {"@type": "xsd:float", "@value": "7.85747480392456"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.6908256972469"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.36052353338911e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.193292933875985"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.227081208121146"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.6908256972469"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.36052353338911e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.193292933875985"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.227081208121146"}
     },
     {
-      "@id": "niiri:88c238030228ae5516f1bcbf1b5503b1",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0f0000559de1833e3cc048c853eaef14",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0004",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-42,-4,28]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-42,-4,28]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f61f477dd0190930988f10ec2ccc3953",
-      "entity": "niiri:b8ed575a90fea174c22e252eeae426ab"
+      "entity_derived": "niiri:1d495ddd1ccf932950c1251a78ced9c4",
+      "entity": "niiri:d496925af8b0958a04278695c2116f14"
     },
     {
-      "@id": "niiri:e50c723a53c65a2817271e37d1ec8888",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:84fe5bdeb23007afdd8dfc54f4030c78",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0005",
-      "prov:atLocation": {"@id": "niiri:aa0c8d4dcf34222f36033c1c97f45d2b"},
+      "prov:atLocation": {"@id": "niiri:7c5bb491b25180b0b7561de85c20c240"},
       "prov:value": {"@type": "xsd:float", "@value": "4.96076774597168"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.65180690060166"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000130200830341765"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.995586804119546"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.508465170731449"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.65180690060166"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000130200830341765"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.995586804119546"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.508465170731449"}
     },
     {
-      "@id": "niiri:aa0c8d4dcf34222f36033c1c97f45d2b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7c5bb491b25180b0b7561de85c20c240",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0005",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-54,4,18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-54,4,18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e50c723a53c65a2817271e37d1ec8888",
-      "entity": "niiri:b8ed575a90fea174c22e252eeae426ab"
+      "entity_derived": "niiri:84fe5bdeb23007afdd8dfc54f4030c78",
+      "entity": "niiri:d496925af8b0958a04278695c2116f14"
     },
     {
-      "@id": "niiri:a5db13e5b7c9fd26e289ccb809b33731",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:18cc6e4de0c9e565941028f84899f9aa",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0006",
-      "prov:atLocation": {"@id": "niiri:d80a26de1dea42815c63a0f365d6449a"},
+      "prov:atLocation": {"@id": "niiri:b8e5d6bbccfb83b99e33609e89895e33"},
       "prov:value": {"@type": "xsd:float", "@value": "4.68419551849365"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.52268507469106"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000213599326911451"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999471213589401"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.58440570253383"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.52268507469106"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000213599326911451"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999471213589401"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.58440570253383"}
     },
     {
-      "@id": "niiri:d80a26de1dea42815c63a0f365d6449a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b8e5d6bbccfb83b99e33609e89895e33",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0006",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-54,6,30]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-54,6,30]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a5db13e5b7c9fd26e289ccb809b33731",
-      "entity": "niiri:b8ed575a90fea174c22e252eeae426ab"
+      "entity_derived": "niiri:18cc6e4de0c9e565941028f84899f9aa",
+      "entity": "niiri:d496925af8b0958a04278695c2116f14"
     },
     {
-      "@id": "niiri:b6ea9a8c98b467318e9d7937f647c6e0",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:2b5fa07d66fa075513a31a38dbaa7bd9",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0007",
-      "prov:atLocation": {"@id": "niiri:84ca29f6444eb392d2cea8daa7d95042"},
+      "prov:atLocation": {"@id": "niiri:5bc970458ceef44ab45ea1e7e7a0635d"},
       "prov:value": {"@type": "xsd:float", "@value": "7.27484846115112"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.51851280417867"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.11377539996549e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.324805789402179"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.227081208121146"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.51851280417867"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.11377539996549e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.324805789402179"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.227081208121146"}
     },
     {
-      "@id": "niiri:84ca29f6444eb392d2cea8daa7d95042",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:5bc970458ceef44ab45ea1e7e7a0635d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0007",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-46,-4,54]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-46,-4,54]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b6ea9a8c98b467318e9d7937f647c6e0",
-      "entity": "niiri:389bda8aa0474cc3a6c1ccbbd257d3aa"
+      "entity_derived": "niiri:2b5fa07d66fa075513a31a38dbaa7bd9",
+      "entity": "niiri:784e20ceac3fc89851575215e2b045a6"
     },
     {
-      "@id": "niiri:54d28453113183258d217e3bdd65c9fc",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f458ed28668e8278b72dffade3f56b36",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0008",
-      "prov:atLocation": {"@id": "niiri:609323e3dad9da267d42d6f70aaf5d39"},
+      "prov:atLocation": {"@id": "niiri:d721095be503b1e0f64a2410036a2eaa"},
       "prov:value": {"@type": "xsd:float", "@value": "6.94224119186401"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.41321599194522"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.09231481560235e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.429119375951011"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.25175924600333"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.41321599194522"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.09231481560235e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.429119375951011"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.25175924600333"}
     },
     {
-      "@id": "niiri:609323e3dad9da267d42d6f70aaf5d39",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d721095be503b1e0f64a2410036a2eaa",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0008",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-42,16,10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-42,16,10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:54d28453113183258d217e3bdd65c9fc",
-      "entity": "niiri:f38df95463ef91d161217362dadf93bc"
+      "entity_derived": "niiri:f458ed28668e8278b72dffade3f56b36",
+      "entity": "niiri:2d8cf2f1c8b135c47e4c992ddddc4603"
     },
     {
-      "@id": "niiri:6c22c0a9d1b60504fdc7690149788276",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d9eeac8bb3ecc01f8076b9144f8408a1",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0009",
-      "prov:atLocation": {"@id": "niiri:cb76fb2bfdcf4897afffecdbd4cc720e"},
+      "prov:atLocation": {"@id": "niiri:b9cce062e2feece03ec35b7263ae63a8"},
       "prov:value": {"@type": "xsd:float", "@value": "6.10717391967773"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.1231772056634"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.86840997530302e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.757824284509807"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.365315662158339"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.1231772056634"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.86840997530302e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.757824284509807"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.365315662158339"}
     },
     {
-      "@id": "niiri:cb76fb2bfdcf4897afffecdbd4cc720e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b9cce062e2feece03ec35b7263ae63a8",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0009",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-34,12,12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-34,12,12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6c22c0a9d1b60504fdc7690149788276",
-      "entity": "niiri:f38df95463ef91d161217362dadf93bc"
+      "entity_derived": "niiri:d9eeac8bb3ecc01f8076b9144f8408a1",
+      "entity": "niiri:2d8cf2f1c8b135c47e4c992ddddc4603"
     },
     {
-      "@id": "niiri:21ad066097d48bf3e388ea1aaa1d1bb1",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e0b762eecb88a3831f1461fcb76acb5e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0010",
-      "prov:atLocation": {"@id": "niiri:0f93d52b9ef25071beea5a20f19d2385"},
+      "prov:atLocation": {"@id": "niiri:7a964994e6526b0666437d95f24abc7c"},
       "prov:value": {"@type": "xsd:float", "@value": "4.91090297698975"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.62901638790644"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000142251590777853"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.996834489281486"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.511946776631986"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.62901638790644"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000142251590777853"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.996834489281486"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.511946776631986"}
     },
     {
-      "@id": "niiri:0f93d52b9ef25071beea5a20f19d2385",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7a964994e6526b0666437d95f24abc7c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0010",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-32,14,20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-32,14,20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:21ad066097d48bf3e388ea1aaa1d1bb1",
-      "entity": "niiri:f38df95463ef91d161217362dadf93bc"
+      "entity_derived": "niiri:e0b762eecb88a3831f1461fcb76acb5e",
+      "entity": "niiri:2d8cf2f1c8b135c47e4c992ddddc4603"
     },
     {
-      "@id": "niiri:cadc3d04f7e89013709b64e325c3f2bb",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5c4ec650d1179cc0393ce006684df798",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0011",
-      "prov:atLocation": {"@id": "niiri:c15020481b8972ad7e8d91b9349191f9"},
+      "prov:atLocation": {"@id": "niiri:ad512c918e7340c95eaef8dfde49052a"},
       "prov:value": {"@type": "xsd:float", "@value": "6.90986013412476"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.40267439233253"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.34622897296888e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.440428166820351"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.25175924600333"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.40267439233253"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.34622897296888e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.440428166820351"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.25175924600333"}
     },
     {
-      "@id": "niiri:c15020481b8972ad7e8d91b9349191f9",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ad512c918e7340c95eaef8dfde49052a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0011",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[58,-34,14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[58,-34,14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cadc3d04f7e89013709b64e325c3f2bb",
-      "entity": "niiri:2c7b298047315ad1d67ac222bd8224bf"
+      "entity_derived": "niiri:5c4ec650d1179cc0393ce006684df798",
+      "entity": "niiri:145e279f67ab0593ed7aad160ef6ec96"
     },
     {
-      "@id": "niiri:4dfc983b8c73943a6be2f0ef27c10643",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:cc7d961cd89c1dd7f8fca1be56c252c2",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0012",
-      "prov:atLocation": {"@id": "niiri:83e9f9748d9e5cf3d505ad3d5f10a0c4"},
+      "prov:atLocation": {"@id": "niiri:c6311ce077927bd49736a0687796e269"},
       "prov:value": {"@type": "xsd:float", "@value": "5.82773351669312"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.01684833891347"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.94908276274874e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.858380226002374"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.365315662158339"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.01684833891347"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.94908276274874e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.858380226002374"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.365315662158339"}
     },
     {
-      "@id": "niiri:83e9f9748d9e5cf3d505ad3d5f10a0c4",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c6311ce077927bd49736a0687796e269",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0012",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[66,-38,14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[66,-38,14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4dfc983b8c73943a6be2f0ef27c10643",
-      "entity": "niiri:2c7b298047315ad1d67ac222bd8224bf"
+      "entity_derived": "niiri:cc7d961cd89c1dd7f8fca1be56c252c2",
+      "entity": "niiri:145e279f67ab0593ed7aad160ef6ec96"
     },
     {
-      "@id": "niiri:47787e0c9c31a52feaf8a0de1a89f61a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5859c0686be12782603570a07ee67698",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0013",
-      "prov:atLocation": {"@id": "niiri:5bd9e6d5e5977a3e317ddebe8a149190"},
+      "prov:atLocation": {"@id": "niiri:9cfe2df9dc6783d6c43a1b8829beb4a8"},
       "prov:value": {"@type": "xsd:float", "@value": "5.4896821975708"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.88117893748276"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.1975659703607e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.944904699668246"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.386351702418292"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.88117893748276"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.1975659703607e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.944904699668246"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.386351702418292"}
     },
     {
-      "@id": "niiri:5bd9e6d5e5977a3e317ddebe8a149190",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:9cfe2df9dc6783d6c43a1b8829beb4a8",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0013",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[52,-38,6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[52,-38,6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:47787e0c9c31a52feaf8a0de1a89f61a",
-      "entity": "niiri:2c7b298047315ad1d67ac222bd8224bf"
+      "entity_derived": "niiri:5859c0686be12782603570a07ee67698",
+      "entity": "niiri:145e279f67ab0593ed7aad160ef6ec96"
     },
     {
-      "@id": "niiri:e2285c6dc1adb636731879c86e1f721a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:2e8112ff496740fe656336a508456db6",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0014",
-      "prov:atLocation": {"@id": "niiri:4b3afc7aad1c553f2802781fb47e49e8"},
+      "prov:atLocation": {"@id": "niiri:7b8b224d0de6e706a8496c51b9ec92c7"},
       "prov:value": {"@type": "xsd:float", "@value": "6.21367645263672"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.1624012348651"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.57459182630326e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.715339849593062"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.365315662158339"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.1624012348651"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.57459182630326e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.715339849593062"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.365315662158339"}
     },
     {
-      "@id": "niiri:4b3afc7aad1c553f2802781fb47e49e8",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7b8b224d0de6e706a8496c51b9ec92c7",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0014",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[8,16,42]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[8,16,42]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e2285c6dc1adb636731879c86e1f721a",
-      "entity": "niiri:b1faa7f7b978858ed6eb410ca05d8b3d"
+      "entity_derived": "niiri:2e8112ff496740fe656336a508456db6",
+      "entity": "niiri:0cf7fbb104195b08838b495de979f17d"
     },
     {
-      "@id": "niiri:d661e0da256925a10f4a6d251c3622c4",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:091092eab6f1574d657d804507dd0192",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0015",
-      "prov:atLocation": {"@id": "niiri:df6e06b7d5e31e146f5ace039de3fdc3"},
+      "prov:atLocation": {"@id": "niiri:a90f5e73e0da209b7207b1ef41a327b8"},
       "prov:value": {"@type": "xsd:float", "@value": "5.72438669204712"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.97621777576085"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.50100040308332e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.889577859110148"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.365315662158339"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.97621777576085"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.50100040308332e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.889577859110148"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.365315662158339"}
     },
     {
-      "@id": "niiri:df6e06b7d5e31e146f5ace039de3fdc3",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a90f5e73e0da209b7207b1ef41a327b8",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0015",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[12,18,34]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[12,18,34]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d661e0da256925a10f4a6d251c3622c4",
-      "entity": "niiri:b1faa7f7b978858ed6eb410ca05d8b3d"
+      "entity_derived": "niiri:091092eab6f1574d657d804507dd0192",
+      "entity": "niiri:0cf7fbb104195b08838b495de979f17d"
     },
     {
-      "@id": "niiri:126eda6e597a08eadcde51b74107b509",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:9a9072a8cc791001f985c339f649ecbc",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0016",
-      "prov:atLocation": {"@id": "niiri:768833a7a7b79bf5192ab69bb1c0333f"},
+      "prov:atLocation": {"@id": "niiri:e75ec0ab2114018af91503adf58ab0b0"},
       "prov:value": {"@type": "xsd:float", "@value": "6.03207159042358"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.09509363345907"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.10998901504222e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.786707462460714"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.365315662158339"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.09509363345907"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.10998901504222e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.786707462460714"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.365315662158339"}
     },
     {
-      "@id": "niiri:768833a7a7b79bf5192ab69bb1c0333f",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e75ec0ab2114018af91503adf58ab0b0",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0016",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[56,-2,46]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[56,-2,46]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:126eda6e597a08eadcde51b74107b509",
-      "entity": "niiri:8d1d785aced1bd1fe4b02bf63b8bc4c4"
+      "entity_derived": "niiri:9a9072a8cc791001f985c339f649ecbc",
+      "entity": "niiri:3fb8d8c50e07f46ff52730667b4ff904"
     },
     {
-      "@id": "niiri:f806d96770dd75bfb97c3d9e29bc57c3",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f06598e58370f70e2f5ce0b47e641909",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0017",
-      "prov:atLocation": {"@id": "niiri:232e902c7d2f2a7e470a5a1508996122"},
+      "prov:atLocation": {"@id": "niiri:0a466a7d36f0e502b275608c297d8bac"},
       "prov:value": {"@type": "xsd:float", "@value": "4.45615816116333"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.4110394440129"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000323578644043643"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999950103431029"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.701250666193361"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.4110394440129"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000323578644043643"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999950103431029"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.701250666193361"}
     },
     {
-      "@id": "niiri:232e902c7d2f2a7e470a5a1508996122",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0a466a7d36f0e502b275608c297d8bac",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0017",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[42,0,40]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[42,0,40]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f806d96770dd75bfb97c3d9e29bc57c3",
-      "entity": "niiri:8d1d785aced1bd1fe4b02bf63b8bc4c4"
+      "entity_derived": "niiri:f06598e58370f70e2f5ce0b47e641909",
+      "entity": "niiri:3fb8d8c50e07f46ff52730667b4ff904"
     },
     {
-      "@id": "niiri:3166b934af2bbe50fd3f62dee033c87f",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:cf9e0ce6702a4bc5d75621bb529bb51e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0018",
-      "prov:atLocation": {"@id": "niiri:e9b297b5d8244bf49539979baf272657"},
+      "prov:atLocation": {"@id": "niiri:2459537b6faed4755f3485553ad12087"},
       "prov:value": {"@type": "xsd:float", "@value": "4.44447803497314"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.40518918809107"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00033059115403522"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999956572496893"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.701250666193361"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.40518918809107"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00033059115403522"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999956572496893"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.701250666193361"}
     },
     {
-      "@id": "niiri:e9b297b5d8244bf49539979baf272657",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:2459537b6faed4755f3485553ad12087",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0018",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[48,2,52]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[48,2,52]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3166b934af2bbe50fd3f62dee033c87f",
-      "entity": "niiri:8d1d785aced1bd1fe4b02bf63b8bc4c4"
+      "entity_derived": "niiri:cf9e0ce6702a4bc5d75621bb529bb51e",
+      "entity": "niiri:3fb8d8c50e07f46ff52730667b4ff904"
     },
     {
-      "@id": "niiri:5496b677c1de93ba7b716cab5c3dddc6",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:1d42f9fcfbb48e74a501c76e58311ef7",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0019",
-      "prov:atLocation": {"@id": "niiri:af1835ce1aa7d7feab5365570fe3679b"},
+      "prov:atLocation": {"@id": "niiri:fbda836c00cc56183550c787012b6eeb"},
       "prov:value": {"@type": "xsd:float", "@value": "5.99733877182007"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.08198490016656"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.23263492938885e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.799672548097648"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.365315662158339"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.08198490016656"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.23263492938885e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.799672548097648"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.365315662158339"}
     },
     {
-      "@id": "niiri:af1835ce1aa7d7feab5365570fe3679b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:fbda836c00cc56183550c787012b6eeb",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0019",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[52,4,20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[52,4,20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5496b677c1de93ba7b716cab5c3dddc6",
-      "entity": "niiri:4a24406f20a447cd18e19bcea9c901b1"
+      "entity_derived": "niiri:1d42f9fcfbb48e74a501c76e58311ef7",
+      "entity": "niiri:24ed53e97502545f0497cc97644535d2"
     },
     {
-      "@id": "niiri:0f2a6098225cb6e376794aec07c3d66c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:2b939bebe4432404eecd773b1a8fa021",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0020",
-      "prov:atLocation": {"@id": "niiri:3fd7f75c193fff89094c56a442500f43"},
+      "prov:atLocation": {"@id": "niiri:8e59c08d21c91e4bd2386b0d3a271df7"},
       "prov:value": {"@type": "xsd:float", "@value": "5.96960115432739"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.07146072717137"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.33596199642472e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.809821953269947"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.365315662158339"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.07146072717137"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.33596199642472e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.809821953269947"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.365315662158339"}
     },
     {
-      "@id": "niiri:3fd7f75c193fff89094c56a442500f43",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:8e59c08d21c91e4bd2386b0d3a271df7",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0020",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[48,14,2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[48,14,2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0f2a6098225cb6e376794aec07c3d66c",
-      "entity": "niiri:4a24406f20a447cd18e19bcea9c901b1"
+      "entity_derived": "niiri:2b939bebe4432404eecd773b1a8fa021",
+      "entity": "niiri:24ed53e97502545f0497cc97644535d2"
     },
     {
-      "@id": "niiri:6f2b2823e0ad35ce3bc060c5ca390936",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d194d8bbb0450258cbb3e2c7b63d052b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0021",
-      "prov:atLocation": {"@id": "niiri:dd6bbe27c2bafe5a161f6e9eaf4e5279"},
+      "prov:atLocation": {"@id": "niiri:6e46e05c89f606b54b383ab231bc4f7f"},
       "prov:value": {"@type": "xsd:float", "@value": "5.32198143005371"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.81081315671811"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.92552142741443e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.970746077807219"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.416365388604658"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.81081315671811"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.92552142741443e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.970746077807219"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.416365388604658"}
     },
     {
-      "@id": "niiri:dd6bbe27c2bafe5a161f6e9eaf4e5279",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6e46e05c89f606b54b383ab231bc4f7f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0021",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[56,12,16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[56,12,16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6f2b2823e0ad35ce3bc060c5ca390936",
-      "entity": "niiri:4a24406f20a447cd18e19bcea9c901b1"
+      "entity_derived": "niiri:d194d8bbb0450258cbb3e2c7b63d052b",
+      "entity": "niiri:24ed53e97502545f0497cc97644535d2"
     },
     {
-      "@id": "niiri:42490924487f49a83d25b91f2de3c800",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:373fb030ca503554429e0d448b03ac03",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0022",
-      "prov:atLocation": {"@id": "niiri:f95d4943830fda794a3c20455fde7ef5"},
+      "prov:atLocation": {"@id": "niiri:8aa50282813e2f149237738250f246d4"},
       "prov:value": {"@type": "xsd:float", "@value": "5.69392824172974"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.96410360090528"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.68361273354045e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.898012948452735"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.365315662158339"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.96410360090528"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.68361273354045e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.898012948452735"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.365315662158339"}
     },
     {
-      "@id": "niiri:f95d4943830fda794a3c20455fde7ef5",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:8aa50282813e2f149237738250f246d4",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0022",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-50,-44,10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-50,-44,10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:42490924487f49a83d25b91f2de3c800",
-      "entity": "niiri:0df7f5664a49553001462c97fe08a90e"
+      "entity_derived": "niiri:373fb030ca503554429e0d448b03ac03",
+      "entity": "niiri:ee68048e8a0744dfd236a85d10e1b80c"
     },
     {
-      "@id": "niiri:3ce0f665c92c0fce8dd2149c88063832",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:88e91db80e4f84543f912f20187894b6",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0023",
-      "prov:atLocation": {"@id": "niiri:5f4fd7726d13278afb8c96179f2f3d06"},
+      "prov:atLocation": {"@id": "niiri:0212c0dd8121cea00a8dbedcf8cd7e3c"},
       "prov:value": {"@type": "xsd:float", "@value": "5.6067042350769"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.9290539558673"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.26403524200758e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.920131147013454"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.365315662158339"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.9290539558673"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.26403524200758e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.920131147013454"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.365315662158339"}
     },
     {
-      "@id": "niiri:5f4fd7726d13278afb8c96179f2f3d06",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0212c0dd8121cea00a8dbedcf8cd7e3c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0023",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-44,-42,18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-44,-42,18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3ce0f665c92c0fce8dd2149c88063832",
-      "entity": "niiri:0df7f5664a49553001462c97fe08a90e"
+      "entity_derived": "niiri:88e91db80e4f84543f912f20187894b6",
+      "entity": "niiri:ee68048e8a0744dfd236a85d10e1b80c"
     },
     {
-      "@id": "niiri:e269262fc1344012d95ae80d29511ae2",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f11f4cdd0aa465dd12a0072b11116c2c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0024",
-      "prov:atLocation": {"@id": "niiri:abe4ad1664833acdef81be07aeab31eb"},
+      "prov:atLocation": {"@id": "niiri:7287fc447fabd0245cc28ac2cf7afc62"},
       "prov:value": {"@type": "xsd:float", "@value": "4.39031887054443"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.37789039899343"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000365220936835664"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999977761191736"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.701250666193361"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.37789039899343"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000365220936835664"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999977761191736"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.701250666193361"}
     },
     {
-      "@id": "niiri:abe4ad1664833acdef81be07aeab31eb",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7287fc447fabd0245cc28ac2cf7afc62",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0024",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-46,-40,28]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-46,-40,28]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e269262fc1344012d95ae80d29511ae2",
-      "entity": "niiri:0df7f5664a49553001462c97fe08a90e"
+      "entity_derived": "niiri:f11f4cdd0aa465dd12a0072b11116c2c",
+      "entity": "niiri:ee68048e8a0744dfd236a85d10e1b80c"
     }
   ]
 }

--- a/spmexport/ex_spm_group_ols/nidm.ttl
+++ b/spmexport/ex_spm_group_ols/nidm.ttl
@@ -4,7 +4,7 @@
 @prefix niiri: <http://iri.nidash.org/> .
 @prefix spm: <http://purl.org/nidash/spm#> .
 @prefix neurolex: <http://neurolex.org/wiki/> .
-@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#> .
+@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
@@ -17,27 +17,27 @@
 @prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-niiri:5bfe8d0b2f440c31510a8db7a990bd46
+niiri:68ee16fec71e89a7b58245aa1b686dfb
   a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
   rdfs:label "NIDM-Results" ;
   nidm_version: "1.3.0"^^xsd:string .
 
-niiri:8dd211f8135c6832c544f144057e23b1
+niiri:4d435dbb932d842eb0f29f9f295f4d39
   a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
   rdfs:label "spm_results_nidm" ;
-  nidm_softwareVersion: "12.6903"^^xsd:string .
+  nidm_softwareVersion: "12.7057"^^xsd:string .
 
-niiri:3141b03efd8fff437c763916b82a53fe
+niiri:67662d8460b62a35fcf8b5cc394aa18c
   a prov:Activity, nidm_NIDMResultsExport: ; 
   rdfs:label "NIDM-Results export" .
 
-niiri:3141b03efd8fff437c763916b82a53fe prov:wasAssociatedWith niiri:8dd211f8135c6832c544f144057e23b1 .
+niiri:67662d8460b62a35fcf8b5cc394aa18c prov:wasAssociatedWith niiri:4d435dbb932d842eb0f29f9f295f4d39 .
 
 _:blank5 a prov:Generation .
 
-niiri:5bfe8d0b2f440c31510a8db7a990bd46 prov:qualifiedGeneration _:blank5 .
+niiri:68ee16fec71e89a7b58245aa1b686dfb prov:qualifiedGeneration _:blank5 .
 
-_:blank5 prov:atTime "2016-12-07T16:08:32"^^xsd:dateTime .
+_:blank5 prov:atTime "2017-04-19T12:18:11"^^xsd:dateTime .
 
 @prefix nidm_Ixi549CoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000050> .
 @prefix src_SPM: <http://scicrunch.org/resolver/SCR_007037> .
@@ -137,12 +137,12 @@ _:blank5 prov:atTime "2016-12-07T16:08:32"^^xsd:dateTime .
 @prefix nidm_Coordinate: <http://purl.org/nidash/nidm#NIDM_0000015> .
 @prefix nidm_coordinateVector: <http://purl.org/nidash/nidm#NIDM_0000086> .
 
-niiri:582e74d3d47d395484eb9750c00b6034
+niiri:94ecae7951d21985687dcb4bf72d88bc
     a prov:Agent, src_SPM:, prov:SoftwareAgent ; 
     rdfs:label "SPM" ;
-    nidm_softwareVersion: "12.12.2"^^xsd:string .
+    nidm_softwareVersion: "12.6906"^^xsd:string .
 
-niiri:9ea612def84c2b00a28fde8461621f3d
+niiri:5e472b9e1804aecf84d34427aeac5d36
     a prov:Entity, nidm_CoordinateSpace: ; 
     rdfs:label "Coordinate space 1" ;
     nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
@@ -152,174 +152,174 @@ niiri:9ea612def84c2b00a28fde8461621f3d
     nidm_numberOfDimensions: "3"^^xsd:int ;
     nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
 
-niiri:6473cb489e3dbb8be338e0ecde88fb03
+niiri:c9a2b27e508148967a08a3beda024191
     a prov:Agent, nlx_Imaginginstrument:, nlx_Magneticresonanceimagingscanner: ; 
     rdfs:label "MRI Scanner" .
 
-niiri:25cb37de070b85d1a0c288c2a24891e1
+niiri:985a4448969a1b0854e49bb2dbdeab6c
     a prov:Agent, obo_studygrouppopulation: ; 
     rdfs:label "Group: Control" ;
     nidm_groupName: "Control"^^xsd:string ;
     nidm_numberOfSubjects: "14"^^xsd:int .
 
-niiri:88e00486db13f79e1d42aee523efe408
+niiri:ca46b04d477ee0f0e6f16c372a1a4976
     a prov:Entity, prov:Collection, nidm_Data: ; 
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "false"^^xsd:boolean ;
     nidm_hasMRIProtocol: nlx_FunctionalMRIprotocol: .
 
-niiri:88e00486db13f79e1d42aee523efe408 prov:wasAttributedTo niiri:6473cb489e3dbb8be338e0ecde88fb03 .
+niiri:ca46b04d477ee0f0e6f16c372a1a4976 prov:wasAttributedTo niiri:c9a2b27e508148967a08a3beda024191 .
 
-niiri:88e00486db13f79e1d42aee523efe408 prov:wasAttributedTo niiri:25cb37de070b85d1a0c288c2a24891e1 .
+niiri:ca46b04d477ee0f0e6f16c372a1a4976 prov:wasAttributedTo niiri:985a4448969a1b0854e49bb2dbdeab6c .
 
-niiri:0486a876a984f0a75a383ff571c65763
+niiri:5974cc100f3ec5600037861f2b9ed1de
     a prov:Entity, nidm_DesignMatrix: ; 
     prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.csv"^^xsd:string ;
     dct:format "text/csv"^^xsd:string ;
-    dc:description niiri:4c7773760fe7e378c9809d4eb3b4285c ;
+    dc:description niiri:153b70474f3c5edca79e4bf57a7ee204 ;
     rdfs:label "Design Matrix" ;
     nidm_regressorNames: "[\"mean\"]"^^xsd:string .
 
-niiri:4c7773760fe7e378c9809d4eb3b4285c
+niiri:153b70474f3c5edca79e4bf57a7ee204
     a prov:Entity, dctype:Image ; 
     prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:98c11fdf4a008d0bb72923f6033452b6
+niiri:7cf52921ad5716e824bef8a127efb7bc
     a prov:Entity, nidm_ErrorModel: ; 
     nidm_hasErrorDistribution: obo_normaldistribution: ;
     nidm_hasErrorDependence: nidm_IndependentError: ;
     nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
     nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
 
-niiri:6991af1c3ba97b3a4470769a6f1f7a1e
+niiri:b74ede46a6fca129f8c8f17e297de5f1
     a prov:Activity, nidm_ModelParametersEstimation: ; 
     rdfs:label "Model parameters estimation" ;
     nidm_withEstimationMethod: obo_ordinaryleastsquaresestimation: .
 
-niiri:6991af1c3ba97b3a4470769a6f1f7a1e prov:wasAssociatedWith niiri:582e74d3d47d395484eb9750c00b6034 .
+niiri:b74ede46a6fca129f8c8f17e297de5f1 prov:wasAssociatedWith niiri:94ecae7951d21985687dcb4bf72d88bc .
 
-niiri:6991af1c3ba97b3a4470769a6f1f7a1e prov:used niiri:0486a876a984f0a75a383ff571c65763 .
+niiri:b74ede46a6fca129f8c8f17e297de5f1 prov:used niiri:5974cc100f3ec5600037861f2b9ed1de .
 
-niiri:6991af1c3ba97b3a4470769a6f1f7a1e prov:used niiri:88e00486db13f79e1d42aee523efe408 .
+niiri:b74ede46a6fca129f8c8f17e297de5f1 prov:used niiri:ca46b04d477ee0f0e6f16c372a1a4976 .
 
-niiri:6991af1c3ba97b3a4470769a6f1f7a1e prov:used niiri:98c11fdf4a008d0bb72923f6033452b6 .
+niiri:b74ede46a6fca129f8c8f17e297de5f1 prov:used niiri:7cf52921ad5716e824bef8a127efb7bc .
 
-niiri:5f0d397b9923b8ec17c86160f22ed3bd
+niiri:134717e80ac83bc17cf1e5f4b6a0dab8
     a prov:Entity, nidm_MaskMap: ; 
     prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
     nidm_isUserDefined: "false"^^xsd:boolean ;
     nfo:fileName "Mask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Mask" ;
-    nidm_inCoordinateSpace: niiri:9ea612def84c2b00a28fde8461621f3d ;
+    nidm_inCoordinateSpace: niiri:5e472b9e1804aecf84d34427aeac5d36 ;
     crypto:sha512 "71153b4ca7e1136cf9ae9cb56eaf6a4ed494bad08a1cfa0659e8e211a36425aaf865c3def12dea06c5595662761b891c87ec7b8fa0b8b75cd31247be9418bf24"^^xsd:string .
 
-niiri:a7746fa9e94e3bd7d0314c8638421507
+niiri:4efbab6889ea73c471c6ec4da367d19d
     a prov:Entity, nidm_MaskMap: ; 
     nfo:fileName "mask.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "e33feb3fddb2a3ee6d91e0b84ce0050a83414df67559e07679326fab2c31494df0a1db2d693027786c839b356626159d9158e4e9766b2bf46be4d32678f356fd"^^xsd:string .
 
-niiri:5f0d397b9923b8ec17c86160f22ed3bd prov:wasDerivedFrom niiri:a7746fa9e94e3bd7d0314c8638421507 .
+niiri:134717e80ac83bc17cf1e5f4b6a0dab8 prov:wasDerivedFrom niiri:4efbab6889ea73c471c6ec4da367d19d .
 
-niiri:5f0d397b9923b8ec17c86160f22ed3bd prov:wasGeneratedBy niiri:6991af1c3ba97b3a4470769a6f1f7a1e .
+niiri:134717e80ac83bc17cf1e5f4b6a0dab8 prov:wasGeneratedBy niiri:b74ede46a6fca129f8c8f17e297de5f1 .
 
-niiri:07cbaf4796e0fb7cb545a8900d2a7073
+niiri:b1aa0fbd676b8d41f017be6bdbd31cd3
     a prov:Entity, nidm_GrandMeanMap: ; 
     prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
     nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Grand Mean Map" ;
     nidm_maskedMedian: "-0.0577427912503481"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:9ea612def84c2b00a28fde8461621f3d ;
+    nidm_inCoordinateSpace: niiri:5e472b9e1804aecf84d34427aeac5d36 ;
     crypto:sha512 "f35910a69f57ca530caf395eff6a18f7c8b9715206695cbe6852d4a235128edd4cfecd11f613eb3b9a1ffc9b471d3018bb14472c92453bcd9fc5afe8715c78ca"^^xsd:string .
 
-niiri:07cbaf4796e0fb7cb545a8900d2a7073 prov:wasGeneratedBy niiri:6991af1c3ba97b3a4470769a6f1f7a1e .
+niiri:b1aa0fbd676b8d41f017be6bdbd31cd3 prov:wasGeneratedBy niiri:b74ede46a6fca129f8c8f17e297de5f1 .
 
-niiri:95e672dbad1f46daac797ad2f195f98e
+niiri:2c7195286f0c7c5d7c26fed41636166c
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0001.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0001.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 1" ;
-    nidm_inCoordinateSpace: niiri:9ea612def84c2b00a28fde8461621f3d ;
+    nidm_inCoordinateSpace: niiri:5e472b9e1804aecf84d34427aeac5d36 ;
     crypto:sha512 "7ec9d8c6e184528ab65f3f51dd1622acede31fc2cf3b7f26c4f5769401eee3b887248e8dc51868dfb21fc8e5890cf911194796857ea0bd33db8a24d95faaf1ac"^^xsd:string .
 
-niiri:b5883b67a019ff8d4f45ac8adcd4661a
+niiri:e0f5b0a00cdf4664ae1696f06275d443
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "7ec9d8c6e184528ab65f3f51dd1622acede31fc2cf3b7f26c4f5769401eee3b887248e8dc51868dfb21fc8e5890cf911194796857ea0bd33db8a24d95faaf1ac"^^xsd:string .
 
-niiri:95e672dbad1f46daac797ad2f195f98e prov:wasDerivedFrom niiri:b5883b67a019ff8d4f45ac8adcd4661a .
+niiri:2c7195286f0c7c5d7c26fed41636166c prov:wasDerivedFrom niiri:e0f5b0a00cdf4664ae1696f06275d443 .
 
-niiri:95e672dbad1f46daac797ad2f195f98e prov:wasGeneratedBy niiri:6991af1c3ba97b3a4470769a6f1f7a1e .
+niiri:2c7195286f0c7c5d7c26fed41636166c prov:wasGeneratedBy niiri:b74ede46a6fca129f8c8f17e297de5f1 .
 
-niiri:78a8fec86dd3b4499bf6d06c20deabff
+niiri:da51626f7a852710359834961cdfa1cc
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Residual Mean Squares Map" ;
-    nidm_inCoordinateSpace: niiri:9ea612def84c2b00a28fde8461621f3d ;
+    nidm_inCoordinateSpace: niiri:5e472b9e1804aecf84d34427aeac5d36 ;
     crypto:sha512 "e15461ad432e63ccb4bb2534e12cc51f5c2e7562130472a6859c850f10bc34b0401f39d357a71eb3d1bd5e764a07ca78103bac52b8d6e2e5229386e51308d013"^^xsd:string .
 
-niiri:c3317aed9d01bf247defeb1eee02f614
+niiri:40534953fad6a4d97f2c2c4210f5f310
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     nfo:fileName "ResMS.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "8fabf9aad5778af79b9ec78de959ac3a5ede3631deeece4528020a0e5b00f3994b2ac5f8805f0dd462adbc4fc7c2775f9b2bab0a2264f50888ff4f114a467338"^^xsd:string .
 
-niiri:78a8fec86dd3b4499bf6d06c20deabff prov:wasDerivedFrom niiri:c3317aed9d01bf247defeb1eee02f614 .
+niiri:da51626f7a852710359834961cdfa1cc prov:wasDerivedFrom niiri:40534953fad6a4d97f2c2c4210f5f310 .
 
-niiri:78a8fec86dd3b4499bf6d06c20deabff prov:wasGeneratedBy niiri:6991af1c3ba97b3a4470769a6f1f7a1e .
+niiri:da51626f7a852710359834961cdfa1cc prov:wasGeneratedBy niiri:b74ede46a6fca129f8c8f17e297de5f1 .
 
-niiri:711c7cbfc366f93b909c1e1c576a04e9
+niiri:999b4c344889226d33a1a3db629bbcdd
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Resels per Voxel Map" ;
-    nidm_inCoordinateSpace: niiri:9ea612def84c2b00a28fde8461621f3d ;
+    nidm_inCoordinateSpace: niiri:5e472b9e1804aecf84d34427aeac5d36 ;
     crypto:sha512 "3568d150737aa60112c469cdd700c1339bcb6fbde9b14fbef1b22f6d05141dcd37fc0fc6cddcd98b4d27c9a2d068b832cf694f57519eebc157c37258ad601538"^^xsd:string .
 
-niiri:dd26ef029ad27502fd0726f4d36b2952
+niiri:f3e33ccbd90b2b0c093f458966ab7ef8
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     nfo:fileName "RPV.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "0ac129143989c790068562a225d8df623a032492270793e9b2a1355c70788ff86279a4debd4c65a9b0c03050b4ba6bbcb88da37a90cdc2dbe470dd618897221b"^^xsd:string .
 
-niiri:711c7cbfc366f93b909c1e1c576a04e9 prov:wasDerivedFrom niiri:dd26ef029ad27502fd0726f4d36b2952 .
+niiri:999b4c344889226d33a1a3db629bbcdd prov:wasDerivedFrom niiri:f3e33ccbd90b2b0c093f458966ab7ef8 .
 
-niiri:711c7cbfc366f93b909c1e1c576a04e9 prov:wasGeneratedBy niiri:6991af1c3ba97b3a4470769a6f1f7a1e .
+niiri:999b4c344889226d33a1a3db629bbcdd prov:wasGeneratedBy niiri:b74ede46a6fca129f8c8f17e297de5f1 .
 
-niiri:6298c9c6b11157fd62e0360b3766a33e
+niiri:a2ce89d6c8d1b7721b0b3ac2a3bad8d8
     a prov:Entity, obo_contrastweightmatrix: ; 
     nidm_statisticType: obo_tstatistic: ;
     nidm_contrastName: "con-01"^^xsd:string ;
     rdfs:label "Contrast: con-01" ;
     prov:value "1"^^xsd:string .
 
-niiri:185937d0b35e3eadd33255ce74b4aafe
+niiri:137adca045c6b01b9508719af960a129
     a prov:Activity, nidm_ContrastEstimation: ; 
     rdfs:label "Contrast estimation" .
 
-niiri:185937d0b35e3eadd33255ce74b4aafe prov:wasAssociatedWith niiri:582e74d3d47d395484eb9750c00b6034 .
+niiri:137adca045c6b01b9508719af960a129 prov:wasAssociatedWith niiri:94ecae7951d21985687dcb4bf72d88bc .
 
-niiri:185937d0b35e3eadd33255ce74b4aafe prov:used niiri:5f0d397b9923b8ec17c86160f22ed3bd .
+niiri:137adca045c6b01b9508719af960a129 prov:used niiri:134717e80ac83bc17cf1e5f4b6a0dab8 .
 
-niiri:185937d0b35e3eadd33255ce74b4aafe prov:used niiri:78a8fec86dd3b4499bf6d06c20deabff .
+niiri:137adca045c6b01b9508719af960a129 prov:used niiri:da51626f7a852710359834961cdfa1cc .
 
-niiri:185937d0b35e3eadd33255ce74b4aafe prov:used niiri:0486a876a984f0a75a383ff571c65763 .
+niiri:137adca045c6b01b9508719af960a129 prov:used niiri:5974cc100f3ec5600037861f2b9ed1de .
 
-niiri:185937d0b35e3eadd33255ce74b4aafe prov:used niiri:6298c9c6b11157fd62e0360b3766a33e .
+niiri:137adca045c6b01b9508719af960a129 prov:used niiri:a2ce89d6c8d1b7721b0b3ac2a3bad8d8 .
 
-niiri:185937d0b35e3eadd33255ce74b4aafe prov:used niiri:95e672dbad1f46daac797ad2f195f98e .
+niiri:137adca045c6b01b9508719af960a129 prov:used niiri:2c7195286f0c7c5d7c26fed41636166c .
 
-niiri:af22bee20fc4bfa20ae2f0da89d98f26
+niiri:65cbca637492fc41602a48854f923270
     a prov:Entity, nidm_StatisticMap: ; 
     prov:atLocation "TStatistic.nii.gz"^^xsd:anyURI ;
     nfo:fileName "TStatistic.nii.gz"^^xsd:string ;
@@ -329,124 +329,124 @@ niiri:af22bee20fc4bfa20ae2f0da89d98f26
     nidm_contrastName: "con-01"^^xsd:string ;
     nidm_errorDegreesOfFreedom: "13"^^xsd:float ;
     nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:9ea612def84c2b00a28fde8461621f3d ;
+    nidm_inCoordinateSpace: niiri:5e472b9e1804aecf84d34427aeac5d36 ;
     crypto:sha512 "b24254216e083a99fcc6d21cb954729c942dc636b49a3961a99c531c8007923031769bae46e5e583ef872f71e62fa3b956257dc2dc7f0b6de7cef6a807d56e91"^^xsd:string .
 
-niiri:fec832466afc3287c89d1c72ecafce1c
+niiri:72875077d4eb68692b3e042d5fcac6e9
     a prov:Entity, nidm_StatisticMap: ; 
     nfo:fileName "spmT_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "fd01b639babd7881fb50aa553d869683c4b04075260bb67a2d4cdbb406b2b7a0c4bf3a23b5486e9a29d6bcf688e1dd39e1568f830189ce9f3bc250e1f285d768"^^xsd:string .
 
-niiri:af22bee20fc4bfa20ae2f0da89d98f26 prov:wasDerivedFrom niiri:fec832466afc3287c89d1c72ecafce1c .
+niiri:65cbca637492fc41602a48854f923270 prov:wasDerivedFrom niiri:72875077d4eb68692b3e042d5fcac6e9 .
 
-niiri:af22bee20fc4bfa20ae2f0da89d98f26 prov:wasGeneratedBy niiri:185937d0b35e3eadd33255ce74b4aafe .
+niiri:65cbca637492fc41602a48854f923270 prov:wasGeneratedBy niiri:137adca045c6b01b9508719af960a129 .
 
-niiri:8e9cb88aaaf6e3cfd6ece5d543736f4b
+niiri:231e885f1374dda1f44a60ed150f55b6
     a prov:Entity, nidm_ContrastMap: ; 
     prov:atLocation "Contrast.nii.gz"^^xsd:anyURI ;
     nfo:fileName "Contrast.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Map: con-01" ;
     nidm_contrastName: "con-01"^^xsd:string ;
-    nidm_inCoordinateSpace: niiri:9ea612def84c2b00a28fde8461621f3d ;
+    nidm_inCoordinateSpace: niiri:5e472b9e1804aecf84d34427aeac5d36 ;
     crypto:sha512 "d73b0fa1856ac6fec8e0fc2c48e858ea1495c7dc6ae1636839cc3e255c2123f2b1e492e6a9c50366b07bfd888c93ea231730f75e28b96d06f846da63da671fd3"^^xsd:string .
 
-niiri:deb03302f5b765ccba5306efe257fedf
+niiri:32d6df109b21d06d7baebdfbabfa9dea
     a prov:Entity, nidm_ContrastMap: ; 
     nfo:fileName "con_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "7fbc36bda26c3089c7a092a58c999815b7f4927960270de331bc8934cd23f8c453ad9860e38a845feb63da5f3eac9a478c9eafb33e11cccf596b4ac6b066b35a"^^xsd:string .
 
-niiri:8e9cb88aaaf6e3cfd6ece5d543736f4b prov:wasDerivedFrom niiri:deb03302f5b765ccba5306efe257fedf .
+niiri:231e885f1374dda1f44a60ed150f55b6 prov:wasDerivedFrom niiri:32d6df109b21d06d7baebdfbabfa9dea .
 
-niiri:8e9cb88aaaf6e3cfd6ece5d543736f4b prov:wasGeneratedBy niiri:185937d0b35e3eadd33255ce74b4aafe .
+niiri:231e885f1374dda1f44a60ed150f55b6 prov:wasGeneratedBy niiri:137adca045c6b01b9508719af960a129 .
 
-niiri:3fa980b5ccd4dfd017bbef0c5e6423f8
+niiri:cd389673c942f3b5e85cbab2a17173b7
     a prov:Entity, nidm_ContrastStandardErrorMap: ; 
     prov:atLocation "ContrastStandardError.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ContrastStandardError.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Standard Error Map" ;
-    nidm_inCoordinateSpace: niiri:9ea612def84c2b00a28fde8461621f3d ;
+    nidm_inCoordinateSpace: niiri:5e472b9e1804aecf84d34427aeac5d36 ;
     crypto:sha512 "7384d50a91b0a096f7ea0027c6681baa90886c59d0bc79806fb2f2005560ca8d2ebef145c1b2286b836fbc556cbef2dead4543d716df39e7b839f992d1f6845f"^^xsd:string .
 
-niiri:3fa980b5ccd4dfd017bbef0c5e6423f8 prov:wasGeneratedBy niiri:185937d0b35e3eadd33255ce74b4aafe .
+niiri:cd389673c942f3b5e85cbab2a17173b7 prov:wasGeneratedBy niiri:137adca045c6b01b9508719af960a129 .
 
-niiri:662e79109731fe9b76e0ad3f17301b55
+niiri:e5b5f613b43832e8ca36c5fcd5e197c7
     a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
-    rdfs:label "Height Threshold: p<0.001000 (unc.)" ;
+    rdfs:label "Height Threshold: p<0.001 (unc.)" ;
     prov:value "0.000999500181305457"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:443ee848bf8d71e2ac13a2d0cefc8cae ;
-    nidm_equivalentThreshold: niiri:bdc6ce774917f3c530b0e48d4f6918f3 .
+    nidm_equivalentThreshold: niiri:1376b409e19b9dd72fe143831aaa2dad ;
+    nidm_equivalentThreshold: niiri:9922364e4e71a98f84cc4bc8276b602f .
 
-niiri:443ee848bf8d71e2ac13a2d0cefc8cae
+niiri:1376b409e19b9dd72fe143831aaa2dad
     a prov:Entity, nidm_HeightThreshold:, obo_statistic: ; 
-    rdfs:label "Height Threshold" ;
+    rdfs:label "Height Threshold: T=3.851982)" ;
     prov:value "3.85198238341593"^^xsd:float .
 
-niiri:bdc6ce774917f3c530b0e48d4f6918f3
+niiri:9922364e4e71a98f84cc4bc8276b602f
     a prov:Entity, nidm_HeightThreshold:, obo_FWERadjustedpvalue: ; 
-    rdfs:label "Height Threshold" ;
+    rdfs:label "Height Threshold: p<1.000000 (FWE)" ;
     prov:value "0.999999998275662"^^xsd:float .
 
-niiri:758a317dc145a95aca39aa6587220d24
+niiri:9244bb6be2f1484bfb4b5d9df64a143c
     a prov:Entity, nidm_ExtentThreshold:, obo_statistic: ; 
     rdfs:label "Extent Threshold: k>=120" ;
     nidm_clusterSizeInVoxels: "120"^^xsd:int ;
     nidm_clusterSizeInResels: "0.878540888502834"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:e28c8f066d8dda2a777f3c99fe22642b ;
-    nidm_equivalentThreshold: niiri:6253986dbb01e4d929b5f54e9fa4e65c .
+    nidm_equivalentThreshold: niiri:920d4d286122d33e6d29abf2133f50e0 ;
+    nidm_equivalentThreshold: niiri:1b1374f5b2ef8094433e27fa63f6ef2b .
 
-niiri:e28c8f066d8dda2a777f3c99fe22642b
+niiri:920d4d286122d33e6d29abf2133f50e0
     a prov:Entity, nidm_ExtentThreshold:, obo_FWERadjustedpvalue: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "0.0208526820077359"^^xsd:float .
 
-niiri:6253986dbb01e4d929b5f54e9fa4e65c
+niiri:1b1374f5b2ef8094433e27fa63f6ef2b
     a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "0.00104434177016124"^^xsd:float .
 
-niiri:5409762af19920f26ce664b4d8f61c97
+niiri:41e52a5a5544a76853bcc91eb3fecb2f
     a prov:Entity, nidm_PeakDefinitionCriteria: ; 
     rdfs:label "Peak Definition Criteria" ;
     nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
     nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
 
-niiri:cacee6ad5d2cb227da01f933db8e6d23
+niiri:ba3936fa8577eac03c9623a5f5eb4c81
     a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
     rdfs:label "Cluster Connectivity Criterion: 18" ;
     nidm_hasConnectivityCriterion: nidm_voxel18connected: .
 
-niiri:4baf3ca1d021e1606e0c84df3af4f006
+niiri:e134b356fffdbdf572967bdab3709e2c
     a prov:Activity, nidm_Inference: ; 
     nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
     rdfs:label "Inference" .
 
-niiri:4baf3ca1d021e1606e0c84df3af4f006 prov:wasAssociatedWith niiri:582e74d3d47d395484eb9750c00b6034 .
+niiri:e134b356fffdbdf572967bdab3709e2c prov:wasAssociatedWith niiri:94ecae7951d21985687dcb4bf72d88bc .
 
-niiri:4baf3ca1d021e1606e0c84df3af4f006 prov:used niiri:662e79109731fe9b76e0ad3f17301b55 .
+niiri:e134b356fffdbdf572967bdab3709e2c prov:used niiri:e5b5f613b43832e8ca36c5fcd5e197c7 .
 
-niiri:4baf3ca1d021e1606e0c84df3af4f006 prov:used niiri:758a317dc145a95aca39aa6587220d24 .
+niiri:e134b356fffdbdf572967bdab3709e2c prov:used niiri:9244bb6be2f1484bfb4b5d9df64a143c .
 
-niiri:4baf3ca1d021e1606e0c84df3af4f006 prov:used niiri:af22bee20fc4bfa20ae2f0da89d98f26 .
+niiri:e134b356fffdbdf572967bdab3709e2c prov:used niiri:65cbca637492fc41602a48854f923270 .
 
-niiri:4baf3ca1d021e1606e0c84df3af4f006 prov:used niiri:711c7cbfc366f93b909c1e1c576a04e9 .
+niiri:e134b356fffdbdf572967bdab3709e2c prov:used niiri:999b4c344889226d33a1a3db629bbcdd .
 
-niiri:4baf3ca1d021e1606e0c84df3af4f006 prov:used niiri:5f0d397b9923b8ec17c86160f22ed3bd .
+niiri:e134b356fffdbdf572967bdab3709e2c prov:used niiri:134717e80ac83bc17cf1e5f4b6a0dab8 .
 
-niiri:4baf3ca1d021e1606e0c84df3af4f006 prov:used niiri:5409762af19920f26ce664b4d8f61c97 .
+niiri:e134b356fffdbdf572967bdab3709e2c prov:used niiri:41e52a5a5544a76853bcc91eb3fecb2f .
 
-niiri:4baf3ca1d021e1606e0c84df3af4f006 prov:used niiri:cacee6ad5d2cb227da01f933db8e6d23 .
+niiri:e134b356fffdbdf572967bdab3709e2c prov:used niiri:ba3936fa8577eac03c9623a5f5eb4c81 .
 
-niiri:a25a4329015a4066066702835b14f949
+niiri:b960c3349651945d424e517bd1730a7d
     a prov:Entity, nidm_SearchSpaceMaskMap: ; 
     prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
     nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Search Space Mask Map" ;
-    nidm_inCoordinateSpace: niiri:9ea612def84c2b00a28fde8461621f3d ;
+    nidm_inCoordinateSpace: niiri:5e472b9e1804aecf84d34427aeac5d36 ;
     nidm_searchVolumeInVoxels: "160902"^^xsd:int ;
     nidm_searchVolumeInUnits: "1287216"^^xsd:float ;
     nidm_reselSizeInVoxels: "136.59011386994"^^xsd:float ;
@@ -463,9 +463,9 @@ niiri:a25a4329015a4066066702835b14f949
     spm_smallestSignificantClusterSizeInVoxelsFWE05: "120"^^xsd:int ;
     spm_smallestSignificantClusterSizeInVoxelsFDR05: "53"^^xsd:int .
 
-niiri:a25a4329015a4066066702835b14f949 prov:wasGeneratedBy niiri:4baf3ca1d021e1606e0c84df3af4f006 .
+niiri:b960c3349651945d424e517bd1730a7d prov:wasGeneratedBy niiri:e134b356fffdbdf572967bdab3709e2c .
 
-niiri:f798f10a54c653caef26b5a29e8fc1a1
+niiri:64e1c232f0bbae773bd50d725f8f456a
     a prov:Entity, nidm_ExcursionSetMap: ; 
     prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
@@ -473,29 +473,29 @@ niiri:f798f10a54c653caef26b5a29e8fc1a1
     rdfs:label "Excursion Set Map" ;
     nidm_numberOfSupraThresholdClusters: "9"^^xsd:int ;
     nidm_pValue: "0"^^xsd:float ;
-    nidm_hasClusterLabelsMap: niiri:776dadec09b8573e7625e36647d7e361 ;
-    nidm_hasMaximumIntensityProjection: niiri:d488f806941c7d95209f82e23fd351e7 ;
-    nidm_inCoordinateSpace: niiri:9ea612def84c2b00a28fde8461621f3d ;
+    nidm_hasClusterLabelsMap: niiri:e020f1e9f1a50dffcbb63594f2caca52 ;
+    nidm_hasMaximumIntensityProjection: niiri:5f5a4e2d87d4741192c9fedabca572eb ;
+    nidm_inCoordinateSpace: niiri:5e472b9e1804aecf84d34427aeac5d36 ;
     crypto:sha512 "2f4011618fe1b59df15513558d716959952362e45f285e1685f6561e4815c19ebf6f1d9cb237b9bdc186055b9b99b9cbd8fd0e0904eee92e35018e4066e212cf"^^xsd:string .
 
-niiri:776dadec09b8573e7625e36647d7e361
+niiri:e020f1e9f1a50dffcbb63594f2caca52
     a prov:Entity, nidm_ClusterLabelsMap: ; 
     prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Cluster Labels Map" ;
-    nidm_inCoordinateSpace: niiri:9ea612def84c2b00a28fde8461621f3d ;
+    nidm_inCoordinateSpace: niiri:5e472b9e1804aecf84d34427aeac5d36 ;
     crypto:sha512 "ce4207d9dc614d3ee94a6068b0f5eeb2f118041ba7a3e02687ec19998e43d7eb059246440f46bda14dfb709d4b45eab1077195b2b82ee2dedbed19a12c1f7ccc"^^xsd:string .
 
-niiri:d488f806941c7d95209f82e23fd351e7
+niiri:5f5a4e2d87d4741192c9fedabca572eb
     a prov:Entity, dctype:Image ; 
     prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
     nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:f798f10a54c653caef26b5a29e8fc1a1 prov:wasGeneratedBy niiri:4baf3ca1d021e1606e0c84df3af4f006 .
+niiri:64e1c232f0bbae773bd50d725f8f456a prov:wasGeneratedBy niiri:e134b356fffdbdf572967bdab3709e2c .
 
-niiri:819bbce44c4139b90c18376738398b7a
+niiri:e3191f42f3f3f4c93e35287c26019f98
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0001" ;
     nidm_clusterSizeInVoxels: "565"^^xsd:int ;
@@ -505,9 +505,9 @@ niiri:819bbce44c4139b90c18376738398b7a
     nidm_qValueFDR: "1.30852409401865e-07"^^xsd:float ;
     nidm_clusterLabelId: "1"^^xsd:int .
 
-niiri:819bbce44c4139b90c18376738398b7a prov:wasDerivedFrom niiri:f798f10a54c653caef26b5a29e8fc1a1 .
+niiri:e3191f42f3f3f4c93e35287c26019f98 prov:wasDerivedFrom niiri:64e1c232f0bbae773bd50d725f8f456a .
 
-niiri:b8ed575a90fea174c22e252eeae426ab
+niiri:d496925af8b0958a04278695c2116f14
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0002" ;
     nidm_clusterSizeInVoxels: "201"^^xsd:int ;
@@ -517,9 +517,9 @@ niiri:b8ed575a90fea174c22e252eeae426ab
     nidm_qValueFDR: "0.000550348915075722"^^xsd:float ;
     nidm_clusterLabelId: "2"^^xsd:int .
 
-niiri:b8ed575a90fea174c22e252eeae426ab prov:wasDerivedFrom niiri:f798f10a54c653caef26b5a29e8fc1a1 .
+niiri:d496925af8b0958a04278695c2116f14 prov:wasDerivedFrom niiri:64e1c232f0bbae773bd50d725f8f456a .
 
-niiri:389bda8aa0474cc3a6c1ccbbd257d3aa
+niiri:784e20ceac3fc89851575215e2b045a6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0003" ;
     nidm_clusterSizeInVoxels: "130"^^xsd:int ;
@@ -529,9 +529,9 @@ niiri:389bda8aa0474cc3a6c1ccbbd257d3aa
     nidm_qValueFDR: "0.00277788016891419"^^xsd:float ;
     nidm_clusterLabelId: "3"^^xsd:int .
 
-niiri:389bda8aa0474cc3a6c1ccbbd257d3aa prov:wasDerivedFrom niiri:f798f10a54c653caef26b5a29e8fc1a1 .
+niiri:784e20ceac3fc89851575215e2b045a6 prov:wasDerivedFrom niiri:64e1c232f0bbae773bd50d725f8f456a .
 
-niiri:f38df95463ef91d161217362dadf93bc
+niiri:2d8cf2f1c8b135c47e4c992ddddc4603
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0004" ;
     nidm_clusterSizeInVoxels: "197"^^xsd:int ;
@@ -541,9 +541,9 @@ niiri:f38df95463ef91d161217362dadf93bc
     nidm_qValueFDR: "0.000550348915075722"^^xsd:float ;
     nidm_clusterLabelId: "4"^^xsd:int .
 
-niiri:f38df95463ef91d161217362dadf93bc prov:wasDerivedFrom niiri:f798f10a54c653caef26b5a29e8fc1a1 .
+niiri:2d8cf2f1c8b135c47e4c992ddddc4603 prov:wasDerivedFrom niiri:64e1c232f0bbae773bd50d725f8f456a .
 
-niiri:2c7b298047315ad1d67ac222bd8224bf
+niiri:145e279f67ab0593ed7aad160ef6ec96
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0005" ;
     nidm_clusterSizeInVoxels: "344"^^xsd:int ;
@@ -553,9 +553,9 @@ niiri:2c7b298047315ad1d67ac222bd8224bf
     nidm_qValueFDR: "1.49416358486251e-05"^^xsd:float ;
     nidm_clusterLabelId: "5"^^xsd:int .
 
-niiri:2c7b298047315ad1d67ac222bd8224bf prov:wasDerivedFrom niiri:f798f10a54c653caef26b5a29e8fc1a1 .
+niiri:145e279f67ab0593ed7aad160ef6ec96 prov:wasDerivedFrom niiri:64e1c232f0bbae773bd50d725f8f456a .
 
-niiri:b1faa7f7b978858ed6eb410ca05d8b3d
+niiri:0cf7fbb104195b08838b495de979f17d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0006" ;
     nidm_clusterSizeInVoxels: "168"^^xsd:int ;
@@ -565,9 +565,9 @@ niiri:b1faa7f7b978858ed6eb410ca05d8b3d
     nidm_qValueFDR: "0.000960276963268989"^^xsd:float ;
     nidm_clusterLabelId: "6"^^xsd:int .
 
-niiri:b1faa7f7b978858ed6eb410ca05d8b3d prov:wasDerivedFrom niiri:f798f10a54c653caef26b5a29e8fc1a1 .
+niiri:0cf7fbb104195b08838b495de979f17d prov:wasDerivedFrom niiri:64e1c232f0bbae773bd50d725f8f456a .
 
-niiri:8d1d785aced1bd1fe4b02bf63b8bc4c4
+niiri:3fb8d8c50e07f46ff52730667b4ff904
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0007" ;
     nidm_clusterSizeInVoxels: "120"^^xsd:int ;
@@ -577,9 +577,9 @@ niiri:8d1d785aced1bd1fe4b02bf63b8bc4c4
     nidm_qValueFDR: "0.00359717720833317"^^xsd:float ;
     nidm_clusterLabelId: "7"^^xsd:int .
 
-niiri:8d1d785aced1bd1fe4b02bf63b8bc4c4 prov:wasDerivedFrom niiri:f798f10a54c653caef26b5a29e8fc1a1 .
+niiri:3fb8d8c50e07f46ff52730667b4ff904 prov:wasDerivedFrom niiri:64e1c232f0bbae773bd50d725f8f456a .
 
-niiri:4a24406f20a447cd18e19bcea9c901b1
+niiri:24ed53e97502545f0497cc97644535d2
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0008" ;
     nidm_clusterSizeInVoxels: "182"^^xsd:int ;
@@ -589,9 +589,9 @@ niiri:4a24406f20a447cd18e19bcea9c901b1
     nidm_qValueFDR: "0.000719593650113681"^^xsd:float ;
     nidm_clusterLabelId: "8"^^xsd:int .
 
-niiri:4a24406f20a447cd18e19bcea9c901b1 prov:wasDerivedFrom niiri:f798f10a54c653caef26b5a29e8fc1a1 .
+niiri:24ed53e97502545f0497cc97644535d2 prov:wasDerivedFrom niiri:64e1c232f0bbae773bd50d725f8f456a .
 
-niiri:0df7f5664a49553001462c97fe08a90e
+niiri:ee68048e8a0744dfd236a85d10e1b80c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0009" ;
     nidm_clusterSizeInVoxels: "144"^^xsd:int ;
@@ -601,413 +601,413 @@ niiri:0df7f5664a49553001462c97fe08a90e
     nidm_qValueFDR: "0.00190463553777346"^^xsd:float ;
     nidm_clusterLabelId: "9"^^xsd:int .
 
-niiri:0df7f5664a49553001462c97fe08a90e prov:wasDerivedFrom niiri:f798f10a54c653caef26b5a29e8fc1a1 .
+niiri:ee68048e8a0744dfd236a85d10e1b80c prov:wasDerivedFrom niiri:64e1c232f0bbae773bd50d725f8f456a .
 
-niiri:086f61ec7a73359b6e6267997b89f1bb
+niiri:ff91629a343c2e8f75793ca5bf4f5456
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0001" ;
-    prov:atLocation niiri:49ebfb89929355725856c4ec88d5dfb3 ;
+    prov:atLocation niiri:71861dca5fb2a8a0c5cc60b4795ea2bd ;
     prov:value "9.0197868347168"^^xsd:float ;
     nidm_equivalentZStatistic: "4.99532807659738"^^xsd:float ;
     nidm_pValueUncorrected: "2.93679147334025e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0472535690597315"^^xsd:float ;
     nidm_qValueFDR: "0.227081208121146"^^xsd:float .
 
-niiri:49ebfb89929355725856c4ec88d5dfb3
+niiri:71861dca5fb2a8a0c5cc60b4795ea2bd
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0001" ;
     nidm_coordinateVector: "[-10,18,42]"^^xsd:string .
 
-niiri:086f61ec7a73359b6e6267997b89f1bb prov:wasDerivedFrom niiri:819bbce44c4139b90c18376738398b7a .
+niiri:ff91629a343c2e8f75793ca5bf4f5456 prov:wasDerivedFrom niiri:e3191f42f3f3f4c93e35287c26019f98 .
 
-niiri:943f8b7d581fc2fe91ca352e90047fe3
+niiri:c49fbca986b7d0a96d37718d1c0d3be1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0002" ;
-    prov:atLocation niiri:481898ea7fc75b4defb526252bbfbc7d ;
+    prov:atLocation niiri:6ebc4745b212479bf3dbc66f61355303 ;
     prov:value "7.42846012115479"^^xsd:float ;
     nidm_equivalentZStatistic: "4.56538453536696"^^xsd:float ;
     nidm_pValueUncorrected: "2.49289781906192e-06"^^xsd:float ;
     nidm_pValueFWER: "0.28406310634998"^^xsd:float ;
     nidm_qValueFDR: "0.227081208121146"^^xsd:float .
 
-niiri:481898ea7fc75b4defb526252bbfbc7d
+niiri:6ebc4745b212479bf3dbc66f61355303
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0002" ;
     nidm_coordinateVector: "[-2,8,66]"^^xsd:string .
 
-niiri:943f8b7d581fc2fe91ca352e90047fe3 prov:wasDerivedFrom niiri:819bbce44c4139b90c18376738398b7a .
+niiri:c49fbca986b7d0a96d37718d1c0d3be1 prov:wasDerivedFrom niiri:e3191f42f3f3f4c93e35287c26019f98 .
 
-niiri:5975bfef0764abc5022af943b2707a09
+niiri:bc90e98330ecd77c0c61eb4ee20896c0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0003" ;
-    prov:atLocation niiri:c91ee784d0f316ca96004840703df487 ;
+    prov:atLocation niiri:0e7af240702d72adc90cf039012896f6 ;
     prov:value "5.63349199295044"^^xsd:float ;
     nidm_equivalentZStatistic: "3.93987516059906"^^xsd:float ;
     nidm_pValueUncorrected: "4.07620106994688e-05"^^xsd:float ;
     nidm_pValueFWER: "0.913665566475084"^^xsd:float ;
     nidm_qValueFDR: "0.365315662158339"^^xsd:float .
 
-niiri:c91ee784d0f316ca96004840703df487
+niiri:0e7af240702d72adc90cf039012896f6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0003" ;
     nidm_coordinateVector: "[8,2,66]"^^xsd:string .
 
-niiri:5975bfef0764abc5022af943b2707a09 prov:wasDerivedFrom niiri:819bbce44c4139b90c18376738398b7a .
+niiri:bc90e98330ecd77c0c61eb4ee20896c0 prov:wasDerivedFrom niiri:e3191f42f3f3f4c93e35287c26019f98 .
 
-niiri:f61f477dd0190930988f10ec2ccc3953
+niiri:1d495ddd1ccf932950c1251a78ced9c4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0004" ;
-    prov:atLocation niiri:88c238030228ae5516f1bcbf1b5503b1 ;
+    prov:atLocation niiri:0f0000559de1833e3cc048c853eaef14 ;
     prov:value "7.85747480392456"^^xsd:float ;
     nidm_equivalentZStatistic: "4.6908256972469"^^xsd:float ;
     nidm_pValueUncorrected: "1.36052353338911e-06"^^xsd:float ;
     nidm_pValueFWER: "0.193292933875985"^^xsd:float ;
     nidm_qValueFDR: "0.227081208121146"^^xsd:float .
 
-niiri:88c238030228ae5516f1bcbf1b5503b1
+niiri:0f0000559de1833e3cc048c853eaef14
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0004" ;
     nidm_coordinateVector: "[-42,-4,28]"^^xsd:string .
 
-niiri:f61f477dd0190930988f10ec2ccc3953 prov:wasDerivedFrom niiri:b8ed575a90fea174c22e252eeae426ab .
+niiri:1d495ddd1ccf932950c1251a78ced9c4 prov:wasDerivedFrom niiri:d496925af8b0958a04278695c2116f14 .
 
-niiri:e50c723a53c65a2817271e37d1ec8888
+niiri:84fe5bdeb23007afdd8dfc54f4030c78
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0005" ;
-    prov:atLocation niiri:aa0c8d4dcf34222f36033c1c97f45d2b ;
+    prov:atLocation niiri:7c5bb491b25180b0b7561de85c20c240 ;
     prov:value "4.96076774597168"^^xsd:float ;
     nidm_equivalentZStatistic: "3.65180690060166"^^xsd:float ;
     nidm_pValueUncorrected: "0.000130200830341765"^^xsd:float ;
     nidm_pValueFWER: "0.995586804119546"^^xsd:float ;
     nidm_qValueFDR: "0.508465170731449"^^xsd:float .
 
-niiri:aa0c8d4dcf34222f36033c1c97f45d2b
+niiri:7c5bb491b25180b0b7561de85c20c240
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0005" ;
     nidm_coordinateVector: "[-54,4,18]"^^xsd:string .
 
-niiri:e50c723a53c65a2817271e37d1ec8888 prov:wasDerivedFrom niiri:b8ed575a90fea174c22e252eeae426ab .
+niiri:84fe5bdeb23007afdd8dfc54f4030c78 prov:wasDerivedFrom niiri:d496925af8b0958a04278695c2116f14 .
 
-niiri:a5db13e5b7c9fd26e289ccb809b33731
+niiri:18cc6e4de0c9e565941028f84899f9aa
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0006" ;
-    prov:atLocation niiri:d80a26de1dea42815c63a0f365d6449a ;
+    prov:atLocation niiri:b8e5d6bbccfb83b99e33609e89895e33 ;
     prov:value "4.68419551849365"^^xsd:float ;
     nidm_equivalentZStatistic: "3.52268507469106"^^xsd:float ;
     nidm_pValueUncorrected: "0.000213599326911451"^^xsd:float ;
     nidm_pValueFWER: "0.999471213589401"^^xsd:float ;
     nidm_qValueFDR: "0.58440570253383"^^xsd:float .
 
-niiri:d80a26de1dea42815c63a0f365d6449a
+niiri:b8e5d6bbccfb83b99e33609e89895e33
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0006" ;
     nidm_coordinateVector: "[-54,6,30]"^^xsd:string .
 
-niiri:a5db13e5b7c9fd26e289ccb809b33731 prov:wasDerivedFrom niiri:b8ed575a90fea174c22e252eeae426ab .
+niiri:18cc6e4de0c9e565941028f84899f9aa prov:wasDerivedFrom niiri:d496925af8b0958a04278695c2116f14 .
 
-niiri:b6ea9a8c98b467318e9d7937f647c6e0
+niiri:2b5fa07d66fa075513a31a38dbaa7bd9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0007" ;
-    prov:atLocation niiri:84ca29f6444eb392d2cea8daa7d95042 ;
+    prov:atLocation niiri:5bc970458ceef44ab45ea1e7e7a0635d ;
     prov:value "7.27484846115112"^^xsd:float ;
     nidm_equivalentZStatistic: "4.51851280417867"^^xsd:float ;
     nidm_pValueUncorrected: "3.11377539996549e-06"^^xsd:float ;
     nidm_pValueFWER: "0.324805789402179"^^xsd:float ;
     nidm_qValueFDR: "0.227081208121146"^^xsd:float .
 
-niiri:84ca29f6444eb392d2cea8daa7d95042
+niiri:5bc970458ceef44ab45ea1e7e7a0635d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0007" ;
     nidm_coordinateVector: "[-46,-4,54]"^^xsd:string .
 
-niiri:b6ea9a8c98b467318e9d7937f647c6e0 prov:wasDerivedFrom niiri:389bda8aa0474cc3a6c1ccbbd257d3aa .
+niiri:2b5fa07d66fa075513a31a38dbaa7bd9 prov:wasDerivedFrom niiri:784e20ceac3fc89851575215e2b045a6 .
 
-niiri:54d28453113183258d217e3bdd65c9fc
+niiri:f458ed28668e8278b72dffade3f56b36
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0008" ;
-    prov:atLocation niiri:609323e3dad9da267d42d6f70aaf5d39 ;
+    prov:atLocation niiri:d721095be503b1e0f64a2410036a2eaa ;
     prov:value "6.94224119186401"^^xsd:float ;
     nidm_equivalentZStatistic: "4.41321599194522"^^xsd:float ;
     nidm_pValueUncorrected: "5.09231481560235e-06"^^xsd:float ;
     nidm_pValueFWER: "0.429119375951011"^^xsd:float ;
     nidm_qValueFDR: "0.25175924600333"^^xsd:float .
 
-niiri:609323e3dad9da267d42d6f70aaf5d39
+niiri:d721095be503b1e0f64a2410036a2eaa
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0008" ;
     nidm_coordinateVector: "[-42,16,10]"^^xsd:string .
 
-niiri:54d28453113183258d217e3bdd65c9fc prov:wasDerivedFrom niiri:f38df95463ef91d161217362dadf93bc .
+niiri:f458ed28668e8278b72dffade3f56b36 prov:wasDerivedFrom niiri:2d8cf2f1c8b135c47e4c992ddddc4603 .
 
-niiri:6c22c0a9d1b60504fdc7690149788276
+niiri:d9eeac8bb3ecc01f8076b9144f8408a1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0009" ;
-    prov:atLocation niiri:cb76fb2bfdcf4897afffecdbd4cc720e ;
+    prov:atLocation niiri:b9cce062e2feece03ec35b7263ae63a8 ;
     prov:value "6.10717391967773"^^xsd:float ;
     nidm_equivalentZStatistic: "4.1231772056634"^^xsd:float ;
     nidm_pValueUncorrected: "1.86840997530302e-05"^^xsd:float ;
     nidm_pValueFWER: "0.757824284509807"^^xsd:float ;
     nidm_qValueFDR: "0.365315662158339"^^xsd:float .
 
-niiri:cb76fb2bfdcf4897afffecdbd4cc720e
+niiri:b9cce062e2feece03ec35b7263ae63a8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0009" ;
     nidm_coordinateVector: "[-34,12,12]"^^xsd:string .
 
-niiri:6c22c0a9d1b60504fdc7690149788276 prov:wasDerivedFrom niiri:f38df95463ef91d161217362dadf93bc .
+niiri:d9eeac8bb3ecc01f8076b9144f8408a1 prov:wasDerivedFrom niiri:2d8cf2f1c8b135c47e4c992ddddc4603 .
 
-niiri:21ad066097d48bf3e388ea1aaa1d1bb1
+niiri:e0b762eecb88a3831f1461fcb76acb5e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0010" ;
-    prov:atLocation niiri:0f93d52b9ef25071beea5a20f19d2385 ;
+    prov:atLocation niiri:7a964994e6526b0666437d95f24abc7c ;
     prov:value "4.91090297698975"^^xsd:float ;
     nidm_equivalentZStatistic: "3.62901638790644"^^xsd:float ;
     nidm_pValueUncorrected: "0.000142251590777853"^^xsd:float ;
     nidm_pValueFWER: "0.996834489281486"^^xsd:float ;
     nidm_qValueFDR: "0.511946776631986"^^xsd:float .
 
-niiri:0f93d52b9ef25071beea5a20f19d2385
+niiri:7a964994e6526b0666437d95f24abc7c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0010" ;
     nidm_coordinateVector: "[-32,14,20]"^^xsd:string .
 
-niiri:21ad066097d48bf3e388ea1aaa1d1bb1 prov:wasDerivedFrom niiri:f38df95463ef91d161217362dadf93bc .
+niiri:e0b762eecb88a3831f1461fcb76acb5e prov:wasDerivedFrom niiri:2d8cf2f1c8b135c47e4c992ddddc4603 .
 
-niiri:cadc3d04f7e89013709b64e325c3f2bb
+niiri:5c4ec650d1179cc0393ce006684df798
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0011" ;
-    prov:atLocation niiri:c15020481b8972ad7e8d91b9349191f9 ;
+    prov:atLocation niiri:ad512c918e7340c95eaef8dfde49052a ;
     prov:value "6.90986013412476"^^xsd:float ;
     nidm_equivalentZStatistic: "4.40267439233253"^^xsd:float ;
     nidm_pValueUncorrected: "5.34622897296888e-06"^^xsd:float ;
     nidm_pValueFWER: "0.440428166820351"^^xsd:float ;
     nidm_qValueFDR: "0.25175924600333"^^xsd:float .
 
-niiri:c15020481b8972ad7e8d91b9349191f9
+niiri:ad512c918e7340c95eaef8dfde49052a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0011" ;
     nidm_coordinateVector: "[58,-34,14]"^^xsd:string .
 
-niiri:cadc3d04f7e89013709b64e325c3f2bb prov:wasDerivedFrom niiri:2c7b298047315ad1d67ac222bd8224bf .
+niiri:5c4ec650d1179cc0393ce006684df798 prov:wasDerivedFrom niiri:145e279f67ab0593ed7aad160ef6ec96 .
 
-niiri:4dfc983b8c73943a6be2f0ef27c10643
+niiri:cc7d961cd89c1dd7f8fca1be56c252c2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0012" ;
-    prov:atLocation niiri:83e9f9748d9e5cf3d505ad3d5f10a0c4 ;
+    prov:atLocation niiri:c6311ce077927bd49736a0687796e269 ;
     prov:value "5.82773351669312"^^xsd:float ;
     nidm_equivalentZStatistic: "4.01684833891347"^^xsd:float ;
     nidm_pValueUncorrected: "2.94908276274874e-05"^^xsd:float ;
     nidm_pValueFWER: "0.858380226002374"^^xsd:float ;
     nidm_qValueFDR: "0.365315662158339"^^xsd:float .
 
-niiri:83e9f9748d9e5cf3d505ad3d5f10a0c4
+niiri:c6311ce077927bd49736a0687796e269
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0012" ;
     nidm_coordinateVector: "[66,-38,14]"^^xsd:string .
 
-niiri:4dfc983b8c73943a6be2f0ef27c10643 prov:wasDerivedFrom niiri:2c7b298047315ad1d67ac222bd8224bf .
+niiri:cc7d961cd89c1dd7f8fca1be56c252c2 prov:wasDerivedFrom niiri:145e279f67ab0593ed7aad160ef6ec96 .
 
-niiri:47787e0c9c31a52feaf8a0de1a89f61a
+niiri:5859c0686be12782603570a07ee67698
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0013" ;
-    prov:atLocation niiri:5bd9e6d5e5977a3e317ddebe8a149190 ;
+    prov:atLocation niiri:9cfe2df9dc6783d6c43a1b8829beb4a8 ;
     prov:value "5.4896821975708"^^xsd:float ;
     nidm_equivalentZStatistic: "3.88117893748276"^^xsd:float ;
     nidm_pValueUncorrected: "5.1975659703607e-05"^^xsd:float ;
     nidm_pValueFWER: "0.944904699668246"^^xsd:float ;
     nidm_qValueFDR: "0.386351702418292"^^xsd:float .
 
-niiri:5bd9e6d5e5977a3e317ddebe8a149190
+niiri:9cfe2df9dc6783d6c43a1b8829beb4a8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0013" ;
     nidm_coordinateVector: "[52,-38,6]"^^xsd:string .
 
-niiri:47787e0c9c31a52feaf8a0de1a89f61a prov:wasDerivedFrom niiri:2c7b298047315ad1d67ac222bd8224bf .
+niiri:5859c0686be12782603570a07ee67698 prov:wasDerivedFrom niiri:145e279f67ab0593ed7aad160ef6ec96 .
 
-niiri:e2285c6dc1adb636731879c86e1f721a
+niiri:2e8112ff496740fe656336a508456db6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0014" ;
-    prov:atLocation niiri:4b3afc7aad1c553f2802781fb47e49e8 ;
+    prov:atLocation niiri:7b8b224d0de6e706a8496c51b9ec92c7 ;
     prov:value "6.21367645263672"^^xsd:float ;
     nidm_equivalentZStatistic: "4.1624012348651"^^xsd:float ;
     nidm_pValueUncorrected: "1.57459182630326e-05"^^xsd:float ;
     nidm_pValueFWER: "0.715339849593062"^^xsd:float ;
     nidm_qValueFDR: "0.365315662158339"^^xsd:float .
 
-niiri:4b3afc7aad1c553f2802781fb47e49e8
+niiri:7b8b224d0de6e706a8496c51b9ec92c7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0014" ;
     nidm_coordinateVector: "[8,16,42]"^^xsd:string .
 
-niiri:e2285c6dc1adb636731879c86e1f721a prov:wasDerivedFrom niiri:b1faa7f7b978858ed6eb410ca05d8b3d .
+niiri:2e8112ff496740fe656336a508456db6 prov:wasDerivedFrom niiri:0cf7fbb104195b08838b495de979f17d .
 
-niiri:d661e0da256925a10f4a6d251c3622c4
+niiri:091092eab6f1574d657d804507dd0192
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0015" ;
-    prov:atLocation niiri:df6e06b7d5e31e146f5ace039de3fdc3 ;
+    prov:atLocation niiri:a90f5e73e0da209b7207b1ef41a327b8 ;
     prov:value "5.72438669204712"^^xsd:float ;
     nidm_equivalentZStatistic: "3.97621777576085"^^xsd:float ;
     nidm_pValueUncorrected: "3.50100040308332e-05"^^xsd:float ;
     nidm_pValueFWER: "0.889577859110148"^^xsd:float ;
     nidm_qValueFDR: "0.365315662158339"^^xsd:float .
 
-niiri:df6e06b7d5e31e146f5ace039de3fdc3
+niiri:a90f5e73e0da209b7207b1ef41a327b8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0015" ;
     nidm_coordinateVector: "[12,18,34]"^^xsd:string .
 
-niiri:d661e0da256925a10f4a6d251c3622c4 prov:wasDerivedFrom niiri:b1faa7f7b978858ed6eb410ca05d8b3d .
+niiri:091092eab6f1574d657d804507dd0192 prov:wasDerivedFrom niiri:0cf7fbb104195b08838b495de979f17d .
 
-niiri:126eda6e597a08eadcde51b74107b509
+niiri:9a9072a8cc791001f985c339f649ecbc
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0016" ;
-    prov:atLocation niiri:768833a7a7b79bf5192ab69bb1c0333f ;
+    prov:atLocation niiri:e75ec0ab2114018af91503adf58ab0b0 ;
     prov:value "6.03207159042358"^^xsd:float ;
     nidm_equivalentZStatistic: "4.09509363345907"^^xsd:float ;
     nidm_pValueUncorrected: "2.10998901504222e-05"^^xsd:float ;
     nidm_pValueFWER: "0.786707462460714"^^xsd:float ;
     nidm_qValueFDR: "0.365315662158339"^^xsd:float .
 
-niiri:768833a7a7b79bf5192ab69bb1c0333f
+niiri:e75ec0ab2114018af91503adf58ab0b0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0016" ;
     nidm_coordinateVector: "[56,-2,46]"^^xsd:string .
 
-niiri:126eda6e597a08eadcde51b74107b509 prov:wasDerivedFrom niiri:8d1d785aced1bd1fe4b02bf63b8bc4c4 .
+niiri:9a9072a8cc791001f985c339f649ecbc prov:wasDerivedFrom niiri:3fb8d8c50e07f46ff52730667b4ff904 .
 
-niiri:f806d96770dd75bfb97c3d9e29bc57c3
+niiri:f06598e58370f70e2f5ce0b47e641909
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0017" ;
-    prov:atLocation niiri:232e902c7d2f2a7e470a5a1508996122 ;
+    prov:atLocation niiri:0a466a7d36f0e502b275608c297d8bac ;
     prov:value "4.45615816116333"^^xsd:float ;
     nidm_equivalentZStatistic: "3.4110394440129"^^xsd:float ;
     nidm_pValueUncorrected: "0.000323578644043643"^^xsd:float ;
     nidm_pValueFWER: "0.999950103431029"^^xsd:float ;
     nidm_qValueFDR: "0.701250666193361"^^xsd:float .
 
-niiri:232e902c7d2f2a7e470a5a1508996122
+niiri:0a466a7d36f0e502b275608c297d8bac
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0017" ;
     nidm_coordinateVector: "[42,0,40]"^^xsd:string .
 
-niiri:f806d96770dd75bfb97c3d9e29bc57c3 prov:wasDerivedFrom niiri:8d1d785aced1bd1fe4b02bf63b8bc4c4 .
+niiri:f06598e58370f70e2f5ce0b47e641909 prov:wasDerivedFrom niiri:3fb8d8c50e07f46ff52730667b4ff904 .
 
-niiri:3166b934af2bbe50fd3f62dee033c87f
+niiri:cf9e0ce6702a4bc5d75621bb529bb51e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0018" ;
-    prov:atLocation niiri:e9b297b5d8244bf49539979baf272657 ;
+    prov:atLocation niiri:2459537b6faed4755f3485553ad12087 ;
     prov:value "4.44447803497314"^^xsd:float ;
     nidm_equivalentZStatistic: "3.40518918809107"^^xsd:float ;
     nidm_pValueUncorrected: "0.00033059115403522"^^xsd:float ;
     nidm_pValueFWER: "0.999956572496893"^^xsd:float ;
     nidm_qValueFDR: "0.701250666193361"^^xsd:float .
 
-niiri:e9b297b5d8244bf49539979baf272657
+niiri:2459537b6faed4755f3485553ad12087
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0018" ;
     nidm_coordinateVector: "[48,2,52]"^^xsd:string .
 
-niiri:3166b934af2bbe50fd3f62dee033c87f prov:wasDerivedFrom niiri:8d1d785aced1bd1fe4b02bf63b8bc4c4 .
+niiri:cf9e0ce6702a4bc5d75621bb529bb51e prov:wasDerivedFrom niiri:3fb8d8c50e07f46ff52730667b4ff904 .
 
-niiri:5496b677c1de93ba7b716cab5c3dddc6
+niiri:1d42f9fcfbb48e74a501c76e58311ef7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0019" ;
-    prov:atLocation niiri:af1835ce1aa7d7feab5365570fe3679b ;
+    prov:atLocation niiri:fbda836c00cc56183550c787012b6eeb ;
     prov:value "5.99733877182007"^^xsd:float ;
     nidm_equivalentZStatistic: "4.08198490016656"^^xsd:float ;
     nidm_pValueUncorrected: "2.23263492938885e-05"^^xsd:float ;
     nidm_pValueFWER: "0.799672548097648"^^xsd:float ;
     nidm_qValueFDR: "0.365315662158339"^^xsd:float .
 
-niiri:af1835ce1aa7d7feab5365570fe3679b
+niiri:fbda836c00cc56183550c787012b6eeb
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0019" ;
     nidm_coordinateVector: "[52,4,20]"^^xsd:string .
 
-niiri:5496b677c1de93ba7b716cab5c3dddc6 prov:wasDerivedFrom niiri:4a24406f20a447cd18e19bcea9c901b1 .
+niiri:1d42f9fcfbb48e74a501c76e58311ef7 prov:wasDerivedFrom niiri:24ed53e97502545f0497cc97644535d2 .
 
-niiri:0f2a6098225cb6e376794aec07c3d66c
+niiri:2b939bebe4432404eecd773b1a8fa021
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0020" ;
-    prov:atLocation niiri:3fd7f75c193fff89094c56a442500f43 ;
+    prov:atLocation niiri:8e59c08d21c91e4bd2386b0d3a271df7 ;
     prov:value "5.96960115432739"^^xsd:float ;
     nidm_equivalentZStatistic: "4.07146072717137"^^xsd:float ;
     nidm_pValueUncorrected: "2.33596199642472e-05"^^xsd:float ;
     nidm_pValueFWER: "0.809821953269947"^^xsd:float ;
     nidm_qValueFDR: "0.365315662158339"^^xsd:float .
 
-niiri:3fd7f75c193fff89094c56a442500f43
+niiri:8e59c08d21c91e4bd2386b0d3a271df7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0020" ;
     nidm_coordinateVector: "[48,14,2]"^^xsd:string .
 
-niiri:0f2a6098225cb6e376794aec07c3d66c prov:wasDerivedFrom niiri:4a24406f20a447cd18e19bcea9c901b1 .
+niiri:2b939bebe4432404eecd773b1a8fa021 prov:wasDerivedFrom niiri:24ed53e97502545f0497cc97644535d2 .
 
-niiri:6f2b2823e0ad35ce3bc060c5ca390936
+niiri:d194d8bbb0450258cbb3e2c7b63d052b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0021" ;
-    prov:atLocation niiri:dd6bbe27c2bafe5a161f6e9eaf4e5279 ;
+    prov:atLocation niiri:6e46e05c89f606b54b383ab231bc4f7f ;
     prov:value "5.32198143005371"^^xsd:float ;
     nidm_equivalentZStatistic: "3.81081315671811"^^xsd:float ;
     nidm_pValueUncorrected: "6.92552142741443e-05"^^xsd:float ;
     nidm_pValueFWER: "0.970746077807219"^^xsd:float ;
     nidm_qValueFDR: "0.416365388604658"^^xsd:float .
 
-niiri:dd6bbe27c2bafe5a161f6e9eaf4e5279
+niiri:6e46e05c89f606b54b383ab231bc4f7f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0021" ;
     nidm_coordinateVector: "[56,12,16]"^^xsd:string .
 
-niiri:6f2b2823e0ad35ce3bc060c5ca390936 prov:wasDerivedFrom niiri:4a24406f20a447cd18e19bcea9c901b1 .
+niiri:d194d8bbb0450258cbb3e2c7b63d052b prov:wasDerivedFrom niiri:24ed53e97502545f0497cc97644535d2 .
 
-niiri:42490924487f49a83d25b91f2de3c800
+niiri:373fb030ca503554429e0d448b03ac03
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0022" ;
-    prov:atLocation niiri:f95d4943830fda794a3c20455fde7ef5 ;
+    prov:atLocation niiri:8aa50282813e2f149237738250f246d4 ;
     prov:value "5.69392824172974"^^xsd:float ;
     nidm_equivalentZStatistic: "3.96410360090528"^^xsd:float ;
     nidm_pValueUncorrected: "3.68361273354045e-05"^^xsd:float ;
     nidm_pValueFWER: "0.898012948452735"^^xsd:float ;
     nidm_qValueFDR: "0.365315662158339"^^xsd:float .
 
-niiri:f95d4943830fda794a3c20455fde7ef5
+niiri:8aa50282813e2f149237738250f246d4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0022" ;
     nidm_coordinateVector: "[-50,-44,10]"^^xsd:string .
 
-niiri:42490924487f49a83d25b91f2de3c800 prov:wasDerivedFrom niiri:0df7f5664a49553001462c97fe08a90e .
+niiri:373fb030ca503554429e0d448b03ac03 prov:wasDerivedFrom niiri:ee68048e8a0744dfd236a85d10e1b80c .
 
-niiri:3ce0f665c92c0fce8dd2149c88063832
+niiri:88e91db80e4f84543f912f20187894b6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0023" ;
-    prov:atLocation niiri:5f4fd7726d13278afb8c96179f2f3d06 ;
+    prov:atLocation niiri:0212c0dd8121cea00a8dbedcf8cd7e3c ;
     prov:value "5.6067042350769"^^xsd:float ;
     nidm_equivalentZStatistic: "3.9290539558673"^^xsd:float ;
     nidm_pValueUncorrected: "4.26403524200758e-05"^^xsd:float ;
     nidm_pValueFWER: "0.920131147013454"^^xsd:float ;
     nidm_qValueFDR: "0.365315662158339"^^xsd:float .
 
-niiri:5f4fd7726d13278afb8c96179f2f3d06
+niiri:0212c0dd8121cea00a8dbedcf8cd7e3c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0023" ;
     nidm_coordinateVector: "[-44,-42,18]"^^xsd:string .
 
-niiri:3ce0f665c92c0fce8dd2149c88063832 prov:wasDerivedFrom niiri:0df7f5664a49553001462c97fe08a90e .
+niiri:88e91db80e4f84543f912f20187894b6 prov:wasDerivedFrom niiri:ee68048e8a0744dfd236a85d10e1b80c .
 
-niiri:e269262fc1344012d95ae80d29511ae2
+niiri:f11f4cdd0aa465dd12a0072b11116c2c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0024" ;
-    prov:atLocation niiri:abe4ad1664833acdef81be07aeab31eb ;
+    prov:atLocation niiri:7287fc447fabd0245cc28ac2cf7afc62 ;
     prov:value "4.39031887054443"^^xsd:float ;
     nidm_equivalentZStatistic: "3.37789039899343"^^xsd:float ;
     nidm_pValueUncorrected: "0.000365220936835664"^^xsd:float ;
     nidm_pValueFWER: "0.999977761191736"^^xsd:float ;
     nidm_qValueFDR: "0.701250666193361"^^xsd:float .
 
-niiri:abe4ad1664833acdef81be07aeab31eb
+niiri:7287fc447fabd0245cc28ac2cf7afc62
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0024" ;
     nidm_coordinateVector: "[-46,-40,28]"^^xsd:string .
 
-niiri:e269262fc1344012d95ae80d29511ae2 prov:wasDerivedFrom niiri:0df7f5664a49553001462c97fe08a90e .
+niiri:f11f4cdd0aa465dd12a0072b11116c2c prov:wasDerivedFrom niiri:ee68048e8a0744dfd236a85d10e1b80c .
 

--- a/spmexport/ex_spm_group_wls/nidm.json
+++ b/spmexport/ex_spm_group_wls/nidm.json
@@ -1,0 +1,4141 @@
+{
+  "prefix": {
+    "nidm": "http://purl.org/nidash/nidm#",
+    "niiri": "http://iri.nidash.org/",
+    "spm": "http://purl.org/nidash/spm#",
+    "neurolex": "http://neurolex.org/wiki/",
+    "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/",
+    "dct": "http://purl.org/dc/terms/",
+    "nfo": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#",
+    "dc": "http://purl.org/dc/elements/1.1/",
+    "dctype": "http://purl.org/dc/dcmitype/",
+    "obo": "http://purl.obolibrary.org/obo/",
+    "nidm_NIDMResults": "http://purl.org/nidash/nidm#NIDM_0000027",
+    "nidm_version": "http://purl.org/nidash/nidm#NIDM_0000127",
+    "nidm_spm_results_nidm": "http://purl.org/nidash/nidm#NIDM_0000168",
+    "nidm_softwareVersion": "http://purl.org/nidash/nidm#NIDM_0000122",
+    "nidm_NIDMResultsExport": "http://purl.org/nidash/nidm#NIDM_0000166"
+  },
+  "entity": {
+    "niiri:fbfb92dd91e30b37df0002dd4a58237d": {
+      "prov:type": [
+        {
+        "$": "prov:Bundle",
+        "type": "xsd:QName"
+        },
+        {
+        "$": "nidm_NIDMResults:",
+        "type": "xsd:QName"
+        }
+      ],
+      "prov:label": {
+        "$": "NIDM-Results",
+        "type": "xsd:string"
+      },
+      "nidm_version:": {
+        "$": "1.3.0",
+        "type": "xsd:string"
+      }
+    }
+  },
+  "activity": {
+    "niiri:0716bbc8504afbc51e82ff51484e584a": {
+      "prov:type": {
+        "$": "nidm_NIDMResultsExport:",
+        "type": "xsd:QName"
+      },
+      "prov:label": {
+        "$": "NIDM-Results export",
+        "type": "xsd:string"
+      }
+    }
+  },
+  "agent": {
+    "niiri:a6b93a73047f21860319c5c6a2bc4bec": {
+      "prov:type": [
+        {
+        "$": "nidm_spm_results_nidm:",
+        "type": "xsd:QName"
+        },
+        {
+        "$": "prov:SoftwareAgent",
+        "type": "xsd:QName"
+        }
+      ],
+      "prov:label": {
+        "$": "spm_results_nidm",
+        "type": "xsd:string"
+      },
+      "nidm_softwareVersion:": {
+        "$": "12.7057",
+        "type": "xsd:string"
+      }
+    }
+  },
+  "wasGeneratedBy": {
+    "_:wGB5": {
+      "prov:entity": "niiri:fbfb92dd91e30b37df0002dd4a58237d",
+      "prov:activity": "niiri:0716bbc8504afbc51e82ff51484e584a",
+      "prov:time": "2017-04-19T12:18:16"
+    }
+  },
+  "wasAssociatedWith": {
+    "_:wAW4": {
+      "prov:activity": "niiri:0716bbc8504afbc51e82ff51484e584a",
+      "prov:agent": "niiri:a6b93a73047f21860319c5c6a2bc4bec"
+    }
+  },
+  "bundle": {
+    "niiri:fbfb92dd91e30b37df0002dd4a58237d": {
+    "prefix": {
+        "nidm_softwareVersion": "http://purl.org/nidash/nidm#NIDM_0000122",
+        "nidm_CoordinateSpace": "http://purl.org/nidash/nidm#NIDM_0000016",
+        "nidm_voxelToWorldMapping": "http://purl.org/nidash/nidm#NIDM_0000132",
+        "nidm_voxelUnits": "http://purl.org/nidash/nidm#NIDM_0000133",
+        "nidm_voxelSize": "http://purl.org/nidash/nidm#NIDM_0000131",
+        "nidm_inWorldCoordinateSystem": "http://purl.org/nidash/nidm#NIDM_0000105",
+        "nidm_numberOfDimensions": "http://purl.org/nidash/nidm#NIDM_0000112",
+        "nidm_dimensionsInVoxels": "http://purl.org/nidash/nidm#NIDM_0000090",
+        "nlx_Imaginginstrument": "http://uri.neuinfo.org/nif/nifstd/birnlex_2094",
+        "nlx_Magneticresonanceimagingscanner": "http://uri.neuinfo.org/nif/nifstd/birnlex_2100",
+        "obo_studygrouppopulation": "http://purl.obolibrary.org/obo/STATO_0000193",
+        "nidm_groupName": "http://purl.org/nidash/nidm#NIDM_0000170",
+        "nidm_numberOfSubjects": "http://purl.org/nidash/nidm#NIDM_0000171",
+        "nidm_grandMeanScaling": "http://purl.org/nidash/nidm#NIDM_0000096",
+        "nidm_hasMRIProtocol": "http://purl.org/nidash/nidm#NIDM_0000172",
+        "nlx_FunctionalMRIprotocol": "http://uri.neuinfo.org/nif/nifstd/birnlex_2250",
+        "nidm_Data": "http://purl.org/nidash/nidm#NIDM_0000169",
+        "nidm_DesignMatrix": "http://purl.org/nidash/nidm#NIDM_0000019",
+        "nidm_regressorNames": "http://purl.org/nidash/nidm#NIDM_0000021",
+        "nidm_hasErrorDependence": "http://purl.org/nidash/nidm#NIDM_0000100",
+        "obo_unstructuredcovariancestructure": "http://purl.obolibrary.org/obo/STATO_0000405",
+        "nidm_dependenceMapWiseDependence": "http://purl.org/nidash/nidm#NIDM_0000089",
+        "nidm_ConstantParameter": "http://purl.org/nidash/nidm#NIDM_0000072",
+        "nidm_errorVarianceHomogeneous": "http://purl.org/nidash/nidm#NIDM_0000094",
+        "nidm_varianceMapWiseDependence": "http://purl.org/nidash/nidm#NIDM_0000126",
+        "nidm_IndependentParameter": "http://purl.org/nidash/nidm#NIDM_0000073",
+        "nidm_withEstimationMethod": "http://purl.org/nidash/nidm#NIDM_0000134",
+        "obo_generalizedleastsquaresestimation": "http://purl.obolibrary.org/obo/STATO_0000372",
+        "nidm_ErrorModel": "http://purl.org/nidash/nidm#NIDM_0000023",
+        "nidm_hasErrorDistribution": "http://purl.org/nidash/nidm#NIDM_0000101",
+        "obo_normaldistribution": "http://purl.obolibrary.org/obo/STATO_0000227",
+        "nidm_ModelParametersEstimation": "http://purl.org/nidash/nidm#NIDM_0000056",
+        "nidm_MaskMap": "http://purl.org/nidash/nidm#NIDM_0000054",
+        "nidm_isUserDefined": "http://purl.org/nidash/nidm#NIDM_0000106",
+        "nidm_inCoordinateSpace": "http://purl.org/nidash/nidm#NIDM_0000104",
+        "nidm_GrandMeanMap": "http://purl.org/nidash/nidm#NIDM_0000033",
+        "nidm_maskedMedian": "http://purl.org/nidash/nidm#NIDM_0000107",
+        "nidm_ParameterEstimateMap": "http://purl.org/nidash/nidm#NIDM_0000061",
+        "nidm_ResidualMeanSquaresMap": "http://purl.org/nidash/nidm#NIDM_0000066",
+        "nidm_ReselsPerVoxelMap": "http://purl.org/nidash/nidm#NIDM_0000144",
+        "obo_contrastweightmatrix": "http://purl.obolibrary.org/obo/STATO_0000323",
+        "nidm_statisticType": "http://purl.org/nidash/nidm#NIDM_0000123",
+        "obo_tstatistic": "http://purl.obolibrary.org/obo/STATO_0000176",
+        "nidm_contrastName": "http://purl.org/nidash/nidm#NIDM_0000085",
+        "nidm_ContrastEstimation": "http://purl.org/nidash/nidm#NIDM_0000001",
+        "nidm_StatisticMap": "http://purl.org/nidash/nidm#NIDM_0000076",
+        "nidm_errorDegreesOfFreedom": "http://purl.org/nidash/nidm#NIDM_0000093",
+        "nidm_effectDegreesOfFreedom": "http://purl.org/nidash/nidm#NIDM_0000091",
+        "nidm_ContrastMap": "http://purl.org/nidash/nidm#NIDM_0000002",
+        "nidm_ContrastStandardErrorMap": "http://purl.org/nidash/nidm#NIDM_0000013",
+        "obo_statistic": "http://purl.obolibrary.org/obo/STATO_0000039",
+        "nidm_PValueUncorrected": "http://purl.org/nidash/nidm#NIDM_0000160",
+        "obo_FWERadjustedpvalue": "http://purl.obolibrary.org/obo/OBI_0001265",
+        "nidm_HeightThreshold": "http://purl.org/nidash/nidm#NIDM_0000034",
+        "nidm_equivalentThreshold": "http://purl.org/nidash/nidm#NIDM_0000161",
+        "nidm_ExtentThreshold": "http://purl.org/nidash/nidm#NIDM_0000026",
+        "nidm_clusterSizeInVoxels": "http://purl.org/nidash/nidm#NIDM_0000084",
+        "nidm_clusterSizeInResels": "http://purl.org/nidash/nidm#NIDM_0000156",
+        "nidm_PeakDefinitionCriteria": "http://purl.org/nidash/nidm#NIDM_0000063",
+        "nidm_maxNumberOfPeaksPerCluster": "http://purl.org/nidash/nidm#NIDM_0000108",
+        "nidm_minDistanceBetweenPeaks": "http://purl.org/nidash/nidm#NIDM_0000109",
+        "nidm_ClusterDefinitionCriteria": "http://purl.org/nidash/nidm#NIDM_0000007",
+        "nidm_hasConnectivityCriterion": "http://purl.org/nidash/nidm#NIDM_0000099",
+        "nidm_voxel18connected": "http://purl.org/nidash/nidm#NIDM_0000128",
+        "nidm_Inference": "http://purl.org/nidash/nidm#NIDM_0000049",
+        "nidm_hasAlternativeHypothesis": "http://purl.org/nidash/nidm#NIDM_0000097",
+        "nidm_OneTailedTest": "http://purl.org/nidash/nidm#NIDM_0000060",
+        "nidm_SearchSpaceMaskMap": "http://purl.org/nidash/nidm#NIDM_0000068",
+        "nidm_searchVolumeInVoxels": "http://purl.org/nidash/nidm#NIDM_0000121",
+        "nidm_searchVolumeInUnits": "http://purl.org/nidash/nidm#NIDM_0000136",
+        "nidm_reselSizeInVoxels": "http://purl.org/nidash/nidm#NIDM_0000148",
+        "nidm_searchVolumeInResels": "http://purl.org/nidash/nidm#NIDM_0000149",
+        "spm_searchVolumeReselsGeometry": "http://purl.org/nidash/spm#SPM_0000010",
+        "nidm_noiseFWHMInVoxels": "http://purl.org/nidash/nidm#NIDM_0000159",
+        "nidm_noiseFWHMInUnits": "http://purl.org/nidash/nidm#NIDM_0000157",
+        "nidm_randomFieldStationarity": "http://purl.org/nidash/nidm#NIDM_0000120",
+        "nidm_expectedNumberOfVoxelsPerCluster": "http://purl.org/nidash/nidm#NIDM_0000143",
+        "nidm_expectedNumberOfClusters": "http://purl.org/nidash/nidm#NIDM_0000141",
+        "nidm_heightCriticalThresholdFWE05": "http://purl.org/nidash/nidm#NIDM_0000147",
+        "nidm_heightCriticalThresholdFDR05": "http://purl.org/nidash/nidm#NIDM_0000146",
+        "spm_smallestSignificantClusterSizeInVoxelsFWE05": "http://purl.org/nidash/spm#SPM_0000014",
+        "spm_smallestSignificantClusterSizeInVoxelsFDR05": "http://purl.org/nidash/spm#SPM_0000013",
+        "nidm_ExcursionSetMap": "http://purl.org/nidash/nidm#NIDM_0000025",
+        "nidm_numberOfSupraThresholdClusters": "http://purl.org/nidash/nidm#NIDM_0000111",
+        "nidm_pValue": "http://purl.org/nidash/nidm#NIDM_0000114",
+        "nidm_hasClusterLabelsMap": "http://purl.org/nidash/nidm#NIDM_0000098",
+        "nidm_hasMaximumIntensityProjection": "http://purl.org/nidash/nidm#NIDM_0000138",
+        "nidm_ClusterLabelsMap": "http://purl.org/nidash/nidm#NIDM_0000008",
+        "nidm_SupraThresholdCluster": "http://purl.org/nidash/nidm#NIDM_0000070",
+        "nidm_pValueUncorrected": "http://purl.org/nidash/nidm#NIDM_0000116",
+        "nidm_pValueFWER": "http://purl.org/nidash/nidm#NIDM_0000115",
+        "nidm_qValueFDR": "http://purl.org/nidash/nidm#NIDM_0000119",
+        "nidm_clusterLabelId": "http://purl.org/nidash/nidm#NIDM_0000082",
+        "nidm_Peak": "http://purl.org/nidash/nidm#NIDM_0000062",
+        "nidm_equivalentZStatistic": "http://purl.org/nidash/nidm#NIDM_0000092",
+        "nidm_Coordinate": "http://purl.org/nidash/nidm#NIDM_0000015",
+        "nidm_coordinateVector": "http://purl.org/nidash/nidm#NIDM_0000086"
+    },
+    "entity": {
+        "niiri:d83638bd84f027751d70f6f76d98df8c": {
+            "prov:type": {
+                "$": "nidm_CoordinateSpace:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Coordinate space 1",
+                "type": "xsd:string"
+            },
+            "nidm_voxelToWorldMapping:": {
+                "$": "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]",
+                "type": "xsd:string"
+            },
+            "nidm_voxelUnits:": {
+                "$": "[\"mm\", \"mm\", \"mm\"]",
+                "type": "xsd:string"
+            },
+            "nidm_voxelSize:": {
+                "$": "[2, 2, 2]",
+                "type": "xsd:string"
+            },
+            "nidm_inWorldCoordinateSystem:": {
+                "$": "nidm_Ixi549CoordinateSystem:",
+                "type": "xsd:string"
+            },
+            "nidm_numberOfDimensions:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_dimensionsInVoxels:": {
+                "$": "[79,95,79]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ebf54f3ce65b0dd2c55759f2bbe79bdf": {
+            "prov:type": [
+                {
+                "$": "prov:Collection",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Data:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Data",
+                "type": "xsd:string"
+            },
+            "nidm_grandMeanScaling:": {
+                "$": "false",
+                "type": "xsd:boolean"
+            },
+            "nidm_hasMRIProtocol:": {
+                "$": "nlx_FunctionalMRIprotocol:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7d3330b641d062fb9c196cfd8e54db38": {
+            "prov:type": {
+                "$": "nidm_DesignMatrix:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "DesignMatrix.csv",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "DesignMatrix.csv",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "text/csv",
+                "type": "xsd:string"
+            },
+            "dc:description": {
+                "$": "niiri:386590f5ae95ecdc71f5c902d3e1e166",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Design Matrix",
+                "type": "xsd:string"
+            },
+            "nidm_regressorNames:": {
+                "$": "[\"contrast 1 parameter 1\", \"contrast 1 parameter 2\", \"contrast 2 parameter 1\", \"contrast 2 parameter 2\"]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:386590f5ae95ecdc71f5c902d3e1e166": {
+            "prov:type": {
+                "$": "dctype:Image",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "DesignMatrix.png",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "DesignMatrix.png",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/png",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e9a458bdd39848b4367b8e1032a2eb15": {
+            "prov:type": {
+                "$": "nidm_ErrorModel:",
+                "type": "xsd:QName"
+            },
+            "nidm_hasErrorDistribution:": {
+                "$": "obo_normaldistribution:",
+                "type": "xsd:string"
+            },
+            "nidm_hasErrorDependence:": {
+                "$": "obo_unstructuredcovariancestructure:",
+                "type": "xsd:string"
+            },
+            "nidm_dependenceMapWiseDependence:": {
+                "$": "nidm_ConstantParameter:",
+                "type": "xsd:string"
+            },
+            "nidm_errorVarianceHomogeneous:": {
+                "$": "false",
+                "type": "xsd:boolean"
+            },
+            "nidm_varianceMapWiseDependence:": {
+                "$": "nidm_IndependentParameter:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e5fc1b30e25a51026dcfa20926d9a8b5": {
+            "prov:type": {
+                "$": "nidm_MaskMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "Mask.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nidm_isUserDefined:": {
+                "$": "false",
+                "type": "xsd:boolean"
+            },
+            "nfo:fileName": {
+                "$": "Mask.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Mask",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:d83638bd84f027751d70f6f76d98df8c",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "71153b4ca7e1136cf9ae9cb56eaf6a4ed494bad08a1cfa0659e8e211a36425aaf865c3def12dea06c5595662761b891c87ec7b8fa0b8b75cd31247be9418bf24",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ab891018531389a0bfea3167dd18265c": {
+            "prov:type": {
+                "$": "nidm_MaskMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "mask.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "e33feb3fddb2a3ee6d91e0b84ce0050a83414df67559e07679326fab2c31494df0a1db2d693027786c839b356626159d9158e4e9766b2bf46be4d32678f356fd",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:bbfee1c49481e576e7001347fc4d3e5f": {
+            "prov:type": {
+                "$": "nidm_GrandMeanMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "GrandMean.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "GrandMean.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Grand Mean Map",
+                "type": "xsd:string"
+            },
+            "nidm_maskedMedian:": {
+                "$": "0.0621182750910521",
+                "type": "xsd:float"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:d83638bd84f027751d70f6f76d98df8c",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "febef0110e49eb683c48b4e93acc72f110abd947f499f87d3f17cdb41d6969b2675f8e4ab3730fd052430b795a23e680633b591415016366d533eb084adc1a7d",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:62c0fd9e9f4574145bf8f023abd11fe4": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0001.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0001.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 1",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:d83638bd84f027751d70f6f76d98df8c",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "c61b294e5c1f475eed3d552bf4ae69dc19526220f069aecb338e5ad0c9359233011c6c9674b587605f343f0253dcbdf87b02f0cbd739d49fc2d41c7ee33eef6d",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:93f6ba1185b029716e107fdb65f43721": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0001.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "c61b294e5c1f475eed3d552bf4ae69dc19526220f069aecb338e5ad0c9359233011c6c9674b587605f343f0253dcbdf87b02f0cbd739d49fc2d41c7ee33eef6d",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e869e1bbd1b78977c814c1dd8eeb515b": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0002.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0002.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 2",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:d83638bd84f027751d70f6f76d98df8c",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "f5cace936fdd2fad096a30b39381b03bdbc1a29fc9377c01aeb0f68ea48bb2e2b70d39103b0303fe81f569419951830e3e122294629600910620bb2c304bc10c",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:87e1c9ecd18191661638cefe66e214f7": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0002.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "f5cace936fdd2fad096a30b39381b03bdbc1a29fc9377c01aeb0f68ea48bb2e2b70d39103b0303fe81f569419951830e3e122294629600910620bb2c304bc10c",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1c471e984c886eb1f4db8fe592efb739": {
+            "prov:type": {
+                "$": "nidm_ResidualMeanSquaresMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ResidualMeanSquares.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ResidualMeanSquares.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Residual Mean Squares Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:d83638bd84f027751d70f6f76d98df8c",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "2b2f9464f8daa548f6c3acae3219167fd598047bf3df591490515ff9dbd98e522dbe12da2d98e2022fe2a96666c200e2de31d598ef5e46dda88130a654b2ce0e",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3feb56c9ca866e36a6777a2db54698dd": {
+            "prov:type": {
+                "$": "nidm_ResidualMeanSquaresMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "ResMS.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "efe8cb9290507e9add77e43e71750dcfea22d1604e332e351c5f1aad25d8c002690d0d9a997ed771abd153811920b5ab23a7c3ca7efe3976c42cb240a6550a10",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9c5c037a27c032171a8e67f8a6148478": {
+            "prov:type": {
+                "$": "nidm_ReselsPerVoxelMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ReselsPerVoxel.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ReselsPerVoxel.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Resels per Voxel Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:d83638bd84f027751d70f6f76d98df8c",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "83ca0764c128b84c66f80535b03005c72ee62f059fa727f5631a170f473150c2d5c2df77c98c975e1b3a2ceaeb986493e126b84f7f58a5d130fc763f2f2a6561",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:88108a0984090a6e26c1358f192a8b0d": {
+            "prov:type": {
+                "$": "nidm_ReselsPerVoxelMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "RPV.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "13d0fe4049334ad44eeef1af42a998fadaa282c9f6e3937a265bdb5e544f0b63d874279d639d7e222aaa8574dd2d975a97cc869874af4457b4002f46f76b3519",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:74dd11ba88fcb33d114031941844efe5": {
+            "prov:type": {
+                "$": "obo_contrastweightmatrix:",
+                "type": "xsd:QName"
+            },
+            "nidm_statisticType:": {
+                "$": "obo_tstatistic:",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "con-01: Tone Counting vs Baseline",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast: con-01: Tone Counting vs Baseline",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "[1, 0]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e15e39f0dd016af9de756e2098156ac6": {
+            "prov:type": {
+                "$": "nidm_StatisticMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "TStatistic.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "TStatistic.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "T-Statistic Map: con-01: Tone Counting vs Baseline",
+                "type": "xsd:string"
+            },
+            "nidm_statisticType:": {
+                "$": "obo_tstatistic:",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "con-01: Tone Counting vs Baseline",
+                "type": "xsd:string"
+            },
+            "nidm_errorDegreesOfFreedom:": {
+                "$": "26",
+                "type": "xsd:float"
+            },
+            "nidm_effectDegreesOfFreedom:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:d83638bd84f027751d70f6f76d98df8c",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "2f0627a2c337fb861f93c924f355b0f55d1845db85d67af0df0ffcd353b481a129f7aeda6211c2642c52c34f2b69fbd9105a07382bf6f3942f03a126d0c98dc6",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4f69102083ed41b95cbe2de23683ac9a": {
+            "prov:type": {
+                "$": "nidm_StatisticMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "spmT_0001.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "9a89273aa6b7428f4e966921b6e64c18a08a84676c08bb01ffc76d8388734be8f17349b279db037c182ca2e63c3f64aab9828d05393712ecba11d1b60d06e4b1",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d9d5054e5ab0391c96478c3815f4efe8": {
+            "prov:type": {
+                "$": "nidm_ContrastMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "Contrast.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "Contrast.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast Map: con-01: Tone Counting vs Baseline",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "con-01: Tone Counting vs Baseline",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:d83638bd84f027751d70f6f76d98df8c",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "ce64789602c82196789a795d9bdc87c8642f8852904d7ec6507eeab7085a02d679a27ac9d3abd0025de90a3d345a7f9113dd42973901ab3f0dfac5c6b757f132",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9b6a64d84e939e0a16a135417f933c5d": {
+            "prov:type": {
+                "$": "nidm_ContrastMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "con_0001.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "9748864f2cd75c915fc9ab64800dd777de76fa4c7de3e707d7d63eab15253001ff13bd4e830bfde8b4892e379c7792e53717f5d027aaf32918542eac63c1b7d8",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3d983cf2d5c2941d0787e4df59f9fd1c": {
+            "prov:type": {
+                "$": "nidm_ContrastStandardErrorMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ContrastStandardError.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ContrastStandardError.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast Standard Error Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:d83638bd84f027751d70f6f76d98df8c",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "735c4c74cf1cbc4d46d35c5fad5f38383b336269bcf1c3edb037201f0fde4f7b2f484f042b1c711323446ac91e54cd997275616ea17c6d4ccd44df19b0f30334",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:cd2ff500c60b8721816179e10e594025": {
+            "prov:type": [
+                {
+                "$": "nidm_HeightThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_PValueUncorrected:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Height Threshold: p<0.001 (unc.)",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "0.000999500199025949",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentThreshold:": [
+                {
+                "$": "niiri:1785712a16e66d419c296ef9f90de994",
+                "type": "xsd:string"
+                },
+                {
+                "$": "niiri:b1120c03f72947c1ba4a6b8c2c3091bc",
+                "type": "xsd:string"
+                }
+            ]
+        },
+        "niiri:1785712a16e66d419c296ef9f90de994": {
+            "prov:type": [
+                {
+                "$": "nidm_HeightThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_statistic:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Height Threshold: T=3.434997)",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.43499716873599",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b1120c03f72947c1ba4a6b8c2c3091bc": {
+            "prov:type": [
+                {
+                "$": "nidm_HeightThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_FWERadjustedpvalue:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Height Threshold: p<1.000000 (FWE)",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "0.999999988250242",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:565302e93e38d1cad805021869fa4c63": {
+            "prov:type": [
+                {
+                "$": "nidm_ExtentThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_statistic:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Extent Threshold: k>=2",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0180239125412657",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentThreshold:": [
+                {
+                "$": "niiri:3969337bc7e24a8f6325c17923baaef5",
+                "type": "xsd:string"
+                },
+                {
+                "$": "niiri:e126b1f4c14b484ce3e6915191bdf447",
+                "type": "xsd:string"
+                }
+            ]
+        },
+        "niiri:3969337bc7e24a8f6325c17923baaef5": {
+            "prov:type": [
+                {
+                "$": "nidm_ExtentThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_FWERadjustedpvalue:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Extent Threshold",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "0.999994028395426",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e126b1f4c14b484ce3e6915191bdf447": {
+            "prov:type": [
+                {
+                "$": "nidm_ExtentThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_PValueUncorrected:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Extent Threshold",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "0.658755107945733",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:20b1c1ee5c6652d4fceb06ebc0cab294": {
+            "prov:type": {
+                "$": "nidm_PeakDefinitionCriteria:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak Definition Criteria",
+                "type": "xsd:string"
+            },
+            "nidm_maxNumberOfPeaksPerCluster:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_minDistanceBetweenPeaks:": {
+                "$": "8",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:23547207d6c2d262d31d7e9e04b6f749": {
+            "prov:type": {
+                "$": "nidm_ClusterDefinitionCriteria:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Cluster Connectivity Criterion: 18",
+                "type": "xsd:string"
+            },
+            "nidm_hasConnectivityCriterion:": {
+                "$": "nidm_voxel18connected:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d86d3799879abef252a01c01223937d2": {
+            "prov:type": {
+                "$": "nidm_SearchSpaceMaskMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "SearchSpaceMask.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "SearchSpaceMask.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Search Space Mask Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:d83638bd84f027751d70f6f76d98df8c",
+                "type": "xsd:string"
+            },
+            "nidm_searchVolumeInVoxels:": {
+                "$": "160902",
+                "type": "xsd:int"
+            },
+            "nidm_searchVolumeInUnits:": {
+                "$": "1287216",
+                "type": "xsd:float"
+            },
+            "nidm_reselSizeInVoxels:": {
+                "$": "110.963698665371",
+                "type": "xsd:float"
+            },
+            "nidm_searchVolumeInResels:": {
+                "$": "1330.17375750168",
+                "type": "xsd:float"
+            },
+            "spm_searchVolumeReselsGeometry:": {
+                "$": "[1, 55.7614198833958, 565.293338923842, 1330.17375750168]",
+                "type": "xsd:string"
+            },
+            "nidm_noiseFWHMInVoxels:": {
+                "$": "[4.79328133251054, 4.70290149875436, 4.92245916235795]",
+                "type": "xsd:string"
+            },
+            "nidm_noiseFWHMInUnits:": {
+                "$": "[9.58656266502107, 9.40580299750872, 9.84491832471589]",
+                "type": "xsd:string"
+            },
+            "nidm_randomFieldStationarity:": {
+                "$": "true",
+                "type": "xsd:boolean"
+            },
+            "nidm_expectedNumberOfVoxelsPerCluster:": {
+                "$": "9.85898447296652",
+                "type": "xsd:float"
+            },
+            "nidm_expectedNumberOfClusters:": {
+                "$": "12.0284948937186",
+                "type": "xsd:float"
+            },
+            "nidm_heightCriticalThresholdFWE05:": {
+                "$": "6.37244381118871",
+                "type": "xsd:float"
+            },
+            "nidm_heightCriticalThresholdFDR05:": {
+                "$": "5.5216121673584",
+                "type": "xsd:float"
+            },
+            "crypto:sha512": {
+                "$": "71153b4ca7e1136cf9ae9cb56eaf6a4ed494bad08a1cfa0659e8e211a36425aaf865c3def12dea06c5595662761b891c87ec7b8fa0b8b75cd31247be9418bf24",
+                "type": "xsd:string"
+            },
+            "spm_smallestSignificantClusterSizeInVoxelsFWE05:": {
+                "$": "186",
+                "type": "xsd:int"
+            },
+            "spm_smallestSignificantClusterSizeInVoxelsFDR05:": {
+                "$": "186",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:fd051605e8c7f96825de2e8c362f619d": {
+            "prov:type": {
+                "$": "nidm_ExcursionSetMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ExcursionSet.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ExcursionSet.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Excursion Set Map",
+                "type": "xsd:string"
+            },
+            "nidm_numberOfSupraThresholdClusters:": {
+                "$": "19",
+                "type": "xsd:int"
+            },
+            "nidm_pValue:": {
+                "$": "0.0381497273362531",
+                "type": "xsd:float"
+            },
+            "nidm_hasClusterLabelsMap:": {
+                "$": "niiri:52de7dcded23dd4a1fd932012d60b81c",
+                "type": "xsd:string"
+            },
+            "nidm_hasMaximumIntensityProjection:": {
+                "$": "niiri:3f22616908b033819a3786fde1496cc7",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:d83638bd84f027751d70f6f76d98df8c",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "048ef4d6ee2e4fd5c85757968e6d5feccfeec3292d691e3e32b4f2553d501813397bb83e7f5616a808f0068c6d3e8f1309654d9f1239e0bab1fea410dcd9cb78",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:52de7dcded23dd4a1fd932012d60b81c": {
+            "prov:type": {
+                "$": "nidm_ClusterLabelsMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ClusterLabels.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ClusterLabels.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Cluster Labels Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:d83638bd84f027751d70f6f76d98df8c",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "f90fdcd70484a1e73a009d9b568825514b14190ee02ea8c61ea7e206dcb5f9b6dfde3931dbc3f4feb1cd358ca0307835fc90b319ab92667eb8af56ef628f5c87",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3f22616908b033819a3786fde1496cc7": {
+            "prov:type": {
+                "$": "dctype:Image",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "MaximumIntensityProjection.png",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "MaximumIntensityProjection.png",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/png",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:01ec637797471e97b81c59d553918fe2": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0001",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1264",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "11.3911127260799",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.46564319955646e-14",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "8.15347789284715e-13",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "9.37785071906856e-13",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "1",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:dc195d458077541582f78033d188351e": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0002",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "273",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "2.46026406188276",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.56401134673758e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.000285538833242782",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "5.47403971358153e-05",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "2",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:125236b3b8db9c4f2b7d390d441d3c18": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0003",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "645",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "5.81271179455818",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.98550701476426e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "5.45136644714006e-08",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "2.08985491033498e-08",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "3",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c7407836fb981de7ef9a1ccaad77eec7": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0004",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "252",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "2.27101298019947",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.77946923942363e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.000507386565178569",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "8.33840771827089e-05",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "4",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:6efb738cf8ae66818b93292de14c66bf": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0005",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "649",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "5.84875961964071",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.7530178167288e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "5.02685436609696e-08",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "2.08985491033498e-08",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "5",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:688ca92e605ac76835652ec4e94cc704": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0006",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "543",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "4.89349225495363",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.50784594384806e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "4.57918350238451e-07",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1.31661912052023e-07",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "6",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:68da208642972437b835af6ed59a660c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0007",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "312",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "2.81173035643744",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.58221623295473e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00010192290996347",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "2.34453081784098e-05",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "7",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f8507bdcacd86027fdafd6fd60ba6874": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0008",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "15",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.135179344059493",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.202037711367992",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.975005365474947",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.353565994893987",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "8",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:d2ca51b89db2e3b1111d7fdbfda64417": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0009",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "186",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.67622386633771",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000190098018775023",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00346506483545928",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000499007299284434",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "9",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:93024a65786df3d21c3afeb2157fda29": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0010",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "32",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.288382600660251",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0706267334937813",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.724620221938759",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.148316140336941",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "10",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:035c0aba4276188a1f52052646ae7120": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0011",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "26",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.234310863036454",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0994868758856398",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.837418191223327",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.189929490327131",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "11",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:2dc499c816a88d424858df07e367da38": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0012",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "12",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.108143475247594",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.252022793965942",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.989966174793775",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.407113744098829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "12",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:809e973106f074b8b57288f78176fadb": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0013",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "33",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.297394556930884",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0668517070898811",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.704968833899269",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.148316140336941",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "13",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:23280aef5e15fc151595ade28a75778f": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0014",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "10",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0901195627063283",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.29508405850199",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.995429202843773",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.442626087752986",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "14",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:a724fab477e1c34dff00939c8a5fe1d9": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0015",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0360478250825313",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.515516155678853",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99991834706655",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.601435514958662",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "15",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:e8d2cf34f04ba64f58f96a3bd57989a0": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0016",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "6",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.054071737623797",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.419692024215448",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999530263417872",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.587568833901628",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "16",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:b073888acef337b87afb0a3f49356435": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0017",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0180239125412657",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.658755107945733",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999994028395426",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.728097750887389",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "17",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:24cb62d0bb1e202be98184cc8d05dffd": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0018",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "5",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0450597813531642",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.4635394969871",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99978906667809",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.601435514958662",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "18",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:824d90300b93425516b70315d9d6f976": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0019",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0360478250825313",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.515516155678853",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99991834706655",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.601435514958662",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "19",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:4b1128660a9a6cee4015a8ff88a80c95": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0001",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:df9bb709e4b052129d18485666595240",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "8.68328475952148",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.89806475543002",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.83894821592645e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.000295890410111577",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00163136813750933",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:df9bb709e4b052129d18485666595240": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0001",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-8,14,44]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:12441664c05631bc80a5589022113423": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0002",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c985252a616227b4de321a67cafc5e9f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "7.33630895614624",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.35354564681114",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.31236324427431e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00693867881448451",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00719550144323139",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c985252a616227b4de321a67cafc5e9f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0002",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-2,8,62]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f35b60f8e0364a64a0d746c299ac0db6": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0003",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e169aecc5f1ea00016ee1e9750c0f735",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.84883069992065",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.13238708590925",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.43045180589496e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0188976197165134",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00835884069841993",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e169aecc5f1ea00016ee1e9750c0f735": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0003",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[8,2,66]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ec7ddf4786fe39f9182536fea466833e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0004",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d54e6ad7e6488168ce22f8734b7eb5f5",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "8.35158634185791",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.77222915803918",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.9114812500074e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.000629365120361269",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00163136813750933",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d54e6ad7e6488168ce22f8734b7eb5f5": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0004",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-46,-4,54]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:beae26e50fc3b9b6095ec0cf978aa74d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0005",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a86b051d7b52ab721f5e5175d20d7eae",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.98639822006226",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.19623635430538",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.01681835729117e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0142675592490157",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00719550144323139",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a86b051d7b52ab721f5e5175d20d7eae": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0005",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-52,-4,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:78a7e02e1865904a3962e95d6e770a76": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0006",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c0d5c03cc49d0e30483f9a8ad3fc7ed6",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.94789028167725",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.11595434674584",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.92790313852109e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.632970462914878",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.106458926829394",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c0d5c03cc49d0e30483f9a8ad3fc7ed6": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0006",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-44,0,36]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:606a12f8dfe1e04b3697ef1eebb14808": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0007",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:3a24858e4f675f4ceec3345587d30aef",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "7.1633768081665",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.27669699963205",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.57665507608485e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00994759733633388",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00719550144323139",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3a24858e4f675f4ceec3345587d30aef": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0007",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-28,20,4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3d611934585d07a97bc5d3fb0a2ae75a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0008",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4c0f3c362a6a4ca000f2e45782ca92d7",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.05753993988037",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.74136371640284",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.06142217415339e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0943293570611123",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0289398009003969",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4c0f3c362a6a4ca000f2e45782ca92d7": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0008",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-32,12,12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:81261cd464ee0b8f22adca3c75f049a3": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0009",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:9460d662c65847aeccb65dca7370d87b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.53688049316406",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.4599738348881",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.09848297133752e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.255369959741091",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0463937463013495",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:9460d662c65847aeccb65dca7370d87b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0009",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-40,14,6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:809e45a8f97c7742d22d07c42e436b9b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0010",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:2d0c2f8f914e3950001f5780fda6d7c5",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "7.03751659393311",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.21966850947269",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.96218316226438e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0128544751144342",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00719550144323139",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:2d0c2f8f914e3950001f5780fda6d7c5": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0010",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[54,0,46]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7d6282c527edd4b542c265187c6fc7a9": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0011",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c5ba100f71d6acc1ce64b2c2026b9ad4",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.67526912689209",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.94678957573653",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.96030553606597e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.826020447766485",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.175133460202579",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c5ba100f71d6acc1ce64b2c2026b9ad4": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0011",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[42,0,40]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e122dfd8cae44bf9b1c9068c52fbb1fd": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0012",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:88eb1ce70078217da9ad80ffbff952c8",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.99186444282532",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.49308716519441",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000238735314068705",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.998766388576126",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.467639377242474",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:88eb1ce70078217da9ad80ffbff952c8": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0012",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[50,4,38]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:10f6bffbb03110c4e326855f654c7053": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0013",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:09bc6e573433407ff8167fd0ec8c3554",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.17448043823242",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.80182851023383",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.86116573836537e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0746359690709463",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0247162735389005",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:09bc6e573433407ff8167fd0ec8c3554": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0013",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[64,-32,14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c4779e84dce494937bda818ef5e669dc": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0014",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ecbd626ad6f08df3e710715c3e5284c2",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.78444290161133",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.59630541537731",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.15024103455974e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.161036372633912",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0384651426630127",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ecbd626ad6f08df3e710715c3e5284c2": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0014",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[54,-36,6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:844b498ab06280ebbe9ee9dceb2a5d16": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0015",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6be9818fbe27aa7823d210572c66e57f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.29158926010132",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.32015757237268",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.79589134014547e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.3885997605562",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0663265650293897",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6be9818fbe27aa7823d210572c66e57f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0015",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[58,-18,-4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3e533998c00bcb7174e1ff58abee7b36": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0016",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:724b45d5eea6ea672d1a7c6765b84433",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.80037450790405",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.60491906158358",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.06313156536631e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.156185504689616",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0384651426630127",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:724b45d5eea6ea672d1a7c6765b84433": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0016",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[32,18,6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3df0e6a6a8d15f376ef1ad04904ac285": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0017",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:688e14ec89daea4fe959e58361ee58a1",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.65365648269653",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.52486817583008",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.02165810672772e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.206207182279971",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0404714050465719",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:688e14ec89daea4fe959e58361ee58a1": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0017",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[46,14,2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:820ea5e2cac41f9259686ca8892a5878": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0018",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a89e043e86acf22adbef2c908f0c940a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.97042274475098",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.12964691442442",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.81660388410831e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.61591975617624",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.106458926829394",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a89e043e86acf22adbef2c908f0c940a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0018",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[52,6,20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:efbc436a1b3678612dfe7f44dd10cbb3": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0019",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:397d2866425d1c295696d0c818d8d533",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.69512796401978",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.54766136430568",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.71226629111609e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.190809496629972",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0390573552317814",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:397d2866425d1c295696d0c818d8d533": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0019",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-50,-44,10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:22dcde4b50ff0337757a88138a5b07fc": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0020",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:36fb849d4a7b16b57fbc1cd5f7c305fc",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.58639812469482",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.89022248971066",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.00761765690472e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.876622606435302",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.203731029267221",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:36fb849d4a7b16b57fbc1cd5f7c305fc": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0020",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-62,-36,8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:880b4afc515a88ebc3cf045d50f3c04a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0021",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:31ed78344a2ca5c440cba467b3a898d7",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.50590515136719",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.83837298746928",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.19261255102588e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.914499359553669",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.232964826348096",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:31ed78344a2ca5c440cba467b3a898d7": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0021",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-44,-40,20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9dbf2c151d9034e9c4371c30e60411e3": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0022",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:622423e8bf7e3d7bd7479503b8fd3628",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.32945966720581",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.34205915406457",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.05767571707039e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.36535430900768",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0637479979695797",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:622423e8bf7e3d7bd7479503b8fd3628": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0022",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-66,-24,8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3826db9e7668227e2a63e832d3c39701": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0023",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:950862f883bf950f211e73006d0c3c3b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.2721529006958",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.30887158779036",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.20448008320707e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.400892212456252",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0665066282431519",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:950862f883bf950f211e73006d0c3c3b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0023",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[54,-36,46]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:24a0a14bebf270cbe73d80ce97ec4c02": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0024",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:16aaa501641c95b0ce42d11047b7fdc4",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.94992017745972",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.11718966304234",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.91760222628679e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.631434661064485",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.106458926829394",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:16aaa501641c95b0ce42d11047b7fdc4": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0024",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[46,-34,42]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0449dda97bea02c246854d99b1b7adbc": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0025",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:987a7b2248b42a3a490d2504cc7e0bf3",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.14882755279541",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.60116037131659",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000158400037829631",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.993008812777799",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.370124878111002",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:987a7b2248b42a3a490d2504cc7e0bf3": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0025",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[36,-46,44]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5eb503813e71b696ec059c3e6a0dd7ef": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0026",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:468734efebc03b0fde1d35df7a8d7b49",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.48920822143555",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.82754387575664",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.47141590200961e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.921344159854026",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.23453068077853",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:468734efebc03b0fde1d35df7a8d7b49": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0026",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-40,10,24]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:27662f80703bab4a958c6b33e1a93fa5": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0027",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:182b7c17f02d49bfc8b89cab22dea1a6",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.37462282180786",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.75253736275656",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.75268659427109e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.958943515151384",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.266450161314934",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:182b7c17f02d49bfc8b89cab22dea1a6": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0027",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[32,-56,-30]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:fe8f5b1d1a7cdd89fdd7e2417cf26341": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0028",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:8612b501b0e12b2f40a16e10ca523880",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.34167242050171",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.7307439273808",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "9.54575986388262e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.966870324720423",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.275753173611261",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:8612b501b0e12b2f40a16e10ca523880": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0028",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-8,20,24]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1b3dd6f8432d3e63adbf5a0aabd4bcc1": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0029",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:90eb444d756e7ff76c9ab977424e6c7b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.3336443901062",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.72541890112066",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "9.74955684317491e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.968621393833285",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.275753173611261",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:90eb444d756e7ff76c9ab977424e6c7b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0029",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[44,38,32]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6622c9c5a5bb5602bc2abeed125325ac": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0030",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:48847d4df5d31de03d50ecd410917b09",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.9835045337677",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.48726495012002",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000243993830123412",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.998891092669635",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.467639377242474",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:48847d4df5d31de03d50ecd410917b09": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0030",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-24,-60,-26]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b184da69003b59767f569647a73c0639": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0031",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c29572676342be86d47e0a7b8ed38732",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.79263067245483",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.35249275717611",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000400436684482419",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999938961389732",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.654094205846141",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c29572676342be86d47e0a7b8ed38732": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0031",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-30,-4,38]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:49e0945fb482cd7b911f2227ceae482f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0032",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:eca01472aea0f0dbd8b94e3e34cd3adc",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.77775311470032",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.34183922268213",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000416126261860494",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999953291766866",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.659449024484444",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:eca01472aea0f0dbd8b94e3e34cd3adc": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0032",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-62,-6,22]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c7dd5a67fe812c0fdcc362965b494898": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0033",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e81d57070082ea2bc67d444e23ad6afe",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.67259907722473",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.26592297145681",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000545539621777169",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999994214217906",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.754841581701232",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e81d57070082ea2bc67d444e23ad6afe": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0033",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-12,-4,4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:84fe5a575cee1440542c990cbf711859": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0034",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7f4fe1df385012266fd6803d3c1079dd",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.66031455993652",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.25698339309234",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000563015103086872",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999995573785363",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.75806989081408",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7f4fe1df385012266fd6803d3c1079dd": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0034",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[38,4,60]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9a32238eb2863717896fffb10d326e05": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0035",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e0df16fae31adde7b1b374630cfb3683",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.63292980194092",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.23700181949284",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000603963207952862",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999997609889049",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.782238022186136",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e0df16fae31adde7b1b374630cfb3683": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0035",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-28,2,38]",
+                "type": "xsd:string"
+            }
+        }
+    },
+    "activity": {
+        "niiri:8b0939c3dda9d8de649d9f6287d600b5": {
+            "prov:type": {
+                "$": "nidm_ModelParametersEstimation:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Model parameters estimation",
+                "type": "xsd:string"
+            },
+            "nidm_withEstimationMethod:": {
+                "$": "obo_generalizedleastsquaresestimation:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:baf1b57a546d4407c295095b2880878b": {
+            "prov:type": {
+                "$": "nidm_ContrastEstimation:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Contrast estimation",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b65d1dde00468cfdc0b2c5c7b16aca85": {
+            "prov:type": {
+                "$": "nidm_Inference:",
+                "type": "xsd:QName"
+            },
+            "nidm_hasAlternativeHypothesis:": {
+                "$": "nidm_OneTailedTest:",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Inference",
+                "type": "xsd:string"
+            }
+        }
+    },
+    "agent": {
+        "niiri:cc07a0149337deefc011f6391ad99352": {
+            "prov:type": [
+                {
+                "$": "src_SPM:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "prov:SoftwareAgent",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "SPM",
+                "type": "xsd:string"
+            },
+            "nidm_softwareVersion:": {
+                "$": "12.6906",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d451d187aabd4470aaaa9ac9338d71f7": {
+            "prov:type": [
+                {
+                "$": "nlx_Imaginginstrument:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nlx_Magneticresonanceimagingscanner:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "MRI Scanner",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1d560f0e3dff39ddf2bbd35fbea493df": {
+            "prov:type": {
+                "$": "obo_studygrouppopulation:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Group: Control",
+                "type": "xsd:string"
+            },
+            "nidm_groupName:": {
+                "$": "Control",
+                "type": "xsd:string"
+            },
+            "nidm_numberOfSubjects:": {
+                "$": "14",
+                "type": "xsd:int"
+            }
+        }
+    },
+    "wasGeneratedBy": {
+        "_:wGB19": {
+            "prov:entity": "niiri:e5fc1b30e25a51026dcfa20926d9a8b5",
+            "prov:activity": "niiri:8b0939c3dda9d8de649d9f6287d600b5"
+        },
+        "_:wGB21": {
+            "prov:entity": "niiri:bbfee1c49481e576e7001347fc4d3e5f",
+            "prov:activity": "niiri:8b0939c3dda9d8de649d9f6287d600b5"
+        },
+        "_:wGB25": {
+            "prov:entity": "niiri:62c0fd9e9f4574145bf8f023abd11fe4",
+            "prov:activity": "niiri:8b0939c3dda9d8de649d9f6287d600b5"
+        },
+        "_:wGB29": {
+            "prov:entity": "niiri:e869e1bbd1b78977c814c1dd8eeb515b",
+            "prov:activity": "niiri:8b0939c3dda9d8de649d9f6287d600b5"
+        },
+        "_:wGB33": {
+            "prov:entity": "niiri:1c471e984c886eb1f4db8fe592efb739",
+            "prov:activity": "niiri:8b0939c3dda9d8de649d9f6287d600b5"
+        },
+        "_:wGB37": {
+            "prov:entity": "niiri:9c5c037a27c032171a8e67f8a6148478",
+            "prov:activity": "niiri:8b0939c3dda9d8de649d9f6287d600b5"
+        },
+        "_:wGB50": {
+            "prov:entity": "niiri:e15e39f0dd016af9de756e2098156ac6",
+            "prov:activity": "niiri:baf1b57a546d4407c295095b2880878b"
+        },
+        "_:wGB54": {
+            "prov:entity": "niiri:d9d5054e5ab0391c96478c3815f4efe8",
+            "prov:activity": "niiri:baf1b57a546d4407c295095b2880878b"
+        },
+        "_:wGB56": {
+            "prov:entity": "niiri:3d983cf2d5c2941d0787e4df59f9fd1c",
+            "prov:activity": "niiri:baf1b57a546d4407c295095b2880878b"
+        },
+        "_:wGB75": {
+            "prov:entity": "niiri:d86d3799879abef252a01c01223937d2",
+            "prov:activity": "niiri:b65d1dde00468cfdc0b2c5c7b16aca85"
+        },
+        "_:wGB79": {
+            "prov:entity": "niiri:fd051605e8c7f96825de2e8c362f619d",
+            "prov:activity": "niiri:b65d1dde00468cfdc0b2c5c7b16aca85"
+        }
+    },
+    "used": {
+        "_:u13": {
+            "prov:activity": "niiri:8b0939c3dda9d8de649d9f6287d600b5",
+            "prov:entity": "niiri:7d3330b641d062fb9c196cfd8e54db38"
+        },
+        "_:u14": {
+            "prov:activity": "niiri:8b0939c3dda9d8de649d9f6287d600b5",
+            "prov:entity": "niiri:ebf54f3ce65b0dd2c55759f2bbe79bdf"
+        },
+        "_:u15": {
+            "prov:activity": "niiri:8b0939c3dda9d8de649d9f6287d600b5",
+            "prov:entity": "niiri:e9a458bdd39848b4367b8e1032a2eb15"
+        },
+        "_:u41": {
+            "prov:activity": "niiri:baf1b57a546d4407c295095b2880878b",
+            "prov:entity": "niiri:e5fc1b30e25a51026dcfa20926d9a8b5"
+        },
+        "_:u42": {
+            "prov:activity": "niiri:baf1b57a546d4407c295095b2880878b",
+            "prov:entity": "niiri:1c471e984c886eb1f4db8fe592efb739"
+        },
+        "_:u43": {
+            "prov:activity": "niiri:baf1b57a546d4407c295095b2880878b",
+            "prov:entity": "niiri:7d3330b641d062fb9c196cfd8e54db38"
+        },
+        "_:u44": {
+            "prov:activity": "niiri:baf1b57a546d4407c295095b2880878b",
+            "prov:entity": "niiri:74dd11ba88fcb33d114031941844efe5"
+        },
+        "_:u45": {
+            "prov:activity": "niiri:baf1b57a546d4407c295095b2880878b",
+            "prov:entity": "niiri:62c0fd9e9f4574145bf8f023abd11fe4"
+        },
+        "_:u46": {
+            "prov:activity": "niiri:baf1b57a546d4407c295095b2880878b",
+            "prov:entity": "niiri:e869e1bbd1b78977c814c1dd8eeb515b"
+        },
+        "_:u67": {
+            "prov:activity": "niiri:b65d1dde00468cfdc0b2c5c7b16aca85",
+            "prov:entity": "niiri:cd2ff500c60b8721816179e10e594025"
+        },
+        "_:u68": {
+            "prov:activity": "niiri:b65d1dde00468cfdc0b2c5c7b16aca85",
+            "prov:entity": "niiri:565302e93e38d1cad805021869fa4c63"
+        },
+        "_:u69": {
+            "prov:activity": "niiri:b65d1dde00468cfdc0b2c5c7b16aca85",
+            "prov:entity": "niiri:e15e39f0dd016af9de756e2098156ac6"
+        },
+        "_:u70": {
+            "prov:activity": "niiri:b65d1dde00468cfdc0b2c5c7b16aca85",
+            "prov:entity": "niiri:9c5c037a27c032171a8e67f8a6148478"
+        },
+        "_:u71": {
+            "prov:activity": "niiri:b65d1dde00468cfdc0b2c5c7b16aca85",
+            "prov:entity": "niiri:e5fc1b30e25a51026dcfa20926d9a8b5"
+        },
+        "_:u72": {
+            "prov:activity": "niiri:b65d1dde00468cfdc0b2c5c7b16aca85",
+            "prov:entity": "niiri:20b1c1ee5c6652d4fceb06ebc0cab294"
+        },
+        "_:u73": {
+            "prov:activity": "niiri:b65d1dde00468cfdc0b2c5c7b16aca85",
+            "prov:entity": "niiri:23547207d6c2d262d31d7e9e04b6f749"
+        }
+    },
+    "wasDerivedFrom": {
+        "_:wDF18": {
+            "prov:generatedEntity": "niiri:e5fc1b30e25a51026dcfa20926d9a8b5",
+            "prov:usedEntity": "niiri:ab891018531389a0bfea3167dd18265c"
+        },
+        "_:wDF24": {
+            "prov:generatedEntity": "niiri:62c0fd9e9f4574145bf8f023abd11fe4",
+            "prov:usedEntity": "niiri:93f6ba1185b029716e107fdb65f43721"
+        },
+        "_:wDF28": {
+            "prov:generatedEntity": "niiri:e869e1bbd1b78977c814c1dd8eeb515b",
+            "prov:usedEntity": "niiri:87e1c9ecd18191661638cefe66e214f7"
+        },
+        "_:wDF32": {
+            "prov:generatedEntity": "niiri:1c471e984c886eb1f4db8fe592efb739",
+            "prov:usedEntity": "niiri:3feb56c9ca866e36a6777a2db54698dd"
+        },
+        "_:wDF36": {
+            "prov:generatedEntity": "niiri:9c5c037a27c032171a8e67f8a6148478",
+            "prov:usedEntity": "niiri:88108a0984090a6e26c1358f192a8b0d"
+        },
+        "_:wDF49": {
+            "prov:generatedEntity": "niiri:e15e39f0dd016af9de756e2098156ac6",
+            "prov:usedEntity": "niiri:4f69102083ed41b95cbe2de23683ac9a"
+        },
+        "_:wDF53": {
+            "prov:generatedEntity": "niiri:d9d5054e5ab0391c96478c3815f4efe8",
+            "prov:usedEntity": "niiri:9b6a64d84e939e0a16a135417f933c5d"
+        },
+        "_:wDF81": {
+            "prov:generatedEntity": "niiri:01ec637797471e97b81c59d553918fe2",
+            "prov:usedEntity": "niiri:fd051605e8c7f96825de2e8c362f619d"
+        },
+        "_:wDF83": {
+            "prov:generatedEntity": "niiri:dc195d458077541582f78033d188351e",
+            "prov:usedEntity": "niiri:fd051605e8c7f96825de2e8c362f619d"
+        },
+        "_:wDF85": {
+            "prov:generatedEntity": "niiri:125236b3b8db9c4f2b7d390d441d3c18",
+            "prov:usedEntity": "niiri:fd051605e8c7f96825de2e8c362f619d"
+        },
+        "_:wDF87": {
+            "prov:generatedEntity": "niiri:c7407836fb981de7ef9a1ccaad77eec7",
+            "prov:usedEntity": "niiri:fd051605e8c7f96825de2e8c362f619d"
+        },
+        "_:wDF89": {
+            "prov:generatedEntity": "niiri:6efb738cf8ae66818b93292de14c66bf",
+            "prov:usedEntity": "niiri:fd051605e8c7f96825de2e8c362f619d"
+        },
+        "_:wDF91": {
+            "prov:generatedEntity": "niiri:688ca92e605ac76835652ec4e94cc704",
+            "prov:usedEntity": "niiri:fd051605e8c7f96825de2e8c362f619d"
+        },
+        "_:wDF93": {
+            "prov:generatedEntity": "niiri:68da208642972437b835af6ed59a660c",
+            "prov:usedEntity": "niiri:fd051605e8c7f96825de2e8c362f619d"
+        },
+        "_:wDF95": {
+            "prov:generatedEntity": "niiri:f8507bdcacd86027fdafd6fd60ba6874",
+            "prov:usedEntity": "niiri:fd051605e8c7f96825de2e8c362f619d"
+        },
+        "_:wDF97": {
+            "prov:generatedEntity": "niiri:d2ca51b89db2e3b1111d7fdbfda64417",
+            "prov:usedEntity": "niiri:fd051605e8c7f96825de2e8c362f619d"
+        },
+        "_:wDF99": {
+            "prov:generatedEntity": "niiri:93024a65786df3d21c3afeb2157fda29",
+            "prov:usedEntity": "niiri:fd051605e8c7f96825de2e8c362f619d"
+        },
+        "_:wDF101": {
+            "prov:generatedEntity": "niiri:035c0aba4276188a1f52052646ae7120",
+            "prov:usedEntity": "niiri:fd051605e8c7f96825de2e8c362f619d"
+        },
+        "_:wDF103": {
+            "prov:generatedEntity": "niiri:2dc499c816a88d424858df07e367da38",
+            "prov:usedEntity": "niiri:fd051605e8c7f96825de2e8c362f619d"
+        },
+        "_:wDF105": {
+            "prov:generatedEntity": "niiri:809e973106f074b8b57288f78176fadb",
+            "prov:usedEntity": "niiri:fd051605e8c7f96825de2e8c362f619d"
+        },
+        "_:wDF107": {
+            "prov:generatedEntity": "niiri:23280aef5e15fc151595ade28a75778f",
+            "prov:usedEntity": "niiri:fd051605e8c7f96825de2e8c362f619d"
+        },
+        "_:wDF109": {
+            "prov:generatedEntity": "niiri:a724fab477e1c34dff00939c8a5fe1d9",
+            "prov:usedEntity": "niiri:fd051605e8c7f96825de2e8c362f619d"
+        },
+        "_:wDF111": {
+            "prov:generatedEntity": "niiri:e8d2cf34f04ba64f58f96a3bd57989a0",
+            "prov:usedEntity": "niiri:fd051605e8c7f96825de2e8c362f619d"
+        },
+        "_:wDF113": {
+            "prov:generatedEntity": "niiri:b073888acef337b87afb0a3f49356435",
+            "prov:usedEntity": "niiri:fd051605e8c7f96825de2e8c362f619d"
+        },
+        "_:wDF115": {
+            "prov:generatedEntity": "niiri:24cb62d0bb1e202be98184cc8d05dffd",
+            "prov:usedEntity": "niiri:fd051605e8c7f96825de2e8c362f619d"
+        },
+        "_:wDF117": {
+            "prov:generatedEntity": "niiri:824d90300b93425516b70315d9d6f976",
+            "prov:usedEntity": "niiri:fd051605e8c7f96825de2e8c362f619d"
+        },
+        "_:wDF120": {
+            "prov:generatedEntity": "niiri:4b1128660a9a6cee4015a8ff88a80c95",
+            "prov:usedEntity": "niiri:01ec637797471e97b81c59d553918fe2"
+        },
+        "_:wDF123": {
+            "prov:generatedEntity": "niiri:12441664c05631bc80a5589022113423",
+            "prov:usedEntity": "niiri:01ec637797471e97b81c59d553918fe2"
+        },
+        "_:wDF126": {
+            "prov:generatedEntity": "niiri:f35b60f8e0364a64a0d746c299ac0db6",
+            "prov:usedEntity": "niiri:01ec637797471e97b81c59d553918fe2"
+        },
+        "_:wDF129": {
+            "prov:generatedEntity": "niiri:ec7ddf4786fe39f9182536fea466833e",
+            "prov:usedEntity": "niiri:dc195d458077541582f78033d188351e"
+        },
+        "_:wDF132": {
+            "prov:generatedEntity": "niiri:beae26e50fc3b9b6095ec0cf978aa74d",
+            "prov:usedEntity": "niiri:dc195d458077541582f78033d188351e"
+        },
+        "_:wDF135": {
+            "prov:generatedEntity": "niiri:78a7e02e1865904a3962e95d6e770a76",
+            "prov:usedEntity": "niiri:dc195d458077541582f78033d188351e"
+        },
+        "_:wDF138": {
+            "prov:generatedEntity": "niiri:606a12f8dfe1e04b3697ef1eebb14808",
+            "prov:usedEntity": "niiri:125236b3b8db9c4f2b7d390d441d3c18"
+        },
+        "_:wDF141": {
+            "prov:generatedEntity": "niiri:3d611934585d07a97bc5d3fb0a2ae75a",
+            "prov:usedEntity": "niiri:125236b3b8db9c4f2b7d390d441d3c18"
+        },
+        "_:wDF144": {
+            "prov:generatedEntity": "niiri:81261cd464ee0b8f22adca3c75f049a3",
+            "prov:usedEntity": "niiri:125236b3b8db9c4f2b7d390d441d3c18"
+        },
+        "_:wDF147": {
+            "prov:generatedEntity": "niiri:809e45a8f97c7742d22d07c42e436b9b",
+            "prov:usedEntity": "niiri:c7407836fb981de7ef9a1ccaad77eec7"
+        },
+        "_:wDF150": {
+            "prov:generatedEntity": "niiri:7d6282c527edd4b542c265187c6fc7a9",
+            "prov:usedEntity": "niiri:c7407836fb981de7ef9a1ccaad77eec7"
+        },
+        "_:wDF153": {
+            "prov:generatedEntity": "niiri:e122dfd8cae44bf9b1c9068c52fbb1fd",
+            "prov:usedEntity": "niiri:c7407836fb981de7ef9a1ccaad77eec7"
+        },
+        "_:wDF156": {
+            "prov:generatedEntity": "niiri:10f6bffbb03110c4e326855f654c7053",
+            "prov:usedEntity": "niiri:6efb738cf8ae66818b93292de14c66bf"
+        },
+        "_:wDF159": {
+            "prov:generatedEntity": "niiri:c4779e84dce494937bda818ef5e669dc",
+            "prov:usedEntity": "niiri:6efb738cf8ae66818b93292de14c66bf"
+        },
+        "_:wDF162": {
+            "prov:generatedEntity": "niiri:844b498ab06280ebbe9ee9dceb2a5d16",
+            "prov:usedEntity": "niiri:6efb738cf8ae66818b93292de14c66bf"
+        },
+        "_:wDF165": {
+            "prov:generatedEntity": "niiri:3e533998c00bcb7174e1ff58abee7b36",
+            "prov:usedEntity": "niiri:688ca92e605ac76835652ec4e94cc704"
+        },
+        "_:wDF168": {
+            "prov:generatedEntity": "niiri:3df0e6a6a8d15f376ef1ad04904ac285",
+            "prov:usedEntity": "niiri:688ca92e605ac76835652ec4e94cc704"
+        },
+        "_:wDF171": {
+            "prov:generatedEntity": "niiri:820ea5e2cac41f9259686ca8892a5878",
+            "prov:usedEntity": "niiri:688ca92e605ac76835652ec4e94cc704"
+        },
+        "_:wDF174": {
+            "prov:generatedEntity": "niiri:efbc436a1b3678612dfe7f44dd10cbb3",
+            "prov:usedEntity": "niiri:68da208642972437b835af6ed59a660c"
+        },
+        "_:wDF177": {
+            "prov:generatedEntity": "niiri:22dcde4b50ff0337757a88138a5b07fc",
+            "prov:usedEntity": "niiri:68da208642972437b835af6ed59a660c"
+        },
+        "_:wDF180": {
+            "prov:generatedEntity": "niiri:880b4afc515a88ebc3cf045d50f3c04a",
+            "prov:usedEntity": "niiri:68da208642972437b835af6ed59a660c"
+        },
+        "_:wDF183": {
+            "prov:generatedEntity": "niiri:9dbf2c151d9034e9c4371c30e60411e3",
+            "prov:usedEntity": "niiri:f8507bdcacd86027fdafd6fd60ba6874"
+        },
+        "_:wDF186": {
+            "prov:generatedEntity": "niiri:3826db9e7668227e2a63e832d3c39701",
+            "prov:usedEntity": "niiri:d2ca51b89db2e3b1111d7fdbfda64417"
+        },
+        "_:wDF189": {
+            "prov:generatedEntity": "niiri:24a0a14bebf270cbe73d80ce97ec4c02",
+            "prov:usedEntity": "niiri:d2ca51b89db2e3b1111d7fdbfda64417"
+        },
+        "_:wDF192": {
+            "prov:generatedEntity": "niiri:0449dda97bea02c246854d99b1b7adbc",
+            "prov:usedEntity": "niiri:d2ca51b89db2e3b1111d7fdbfda64417"
+        },
+        "_:wDF195": {
+            "prov:generatedEntity": "niiri:5eb503813e71b696ec059c3e6a0dd7ef",
+            "prov:usedEntity": "niiri:93024a65786df3d21c3afeb2157fda29"
+        },
+        "_:wDF198": {
+            "prov:generatedEntity": "niiri:27662f80703bab4a958c6b33e1a93fa5",
+            "prov:usedEntity": "niiri:035c0aba4276188a1f52052646ae7120"
+        },
+        "_:wDF201": {
+            "prov:generatedEntity": "niiri:fe8f5b1d1a7cdd89fdd7e2417cf26341",
+            "prov:usedEntity": "niiri:2dc499c816a88d424858df07e367da38"
+        },
+        "_:wDF204": {
+            "prov:generatedEntity": "niiri:1b3dd6f8432d3e63adbf5a0aabd4bcc1",
+            "prov:usedEntity": "niiri:809e973106f074b8b57288f78176fadb"
+        },
+        "_:wDF207": {
+            "prov:generatedEntity": "niiri:6622c9c5a5bb5602bc2abeed125325ac",
+            "prov:usedEntity": "niiri:23280aef5e15fc151595ade28a75778f"
+        },
+        "_:wDF210": {
+            "prov:generatedEntity": "niiri:b184da69003b59767f569647a73c0639",
+            "prov:usedEntity": "niiri:a724fab477e1c34dff00939c8a5fe1d9"
+        },
+        "_:wDF213": {
+            "prov:generatedEntity": "niiri:49e0945fb482cd7b911f2227ceae482f",
+            "prov:usedEntity": "niiri:e8d2cf34f04ba64f58f96a3bd57989a0"
+        },
+        "_:wDF216": {
+            "prov:generatedEntity": "niiri:c7dd5a67fe812c0fdcc362965b494898",
+            "prov:usedEntity": "niiri:b073888acef337b87afb0a3f49356435"
+        },
+        "_:wDF219": {
+            "prov:generatedEntity": "niiri:84fe5a575cee1440542c990cbf711859",
+            "prov:usedEntity": "niiri:24cb62d0bb1e202be98184cc8d05dffd"
+        },
+        "_:wDF222": {
+            "prov:generatedEntity": "niiri:9a32238eb2863717896fffb10d326e05",
+            "prov:usedEntity": "niiri:824d90300b93425516b70315d9d6f976"
+        }
+    },
+    "wasAttributedTo": {
+        "_:wAT6": {
+            "prov:entity": "niiri:ebf54f3ce65b0dd2c55759f2bbe79bdf",
+            "prov:agent": "niiri:d451d187aabd4470aaaa9ac9338d71f7"
+        },
+        "_:wAT7": {
+            "prov:entity": "niiri:ebf54f3ce65b0dd2c55759f2bbe79bdf",
+            "prov:agent": "niiri:1d560f0e3dff39ddf2bbd35fbea493df"
+        }
+    },
+    "wasAssociatedWith": {
+        "_:wAW12": {
+            "prov:activity": "niiri:8b0939c3dda9d8de649d9f6287d600b5",
+            "prov:agent": "niiri:cc07a0149337deefc011f6391ad99352"
+        },
+        "_:wAW40": {
+            "prov:activity": "niiri:baf1b57a546d4407c295095b2880878b",
+            "prov:agent": "niiri:cc07a0149337deefc011f6391ad99352"
+        },
+        "_:wAW66": {
+            "prov:activity": "niiri:b65d1dde00468cfdc0b2c5c7b16aca85",
+            "prov:agent": "niiri:cc07a0149337deefc011f6391ad99352"
+        }
+    }
+    }
+  }
+}

--- a/spmexport/ex_spm_group_wls/nidm.jsonld
+++ b/spmexport/ex_spm_group_wls/nidm.jsonld
@@ -7,7 +7,7 @@
       "niiri": "http://iri.nidash.org/",
       "spm": "http://purl.org/nidash/spm#",
       "neurolex": "http://neurolex.org/wiki/",
-      "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#",
+      "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/",
       "dct": "http://purl.org/dc/terms/",
       "nfo": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#",
       "dc": "http://purl.org/dc/elements/1.1/",
@@ -22,32 +22,32 @@
   ],
   "@graph": [
     {
-      "@id": "niiri:e8c2fc9cda9df248317c3d947b04ea67",
-      "@type": ["prov:Entity","prov:Bundle","nidm_NIDMResults:"],
+      "@id": "niiri:fbfb92dd91e30b37df0002dd4a58237d",
+      "@type": ["prov:Entity","prov:Bundle","nidm_NIDMResults"],
       "rdfs:label": "NIDM-Results",
-      "nidm_version:": {"@type": "xsd:string", "@value": "1.3.0"}
+      "nidm_version": {"@type": "xsd:string", "@value": "1.3.0"}
     },
     {
-      "@id": "niiri:dd1eeb14957c977edf2871d42ed4b1c9",
-      "@type": ["prov:Agent","nidm_spm_results_nidm:","prov:SoftwareAgent"],
+      "@id": "niiri:a6b93a73047f21860319c5c6a2bc4bec",
+      "@type": ["prov:Agent","nidm_spm_results_nidm","prov:SoftwareAgent"],
       "rdfs:label": "spm_results_nidm",
-      "nidm_softwareVersion:": {"@type": "xsd:string", "@value": "12.6903"}
+      "nidm_softwareVersion": {"@type": "xsd:string", "@value": "12.7057"}
     },
     {
-      "@id": "niiri:73ac027704cb44ad9af477f190827e87",
-      "@type": ["prov:Activity","nidm_NIDMResultsExport:"],
+      "@id": "niiri:0716bbc8504afbc51e82ff51484e584a",
+      "@type": ["prov:Activity","nidm_NIDMResultsExport"],
       "rdfs:label": "NIDM-Results export"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:73ac027704cb44ad9af477f190827e87",
-      "agent": "niiri:dd1eeb14957c977edf2871d42ed4b1c9"
+      "activity_associated": "niiri:0716bbc8504afbc51e82ff51484e584a",
+      "agent": "niiri:a6b93a73047f21860319c5c6a2bc4bec"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:e8c2fc9cda9df248317c3d947b04ea67",
-      "activity": "niiri:73ac027704cb44ad9af477f190827e87",
-      "atTime": "2016-12-07T16:08:37"
+      "entity_generated": "niiri:fbfb92dd91e30b37df0002dd4a58237d",
+      "activity": "niiri:0716bbc8504afbc51e82ff51484e584a",
+      "atTime": "2017-04-19T12:18:16"
     }
   ]
 },
@@ -155,533 +155,533 @@
       "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
     }
   ],
-  "@id": "niiri:e8c2fc9cda9df248317c3d947b04ea67",
+  "@id": "niiri:fbfb92dd91e30b37df0002dd4a58237d",
   "@graph": [
     {
-      "@id": "niiri:a536fc9b17bd68b4700183ad8ad511e8",
-      "@type": ["prov:Agent","src_SPM:","prov:SoftwareAgent"],
+      "@id": "niiri:cc07a0149337deefc011f6391ad99352",
+      "@type": ["prov:Agent","src_SPM","prov:SoftwareAgent"],
       "rdfs:label": "SPM",
-      "nidm_softwareVersion:": {"@type": "xsd:string", "@value": "12.12.2"}
+      "nidm_softwareVersion": {"@type": "xsd:string", "@value": "12.6906"}
     },
     {
-      "@id": "niiri:1b7e4b57cfbc311750156373ae9ba795",
-      "@type": ["prov:Entity","nidm_CoordinateSpace:"],
+      "@id": "niiri:d83638bd84f027751d70f6f76d98df8c",
+      "@type": ["prov:Entity","nidm_CoordinateSpace"],
       "rdfs:label": "Coordinate space 1",
-      "nidm_voxelToWorldMapping:": {"@type": "xsd:string", "@value": "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"},
-      "nidm_voxelUnits:": {"@type": "xsd:string", "@value": "[\"mm\", \"mm\", \"mm\"]"},
-      "nidm_voxelSize:": {"@type": "xsd:string", "@value": "[2, 2, 2]"},
-      "nidm_inWorldCoordinateSystem:": {"@id": "nidm_Ixi549CoordinateSystem:"},
-      "nidm_numberOfDimensions:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_dimensionsInVoxels:": {"@type": "xsd:string", "@value": "[79,95,79]"}
+      "nidm_voxelToWorldMapping": {"@type": "xsd:string", "@value": "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"},
+      "nidm_voxelUnits": {"@type": "xsd:string", "@value": "[\"mm\", \"mm\", \"mm\"]"},
+      "nidm_voxelSize": {"@type": "xsd:string", "@value": "[2, 2, 2]"},
+      "nidm_inWorldCoordinateSystem": {"@id": "nidm_Ixi549CoordinateSystem"},
+      "nidm_numberOfDimensions": {"@type": "xsd:int", "@value": "3"},
+      "nidm_dimensionsInVoxels": {"@type": "xsd:string", "@value": "[79,95,79]"}
     },
     {
-      "@id": "niiri:79197ae8f2809c9d976bf30adb690a11",
-      "@type": ["prov:Agent","nlx_Imaginginstrument:","nlx_Magneticresonanceimagingscanner:"],
+      "@id": "niiri:d451d187aabd4470aaaa9ac9338d71f7",
+      "@type": ["prov:Agent","nlx_Imaginginstrument","nlx_Magneticresonanceimagingscanner"],
       "rdfs:label": "MRI Scanner"
     },
     {
-      "@id": "niiri:4ca53c4b7e22533252bbed50cffac550",
-      "@type": ["prov:Agent","obo_studygrouppopulation:"],
+      "@id": "niiri:1d560f0e3dff39ddf2bbd35fbea493df",
+      "@type": ["prov:Agent","obo_studygrouppopulation"],
       "rdfs:label": "Group: Control",
-      "nidm_groupName:": {"@type": "xsd:string", "@value": "Control"},
-      "nidm_numberOfSubjects:": {"@type": "xsd:int", "@value": "14"}
+      "nidm_groupName": {"@type": "xsd:string", "@value": "Control"},
+      "nidm_numberOfSubjects": {"@type": "xsd:int", "@value": "14"}
     },
     {
-      "@id": "niiri:050e089fed5637bfef8762d516f68935",
-      "@type": ["prov:Entity","prov:Collection","nidm_Data:"],
+      "@id": "niiri:ebf54f3ce65b0dd2c55759f2bbe79bdf",
+      "@type": ["prov:Entity","prov:Collection","nidm_Data"],
       "rdfs:label": "Data",
-      "nidm_grandMeanScaling:": {"@type": "xsd:boolean", "@value": "false"},
-      "nidm_hasMRIProtocol:": {"@id": "nlx_FunctionalMRIprotocol:"}
+      "nidm_grandMeanScaling": {"@type": "xsd:boolean", "@value": "false"},
+      "nidm_hasMRIProtocol": {"@id": "nlx_FunctionalMRIprotocol"}
     },
     {
       "@type": "prov:Attribution",
-      "entity_attributed": "niiri:050e089fed5637bfef8762d516f68935",
-      "agent": "niiri:79197ae8f2809c9d976bf30adb690a11"
+      "entity_attributed": "niiri:ebf54f3ce65b0dd2c55759f2bbe79bdf",
+      "agent": "niiri:d451d187aabd4470aaaa9ac9338d71f7"
     },
     {
       "@type": "prov:Attribution",
-      "entity_attributed": "niiri:050e089fed5637bfef8762d516f68935",
-      "agent": "niiri:4ca53c4b7e22533252bbed50cffac550"
+      "entity_attributed": "niiri:ebf54f3ce65b0dd2c55759f2bbe79bdf",
+      "agent": "niiri:1d560f0e3dff39ddf2bbd35fbea493df"
     },
     {
-      "@id": "niiri:1db0a0b58a5d1e63fbd7f80a9790fc04",
-      "@type": ["prov:Entity","nidm_DesignMatrix:"],
+      "@id": "niiri:7d3330b641d062fb9c196cfd8e54db38",
+      "@type": ["prov:Entity","nidm_DesignMatrix"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "DesignMatrix.csv"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "DesignMatrix.csv"},
       "dct:format": {"@type": "xsd:string", "@value": "text/csv"},
-      "dc:description": {"@id": "niiri:48b07ec102ba87dbfa3e7c180799c886"},
+      "dc:description": {"@id": "niiri:386590f5ae95ecdc71f5c902d3e1e166"},
       "rdfs:label": "Design Matrix",
-      "nidm_regressorNames:": {"@type": "xsd:string", "@value": "[\"contrast 1 parameter 1\", \"contrast 1 parameter 2\", \"contrast 2 parameter 1\", \"contrast 2 parameter 2\"]"}
+      "nidm_regressorNames": {"@type": "xsd:string", "@value": "[\"contrast 1 parameter 1\", \"contrast 1 parameter 2\", \"contrast 2 parameter 1\", \"contrast 2 parameter 2\"]"}
     },
     {
-      "@id": "niiri:48b07ec102ba87dbfa3e7c180799c886",
+      "@id": "niiri:386590f5ae95ecdc71f5c902d3e1e166",
       "@type": ["prov:Entity","dctype:Image"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "DesignMatrix.png"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "DesignMatrix.png"},
       "dct:format": {"@type": "xsd:string", "@value": "image/png"}
     },
     {
-      "@id": "niiri:e2f5c53deadf4cdce9e6951f8c178a4e",
-      "@type": ["prov:Entity","nidm_ErrorModel:"],
-      "nidm_hasErrorDistribution:": {"@id": "obo_normaldistribution:"},
-      "nidm_hasErrorDependence:": {"@id": "obo_unstructuredcovariancestructure:"},
-      "nidm_dependenceMapWiseDependence:": {"@id": "nidm_ConstantParameter:"},
-      "nidm_errorVarianceHomogeneous:": {"@type": "xsd:boolean", "@value": "false"},
-      "nidm_varianceMapWiseDependence:": {"@id": "nidm_IndependentParameter:"}
+      "@id": "niiri:e9a458bdd39848b4367b8e1032a2eb15",
+      "@type": ["prov:Entity","nidm_ErrorModel"],
+      "nidm_hasErrorDistribution": {"@id": "obo_normaldistribution"},
+      "nidm_hasErrorDependence": {"@id": "obo_unstructuredcovariancestructure"},
+      "nidm_dependenceMapWiseDependence": {"@id": "nidm_ConstantParameter"},
+      "nidm_errorVarianceHomogeneous": {"@type": "xsd:boolean", "@value": "false"},
+      "nidm_varianceMapWiseDependence": {"@id": "nidm_IndependentParameter"}
     },
     {
-      "@id": "niiri:bd3f326ef762822a20864156ea77d423",
-      "@type": ["prov:Activity","nidm_ModelParametersEstimation:"],
+      "@id": "niiri:8b0939c3dda9d8de649d9f6287d600b5",
+      "@type": ["prov:Activity","nidm_ModelParametersEstimation"],
       "rdfs:label": "Model parameters estimation",
-      "nidm_withEstimationMethod:": {"@id": "obo_generalizedleastsquaresestimation:"}
+      "nidm_withEstimationMethod": {"@id": "obo_generalizedleastsquaresestimation"}
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:bd3f326ef762822a20864156ea77d423",
-      "agent": "niiri:a536fc9b17bd68b4700183ad8ad511e8"
+      "activity_associated": "niiri:8b0939c3dda9d8de649d9f6287d600b5",
+      "agent": "niiri:cc07a0149337deefc011f6391ad99352"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:bd3f326ef762822a20864156ea77d423",
-      "entity": "niiri:1db0a0b58a5d1e63fbd7f80a9790fc04"
+      "activity_using": "niiri:8b0939c3dda9d8de649d9f6287d600b5",
+      "entity": "niiri:7d3330b641d062fb9c196cfd8e54db38"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:bd3f326ef762822a20864156ea77d423",
-      "entity": "niiri:050e089fed5637bfef8762d516f68935"
+      "activity_using": "niiri:8b0939c3dda9d8de649d9f6287d600b5",
+      "entity": "niiri:ebf54f3ce65b0dd2c55759f2bbe79bdf"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:bd3f326ef762822a20864156ea77d423",
-      "entity": "niiri:e2f5c53deadf4cdce9e6951f8c178a4e"
+      "activity_using": "niiri:8b0939c3dda9d8de649d9f6287d600b5",
+      "entity": "niiri:e9a458bdd39848b4367b8e1032a2eb15"
     },
     {
-      "@id": "niiri:3b714fbd2fbe9e64f03779e899c0c6dc",
-      "@type": ["prov:Entity","nidm_MaskMap:"],
+      "@id": "niiri:e5fc1b30e25a51026dcfa20926d9a8b5",
+      "@type": ["prov:Entity","nidm_MaskMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "Mask.nii.gz"},
-      "nidm_isUserDefined:": {"@type": "xsd:boolean", "@value": "false"},
+      "nidm_isUserDefined": {"@type": "xsd:boolean", "@value": "false"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "Mask.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Mask",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:1b7e4b57cfbc311750156373ae9ba795"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:d83638bd84f027751d70f6f76d98df8c"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "71153b4ca7e1136cf9ae9cb56eaf6a4ed494bad08a1cfa0659e8e211a36425aaf865c3def12dea06c5595662761b891c87ec7b8fa0b8b75cd31247be9418bf24"}
     },
     {
-      "@id": "niiri:e270063d61181f205b60db54bd090f7d",
-      "@type": ["prov:Entity","nidm_MaskMap:"],
+      "@id": "niiri:ab891018531389a0bfea3167dd18265c",
+      "@type": ["prov:Entity","nidm_MaskMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "mask.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "e33feb3fddb2a3ee6d91e0b84ce0050a83414df67559e07679326fab2c31494df0a1db2d693027786c839b356626159d9158e4e9766b2bf46be4d32678f356fd"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3b714fbd2fbe9e64f03779e899c0c6dc",
-      "entity": "niiri:e270063d61181f205b60db54bd090f7d"
+      "entity_derived": "niiri:e5fc1b30e25a51026dcfa20926d9a8b5",
+      "entity": "niiri:ab891018531389a0bfea3167dd18265c"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:3b714fbd2fbe9e64f03779e899c0c6dc",
-      "activity": "niiri:bd3f326ef762822a20864156ea77d423"
+      "entity_generated": "niiri:e5fc1b30e25a51026dcfa20926d9a8b5",
+      "activity": "niiri:8b0939c3dda9d8de649d9f6287d600b5"
     },
     {
-      "@id": "niiri:b2d84b897895c159a5453fdccc2fb28c",
-      "@type": ["prov:Entity","nidm_GrandMeanMap:"],
+      "@id": "niiri:bbfee1c49481e576e7001347fc4d3e5f",
+      "@type": ["prov:Entity","nidm_GrandMeanMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "GrandMean.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "GrandMean.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Grand Mean Map",
-      "nidm_maskedMedian:": {"@type": "xsd:float", "@value": "0.0621182750910521"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:1b7e4b57cfbc311750156373ae9ba795"},
+      "nidm_maskedMedian": {"@type": "xsd:float", "@value": "0.0621182750910521"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:d83638bd84f027751d70f6f76d98df8c"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "febef0110e49eb683c48b4e93acc72f110abd947f499f87d3f17cdb41d6969b2675f8e4ab3730fd052430b795a23e680633b591415016366d533eb084adc1a7d"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:b2d84b897895c159a5453fdccc2fb28c",
-      "activity": "niiri:bd3f326ef762822a20864156ea77d423"
+      "entity_generated": "niiri:bbfee1c49481e576e7001347fc4d3e5f",
+      "activity": "niiri:8b0939c3dda9d8de649d9f6287d600b5"
     },
     {
-      "@id": "niiri:eb686fb49520484f372d9f18b173329c",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:62c0fd9e9f4574145bf8f023abd11fe4",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0001.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0001.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 1",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:1b7e4b57cfbc311750156373ae9ba795"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:d83638bd84f027751d70f6f76d98df8c"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "c61b294e5c1f475eed3d552bf4ae69dc19526220f069aecb338e5ad0c9359233011c6c9674b587605f343f0253dcbdf87b02f0cbd739d49fc2d41c7ee33eef6d"}
     },
     {
-      "@id": "niiri:79340bad7335ca74904c2ba10fb69ef3",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:93f6ba1185b029716e107fdb65f43721",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0001.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "c61b294e5c1f475eed3d552bf4ae69dc19526220f069aecb338e5ad0c9359233011c6c9674b587605f343f0253dcbdf87b02f0cbd739d49fc2d41c7ee33eef6d"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:eb686fb49520484f372d9f18b173329c",
-      "entity": "niiri:79340bad7335ca74904c2ba10fb69ef3"
+      "entity_derived": "niiri:62c0fd9e9f4574145bf8f023abd11fe4",
+      "entity": "niiri:93f6ba1185b029716e107fdb65f43721"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:eb686fb49520484f372d9f18b173329c",
-      "activity": "niiri:bd3f326ef762822a20864156ea77d423"
+      "entity_generated": "niiri:62c0fd9e9f4574145bf8f023abd11fe4",
+      "activity": "niiri:8b0939c3dda9d8de649d9f6287d600b5"
     },
     {
-      "@id": "niiri:02854eb39d42b0c821bd022c91f45154",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:e869e1bbd1b78977c814c1dd8eeb515b",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0002.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0002.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 2",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:1b7e4b57cfbc311750156373ae9ba795"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:d83638bd84f027751d70f6f76d98df8c"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "f5cace936fdd2fad096a30b39381b03bdbc1a29fc9377c01aeb0f68ea48bb2e2b70d39103b0303fe81f569419951830e3e122294629600910620bb2c304bc10c"}
     },
     {
-      "@id": "niiri:c507403223d6871596165f503b563e97",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:87e1c9ecd18191661638cefe66e214f7",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0002.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "f5cace936fdd2fad096a30b39381b03bdbc1a29fc9377c01aeb0f68ea48bb2e2b70d39103b0303fe81f569419951830e3e122294629600910620bb2c304bc10c"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:02854eb39d42b0c821bd022c91f45154",
-      "entity": "niiri:c507403223d6871596165f503b563e97"
+      "entity_derived": "niiri:e869e1bbd1b78977c814c1dd8eeb515b",
+      "entity": "niiri:87e1c9ecd18191661638cefe66e214f7"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:02854eb39d42b0c821bd022c91f45154",
-      "activity": "niiri:bd3f326ef762822a20864156ea77d423"
+      "entity_generated": "niiri:e869e1bbd1b78977c814c1dd8eeb515b",
+      "activity": "niiri:8b0939c3dda9d8de649d9f6287d600b5"
     },
     {
-      "@id": "niiri:a61ce13f7f1dc65b29f723d8386df7ec",
-      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap:"],
+      "@id": "niiri:1c471e984c886eb1f4db8fe592efb739",
+      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ResidualMeanSquares.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ResidualMeanSquares.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Residual Mean Squares Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:1b7e4b57cfbc311750156373ae9ba795"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:d83638bd84f027751d70f6f76d98df8c"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "2b2f9464f8daa548f6c3acae3219167fd598047bf3df591490515ff9dbd98e522dbe12da2d98e2022fe2a96666c200e2de31d598ef5e46dda88130a654b2ce0e"}
     },
     {
-      "@id": "niiri:a07e8586e9652b048cd3ede7b1e4fe4d",
-      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap:"],
+      "@id": "niiri:3feb56c9ca866e36a6777a2db54698dd",
+      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "ResMS.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "efe8cb9290507e9add77e43e71750dcfea22d1604e332e351c5f1aad25d8c002690d0d9a997ed771abd153811920b5ab23a7c3ca7efe3976c42cb240a6550a10"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a61ce13f7f1dc65b29f723d8386df7ec",
-      "entity": "niiri:a07e8586e9652b048cd3ede7b1e4fe4d"
+      "entity_derived": "niiri:1c471e984c886eb1f4db8fe592efb739",
+      "entity": "niiri:3feb56c9ca866e36a6777a2db54698dd"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:a61ce13f7f1dc65b29f723d8386df7ec",
-      "activity": "niiri:bd3f326ef762822a20864156ea77d423"
+      "entity_generated": "niiri:1c471e984c886eb1f4db8fe592efb739",
+      "activity": "niiri:8b0939c3dda9d8de649d9f6287d600b5"
     },
     {
-      "@id": "niiri:2f80ca575ff68f60a321c56d5a33b25e",
-      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap:"],
+      "@id": "niiri:9c5c037a27c032171a8e67f8a6148478",
+      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ReselsPerVoxel.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ReselsPerVoxel.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Resels per Voxel Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:1b7e4b57cfbc311750156373ae9ba795"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:d83638bd84f027751d70f6f76d98df8c"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "83ca0764c128b84c66f80535b03005c72ee62f059fa727f5631a170f473150c2d5c2df77c98c975e1b3a2ceaeb986493e126b84f7f58a5d130fc763f2f2a6561"}
     },
     {
-      "@id": "niiri:0fa20b508989795593d226245695d594",
-      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap:"],
+      "@id": "niiri:88108a0984090a6e26c1358f192a8b0d",
+      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "RPV.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "13d0fe4049334ad44eeef1af42a998fadaa282c9f6e3937a265bdb5e544f0b63d874279d639d7e222aaa8574dd2d975a97cc869874af4457b4002f46f76b3519"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2f80ca575ff68f60a321c56d5a33b25e",
-      "entity": "niiri:0fa20b508989795593d226245695d594"
+      "entity_derived": "niiri:9c5c037a27c032171a8e67f8a6148478",
+      "entity": "niiri:88108a0984090a6e26c1358f192a8b0d"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:2f80ca575ff68f60a321c56d5a33b25e",
-      "activity": "niiri:bd3f326ef762822a20864156ea77d423"
+      "entity_generated": "niiri:9c5c037a27c032171a8e67f8a6148478",
+      "activity": "niiri:8b0939c3dda9d8de649d9f6287d600b5"
     },
     {
-      "@id": "niiri:3ff83f2400e61059dee70433e6a41d37",
-      "@type": ["prov:Entity","obo_contrastweightmatrix:"],
-      "nidm_statisticType:": {"@id": "obo_tstatistic:"},
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "con-01: Tone Counting vs Baseline"},
+      "@id": "niiri:74dd11ba88fcb33d114031941844efe5",
+      "@type": ["prov:Entity","obo_contrastweightmatrix"],
+      "nidm_statisticType": {"@id": "obo_tstatistic"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "con-01: Tone Counting vs Baseline"},
       "rdfs:label": "Contrast: con-01: Tone Counting vs Baseline",
       "prov:value": {"@type": "xsd:string", "@value": "[1, 0]"}
     },
     {
-      "@id": "niiri:b942d8ec0e84cecc6d910d658d00eea4",
-      "@type": ["prov:Activity","nidm_ContrastEstimation:"],
+      "@id": "niiri:baf1b57a546d4407c295095b2880878b",
+      "@type": ["prov:Activity","nidm_ContrastEstimation"],
       "rdfs:label": "Contrast estimation"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:b942d8ec0e84cecc6d910d658d00eea4",
-      "agent": "niiri:a536fc9b17bd68b4700183ad8ad511e8"
+      "activity_associated": "niiri:baf1b57a546d4407c295095b2880878b",
+      "agent": "niiri:cc07a0149337deefc011f6391ad99352"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:b942d8ec0e84cecc6d910d658d00eea4",
-      "entity": "niiri:3b714fbd2fbe9e64f03779e899c0c6dc"
+      "activity_using": "niiri:baf1b57a546d4407c295095b2880878b",
+      "entity": "niiri:e5fc1b30e25a51026dcfa20926d9a8b5"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:b942d8ec0e84cecc6d910d658d00eea4",
-      "entity": "niiri:a61ce13f7f1dc65b29f723d8386df7ec"
+      "activity_using": "niiri:baf1b57a546d4407c295095b2880878b",
+      "entity": "niiri:1c471e984c886eb1f4db8fe592efb739"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:b942d8ec0e84cecc6d910d658d00eea4",
-      "entity": "niiri:1db0a0b58a5d1e63fbd7f80a9790fc04"
+      "activity_using": "niiri:baf1b57a546d4407c295095b2880878b",
+      "entity": "niiri:7d3330b641d062fb9c196cfd8e54db38"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:b942d8ec0e84cecc6d910d658d00eea4",
-      "entity": "niiri:3ff83f2400e61059dee70433e6a41d37"
+      "activity_using": "niiri:baf1b57a546d4407c295095b2880878b",
+      "entity": "niiri:74dd11ba88fcb33d114031941844efe5"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:b942d8ec0e84cecc6d910d658d00eea4",
-      "entity": "niiri:eb686fb49520484f372d9f18b173329c"
+      "activity_using": "niiri:baf1b57a546d4407c295095b2880878b",
+      "entity": "niiri:62c0fd9e9f4574145bf8f023abd11fe4"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:b942d8ec0e84cecc6d910d658d00eea4",
-      "entity": "niiri:02854eb39d42b0c821bd022c91f45154"
+      "activity_using": "niiri:baf1b57a546d4407c295095b2880878b",
+      "entity": "niiri:e869e1bbd1b78977c814c1dd8eeb515b"
     },
     {
-      "@id": "niiri:cfd00476a556f41d59890863b1be4688",
-      "@type": ["prov:Entity","nidm_StatisticMap:"],
+      "@id": "niiri:e15e39f0dd016af9de756e2098156ac6",
+      "@type": ["prov:Entity","nidm_StatisticMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "TStatistic.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "TStatistic.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "T-Statistic Map: con-01: Tone Counting vs Baseline",
-      "nidm_statisticType:": {"@id": "obo_tstatistic:"},
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "con-01: Tone Counting vs Baseline"},
-      "nidm_errorDegreesOfFreedom:": {"@type": "xsd:float", "@value": "26"},
-      "nidm_effectDegreesOfFreedom:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:1b7e4b57cfbc311750156373ae9ba795"},
+      "nidm_statisticType": {"@id": "obo_tstatistic"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "con-01: Tone Counting vs Baseline"},
+      "nidm_errorDegreesOfFreedom": {"@type": "xsd:float", "@value": "26"},
+      "nidm_effectDegreesOfFreedom": {"@type": "xsd:float", "@value": "1"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:d83638bd84f027751d70f6f76d98df8c"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "2f0627a2c337fb861f93c924f355b0f55d1845db85d67af0df0ffcd353b481a129f7aeda6211c2642c52c34f2b69fbd9105a07382bf6f3942f03a126d0c98dc6"}
     },
     {
-      "@id": "niiri:ed0e82be69523831a96bb5b7a2bc1674",
-      "@type": ["prov:Entity","nidm_StatisticMap:"],
+      "@id": "niiri:4f69102083ed41b95cbe2de23683ac9a",
+      "@type": ["prov:Entity","nidm_StatisticMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "spmT_0001.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "9a89273aa6b7428f4e966921b6e64c18a08a84676c08bb01ffc76d8388734be8f17349b279db037c182ca2e63c3f64aab9828d05393712ecba11d1b60d06e4b1"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cfd00476a556f41d59890863b1be4688",
-      "entity": "niiri:ed0e82be69523831a96bb5b7a2bc1674"
+      "entity_derived": "niiri:e15e39f0dd016af9de756e2098156ac6",
+      "entity": "niiri:4f69102083ed41b95cbe2de23683ac9a"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:cfd00476a556f41d59890863b1be4688",
-      "activity": "niiri:b942d8ec0e84cecc6d910d658d00eea4"
+      "entity_generated": "niiri:e15e39f0dd016af9de756e2098156ac6",
+      "activity": "niiri:baf1b57a546d4407c295095b2880878b"
     },
     {
-      "@id": "niiri:97d5dcaae0e9ba7f61c44933162ce24a",
-      "@type": ["prov:Entity","nidm_ContrastMap:"],
+      "@id": "niiri:d9d5054e5ab0391c96478c3815f4efe8",
+      "@type": ["prov:Entity","nidm_ContrastMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "Contrast.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "Contrast.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Contrast Map: con-01: Tone Counting vs Baseline",
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "con-01: Tone Counting vs Baseline"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:1b7e4b57cfbc311750156373ae9ba795"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "con-01: Tone Counting vs Baseline"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:d83638bd84f027751d70f6f76d98df8c"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "ce64789602c82196789a795d9bdc87c8642f8852904d7ec6507eeab7085a02d679a27ac9d3abd0025de90a3d345a7f9113dd42973901ab3f0dfac5c6b757f132"}
     },
     {
-      "@id": "niiri:7641f8b1292a3e041f5b1f51afbc81be",
-      "@type": ["prov:Entity","nidm_ContrastMap:"],
+      "@id": "niiri:9b6a64d84e939e0a16a135417f933c5d",
+      "@type": ["prov:Entity","nidm_ContrastMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "con_0001.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "9748864f2cd75c915fc9ab64800dd777de76fa4c7de3e707d7d63eab15253001ff13bd4e830bfde8b4892e379c7792e53717f5d027aaf32918542eac63c1b7d8"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:97d5dcaae0e9ba7f61c44933162ce24a",
-      "entity": "niiri:7641f8b1292a3e041f5b1f51afbc81be"
+      "entity_derived": "niiri:d9d5054e5ab0391c96478c3815f4efe8",
+      "entity": "niiri:9b6a64d84e939e0a16a135417f933c5d"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:97d5dcaae0e9ba7f61c44933162ce24a",
-      "activity": "niiri:b942d8ec0e84cecc6d910d658d00eea4"
+      "entity_generated": "niiri:d9d5054e5ab0391c96478c3815f4efe8",
+      "activity": "niiri:baf1b57a546d4407c295095b2880878b"
     },
     {
-      "@id": "niiri:e6129899605ca5b8dbe32a0df271e7b0",
-      "@type": ["prov:Entity","nidm_ContrastStandardErrorMap:"],
+      "@id": "niiri:3d983cf2d5c2941d0787e4df59f9fd1c",
+      "@type": ["prov:Entity","nidm_ContrastStandardErrorMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ContrastStandardError.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ContrastStandardError.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Contrast Standard Error Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:1b7e4b57cfbc311750156373ae9ba795"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:d83638bd84f027751d70f6f76d98df8c"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "735c4c74cf1cbc4d46d35c5fad5f38383b336269bcf1c3edb037201f0fde4f7b2f484f042b1c711323446ac91e54cd997275616ea17c6d4ccd44df19b0f30334"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:e6129899605ca5b8dbe32a0df271e7b0",
-      "activity": "niiri:b942d8ec0e84cecc6d910d658d00eea4"
+      "entity_generated": "niiri:3d983cf2d5c2941d0787e4df59f9fd1c",
+      "activity": "niiri:baf1b57a546d4407c295095b2880878b"
     },
     {
-      "@id": "niiri:6796323ef3d1da76b0e28489f43adc81",
-      "@type": ["prov:Entity","nidm_HeightThreshold:","nidm_PValueUncorrected:"],
-      "rdfs:label": "Height Threshold: p<0.001000 (unc.)",
+      "@id": "niiri:cd2ff500c60b8721816179e10e594025",
+      "@type": ["prov:Entity","nidm_HeightThreshold","nidm_PValueUncorrected"],
+      "rdfs:label": "Height Threshold: p<0.001 (unc.)",
       "prov:value": {"@type": "xsd:float", "@value": "0.000999500199025949"},
-      "nidm_equivalentThreshold:": [{"@id": "niiri:efdb35511ad9c3155512e221a6770fd7"},{"@id": "niiri:4d052d9fe9814fe7996ec8da83652164"}]
+      "nidm_equivalentThreshold": [{"@id": "niiri:1785712a16e66d419c296ef9f90de994"},{"@id": "niiri:b1120c03f72947c1ba4a6b8c2c3091bc"}]
     },
     {
-      "@id": "niiri:efdb35511ad9c3155512e221a6770fd7",
-      "@type": ["prov:Entity","nidm_HeightThreshold:","obo_statistic:"],
-      "rdfs:label": "Height Threshold",
+      "@id": "niiri:1785712a16e66d419c296ef9f90de994",
+      "@type": ["prov:Entity","nidm_HeightThreshold","obo_statistic"],
+      "rdfs:label": "Height Threshold: T=3.434997)",
       "prov:value": {"@type": "xsd:float", "@value": "3.43499716873599"}
     },
     {
-      "@id": "niiri:4d052d9fe9814fe7996ec8da83652164",
-      "@type": ["prov:Entity","nidm_HeightThreshold:","obo_FWERadjustedpvalue:"],
-      "rdfs:label": "Height Threshold",
+      "@id": "niiri:b1120c03f72947c1ba4a6b8c2c3091bc",
+      "@type": ["prov:Entity","nidm_HeightThreshold","obo_FWERadjustedpvalue"],
+      "rdfs:label": "Height Threshold: p<1.000000 (FWE)",
       "prov:value": {"@type": "xsd:float", "@value": "0.999999988250242"}
     },
     {
-      "@id": "niiri:a3025c9620d2ee84c11e7641259b25ef",
-      "@type": ["prov:Entity","nidm_ExtentThreshold:","obo_statistic:"],
+      "@id": "niiri:565302e93e38d1cad805021869fa4c63",
+      "@type": ["prov:Entity","nidm_ExtentThreshold","obo_statistic"],
       "rdfs:label": "Extent Threshold: k>=2",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0180239125412657"},
-      "nidm_equivalentThreshold:": [{"@id": "niiri:af6f08aa64301671af41af33ed0cc45a"},{"@id": "niiri:b0408ccf4d12c88a6fad6ebba3fece3c"}]
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0180239125412657"},
+      "nidm_equivalentThreshold": [{"@id": "niiri:3969337bc7e24a8f6325c17923baaef5"},{"@id": "niiri:e126b1f4c14b484ce3e6915191bdf447"}]
     },
     {
-      "@id": "niiri:af6f08aa64301671af41af33ed0cc45a",
-      "@type": ["prov:Entity","nidm_ExtentThreshold:","obo_FWERadjustedpvalue:"],
+      "@id": "niiri:3969337bc7e24a8f6325c17923baaef5",
+      "@type": ["prov:Entity","nidm_ExtentThreshold","obo_FWERadjustedpvalue"],
       "rdfs:label": "Extent Threshold",
       "prov:value": {"@type": "xsd:float", "@value": "0.999994028395426"}
     },
     {
-      "@id": "niiri:b0408ccf4d12c88a6fad6ebba3fece3c",
-      "@type": ["prov:Entity","nidm_ExtentThreshold:","nidm_PValueUncorrected:"],
+      "@id": "niiri:e126b1f4c14b484ce3e6915191bdf447",
+      "@type": ["prov:Entity","nidm_ExtentThreshold","nidm_PValueUncorrected"],
       "rdfs:label": "Extent Threshold",
       "prov:value": {"@type": "xsd:float", "@value": "0.658755107945733"}
     },
     {
-      "@id": "niiri:3210e30dea7fe15ffdfa6b273e584590",
-      "@type": ["prov:Entity","nidm_PeakDefinitionCriteria:"],
+      "@id": "niiri:20b1c1ee5c6652d4fceb06ebc0cab294",
+      "@type": ["prov:Entity","nidm_PeakDefinitionCriteria"],
       "rdfs:label": "Peak Definition Criteria",
-      "nidm_maxNumberOfPeaksPerCluster:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_minDistanceBetweenPeaks:": {"@type": "xsd:float", "@value": "8"}
+      "nidm_maxNumberOfPeaksPerCluster": {"@type": "xsd:int", "@value": "3"},
+      "nidm_minDistanceBetweenPeaks": {"@type": "xsd:float", "@value": "8"}
     },
     {
-      "@id": "niiri:1e1086bab21dd18b3498fa96ae1dd409",
-      "@type": ["prov:Entity","nidm_ClusterDefinitionCriteria:"],
+      "@id": "niiri:23547207d6c2d262d31d7e9e04b6f749",
+      "@type": ["prov:Entity","nidm_ClusterDefinitionCriteria"],
       "rdfs:label": "Cluster Connectivity Criterion: 18",
-      "nidm_hasConnectivityCriterion:": {"@id": "nidm_voxel18connected:"}
+      "nidm_hasConnectivityCriterion": {"@id": "nidm_voxel18connected"}
     },
     {
-      "@id": "niiri:1abc4a77e9c6d1b1d0651d63a40e8a8d",
-      "@type": ["prov:Activity","nidm_Inference:"],
-      "nidm_hasAlternativeHypothesis:": {"@id": "nidm_OneTailedTest:"},
+      "@id": "niiri:b65d1dde00468cfdc0b2c5c7b16aca85",
+      "@type": ["prov:Activity","nidm_Inference"],
+      "nidm_hasAlternativeHypothesis": {"@id": "nidm_OneTailedTest"},
       "rdfs:label": "Inference"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:1abc4a77e9c6d1b1d0651d63a40e8a8d",
-      "agent": "niiri:a536fc9b17bd68b4700183ad8ad511e8"
+      "activity_associated": "niiri:b65d1dde00468cfdc0b2c5c7b16aca85",
+      "agent": "niiri:cc07a0149337deefc011f6391ad99352"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:1abc4a77e9c6d1b1d0651d63a40e8a8d",
-      "entity": "niiri:6796323ef3d1da76b0e28489f43adc81"
+      "activity_using": "niiri:b65d1dde00468cfdc0b2c5c7b16aca85",
+      "entity": "niiri:cd2ff500c60b8721816179e10e594025"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:1abc4a77e9c6d1b1d0651d63a40e8a8d",
-      "entity": "niiri:a3025c9620d2ee84c11e7641259b25ef"
+      "activity_using": "niiri:b65d1dde00468cfdc0b2c5c7b16aca85",
+      "entity": "niiri:565302e93e38d1cad805021869fa4c63"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:1abc4a77e9c6d1b1d0651d63a40e8a8d",
-      "entity": "niiri:cfd00476a556f41d59890863b1be4688"
+      "activity_using": "niiri:b65d1dde00468cfdc0b2c5c7b16aca85",
+      "entity": "niiri:e15e39f0dd016af9de756e2098156ac6"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:1abc4a77e9c6d1b1d0651d63a40e8a8d",
-      "entity": "niiri:2f80ca575ff68f60a321c56d5a33b25e"
+      "activity_using": "niiri:b65d1dde00468cfdc0b2c5c7b16aca85",
+      "entity": "niiri:9c5c037a27c032171a8e67f8a6148478"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:1abc4a77e9c6d1b1d0651d63a40e8a8d",
-      "entity": "niiri:3b714fbd2fbe9e64f03779e899c0c6dc"
+      "activity_using": "niiri:b65d1dde00468cfdc0b2c5c7b16aca85",
+      "entity": "niiri:e5fc1b30e25a51026dcfa20926d9a8b5"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:1abc4a77e9c6d1b1d0651d63a40e8a8d",
-      "entity": "niiri:3210e30dea7fe15ffdfa6b273e584590"
+      "activity_using": "niiri:b65d1dde00468cfdc0b2c5c7b16aca85",
+      "entity": "niiri:20b1c1ee5c6652d4fceb06ebc0cab294"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:1abc4a77e9c6d1b1d0651d63a40e8a8d",
-      "entity": "niiri:1e1086bab21dd18b3498fa96ae1dd409"
+      "activity_using": "niiri:b65d1dde00468cfdc0b2c5c7b16aca85",
+      "entity": "niiri:23547207d6c2d262d31d7e9e04b6f749"
     },
     {
-      "@id": "niiri:bd447bc0505a0bf0ab3b188daf510c69",
-      "@type": ["prov:Entity","nidm_SearchSpaceMaskMap:"],
+      "@id": "niiri:d86d3799879abef252a01c01223937d2",
+      "@type": ["prov:Entity","nidm_SearchSpaceMaskMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "SearchSpaceMask.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "SearchSpaceMask.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Search Space Mask Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:1b7e4b57cfbc311750156373ae9ba795"},
-      "nidm_searchVolumeInVoxels:": {"@type": "xsd:int", "@value": "160902"},
-      "nidm_searchVolumeInUnits:": {"@type": "xsd:float", "@value": "1287216"},
-      "nidm_reselSizeInVoxels:": {"@type": "xsd:float", "@value": "110.963698665371"},
-      "nidm_searchVolumeInResels:": {"@type": "xsd:float", "@value": "1330.17375750168"},
-      "spm_searchVolumeReselsGeometry:": {"@type": "xsd:string", "@value": "[1, 55.7614198833958, 565.293338923842, 1330.17375750168]"},
-      "nidm_noiseFWHMInVoxels:": {"@type": "xsd:string", "@value": "[4.79328133251054, 4.70290149875436, 4.92245916235795]"},
-      "nidm_noiseFWHMInUnits:": {"@type": "xsd:string", "@value": "[9.58656266502107, 9.40580299750872, 9.84491832471589]"},
-      "nidm_randomFieldStationarity:": {"@type": "xsd:boolean", "@value": "true"},
-      "nidm_expectedNumberOfVoxelsPerCluster:": {"@type": "xsd:float", "@value": "9.85898447296652"},
-      "nidm_expectedNumberOfClusters:": {"@type": "xsd:float", "@value": "12.0284948937186"},
-      "nidm_heightCriticalThresholdFWE05:": {"@type": "xsd:float", "@value": "6.37244381118871"},
-      "nidm_heightCriticalThresholdFDR05:": {"@type": "xsd:float", "@value": "5.5216121673584"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:d83638bd84f027751d70f6f76d98df8c"},
+      "nidm_searchVolumeInVoxels": {"@type": "xsd:int", "@value": "160902"},
+      "nidm_searchVolumeInUnits": {"@type": "xsd:float", "@value": "1287216"},
+      "nidm_reselSizeInVoxels": {"@type": "xsd:float", "@value": "110.963698665371"},
+      "nidm_searchVolumeInResels": {"@type": "xsd:float", "@value": "1330.17375750168"},
+      "spm_searchVolumeReselsGeometry": {"@type": "xsd:string", "@value": "[1, 55.7614198833958, 565.293338923842, 1330.17375750168]"},
+      "nidm_noiseFWHMInVoxels": {"@type": "xsd:string", "@value": "[4.79328133251054, 4.70290149875436, 4.92245916235795]"},
+      "nidm_noiseFWHMInUnits": {"@type": "xsd:string", "@value": "[9.58656266502107, 9.40580299750872, 9.84491832471589]"},
+      "nidm_randomFieldStationarity": {"@type": "xsd:boolean", "@value": "true"},
+      "nidm_expectedNumberOfVoxelsPerCluster": {"@type": "xsd:float", "@value": "9.85898447296652"},
+      "nidm_expectedNumberOfClusters": {"@type": "xsd:float", "@value": "12.0284948937186"},
+      "nidm_heightCriticalThresholdFWE05": {"@type": "xsd:float", "@value": "6.37244381118871"},
+      "nidm_heightCriticalThresholdFDR05": {"@type": "xsd:float", "@value": "5.5216121673584"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "71153b4ca7e1136cf9ae9cb56eaf6a4ed494bad08a1cfa0659e8e211a36425aaf865c3def12dea06c5595662761b891c87ec7b8fa0b8b75cd31247be9418bf24"},
-      "spm_smallestSignificantClusterSizeInVoxelsFWE05:": {"@type": "xsd:int", "@value": "186"},
-      "spm_smallestSignificantClusterSizeInVoxelsFDR05:": {"@type": "xsd:int", "@value": "186"}
+      "spm_smallestSignificantClusterSizeInVoxelsFWE05": {"@type": "xsd:int", "@value": "186"},
+      "spm_smallestSignificantClusterSizeInVoxelsFDR05": {"@type": "xsd:int", "@value": "186"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:bd447bc0505a0bf0ab3b188daf510c69",
-      "activity": "niiri:1abc4a77e9c6d1b1d0651d63a40e8a8d"
+      "entity_generated": "niiri:d86d3799879abef252a01c01223937d2",
+      "activity": "niiri:b65d1dde00468cfdc0b2c5c7b16aca85"
     },
     {
-      "@id": "niiri:dc8fee2c80984a4e4da98aaa0284ab39",
-      "@type": ["prov:Entity","nidm_ExcursionSetMap:"],
+      "@id": "niiri:fd051605e8c7f96825de2e8c362f619d",
+      "@type": ["prov:Entity","nidm_ExcursionSetMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ExcursionSet.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ExcursionSet.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Excursion Set Map",
-      "nidm_numberOfSupraThresholdClusters:": {"@type": "xsd:int", "@value": "19"},
-      "nidm_pValue:": {"@type": "xsd:float", "@value": "0.0381497273362531"},
-      "nidm_hasClusterLabelsMap:": {"@id": "niiri:c804e7a5c284ea00ab8f31fc071824f3"},
-      "nidm_hasMaximumIntensityProjection:": {"@id": "niiri:09db6d6737588a7694ffd334225ba531"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:1b7e4b57cfbc311750156373ae9ba795"},
+      "nidm_numberOfSupraThresholdClusters": {"@type": "xsd:int", "@value": "19"},
+      "nidm_pValue": {"@type": "xsd:float", "@value": "0.0381497273362531"},
+      "nidm_hasClusterLabelsMap": {"@id": "niiri:52de7dcded23dd4a1fd932012d60b81c"},
+      "nidm_hasMaximumIntensityProjection": {"@id": "niiri:3f22616908b033819a3786fde1496cc7"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:d83638bd84f027751d70f6f76d98df8c"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "048ef4d6ee2e4fd5c85757968e6d5feccfeec3292d691e3e32b4f2553d501813397bb83e7f5616a808f0068c6d3e8f1309654d9f1239e0bab1fea410dcd9cb78"}
     },
     {
-      "@id": "niiri:c804e7a5c284ea00ab8f31fc071824f3",
-      "@type": ["prov:Entity","nidm_ClusterLabelsMap:"],
+      "@id": "niiri:52de7dcded23dd4a1fd932012d60b81c",
+      "@type": ["prov:Entity","nidm_ClusterLabelsMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ClusterLabels.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ClusterLabels.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Cluster Labels Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:1b7e4b57cfbc311750156373ae9ba795"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:d83638bd84f027751d70f6f76d98df8c"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "f90fdcd70484a1e73a009d9b568825514b14190ee02ea8c61ea7e206dcb5f9b6dfde3931dbc3f4feb1cd358ca0307835fc90b319ab92667eb8af56ef628f5c87"}
     },
     {
-      "@id": "niiri:09db6d6737588a7694ffd334225ba531",
+      "@id": "niiri:3f22616908b033819a3786fde1496cc7",
       "@type": ["prov:Entity","dctype:Image"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "MaximumIntensityProjection.png"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "MaximumIntensityProjection.png"},
@@ -689,1082 +689,1082 @@
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:dc8fee2c80984a4e4da98aaa0284ab39",
-      "activity": "niiri:1abc4a77e9c6d1b1d0651d63a40e8a8d"
+      "entity_generated": "niiri:fd051605e8c7f96825de2e8c362f619d",
+      "activity": "niiri:b65d1dde00468cfdc0b2c5c7b16aca85"
     },
     {
-      "@id": "niiri:fea0f4eb720496a64dd119edf1c8fd20",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:01ec637797471e97b81c59d553918fe2",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0001",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1264"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "11.3911127260799"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.46564319955646e-14"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "8.15347789284715e-13"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "9.37785071906856e-13"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "1"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1264"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "11.3911127260799"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.46564319955646e-14"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "8.15347789284715e-13"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "9.37785071906856e-13"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "1"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:fea0f4eb720496a64dd119edf1c8fd20",
-      "entity": "niiri:dc8fee2c80984a4e4da98aaa0284ab39"
+      "entity_derived": "niiri:01ec637797471e97b81c59d553918fe2",
+      "entity": "niiri:fd051605e8c7f96825de2e8c362f619d"
     },
     {
-      "@id": "niiri:5be690c7137b49b7de3a5957b1c2e009",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:dc195d458077541582f78033d188351e",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0002",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "273"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "2.46026406188276"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.56401134673758e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.000285538833242782"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "5.47403971358153e-05"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "2"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "273"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "2.46026406188276"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.56401134673758e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.000285538833242782"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "5.47403971358153e-05"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "2"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5be690c7137b49b7de3a5957b1c2e009",
-      "entity": "niiri:dc8fee2c80984a4e4da98aaa0284ab39"
+      "entity_derived": "niiri:dc195d458077541582f78033d188351e",
+      "entity": "niiri:fd051605e8c7f96825de2e8c362f619d"
     },
     {
-      "@id": "niiri:8274df6982dc764d903aeb32906fa99e",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:125236b3b8db9c4f2b7d390d441d3c18",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0003",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "645"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "5.81271179455818"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.98550701476426e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "5.45136644714006e-08"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "2.08985491033498e-08"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "3"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "645"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "5.81271179455818"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.98550701476426e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "5.45136644714006e-08"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "2.08985491033498e-08"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "3"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8274df6982dc764d903aeb32906fa99e",
-      "entity": "niiri:dc8fee2c80984a4e4da98aaa0284ab39"
+      "entity_derived": "niiri:125236b3b8db9c4f2b7d390d441d3c18",
+      "entity": "niiri:fd051605e8c7f96825de2e8c362f619d"
     },
     {
-      "@id": "niiri:bd2d07ab483a43de0c2ab5d363f8a39f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c7407836fb981de7ef9a1ccaad77eec7",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0004",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "252"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "2.27101298019947"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.77946923942363e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.000507386565178569"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "8.33840771827089e-05"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "4"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "252"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "2.27101298019947"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.77946923942363e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.000507386565178569"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "8.33840771827089e-05"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "4"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:bd2d07ab483a43de0c2ab5d363f8a39f",
-      "entity": "niiri:dc8fee2c80984a4e4da98aaa0284ab39"
+      "entity_derived": "niiri:c7407836fb981de7ef9a1ccaad77eec7",
+      "entity": "niiri:fd051605e8c7f96825de2e8c362f619d"
     },
     {
-      "@id": "niiri:366992a084b7ef6a24b39de104a74c9f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:6efb738cf8ae66818b93292de14c66bf",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0005",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "649"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "5.84875961964071"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.7530178167288e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "5.02685436609696e-08"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "2.08985491033498e-08"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "5"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "649"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "5.84875961964071"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.7530178167288e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "5.02685436609696e-08"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "2.08985491033498e-08"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "5"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:366992a084b7ef6a24b39de104a74c9f",
-      "entity": "niiri:dc8fee2c80984a4e4da98aaa0284ab39"
+      "entity_derived": "niiri:6efb738cf8ae66818b93292de14c66bf",
+      "entity": "niiri:fd051605e8c7f96825de2e8c362f619d"
     },
     {
-      "@id": "niiri:346bffef3940af9cd3edb04ed96ce19c",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:688ca92e605ac76835652ec4e94cc704",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0006",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "543"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "4.89349225495363"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.50784594384806e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "4.57918350238451e-07"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1.31661912052023e-07"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "6"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "543"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "4.89349225495363"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.50784594384806e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "4.57918350238451e-07"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1.31661912052023e-07"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "6"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:346bffef3940af9cd3edb04ed96ce19c",
-      "entity": "niiri:dc8fee2c80984a4e4da98aaa0284ab39"
+      "entity_derived": "niiri:688ca92e605ac76835652ec4e94cc704",
+      "entity": "niiri:fd051605e8c7f96825de2e8c362f619d"
     },
     {
-      "@id": "niiri:f1d6e888b3036a10e15107b3d4ffaa31",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:68da208642972437b835af6ed59a660c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0007",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "312"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "2.81173035643744"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.58221623295473e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00010192290996347"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "2.34453081784098e-05"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "7"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "312"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "2.81173035643744"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.58221623295473e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00010192290996347"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "2.34453081784098e-05"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "7"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f1d6e888b3036a10e15107b3d4ffaa31",
-      "entity": "niiri:dc8fee2c80984a4e4da98aaa0284ab39"
+      "entity_derived": "niiri:68da208642972437b835af6ed59a660c",
+      "entity": "niiri:fd051605e8c7f96825de2e8c362f619d"
     },
     {
-      "@id": "niiri:39bbd361b635bf63dc6b25f92c18b7ca",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f8507bdcacd86027fdafd6fd60ba6874",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0008",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "15"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.135179344059493"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.202037711367992"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.975005365474947"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.353565994893987"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "8"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "15"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.135179344059493"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.202037711367992"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.975005365474947"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.353565994893987"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "8"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:39bbd361b635bf63dc6b25f92c18b7ca",
-      "entity": "niiri:dc8fee2c80984a4e4da98aaa0284ab39"
+      "entity_derived": "niiri:f8507bdcacd86027fdafd6fd60ba6874",
+      "entity": "niiri:fd051605e8c7f96825de2e8c362f619d"
     },
     {
-      "@id": "niiri:8ab7185bd26c34dee98b0031b8d417ac",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:d2ca51b89db2e3b1111d7fdbfda64417",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0009",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "186"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.67622386633771"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000190098018775023"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00346506483545928"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000499007299284434"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "9"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "186"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.67622386633771"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000190098018775023"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00346506483545928"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000499007299284434"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "9"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8ab7185bd26c34dee98b0031b8d417ac",
-      "entity": "niiri:dc8fee2c80984a4e4da98aaa0284ab39"
+      "entity_derived": "niiri:d2ca51b89db2e3b1111d7fdbfda64417",
+      "entity": "niiri:fd051605e8c7f96825de2e8c362f619d"
     },
     {
-      "@id": "niiri:cb714b171c3d5683c2c98af66cf6eabb",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:93024a65786df3d21c3afeb2157fda29",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0010",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "32"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.288382600660251"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0706267334937813"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.724620221938759"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.148316140336941"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "10"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "32"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.288382600660251"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0706267334937813"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.724620221938759"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.148316140336941"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "10"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cb714b171c3d5683c2c98af66cf6eabb",
-      "entity": "niiri:dc8fee2c80984a4e4da98aaa0284ab39"
+      "entity_derived": "niiri:93024a65786df3d21c3afeb2157fda29",
+      "entity": "niiri:fd051605e8c7f96825de2e8c362f619d"
     },
     {
-      "@id": "niiri:0ff9d90df9162134b0a5b1c57873965e",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:035c0aba4276188a1f52052646ae7120",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0011",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "26"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.234310863036454"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0994868758856398"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.837418191223327"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.189929490327131"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "11"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "26"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.234310863036454"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0994868758856398"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.837418191223327"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.189929490327131"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "11"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0ff9d90df9162134b0a5b1c57873965e",
-      "entity": "niiri:dc8fee2c80984a4e4da98aaa0284ab39"
+      "entity_derived": "niiri:035c0aba4276188a1f52052646ae7120",
+      "entity": "niiri:fd051605e8c7f96825de2e8c362f619d"
     },
     {
-      "@id": "niiri:4cd12d51d9021fd8adb9844533537b73",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:2dc499c816a88d424858df07e367da38",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0012",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "12"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.108143475247594"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.252022793965942"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.989966174793775"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.407113744098829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "12"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "12"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.108143475247594"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.252022793965942"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.989966174793775"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.407113744098829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "12"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4cd12d51d9021fd8adb9844533537b73",
-      "entity": "niiri:dc8fee2c80984a4e4da98aaa0284ab39"
+      "entity_derived": "niiri:2dc499c816a88d424858df07e367da38",
+      "entity": "niiri:fd051605e8c7f96825de2e8c362f619d"
     },
     {
-      "@id": "niiri:1b789db1ce53a57bbc25c68cdac66c2d",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:809e973106f074b8b57288f78176fadb",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0013",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "33"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.297394556930884"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0668517070898811"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.704968833899269"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.148316140336941"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "13"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "33"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.297394556930884"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0668517070898811"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.704968833899269"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.148316140336941"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "13"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1b789db1ce53a57bbc25c68cdac66c2d",
-      "entity": "niiri:dc8fee2c80984a4e4da98aaa0284ab39"
+      "entity_derived": "niiri:809e973106f074b8b57288f78176fadb",
+      "entity": "niiri:fd051605e8c7f96825de2e8c362f619d"
     },
     {
-      "@id": "niiri:8d9aa6d1ec6c37718c5a8b44989b6f5f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:23280aef5e15fc151595ade28a75778f",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0014",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "10"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0901195627063283"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.29508405850199"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.995429202843773"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.442626087752986"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "14"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "10"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0901195627063283"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.29508405850199"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.995429202843773"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.442626087752986"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "14"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8d9aa6d1ec6c37718c5a8b44989b6f5f",
-      "entity": "niiri:dc8fee2c80984a4e4da98aaa0284ab39"
+      "entity_derived": "niiri:23280aef5e15fc151595ade28a75778f",
+      "entity": "niiri:fd051605e8c7f96825de2e8c362f619d"
     },
     {
-      "@id": "niiri:8d5aa4d277ff8060425a7d8827846199",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:a724fab477e1c34dff00939c8a5fe1d9",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0015",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0360478250825313"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.515516155678853"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99991834706655"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.601435514958662"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "15"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0360478250825313"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.515516155678853"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99991834706655"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.601435514958662"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "15"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8d5aa4d277ff8060425a7d8827846199",
-      "entity": "niiri:dc8fee2c80984a4e4da98aaa0284ab39"
+      "entity_derived": "niiri:a724fab477e1c34dff00939c8a5fe1d9",
+      "entity": "niiri:fd051605e8c7f96825de2e8c362f619d"
     },
     {
-      "@id": "niiri:c3faa5585abf8fd6ae5f51bed00a5c44",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:e8d2cf34f04ba64f58f96a3bd57989a0",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0016",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "6"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.054071737623797"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.419692024215448"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999530263417872"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.587568833901628"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "16"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "6"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.054071737623797"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.419692024215448"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999530263417872"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.587568833901628"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "16"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c3faa5585abf8fd6ae5f51bed00a5c44",
-      "entity": "niiri:dc8fee2c80984a4e4da98aaa0284ab39"
+      "entity_derived": "niiri:e8d2cf34f04ba64f58f96a3bd57989a0",
+      "entity": "niiri:fd051605e8c7f96825de2e8c362f619d"
     },
     {
-      "@id": "niiri:860d4c90c76b09b791e464d1115fe241",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:b073888acef337b87afb0a3f49356435",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0017",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0180239125412657"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.658755107945733"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999994028395426"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.728097750887389"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "17"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0180239125412657"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.658755107945733"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999994028395426"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.728097750887389"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "17"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:860d4c90c76b09b791e464d1115fe241",
-      "entity": "niiri:dc8fee2c80984a4e4da98aaa0284ab39"
+      "entity_derived": "niiri:b073888acef337b87afb0a3f49356435",
+      "entity": "niiri:fd051605e8c7f96825de2e8c362f619d"
     },
     {
-      "@id": "niiri:99f2be73be2c6be215bfd9faf3a92a39",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:24cb62d0bb1e202be98184cc8d05dffd",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0018",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "5"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0450597813531642"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.4635394969871"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99978906667809"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.601435514958662"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "18"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "5"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0450597813531642"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.4635394969871"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99978906667809"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.601435514958662"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "18"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:99f2be73be2c6be215bfd9faf3a92a39",
-      "entity": "niiri:dc8fee2c80984a4e4da98aaa0284ab39"
+      "entity_derived": "niiri:24cb62d0bb1e202be98184cc8d05dffd",
+      "entity": "niiri:fd051605e8c7f96825de2e8c362f619d"
     },
     {
-      "@id": "niiri:1e52aefb94abdf0e6614ea5a19db8bab",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:824d90300b93425516b70315d9d6f976",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0019",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0360478250825313"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.515516155678853"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99991834706655"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.601435514958662"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "19"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0360478250825313"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.515516155678853"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99991834706655"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.601435514958662"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "19"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1e52aefb94abdf0e6614ea5a19db8bab",
-      "entity": "niiri:dc8fee2c80984a4e4da98aaa0284ab39"
+      "entity_derived": "niiri:824d90300b93425516b70315d9d6f976",
+      "entity": "niiri:fd051605e8c7f96825de2e8c362f619d"
     },
     {
-      "@id": "niiri:f5d12376dc838c360907fa99f57693b3",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:4b1128660a9a6cee4015a8ff88a80c95",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0001",
-      "prov:atLocation": {"@id": "niiri:063accc4d27557385539d241f4400c7b"},
+      "prov:atLocation": {"@id": "niiri:df9bb709e4b052129d18485666595240"},
       "prov:value": {"@type": "xsd:float", "@value": "8.68328475952148"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.89806475543002"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.83894821592645e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.000295890410111577"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00163136813750933"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.89806475543002"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.83894821592645e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.000295890410111577"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00163136813750933"}
     },
     {
-      "@id": "niiri:063accc4d27557385539d241f4400c7b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:df9bb709e4b052129d18485666595240",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0001",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-8,14,44]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-8,14,44]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f5d12376dc838c360907fa99f57693b3",
-      "entity": "niiri:fea0f4eb720496a64dd119edf1c8fd20"
+      "entity_derived": "niiri:4b1128660a9a6cee4015a8ff88a80c95",
+      "entity": "niiri:01ec637797471e97b81c59d553918fe2"
     },
     {
-      "@id": "niiri:8b6d437e8a2dc4bb10db5f840ad5cb0b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:12441664c05631bc80a5589022113423",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0002",
-      "prov:atLocation": {"@id": "niiri:4f622b98376b0203b6fc463810fda26b"},
+      "prov:atLocation": {"@id": "niiri:c985252a616227b4de321a67cafc5e9f"},
       "prov:value": {"@type": "xsd:float", "@value": "7.33630895614624"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.35354564681114"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.31236324427431e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00693867881448451"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00719550144323139"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.35354564681114"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.31236324427431e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00693867881448451"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00719550144323139"}
     },
     {
-      "@id": "niiri:4f622b98376b0203b6fc463810fda26b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c985252a616227b4de321a67cafc5e9f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0002",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-2,8,62]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-2,8,62]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8b6d437e8a2dc4bb10db5f840ad5cb0b",
-      "entity": "niiri:fea0f4eb720496a64dd119edf1c8fd20"
+      "entity_derived": "niiri:12441664c05631bc80a5589022113423",
+      "entity": "niiri:01ec637797471e97b81c59d553918fe2"
     },
     {
-      "@id": "niiri:3fd07c7c0da35cfc103353962d0cb298",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f35b60f8e0364a64a0d746c299ac0db6",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0003",
-      "prov:atLocation": {"@id": "niiri:d334b839c5aac2c367ee63f7000b9f1c"},
+      "prov:atLocation": {"@id": "niiri:e169aecc5f1ea00016ee1e9750c0f735"},
       "prov:value": {"@type": "xsd:float", "@value": "6.84883069992065"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.13238708590925"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.43045180589496e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0188976197165134"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00835884069841993"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.13238708590925"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.43045180589496e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0188976197165134"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00835884069841993"}
     },
     {
-      "@id": "niiri:d334b839c5aac2c367ee63f7000b9f1c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e169aecc5f1ea00016ee1e9750c0f735",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0003",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[8,2,66]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[8,2,66]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3fd07c7c0da35cfc103353962d0cb298",
-      "entity": "niiri:fea0f4eb720496a64dd119edf1c8fd20"
+      "entity_derived": "niiri:f35b60f8e0364a64a0d746c299ac0db6",
+      "entity": "niiri:01ec637797471e97b81c59d553918fe2"
     },
     {
-      "@id": "niiri:c00def4a48d5a30f5a0b70a012758d41",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ec7ddf4786fe39f9182536fea466833e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0004",
-      "prov:atLocation": {"@id": "niiri:80db77128b371a6b29ab4b607db75fbd"},
+      "prov:atLocation": {"@id": "niiri:d54e6ad7e6488168ce22f8734b7eb5f5"},
       "prov:value": {"@type": "xsd:float", "@value": "8.35158634185791"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.77222915803918"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.9114812500074e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.000629365120361269"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00163136813750933"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.77222915803918"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.9114812500074e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.000629365120361269"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00163136813750933"}
     },
     {
-      "@id": "niiri:80db77128b371a6b29ab4b607db75fbd",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d54e6ad7e6488168ce22f8734b7eb5f5",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0004",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-46,-4,54]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-46,-4,54]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c00def4a48d5a30f5a0b70a012758d41",
-      "entity": "niiri:5be690c7137b49b7de3a5957b1c2e009"
+      "entity_derived": "niiri:ec7ddf4786fe39f9182536fea466833e",
+      "entity": "niiri:dc195d458077541582f78033d188351e"
     },
     {
-      "@id": "niiri:e0d8a9ff23aa198493f707eed8ef4541",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:beae26e50fc3b9b6095ec0cf978aa74d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0005",
-      "prov:atLocation": {"@id": "niiri:b471f18eed004f6b436cf02c9eeb0001"},
+      "prov:atLocation": {"@id": "niiri:a86b051d7b52ab721f5e5175d20d7eae"},
       "prov:value": {"@type": "xsd:float", "@value": "6.98639822006226"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.19623635430538"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.01681835729117e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0142675592490157"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00719550144323139"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.19623635430538"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.01681835729117e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0142675592490157"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00719550144323139"}
     },
     {
-      "@id": "niiri:b471f18eed004f6b436cf02c9eeb0001",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a86b051d7b52ab721f5e5175d20d7eae",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0005",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-52,-4,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-52,-4,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e0d8a9ff23aa198493f707eed8ef4541",
-      "entity": "niiri:5be690c7137b49b7de3a5957b1c2e009"
+      "entity_derived": "niiri:beae26e50fc3b9b6095ec0cf978aa74d",
+      "entity": "niiri:dc195d458077541582f78033d188351e"
     },
     {
-      "@id": "niiri:674261e537481975fae3b273665d3696",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:78a7e02e1865904a3962e95d6e770a76",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0006",
-      "prov:atLocation": {"@id": "niiri:410fae38a3d3669805433fa1ffef060a"},
+      "prov:atLocation": {"@id": "niiri:c0d5c03cc49d0e30483f9a8ad3fc7ed6"},
       "prov:value": {"@type": "xsd:float", "@value": "4.94789028167725"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.11595434674584"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.92790313852109e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.632970462914878"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.106458926829394"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.11595434674584"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.92790313852109e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.632970462914878"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.106458926829394"}
     },
     {
-      "@id": "niiri:410fae38a3d3669805433fa1ffef060a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c0d5c03cc49d0e30483f9a8ad3fc7ed6",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0006",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-44,0,36]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-44,0,36]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:674261e537481975fae3b273665d3696",
-      "entity": "niiri:5be690c7137b49b7de3a5957b1c2e009"
+      "entity_derived": "niiri:78a7e02e1865904a3962e95d6e770a76",
+      "entity": "niiri:dc195d458077541582f78033d188351e"
     },
     {
-      "@id": "niiri:9c7572593a901012448046d97f575824",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:606a12f8dfe1e04b3697ef1eebb14808",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0007",
-      "prov:atLocation": {"@id": "niiri:dc36b3bfe116277634ce635e53fee2c4"},
+      "prov:atLocation": {"@id": "niiri:3a24858e4f675f4ceec3345587d30aef"},
       "prov:value": {"@type": "xsd:float", "@value": "7.1633768081665"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.27669699963205"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.57665507608485e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00994759733633388"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00719550144323139"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.27669699963205"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.57665507608485e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00994759733633388"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00719550144323139"}
     },
     {
-      "@id": "niiri:dc36b3bfe116277634ce635e53fee2c4",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:3a24858e4f675f4ceec3345587d30aef",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0007",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-28,20,4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-28,20,4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9c7572593a901012448046d97f575824",
-      "entity": "niiri:8274df6982dc764d903aeb32906fa99e"
+      "entity_derived": "niiri:606a12f8dfe1e04b3697ef1eebb14808",
+      "entity": "niiri:125236b3b8db9c4f2b7d390d441d3c18"
     },
     {
-      "@id": "niiri:f344995ee9396ec2b22436da6abdfc01",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3d611934585d07a97bc5d3fb0a2ae75a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0008",
-      "prov:atLocation": {"@id": "niiri:7c1bef178f76c4737604068ad1821fb8"},
+      "prov:atLocation": {"@id": "niiri:4c0f3c362a6a4ca000f2e45782ca92d7"},
       "prov:value": {"@type": "xsd:float", "@value": "6.05753993988037"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.74136371640284"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.06142217415339e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0943293570611123"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0289398009003969"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.74136371640284"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.06142217415339e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0943293570611123"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0289398009003969"}
     },
     {
-      "@id": "niiri:7c1bef178f76c4737604068ad1821fb8",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4c0f3c362a6a4ca000f2e45782ca92d7",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0008",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-32,12,12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-32,12,12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f344995ee9396ec2b22436da6abdfc01",
-      "entity": "niiri:8274df6982dc764d903aeb32906fa99e"
+      "entity_derived": "niiri:3d611934585d07a97bc5d3fb0a2ae75a",
+      "entity": "niiri:125236b3b8db9c4f2b7d390d441d3c18"
     },
     {
-      "@id": "niiri:d1f339ee53c67a39858a02aab0c7fc68",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:81261cd464ee0b8f22adca3c75f049a3",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0009",
-      "prov:atLocation": {"@id": "niiri:8159917a3daf71fd51837d08aa36c2e3"},
+      "prov:atLocation": {"@id": "niiri:9460d662c65847aeccb65dca7370d87b"},
       "prov:value": {"@type": "xsd:float", "@value": "5.53688049316406"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.4599738348881"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.09848297133752e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.255369959741091"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0463937463013495"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.4599738348881"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.09848297133752e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.255369959741091"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0463937463013495"}
     },
     {
-      "@id": "niiri:8159917a3daf71fd51837d08aa36c2e3",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:9460d662c65847aeccb65dca7370d87b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0009",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-40,14,6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-40,14,6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d1f339ee53c67a39858a02aab0c7fc68",
-      "entity": "niiri:8274df6982dc764d903aeb32906fa99e"
+      "entity_derived": "niiri:81261cd464ee0b8f22adca3c75f049a3",
+      "entity": "niiri:125236b3b8db9c4f2b7d390d441d3c18"
     },
     {
-      "@id": "niiri:07d2d8dacefd14b5512b2780fe8e9418",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:809e45a8f97c7742d22d07c42e436b9b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0010",
-      "prov:atLocation": {"@id": "niiri:69f8f24492b6358c98c62bb755257e4d"},
+      "prov:atLocation": {"@id": "niiri:2d0c2f8f914e3950001f5780fda6d7c5"},
       "prov:value": {"@type": "xsd:float", "@value": "7.03751659393311"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.21966850947269"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.96218316226438e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0128544751144342"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00719550144323139"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.21966850947269"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.96218316226438e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0128544751144342"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00719550144323139"}
     },
     {
-      "@id": "niiri:69f8f24492b6358c98c62bb755257e4d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:2d0c2f8f914e3950001f5780fda6d7c5",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0010",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[54,0,46]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[54,0,46]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:07d2d8dacefd14b5512b2780fe8e9418",
-      "entity": "niiri:bd2d07ab483a43de0c2ab5d363f8a39f"
+      "entity_derived": "niiri:809e45a8f97c7742d22d07c42e436b9b",
+      "entity": "niiri:c7407836fb981de7ef9a1ccaad77eec7"
     },
     {
-      "@id": "niiri:9dd6bc79a73003860246fdbd4d6e50ac",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:7d6282c527edd4b542c265187c6fc7a9",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0011",
-      "prov:atLocation": {"@id": "niiri:e21e7ba6c3100ae713d83f7f7de299ef"},
+      "prov:atLocation": {"@id": "niiri:c5ba100f71d6acc1ce64b2c2026b9ad4"},
       "prov:value": {"@type": "xsd:float", "@value": "4.67526912689209"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.94678957573653"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.96030553606597e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.826020447766485"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.175133460202579"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.94678957573653"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.96030553606597e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.826020447766485"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.175133460202579"}
     },
     {
-      "@id": "niiri:e21e7ba6c3100ae713d83f7f7de299ef",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c5ba100f71d6acc1ce64b2c2026b9ad4",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0011",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[42,0,40]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[42,0,40]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9dd6bc79a73003860246fdbd4d6e50ac",
-      "entity": "niiri:bd2d07ab483a43de0c2ab5d363f8a39f"
+      "entity_derived": "niiri:7d6282c527edd4b542c265187c6fc7a9",
+      "entity": "niiri:c7407836fb981de7ef9a1ccaad77eec7"
     },
     {
-      "@id": "niiri:a54191fd77e1cffaaa265aa0ff737a0d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e122dfd8cae44bf9b1c9068c52fbb1fd",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0012",
-      "prov:atLocation": {"@id": "niiri:bb7e2fd466b439dfe1cdad53c0cbcce1"},
+      "prov:atLocation": {"@id": "niiri:88eb1ce70078217da9ad80ffbff952c8"},
       "prov:value": {"@type": "xsd:float", "@value": "3.99186444282532"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.49308716519441"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000238735314068705"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.998766388576126"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.467639377242474"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.49308716519441"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000238735314068705"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.998766388576126"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.467639377242474"}
     },
     {
-      "@id": "niiri:bb7e2fd466b439dfe1cdad53c0cbcce1",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:88eb1ce70078217da9ad80ffbff952c8",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0012",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[50,4,38]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[50,4,38]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a54191fd77e1cffaaa265aa0ff737a0d",
-      "entity": "niiri:bd2d07ab483a43de0c2ab5d363f8a39f"
+      "entity_derived": "niiri:e122dfd8cae44bf9b1c9068c52fbb1fd",
+      "entity": "niiri:c7407836fb981de7ef9a1ccaad77eec7"
     },
     {
-      "@id": "niiri:73576e6f6e96479fa537ebb5a320da45",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:10f6bffbb03110c4e326855f654c7053",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0013",
-      "prov:atLocation": {"@id": "niiri:15ab25d6eb17fe855b3e4cd781c8558d"},
+      "prov:atLocation": {"@id": "niiri:09bc6e573433407ff8167fd0ec8c3554"},
       "prov:value": {"@type": "xsd:float", "@value": "6.17448043823242"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.80182851023383"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.86116573836537e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0746359690709463"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0247162735389005"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.80182851023383"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.86116573836537e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0746359690709463"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0247162735389005"}
     },
     {
-      "@id": "niiri:15ab25d6eb17fe855b3e4cd781c8558d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:09bc6e573433407ff8167fd0ec8c3554",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0013",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[64,-32,14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[64,-32,14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:73576e6f6e96479fa537ebb5a320da45",
-      "entity": "niiri:366992a084b7ef6a24b39de104a74c9f"
+      "entity_derived": "niiri:10f6bffbb03110c4e326855f654c7053",
+      "entity": "niiri:6efb738cf8ae66818b93292de14c66bf"
     },
     {
-      "@id": "niiri:0e1e7b9bc1a6cf4f76ff149e1a986076",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c4779e84dce494937bda818ef5e669dc",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0014",
-      "prov:atLocation": {"@id": "niiri:4e9baf1f2c75efd517106374f31f08b1"},
+      "prov:atLocation": {"@id": "niiri:ecbd626ad6f08df3e710715c3e5284c2"},
       "prov:value": {"@type": "xsd:float", "@value": "5.78444290161133"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.59630541537731"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.15024103455974e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.161036372633912"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0384651426630127"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.59630541537731"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.15024103455974e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.161036372633912"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0384651426630127"}
     },
     {
-      "@id": "niiri:4e9baf1f2c75efd517106374f31f08b1",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ecbd626ad6f08df3e710715c3e5284c2",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0014",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[54,-36,6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[54,-36,6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0e1e7b9bc1a6cf4f76ff149e1a986076",
-      "entity": "niiri:366992a084b7ef6a24b39de104a74c9f"
+      "entity_derived": "niiri:c4779e84dce494937bda818ef5e669dc",
+      "entity": "niiri:6efb738cf8ae66818b93292de14c66bf"
     },
     {
-      "@id": "niiri:215ee51142ace5bc800ea56a96069019",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:844b498ab06280ebbe9ee9dceb2a5d16",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0015",
-      "prov:atLocation": {"@id": "niiri:3c407f555837fd3219d33ddf197b2654"},
+      "prov:atLocation": {"@id": "niiri:6be9818fbe27aa7823d210572c66e57f"},
       "prov:value": {"@type": "xsd:float", "@value": "5.29158926010132"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.32015757237268"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.79589134014547e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.3885997605562"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0663265650293897"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.32015757237268"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.79589134014547e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.3885997605562"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0663265650293897"}
     },
     {
-      "@id": "niiri:3c407f555837fd3219d33ddf197b2654",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6be9818fbe27aa7823d210572c66e57f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0015",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[58,-18,-4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[58,-18,-4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:215ee51142ace5bc800ea56a96069019",
-      "entity": "niiri:366992a084b7ef6a24b39de104a74c9f"
+      "entity_derived": "niiri:844b498ab06280ebbe9ee9dceb2a5d16",
+      "entity": "niiri:6efb738cf8ae66818b93292de14c66bf"
     },
     {
-      "@id": "niiri:40729988e97b5bc5fe7c276102dbcd6b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3e533998c00bcb7174e1ff58abee7b36",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0016",
-      "prov:atLocation": {"@id": "niiri:b66375039d5f769dfb5f115db1f5781c"},
+      "prov:atLocation": {"@id": "niiri:724b45d5eea6ea672d1a7c6765b84433"},
       "prov:value": {"@type": "xsd:float", "@value": "5.80037450790405"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.60491906158358"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.06313156536631e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.156185504689616"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0384651426630127"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.60491906158358"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.06313156536631e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.156185504689616"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0384651426630127"}
     },
     {
-      "@id": "niiri:b66375039d5f769dfb5f115db1f5781c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:724b45d5eea6ea672d1a7c6765b84433",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0016",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[32,18,6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[32,18,6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:40729988e97b5bc5fe7c276102dbcd6b",
-      "entity": "niiri:346bffef3940af9cd3edb04ed96ce19c"
+      "entity_derived": "niiri:3e533998c00bcb7174e1ff58abee7b36",
+      "entity": "niiri:688ca92e605ac76835652ec4e94cc704"
     },
     {
-      "@id": "niiri:fa7e2af5036aae17f3d6d347ea3655b3",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3df0e6a6a8d15f376ef1ad04904ac285",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0017",
-      "prov:atLocation": {"@id": "niiri:57af4eea0139686f537c81cdd2dbe5cc"},
+      "prov:atLocation": {"@id": "niiri:688e14ec89daea4fe959e58361ee58a1"},
       "prov:value": {"@type": "xsd:float", "@value": "5.65365648269653"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.52486817583008"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.02165810672772e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.206207182279971"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0404714050465719"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.52486817583008"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.02165810672772e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.206207182279971"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0404714050465719"}
     },
     {
-      "@id": "niiri:57af4eea0139686f537c81cdd2dbe5cc",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:688e14ec89daea4fe959e58361ee58a1",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0017",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[46,14,2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[46,14,2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:fa7e2af5036aae17f3d6d347ea3655b3",
-      "entity": "niiri:346bffef3940af9cd3edb04ed96ce19c"
+      "entity_derived": "niiri:3df0e6a6a8d15f376ef1ad04904ac285",
+      "entity": "niiri:688ca92e605ac76835652ec4e94cc704"
     },
     {
-      "@id": "niiri:296a366820300d5df08a3d708d64d346",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:820ea5e2cac41f9259686ca8892a5878",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0018",
-      "prov:atLocation": {"@id": "niiri:2dc12cbb22f93d17b25d19b10313d8a6"},
+      "prov:atLocation": {"@id": "niiri:a89e043e86acf22adbef2c908f0c940a"},
       "prov:value": {"@type": "xsd:float", "@value": "4.97042274475098"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.12964691442442"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.81660388410831e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.61591975617624"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.106458926829394"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.12964691442442"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.81660388410831e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.61591975617624"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.106458926829394"}
     },
     {
-      "@id": "niiri:2dc12cbb22f93d17b25d19b10313d8a6",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a89e043e86acf22adbef2c908f0c940a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0018",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[52,6,20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[52,6,20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:296a366820300d5df08a3d708d64d346",
-      "entity": "niiri:346bffef3940af9cd3edb04ed96ce19c"
+      "entity_derived": "niiri:820ea5e2cac41f9259686ca8892a5878",
+      "entity": "niiri:688ca92e605ac76835652ec4e94cc704"
     },
     {
-      "@id": "niiri:e64d9d9e2f71702fc14e7158572a1a6c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:efbc436a1b3678612dfe7f44dd10cbb3",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0019",
-      "prov:atLocation": {"@id": "niiri:98ab5c1a1e4e369c1246d0134debdbfd"},
+      "prov:atLocation": {"@id": "niiri:397d2866425d1c295696d0c818d8d533"},
       "prov:value": {"@type": "xsd:float", "@value": "5.69512796401978"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.54766136430568"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.71226629111609e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.190809496629972"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0390573552317814"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.54766136430568"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.71226629111609e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.190809496629972"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0390573552317814"}
     },
     {
-      "@id": "niiri:98ab5c1a1e4e369c1246d0134debdbfd",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:397d2866425d1c295696d0c818d8d533",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0019",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-50,-44,10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-50,-44,10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e64d9d9e2f71702fc14e7158572a1a6c",
-      "entity": "niiri:f1d6e888b3036a10e15107b3d4ffaa31"
+      "entity_derived": "niiri:efbc436a1b3678612dfe7f44dd10cbb3",
+      "entity": "niiri:68da208642972437b835af6ed59a660c"
     },
     {
-      "@id": "niiri:7ccdc091157500cdd924e120d242a240",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:22dcde4b50ff0337757a88138a5b07fc",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0020",
-      "prov:atLocation": {"@id": "niiri:11a29c9524e7e456200532633e297bd9"},
+      "prov:atLocation": {"@id": "niiri:36fb849d4a7b16b57fbc1cd5f7c305fc"},
       "prov:value": {"@type": "xsd:float", "@value": "4.58639812469482"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.89022248971066"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.00761765690472e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.876622606435302"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.203731029267221"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.89022248971066"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.00761765690472e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.876622606435302"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.203731029267221"}
     },
     {
-      "@id": "niiri:11a29c9524e7e456200532633e297bd9",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:36fb849d4a7b16b57fbc1cd5f7c305fc",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0020",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-62,-36,8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-62,-36,8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7ccdc091157500cdd924e120d242a240",
-      "entity": "niiri:f1d6e888b3036a10e15107b3d4ffaa31"
+      "entity_derived": "niiri:22dcde4b50ff0337757a88138a5b07fc",
+      "entity": "niiri:68da208642972437b835af6ed59a660c"
     },
     {
-      "@id": "niiri:8ee9a8b687dcc085503323011e230a5c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:880b4afc515a88ebc3cf045d50f3c04a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0021",
-      "prov:atLocation": {"@id": "niiri:b9a5cd2efb5be31c8530c8899aaca4b8"},
+      "prov:atLocation": {"@id": "niiri:31ed78344a2ca5c440cba467b3a898d7"},
       "prov:value": {"@type": "xsd:float", "@value": "4.50590515136719"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.83837298746928"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.19261255102588e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.914499359553669"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.232964826348096"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.83837298746928"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.19261255102588e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.914499359553669"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.232964826348096"}
     },
     {
-      "@id": "niiri:b9a5cd2efb5be31c8530c8899aaca4b8",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:31ed78344a2ca5c440cba467b3a898d7",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0021",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-44,-40,20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-44,-40,20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8ee9a8b687dcc085503323011e230a5c",
-      "entity": "niiri:f1d6e888b3036a10e15107b3d4ffaa31"
+      "entity_derived": "niiri:880b4afc515a88ebc3cf045d50f3c04a",
+      "entity": "niiri:68da208642972437b835af6ed59a660c"
     },
     {
-      "@id": "niiri:6020e5e9c767f76447ce8c5737dfa47b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:9dbf2c151d9034e9c4371c30e60411e3",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0022",
-      "prov:atLocation": {"@id": "niiri:455364cd53f6c80b439be1f9454d8efe"},
+      "prov:atLocation": {"@id": "niiri:622423e8bf7e3d7bd7479503b8fd3628"},
       "prov:value": {"@type": "xsd:float", "@value": "5.32945966720581"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.34205915406457"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.05767571707039e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.36535430900768"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0637479979695797"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.34205915406457"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.05767571707039e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.36535430900768"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0637479979695797"}
     },
     {
-      "@id": "niiri:455364cd53f6c80b439be1f9454d8efe",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:622423e8bf7e3d7bd7479503b8fd3628",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0022",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-66,-24,8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-66,-24,8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6020e5e9c767f76447ce8c5737dfa47b",
-      "entity": "niiri:39bbd361b635bf63dc6b25f92c18b7ca"
+      "entity_derived": "niiri:9dbf2c151d9034e9c4371c30e60411e3",
+      "entity": "niiri:f8507bdcacd86027fdafd6fd60ba6874"
     },
     {
-      "@id": "niiri:d2a2fafd4a599c37791055299a6834b3",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3826db9e7668227e2a63e832d3c39701",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0023",
-      "prov:atLocation": {"@id": "niiri:8ca651ed084d6c59ca691676b5040b0f"},
+      "prov:atLocation": {"@id": "niiri:950862f883bf950f211e73006d0c3c3b"},
       "prov:value": {"@type": "xsd:float", "@value": "5.2721529006958"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.30887158779036"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.20448008320707e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.400892212456252"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0665066282431519"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.30887158779036"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.20448008320707e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.400892212456252"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0665066282431519"}
     },
     {
-      "@id": "niiri:8ca651ed084d6c59ca691676b5040b0f",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:950862f883bf950f211e73006d0c3c3b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0023",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[54,-36,46]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[54,-36,46]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d2a2fafd4a599c37791055299a6834b3",
-      "entity": "niiri:8ab7185bd26c34dee98b0031b8d417ac"
+      "entity_derived": "niiri:3826db9e7668227e2a63e832d3c39701",
+      "entity": "niiri:d2ca51b89db2e3b1111d7fdbfda64417"
     },
     {
-      "@id": "niiri:f025b5b245e205095b03f5b66f54b5d4",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:24a0a14bebf270cbe73d80ce97ec4c02",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0024",
-      "prov:atLocation": {"@id": "niiri:1bdbb204e1f260c3ff9842076505bac5"},
+      "prov:atLocation": {"@id": "niiri:16aaa501641c95b0ce42d11047b7fdc4"},
       "prov:value": {"@type": "xsd:float", "@value": "4.94992017745972"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.11718966304234"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.91760222628679e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.631434661064485"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.106458926829394"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.11718966304234"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.91760222628679e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.631434661064485"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.106458926829394"}
     },
     {
-      "@id": "niiri:1bdbb204e1f260c3ff9842076505bac5",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:16aaa501641c95b0ce42d11047b7fdc4",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0024",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[46,-34,42]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[46,-34,42]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f025b5b245e205095b03f5b66f54b5d4",
-      "entity": "niiri:8ab7185bd26c34dee98b0031b8d417ac"
+      "entity_derived": "niiri:24a0a14bebf270cbe73d80ce97ec4c02",
+      "entity": "niiri:d2ca51b89db2e3b1111d7fdbfda64417"
     },
     {
-      "@id": "niiri:cdb9bb633e289c00f539b1abe86e0bb9",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0449dda97bea02c246854d99b1b7adbc",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0025",
-      "prov:atLocation": {"@id": "niiri:9d0d38902d2d41dd611dd432725a1ee5"},
+      "prov:atLocation": {"@id": "niiri:987a7b2248b42a3a490d2504cc7e0bf3"},
       "prov:value": {"@type": "xsd:float", "@value": "4.14882755279541"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.60116037131659"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000158400037829631"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.993008812777799"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.370124878111002"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.60116037131659"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000158400037829631"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.993008812777799"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.370124878111002"}
     },
     {
-      "@id": "niiri:9d0d38902d2d41dd611dd432725a1ee5",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:987a7b2248b42a3a490d2504cc7e0bf3",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0025",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[36,-46,44]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[36,-46,44]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cdb9bb633e289c00f539b1abe86e0bb9",
-      "entity": "niiri:8ab7185bd26c34dee98b0031b8d417ac"
+      "entity_derived": "niiri:0449dda97bea02c246854d99b1b7adbc",
+      "entity": "niiri:d2ca51b89db2e3b1111d7fdbfda64417"
     },
     {
-      "@id": "niiri:9da337642884206da02e8e4ea8f1dc59",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5eb503813e71b696ec059c3e6a0dd7ef",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0026",
-      "prov:atLocation": {"@id": "niiri:ec0b8a8e56f2ca38cd26a98d1f8e68fa"},
+      "prov:atLocation": {"@id": "niiri:468734efebc03b0fde1d35df7a8d7b49"},
       "prov:value": {"@type": "xsd:float", "@value": "4.48920822143555"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.82754387575664"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.47141590200961e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.921344159854026"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.23453068077853"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.82754387575664"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.47141590200961e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.921344159854026"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.23453068077853"}
     },
     {
-      "@id": "niiri:ec0b8a8e56f2ca38cd26a98d1f8e68fa",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:468734efebc03b0fde1d35df7a8d7b49",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0026",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-40,10,24]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-40,10,24]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9da337642884206da02e8e4ea8f1dc59",
-      "entity": "niiri:cb714b171c3d5683c2c98af66cf6eabb"
+      "entity_derived": "niiri:5eb503813e71b696ec059c3e6a0dd7ef",
+      "entity": "niiri:93024a65786df3d21c3afeb2157fda29"
     },
     {
-      "@id": "niiri:2c6f94145ac72e98627bc3bbefa70aa9",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:27662f80703bab4a958c6b33e1a93fa5",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0027",
-      "prov:atLocation": {"@id": "niiri:07174813566ead15f8358777d2d1e1c1"},
+      "prov:atLocation": {"@id": "niiri:182b7c17f02d49bfc8b89cab22dea1a6"},
       "prov:value": {"@type": "xsd:float", "@value": "4.37462282180786"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.75253736275656"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.75268659427109e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.958943515151384"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.266450161314934"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.75253736275656"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.75268659427109e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.958943515151384"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.266450161314934"}
     },
     {
-      "@id": "niiri:07174813566ead15f8358777d2d1e1c1",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:182b7c17f02d49bfc8b89cab22dea1a6",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0027",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[32,-56,-30]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[32,-56,-30]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2c6f94145ac72e98627bc3bbefa70aa9",
-      "entity": "niiri:0ff9d90df9162134b0a5b1c57873965e"
+      "entity_derived": "niiri:27662f80703bab4a958c6b33e1a93fa5",
+      "entity": "niiri:035c0aba4276188a1f52052646ae7120"
     },
     {
-      "@id": "niiri:255d9587b36286085e4a8baf4add697d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:fe8f5b1d1a7cdd89fdd7e2417cf26341",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0028",
-      "prov:atLocation": {"@id": "niiri:657de4f2c13844877179ea5d53199550"},
+      "prov:atLocation": {"@id": "niiri:8612b501b0e12b2f40a16e10ca523880"},
       "prov:value": {"@type": "xsd:float", "@value": "4.34167242050171"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.7307439273808"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "9.54575986388262e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.966870324720423"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.275753173611261"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.7307439273808"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "9.54575986388262e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.966870324720423"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.275753173611261"}
     },
     {
-      "@id": "niiri:657de4f2c13844877179ea5d53199550",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:8612b501b0e12b2f40a16e10ca523880",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0028",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-8,20,24]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-8,20,24]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:255d9587b36286085e4a8baf4add697d",
-      "entity": "niiri:4cd12d51d9021fd8adb9844533537b73"
+      "entity_derived": "niiri:fe8f5b1d1a7cdd89fdd7e2417cf26341",
+      "entity": "niiri:2dc499c816a88d424858df07e367da38"
     },
     {
-      "@id": "niiri:eb6e3920a1b0f6372cbacc00652750e0",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:1b3dd6f8432d3e63adbf5a0aabd4bcc1",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0029",
-      "prov:atLocation": {"@id": "niiri:658eead9cda4e56ebe20d0bcd77dc3e4"},
+      "prov:atLocation": {"@id": "niiri:90eb444d756e7ff76c9ab977424e6c7b"},
       "prov:value": {"@type": "xsd:float", "@value": "4.3336443901062"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.72541890112066"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "9.74955684317491e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.968621393833285"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.275753173611261"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.72541890112066"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "9.74955684317491e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.968621393833285"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.275753173611261"}
     },
     {
-      "@id": "niiri:658eead9cda4e56ebe20d0bcd77dc3e4",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:90eb444d756e7ff76c9ab977424e6c7b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0029",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[44,38,32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[44,38,32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:eb6e3920a1b0f6372cbacc00652750e0",
-      "entity": "niiri:1b789db1ce53a57bbc25c68cdac66c2d"
+      "entity_derived": "niiri:1b3dd6f8432d3e63adbf5a0aabd4bcc1",
+      "entity": "niiri:809e973106f074b8b57288f78176fadb"
     },
     {
-      "@id": "niiri:eb016a7153b8b55763c7f7fbf0ec00d3",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:6622c9c5a5bb5602bc2abeed125325ac",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0030",
-      "prov:atLocation": {"@id": "niiri:3de15e47c2cc57eaf165bb760fb17d31"},
+      "prov:atLocation": {"@id": "niiri:48847d4df5d31de03d50ecd410917b09"},
       "prov:value": {"@type": "xsd:float", "@value": "3.9835045337677"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.48726495012002"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000243993830123412"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.998891092669635"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.467639377242474"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.48726495012002"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000243993830123412"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.998891092669635"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.467639377242474"}
     },
     {
-      "@id": "niiri:3de15e47c2cc57eaf165bb760fb17d31",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:48847d4df5d31de03d50ecd410917b09",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0030",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-24,-60,-26]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-24,-60,-26]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:eb016a7153b8b55763c7f7fbf0ec00d3",
-      "entity": "niiri:8d9aa6d1ec6c37718c5a8b44989b6f5f"
+      "entity_derived": "niiri:6622c9c5a5bb5602bc2abeed125325ac",
+      "entity": "niiri:23280aef5e15fc151595ade28a75778f"
     },
     {
-      "@id": "niiri:bea5c0edf808c42b87619f4f3daf8458",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b184da69003b59767f569647a73c0639",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0031",
-      "prov:atLocation": {"@id": "niiri:1adf18544faaba5a99e94468891a8d49"},
+      "prov:atLocation": {"@id": "niiri:c29572676342be86d47e0a7b8ed38732"},
       "prov:value": {"@type": "xsd:float", "@value": "3.79263067245483"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.35249275717611"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000400436684482419"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999938961389732"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.654094205846141"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.35249275717611"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000400436684482419"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999938961389732"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.654094205846141"}
     },
     {
-      "@id": "niiri:1adf18544faaba5a99e94468891a8d49",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c29572676342be86d47e0a7b8ed38732",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0031",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-30,-4,38]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-30,-4,38]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:bea5c0edf808c42b87619f4f3daf8458",
-      "entity": "niiri:8d5aa4d277ff8060425a7d8827846199"
+      "entity_derived": "niiri:b184da69003b59767f569647a73c0639",
+      "entity": "niiri:a724fab477e1c34dff00939c8a5fe1d9"
     },
     {
-      "@id": "niiri:717486fee4d16edf303b6cbfbc42c049",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:49e0945fb482cd7b911f2227ceae482f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0032",
-      "prov:atLocation": {"@id": "niiri:cba848835ff9380d6d7034ff8de12ff8"},
+      "prov:atLocation": {"@id": "niiri:eca01472aea0f0dbd8b94e3e34cd3adc"},
       "prov:value": {"@type": "xsd:float", "@value": "3.77775311470032"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.34183922268213"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000416126261860494"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999953291766866"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.659449024484444"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.34183922268213"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000416126261860494"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999953291766866"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.659449024484444"}
     },
     {
-      "@id": "niiri:cba848835ff9380d6d7034ff8de12ff8",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:eca01472aea0f0dbd8b94e3e34cd3adc",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0032",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-62,-6,22]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-62,-6,22]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:717486fee4d16edf303b6cbfbc42c049",
-      "entity": "niiri:c3faa5585abf8fd6ae5f51bed00a5c44"
+      "entity_derived": "niiri:49e0945fb482cd7b911f2227ceae482f",
+      "entity": "niiri:e8d2cf34f04ba64f58f96a3bd57989a0"
     },
     {
-      "@id": "niiri:59be27f7d0fa71086a575f6e70a6926b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c7dd5a67fe812c0fdcc362965b494898",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0033",
-      "prov:atLocation": {"@id": "niiri:83040c69bfbea01cb38e4c8eeeb89117"},
+      "prov:atLocation": {"@id": "niiri:e81d57070082ea2bc67d444e23ad6afe"},
       "prov:value": {"@type": "xsd:float", "@value": "3.67259907722473"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.26592297145681"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000545539621777169"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999994214217906"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.754841581701232"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.26592297145681"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000545539621777169"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999994214217906"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.754841581701232"}
     },
     {
-      "@id": "niiri:83040c69bfbea01cb38e4c8eeeb89117",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e81d57070082ea2bc67d444e23ad6afe",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0033",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-12,-4,4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-12,-4,4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:59be27f7d0fa71086a575f6e70a6926b",
-      "entity": "niiri:860d4c90c76b09b791e464d1115fe241"
+      "entity_derived": "niiri:c7dd5a67fe812c0fdcc362965b494898",
+      "entity": "niiri:b073888acef337b87afb0a3f49356435"
     },
     {
-      "@id": "niiri:9d67e02ddc425b561b46d3cfbd0fccca",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:84fe5a575cee1440542c990cbf711859",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0034",
-      "prov:atLocation": {"@id": "niiri:30e81b907fe511bfad310c755b4411c1"},
+      "prov:atLocation": {"@id": "niiri:7f4fe1df385012266fd6803d3c1079dd"},
       "prov:value": {"@type": "xsd:float", "@value": "3.66031455993652"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.25698339309234"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000563015103086872"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999995573785363"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.75806989081408"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.25698339309234"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000563015103086872"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999995573785363"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.75806989081408"}
     },
     {
-      "@id": "niiri:30e81b907fe511bfad310c755b4411c1",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7f4fe1df385012266fd6803d3c1079dd",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0034",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[38,4,60]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[38,4,60]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9d67e02ddc425b561b46d3cfbd0fccca",
-      "entity": "niiri:99f2be73be2c6be215bfd9faf3a92a39"
+      "entity_derived": "niiri:84fe5a575cee1440542c990cbf711859",
+      "entity": "niiri:24cb62d0bb1e202be98184cc8d05dffd"
     },
     {
-      "@id": "niiri:b5179839f97964be94c32b6224e91b62",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:9a32238eb2863717896fffb10d326e05",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0035",
-      "prov:atLocation": {"@id": "niiri:b4a2f9cb468ff42883d02dd9ddf5cf40"},
+      "prov:atLocation": {"@id": "niiri:e0df16fae31adde7b1b374630cfb3683"},
       "prov:value": {"@type": "xsd:float", "@value": "3.63292980194092"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.23700181949284"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000603963207952862"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999997609889049"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.782238022186136"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.23700181949284"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000603963207952862"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999997609889049"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.782238022186136"}
     },
     {
-      "@id": "niiri:b4a2f9cb468ff42883d02dd9ddf5cf40",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e0df16fae31adde7b1b374630cfb3683",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0035",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-28,2,38]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-28,2,38]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b5179839f97964be94c32b6224e91b62",
-      "entity": "niiri:1e52aefb94abdf0e6614ea5a19db8bab"
+      "entity_derived": "niiri:9a32238eb2863717896fffb10d326e05",
+      "entity": "niiri:824d90300b93425516b70315d9d6f976"
     }
   ]
 }

--- a/spmexport/ex_spm_group_wls/nidm.ttl
+++ b/spmexport/ex_spm_group_wls/nidm.ttl
@@ -4,7 +4,7 @@
 @prefix niiri: <http://iri.nidash.org/> .
 @prefix spm: <http://purl.org/nidash/spm#> .
 @prefix neurolex: <http://neurolex.org/wiki/> .
-@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#> .
+@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
@@ -17,27 +17,27 @@
 @prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-niiri:e8c2fc9cda9df248317c3d947b04ea67
+niiri:fbfb92dd91e30b37df0002dd4a58237d
   a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
   rdfs:label "NIDM-Results" ;
   nidm_version: "1.3.0"^^xsd:string .
 
-niiri:dd1eeb14957c977edf2871d42ed4b1c9
+niiri:a6b93a73047f21860319c5c6a2bc4bec
   a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
   rdfs:label "spm_results_nidm" ;
-  nidm_softwareVersion: "12.6903"^^xsd:string .
+  nidm_softwareVersion: "12.7057"^^xsd:string .
 
-niiri:73ac027704cb44ad9af477f190827e87
+niiri:0716bbc8504afbc51e82ff51484e584a
   a prov:Activity, nidm_NIDMResultsExport: ; 
   rdfs:label "NIDM-Results export" .
 
-niiri:73ac027704cb44ad9af477f190827e87 prov:wasAssociatedWith niiri:dd1eeb14957c977edf2871d42ed4b1c9 .
+niiri:0716bbc8504afbc51e82ff51484e584a prov:wasAssociatedWith niiri:a6b93a73047f21860319c5c6a2bc4bec .
 
 _:blank5 a prov:Generation .
 
-niiri:e8c2fc9cda9df248317c3d947b04ea67 prov:qualifiedGeneration _:blank5 .
+niiri:fbfb92dd91e30b37df0002dd4a58237d prov:qualifiedGeneration _:blank5 .
 
-_:blank5 prov:atTime "2016-12-07T16:08:37"^^xsd:dateTime .
+_:blank5 prov:atTime "2017-04-19T12:18:16"^^xsd:dateTime .
 
 @prefix nidm_Ixi549CoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000050> .
 @prefix src_SPM: <http://scicrunch.org/resolver/SCR_007037> .
@@ -139,12 +139,12 @@ _:blank5 prov:atTime "2016-12-07T16:08:37"^^xsd:dateTime .
 @prefix nidm_Coordinate: <http://purl.org/nidash/nidm#NIDM_0000015> .
 @prefix nidm_coordinateVector: <http://purl.org/nidash/nidm#NIDM_0000086> .
 
-niiri:a536fc9b17bd68b4700183ad8ad511e8
+niiri:cc07a0149337deefc011f6391ad99352
     a prov:Agent, src_SPM:, prov:SoftwareAgent ; 
     rdfs:label "SPM" ;
-    nidm_softwareVersion: "12.12.2"^^xsd:string .
+    nidm_softwareVersion: "12.6906"^^xsd:string .
 
-niiri:1b7e4b57cfbc311750156373ae9ba795
+niiri:d83638bd84f027751d70f6f76d98df8c
     a prov:Entity, nidm_CoordinateSpace: ; 
     rdfs:label "Coordinate space 1" ;
     nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
@@ -154,42 +154,42 @@ niiri:1b7e4b57cfbc311750156373ae9ba795
     nidm_numberOfDimensions: "3"^^xsd:int ;
     nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
 
-niiri:79197ae8f2809c9d976bf30adb690a11
+niiri:d451d187aabd4470aaaa9ac9338d71f7
     a prov:Agent, nlx_Imaginginstrument:, nlx_Magneticresonanceimagingscanner: ; 
     rdfs:label "MRI Scanner" .
 
-niiri:4ca53c4b7e22533252bbed50cffac550
+niiri:1d560f0e3dff39ddf2bbd35fbea493df
     a prov:Agent, obo_studygrouppopulation: ; 
     rdfs:label "Group: Control" ;
     nidm_groupName: "Control"^^xsd:string ;
     nidm_numberOfSubjects: "14"^^xsd:int .
 
-niiri:050e089fed5637bfef8762d516f68935
+niiri:ebf54f3ce65b0dd2c55759f2bbe79bdf
     a prov:Entity, prov:Collection, nidm_Data: ; 
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "false"^^xsd:boolean ;
     nidm_hasMRIProtocol: nlx_FunctionalMRIprotocol: .
 
-niiri:050e089fed5637bfef8762d516f68935 prov:wasAttributedTo niiri:79197ae8f2809c9d976bf30adb690a11 .
+niiri:ebf54f3ce65b0dd2c55759f2bbe79bdf prov:wasAttributedTo niiri:d451d187aabd4470aaaa9ac9338d71f7 .
 
-niiri:050e089fed5637bfef8762d516f68935 prov:wasAttributedTo niiri:4ca53c4b7e22533252bbed50cffac550 .
+niiri:ebf54f3ce65b0dd2c55759f2bbe79bdf prov:wasAttributedTo niiri:1d560f0e3dff39ddf2bbd35fbea493df .
 
-niiri:1db0a0b58a5d1e63fbd7f80a9790fc04
+niiri:7d3330b641d062fb9c196cfd8e54db38
     a prov:Entity, nidm_DesignMatrix: ; 
     prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.csv"^^xsd:string ;
     dct:format "text/csv"^^xsd:string ;
-    dc:description niiri:48b07ec102ba87dbfa3e7c180799c886 ;
+    dc:description niiri:386590f5ae95ecdc71f5c902d3e1e166 ;
     rdfs:label "Design Matrix" ;
     nidm_regressorNames: "[\"contrast 1 parameter 1\", \"contrast 1 parameter 2\", \"contrast 2 parameter 1\", \"contrast 2 parameter 2\"]"^^xsd:string .
 
-niiri:48b07ec102ba87dbfa3e7c180799c886
+niiri:386590f5ae95ecdc71f5c902d3e1e166
     a prov:Entity, dctype:Image ; 
     prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:e2f5c53deadf4cdce9e6951f8c178a4e
+niiri:e9a458bdd39848b4367b8e1032a2eb15
     a prov:Entity, nidm_ErrorModel: ; 
     nidm_hasErrorDistribution: obo_normaldistribution: ;
     nidm_hasErrorDependence: obo_unstructuredcovariancestructure: ;
@@ -197,153 +197,153 @@ niiri:e2f5c53deadf4cdce9e6951f8c178a4e
     nidm_errorVarianceHomogeneous: "false"^^xsd:boolean ;
     nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
 
-niiri:bd3f326ef762822a20864156ea77d423
+niiri:8b0939c3dda9d8de649d9f6287d600b5
     a prov:Activity, nidm_ModelParametersEstimation: ; 
     rdfs:label "Model parameters estimation" ;
     nidm_withEstimationMethod: obo_generalizedleastsquaresestimation: .
 
-niiri:bd3f326ef762822a20864156ea77d423 prov:wasAssociatedWith niiri:a536fc9b17bd68b4700183ad8ad511e8 .
+niiri:8b0939c3dda9d8de649d9f6287d600b5 prov:wasAssociatedWith niiri:cc07a0149337deefc011f6391ad99352 .
 
-niiri:bd3f326ef762822a20864156ea77d423 prov:used niiri:1db0a0b58a5d1e63fbd7f80a9790fc04 .
+niiri:8b0939c3dda9d8de649d9f6287d600b5 prov:used niiri:7d3330b641d062fb9c196cfd8e54db38 .
 
-niiri:bd3f326ef762822a20864156ea77d423 prov:used niiri:050e089fed5637bfef8762d516f68935 .
+niiri:8b0939c3dda9d8de649d9f6287d600b5 prov:used niiri:ebf54f3ce65b0dd2c55759f2bbe79bdf .
 
-niiri:bd3f326ef762822a20864156ea77d423 prov:used niiri:e2f5c53deadf4cdce9e6951f8c178a4e .
+niiri:8b0939c3dda9d8de649d9f6287d600b5 prov:used niiri:e9a458bdd39848b4367b8e1032a2eb15 .
 
-niiri:3b714fbd2fbe9e64f03779e899c0c6dc
+niiri:e5fc1b30e25a51026dcfa20926d9a8b5
     a prov:Entity, nidm_MaskMap: ; 
     prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
     nidm_isUserDefined: "false"^^xsd:boolean ;
     nfo:fileName "Mask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Mask" ;
-    nidm_inCoordinateSpace: niiri:1b7e4b57cfbc311750156373ae9ba795 ;
+    nidm_inCoordinateSpace: niiri:d83638bd84f027751d70f6f76d98df8c ;
     crypto:sha512 "71153b4ca7e1136cf9ae9cb56eaf6a4ed494bad08a1cfa0659e8e211a36425aaf865c3def12dea06c5595662761b891c87ec7b8fa0b8b75cd31247be9418bf24"^^xsd:string .
 
-niiri:e270063d61181f205b60db54bd090f7d
+niiri:ab891018531389a0bfea3167dd18265c
     a prov:Entity, nidm_MaskMap: ; 
     nfo:fileName "mask.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "e33feb3fddb2a3ee6d91e0b84ce0050a83414df67559e07679326fab2c31494df0a1db2d693027786c839b356626159d9158e4e9766b2bf46be4d32678f356fd"^^xsd:string .
 
-niiri:3b714fbd2fbe9e64f03779e899c0c6dc prov:wasDerivedFrom niiri:e270063d61181f205b60db54bd090f7d .
+niiri:e5fc1b30e25a51026dcfa20926d9a8b5 prov:wasDerivedFrom niiri:ab891018531389a0bfea3167dd18265c .
 
-niiri:3b714fbd2fbe9e64f03779e899c0c6dc prov:wasGeneratedBy niiri:bd3f326ef762822a20864156ea77d423 .
+niiri:e5fc1b30e25a51026dcfa20926d9a8b5 prov:wasGeneratedBy niiri:8b0939c3dda9d8de649d9f6287d600b5 .
 
-niiri:b2d84b897895c159a5453fdccc2fb28c
+niiri:bbfee1c49481e576e7001347fc4d3e5f
     a prov:Entity, nidm_GrandMeanMap: ; 
     prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
     nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Grand Mean Map" ;
     nidm_maskedMedian: "0.0621182750910521"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:1b7e4b57cfbc311750156373ae9ba795 ;
+    nidm_inCoordinateSpace: niiri:d83638bd84f027751d70f6f76d98df8c ;
     crypto:sha512 "febef0110e49eb683c48b4e93acc72f110abd947f499f87d3f17cdb41d6969b2675f8e4ab3730fd052430b795a23e680633b591415016366d533eb084adc1a7d"^^xsd:string .
 
-niiri:b2d84b897895c159a5453fdccc2fb28c prov:wasGeneratedBy niiri:bd3f326ef762822a20864156ea77d423 .
+niiri:bbfee1c49481e576e7001347fc4d3e5f prov:wasGeneratedBy niiri:8b0939c3dda9d8de649d9f6287d600b5 .
 
-niiri:eb686fb49520484f372d9f18b173329c
+niiri:62c0fd9e9f4574145bf8f023abd11fe4
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0001.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0001.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 1" ;
-    nidm_inCoordinateSpace: niiri:1b7e4b57cfbc311750156373ae9ba795 ;
+    nidm_inCoordinateSpace: niiri:d83638bd84f027751d70f6f76d98df8c ;
     crypto:sha512 "c61b294e5c1f475eed3d552bf4ae69dc19526220f069aecb338e5ad0c9359233011c6c9674b587605f343f0253dcbdf87b02f0cbd739d49fc2d41c7ee33eef6d"^^xsd:string .
 
-niiri:79340bad7335ca74904c2ba10fb69ef3
+niiri:93f6ba1185b029716e107fdb65f43721
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "c61b294e5c1f475eed3d552bf4ae69dc19526220f069aecb338e5ad0c9359233011c6c9674b587605f343f0253dcbdf87b02f0cbd739d49fc2d41c7ee33eef6d"^^xsd:string .
 
-niiri:eb686fb49520484f372d9f18b173329c prov:wasDerivedFrom niiri:79340bad7335ca74904c2ba10fb69ef3 .
+niiri:62c0fd9e9f4574145bf8f023abd11fe4 prov:wasDerivedFrom niiri:93f6ba1185b029716e107fdb65f43721 .
 
-niiri:eb686fb49520484f372d9f18b173329c prov:wasGeneratedBy niiri:bd3f326ef762822a20864156ea77d423 .
+niiri:62c0fd9e9f4574145bf8f023abd11fe4 prov:wasGeneratedBy niiri:8b0939c3dda9d8de649d9f6287d600b5 .
 
-niiri:02854eb39d42b0c821bd022c91f45154
+niiri:e869e1bbd1b78977c814c1dd8eeb515b
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0002.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0002.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 2" ;
-    nidm_inCoordinateSpace: niiri:1b7e4b57cfbc311750156373ae9ba795 ;
+    nidm_inCoordinateSpace: niiri:d83638bd84f027751d70f6f76d98df8c ;
     crypto:sha512 "f5cace936fdd2fad096a30b39381b03bdbc1a29fc9377c01aeb0f68ea48bb2e2b70d39103b0303fe81f569419951830e3e122294629600910620bb2c304bc10c"^^xsd:string .
 
-niiri:c507403223d6871596165f503b563e97
+niiri:87e1c9ecd18191661638cefe66e214f7
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0002.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "f5cace936fdd2fad096a30b39381b03bdbc1a29fc9377c01aeb0f68ea48bb2e2b70d39103b0303fe81f569419951830e3e122294629600910620bb2c304bc10c"^^xsd:string .
 
-niiri:02854eb39d42b0c821bd022c91f45154 prov:wasDerivedFrom niiri:c507403223d6871596165f503b563e97 .
+niiri:e869e1bbd1b78977c814c1dd8eeb515b prov:wasDerivedFrom niiri:87e1c9ecd18191661638cefe66e214f7 .
 
-niiri:02854eb39d42b0c821bd022c91f45154 prov:wasGeneratedBy niiri:bd3f326ef762822a20864156ea77d423 .
+niiri:e869e1bbd1b78977c814c1dd8eeb515b prov:wasGeneratedBy niiri:8b0939c3dda9d8de649d9f6287d600b5 .
 
-niiri:a61ce13f7f1dc65b29f723d8386df7ec
+niiri:1c471e984c886eb1f4db8fe592efb739
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Residual Mean Squares Map" ;
-    nidm_inCoordinateSpace: niiri:1b7e4b57cfbc311750156373ae9ba795 ;
+    nidm_inCoordinateSpace: niiri:d83638bd84f027751d70f6f76d98df8c ;
     crypto:sha512 "2b2f9464f8daa548f6c3acae3219167fd598047bf3df591490515ff9dbd98e522dbe12da2d98e2022fe2a96666c200e2de31d598ef5e46dda88130a654b2ce0e"^^xsd:string .
 
-niiri:a07e8586e9652b048cd3ede7b1e4fe4d
+niiri:3feb56c9ca866e36a6777a2db54698dd
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     nfo:fileName "ResMS.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "efe8cb9290507e9add77e43e71750dcfea22d1604e332e351c5f1aad25d8c002690d0d9a997ed771abd153811920b5ab23a7c3ca7efe3976c42cb240a6550a10"^^xsd:string .
 
-niiri:a61ce13f7f1dc65b29f723d8386df7ec prov:wasDerivedFrom niiri:a07e8586e9652b048cd3ede7b1e4fe4d .
+niiri:1c471e984c886eb1f4db8fe592efb739 prov:wasDerivedFrom niiri:3feb56c9ca866e36a6777a2db54698dd .
 
-niiri:a61ce13f7f1dc65b29f723d8386df7ec prov:wasGeneratedBy niiri:bd3f326ef762822a20864156ea77d423 .
+niiri:1c471e984c886eb1f4db8fe592efb739 prov:wasGeneratedBy niiri:8b0939c3dda9d8de649d9f6287d600b5 .
 
-niiri:2f80ca575ff68f60a321c56d5a33b25e
+niiri:9c5c037a27c032171a8e67f8a6148478
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Resels per Voxel Map" ;
-    nidm_inCoordinateSpace: niiri:1b7e4b57cfbc311750156373ae9ba795 ;
+    nidm_inCoordinateSpace: niiri:d83638bd84f027751d70f6f76d98df8c ;
     crypto:sha512 "83ca0764c128b84c66f80535b03005c72ee62f059fa727f5631a170f473150c2d5c2df77c98c975e1b3a2ceaeb986493e126b84f7f58a5d130fc763f2f2a6561"^^xsd:string .
 
-niiri:0fa20b508989795593d226245695d594
+niiri:88108a0984090a6e26c1358f192a8b0d
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     nfo:fileName "RPV.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "13d0fe4049334ad44eeef1af42a998fadaa282c9f6e3937a265bdb5e544f0b63d874279d639d7e222aaa8574dd2d975a97cc869874af4457b4002f46f76b3519"^^xsd:string .
 
-niiri:2f80ca575ff68f60a321c56d5a33b25e prov:wasDerivedFrom niiri:0fa20b508989795593d226245695d594 .
+niiri:9c5c037a27c032171a8e67f8a6148478 prov:wasDerivedFrom niiri:88108a0984090a6e26c1358f192a8b0d .
 
-niiri:2f80ca575ff68f60a321c56d5a33b25e prov:wasGeneratedBy niiri:bd3f326ef762822a20864156ea77d423 .
+niiri:9c5c037a27c032171a8e67f8a6148478 prov:wasGeneratedBy niiri:8b0939c3dda9d8de649d9f6287d600b5 .
 
-niiri:3ff83f2400e61059dee70433e6a41d37
+niiri:74dd11ba88fcb33d114031941844efe5
     a prov:Entity, obo_contrastweightmatrix: ; 
     nidm_statisticType: obo_tstatistic: ;
     nidm_contrastName: "con-01: Tone Counting vs Baseline"^^xsd:string ;
     rdfs:label "Contrast: con-01: Tone Counting vs Baseline" ;
     prov:value "[1, 0]"^^xsd:string .
 
-niiri:b942d8ec0e84cecc6d910d658d00eea4
+niiri:baf1b57a546d4407c295095b2880878b
     a prov:Activity, nidm_ContrastEstimation: ; 
     rdfs:label "Contrast estimation" .
 
-niiri:b942d8ec0e84cecc6d910d658d00eea4 prov:wasAssociatedWith niiri:a536fc9b17bd68b4700183ad8ad511e8 .
+niiri:baf1b57a546d4407c295095b2880878b prov:wasAssociatedWith niiri:cc07a0149337deefc011f6391ad99352 .
 
-niiri:b942d8ec0e84cecc6d910d658d00eea4 prov:used niiri:3b714fbd2fbe9e64f03779e899c0c6dc .
+niiri:baf1b57a546d4407c295095b2880878b prov:used niiri:e5fc1b30e25a51026dcfa20926d9a8b5 .
 
-niiri:b942d8ec0e84cecc6d910d658d00eea4 prov:used niiri:a61ce13f7f1dc65b29f723d8386df7ec .
+niiri:baf1b57a546d4407c295095b2880878b prov:used niiri:1c471e984c886eb1f4db8fe592efb739 .
 
-niiri:b942d8ec0e84cecc6d910d658d00eea4 prov:used niiri:1db0a0b58a5d1e63fbd7f80a9790fc04 .
+niiri:baf1b57a546d4407c295095b2880878b prov:used niiri:7d3330b641d062fb9c196cfd8e54db38 .
 
-niiri:b942d8ec0e84cecc6d910d658d00eea4 prov:used niiri:3ff83f2400e61059dee70433e6a41d37 .
+niiri:baf1b57a546d4407c295095b2880878b prov:used niiri:74dd11ba88fcb33d114031941844efe5 .
 
-niiri:b942d8ec0e84cecc6d910d658d00eea4 prov:used niiri:eb686fb49520484f372d9f18b173329c .
+niiri:baf1b57a546d4407c295095b2880878b prov:used niiri:62c0fd9e9f4574145bf8f023abd11fe4 .
 
-niiri:b942d8ec0e84cecc6d910d658d00eea4 prov:used niiri:02854eb39d42b0c821bd022c91f45154 .
+niiri:baf1b57a546d4407c295095b2880878b prov:used niiri:e869e1bbd1b78977c814c1dd8eeb515b .
 
-niiri:cfd00476a556f41d59890863b1be4688
+niiri:e15e39f0dd016af9de756e2098156ac6
     a prov:Entity, nidm_StatisticMap: ; 
     prov:atLocation "TStatistic.nii.gz"^^xsd:anyURI ;
     nfo:fileName "TStatistic.nii.gz"^^xsd:string ;
@@ -353,124 +353,124 @@ niiri:cfd00476a556f41d59890863b1be4688
     nidm_contrastName: "con-01: Tone Counting vs Baseline"^^xsd:string ;
     nidm_errorDegreesOfFreedom: "26"^^xsd:float ;
     nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:1b7e4b57cfbc311750156373ae9ba795 ;
+    nidm_inCoordinateSpace: niiri:d83638bd84f027751d70f6f76d98df8c ;
     crypto:sha512 "2f0627a2c337fb861f93c924f355b0f55d1845db85d67af0df0ffcd353b481a129f7aeda6211c2642c52c34f2b69fbd9105a07382bf6f3942f03a126d0c98dc6"^^xsd:string .
 
-niiri:ed0e82be69523831a96bb5b7a2bc1674
+niiri:4f69102083ed41b95cbe2de23683ac9a
     a prov:Entity, nidm_StatisticMap: ; 
     nfo:fileName "spmT_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "9a89273aa6b7428f4e966921b6e64c18a08a84676c08bb01ffc76d8388734be8f17349b279db037c182ca2e63c3f64aab9828d05393712ecba11d1b60d06e4b1"^^xsd:string .
 
-niiri:cfd00476a556f41d59890863b1be4688 prov:wasDerivedFrom niiri:ed0e82be69523831a96bb5b7a2bc1674 .
+niiri:e15e39f0dd016af9de756e2098156ac6 prov:wasDerivedFrom niiri:4f69102083ed41b95cbe2de23683ac9a .
 
-niiri:cfd00476a556f41d59890863b1be4688 prov:wasGeneratedBy niiri:b942d8ec0e84cecc6d910d658d00eea4 .
+niiri:e15e39f0dd016af9de756e2098156ac6 prov:wasGeneratedBy niiri:baf1b57a546d4407c295095b2880878b .
 
-niiri:97d5dcaae0e9ba7f61c44933162ce24a
+niiri:d9d5054e5ab0391c96478c3815f4efe8
     a prov:Entity, nidm_ContrastMap: ; 
     prov:atLocation "Contrast.nii.gz"^^xsd:anyURI ;
     nfo:fileName "Contrast.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Map: con-01: Tone Counting vs Baseline" ;
     nidm_contrastName: "con-01: Tone Counting vs Baseline"^^xsd:string ;
-    nidm_inCoordinateSpace: niiri:1b7e4b57cfbc311750156373ae9ba795 ;
+    nidm_inCoordinateSpace: niiri:d83638bd84f027751d70f6f76d98df8c ;
     crypto:sha512 "ce64789602c82196789a795d9bdc87c8642f8852904d7ec6507eeab7085a02d679a27ac9d3abd0025de90a3d345a7f9113dd42973901ab3f0dfac5c6b757f132"^^xsd:string .
 
-niiri:7641f8b1292a3e041f5b1f51afbc81be
+niiri:9b6a64d84e939e0a16a135417f933c5d
     a prov:Entity, nidm_ContrastMap: ; 
     nfo:fileName "con_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "9748864f2cd75c915fc9ab64800dd777de76fa4c7de3e707d7d63eab15253001ff13bd4e830bfde8b4892e379c7792e53717f5d027aaf32918542eac63c1b7d8"^^xsd:string .
 
-niiri:97d5dcaae0e9ba7f61c44933162ce24a prov:wasDerivedFrom niiri:7641f8b1292a3e041f5b1f51afbc81be .
+niiri:d9d5054e5ab0391c96478c3815f4efe8 prov:wasDerivedFrom niiri:9b6a64d84e939e0a16a135417f933c5d .
 
-niiri:97d5dcaae0e9ba7f61c44933162ce24a prov:wasGeneratedBy niiri:b942d8ec0e84cecc6d910d658d00eea4 .
+niiri:d9d5054e5ab0391c96478c3815f4efe8 prov:wasGeneratedBy niiri:baf1b57a546d4407c295095b2880878b .
 
-niiri:e6129899605ca5b8dbe32a0df271e7b0
+niiri:3d983cf2d5c2941d0787e4df59f9fd1c
     a prov:Entity, nidm_ContrastStandardErrorMap: ; 
     prov:atLocation "ContrastStandardError.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ContrastStandardError.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Standard Error Map" ;
-    nidm_inCoordinateSpace: niiri:1b7e4b57cfbc311750156373ae9ba795 ;
+    nidm_inCoordinateSpace: niiri:d83638bd84f027751d70f6f76d98df8c ;
     crypto:sha512 "735c4c74cf1cbc4d46d35c5fad5f38383b336269bcf1c3edb037201f0fde4f7b2f484f042b1c711323446ac91e54cd997275616ea17c6d4ccd44df19b0f30334"^^xsd:string .
 
-niiri:e6129899605ca5b8dbe32a0df271e7b0 prov:wasGeneratedBy niiri:b942d8ec0e84cecc6d910d658d00eea4 .
+niiri:3d983cf2d5c2941d0787e4df59f9fd1c prov:wasGeneratedBy niiri:baf1b57a546d4407c295095b2880878b .
 
-niiri:6796323ef3d1da76b0e28489f43adc81
+niiri:cd2ff500c60b8721816179e10e594025
     a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
-    rdfs:label "Height Threshold: p<0.001000 (unc.)" ;
+    rdfs:label "Height Threshold: p<0.001 (unc.)" ;
     prov:value "0.000999500199025949"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:efdb35511ad9c3155512e221a6770fd7 ;
-    nidm_equivalentThreshold: niiri:4d052d9fe9814fe7996ec8da83652164 .
+    nidm_equivalentThreshold: niiri:1785712a16e66d419c296ef9f90de994 ;
+    nidm_equivalentThreshold: niiri:b1120c03f72947c1ba4a6b8c2c3091bc .
 
-niiri:efdb35511ad9c3155512e221a6770fd7
+niiri:1785712a16e66d419c296ef9f90de994
     a prov:Entity, nidm_HeightThreshold:, obo_statistic: ; 
-    rdfs:label "Height Threshold" ;
+    rdfs:label "Height Threshold: T=3.434997)" ;
     prov:value "3.43499716873599"^^xsd:float .
 
-niiri:4d052d9fe9814fe7996ec8da83652164
+niiri:b1120c03f72947c1ba4a6b8c2c3091bc
     a prov:Entity, nidm_HeightThreshold:, obo_FWERadjustedpvalue: ; 
-    rdfs:label "Height Threshold" ;
+    rdfs:label "Height Threshold: p<1.000000 (FWE)" ;
     prov:value "0.999999988250242"^^xsd:float .
 
-niiri:a3025c9620d2ee84c11e7641259b25ef
+niiri:565302e93e38d1cad805021869fa4c63
     a prov:Entity, nidm_ExtentThreshold:, obo_statistic: ; 
     rdfs:label "Extent Threshold: k>=2" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
     nidm_clusterSizeInResels: "0.0180239125412657"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:af6f08aa64301671af41af33ed0cc45a ;
-    nidm_equivalentThreshold: niiri:b0408ccf4d12c88a6fad6ebba3fece3c .
+    nidm_equivalentThreshold: niiri:3969337bc7e24a8f6325c17923baaef5 ;
+    nidm_equivalentThreshold: niiri:e126b1f4c14b484ce3e6915191bdf447 .
 
-niiri:af6f08aa64301671af41af33ed0cc45a
+niiri:3969337bc7e24a8f6325c17923baaef5
     a prov:Entity, nidm_ExtentThreshold:, obo_FWERadjustedpvalue: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "0.999994028395426"^^xsd:float .
 
-niiri:b0408ccf4d12c88a6fad6ebba3fece3c
+niiri:e126b1f4c14b484ce3e6915191bdf447
     a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "0.658755107945733"^^xsd:float .
 
-niiri:3210e30dea7fe15ffdfa6b273e584590
+niiri:20b1c1ee5c6652d4fceb06ebc0cab294
     a prov:Entity, nidm_PeakDefinitionCriteria: ; 
     rdfs:label "Peak Definition Criteria" ;
     nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
     nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
 
-niiri:1e1086bab21dd18b3498fa96ae1dd409
+niiri:23547207d6c2d262d31d7e9e04b6f749
     a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
     rdfs:label "Cluster Connectivity Criterion: 18" ;
     nidm_hasConnectivityCriterion: nidm_voxel18connected: .
 
-niiri:1abc4a77e9c6d1b1d0651d63a40e8a8d
+niiri:b65d1dde00468cfdc0b2c5c7b16aca85
     a prov:Activity, nidm_Inference: ; 
     nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
     rdfs:label "Inference" .
 
-niiri:1abc4a77e9c6d1b1d0651d63a40e8a8d prov:wasAssociatedWith niiri:a536fc9b17bd68b4700183ad8ad511e8 .
+niiri:b65d1dde00468cfdc0b2c5c7b16aca85 prov:wasAssociatedWith niiri:cc07a0149337deefc011f6391ad99352 .
 
-niiri:1abc4a77e9c6d1b1d0651d63a40e8a8d prov:used niiri:6796323ef3d1da76b0e28489f43adc81 .
+niiri:b65d1dde00468cfdc0b2c5c7b16aca85 prov:used niiri:cd2ff500c60b8721816179e10e594025 .
 
-niiri:1abc4a77e9c6d1b1d0651d63a40e8a8d prov:used niiri:a3025c9620d2ee84c11e7641259b25ef .
+niiri:b65d1dde00468cfdc0b2c5c7b16aca85 prov:used niiri:565302e93e38d1cad805021869fa4c63 .
 
-niiri:1abc4a77e9c6d1b1d0651d63a40e8a8d prov:used niiri:cfd00476a556f41d59890863b1be4688 .
+niiri:b65d1dde00468cfdc0b2c5c7b16aca85 prov:used niiri:e15e39f0dd016af9de756e2098156ac6 .
 
-niiri:1abc4a77e9c6d1b1d0651d63a40e8a8d prov:used niiri:2f80ca575ff68f60a321c56d5a33b25e .
+niiri:b65d1dde00468cfdc0b2c5c7b16aca85 prov:used niiri:9c5c037a27c032171a8e67f8a6148478 .
 
-niiri:1abc4a77e9c6d1b1d0651d63a40e8a8d prov:used niiri:3b714fbd2fbe9e64f03779e899c0c6dc .
+niiri:b65d1dde00468cfdc0b2c5c7b16aca85 prov:used niiri:e5fc1b30e25a51026dcfa20926d9a8b5 .
 
-niiri:1abc4a77e9c6d1b1d0651d63a40e8a8d prov:used niiri:3210e30dea7fe15ffdfa6b273e584590 .
+niiri:b65d1dde00468cfdc0b2c5c7b16aca85 prov:used niiri:20b1c1ee5c6652d4fceb06ebc0cab294 .
 
-niiri:1abc4a77e9c6d1b1d0651d63a40e8a8d prov:used niiri:1e1086bab21dd18b3498fa96ae1dd409 .
+niiri:b65d1dde00468cfdc0b2c5c7b16aca85 prov:used niiri:23547207d6c2d262d31d7e9e04b6f749 .
 
-niiri:bd447bc0505a0bf0ab3b188daf510c69
+niiri:d86d3799879abef252a01c01223937d2
     a prov:Entity, nidm_SearchSpaceMaskMap: ; 
     prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
     nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Search Space Mask Map" ;
-    nidm_inCoordinateSpace: niiri:1b7e4b57cfbc311750156373ae9ba795 ;
+    nidm_inCoordinateSpace: niiri:d83638bd84f027751d70f6f76d98df8c ;
     nidm_searchVolumeInVoxels: "160902"^^xsd:int ;
     nidm_searchVolumeInUnits: "1287216"^^xsd:float ;
     nidm_reselSizeInVoxels: "110.963698665371"^^xsd:float ;
@@ -487,9 +487,9 @@ niiri:bd447bc0505a0bf0ab3b188daf510c69
     spm_smallestSignificantClusterSizeInVoxelsFWE05: "186"^^xsd:int ;
     spm_smallestSignificantClusterSizeInVoxelsFDR05: "186"^^xsd:int .
 
-niiri:bd447bc0505a0bf0ab3b188daf510c69 prov:wasGeneratedBy niiri:1abc4a77e9c6d1b1d0651d63a40e8a8d .
+niiri:d86d3799879abef252a01c01223937d2 prov:wasGeneratedBy niiri:b65d1dde00468cfdc0b2c5c7b16aca85 .
 
-niiri:dc8fee2c80984a4e4da98aaa0284ab39
+niiri:fd051605e8c7f96825de2e8c362f619d
     a prov:Entity, nidm_ExcursionSetMap: ; 
     prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
@@ -497,29 +497,29 @@ niiri:dc8fee2c80984a4e4da98aaa0284ab39
     rdfs:label "Excursion Set Map" ;
     nidm_numberOfSupraThresholdClusters: "19"^^xsd:int ;
     nidm_pValue: "0.0381497273362531"^^xsd:float ;
-    nidm_hasClusterLabelsMap: niiri:c804e7a5c284ea00ab8f31fc071824f3 ;
-    nidm_hasMaximumIntensityProjection: niiri:09db6d6737588a7694ffd334225ba531 ;
-    nidm_inCoordinateSpace: niiri:1b7e4b57cfbc311750156373ae9ba795 ;
+    nidm_hasClusterLabelsMap: niiri:52de7dcded23dd4a1fd932012d60b81c ;
+    nidm_hasMaximumIntensityProjection: niiri:3f22616908b033819a3786fde1496cc7 ;
+    nidm_inCoordinateSpace: niiri:d83638bd84f027751d70f6f76d98df8c ;
     crypto:sha512 "048ef4d6ee2e4fd5c85757968e6d5feccfeec3292d691e3e32b4f2553d501813397bb83e7f5616a808f0068c6d3e8f1309654d9f1239e0bab1fea410dcd9cb78"^^xsd:string .
 
-niiri:c804e7a5c284ea00ab8f31fc071824f3
+niiri:52de7dcded23dd4a1fd932012d60b81c
     a prov:Entity, nidm_ClusterLabelsMap: ; 
     prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Cluster Labels Map" ;
-    nidm_inCoordinateSpace: niiri:1b7e4b57cfbc311750156373ae9ba795 ;
+    nidm_inCoordinateSpace: niiri:d83638bd84f027751d70f6f76d98df8c ;
     crypto:sha512 "f90fdcd70484a1e73a009d9b568825514b14190ee02ea8c61ea7e206dcb5f9b6dfde3931dbc3f4feb1cd358ca0307835fc90b319ab92667eb8af56ef628f5c87"^^xsd:string .
 
-niiri:09db6d6737588a7694ffd334225ba531
+niiri:3f22616908b033819a3786fde1496cc7
     a prov:Entity, dctype:Image ; 
     prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
     nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:dc8fee2c80984a4e4da98aaa0284ab39 prov:wasGeneratedBy niiri:1abc4a77e9c6d1b1d0651d63a40e8a8d .
+niiri:fd051605e8c7f96825de2e8c362f619d prov:wasGeneratedBy niiri:b65d1dde00468cfdc0b2c5c7b16aca85 .
 
-niiri:fea0f4eb720496a64dd119edf1c8fd20
+niiri:01ec637797471e97b81c59d553918fe2
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0001" ;
     nidm_clusterSizeInVoxels: "1264"^^xsd:int ;
@@ -529,9 +529,9 @@ niiri:fea0f4eb720496a64dd119edf1c8fd20
     nidm_qValueFDR: "9.37785071906856e-13"^^xsd:float ;
     nidm_clusterLabelId: "1"^^xsd:int .
 
-niiri:fea0f4eb720496a64dd119edf1c8fd20 prov:wasDerivedFrom niiri:dc8fee2c80984a4e4da98aaa0284ab39 .
+niiri:01ec637797471e97b81c59d553918fe2 prov:wasDerivedFrom niiri:fd051605e8c7f96825de2e8c362f619d .
 
-niiri:5be690c7137b49b7de3a5957b1c2e009
+niiri:dc195d458077541582f78033d188351e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0002" ;
     nidm_clusterSizeInVoxels: "273"^^xsd:int ;
@@ -541,9 +541,9 @@ niiri:5be690c7137b49b7de3a5957b1c2e009
     nidm_qValueFDR: "5.47403971358153e-05"^^xsd:float ;
     nidm_clusterLabelId: "2"^^xsd:int .
 
-niiri:5be690c7137b49b7de3a5957b1c2e009 prov:wasDerivedFrom niiri:dc8fee2c80984a4e4da98aaa0284ab39 .
+niiri:dc195d458077541582f78033d188351e prov:wasDerivedFrom niiri:fd051605e8c7f96825de2e8c362f619d .
 
-niiri:8274df6982dc764d903aeb32906fa99e
+niiri:125236b3b8db9c4f2b7d390d441d3c18
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0003" ;
     nidm_clusterSizeInVoxels: "645"^^xsd:int ;
@@ -553,9 +553,9 @@ niiri:8274df6982dc764d903aeb32906fa99e
     nidm_qValueFDR: "2.08985491033498e-08"^^xsd:float ;
     nidm_clusterLabelId: "3"^^xsd:int .
 
-niiri:8274df6982dc764d903aeb32906fa99e prov:wasDerivedFrom niiri:dc8fee2c80984a4e4da98aaa0284ab39 .
+niiri:125236b3b8db9c4f2b7d390d441d3c18 prov:wasDerivedFrom niiri:fd051605e8c7f96825de2e8c362f619d .
 
-niiri:bd2d07ab483a43de0c2ab5d363f8a39f
+niiri:c7407836fb981de7ef9a1ccaad77eec7
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0004" ;
     nidm_clusterSizeInVoxels: "252"^^xsd:int ;
@@ -565,9 +565,9 @@ niiri:bd2d07ab483a43de0c2ab5d363f8a39f
     nidm_qValueFDR: "8.33840771827089e-05"^^xsd:float ;
     nidm_clusterLabelId: "4"^^xsd:int .
 
-niiri:bd2d07ab483a43de0c2ab5d363f8a39f prov:wasDerivedFrom niiri:dc8fee2c80984a4e4da98aaa0284ab39 .
+niiri:c7407836fb981de7ef9a1ccaad77eec7 prov:wasDerivedFrom niiri:fd051605e8c7f96825de2e8c362f619d .
 
-niiri:366992a084b7ef6a24b39de104a74c9f
+niiri:6efb738cf8ae66818b93292de14c66bf
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0005" ;
     nidm_clusterSizeInVoxels: "649"^^xsd:int ;
@@ -577,9 +577,9 @@ niiri:366992a084b7ef6a24b39de104a74c9f
     nidm_qValueFDR: "2.08985491033498e-08"^^xsd:float ;
     nidm_clusterLabelId: "5"^^xsd:int .
 
-niiri:366992a084b7ef6a24b39de104a74c9f prov:wasDerivedFrom niiri:dc8fee2c80984a4e4da98aaa0284ab39 .
+niiri:6efb738cf8ae66818b93292de14c66bf prov:wasDerivedFrom niiri:fd051605e8c7f96825de2e8c362f619d .
 
-niiri:346bffef3940af9cd3edb04ed96ce19c
+niiri:688ca92e605ac76835652ec4e94cc704
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0006" ;
     nidm_clusterSizeInVoxels: "543"^^xsd:int ;
@@ -589,9 +589,9 @@ niiri:346bffef3940af9cd3edb04ed96ce19c
     nidm_qValueFDR: "1.31661912052023e-07"^^xsd:float ;
     nidm_clusterLabelId: "6"^^xsd:int .
 
-niiri:346bffef3940af9cd3edb04ed96ce19c prov:wasDerivedFrom niiri:dc8fee2c80984a4e4da98aaa0284ab39 .
+niiri:688ca92e605ac76835652ec4e94cc704 prov:wasDerivedFrom niiri:fd051605e8c7f96825de2e8c362f619d .
 
-niiri:f1d6e888b3036a10e15107b3d4ffaa31
+niiri:68da208642972437b835af6ed59a660c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0007" ;
     nidm_clusterSizeInVoxels: "312"^^xsd:int ;
@@ -601,9 +601,9 @@ niiri:f1d6e888b3036a10e15107b3d4ffaa31
     nidm_qValueFDR: "2.34453081784098e-05"^^xsd:float ;
     nidm_clusterLabelId: "7"^^xsd:int .
 
-niiri:f1d6e888b3036a10e15107b3d4ffaa31 prov:wasDerivedFrom niiri:dc8fee2c80984a4e4da98aaa0284ab39 .
+niiri:68da208642972437b835af6ed59a660c prov:wasDerivedFrom niiri:fd051605e8c7f96825de2e8c362f619d .
 
-niiri:39bbd361b635bf63dc6b25f92c18b7ca
+niiri:f8507bdcacd86027fdafd6fd60ba6874
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0008" ;
     nidm_clusterSizeInVoxels: "15"^^xsd:int ;
@@ -613,9 +613,9 @@ niiri:39bbd361b635bf63dc6b25f92c18b7ca
     nidm_qValueFDR: "0.353565994893987"^^xsd:float ;
     nidm_clusterLabelId: "8"^^xsd:int .
 
-niiri:39bbd361b635bf63dc6b25f92c18b7ca prov:wasDerivedFrom niiri:dc8fee2c80984a4e4da98aaa0284ab39 .
+niiri:f8507bdcacd86027fdafd6fd60ba6874 prov:wasDerivedFrom niiri:fd051605e8c7f96825de2e8c362f619d .
 
-niiri:8ab7185bd26c34dee98b0031b8d417ac
+niiri:d2ca51b89db2e3b1111d7fdbfda64417
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0009" ;
     nidm_clusterSizeInVoxels: "186"^^xsd:int ;
@@ -625,9 +625,9 @@ niiri:8ab7185bd26c34dee98b0031b8d417ac
     nidm_qValueFDR: "0.000499007299284434"^^xsd:float ;
     nidm_clusterLabelId: "9"^^xsd:int .
 
-niiri:8ab7185bd26c34dee98b0031b8d417ac prov:wasDerivedFrom niiri:dc8fee2c80984a4e4da98aaa0284ab39 .
+niiri:d2ca51b89db2e3b1111d7fdbfda64417 prov:wasDerivedFrom niiri:fd051605e8c7f96825de2e8c362f619d .
 
-niiri:cb714b171c3d5683c2c98af66cf6eabb
+niiri:93024a65786df3d21c3afeb2157fda29
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0010" ;
     nidm_clusterSizeInVoxels: "32"^^xsd:int ;
@@ -637,9 +637,9 @@ niiri:cb714b171c3d5683c2c98af66cf6eabb
     nidm_qValueFDR: "0.148316140336941"^^xsd:float ;
     nidm_clusterLabelId: "10"^^xsd:int .
 
-niiri:cb714b171c3d5683c2c98af66cf6eabb prov:wasDerivedFrom niiri:dc8fee2c80984a4e4da98aaa0284ab39 .
+niiri:93024a65786df3d21c3afeb2157fda29 prov:wasDerivedFrom niiri:fd051605e8c7f96825de2e8c362f619d .
 
-niiri:0ff9d90df9162134b0a5b1c57873965e
+niiri:035c0aba4276188a1f52052646ae7120
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0011" ;
     nidm_clusterSizeInVoxels: "26"^^xsd:int ;
@@ -649,9 +649,9 @@ niiri:0ff9d90df9162134b0a5b1c57873965e
     nidm_qValueFDR: "0.189929490327131"^^xsd:float ;
     nidm_clusterLabelId: "11"^^xsd:int .
 
-niiri:0ff9d90df9162134b0a5b1c57873965e prov:wasDerivedFrom niiri:dc8fee2c80984a4e4da98aaa0284ab39 .
+niiri:035c0aba4276188a1f52052646ae7120 prov:wasDerivedFrom niiri:fd051605e8c7f96825de2e8c362f619d .
 
-niiri:4cd12d51d9021fd8adb9844533537b73
+niiri:2dc499c816a88d424858df07e367da38
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0012" ;
     nidm_clusterSizeInVoxels: "12"^^xsd:int ;
@@ -661,9 +661,9 @@ niiri:4cd12d51d9021fd8adb9844533537b73
     nidm_qValueFDR: "0.407113744098829"^^xsd:float ;
     nidm_clusterLabelId: "12"^^xsd:int .
 
-niiri:4cd12d51d9021fd8adb9844533537b73 prov:wasDerivedFrom niiri:dc8fee2c80984a4e4da98aaa0284ab39 .
+niiri:2dc499c816a88d424858df07e367da38 prov:wasDerivedFrom niiri:fd051605e8c7f96825de2e8c362f619d .
 
-niiri:1b789db1ce53a57bbc25c68cdac66c2d
+niiri:809e973106f074b8b57288f78176fadb
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0013" ;
     nidm_clusterSizeInVoxels: "33"^^xsd:int ;
@@ -673,9 +673,9 @@ niiri:1b789db1ce53a57bbc25c68cdac66c2d
     nidm_qValueFDR: "0.148316140336941"^^xsd:float ;
     nidm_clusterLabelId: "13"^^xsd:int .
 
-niiri:1b789db1ce53a57bbc25c68cdac66c2d prov:wasDerivedFrom niiri:dc8fee2c80984a4e4da98aaa0284ab39 .
+niiri:809e973106f074b8b57288f78176fadb prov:wasDerivedFrom niiri:fd051605e8c7f96825de2e8c362f619d .
 
-niiri:8d9aa6d1ec6c37718c5a8b44989b6f5f
+niiri:23280aef5e15fc151595ade28a75778f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0014" ;
     nidm_clusterSizeInVoxels: "10"^^xsd:int ;
@@ -685,9 +685,9 @@ niiri:8d9aa6d1ec6c37718c5a8b44989b6f5f
     nidm_qValueFDR: "0.442626087752986"^^xsd:float ;
     nidm_clusterLabelId: "14"^^xsd:int .
 
-niiri:8d9aa6d1ec6c37718c5a8b44989b6f5f prov:wasDerivedFrom niiri:dc8fee2c80984a4e4da98aaa0284ab39 .
+niiri:23280aef5e15fc151595ade28a75778f prov:wasDerivedFrom niiri:fd051605e8c7f96825de2e8c362f619d .
 
-niiri:8d5aa4d277ff8060425a7d8827846199
+niiri:a724fab477e1c34dff00939c8a5fe1d9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0015" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -697,9 +697,9 @@ niiri:8d5aa4d277ff8060425a7d8827846199
     nidm_qValueFDR: "0.601435514958662"^^xsd:float ;
     nidm_clusterLabelId: "15"^^xsd:int .
 
-niiri:8d5aa4d277ff8060425a7d8827846199 prov:wasDerivedFrom niiri:dc8fee2c80984a4e4da98aaa0284ab39 .
+niiri:a724fab477e1c34dff00939c8a5fe1d9 prov:wasDerivedFrom niiri:fd051605e8c7f96825de2e8c362f619d .
 
-niiri:c3faa5585abf8fd6ae5f51bed00a5c44
+niiri:e8d2cf34f04ba64f58f96a3bd57989a0
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0016" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -709,9 +709,9 @@ niiri:c3faa5585abf8fd6ae5f51bed00a5c44
     nidm_qValueFDR: "0.587568833901628"^^xsd:float ;
     nidm_clusterLabelId: "16"^^xsd:int .
 
-niiri:c3faa5585abf8fd6ae5f51bed00a5c44 prov:wasDerivedFrom niiri:dc8fee2c80984a4e4da98aaa0284ab39 .
+niiri:e8d2cf34f04ba64f58f96a3bd57989a0 prov:wasDerivedFrom niiri:fd051605e8c7f96825de2e8c362f619d .
 
-niiri:860d4c90c76b09b791e464d1115fe241
+niiri:b073888acef337b87afb0a3f49356435
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0017" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -721,9 +721,9 @@ niiri:860d4c90c76b09b791e464d1115fe241
     nidm_qValueFDR: "0.728097750887389"^^xsd:float ;
     nidm_clusterLabelId: "17"^^xsd:int .
 
-niiri:860d4c90c76b09b791e464d1115fe241 prov:wasDerivedFrom niiri:dc8fee2c80984a4e4da98aaa0284ab39 .
+niiri:b073888acef337b87afb0a3f49356435 prov:wasDerivedFrom niiri:fd051605e8c7f96825de2e8c362f619d .
 
-niiri:99f2be73be2c6be215bfd9faf3a92a39
+niiri:24cb62d0bb1e202be98184cc8d05dffd
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0018" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -733,9 +733,9 @@ niiri:99f2be73be2c6be215bfd9faf3a92a39
     nidm_qValueFDR: "0.601435514958662"^^xsd:float ;
     nidm_clusterLabelId: "18"^^xsd:int .
 
-niiri:99f2be73be2c6be215bfd9faf3a92a39 prov:wasDerivedFrom niiri:dc8fee2c80984a4e4da98aaa0284ab39 .
+niiri:24cb62d0bb1e202be98184cc8d05dffd prov:wasDerivedFrom niiri:fd051605e8c7f96825de2e8c362f619d .
 
-niiri:1e52aefb94abdf0e6614ea5a19db8bab
+niiri:824d90300b93425516b70315d9d6f976
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0019" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -745,600 +745,600 @@ niiri:1e52aefb94abdf0e6614ea5a19db8bab
     nidm_qValueFDR: "0.601435514958662"^^xsd:float ;
     nidm_clusterLabelId: "19"^^xsd:int .
 
-niiri:1e52aefb94abdf0e6614ea5a19db8bab prov:wasDerivedFrom niiri:dc8fee2c80984a4e4da98aaa0284ab39 .
+niiri:824d90300b93425516b70315d9d6f976 prov:wasDerivedFrom niiri:fd051605e8c7f96825de2e8c362f619d .
 
-niiri:f5d12376dc838c360907fa99f57693b3
+niiri:4b1128660a9a6cee4015a8ff88a80c95
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0001" ;
-    prov:atLocation niiri:063accc4d27557385539d241f4400c7b ;
+    prov:atLocation niiri:df9bb709e4b052129d18485666595240 ;
     prov:value "8.68328475952148"^^xsd:float ;
     nidm_equivalentZStatistic: "5.89806475543002"^^xsd:float ;
     nidm_pValueUncorrected: "1.83894821592645e-09"^^xsd:float ;
     nidm_pValueFWER: "0.000295890410111577"^^xsd:float ;
     nidm_qValueFDR: "0.00163136813750933"^^xsd:float .
 
-niiri:063accc4d27557385539d241f4400c7b
+niiri:df9bb709e4b052129d18485666595240
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0001" ;
     nidm_coordinateVector: "[-8,14,44]"^^xsd:string .
 
-niiri:f5d12376dc838c360907fa99f57693b3 prov:wasDerivedFrom niiri:fea0f4eb720496a64dd119edf1c8fd20 .
+niiri:4b1128660a9a6cee4015a8ff88a80c95 prov:wasDerivedFrom niiri:01ec637797471e97b81c59d553918fe2 .
 
-niiri:8b6d437e8a2dc4bb10db5f840ad5cb0b
+niiri:12441664c05631bc80a5589022113423
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0002" ;
-    prov:atLocation niiri:4f622b98376b0203b6fc463810fda26b ;
+    prov:atLocation niiri:c985252a616227b4de321a67cafc5e9f ;
     prov:value "7.33630895614624"^^xsd:float ;
     nidm_equivalentZStatistic: "5.35354564681114"^^xsd:float ;
     nidm_pValueUncorrected: "4.31236324427431e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00693867881448451"^^xsd:float ;
     nidm_qValueFDR: "0.00719550144323139"^^xsd:float .
 
-niiri:4f622b98376b0203b6fc463810fda26b
+niiri:c985252a616227b4de321a67cafc5e9f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0002" ;
     nidm_coordinateVector: "[-2,8,62]"^^xsd:string .
 
-niiri:8b6d437e8a2dc4bb10db5f840ad5cb0b prov:wasDerivedFrom niiri:fea0f4eb720496a64dd119edf1c8fd20 .
+niiri:12441664c05631bc80a5589022113423 prov:wasDerivedFrom niiri:01ec637797471e97b81c59d553918fe2 .
 
-niiri:3fd07c7c0da35cfc103353962d0cb298
+niiri:f35b60f8e0364a64a0d746c299ac0db6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0003" ;
-    prov:atLocation niiri:d334b839c5aac2c367ee63f7000b9f1c ;
+    prov:atLocation niiri:e169aecc5f1ea00016ee1e9750c0f735 ;
     prov:value "6.84883069992065"^^xsd:float ;
     nidm_equivalentZStatistic: "5.13238708590925"^^xsd:float ;
     nidm_pValueUncorrected: "1.43045180589496e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0188976197165134"^^xsd:float ;
     nidm_qValueFDR: "0.00835884069841993"^^xsd:float .
 
-niiri:d334b839c5aac2c367ee63f7000b9f1c
+niiri:e169aecc5f1ea00016ee1e9750c0f735
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0003" ;
     nidm_coordinateVector: "[8,2,66]"^^xsd:string .
 
-niiri:3fd07c7c0da35cfc103353962d0cb298 prov:wasDerivedFrom niiri:fea0f4eb720496a64dd119edf1c8fd20 .
+niiri:f35b60f8e0364a64a0d746c299ac0db6 prov:wasDerivedFrom niiri:01ec637797471e97b81c59d553918fe2 .
 
-niiri:c00def4a48d5a30f5a0b70a012758d41
+niiri:ec7ddf4786fe39f9182536fea466833e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0004" ;
-    prov:atLocation niiri:80db77128b371a6b29ab4b607db75fbd ;
+    prov:atLocation niiri:d54e6ad7e6488168ce22f8734b7eb5f5 ;
     prov:value "8.35158634185791"^^xsd:float ;
     nidm_equivalentZStatistic: "5.77222915803918"^^xsd:float ;
     nidm_pValueUncorrected: "3.9114812500074e-09"^^xsd:float ;
     nidm_pValueFWER: "0.000629365120361269"^^xsd:float ;
     nidm_qValueFDR: "0.00163136813750933"^^xsd:float .
 
-niiri:80db77128b371a6b29ab4b607db75fbd
+niiri:d54e6ad7e6488168ce22f8734b7eb5f5
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0004" ;
     nidm_coordinateVector: "[-46,-4,54]"^^xsd:string .
 
-niiri:c00def4a48d5a30f5a0b70a012758d41 prov:wasDerivedFrom niiri:5be690c7137b49b7de3a5957b1c2e009 .
+niiri:ec7ddf4786fe39f9182536fea466833e prov:wasDerivedFrom niiri:dc195d458077541582f78033d188351e .
 
-niiri:e0d8a9ff23aa198493f707eed8ef4541
+niiri:beae26e50fc3b9b6095ec0cf978aa74d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0005" ;
-    prov:atLocation niiri:b471f18eed004f6b436cf02c9eeb0001 ;
+    prov:atLocation niiri:a86b051d7b52ab721f5e5175d20d7eae ;
     prov:value "6.98639822006226"^^xsd:float ;
     nidm_equivalentZStatistic: "5.19623635430538"^^xsd:float ;
     nidm_pValueUncorrected: "1.01681835729117e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0142675592490157"^^xsd:float ;
     nidm_qValueFDR: "0.00719550144323139"^^xsd:float .
 
-niiri:b471f18eed004f6b436cf02c9eeb0001
+niiri:a86b051d7b52ab721f5e5175d20d7eae
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0005" ;
     nidm_coordinateVector: "[-52,-4,48]"^^xsd:string .
 
-niiri:e0d8a9ff23aa198493f707eed8ef4541 prov:wasDerivedFrom niiri:5be690c7137b49b7de3a5957b1c2e009 .
+niiri:beae26e50fc3b9b6095ec0cf978aa74d prov:wasDerivedFrom niiri:dc195d458077541582f78033d188351e .
 
-niiri:674261e537481975fae3b273665d3696
+niiri:78a7e02e1865904a3962e95d6e770a76
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0006" ;
-    prov:atLocation niiri:410fae38a3d3669805433fa1ffef060a ;
+    prov:atLocation niiri:c0d5c03cc49d0e30483f9a8ad3fc7ed6 ;
     prov:value "4.94789028167725"^^xsd:float ;
     nidm_equivalentZStatistic: "4.11595434674584"^^xsd:float ;
     nidm_pValueUncorrected: "1.92790313852109e-05"^^xsd:float ;
     nidm_pValueFWER: "0.632970462914878"^^xsd:float ;
     nidm_qValueFDR: "0.106458926829394"^^xsd:float .
 
-niiri:410fae38a3d3669805433fa1ffef060a
+niiri:c0d5c03cc49d0e30483f9a8ad3fc7ed6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0006" ;
     nidm_coordinateVector: "[-44,0,36]"^^xsd:string .
 
-niiri:674261e537481975fae3b273665d3696 prov:wasDerivedFrom niiri:5be690c7137b49b7de3a5957b1c2e009 .
+niiri:78a7e02e1865904a3962e95d6e770a76 prov:wasDerivedFrom niiri:dc195d458077541582f78033d188351e .
 
-niiri:9c7572593a901012448046d97f575824
+niiri:606a12f8dfe1e04b3697ef1eebb14808
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0007" ;
-    prov:atLocation niiri:dc36b3bfe116277634ce635e53fee2c4 ;
+    prov:atLocation niiri:3a24858e4f675f4ceec3345587d30aef ;
     prov:value "7.1633768081665"^^xsd:float ;
     nidm_equivalentZStatistic: "5.27669699963205"^^xsd:float ;
     nidm_pValueUncorrected: "6.57665507608485e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00994759733633388"^^xsd:float ;
     nidm_qValueFDR: "0.00719550144323139"^^xsd:float .
 
-niiri:dc36b3bfe116277634ce635e53fee2c4
+niiri:3a24858e4f675f4ceec3345587d30aef
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0007" ;
     nidm_coordinateVector: "[-28,20,4]"^^xsd:string .
 
-niiri:9c7572593a901012448046d97f575824 prov:wasDerivedFrom niiri:8274df6982dc764d903aeb32906fa99e .
+niiri:606a12f8dfe1e04b3697ef1eebb14808 prov:wasDerivedFrom niiri:125236b3b8db9c4f2b7d390d441d3c18 .
 
-niiri:f344995ee9396ec2b22436da6abdfc01
+niiri:3d611934585d07a97bc5d3fb0a2ae75a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0008" ;
-    prov:atLocation niiri:7c1bef178f76c4737604068ad1821fb8 ;
+    prov:atLocation niiri:4c0f3c362a6a4ca000f2e45782ca92d7 ;
     prov:value "6.05753993988037"^^xsd:float ;
     nidm_equivalentZStatistic: "4.74136371640284"^^xsd:float ;
     nidm_pValueUncorrected: "1.06142217415339e-06"^^xsd:float ;
     nidm_pValueFWER: "0.0943293570611123"^^xsd:float ;
     nidm_qValueFDR: "0.0289398009003969"^^xsd:float .
 
-niiri:7c1bef178f76c4737604068ad1821fb8
+niiri:4c0f3c362a6a4ca000f2e45782ca92d7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0008" ;
     nidm_coordinateVector: "[-32,12,12]"^^xsd:string .
 
-niiri:f344995ee9396ec2b22436da6abdfc01 prov:wasDerivedFrom niiri:8274df6982dc764d903aeb32906fa99e .
+niiri:3d611934585d07a97bc5d3fb0a2ae75a prov:wasDerivedFrom niiri:125236b3b8db9c4f2b7d390d441d3c18 .
 
-niiri:d1f339ee53c67a39858a02aab0c7fc68
+niiri:81261cd464ee0b8f22adca3c75f049a3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0009" ;
-    prov:atLocation niiri:8159917a3daf71fd51837d08aa36c2e3 ;
+    prov:atLocation niiri:9460d662c65847aeccb65dca7370d87b ;
     prov:value "5.53688049316406"^^xsd:float ;
     nidm_equivalentZStatistic: "4.4599738348881"^^xsd:float ;
     nidm_pValueUncorrected: "4.09848297133752e-06"^^xsd:float ;
     nidm_pValueFWER: "0.255369959741091"^^xsd:float ;
     nidm_qValueFDR: "0.0463937463013495"^^xsd:float .
 
-niiri:8159917a3daf71fd51837d08aa36c2e3
+niiri:9460d662c65847aeccb65dca7370d87b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0009" ;
     nidm_coordinateVector: "[-40,14,6]"^^xsd:string .
 
-niiri:d1f339ee53c67a39858a02aab0c7fc68 prov:wasDerivedFrom niiri:8274df6982dc764d903aeb32906fa99e .
+niiri:81261cd464ee0b8f22adca3c75f049a3 prov:wasDerivedFrom niiri:125236b3b8db9c4f2b7d390d441d3c18 .
 
-niiri:07d2d8dacefd14b5512b2780fe8e9418
+niiri:809e45a8f97c7742d22d07c42e436b9b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0010" ;
-    prov:atLocation niiri:69f8f24492b6358c98c62bb755257e4d ;
+    prov:atLocation niiri:2d0c2f8f914e3950001f5780fda6d7c5 ;
     prov:value "7.03751659393311"^^xsd:float ;
     nidm_equivalentZStatistic: "5.21966850947269"^^xsd:float ;
     nidm_pValueUncorrected: "8.96218316226438e-08"^^xsd:float ;
     nidm_pValueFWER: "0.0128544751144342"^^xsd:float ;
     nidm_qValueFDR: "0.00719550144323139"^^xsd:float .
 
-niiri:69f8f24492b6358c98c62bb755257e4d
+niiri:2d0c2f8f914e3950001f5780fda6d7c5
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0010" ;
     nidm_coordinateVector: "[54,0,46]"^^xsd:string .
 
-niiri:07d2d8dacefd14b5512b2780fe8e9418 prov:wasDerivedFrom niiri:bd2d07ab483a43de0c2ab5d363f8a39f .
+niiri:809e45a8f97c7742d22d07c42e436b9b prov:wasDerivedFrom niiri:c7407836fb981de7ef9a1ccaad77eec7 .
 
-niiri:9dd6bc79a73003860246fdbd4d6e50ac
+niiri:7d6282c527edd4b542c265187c6fc7a9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0011" ;
-    prov:atLocation niiri:e21e7ba6c3100ae713d83f7f7de299ef ;
+    prov:atLocation niiri:c5ba100f71d6acc1ce64b2c2026b9ad4 ;
     prov:value "4.67526912689209"^^xsd:float ;
     nidm_equivalentZStatistic: "3.94678957573653"^^xsd:float ;
     nidm_pValueUncorrected: "3.96030553606597e-05"^^xsd:float ;
     nidm_pValueFWER: "0.826020447766485"^^xsd:float ;
     nidm_qValueFDR: "0.175133460202579"^^xsd:float .
 
-niiri:e21e7ba6c3100ae713d83f7f7de299ef
+niiri:c5ba100f71d6acc1ce64b2c2026b9ad4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0011" ;
     nidm_coordinateVector: "[42,0,40]"^^xsd:string .
 
-niiri:9dd6bc79a73003860246fdbd4d6e50ac prov:wasDerivedFrom niiri:bd2d07ab483a43de0c2ab5d363f8a39f .
+niiri:7d6282c527edd4b542c265187c6fc7a9 prov:wasDerivedFrom niiri:c7407836fb981de7ef9a1ccaad77eec7 .
 
-niiri:a54191fd77e1cffaaa265aa0ff737a0d
+niiri:e122dfd8cae44bf9b1c9068c52fbb1fd
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0012" ;
-    prov:atLocation niiri:bb7e2fd466b439dfe1cdad53c0cbcce1 ;
+    prov:atLocation niiri:88eb1ce70078217da9ad80ffbff952c8 ;
     prov:value "3.99186444282532"^^xsd:float ;
     nidm_equivalentZStatistic: "3.49308716519441"^^xsd:float ;
     nidm_pValueUncorrected: "0.000238735314068705"^^xsd:float ;
     nidm_pValueFWER: "0.998766388576126"^^xsd:float ;
     nidm_qValueFDR: "0.467639377242474"^^xsd:float .
 
-niiri:bb7e2fd466b439dfe1cdad53c0cbcce1
+niiri:88eb1ce70078217da9ad80ffbff952c8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0012" ;
     nidm_coordinateVector: "[50,4,38]"^^xsd:string .
 
-niiri:a54191fd77e1cffaaa265aa0ff737a0d prov:wasDerivedFrom niiri:bd2d07ab483a43de0c2ab5d363f8a39f .
+niiri:e122dfd8cae44bf9b1c9068c52fbb1fd prov:wasDerivedFrom niiri:c7407836fb981de7ef9a1ccaad77eec7 .
 
-niiri:73576e6f6e96479fa537ebb5a320da45
+niiri:10f6bffbb03110c4e326855f654c7053
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0013" ;
-    prov:atLocation niiri:15ab25d6eb17fe855b3e4cd781c8558d ;
+    prov:atLocation niiri:09bc6e573433407ff8167fd0ec8c3554 ;
     prov:value "6.17448043823242"^^xsd:float ;
     nidm_equivalentZStatistic: "4.80182851023383"^^xsd:float ;
     nidm_pValueUncorrected: "7.86116573836537e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0746359690709463"^^xsd:float ;
     nidm_qValueFDR: "0.0247162735389005"^^xsd:float .
 
-niiri:15ab25d6eb17fe855b3e4cd781c8558d
+niiri:09bc6e573433407ff8167fd0ec8c3554
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0013" ;
     nidm_coordinateVector: "[64,-32,14]"^^xsd:string .
 
-niiri:73576e6f6e96479fa537ebb5a320da45 prov:wasDerivedFrom niiri:366992a084b7ef6a24b39de104a74c9f .
+niiri:10f6bffbb03110c4e326855f654c7053 prov:wasDerivedFrom niiri:6efb738cf8ae66818b93292de14c66bf .
 
-niiri:0e1e7b9bc1a6cf4f76ff149e1a986076
+niiri:c4779e84dce494937bda818ef5e669dc
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0014" ;
-    prov:atLocation niiri:4e9baf1f2c75efd517106374f31f08b1 ;
+    prov:atLocation niiri:ecbd626ad6f08df3e710715c3e5284c2 ;
     prov:value "5.78444290161133"^^xsd:float ;
     nidm_equivalentZStatistic: "4.59630541537731"^^xsd:float ;
     nidm_pValueUncorrected: "2.15024103455974e-06"^^xsd:float ;
     nidm_pValueFWER: "0.161036372633912"^^xsd:float ;
     nidm_qValueFDR: "0.0384651426630127"^^xsd:float .
 
-niiri:4e9baf1f2c75efd517106374f31f08b1
+niiri:ecbd626ad6f08df3e710715c3e5284c2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0014" ;
     nidm_coordinateVector: "[54,-36,6]"^^xsd:string .
 
-niiri:0e1e7b9bc1a6cf4f76ff149e1a986076 prov:wasDerivedFrom niiri:366992a084b7ef6a24b39de104a74c9f .
+niiri:c4779e84dce494937bda818ef5e669dc prov:wasDerivedFrom niiri:6efb738cf8ae66818b93292de14c66bf .
 
-niiri:215ee51142ace5bc800ea56a96069019
+niiri:844b498ab06280ebbe9ee9dceb2a5d16
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0015" ;
-    prov:atLocation niiri:3c407f555837fd3219d33ddf197b2654 ;
+    prov:atLocation niiri:6be9818fbe27aa7823d210572c66e57f ;
     prov:value "5.29158926010132"^^xsd:float ;
     nidm_equivalentZStatistic: "4.32015757237268"^^xsd:float ;
     nidm_pValueUncorrected: "7.79589134014547e-06"^^xsd:float ;
     nidm_pValueFWER: "0.3885997605562"^^xsd:float ;
     nidm_qValueFDR: "0.0663265650293897"^^xsd:float .
 
-niiri:3c407f555837fd3219d33ddf197b2654
+niiri:6be9818fbe27aa7823d210572c66e57f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0015" ;
     nidm_coordinateVector: "[58,-18,-4]"^^xsd:string .
 
-niiri:215ee51142ace5bc800ea56a96069019 prov:wasDerivedFrom niiri:366992a084b7ef6a24b39de104a74c9f .
+niiri:844b498ab06280ebbe9ee9dceb2a5d16 prov:wasDerivedFrom niiri:6efb738cf8ae66818b93292de14c66bf .
 
-niiri:40729988e97b5bc5fe7c276102dbcd6b
+niiri:3e533998c00bcb7174e1ff58abee7b36
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0016" ;
-    prov:atLocation niiri:b66375039d5f769dfb5f115db1f5781c ;
+    prov:atLocation niiri:724b45d5eea6ea672d1a7c6765b84433 ;
     prov:value "5.80037450790405"^^xsd:float ;
     nidm_equivalentZStatistic: "4.60491906158358"^^xsd:float ;
     nidm_pValueUncorrected: "2.06313156536631e-06"^^xsd:float ;
     nidm_pValueFWER: "0.156185504689616"^^xsd:float ;
     nidm_qValueFDR: "0.0384651426630127"^^xsd:float .
 
-niiri:b66375039d5f769dfb5f115db1f5781c
+niiri:724b45d5eea6ea672d1a7c6765b84433
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0016" ;
     nidm_coordinateVector: "[32,18,6]"^^xsd:string .
 
-niiri:40729988e97b5bc5fe7c276102dbcd6b prov:wasDerivedFrom niiri:346bffef3940af9cd3edb04ed96ce19c .
+niiri:3e533998c00bcb7174e1ff58abee7b36 prov:wasDerivedFrom niiri:688ca92e605ac76835652ec4e94cc704 .
 
-niiri:fa7e2af5036aae17f3d6d347ea3655b3
+niiri:3df0e6a6a8d15f376ef1ad04904ac285
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0017" ;
-    prov:atLocation niiri:57af4eea0139686f537c81cdd2dbe5cc ;
+    prov:atLocation niiri:688e14ec89daea4fe959e58361ee58a1 ;
     prov:value "5.65365648269653"^^xsd:float ;
     nidm_equivalentZStatistic: "4.52486817583008"^^xsd:float ;
     nidm_pValueUncorrected: "3.02165810672772e-06"^^xsd:float ;
     nidm_pValueFWER: "0.206207182279971"^^xsd:float ;
     nidm_qValueFDR: "0.0404714050465719"^^xsd:float .
 
-niiri:57af4eea0139686f537c81cdd2dbe5cc
+niiri:688e14ec89daea4fe959e58361ee58a1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0017" ;
     nidm_coordinateVector: "[46,14,2]"^^xsd:string .
 
-niiri:fa7e2af5036aae17f3d6d347ea3655b3 prov:wasDerivedFrom niiri:346bffef3940af9cd3edb04ed96ce19c .
+niiri:3df0e6a6a8d15f376ef1ad04904ac285 prov:wasDerivedFrom niiri:688ca92e605ac76835652ec4e94cc704 .
 
-niiri:296a366820300d5df08a3d708d64d346
+niiri:820ea5e2cac41f9259686ca8892a5878
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0018" ;
-    prov:atLocation niiri:2dc12cbb22f93d17b25d19b10313d8a6 ;
+    prov:atLocation niiri:a89e043e86acf22adbef2c908f0c940a ;
     prov:value "4.97042274475098"^^xsd:float ;
     nidm_equivalentZStatistic: "4.12964691442442"^^xsd:float ;
     nidm_pValueUncorrected: "1.81660388410831e-05"^^xsd:float ;
     nidm_pValueFWER: "0.61591975617624"^^xsd:float ;
     nidm_qValueFDR: "0.106458926829394"^^xsd:float .
 
-niiri:2dc12cbb22f93d17b25d19b10313d8a6
+niiri:a89e043e86acf22adbef2c908f0c940a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0018" ;
     nidm_coordinateVector: "[52,6,20]"^^xsd:string .
 
-niiri:296a366820300d5df08a3d708d64d346 prov:wasDerivedFrom niiri:346bffef3940af9cd3edb04ed96ce19c .
+niiri:820ea5e2cac41f9259686ca8892a5878 prov:wasDerivedFrom niiri:688ca92e605ac76835652ec4e94cc704 .
 
-niiri:e64d9d9e2f71702fc14e7158572a1a6c
+niiri:efbc436a1b3678612dfe7f44dd10cbb3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0019" ;
-    prov:atLocation niiri:98ab5c1a1e4e369c1246d0134debdbfd ;
+    prov:atLocation niiri:397d2866425d1c295696d0c818d8d533 ;
     prov:value "5.69512796401978"^^xsd:float ;
     nidm_equivalentZStatistic: "4.54766136430568"^^xsd:float ;
     nidm_pValueUncorrected: "2.71226629111609e-06"^^xsd:float ;
     nidm_pValueFWER: "0.190809496629972"^^xsd:float ;
     nidm_qValueFDR: "0.0390573552317814"^^xsd:float .
 
-niiri:98ab5c1a1e4e369c1246d0134debdbfd
+niiri:397d2866425d1c295696d0c818d8d533
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0019" ;
     nidm_coordinateVector: "[-50,-44,10]"^^xsd:string .
 
-niiri:e64d9d9e2f71702fc14e7158572a1a6c prov:wasDerivedFrom niiri:f1d6e888b3036a10e15107b3d4ffaa31 .
+niiri:efbc436a1b3678612dfe7f44dd10cbb3 prov:wasDerivedFrom niiri:68da208642972437b835af6ed59a660c .
 
-niiri:7ccdc091157500cdd924e120d242a240
+niiri:22dcde4b50ff0337757a88138a5b07fc
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0020" ;
-    prov:atLocation niiri:11a29c9524e7e456200532633e297bd9 ;
+    prov:atLocation niiri:36fb849d4a7b16b57fbc1cd5f7c305fc ;
     prov:value "4.58639812469482"^^xsd:float ;
     nidm_equivalentZStatistic: "3.89022248971066"^^xsd:float ;
     nidm_pValueUncorrected: "5.00761765690472e-05"^^xsd:float ;
     nidm_pValueFWER: "0.876622606435302"^^xsd:float ;
     nidm_qValueFDR: "0.203731029267221"^^xsd:float .
 
-niiri:11a29c9524e7e456200532633e297bd9
+niiri:36fb849d4a7b16b57fbc1cd5f7c305fc
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0020" ;
     nidm_coordinateVector: "[-62,-36,8]"^^xsd:string .
 
-niiri:7ccdc091157500cdd924e120d242a240 prov:wasDerivedFrom niiri:f1d6e888b3036a10e15107b3d4ffaa31 .
+niiri:22dcde4b50ff0337757a88138a5b07fc prov:wasDerivedFrom niiri:68da208642972437b835af6ed59a660c .
 
-niiri:8ee9a8b687dcc085503323011e230a5c
+niiri:880b4afc515a88ebc3cf045d50f3c04a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0021" ;
-    prov:atLocation niiri:b9a5cd2efb5be31c8530c8899aaca4b8 ;
+    prov:atLocation niiri:31ed78344a2ca5c440cba467b3a898d7 ;
     prov:value "4.50590515136719"^^xsd:float ;
     nidm_equivalentZStatistic: "3.83837298746928"^^xsd:float ;
     nidm_pValueUncorrected: "6.19261255102588e-05"^^xsd:float ;
     nidm_pValueFWER: "0.914499359553669"^^xsd:float ;
     nidm_qValueFDR: "0.232964826348096"^^xsd:float .
 
-niiri:b9a5cd2efb5be31c8530c8899aaca4b8
+niiri:31ed78344a2ca5c440cba467b3a898d7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0021" ;
     nidm_coordinateVector: "[-44,-40,20]"^^xsd:string .
 
-niiri:8ee9a8b687dcc085503323011e230a5c prov:wasDerivedFrom niiri:f1d6e888b3036a10e15107b3d4ffaa31 .
+niiri:880b4afc515a88ebc3cf045d50f3c04a prov:wasDerivedFrom niiri:68da208642972437b835af6ed59a660c .
 
-niiri:6020e5e9c767f76447ce8c5737dfa47b
+niiri:9dbf2c151d9034e9c4371c30e60411e3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0022" ;
-    prov:atLocation niiri:455364cd53f6c80b439be1f9454d8efe ;
+    prov:atLocation niiri:622423e8bf7e3d7bd7479503b8fd3628 ;
     prov:value "5.32945966720581"^^xsd:float ;
     nidm_equivalentZStatistic: "4.34205915406457"^^xsd:float ;
     nidm_pValueUncorrected: "7.05767571707039e-06"^^xsd:float ;
     nidm_pValueFWER: "0.36535430900768"^^xsd:float ;
     nidm_qValueFDR: "0.0637479979695797"^^xsd:float .
 
-niiri:455364cd53f6c80b439be1f9454d8efe
+niiri:622423e8bf7e3d7bd7479503b8fd3628
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0022" ;
     nidm_coordinateVector: "[-66,-24,8]"^^xsd:string .
 
-niiri:6020e5e9c767f76447ce8c5737dfa47b prov:wasDerivedFrom niiri:39bbd361b635bf63dc6b25f92c18b7ca .
+niiri:9dbf2c151d9034e9c4371c30e60411e3 prov:wasDerivedFrom niiri:f8507bdcacd86027fdafd6fd60ba6874 .
 
-niiri:d2a2fafd4a599c37791055299a6834b3
+niiri:3826db9e7668227e2a63e832d3c39701
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0023" ;
-    prov:atLocation niiri:8ca651ed084d6c59ca691676b5040b0f ;
+    prov:atLocation niiri:950862f883bf950f211e73006d0c3c3b ;
     prov:value "5.2721529006958"^^xsd:float ;
     nidm_equivalentZStatistic: "4.30887158779036"^^xsd:float ;
     nidm_pValueUncorrected: "8.20448008320707e-06"^^xsd:float ;
     nidm_pValueFWER: "0.400892212456252"^^xsd:float ;
     nidm_qValueFDR: "0.0665066282431519"^^xsd:float .
 
-niiri:8ca651ed084d6c59ca691676b5040b0f
+niiri:950862f883bf950f211e73006d0c3c3b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0023" ;
     nidm_coordinateVector: "[54,-36,46]"^^xsd:string .
 
-niiri:d2a2fafd4a599c37791055299a6834b3 prov:wasDerivedFrom niiri:8ab7185bd26c34dee98b0031b8d417ac .
+niiri:3826db9e7668227e2a63e832d3c39701 prov:wasDerivedFrom niiri:d2ca51b89db2e3b1111d7fdbfda64417 .
 
-niiri:f025b5b245e205095b03f5b66f54b5d4
+niiri:24a0a14bebf270cbe73d80ce97ec4c02
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0024" ;
-    prov:atLocation niiri:1bdbb204e1f260c3ff9842076505bac5 ;
+    prov:atLocation niiri:16aaa501641c95b0ce42d11047b7fdc4 ;
     prov:value "4.94992017745972"^^xsd:float ;
     nidm_equivalentZStatistic: "4.11718966304234"^^xsd:float ;
     nidm_pValueUncorrected: "1.91760222628679e-05"^^xsd:float ;
     nidm_pValueFWER: "0.631434661064485"^^xsd:float ;
     nidm_qValueFDR: "0.106458926829394"^^xsd:float .
 
-niiri:1bdbb204e1f260c3ff9842076505bac5
+niiri:16aaa501641c95b0ce42d11047b7fdc4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0024" ;
     nidm_coordinateVector: "[46,-34,42]"^^xsd:string .
 
-niiri:f025b5b245e205095b03f5b66f54b5d4 prov:wasDerivedFrom niiri:8ab7185bd26c34dee98b0031b8d417ac .
+niiri:24a0a14bebf270cbe73d80ce97ec4c02 prov:wasDerivedFrom niiri:d2ca51b89db2e3b1111d7fdbfda64417 .
 
-niiri:cdb9bb633e289c00f539b1abe86e0bb9
+niiri:0449dda97bea02c246854d99b1b7adbc
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0025" ;
-    prov:atLocation niiri:9d0d38902d2d41dd611dd432725a1ee5 ;
+    prov:atLocation niiri:987a7b2248b42a3a490d2504cc7e0bf3 ;
     prov:value "4.14882755279541"^^xsd:float ;
     nidm_equivalentZStatistic: "3.60116037131659"^^xsd:float ;
     nidm_pValueUncorrected: "0.000158400037829631"^^xsd:float ;
     nidm_pValueFWER: "0.993008812777799"^^xsd:float ;
     nidm_qValueFDR: "0.370124878111002"^^xsd:float .
 
-niiri:9d0d38902d2d41dd611dd432725a1ee5
+niiri:987a7b2248b42a3a490d2504cc7e0bf3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0025" ;
     nidm_coordinateVector: "[36,-46,44]"^^xsd:string .
 
-niiri:cdb9bb633e289c00f539b1abe86e0bb9 prov:wasDerivedFrom niiri:8ab7185bd26c34dee98b0031b8d417ac .
+niiri:0449dda97bea02c246854d99b1b7adbc prov:wasDerivedFrom niiri:d2ca51b89db2e3b1111d7fdbfda64417 .
 
-niiri:9da337642884206da02e8e4ea8f1dc59
+niiri:5eb503813e71b696ec059c3e6a0dd7ef
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0026" ;
-    prov:atLocation niiri:ec0b8a8e56f2ca38cd26a98d1f8e68fa ;
+    prov:atLocation niiri:468734efebc03b0fde1d35df7a8d7b49 ;
     prov:value "4.48920822143555"^^xsd:float ;
     nidm_equivalentZStatistic: "3.82754387575664"^^xsd:float ;
     nidm_pValueUncorrected: "6.47141590200961e-05"^^xsd:float ;
     nidm_pValueFWER: "0.921344159854026"^^xsd:float ;
     nidm_qValueFDR: "0.23453068077853"^^xsd:float .
 
-niiri:ec0b8a8e56f2ca38cd26a98d1f8e68fa
+niiri:468734efebc03b0fde1d35df7a8d7b49
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0026" ;
     nidm_coordinateVector: "[-40,10,24]"^^xsd:string .
 
-niiri:9da337642884206da02e8e4ea8f1dc59 prov:wasDerivedFrom niiri:cb714b171c3d5683c2c98af66cf6eabb .
+niiri:5eb503813e71b696ec059c3e6a0dd7ef prov:wasDerivedFrom niiri:93024a65786df3d21c3afeb2157fda29 .
 
-niiri:2c6f94145ac72e98627bc3bbefa70aa9
+niiri:27662f80703bab4a958c6b33e1a93fa5
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0027" ;
-    prov:atLocation niiri:07174813566ead15f8358777d2d1e1c1 ;
+    prov:atLocation niiri:182b7c17f02d49bfc8b89cab22dea1a6 ;
     prov:value "4.37462282180786"^^xsd:float ;
     nidm_equivalentZStatistic: "3.75253736275656"^^xsd:float ;
     nidm_pValueUncorrected: "8.75268659427109e-05"^^xsd:float ;
     nidm_pValueFWER: "0.958943515151384"^^xsd:float ;
     nidm_qValueFDR: "0.266450161314934"^^xsd:float .
 
-niiri:07174813566ead15f8358777d2d1e1c1
+niiri:182b7c17f02d49bfc8b89cab22dea1a6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0027" ;
     nidm_coordinateVector: "[32,-56,-30]"^^xsd:string .
 
-niiri:2c6f94145ac72e98627bc3bbefa70aa9 prov:wasDerivedFrom niiri:0ff9d90df9162134b0a5b1c57873965e .
+niiri:27662f80703bab4a958c6b33e1a93fa5 prov:wasDerivedFrom niiri:035c0aba4276188a1f52052646ae7120 .
 
-niiri:255d9587b36286085e4a8baf4add697d
+niiri:fe8f5b1d1a7cdd89fdd7e2417cf26341
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0028" ;
-    prov:atLocation niiri:657de4f2c13844877179ea5d53199550 ;
+    prov:atLocation niiri:8612b501b0e12b2f40a16e10ca523880 ;
     prov:value "4.34167242050171"^^xsd:float ;
     nidm_equivalentZStatistic: "3.7307439273808"^^xsd:float ;
     nidm_pValueUncorrected: "9.54575986388262e-05"^^xsd:float ;
     nidm_pValueFWER: "0.966870324720423"^^xsd:float ;
     nidm_qValueFDR: "0.275753173611261"^^xsd:float .
 
-niiri:657de4f2c13844877179ea5d53199550
+niiri:8612b501b0e12b2f40a16e10ca523880
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0028" ;
     nidm_coordinateVector: "[-8,20,24]"^^xsd:string .
 
-niiri:255d9587b36286085e4a8baf4add697d prov:wasDerivedFrom niiri:4cd12d51d9021fd8adb9844533537b73 .
+niiri:fe8f5b1d1a7cdd89fdd7e2417cf26341 prov:wasDerivedFrom niiri:2dc499c816a88d424858df07e367da38 .
 
-niiri:eb6e3920a1b0f6372cbacc00652750e0
+niiri:1b3dd6f8432d3e63adbf5a0aabd4bcc1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0029" ;
-    prov:atLocation niiri:658eead9cda4e56ebe20d0bcd77dc3e4 ;
+    prov:atLocation niiri:90eb444d756e7ff76c9ab977424e6c7b ;
     prov:value "4.3336443901062"^^xsd:float ;
     nidm_equivalentZStatistic: "3.72541890112066"^^xsd:float ;
     nidm_pValueUncorrected: "9.74955684317491e-05"^^xsd:float ;
     nidm_pValueFWER: "0.968621393833285"^^xsd:float ;
     nidm_qValueFDR: "0.275753173611261"^^xsd:float .
 
-niiri:658eead9cda4e56ebe20d0bcd77dc3e4
+niiri:90eb444d756e7ff76c9ab977424e6c7b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0029" ;
     nidm_coordinateVector: "[44,38,32]"^^xsd:string .
 
-niiri:eb6e3920a1b0f6372cbacc00652750e0 prov:wasDerivedFrom niiri:1b789db1ce53a57bbc25c68cdac66c2d .
+niiri:1b3dd6f8432d3e63adbf5a0aabd4bcc1 prov:wasDerivedFrom niiri:809e973106f074b8b57288f78176fadb .
 
-niiri:eb016a7153b8b55763c7f7fbf0ec00d3
+niiri:6622c9c5a5bb5602bc2abeed125325ac
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0030" ;
-    prov:atLocation niiri:3de15e47c2cc57eaf165bb760fb17d31 ;
+    prov:atLocation niiri:48847d4df5d31de03d50ecd410917b09 ;
     prov:value "3.9835045337677"^^xsd:float ;
     nidm_equivalentZStatistic: "3.48726495012002"^^xsd:float ;
     nidm_pValueUncorrected: "0.000243993830123412"^^xsd:float ;
     nidm_pValueFWER: "0.998891092669635"^^xsd:float ;
     nidm_qValueFDR: "0.467639377242474"^^xsd:float .
 
-niiri:3de15e47c2cc57eaf165bb760fb17d31
+niiri:48847d4df5d31de03d50ecd410917b09
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0030" ;
     nidm_coordinateVector: "[-24,-60,-26]"^^xsd:string .
 
-niiri:eb016a7153b8b55763c7f7fbf0ec00d3 prov:wasDerivedFrom niiri:8d9aa6d1ec6c37718c5a8b44989b6f5f .
+niiri:6622c9c5a5bb5602bc2abeed125325ac prov:wasDerivedFrom niiri:23280aef5e15fc151595ade28a75778f .
 
-niiri:bea5c0edf808c42b87619f4f3daf8458
+niiri:b184da69003b59767f569647a73c0639
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0031" ;
-    prov:atLocation niiri:1adf18544faaba5a99e94468891a8d49 ;
+    prov:atLocation niiri:c29572676342be86d47e0a7b8ed38732 ;
     prov:value "3.79263067245483"^^xsd:float ;
     nidm_equivalentZStatistic: "3.35249275717611"^^xsd:float ;
     nidm_pValueUncorrected: "0.000400436684482419"^^xsd:float ;
     nidm_pValueFWER: "0.999938961389732"^^xsd:float ;
     nidm_qValueFDR: "0.654094205846141"^^xsd:float .
 
-niiri:1adf18544faaba5a99e94468891a8d49
+niiri:c29572676342be86d47e0a7b8ed38732
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0031" ;
     nidm_coordinateVector: "[-30,-4,38]"^^xsd:string .
 
-niiri:bea5c0edf808c42b87619f4f3daf8458 prov:wasDerivedFrom niiri:8d5aa4d277ff8060425a7d8827846199 .
+niiri:b184da69003b59767f569647a73c0639 prov:wasDerivedFrom niiri:a724fab477e1c34dff00939c8a5fe1d9 .
 
-niiri:717486fee4d16edf303b6cbfbc42c049
+niiri:49e0945fb482cd7b911f2227ceae482f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0032" ;
-    prov:atLocation niiri:cba848835ff9380d6d7034ff8de12ff8 ;
+    prov:atLocation niiri:eca01472aea0f0dbd8b94e3e34cd3adc ;
     prov:value "3.77775311470032"^^xsd:float ;
     nidm_equivalentZStatistic: "3.34183922268213"^^xsd:float ;
     nidm_pValueUncorrected: "0.000416126261860494"^^xsd:float ;
     nidm_pValueFWER: "0.999953291766866"^^xsd:float ;
     nidm_qValueFDR: "0.659449024484444"^^xsd:float .
 
-niiri:cba848835ff9380d6d7034ff8de12ff8
+niiri:eca01472aea0f0dbd8b94e3e34cd3adc
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0032" ;
     nidm_coordinateVector: "[-62,-6,22]"^^xsd:string .
 
-niiri:717486fee4d16edf303b6cbfbc42c049 prov:wasDerivedFrom niiri:c3faa5585abf8fd6ae5f51bed00a5c44 .
+niiri:49e0945fb482cd7b911f2227ceae482f prov:wasDerivedFrom niiri:e8d2cf34f04ba64f58f96a3bd57989a0 .
 
-niiri:59be27f7d0fa71086a575f6e70a6926b
+niiri:c7dd5a67fe812c0fdcc362965b494898
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0033" ;
-    prov:atLocation niiri:83040c69bfbea01cb38e4c8eeeb89117 ;
+    prov:atLocation niiri:e81d57070082ea2bc67d444e23ad6afe ;
     prov:value "3.67259907722473"^^xsd:float ;
     nidm_equivalentZStatistic: "3.26592297145681"^^xsd:float ;
     nidm_pValueUncorrected: "0.000545539621777169"^^xsd:float ;
     nidm_pValueFWER: "0.999994214217906"^^xsd:float ;
     nidm_qValueFDR: "0.754841581701232"^^xsd:float .
 
-niiri:83040c69bfbea01cb38e4c8eeeb89117
+niiri:e81d57070082ea2bc67d444e23ad6afe
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0033" ;
     nidm_coordinateVector: "[-12,-4,4]"^^xsd:string .
 
-niiri:59be27f7d0fa71086a575f6e70a6926b prov:wasDerivedFrom niiri:860d4c90c76b09b791e464d1115fe241 .
+niiri:c7dd5a67fe812c0fdcc362965b494898 prov:wasDerivedFrom niiri:b073888acef337b87afb0a3f49356435 .
 
-niiri:9d67e02ddc425b561b46d3cfbd0fccca
+niiri:84fe5a575cee1440542c990cbf711859
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0034" ;
-    prov:atLocation niiri:30e81b907fe511bfad310c755b4411c1 ;
+    prov:atLocation niiri:7f4fe1df385012266fd6803d3c1079dd ;
     prov:value "3.66031455993652"^^xsd:float ;
     nidm_equivalentZStatistic: "3.25698339309234"^^xsd:float ;
     nidm_pValueUncorrected: "0.000563015103086872"^^xsd:float ;
     nidm_pValueFWER: "0.999995573785363"^^xsd:float ;
     nidm_qValueFDR: "0.75806989081408"^^xsd:float .
 
-niiri:30e81b907fe511bfad310c755b4411c1
+niiri:7f4fe1df385012266fd6803d3c1079dd
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0034" ;
     nidm_coordinateVector: "[38,4,60]"^^xsd:string .
 
-niiri:9d67e02ddc425b561b46d3cfbd0fccca prov:wasDerivedFrom niiri:99f2be73be2c6be215bfd9faf3a92a39 .
+niiri:84fe5a575cee1440542c990cbf711859 prov:wasDerivedFrom niiri:24cb62d0bb1e202be98184cc8d05dffd .
 
-niiri:b5179839f97964be94c32b6224e91b62
+niiri:9a32238eb2863717896fffb10d326e05
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0035" ;
-    prov:atLocation niiri:b4a2f9cb468ff42883d02dd9ddf5cf40 ;
+    prov:atLocation niiri:e0df16fae31adde7b1b374630cfb3683 ;
     prov:value "3.63292980194092"^^xsd:float ;
     nidm_equivalentZStatistic: "3.23700181949284"^^xsd:float ;
     nidm_pValueUncorrected: "0.000603963207952862"^^xsd:float ;
     nidm_pValueFWER: "0.999997609889049"^^xsd:float ;
     nidm_qValueFDR: "0.782238022186136"^^xsd:float .
 
-niiri:b4a2f9cb468ff42883d02dd9ddf5cf40
+niiri:e0df16fae31adde7b1b374630cfb3683
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0035" ;
     nidm_coordinateVector: "[-28,2,38]"^^xsd:string .
 
-niiri:b5179839f97964be94c32b6224e91b62 prov:wasDerivedFrom niiri:1e52aefb94abdf0e6614ea5a19db8bab .
+niiri:9a32238eb2863717896fffb10d326e05 prov:wasDerivedFrom niiri:824d90300b93425516b70315d9d6f976 .
 

--- a/spmexport/ex_spm_hrf_fir/nidm.json
+++ b/spmexport/ex_spm_hrf_fir/nidm.json
@@ -1,0 +1,27351 @@
+{
+  "prefix": {
+    "nidm": "http://purl.org/nidash/nidm#",
+    "niiri": "http://iri.nidash.org/",
+    "spm": "http://purl.org/nidash/spm#",
+    "neurolex": "http://neurolex.org/wiki/",
+    "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/",
+    "dct": "http://purl.org/dc/terms/",
+    "nfo": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#",
+    "dc": "http://purl.org/dc/elements/1.1/",
+    "dctype": "http://purl.org/dc/dcmitype/",
+    "obo": "http://purl.obolibrary.org/obo/",
+    "nidm_NIDMResults": "http://purl.org/nidash/nidm#NIDM_0000027",
+    "nidm_version": "http://purl.org/nidash/nidm#NIDM_0000127",
+    "nidm_spm_results_nidm": "http://purl.org/nidash/nidm#NIDM_0000168",
+    "nidm_softwareVersion": "http://purl.org/nidash/nidm#NIDM_0000122",
+    "nidm_NIDMResultsExport": "http://purl.org/nidash/nidm#NIDM_0000166"
+  },
+  "entity": {
+    "niiri:36c29725f6c7f64a0ab322716c073611": {
+      "prov:type": [
+        {
+        "$": "prov:Bundle",
+        "type": "xsd:QName"
+        },
+        {
+        "$": "nidm_NIDMResults:",
+        "type": "xsd:QName"
+        }
+      ],
+      "prov:label": {
+        "$": "NIDM-Results",
+        "type": "xsd:string"
+      },
+      "nidm_version:": {
+        "$": "1.3.0",
+        "type": "xsd:string"
+      }
+    }
+  },
+  "activity": {
+    "niiri:de4cf047e6d9cda522f7ec10c3c92475": {
+      "prov:type": {
+        "$": "nidm_NIDMResultsExport:",
+        "type": "xsd:QName"
+      },
+      "prov:label": {
+        "$": "NIDM-Results export",
+        "type": "xsd:string"
+      }
+    }
+  },
+  "agent": {
+    "niiri:dd800a501694fa49759a45e9b9e77f27": {
+      "prov:type": [
+        {
+        "$": "nidm_spm_results_nidm:",
+        "type": "xsd:QName"
+        },
+        {
+        "$": "prov:SoftwareAgent",
+        "type": "xsd:QName"
+        }
+      ],
+      "prov:label": {
+        "$": "spm_results_nidm",
+        "type": "xsd:string"
+      },
+      "nidm_softwareVersion:": {
+        "$": "12.7057",
+        "type": "xsd:string"
+      }
+    }
+  },
+  "wasGeneratedBy": {
+    "_:wGB5": {
+      "prov:entity": "niiri:36c29725f6c7f64a0ab322716c073611",
+      "prov:activity": "niiri:de4cf047e6d9cda522f7ec10c3c92475",
+      "prov:time": "2017-04-19T12:18:24"
+    }
+  },
+  "wasAssociatedWith": {
+    "_:wAW4": {
+      "prov:activity": "niiri:de4cf047e6d9cda522f7ec10c3c92475",
+      "prov:agent": "niiri:dd800a501694fa49759a45e9b9e77f27"
+    }
+  },
+  "bundle": {
+    "niiri:36c29725f6c7f64a0ab322716c073611": {
+    "prefix": {
+        "nidm_softwareVersion": "http://purl.org/nidash/nidm#NIDM_0000122",
+        "nidm_CoordinateSpace": "http://purl.org/nidash/nidm#NIDM_0000016",
+        "nidm_voxelToWorldMapping": "http://purl.org/nidash/nidm#NIDM_0000132",
+        "nidm_voxelUnits": "http://purl.org/nidash/nidm#NIDM_0000133",
+        "nidm_voxelSize": "http://purl.org/nidash/nidm#NIDM_0000131",
+        "nidm_inWorldCoordinateSystem": "http://purl.org/nidash/nidm#NIDM_0000105",
+        "nidm_numberOfDimensions": "http://purl.org/nidash/nidm#NIDM_0000112",
+        "nidm_dimensionsInVoxels": "http://purl.org/nidash/nidm#NIDM_0000090",
+        "nlx_Imaginginstrument": "http://uri.neuinfo.org/nif/nifstd/birnlex_2094",
+        "nlx_Magneticresonanceimagingscanner": "http://uri.neuinfo.org/nif/nifstd/birnlex_2100",
+        "nidm_grandMeanScaling": "http://purl.org/nidash/nidm#NIDM_0000096",
+        "nidm_targetIntensity": "http://purl.org/nidash/nidm#NIDM_0000124",
+        "nidm_hasMRIProtocol": "http://purl.org/nidash/nidm#NIDM_0000172",
+        "nlx_FunctionalMRIprotocol": "http://uri.neuinfo.org/nif/nifstd/birnlex_2250",
+        "nidm_Data": "http://purl.org/nidash/nidm#NIDM_0000169",
+        "spm_DCTDriftModel": "http://purl.org/nidash/spm#SPM_0000002",
+        "spm_SPMsDriftCutoffPeriod": "http://purl.org/nidash/spm#SPM_0000001",
+        "nidm_hasDriftModel": "http://purl.org/nidash/nidm#NIDM_0000088",
+        "nidm_hasHRFBasis": "http://purl.org/nidash/nidm#NIDM_0000102",
+        "nidm_FiniteImpulseResponseBasisSet": "http://purl.org/nidash/nidm#NIDM_0000028",
+        "nidm_DesignMatrix": "http://purl.org/nidash/nidm#NIDM_0000019",
+        "nidm_regressorNames": "http://purl.org/nidash/nidm#NIDM_0000021",
+        "nidm_hasErrorDependence": "http://purl.org/nidash/nidm#NIDM_0000100",
+        "obo_Toeplitzcovariancestructure": "http://purl.obolibrary.org/obo/STATO_0000357",
+        "nidm_dependenceMapWiseDependence": "http://purl.org/nidash/nidm#NIDM_0000089",
+        "nidm_ConstantParameter": "http://purl.org/nidash/nidm#NIDM_0000072",
+        "nidm_errorVarianceHomogeneous": "http://purl.org/nidash/nidm#NIDM_0000094",
+        "nidm_varianceMapWiseDependence": "http://purl.org/nidash/nidm#NIDM_0000126",
+        "nidm_IndependentParameter": "http://purl.org/nidash/nidm#NIDM_0000073",
+        "nidm_withEstimationMethod": "http://purl.org/nidash/nidm#NIDM_0000134",
+        "obo_generalizedleastsquaresestimation": "http://purl.obolibrary.org/obo/STATO_0000372",
+        "nidm_ErrorModel": "http://purl.org/nidash/nidm#NIDM_0000023",
+        "nidm_hasErrorDistribution": "http://purl.org/nidash/nidm#NIDM_0000101",
+        "obo_normaldistribution": "http://purl.obolibrary.org/obo/STATO_0000227",
+        "nidm_ModelParametersEstimation": "http://purl.org/nidash/nidm#NIDM_0000056",
+        "nidm_MaskMap": "http://purl.org/nidash/nidm#NIDM_0000054",
+        "nidm_isUserDefined": "http://purl.org/nidash/nidm#NIDM_0000106",
+        "nidm_inCoordinateSpace": "http://purl.org/nidash/nidm#NIDM_0000104",
+        "nidm_GrandMeanMap": "http://purl.org/nidash/nidm#NIDM_0000033",
+        "nidm_maskedMedian": "http://purl.org/nidash/nidm#NIDM_0000107",
+        "nidm_ParameterEstimateMap": "http://purl.org/nidash/nidm#NIDM_0000061",
+        "nidm_ResidualMeanSquaresMap": "http://purl.org/nidash/nidm#NIDM_0000066",
+        "nidm_ReselsPerVoxelMap": "http://purl.org/nidash/nidm#NIDM_0000144",
+        "obo_contrastweightmatrix": "http://purl.obolibrary.org/obo/STATO_0000323",
+        "nidm_statisticType": "http://purl.org/nidash/nidm#NIDM_0000123",
+        "obo_Fstatistic": "http://purl.obolibrary.org/obo/STATO_0000282",
+        "nidm_contrastName": "http://purl.org/nidash/nidm#NIDM_0000085",
+        "nidm_ContrastEstimation": "http://purl.org/nidash/nidm#NIDM_0000001",
+        "nidm_StatisticMap": "http://purl.org/nidash/nidm#NIDM_0000076",
+        "nidm_errorDegreesOfFreedom": "http://purl.org/nidash/nidm#NIDM_0000093",
+        "nidm_effectDegreesOfFreedom": "http://purl.org/nidash/nidm#NIDM_0000091",
+        "nidm_ContrastExplainedMeanSquareMap": "http://purl.org/nidash/nidm#NIDM_0000163",
+        "obo_statistic": "http://purl.obolibrary.org/obo/STATO_0000039",
+        "nidm_PValueUncorrected": "http://purl.org/nidash/nidm#NIDM_0000160",
+        "obo_FWERadjustedpvalue": "http://purl.obolibrary.org/obo/OBI_0001265",
+        "nidm_HeightThreshold": "http://purl.org/nidash/nidm#NIDM_0000034",
+        "nidm_equivalentThreshold": "http://purl.org/nidash/nidm#NIDM_0000161",
+        "nidm_ExtentThreshold": "http://purl.org/nidash/nidm#NIDM_0000026",
+        "nidm_clusterSizeInVoxels": "http://purl.org/nidash/nidm#NIDM_0000084",
+        "nidm_clusterSizeInResels": "http://purl.org/nidash/nidm#NIDM_0000156",
+        "nidm_PeakDefinitionCriteria": "http://purl.org/nidash/nidm#NIDM_0000063",
+        "nidm_maxNumberOfPeaksPerCluster": "http://purl.org/nidash/nidm#NIDM_0000108",
+        "nidm_minDistanceBetweenPeaks": "http://purl.org/nidash/nidm#NIDM_0000109",
+        "nidm_ClusterDefinitionCriteria": "http://purl.org/nidash/nidm#NIDM_0000007",
+        "nidm_hasConnectivityCriterion": "http://purl.org/nidash/nidm#NIDM_0000099",
+        "nidm_voxel18connected": "http://purl.org/nidash/nidm#NIDM_0000128",
+        "nidm_Inference": "http://purl.org/nidash/nidm#NIDM_0000049",
+        "nidm_hasAlternativeHypothesis": "http://purl.org/nidash/nidm#NIDM_0000097",
+        "nidm_OneTailedTest": "http://purl.org/nidash/nidm#NIDM_0000060",
+        "nidm_SearchSpaceMaskMap": "http://purl.org/nidash/nidm#NIDM_0000068",
+        "nidm_searchVolumeInVoxels": "http://purl.org/nidash/nidm#NIDM_0000121",
+        "nidm_searchVolumeInUnits": "http://purl.org/nidash/nidm#NIDM_0000136",
+        "nidm_reselSizeInVoxels": "http://purl.org/nidash/nidm#NIDM_0000148",
+        "nidm_searchVolumeInResels": "http://purl.org/nidash/nidm#NIDM_0000149",
+        "spm_searchVolumeReselsGeometry": "http://purl.org/nidash/spm#SPM_0000010",
+        "nidm_noiseFWHMInVoxels": "http://purl.org/nidash/nidm#NIDM_0000159",
+        "nidm_noiseFWHMInUnits": "http://purl.org/nidash/nidm#NIDM_0000157",
+        "nidm_randomFieldStationarity": "http://purl.org/nidash/nidm#NIDM_0000120",
+        "nidm_expectedNumberOfVoxelsPerCluster": "http://purl.org/nidash/nidm#NIDM_0000143",
+        "nidm_expectedNumberOfClusters": "http://purl.org/nidash/nidm#NIDM_0000141",
+        "nidm_heightCriticalThresholdFWE05": "http://purl.org/nidash/nidm#NIDM_0000147",
+        "nidm_heightCriticalThresholdFDR05": "http://purl.org/nidash/nidm#NIDM_0000146",
+        "spm_smallestSignificantClusterSizeInVoxelsFWE05": "http://purl.org/nidash/spm#SPM_0000014",
+        "spm_smallestSignificantClusterSizeInVoxelsFDR05": "http://purl.org/nidash/spm#SPM_0000013",
+        "nidm_ExcursionSetMap": "http://purl.org/nidash/nidm#NIDM_0000025",
+        "nidm_numberOfSupraThresholdClusters": "http://purl.org/nidash/nidm#NIDM_0000111",
+        "nidm_pValue": "http://purl.org/nidash/nidm#NIDM_0000114",
+        "nidm_hasClusterLabelsMap": "http://purl.org/nidash/nidm#NIDM_0000098",
+        "nidm_hasMaximumIntensityProjection": "http://purl.org/nidash/nidm#NIDM_0000138",
+        "nidm_ClusterLabelsMap": "http://purl.org/nidash/nidm#NIDM_0000008",
+        "nidm_SupraThresholdCluster": "http://purl.org/nidash/nidm#NIDM_0000070",
+        "nidm_pValueUncorrected": "http://purl.org/nidash/nidm#NIDM_0000116",
+        "nidm_pValueFWER": "http://purl.org/nidash/nidm#NIDM_0000115",
+        "nidm_qValueFDR": "http://purl.org/nidash/nidm#NIDM_0000119",
+        "nidm_clusterLabelId": "http://purl.org/nidash/nidm#NIDM_0000082",
+        "nidm_Peak": "http://purl.org/nidash/nidm#NIDM_0000062",
+        "nidm_equivalentZStatistic": "http://purl.org/nidash/nidm#NIDM_0000092",
+        "nidm_Coordinate": "http://purl.org/nidash/nidm#NIDM_0000015",
+        "nidm_coordinateVector": "http://purl.org/nidash/nidm#NIDM_0000086"
+    },
+    "entity": {
+        "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c": {
+            "prov:type": {
+                "$": "nidm_CoordinateSpace:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Coordinate space 1",
+                "type": "xsd:string"
+            },
+            "nidm_voxelToWorldMapping:": {
+                "$": "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]",
+                "type": "xsd:string"
+            },
+            "nidm_voxelUnits:": {
+                "$": "[\"mm\", \"mm\", \"mm\"]",
+                "type": "xsd:string"
+            },
+            "nidm_voxelSize:": {
+                "$": "[2, 2, 2]",
+                "type": "xsd:string"
+            },
+            "nidm_inWorldCoordinateSystem:": {
+                "$": "nidm_Ixi549CoordinateSystem:",
+                "type": "xsd:string"
+            },
+            "nidm_numberOfDimensions:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_dimensionsInVoxels:": {
+                "$": "[79,95,79]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d23b22fadb663709f46b3ab69916d020": {
+            "prov:type": [
+                {
+                "$": "prov:Collection",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Data:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Data",
+                "type": "xsd:string"
+            },
+            "nidm_grandMeanScaling:": {
+                "$": "true",
+                "type": "xsd:boolean"
+            },
+            "nidm_targetIntensity:": {
+                "$": "100",
+                "type": "xsd:float"
+            },
+            "nidm_hasMRIProtocol:": {
+                "$": "nlx_FunctionalMRIprotocol:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:470096f779b79da44b4d0df59add54c2": {
+            "prov:type": {
+                "$": "spm_DCTDriftModel:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "SPM's DCT Drift Model",
+                "type": "xsd:string"
+            },
+            "spm_SPMsDriftCutoffPeriod:": {
+                "$": "128",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:03fe576d4676dc2c478698e09040bd38": {
+            "prov:type": {
+                "$": "nidm_DesignMatrix:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "DesignMatrix.csv",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "DesignMatrix.csv",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "text/csv",
+                "type": "xsd:string"
+            },
+            "dc:description": {
+                "$": "niiri:e87650be9879dfa4463aee62d8f91cb6",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Design Matrix",
+                "type": "xsd:string"
+            },
+            "nidm_regressorNames:": {
+                "$": "[\"Sn(1) to*bf(1)\", \"Sn(1) to*bf(2)\", \"Sn(1) to*bf(3)\", \"Sn(1) to*bf(4)\", \"Sn(1) to*bf(5)\", \"Sn(1) to*bf(6)\", \"Sn(1) to*bf(7)\", \"Sn(1) to*bf(8)\", \"Sn(1) to*bf(9)\", \"Sn(1) to*bf(10)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) \ntask001 co*bf(2)\", \"Sn(1) \ntask001 co*bf(3)\", \"Sn(1) \ntask001 co*bf(4)\", \"Sn(1) \ntask001 co*bf(5)\", \"Sn(1) \ntask001 co*bf(6)\", \"Sn(1) \ntask001 co*bf(7)\", \"Sn(1) \ntask001 co*bf(8)\", \"Sn(1) \ntask001 co*bf(9)\", \"Sn(1) \ntask001 co*bf(10)\", \"Sn(1) constant\"]",
+                "type": "xsd:string"
+            },
+            "nidm_hasDriftModel:": {
+                "$": "niiri:470096f779b79da44b4d0df59add54c2",
+                "type": "xsd:string"
+            },
+            "nidm_hasHRFBasis:": {
+                "$": "nidm_FiniteImpulseResponseBasisSet:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e87650be9879dfa4463aee62d8f91cb6": {
+            "prov:type": {
+                "$": "dctype:Image",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "DesignMatrix.png",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "DesignMatrix.png",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/png",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2411622502cf663c690e37bc572df1f3": {
+            "prov:type": {
+                "$": "nidm_ErrorModel:",
+                "type": "xsd:QName"
+            },
+            "nidm_hasErrorDistribution:": {
+                "$": "obo_normaldistribution:",
+                "type": "xsd:string"
+            },
+            "nidm_hasErrorDependence:": {
+                "$": "obo_Toeplitzcovariancestructure:",
+                "type": "xsd:string"
+            },
+            "nidm_dependenceMapWiseDependence:": {
+                "$": "nidm_ConstantParameter:",
+                "type": "xsd:string"
+            },
+            "nidm_errorVarianceHomogeneous:": {
+                "$": "true",
+                "type": "xsd:boolean"
+            },
+            "nidm_varianceMapWiseDependence:": {
+                "$": "nidm_IndependentParameter:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:701d77588170de3f2a3a5cae849cee5b": {
+            "prov:type": {
+                "$": "nidm_MaskMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "Mask.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nidm_isUserDefined:": {
+                "$": "false",
+                "type": "xsd:boolean"
+            },
+            "nfo:fileName": {
+                "$": "Mask.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Mask",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:68240aa5f992dd1323cc9f0c0e3a3639": {
+            "prov:type": {
+                "$": "nidm_MaskMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "mask.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "36929e1f5f4143bd9cc818cd896a25f129961fab208c3a4438555f40444c08347b359142ee8c53ece6e8cca1627f49db0788a1fd3b9e2ecaef61999c6c6c67ac",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2759c13e0ec7d1d95a0ecd06a3481373": {
+            "prov:type": {
+                "$": "nidm_GrandMeanMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "GrandMean.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "GrandMean.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Grand Mean Map",
+                "type": "xsd:string"
+            },
+            "nidm_maskedMedian:": {
+                "$": "116.759864807129",
+                "type": "xsd:float"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "c9f870cdec14d68f6155f69fff57c713e04ba77396008f146de034a59019081d730f36a8d3da8abed1888f20ec50b2fef12d42f65398b47980f3c8f4f9621e30",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7cfe9f21fb53f5db106ee22b82a0fe77": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0001.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0001.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 1",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "ab4f341fdc6bb61ed1858ac74fedbac74fcc7d8bb81ad62df8362a733702555296077259ebdbc9255f7fbfdcbf3818802601d04117f70115bb7b2dec0508ad33",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:089827f143cffa9301487e18ac4f137b": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0001.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "ab4f341fdc6bb61ed1858ac74fedbac74fcc7d8bb81ad62df8362a733702555296077259ebdbc9255f7fbfdcbf3818802601d04117f70115bb7b2dec0508ad33",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:43283050484b34063061bdb16cb80c6a": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0002.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0002.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 2",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "553b1841b724f521f7df6a39860f8d936fd47b0d9050cc0d11514571198520a4748f95110e809e16801cb8541c0d3f11db5515b9be6a335cc7a32c4cb4bff458",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:329c6968efa0ef3a9c454bf61031c775": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0002.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "553b1841b724f521f7df6a39860f8d936fd47b0d9050cc0d11514571198520a4748f95110e809e16801cb8541c0d3f11db5515b9be6a335cc7a32c4cb4bff458",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:977b0276cc808425abbde5601d66f7f1": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0003.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0003.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 3",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "8b865f4a40e90f00870f1fb7ef2c526ed19dff1736129d20b7fb0f56bc0b3e5765fbe25ac2011fcc9a0dfb0a1fdee3c9a0cb4208d575eff4ea1e60b0a1248c89",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:eb7cef4922655d41030fe942fbcf92d0": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0003.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "8b865f4a40e90f00870f1fb7ef2c526ed19dff1736129d20b7fb0f56bc0b3e5765fbe25ac2011fcc9a0dfb0a1fdee3c9a0cb4208d575eff4ea1e60b0a1248c89",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ed63a46c0d2c960f86afcc856493eba3": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0004.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0004.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 4",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "66f8b072dd8b6311a71e1da755c6e878723be8030f3cced7e61d9de0455ddd357733cece45530571e955093c1611ff50161a398ca59bc4f5d412ae9beff68b1d",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4253cad80266847727bfd03c0f113481": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0004.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "66f8b072dd8b6311a71e1da755c6e878723be8030f3cced7e61d9de0455ddd357733cece45530571e955093c1611ff50161a398ca59bc4f5d412ae9beff68b1d",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0f11c4b5e831cc47e20327b9561101d1": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0005.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0005.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 5",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "8cc9e95e7a8fed19b960048ee106a347b1f19de664cce72ef19eeddcfb99fb83f2c47d9042a1b2ebd035ebbe53e156bdfa991586d61633f1bf8683d68749c581",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5e2edc7c4f0179e995e1d8a613e7f3f5": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0005.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "8cc9e95e7a8fed19b960048ee106a347b1f19de664cce72ef19eeddcfb99fb83f2c47d9042a1b2ebd035ebbe53e156bdfa991586d61633f1bf8683d68749c581",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:48291f5a02d1cc7b2042bb3d593d7fff": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0006.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0006.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 6",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "62c235f5803befb467c0e211761d3969a92708699589dca1e61f45abeee452c3aeff7b0654acc13df518a73251efcfc5ce54b68b351f282f7240a3e200cece00",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a32c3f75242cd2d6bdf7364d58ecabaa": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0006.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "62c235f5803befb467c0e211761d3969a92708699589dca1e61f45abeee452c3aeff7b0654acc13df518a73251efcfc5ce54b68b351f282f7240a3e200cece00",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8f783b7ccac78e3e7bdec49afe00edd2": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0007.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0007.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 7",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "503eac361a50d582f783868de851f17396fdaede65faabc382b3ed8794bc42d4a6b1a0192cd1646145777fff9ba3f1fc14610fac5616a4e8a49e801fe50c1fb0",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f8a0341ad0e00972a335bb4d5abdf527": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0007.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "503eac361a50d582f783868de851f17396fdaede65faabc382b3ed8794bc42d4a6b1a0192cd1646145777fff9ba3f1fc14610fac5616a4e8a49e801fe50c1fb0",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:242b483bd1eee1b930fc5cca16db8bd0": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0008.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0008.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 8",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "7ff16e915edd22e3b69ad9337a39e81470000b43b3e01582dadd95ac6b75e4dae59468d1ee28423da6a5b6e61f8ce4a56016da8b37b0b3b5896adad675ad8bf0",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2aa65d5429266d49e3eb2223f5d00c0f": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0008.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "7ff16e915edd22e3b69ad9337a39e81470000b43b3e01582dadd95ac6b75e4dae59468d1ee28423da6a5b6e61f8ce4a56016da8b37b0b3b5896adad675ad8bf0",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:133e1e9add501047daab53a9c6301964": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0009.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0009.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 9",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "e470031c887654d88c3720ca80d430fb890ed6eb50f06947ccfcf5add371f10f5f0264fa29314da1b1860d8f9c46fd0d5d348d34ae430c918129e28dc687d941",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d99c4966dd6f79fa35b1936be239db4a": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0009.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "e470031c887654d88c3720ca80d430fb890ed6eb50f06947ccfcf5add371f10f5f0264fa29314da1b1860d8f9c46fd0d5d348d34ae430c918129e28dc687d941",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1e8ad4131b61696d7f4e8f0d62cc8247": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0010.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0010.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 10",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "84a21319af5843da90c9a80cce510a3ce962d9cf5c17e9aae6c9f68caf849b2a48554dc0edaf4bc6869e139a83a40a1241598e5c3eaf850c1877cd7d89092772",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3b7f58f0e40d4420da47ee38ea6e01f4": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0010.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "84a21319af5843da90c9a80cce510a3ce962d9cf5c17e9aae6c9f68caf849b2a48554dc0edaf4bc6869e139a83a40a1241598e5c3eaf850c1877cd7d89092772",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:21ab0f8b00a00ed52acdb49a05c615c3": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0011.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0011.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 11",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "79c5038da96f3fa6f62a85fc10874a19b8def87cdf22be32b896a4cb1816aab1123e4fde54cdbfe4d92bb2e86f1af66cce152604df2f617db594def52e10975b",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e81af0e320d70f0c3b56e6ba69ab24b3": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0011.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "79c5038da96f3fa6f62a85fc10874a19b8def87cdf22be32b896a4cb1816aab1123e4fde54cdbfe4d92bb2e86f1af66cce152604df2f617db594def52e10975b",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8c85285ad275239152b5e31bdf64af12": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0012.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0012.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 12",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "aa63e2b2dc5c82b5de51c5dbf288e74e2135aa59df78d8e9c42d29c54bd1091a6e2d7d19a0f3f5b2bc38e620ff705cb51d12904557f23880d0d6ea5920e8774c",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e07667d489f48b12e6c861fd0f90c6b2": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0012.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "aa63e2b2dc5c82b5de51c5dbf288e74e2135aa59df78d8e9c42d29c54bd1091a6e2d7d19a0f3f5b2bc38e620ff705cb51d12904557f23880d0d6ea5920e8774c",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2bf2dfa438b489a6f9109550ebd7bc98": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0013.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0013.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 13",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "aad291cd77ce0f4c11b7e90f630400d464d26a3e83e751f811a0f077617d9770bf67d9746d1932ec1d83fde054cefd0d9a8e01d600369da1042d1925bb5f9c01",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7b36c6521cdd3ed1a0440a51a36ed339": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0013.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "aad291cd77ce0f4c11b7e90f630400d464d26a3e83e751f811a0f077617d9770bf67d9746d1932ec1d83fde054cefd0d9a8e01d600369da1042d1925bb5f9c01",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d1214d3e1d706371966179c913755cb7": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0014.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0014.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 14",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "129cbf53f40e0f17148e0f2b09a9fc69043e42e71c5ad30362034660c39e4bddbdab423b5ab3b1ba828d335d714f93e1ad6aef35eb18b77c28c675d33d9eacf6",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9c4ae77f74400a1405d71f6f92c62e06": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0014.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "129cbf53f40e0f17148e0f2b09a9fc69043e42e71c5ad30362034660c39e4bddbdab423b5ab3b1ba828d335d714f93e1ad6aef35eb18b77c28c675d33d9eacf6",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:067750a93237f9d14c0ce7af50da4f3c": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0015.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0015.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 15",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "71639fb3c9115d83f377228cc11bfda9f4deb51c53b79094baccc446213cb5e197e7eb63479d1bfc2a5dfde9ca5f6e330b1e477d02448d829010715f72c32e22",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:07be9f58a9f65a0bcedc3f67a360ae25": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0015.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "71639fb3c9115d83f377228cc11bfda9f4deb51c53b79094baccc446213cb5e197e7eb63479d1bfc2a5dfde9ca5f6e330b1e477d02448d829010715f72c32e22",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0d7a4762edd076ba489e5cfade96a9fc": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0016.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0016.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 16",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "a4359da69efe29d916afa7cbb9e7c021c354b4fe3623b6a4547216a5aff27e75cefc94f99d1d4fb5151523b0de3b221a6c949be59dc01fea3554e872ff8318f0",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d763714606a30881b76dbdbf13aa45f0": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0016.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "a4359da69efe29d916afa7cbb9e7c021c354b4fe3623b6a4547216a5aff27e75cefc94f99d1d4fb5151523b0de3b221a6c949be59dc01fea3554e872ff8318f0",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:239f80ca4290c616514b508515eba255": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0017.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0017.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 17",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "d3641c92698032f2ac880b84a2450f16e837354e289fb3b1190d6a37cd6d144c44f6b546d2990768bb7a55827cd2149f0fe4bb8b5b657c1e875fb979e25b55ff",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7894ca83b4d7bbe3efc917dce739071e": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0017.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "d3641c92698032f2ac880b84a2450f16e837354e289fb3b1190d6a37cd6d144c44f6b546d2990768bb7a55827cd2149f0fe4bb8b5b657c1e875fb979e25b55ff",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4e4595ea20f67bd5529f3d2e095f8043": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0018.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0018.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 18",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "11bb520f059bbf675e597a18a69fbe20d2c00ad4f2e4048e662f1e50d466ebece3285602c7737b32b2dc7177cb06b964053a133789f60b8c6a117a2887946f43",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:157eda0d89d7ceb121cc325642f884bc": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0018.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "11bb520f059bbf675e597a18a69fbe20d2c00ad4f2e4048e662f1e50d466ebece3285602c7737b32b2dc7177cb06b964053a133789f60b8c6a117a2887946f43",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:069ab84a0bc77f8bbe6fbf8bb2bb80fc": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0019.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0019.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 19",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "7265ca9b2713d334013587196872999038d4b9a1aa18d4a28daa1e14c509a555ef5cae893952d60604f7ce19c0e72ce33c0e11374e1802bae57d858aee9bf47e",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:22a1c0d63f9d2cf485131f1c86148558": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0019.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "7265ca9b2713d334013587196872999038d4b9a1aa18d4a28daa1e14c509a555ef5cae893952d60604f7ce19c0e72ce33c0e11374e1802bae57d858aee9bf47e",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0f888978a8a86a495939e12690e2bcf8": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0020.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0020.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 20",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "3f2e9de942f81adf736fbdee718b1708a1b2e978482dbe0fc68141fc59f7f59cc66191bf4c59e48d5850ffd708527ff0a1ec1835c76e7466466841f349bb793e",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e7d4386ec97d8e529d6fde660a4adc75": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0020.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "3f2e9de942f81adf736fbdee718b1708a1b2e978482dbe0fc68141fc59f7f59cc66191bf4c59e48d5850ffd708527ff0a1ec1835c76e7466466841f349bb793e",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4dc9f226357a6ab7f5e304324e2bcbfd": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0021.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0021.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 21",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "0e2c3b4b5e08e5167d4e7ef3dd3f8e2c2f7bb3d0d530889dceeb306f67758558be8cd1531caab46240406285577babef37c24d49567c4c0410ded0cd3aca0e47",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:14c8f75ed277956b9ba6f87eb9db82e8": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0021.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "0e2c3b4b5e08e5167d4e7ef3dd3f8e2c2f7bb3d0d530889dceeb306f67758558be8cd1531caab46240406285577babef37c24d49567c4c0410ded0cd3aca0e47",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d1abc868edbc84f873320116529f4be5": {
+            "prov:type": {
+                "$": "nidm_ResidualMeanSquaresMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ResidualMeanSquares.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ResidualMeanSquares.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Residual Mean Squares Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "9992ae2923012fed54b3812708cd3b60f75373d57ff1adc2205155139f1320943649e7830fd0cef48fb9364ceec9ffb18ab458c47fab082783d8262d0a5b7e4e",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:012705be5593997e59490b3d6466d660": {
+            "prov:type": {
+                "$": "nidm_ResidualMeanSquaresMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "ResMS.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "29e0870b07948253df9f088ac41fd14172c0ce0fb0838c6c32f399622f75ba05856cfae66041c4ecc8dadd513e7bc4402f6a6dc371f62a58a2565dee13b1b853",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:799a884fae2a161e9aadf96d9f7e36f8": {
+            "prov:type": {
+                "$": "nidm_ReselsPerVoxelMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ReselsPerVoxel.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ReselsPerVoxel.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Resels per Voxel Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "e4cc508a935582c9626e9e67fbe3c169a6ba856c20047bb79af4fbdfbd0eddf56b6068e4e54a09ff62c3c7d3c63ddaa6d1d4b213ae65b506447addc8a957ca36",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:129241c961b40e0c62467f34d91dab7e": {
+            "prov:type": {
+                "$": "nidm_ReselsPerVoxelMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "RPV.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "2f28d80ced43971006071cce9126ba56245647cd4f0f5f47497c25660d144b19e30b9868bcefc3786b1d2459986e17cdb8cd37fe515839dd062fa6277e369bce",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:adea7750ce17c82bde1a6b2deaac6a59": {
+            "prov:type": {
+                "$": "obo_contrastweightmatrix:",
+                "type": "xsd:QName"
+            },
+            "nidm_statisticType:": {
+                "$": "obo_Fstatistic:",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "Tone Counting vs Baseline",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast: Tone Counting vs Baseline",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "[[1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],[0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],[0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],[0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],[0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],[0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],[0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],[0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],[0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],[0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a58ef4cb06ae0d7d8f0c14e5f016db3c": {
+            "prov:type": {
+                "$": "nidm_StatisticMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "FStatistic.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "FStatistic.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "F-Statistic Map: Tone Counting vs Baseline",
+                "type": "xsd:string"
+            },
+            "nidm_statisticType:": {
+                "$": "obo_Fstatistic:",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "Tone Counting vs Baseline",
+                "type": "xsd:string"
+            },
+            "nidm_errorDegreesOfFreedom:": {
+                "$": "79.9999999999727",
+                "type": "xsd:float"
+            },
+            "nidm_effectDegreesOfFreedom:": {
+                "$": "9.99999999999902",
+                "type": "xsd:float"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "d929be872bc4e50522f425af19834ae0fdffb717909e441f01354d5d49fa33db0b86fb6054d74fdfaaf5288288f3b827eca9c06969bf5ca07da368b9c2983331",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4a659d96c27e7d9b44774d45d04e80fe": {
+            "prov:type": {
+                "$": "nidm_StatisticMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "spmF_0001.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "fc863f9f5a0f55d3013a44bc04c0144d78238bb193d7176caebb1fd666c4f342ae1e4f7f89a379811e06eefc054d74e6cf610556bf8e4942c82ea36ed4acf8be",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ce5a4b9b70b53160de00542203e0ef42": {
+            "prov:type": {
+                "$": "nidm_ContrastExplainedMeanSquareMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ContrastExplainedMeanSquare.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ContrastExplainedMeanSquare.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast Explained Mean Square Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "413ba8ccbb0f2a6d28833434d74e7c0e86ba02e18e6b4a3ce9cd4f6261d96fcc6a469adbde0bdca4367446a5857cd90bfd495cbd432064288b12cb5a456ceb32",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3cdb938d0d98089a2daa2c42933f776f": {
+            "prov:type": [
+                {
+                "$": "nidm_HeightThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_PValueUncorrected:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Height Threshold: p<0.001 (unc.)",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "0.000999500040298695",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentThreshold:": [
+                {
+                "$": "niiri:b32341380b98d15b8fd2009d71b54406",
+                "type": "xsd:string"
+                },
+                {
+                "$": "niiri:0700cb52ae8c414bd0981a1a1b41108c",
+                "type": "xsd:string"
+                }
+            ]
+        },
+        "niiri:b32341380b98d15b8fd2009d71b54406": {
+            "prov:type": [
+                {
+                "$": "nidm_HeightThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_statistic:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Height Threshold: F=3.385914)",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.38591395681668",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0700cb52ae8c414bd0981a1a1b41108c": {
+            "prov:type": [
+                {
+                "$": "nidm_HeightThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_FWERadjustedpvalue:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Height Threshold: p<1.000000 (FWE)",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ec3787cbdbedf5e1c42112b88a72d8a8": {
+            "prov:type": [
+                {
+                "$": "nidm_ExtentThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_statistic:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Extent Threshold: k>=0",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "0",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentThreshold:": [
+                {
+                "$": "niiri:db0a4cdd3410e9ced5166eed42dc1593",
+                "type": "xsd:string"
+                },
+                {
+                "$": "niiri:1a26121240ec6092679db261d7ef1d67",
+                "type": "xsd:string"
+                }
+            ]
+        },
+        "niiri:db0a4cdd3410e9ced5166eed42dc1593": {
+            "prov:type": [
+                {
+                "$": "nidm_ExtentThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_FWERadjustedpvalue:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Extent Threshold",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:1a26121240ec6092679db261d7ef1d67": {
+            "prov:type": [
+                {
+                "$": "nidm_ExtentThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_PValueUncorrected:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Extent Threshold",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:5f2a0985f22401ffe697c6cbad69a014": {
+            "prov:type": {
+                "$": "nidm_PeakDefinitionCriteria:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak Definition Criteria",
+                "type": "xsd:string"
+            },
+            "nidm_maxNumberOfPeaksPerCluster:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_minDistanceBetweenPeaks:": {
+                "$": "8",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:5375a11691240712e54191f850b6a223": {
+            "prov:type": {
+                "$": "nidm_ClusterDefinitionCriteria:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Cluster Connectivity Criterion: 18",
+                "type": "xsd:string"
+            },
+            "nidm_hasConnectivityCriterion:": {
+                "$": "nidm_voxel18connected:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4f06d69ed569f568944f5c14d618d42b": {
+            "prov:type": {
+                "$": "nidm_SearchSpaceMaskMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "SearchSpaceMask.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "SearchSpaceMask.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Search Space Mask Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c",
+                "type": "xsd:string"
+            },
+            "nidm_searchVolumeInVoxels:": {
+                "$": "223057",
+                "type": "xsd:int"
+            },
+            "nidm_searchVolumeInUnits:": {
+                "$": "1784456",
+                "type": "xsd:float"
+            },
+            "nidm_reselSizeInVoxels:": {
+                "$": "61.0192089405672",
+                "type": "xsd:float"
+            },
+            "nidm_searchVolumeInResels:": {
+                "$": "3391.65327760272",
+                "type": "xsd:float"
+            },
+            "spm_searchVolumeReselsGeometry:": {
+                "$": "[6, 100.17222995762, 1013.43634591138, 3391.65327760272]",
+                "type": "xsd:string"
+            },
+            "nidm_noiseFWHMInVoxels:": {
+                "$": "[3.98580588901192, 3.92965863532102, 3.89579058084751]",
+                "type": "xsd:string"
+            },
+            "nidm_noiseFWHMInUnits:": {
+                "$": "[7.97161177802383, 7.85931727064203, 7.79158116169502]",
+                "type": "xsd:string"
+            },
+            "nidm_randomFieldStationarity:": {
+                "$": "true",
+                "type": "xsd:boolean"
+            },
+            "nidm_expectedNumberOfVoxelsPerCluster:": {
+                "$": "3.28593722598409",
+                "type": "xsd:float"
+            },
+            "nidm_expectedNumberOfClusters:": {
+                "$": "71.0755433009035",
+                "type": "xsd:float"
+            },
+            "nidm_heightCriticalThresholdFWE05:": {
+                "$": "6.60490273485611",
+                "type": "xsd:float"
+            },
+            "nidm_heightCriticalThresholdFDR05:": {
+                "$": "5.22679281234741",
+                "type": "xsd:float"
+            },
+            "crypto:sha512": {
+                "$": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876",
+                "type": "xsd:string"
+            },
+            "spm_smallestSignificantClusterSizeInVoxelsFWE05:": {
+                "$": "50",
+                "type": "xsd:int"
+            },
+            "spm_smallestSignificantClusterSizeInVoxelsFDR05:": {
+                "$": "27",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:8c8ad5dc532e1fc2320f4c3356bdd145": {
+            "prov:type": {
+                "$": "nidm_ExcursionSetMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ExcursionSet.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ExcursionSet.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Excursion Set Map",
+                "type": "xsd:string"
+            },
+            "nidm_numberOfSupraThresholdClusters:": {
+                "$": "233",
+                "type": "xsd:int"
+            },
+            "nidm_pValue:": {
+                "$": "0",
+                "type": "xsd:float"
+            },
+            "nidm_hasClusterLabelsMap:": {
+                "$": "niiri:0bc71c587ee079ccd7e9e7c78d309612",
+                "type": "xsd:string"
+            },
+            "nidm_hasMaximumIntensityProjection:": {
+                "$": "niiri:ff39a18fca2ad1e06ab58e61826a6e4e",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "2c020948d33abb498f0c56063da36e748988840af6d965454a32bb8eb7eaf376b82773a26e325acb6da10cc41fbee4e1a4c8cec6e5f335e3ca9d5e01bec47cec",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0bc71c587ee079ccd7e9e7c78d309612": {
+            "prov:type": {
+                "$": "nidm_ClusterLabelsMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ClusterLabels.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ClusterLabels.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Cluster Labels Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "6a4279ff424d9aee83ff86b3a7fbe1c99f15bfbfda56cf88ca167390de958eb1fce4cf5c82cd12818a6f0e3cc06e0a3b49d6e7491992d21e7047633059b0b333",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ff39a18fca2ad1e06ab58e61826a6e4e": {
+            "prov:type": {
+                "$": "dctype:Image",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "MaximumIntensityProjection.png",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "MaximumIntensityProjection.png",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/png",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:85fec2a2169d10c191c4e617a17cdba0": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0001",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "29439",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "482.454632092554",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.22840660865927e-227",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "7.5221873981761e-225",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "1",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:1aa2c5542022d8edfbe6faaf12d4ebb7": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0002",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "125",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "2.04853524275856",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.15095913141277e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "8.18016996407822e-05",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "3.35216847023969e-05",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "2",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f9d722fcce853c033260a3ae532235c1": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0003",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1968",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "32.2521388619908",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.93628745979793e-38",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "5.75077489066459e-36",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "3",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:73ec267aa6e4362aa22b8bf333d9a6f3": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0004",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "170",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "2.78600793015164",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.12715600843801e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "3.64414734899121e-06",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "2.12665981162699e-06",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "4",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:a78547a90624868c0aef3cebdd83d669": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0005",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "131",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "2.14686493441097",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.45594393969356e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "5.29921225013164e-05",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "2.48176419706943e-05",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "5",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:940cf2d7b7d0eb179a5d87089cdef025": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0006",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "13",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.21304766524689",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0485956620121857",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.968379925135842",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.164098394910714",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "6",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:22f7499c81f2b4cfb5d9464b77334f85": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0007",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "51",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.835802379045492",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000540755081088917",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0377052296641641",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00629979669468589",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "7",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:313e60cc130ee5f7b46b9a70c28c95a0": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0008",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "507",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "8.30885894462871",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.86063251674991e-16",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "5.58442181386454e-14",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "6.10509125467576e-14",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "8",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:5755c7b6f3b8bb9a495a80e69a7ab94e": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0009",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "37",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.606366431856533",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00230266652416726",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.150972136700134",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0178840433376991",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "9",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:23f5c60185b27f2be0dd455c41c3fde3": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0010",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "39",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.63914299574067",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00185358588005153",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.123435179427901",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0154244825018574",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "10",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:33cca310ebec4700e45b0560235f03cd": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0011",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "265",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "4.34289471464814",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.58159348981872e-10",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1.12412615882462e-08",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "9.21278207819405e-09",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "11",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:68605e1a07366f1a9aaae9f04eb3bbcf": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0012",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "61",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.999685198466177",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000208355503966508",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0146998669750764",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00303417702651228",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "12",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:ab91ba995acbb604c8550a19c6d56878": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0013",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "103",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.68799304003305",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.02727767740283e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.000428300288780381",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000156039522092762",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "13",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:8ddb469ed3d8d13f9f3b41143b2bc54e": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0014",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "54",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.884967224871697",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00040374512099407",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0282885724424913",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00553368312891872",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "14",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:fe3d995dc2bfdeb5f29182f0558560a6": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0015",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "50",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.819414097103423",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000596825369072588",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0415325605221553",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00632092322699605",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "15",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:cfbb41a715a689539e32d23fa5ecf0ad": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0016",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "50",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.819414097103423",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000596825369072588",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0415325605221553",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00632092322699605",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "16",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:1ea775914efd19bdf7935c45c2fc61d7": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0017",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "69",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.13079145400272",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000100833701130562",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00714118974936662",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00167816088310149",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "17",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c9c2075e31233972320b91bbe319e15d": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0018",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "43",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.704696123508944",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00121413216251589",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0826765137219736",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.010880492071777",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "18",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:184504b2959cc0300f56dbed9be3df0a": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0019",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "48",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.786637533219287",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000728464342132796",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0504584586207069",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00737966050943224",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "19",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:e56b27d2108b9aebc19f9ff56ac97dce": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0020",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "15",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.245824229131027",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0359026634119283",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.922058856524574",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.141785094491174",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "20",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:e78e0827b0a80cf9fb06ff0a74ee9600": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0021",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "28",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.458871894377917",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00644928550392363",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.367696937875251",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0429338149261202",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "21",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:461b922ff7bd3d15d33f54bcbd492da3": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0022",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "52",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.85219066098756",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000490267487593057",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.034245896140666",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0060122276110096",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "22",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:1cfc9f0a458d8852ad0759c9e8be8a6a": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0023",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "15",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.245824229131027",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0359026634119283",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.922058856524574",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.141785094491174",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "23",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:5bbe3c6a1630a3c2cc55aa12dfd9e286": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0024",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "17",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.278600793015164",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0268776015038201",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.851969971349154",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.120432329815194",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "24",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:1e1925d1a7237f41c7f4bbc7a938991e": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0025",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "45",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.737472687393081",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000987511938850411",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0677814047796702",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00920361127008583",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "25",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:45311fe546d4fc676e17072f500c1575": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0026",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "22",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.360542202725506",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0136406300322587",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.620733134284922",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0739131813375881",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "26",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:12134d971afb042d040aea6cecc0ebec": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0027",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "98",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.60605163032271",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.92167500672803e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.000633911891162686",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000207875027656763",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "27",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:7dfc1da184d477320648da6e59dc2a7c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0028",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "16",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.262212511073096",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0310172463051921",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.889701795682265",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.13140033434745",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "28",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:ff37e6b9b5486e16e27ae0fca1db545d": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0029",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "38",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.622754713798602",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00206497707345811",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.136506895887386",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0165910226936462",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "29",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:bfb3c58b6c12062e86b12426bbf496d9": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0030",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "169",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "2.76961964820957",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.47637719732272e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "3.89235727094039e-06",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "2.12665981162699e-06",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "30",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:b1059120ca68f8c294f13d22a334afc5": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0031",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "22",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.360542202725506",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0136406300322587",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.620733134284922",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0739131813375881",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "31",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:dd43f04c7775bf5d225a62b05a1f8275": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0032",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "53",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.868578942929629",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000444772158654789",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0311179741203415",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00575732849814255",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "32",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c723d93708cb4dee84578d4dad2314df": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0033",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "20",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.327765638841369",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0177689026939896",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.717177111469273",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.090003354949991",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "33",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:d30171bbdc271c074a6050acb8a4d34e": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0034",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "22",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.360542202725506",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0136406300322587",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.620733134284922",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0739131813375881",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "34",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:ea2ed9cc4d84a345a4920b11801993b3": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0035",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "47",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.770249251277218",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000805635676899239",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0556524313184183",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00782137969656345",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "35",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:cf3d3e192bab8fb0febbddda2b472570": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0036",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "7",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.114717973594479",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.135115167401345",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999932500065553",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.317998323277913",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "36",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:a6ee0e116834a7cbcea03e95f20dae54": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0037",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "27",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.442483612435849",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00727748912325509",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.403843160672682",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0458285125869847",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "37",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:e9b27c64b1591506ec57168d7dbf134f": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0038",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "14",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.229435947188959",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0416945009118955",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.948360030569285",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.15179404238237",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "38",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:35e614f307abb1c7215e649c0bbf0aa0": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0039",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "13",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.21304766524689",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0485956620121857",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.968379925135842",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.164098394910714",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "39",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:84661ae12e172546f496d4b26feacce8": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0040",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "12",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.196659383304822",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0568651131936359",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.982432748406332",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.181500977727632",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "40",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:b3ab45e7aaebdd6d5415f3e8fb8365d3": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0041",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "22",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.360542202725506",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0136406300322587",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.620733134284922",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0739131813375881",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "41",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:a9dd639eb89226977a3ede42cafc093c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0042",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "28",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.458871894377917",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00644928550392363",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.367696937875251",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0429338149261202",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "42",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:01b4ff55ed7965f77f28199c98d35002": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0043",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "77",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.26189770953927",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.01633443149056e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00355903850604589",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00106255083867027",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "43",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f606725494013a6004aeb7f3234c5659": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0044",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "20",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.327765638841369",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0177689026939896",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.717177111469273",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.090003354949991",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "44",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:d70674f2ab25c84bf1ccbf050e157cb6": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0045",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "10",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0789505715685566",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.996344252777198",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.232854217411059",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "45",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:d3a715b103390651d1c521ee09f466c0": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0046",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "17",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.278600793015164",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0268776015038201",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.851969971349154",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.120432329815194",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "46",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:3577f89d6cde1468b3bf7bab875643fa": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0047",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "35",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.573589867972396",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00287186075767805",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.18463471494823",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0215852760173866",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "47",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:6b28309025a8c950f906f3a74a6104c4": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0048",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "19",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.311377356899301",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0203471033691263",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.764532275661737",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0987682309376339",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "48",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:40f12e78ef285dbb693762e0e24f5a51": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0049",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "27",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.442483612435849",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00727748912325509",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.403843160672682",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0458285125869847",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "49",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:708e2b5584c9334ba1cde9334d8aee40": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0050",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "15",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.245824229131027",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0359026634119283",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.922058856524574",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.141785094491174",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "50",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:2ed437f95a18d4610e20aee5f5ca8ca1": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0051",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "33",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.540813304088259",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00359701038553917",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.225594365748219",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0261907318697071",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "51",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c4315919bc864f2492337dd699116ee4": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0052",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "75",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.22912114565514",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.95888146608574e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00422635111103054",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00106801490892152",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "52",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:5ad7bfc734bce8d2e03526bbce4c1642": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0053",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "75",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.22912114565514",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.95888146608574e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00422635111103054",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00106801490892152",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "53",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f28a45db3e8e726134be22dd55ada8fc": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0054",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "16",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.262212511073096",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0310172463051921",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.889701795682265",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.13140033434745",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "54",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:7dbd526d156c17d030cb03d4502bec48": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0055",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "66",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.08162660817652",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000131916545650145",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00933222214140361",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00204910367576558",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "55",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:db64bef791d519bd840c407a07274b39": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0056",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "14",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.229435947188959",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0416945009118955",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.948360030569285",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.15179404238237",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "56",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:261d424ff1d40e2e1212f8b47057e08d": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0057",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "9",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.147494537478616",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0937881444422454",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.998726572661126",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.257089854765214",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "57",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f0b1b468bf91334fdba7c8b7612cca41": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0058",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "16",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.262212511073096",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0310172463051921",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.889701795682265",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.13140033434745",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "58",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:6faaad2ce4a4160eadbbce94632ec2bf": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0059",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "41",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.671919559624807",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00149758703167023",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.100972640681538",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0129236214214505",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "59",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:8451b5d05d4d0f88becbc68925bab4c9": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0060",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "15",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.245824229131027",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0359026634119283",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.922058856524574",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.141785094491174",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "60",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:e8d74786a114ffeb6114fffeeb2583da": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0061",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "19",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.311377356899301",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0203471033691263",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.764532275661737",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0987682309376339",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "61",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:af4cb856d066cec808680cb766e205ae": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0062",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "7",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.114717973594479",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.135115167401345",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999932500065553",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.317998323277913",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "62",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:64c74f4674adc0005dffc886ffba3300": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0063",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "8",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.131106255536548",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.112142332373161",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999654520482601",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.296922311851664",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "63",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:878873f431f64df4853365a578c78440": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0064",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "6",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0983296916524108",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.164286574579321",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999991511154457",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.361120489405488",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "64",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:62873793384331403012ec1c900656e0": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0065",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "29",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.475260176319986",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00572351378979088",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.334223900698014",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0404114761521598",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "65",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:cf86c38738ff15923d1bfe58d642e526": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0066",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0655531277682739",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.251995246521365",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999983347393",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.477356849101447",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "66",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:6eb2f26421b4abdd2aff61056be6347c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0067",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "67",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:464e6cc9ad8cde4967c4e8430942863e": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0068",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "12",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.196659383304822",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0568651131936359",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.982432748406332",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.181500977727632",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "68",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:0f59b224fb308f5b33db0b615cec440e": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0069",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "9",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.147494537478616",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0937881444422454",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.998726572661126",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.257089854765214",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "69",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:61f0e2e951d39892ec38816ca4ff7b91": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0070",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "13",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.21304766524689",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0485956620121857",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.968379925135842",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.164098394910714",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "70",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:9764501f1b27ea039a6888cad5412dc6": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0071",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "7",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.114717973594479",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.135115167401345",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999932500065553",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.317998323277913",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "71",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c4798ee5bb6817f0ac7d3d1f7cbb895d": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0072",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "14",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.229435947188959",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0416945009118955",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.948360030569285",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.15179404238237",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "72",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:5499ba7833a3a03073324dac7488ac06": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0073",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "20",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.327765638841369",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0177689026939896",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.717177111469273",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.090003354949991",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "73",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:50c6ebb589d5bdb3e362aaf8f837978b": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0074",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "7",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.114717973594479",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.135115167401345",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999932500065553",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.317998323277913",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "74",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:a489f5516c417d51a01d581c1281955e": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0075",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "11",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.180271101362753",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.066837364763348",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.991352646973414",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.204909289340264",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "75",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:e4ff54dd97ad1e3f10b9d1c7027c4645": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0076",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "24",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.393318766609643",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0105545831208163",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.527715031910996",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0647162596618474",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "76",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:8de83fae7bd6e9f8380ec49cdc4829ae": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0077",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "13",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.21304766524689",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0485956620121857",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.968379925135842",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.164098394910714",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "77",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:85491f67ab81ddeb946caf2849c4b9f4": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0078",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "6",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0983296916524108",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.164286574579321",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999991511154457",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.361120489405488",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "78",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:3e9eba22eff518f24b14c038fe2913df": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0079",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "13",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.21304766524689",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0485956620121857",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.968379925135842",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.164098394910714",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "79",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:2b503ca3533d10a4f1f80dad7060444a": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0080",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "8",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.131106255536548",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.112142332373161",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999654520482601",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.296922311851664",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "80",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:cf6de656d89419d4ac154fd946ec6388": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0081",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "14",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.229435947188959",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0416945009118955",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.948360030569285",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.15179404238237",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "81",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:9c0f05c7637bc2f31d907b17584b6aa0": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0082",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0491648458262054",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.320523791287721",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999872308",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.529659882057015",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "82",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:62e799c85533fe86208bf5e33c6a326d": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0083",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "18",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.294989074957232",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0233553599209337",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.809860049306577",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.111057119624032",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "83",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:7b8b805f3c10072513741773f37173a9": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0084",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "9",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.147494537478616",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0937881444422454",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.998726572661126",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.257089854765214",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "84",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c8967930ef6b4850b98397e5a02cf2f7": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0085",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0655531277682739",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.251995246521365",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999983347393",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.477356849101447",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "85",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:162bab89b0c20f6474f1241e5c7169b3": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0086",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0655531277682739",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.251995246521365",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999983347393",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.477356849101447",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "86",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:91dc841836bbf5d1c0b426905fb75e01": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0087",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "7",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.114717973594479",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.135115167401345",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999932500065553",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.317998323277913",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "87",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:3f463a005d2c5f82895c19639d89d232": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0088",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "17",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.278600793015164",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0268776015038201",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.851969971349154",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.120432329815194",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "88",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:a088e0c82151087e1bf9897ac5ca3823": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0089",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "7",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.114717973594479",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.135115167401345",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999932500065553",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.317998323277913",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "89",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:321fa4b64bb46facf5ed354080dc1587": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0090",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "6",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0983296916524108",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.164286574579321",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999991511154457",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.361120489405488",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "90",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:1bb068ae0340b41c3c1e0585e61ab7a2": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0091",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "23",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.376930484667575",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0119876489573956",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.573451269803323",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0716185181300816",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "91",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:0b5c4b3fea9afd08f274ad657436f2dd": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0092",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "10",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0789505715685566",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.996344252777198",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.232854217411059",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "92",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:7b0e7637357771b4e3c95b60da0daba2": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0093",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "5",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0819414097103423",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.202012085605038",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999418769679",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.427898326781582",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "93",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:b8afe5b11ecf6b25c3098ac5c67b90a0": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0094",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0327765638841369",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.419663124449093",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999889",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.552437898286094",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "94",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:a2a8b82493043f5593bcde950e35d4f5": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0095",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "12",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.196659383304822",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0568651131936359",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.982432748406332",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.181500977727632",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "95",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:13a870b0869420f093e2bf23ab79a37e": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0096",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "96",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:9e62040415b20939b8c829b35ac0b428": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0097",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0327765638841369",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.419663124449093",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999889",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.552437898286094",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "97",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:ef74f8693d6b0cc1f8f7291479877d46": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0098",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0491648458262054",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.320523791287721",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999872308",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.529659882057015",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "98",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:b4f4a8e2b968691b39abdbd7cd10251b": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0099",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "99",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:b479ffd217729f45ba8e8b497543b71d": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0100",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0491648458262054",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.320523791287721",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999872308",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.529659882057015",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "100",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:64b1c86050912153a776e757204d9bd6": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0101",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0327765638841369",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.419663124449093",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999889",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.552437898286094",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "101",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:2262ce46c8d9d3e44fca9d2b9991842a": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0102",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "9",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.147494537478616",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0937881444422454",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.998726572661126",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.257089854765214",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "102",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:03e5589e0cbf8390adc9f572f09c2111": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0103",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "11",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.180271101362753",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.066837364763348",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.991352646973414",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.204909289340264",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "103",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:183d033f8dc6f63dd2d370f917d30bf5": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0104",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "104",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:82ed6a608808b53426982c1cc66a2ec6": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0105",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "11",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.180271101362753",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.066837364763348",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.991352646973414",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.204909289340264",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "105",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c38a12c7c56a4a6bcef1a3f1defaede6": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0106",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "14",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.229435947188959",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0416945009118955",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.948360030569285",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.15179404238237",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "106",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:b903a819026d14c010b6e3c047f2d1f1": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0107",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "7",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.114717973594479",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.135115167401345",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999932500065553",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.317998323277913",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "107",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:932955007c6604e912ca88f69e4b71b2": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0108",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0655531277682739",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.251995246521365",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999983347393",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.477356849101447",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "108",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:19bb8ba20387a263ccc2a4033c4a6959": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0109",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0655531277682739",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.251995246521365",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999983347393",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.477356849101447",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "109",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:4c267352cce4185f6d8f19642a2432ea": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0110",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0327765638841369",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.419663124449093",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999889",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.552437898286094",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "110",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:b779ca098f1180fe09ebe0414895c731": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0111",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "6",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0983296916524108",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.164286574579321",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999991511154457",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.361120489405488",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "111",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:b7385089cc22c8804fc256dff15181f6": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0112",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "12",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.196659383304822",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0568651131936359",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.982432748406332",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.181500977727632",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "112",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:a34044dfcf23dfe53b2945318b0397f1": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0113",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0327765638841369",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.419663124449093",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999889",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.552437898286094",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "113",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:e3223bf7299c1367c69b65daadf7dab4": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0114",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "9",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.147494537478616",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0937881444422454",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.998726572661126",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.257089854765214",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "114",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:315a3351fd67e6810a0558156faed379": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0115",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "5",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0819414097103423",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.202012085605038",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999418769679",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.427898326781582",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "115",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:956afe330511d5dec77faf29c8e66c5b": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0116",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0655531277682739",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.251995246521365",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999983347393",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.477356849101447",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "116",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:4740016eb1ce8e7ec8341eb44cf9ffa5": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0117",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "8",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.131106255536548",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.112142332373161",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999654520482601",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.296922311851664",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "117",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f956c3347b26a7454fde4d7c1ee3dfac": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0118",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "6",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0983296916524108",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.164286574579321",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999991511154457",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.361120489405488",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "118",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:0306caf1c070bce484bea6d4d02ee4b9": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0119",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "6",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0983296916524108",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.164286574579321",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999991511154457",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.361120489405488",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "119",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:0718df40c87e4adde0a6b31fdd007bb4": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0120",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0327765638841369",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.419663124449093",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999889",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.552437898286094",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "120",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c3345fe728c02a6d54b764235fc35217": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0121",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0491648458262054",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.320523791287721",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999872308",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.529659882057015",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "121",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:db4e8782b5b474daeb575623d11d8f36": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0122",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0491648458262054",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.320523791287721",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999872308",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.529659882057015",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "122",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:3a7bd3c73757ad2c63a505ac44ee7de9": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0123",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0655531277682739",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.251995246521365",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999983347393",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.477356849101447",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "123",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:ca632dc1f3d6a97bb76e5a785e5f4b39": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0124",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0491648458262054",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.320523791287721",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999872308",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.529659882057015",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "124",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:4d501ade9f45e68e86c0aef60754a9aa": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0125",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0491648458262054",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.320523791287721",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999872308",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.529659882057015",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "125",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:4353f4b513f6d03c8ce9a7ee07ac3524": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0126",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0327765638841369",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.419663124449093",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999889",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.552437898286094",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "126",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:d24c03f6c5960ef050e1d0a675496464": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0127",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "10",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0789505715685566",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.996344252777198",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.232854217411059",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "127",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:0630bc3a96bd8ec1bd4f2dbb98bd8a68": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0128",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "9",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.147494537478616",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0937881444422454",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.998726572661126",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.257089854765214",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "128",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:7a6a9d89a41bce106a6e3f6b9bf39fc2": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0129",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0491648458262054",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.320523791287721",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999872308",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.529659882057015",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "129",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:6cd9c8b1f2dc650429e50bd72f6da32d": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0130",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0327765638841369",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.419663124449093",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999889",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.552437898286094",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "130",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f0caefb73eec8df07661fca6c2cc2a56": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0131",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0327765638841369",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.419663124449093",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999889",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.552437898286094",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "131",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:10dda0f512d376c45616527318012baa": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0132",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0491648458262054",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.320523791287721",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999872308",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.529659882057015",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "132",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:3aeaeffb7762bacf9f1b2dc630012fe3": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0133",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0491648458262054",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.320523791287721",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999872308",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.529659882057015",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "133",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:88ee03bc281326c9948572b0834fecf3": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0134",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0655531277682739",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.251995246521365",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999983347393",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.477356849101447",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "134",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:30868fad9324d3113736d83bd681718a": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0135",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "6",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0983296916524108",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.164286574579321",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999991511154457",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.361120489405488",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "135",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:4b462b6d837ce2e27bce61ed0c368fd6": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0136",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0655531277682739",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.251995246521365",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999983347393",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.477356849101447",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "136",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:1bf97c65bec07a1317ef69c944689cf8": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0137",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0327765638841369",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.419663124449093",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999889",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.552437898286094",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "137",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:cd27fa26bbd5aa4fa8cfbebf1bb95ad9": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0138",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0327765638841369",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.419663124449093",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999889",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.552437898286094",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "138",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:31a80df97955e986f4be4839a052a5db": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0139",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "7",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.114717973594479",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.135115167401345",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999932500065553",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.317998323277913",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "139",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:39fc04da006cbf70670a7f80045d0d49": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0140",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "140",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:a2df6515d44ea1c2de2e20cd83b43f91": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0141",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0655531277682739",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.251995246521365",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999983347393",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.477356849101447",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "141",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:9b33ff671ff0c042af89e5b1be1377da": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0142",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "142",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:25e2f4ca28679423b49be4329eea0bc3": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0143",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0491648458262054",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.320523791287721",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999872308",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.529659882057015",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "143",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:0a729befa841fff84fcf2612fb2ce4a5": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0144",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "7",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.114717973594479",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.135115167401345",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999932500065553",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.317998323277913",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "144",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:501da0873de972e1023817d65202130e": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0145",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "5",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0819414097103423",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.202012085605038",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999418769679",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.427898326781582",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "145",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:0336a0114f6c74e1df58148ee9b074f4": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0146",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0327765638841369",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.419663124449093",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999889",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.552437898286094",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "146",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:06324b32c616d4e45a79cb65a439ac48": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0147",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0327765638841369",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.419663124449093",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999889",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.552437898286094",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "147",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:ac9a19a2b1c9949a888ebae7d65a2399": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0148",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0327765638841369",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.419663124449093",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999889",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.552437898286094",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "148",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:061dca60ff6ace182bd1ebe945535ace": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0149",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "149",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:6242500a1c0ecfe873a2799eca21133b": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0150",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "150",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:62f0dcd6742c42c5c8a69829ea982b14": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0151",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "151",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:ed86b8af25a7303faba66f96f7427038": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0152",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "152",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:81c63725e4640647cd75f101cc0fc8a7": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0153",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0491648458262054",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.320523791287721",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999872308",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.529659882057015",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "153",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:4b2e0a2531b0291df0fe5df5bc205ec9": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0154",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0327765638841369",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.419663124449093",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999889",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.552437898286094",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "154",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:7f91f8087c7d8ec7eda6204b5b39482d": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0155",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0327765638841369",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.419663124449093",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999889",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.552437898286094",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "155",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:2c7f0285c24b2b8b65a032418b15cd16": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0156",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "7",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.114717973594479",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.135115167401345",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999932500065553",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.317998323277913",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "156",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:7ed3fe10280b67503b5448524a04f269": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0157",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "7",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.114717973594479",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.135115167401345",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999932500065553",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.317998323277913",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "157",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:99c58e7d96cf7da6763a2e1cbba873ae": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0158",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "158",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:d5206500679003f5f39472159c4ad0de": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0159",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0491648458262054",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.320523791287721",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999872308",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.529659882057015",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "159",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:0803006e1feea37abdc724f07464d7a9": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0160",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "160",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:abae6765a0aa40936d109b9a2fd5acbf": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0161",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0327765638841369",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.419663124449093",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999889",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.552437898286094",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "161",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:4b0a463a8d9ceb66a11c49348ae1f5fc": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0162",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0327765638841369",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.419663124449093",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999889",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.552437898286094",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "162",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:ca33d7428ff48eafbc3f213db2286c92": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0163",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0327765638841369",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.419663124449093",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999889",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.552437898286094",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "163",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:a2d559eeea3fd425019a74c32cb07b03": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0164",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0655531277682739",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.251995246521365",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999983347393",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.477356849101447",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "164",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:1cffc79d71ec5b44f8be32f71d15b738": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0165",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0491648458262054",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.320523791287721",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999872308",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.529659882057015",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "165",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:08835c169510829e8effda3071bba336": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0166",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0327765638841369",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.419663124449093",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999889",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.552437898286094",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "166",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:d5a3f5e4133bc22e2c189ceeb5b93544": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0167",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0327765638841369",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.419663124449093",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999889",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.552437898286094",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "167",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:9b44436d58818f06cd48133f714e8a99": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0168",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "168",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:051457613c34bfa68d60b137e8c7ae17": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0169",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0491648458262054",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.320523791287721",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999872308",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.529659882057015",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "169",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:ea9fe9402f815e54e3cef6704ebcb2e4": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0170",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0327765638841369",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.419663124449093",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999889",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.552437898286094",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "170",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:1dce01b8df60884c582e29243c828080": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0171",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0327765638841369",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.419663124449093",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999889",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.552437898286094",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "171",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:eb8a2332e6ccc41b6d1a8cca84b280fe": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0172",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0327765638841369",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.419663124449093",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999889",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.552437898286094",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "172",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:3ab29b7a5414afa7ee3dad94fe418d2f": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0173",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "173",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:de99f369510067d001dcfc78a4b7ee95": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0174",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0491648458262054",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.320523791287721",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999872308",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.529659882057015",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "174",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:03516b1ded0c354154f06310cfeb09c0": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0175",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "175",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:56da6908cbe82b7569f6ca2737e51eb6": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0176",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "5",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0819414097103423",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.202012085605038",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999418769679",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.427898326781582",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "176",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:087ce96dd01c83b4336943a7df6de172": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0177",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "177",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:1a5540bf2e828d5e14c6001adb4f30d5": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0178",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0327765638841369",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.419663124449093",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999889",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.552437898286094",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "178",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:b54974658dcfd8d91a65540d01e3250b": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0179",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "179",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:b1012bc624cd6b3f47ff149073d0a78b": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0180",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "180",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:d45da63c733d96ddba5cf2fb05dc0b58": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0181",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "181",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:14e793643765a6fe10fb66237bee63db": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0182",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0491648458262054",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.320523791287721",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999872308",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.529659882057015",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "182",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:a3b1937d74b3d7366255ed05df95e8dc": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0183",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0655531277682739",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.251995246521365",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999983347393",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.477356849101447",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "183",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:4f0d78d14b791c15d9759ece4ec7e6ed": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0184",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "184",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f569ae7a0c44f14440097fc2492d13ab": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0185",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "185",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:2fd27f14078fbb1aa402a271e101e35f": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0186",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0327765638841369",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.419663124449093",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999889",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.552437898286094",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "186",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:5476fcd5093f7c864637efaafd42b996": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0187",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "187",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:10bac4ccf6049482f632adb3952c3c8c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0188",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "188",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:cda273936fc980c18403b41fb8533954": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0189",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "189",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:89501dfa67d1d32810bbe20fd9b1fe8c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0190",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0327765638841369",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.419663124449093",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999889",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.552437898286094",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "190",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:02f6f6429a8304a7731a404570cb4b94": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0191",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0655531277682739",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.251995246521365",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999983347393",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.477356849101447",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "191",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:8747a3ddd24cbd71e40672d541cefee5": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0192",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0327765638841369",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.419663124449093",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999889",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.552437898286094",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "192",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c885eb98b2506b007c2d8feb2e37f08e": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0193",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "193",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:bd96226234de4e21627b04208c7e537f": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0194",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0327765638841369",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.419663124449093",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999889",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.552437898286094",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "194",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:8b7eb042176ff4b34dbab2133217acff": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0195",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "195",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:74aa1acb0840e11af474625bf18a205b": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0196",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "196",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:1f8d909cef3803a0e6a8e31c86e2cb37": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0197",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "197",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:d1b86bb927184d1863bf16406cbb38ef": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0198",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "198",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:8681fd0b6a40a88059175d0b5804a743": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0199",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "199",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:53d7d39a6b6a7a44a92c2cdc58facf3a": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0200",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "200",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:b8f303a3f6e3ffbd2a86dd99d6d873fb": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0201",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "201",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:555db4d96064ec58a79e6099a79dd060": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0202",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0327765638841369",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.419663124449093",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999889",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.552437898286094",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "202",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:df9fe6cd3c5bf212b4c85e3bd119959c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0203",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0491648458262054",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.320523791287721",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999872308",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.529659882057015",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "203",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:17f6f685daf3b085f3dac6c057c020c1": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0204",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "204",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c5cf9af3cc2424e4b8e65eb6049706ed": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0205",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0327765638841369",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.419663124449093",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999889",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.552437898286094",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "205",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:24b677d8caebb84711be327c29be20b9": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0206",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "206",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c9997d6b8885703c61c50e9494f01f5b": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0207",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "207",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:18c389e9f560a707e21a88082c18399f": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0208",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0327765638841369",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.419663124449093",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999889",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.552437898286094",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "208",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:4f2617299971ce7d3a16c3c37b0badbd": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0209",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "209",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:7ab88d893988ef5840b83076dc34632a": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0210",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "210",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:ad4b61cba6b4e1ac8b424d69a662357a": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0211",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0327765638841369",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.419663124449093",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999889",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.552437898286094",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "211",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:18172de66764cc046e57e3f71900f308": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0212",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "212",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:5b864821dad832cdea33cc2c71107b5d": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0213",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "213",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:54af2492a558bd6b541a83efffeacbc6": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0214",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0327765638841369",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.419663124449093",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999889",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.552437898286094",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "214",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:4c87d31930bd2a3884bfbd054121e8ea": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0215",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "215",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:0c1ba90c913890f99f03e9c6732b7833": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0216",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "216",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:7e48fd00328505ec2f7c55286029038c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0217",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "217",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:fe7b7aeb5b19bcdfb6ba3b9e7bbc0530": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0218",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0327765638841369",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.419663124449093",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999889",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.552437898286094",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "218",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:2598e0a8af6b254c19ea1eae1c055e59": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0219",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "219",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:ef260aa5a1800f7a5b96c1d3f96edac0": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0220",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "220",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:9edfdd818d3f428259751e3a1f4426fa": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0221",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "221",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:1667cff121b7be39391cc74c4150a6e4": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0222",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "222",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:8a9dbe909430bab19de8984a30f0827c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0223",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "223",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:73e5d22f5e99f7222d046e5c8b8f17e5": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0224",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "224",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:8015064bc0743ed13468353e18ca0971": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0225",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "225",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:eb612c2c1cebda064d6320c535f9294f": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0226",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "226",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:6369784f4c4b56deb50440d6515b981e": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0227",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "227",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:2147d82387f71f29a3d3dfb09b7b8d64": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0228",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0327765638841369",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.419663124449093",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999889",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.552437898286094",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "228",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:790465006aaf87ef2289ea019fdb0b83": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0229",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "229",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:730c6026b96772dd69384df78d1b3195": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0230",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "230",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:26bef1517140b96419bd96743968bf5a": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0231",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "231",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c80e777eb02827978765763f51129026": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0232",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "232",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:6eb9789a31f1c0da3f5dc3fb64518f9e": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0233",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0163882819420685",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.578685227694606",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "233",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:6375cbd08f405cfa4aa923cd73003620": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0001",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ce4a406feff03df1c1bc96f3bb8b1a6a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "12.195366859436",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "6.97053078023572",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.57873714101697e-12",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "3.52098841860382e-07",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1.32821571221074e-05",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ce4a406feff03df1c1bc96f3bb8b1a6a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0001",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-12,-20,80]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f9affa16a68b7d08052caab897982f1e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0002",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:948e4a7ef33c3baa7c4f2617243129ae",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "12.0285215377808",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "6.92667949448921",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.15416573468019e-12",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "4.80452217677119e-07",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1.32821571221074e-05",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:948e4a7ef33c3baa7c4f2617243129ae": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0002",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-2,48,28]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:760b5861535d1b8d351a8ea1c8e8055e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0003",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:2981f98fafc6bbd2a22c1698fffaeee3",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "11.1319952011108",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "6.68038320254177",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.19159127009993e-11",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "2.65787821074337e-06",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "2.57057234849773e-05",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:2981f98fafc6bbd2a22c1698fffaeee3": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0003",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[28,-82,-34]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:01d92dcf2decdbf979916bc117777a31": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0004",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:991de64484a40e2c43025eb986c3aeb0",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "11.1767311096191",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "6.69312218368378",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.09229292277746e-11",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "2.43638629615628e-06",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "2.57057234849773e-05",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:991de64484a40e2c43025eb986c3aeb0": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0004",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[16,-18,24]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:85893fd2a80f9cb9a50aeeaf16aa5be0": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0005",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:50a673aee12d5977c697358610b82f93",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "8.21963119506836",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.72404476343991",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.20086618216453e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00116008955846647",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000453192860238723",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:50a673aee12d5977c697358610b82f93": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0005",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[10,0,22]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:eb798644a33419afda56222bf6a4057c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0006",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:79715caa4b342489144deaf29cf8907b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "7.89727067947388",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.59926411112285",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.0763181346185e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00240080291677169",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000683233949888892",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:79715caa4b342489144deaf29cf8907b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0006",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[18,-32,20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8b04f6c0610c61ade2031f4e0e7fd687": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0007",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:df7b218fff7e31a0a6a4a8706cdb282e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "9.78486633300781",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "6.27176668468128",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.7848711397761e-10",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "3.98127506539003e-05",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "6.33393663622056e-05",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:df7b218fff7e31a0a6a4a8706cdb282e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0007",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-36,46,-14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8d815390449dd61ecf2635b2c7a5611c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0008",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:31d492f86d25c7bb3c9b9d2dae269db3",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "8.99272632598877",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "6.00574234084408",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "9.52292245059994e-10",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.000212415401777744",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000159959987970191",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:31d492f86d25c7bb3c9b9d2dae269db3": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0008",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-36,52,8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b2ac34a9e9c7de3ca84c442f813d01ef": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0009",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a9d3837fe2e1545ff57eec0afa450f12",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "8.32958316802979",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.76557366261307",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.06902733729453e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.000907624981246302",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000384701368615494",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a9d3837fe2e1545ff57eec0afa450f12": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0009",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-30,26,0]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:007c46c3626dce09d1207554312d2e9a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0010",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:8d8e9e0f9f2b81a67a6a5db0d0d20327",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "7.92342185974121",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.60956000685145",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.01420828402254e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00226226252256356",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000660665293349347",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:8d8e9e0f9f2b81a67a6a5db0d0d20327": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0010",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[34,24,58]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0f083958a49b6859e479679cb5c0b402": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0011",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6d5d48b7c274665475b2ca71cbe88e23",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.66889333724976",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.58322220042275",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.28932521062486e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.405319777142171",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0228998003891751",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6d5d48b7c274665475b2ca71cbe88e23": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0011",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[42,22,52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:495925dd7a5c597e0b631259e27402bc": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0012",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:95d95856a6aad86946eb9d81f7bf0673",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.58756303787231",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.95550547589705",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.81864993630465e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.996114645664071",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.142799623959245",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:95d95856a6aad86946eb9d81f7bf0673": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0012",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[30,18,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:78d8a083c90c99f5fc07322a26f5cde9": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0013",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:34d2ae37ad9642bcc041fa8361a900ea",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "7.39782667160034",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.39638585124024",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.3998318493822e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00758356300256935",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00138047262763128",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:34d2ae37ad9642bcc041fa8361a900ea": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0013",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-30,52,-44]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c53b99e7694641c31b95648ff991e8a5": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0014",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c234452f63bb3ac27195fdeb47ad40bf",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "7.36954021453857",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.38452514941599",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.6318073992625e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00810100072963016",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00145261378503197",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c234452f63bb3ac27195fdeb47ad40bf": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0014",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[20,62,4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b3b4ea8ddeb67b7b4031f94f6efe9a70": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0015",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7a54b5ab9f0eb5be2d355ab612b3e8dc",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "7.21618938446045",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.31949501913396",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.20278310434108e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0116051721566931",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00179005739670645",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7a54b5ab9f0eb5be2d355ab612b3e8dc": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0015",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[52,-72,2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:61b0171a6b5389bc91ab6b1f988304af": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0016",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:210a02ccb07cf88b19c88732436048e4",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.82430219650269",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.43170583345079",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000299898886572558",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999682",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.500860780805665",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:210a02ccb07cf88b19c88732436048e4": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0016",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[40,-72,0]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:395843f5ca50db682d73ad4b552a0079": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0017",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:8cde37036aee8f9ea450e67d6b4737cf",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "7.19049739837646",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.30847761867744",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.52723281588285e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0123288799992954",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00187574777550428",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:8cde37036aee8f9ea450e67d6b4737cf": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0017",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-40,-72,26]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c9497860d4fc106d2a8129f3a41c5e21": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0018",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:3ed159a6a6e2cc0ca8d0aa8e7ada491e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.70591068267822",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.09372181887081",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.75550912029365e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0391578631772435",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00399264077980742",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3ed159a6a6e2cc0ca8d0aa8e7ada491e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0018",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-40,-86,14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5ecb0bf5c97b7f24045a8880831fa426": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0019",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:81b9cf871bc6bec3e655da3ee187b454",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.08404064178467",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.79678082629552",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.06179272005991e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.179824002311423",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0113500948707688",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:81b9cf871bc6bec3e655da3ee187b454": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0019",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-48,-60,30]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d36f5f82de4a3b0715a81212cca9c290": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0020",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c6a5ddbf6aa7d460ec508fd316db2784",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.76158666610718",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.1190933210259",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.53504013944428e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0342401474138896",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0036643210853873",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c6a5ddbf6aa7d460ec508fd316db2784": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0020",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-28,60,8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e00bf7ebffe936d438f170dfbba1c2bf": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0021",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:837aa2fe6f0b45ab2a10036c63a7f241",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.00573968887329",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.56362489977281",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000182884266391126",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999996836787",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.371800092457092",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:837aa2fe6f0b45ab2a10036c63a7f241": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0021",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-22,54,4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:44b0e53d8cb7cd288c880c38c3120379": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0022",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:3cec1451f5427e2546489737253c024b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.5752739906311",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.03344180146668",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.40875558610298e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0537289858908915",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00495708453245008",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3cec1451f5427e2546489737253c024b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0022",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[60,-54,18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ac8f339519721b314dfbcb54584abed9": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0023",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:78a873ea8d79ec4f3f6fe4d0cab6817d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.51905012130737",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.00716804962526",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.76183492853299e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0616046698347695",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00529817216776537",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:78a873ea8d79ec4f3f6fe4d0cab6817d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0023",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[0,-22,-20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6614974273127e7f54c4cba899f3eab6": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0024",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:333c34b3d2f8aaf1993c6b604235f256",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.48744344711304",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.99230910659331",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.98308350576981e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0665397756356061",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00561544623172705",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:333c34b3d2f8aaf1993c6b604235f256": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0024",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[10,-30,-36]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c742243cf82a89d57a67528234343c14": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0025",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:97130dd3e85c7fe87b1fd88f3a5aca5b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.05579805374146",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.24143816665454",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.11046039252827e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.863212474362956",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.06785188529979",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:97130dd3e85c7fe87b1fd88f3a5aca5b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0025",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-10,-24,-18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ef6c96561d3475ee3682ddd186166797": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0026",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d05de1a91aa11cafd11ee52e4c03f599",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.43919801712036",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.96950298960416",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.35623679514896e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0748632235875265",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00602839301790402",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d05de1a91aa11cafd11ee52e4c03f599": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0026",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[32,38,50]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9f24a0581a298125f2f285b756d18966": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0027",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e0fd94a7bd3607684a684406ed869b37",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.89343357086182",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.14494916695648",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.69944550607593e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.941605195071017",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0877947883186739",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e0fd94a7bd3607684a684406ed869b37": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0027",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[38,36,44]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9c2ce6348aeb7ede7a631d7c312619e2": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0028",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ad04211aace9e5e98ebb27cbef6f70cf",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.84852504730225",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.44961290393203",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000280695459907387",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999998663",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.483436985514074",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ad04211aace9e5e98ebb27cbef6f70cf": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0028",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[28,48,42]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f71d38ee9ef7cc1c310f15620e0322f1": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0029",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:bd832f486ff152b465d631cc0a7e77e4",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.41994762420654",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.96036060921301",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.51812182386446e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.078474183710761",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00622569915917693",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:bd832f486ff152b465d631cc0a7e77e4": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0029",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-50,26,32]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:bcb9b4ab7230df4bb758bc460b37e486": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0030",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ef55d50c8d316e7518f786ea262cdb42",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.49974060058594",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.89913272010445",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.82689255971724e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.998798077640618",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.163634540984241",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ef55d50c8d316e7518f786ea262cdb42": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0030",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-40,22,36]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0524275a9408ea6e1dc8e1d6c4ce5393": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0031",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:cd88feb0442eabffbada9c5ef879e111",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.05374956130981",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.59770236066326",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000160520349498539",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999978604915",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.342543683213877",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:cd88feb0442eabffbada9c5ef879e111": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0031",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-42,32,42]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1c7d7853345eae89866ead4836881a90": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0032",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c4b770507a4d7626f6271474d76c97b2",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.25023365020752",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.87868788208187",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.339695245965e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.119105671995756",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00839771733178921",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c4b770507a4d7626f6271474d76c97b2": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0032",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[52,-6,-34]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1ed918e3e6e487b700b47936095209c4": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0033",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ae31349ed28884159eb4d5d66d33e3e3",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.18567895889282",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.84710419253793",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.26383204971326e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.139719202260282",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00953069985592431",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ae31349ed28884159eb4d5d66d33e3e3": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0033",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-4,-46,-52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:837348f6ba9eea5a44579dfe608168d9": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0034",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ef98480f2fd69f2c61f22a53502771c8",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.76085114479065",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.38435212152789",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00035673219891208",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999995",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.549736132547086",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ef98480f2fd69f2c61f22a53502771c8": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0034",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[2,-40,-56]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:fe8cde79b36b2168ffe3f9627203cbad": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0035",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:aa376e8ac8714d8b18eae18d6a4283b5",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.11011409759521",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.80976084297033",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.55554926290536e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.168531878813079",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0108578016540005",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:aa376e8ac8714d8b18eae18d6a4283b5": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0035",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-16,-22,24]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d013871b13a39a72c56c973d8d7c69ea": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0036",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a0b4f6af10f809dffb754718d563928f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.73779535293579",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.04985330158103",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.56248750450938e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.981601010330499",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.113611991025762",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a0b4f6af10f809dffb754718d563928f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0036",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-16,-12,22]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4edccd0555b06c37550a7a304066b78e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0037",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0199c0fccb5983aad9bd979030e607bb",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.99648928642273",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.55702003485366",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000187542779954697",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999997859921",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.376379972172505",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0199c0fccb5983aad9bd979030e607bb": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0037",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-12,0,12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:937b4c105cb8dab064d0662d01153915": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0038",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ec598d9792349b28137d53c0e27bdcc9",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.04269409179688",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.77609641444734",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.9365362176963e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.199335784938733",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0122656272857256",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ec598d9792349b28137d53c0e27bdcc9": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0038",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[60,-26,-26]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5ef928ba0042c21ed23333a93026c5a5": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0039",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:8d5aa4270374437a601d634b8fcd9627",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.89026117324829",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.69874511544533",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.3088244658066e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.274583699216449",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0161783507049903",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:8d5aa4270374437a601d634b8fcd9627": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0039",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-28,-58,-58]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3b48cac23fce59fddaa73fd59df07df2": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0040",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e622a01f345c7734af0c378f60d34ee8",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.82566070556641",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.6654316334069",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.5398494003227e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.308848975990721",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0177557080539423",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e622a01f345c7734af0c378f60d34ee8": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0040",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-48,8,-34]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:91271dfe97a1459e04ef73790c14a894": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0041",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:666e30cb3b16d69e841f24335d524041",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.81330108642578",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.65902103562978",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.58858368881631e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.315770599808423",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0181106043668944",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:666e30cb3b16d69e841f24335d524041": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0041",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[42,-62,30]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:bd1b4d2f824f4a7a06cbe3b08d77df91": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0042",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:305ee930a25a4859579df48853fbc995",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.74564361572266",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.62371573654215",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.8846316389709e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.355751628578317",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0201990755486958",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:305ee930a25a4859579df48853fbc995": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0042",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-66,-34,6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d1e90a72a70964a43504b62fa88ceb97": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0043",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7a6d9d5ba64d3a00dfc724e8fda92efd",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.72459840774536",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.61265957667344",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.98774558690662e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.368904498827799",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0207237790143809",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7a6d9d5ba64d3a00dfc724e8fda92efd": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0043",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[36,-10,-30]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e777d8426ec1922a9300b8c510619da9": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0044",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:23b0f724f37361cf3634731181e5dc78",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.54388046264648",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.51622836043788",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.14753889907315e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.494815113923139",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0284655212355184",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:23b0f724f37361cf3634731181e5dc78": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0044",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[30,-8,-36]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:87ad6041e36ec3077cd5b4ed5e1e763f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0045",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:3e3954b4c6a217ea807c8782412311d6",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.70221662521362",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.60086214528593",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.10372912945456e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.38325974300236",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0216156089926179",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3e3954b4c6a217ea807c8782412311d6": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0045",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[20,-12,-32]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:40a241f7cfcef8552dfd5aadd9a4fbf1": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0046",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:02ae91295919dd56e833cd7a1878872d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.64641094207764",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.57126970388676",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.42388931537274e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.420654930029894",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0237830877156679",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:02ae91295919dd56e833cd7a1878872d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0046",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-18,40,-18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8454ccb4e839a31841899dbcc90d3705": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0047",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c1b0358ca9a48ab3254cdf0336ad4a33",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.51601076126099",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.50111380137384",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.37991495569234e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.516023728324697",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0299758857250781",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c1b0358ca9a48ab3254cdf0336ad4a33": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0047",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-64,-22,18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:25112a96f0a534131b06def72c92db36": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0048",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a8ffc84bd049668e67aacf1f8dd72e50",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.82918906211853",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.43532602661172",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000295920667697569",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999572",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.497645692606821",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a8ffc84bd049668e67aacf1f8dd72e50": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0048",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-66,-14,12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ebbe77abb440c0b57b92a0f3181bf3ef": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0049",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:3157cc359f1512741beefb7f95680def",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.50570774078369",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.49550933866504",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.47018059765336e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.523959489710639",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0302612822408903",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3157cc359f1512741beefb7f95680def": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0049",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-66,-48,6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:622888501323beabd65ee1c12fd5258f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0050",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:fb270858fb08b357c3467e4870a4a457",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.62412595748901",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.28004199841764",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00051895817294012",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.680244967613049",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:fb270858fb08b357c3467e4870a4a457": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0050",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-62,-54,12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2cc303fb0baeaaf69f5c83c6ace6046d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0051",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:607064945943841f97401329f5ca9097",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.30499839782715",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.38447219630665",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.81336653915354e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.683924483063057",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0434545575886298",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:607064945943841f97401329f5ca9097": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0051",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[60,-24,12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:939c3046fadf99b92e995efdba77b780": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0052",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:614cae25fc7f61eac2167c4d17908165",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.79114770889282",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.08274799068102",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.22531390113856e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.971408745964108",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.103697297505344",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:614cae25fc7f61eac2167c4d17908165": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0052",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[52,-26,14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:59954b6fbe4f7e0ee8297e3dfb447725": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0053",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e83fc68807e48503e867fd7c663330c0",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.23910284042358",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.34722318758447",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.89359534200573e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.735719811343891",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0492439815526957",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e83fc68807e48503e867fd7c663330c0": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0053",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-6,-76,-44]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0d75e98dbb1ee49d43d97017b2bc924f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0054",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:26be6593f3f57b0aed0ef977c3e0e360",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.23777103424072",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.34646618864733",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.91741829794701e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.736746205981572",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0492530384603998",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:26be6593f3f57b0aed0ef977c3e0e360": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0054",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-46,16,42]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:60e306c02d06deb6b75ca415cf7afa84": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0055",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a44a17f66a85b8599debb783042f342d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.16541767120361",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.30508875032236",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.34594019494261e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.79072771323468",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0554020873789584",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a44a17f66a85b8599debb783042f342d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0055",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[48,-16,14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:70c48b68597d17a57d7df6777d571a0d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0056",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:63c92f8e694fff1184419aacd9378eaa",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.04228210449219",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.23350816985445",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.1503691013437e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.871162148697437",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0694084780297125",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:63c92f8e694fff1184419aacd9378eaa": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0056",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[56,-14,10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4febc9242872f447f9f0fb6d8187edd9": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0057",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:9cc744b2ef0b321a73a7c3ffc643b63c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.93621253967285",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.17063459410943",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.51876293638109e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.924687668878693",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0829690614620754",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:9cc744b2ef0b321a73a7c3ffc643b63c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0057",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[40,-12,14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6309cc2f72b3ba21a56aceea534b259c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0058",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:16fe50f2d483d0250919ca566d224a60",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.16341876983643",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.30393854152611",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.38941134995164e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.792161008528185",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0554020873789584",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:16fe50f2d483d0250919ca566d224a60": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0058",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-28,6,62]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3af656624dd76ed9af5b633959de57aa": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0059",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:2207a1786e7e1335381eca0ad553a27d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.15367984771729",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.29832907222195",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.60452684559032e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.799092501739318",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0561583848310698",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:2207a1786e7e1335381eca0ad553a27d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0059",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-60,8,0]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6a4d1d270484e6aaf38f13bdd3037234": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0060",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f9bd5a66fb8e6af654b99e17a2115983",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.63001489639282",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.98242834282796",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.41073475436104e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.993645272304345",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.133707794797061",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f9bd5a66fb8e6af654b99e17a2115983": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0060",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-58,0,2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c6fcc1f2ec131691f25f7ea0f2e12eb7": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0061",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d28f87df7e33ffced1cd1c65433f6dd9",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.13582944869995",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.28802377033811",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "9.01349028958887e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.811564040895531",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0582499630192324",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d28f87df7e33ffced1cd1c65433f6dd9": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0061",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[62,-4,-18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b749f6df0e9c14d8711813f709744b7f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0062",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ffb706fd0bf0d0619cb3999481194ffb",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.06757831573486",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.24833497375142",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.07682603029957e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.856090469899599",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0664563384555011",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ffb706fd0bf0d0619cb3999481194ffb": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0062",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[30,54,-44]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:31f45e8d9b10c8383ebb56334d2cd5f6": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0063",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:eea3a5acdf27e2de2dab85015bbaea23",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.02421474456787",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.2228792447941",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.20600532134141e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.881407445915171",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.071813553261658",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:eea3a5acdf27e2de2dab85015bbaea23": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0063",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-30,-16,-20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:daf29f6ab3520aed8f7ff3bc5e75f2ab": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0064",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7f8295ad4df78742c62a26488eb8fad3",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.74015760421753",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.05131641531498",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.54651392115335e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.981217661454756",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.113611991025762",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7f8295ad4df78742c62a26488eb8fad3": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0064",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-22,-18,-20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ad918640c79c32e0c9a09cfe39505035": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0065",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:9b2d2ac968f225bd22ee939592ac64c4",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.96017456054688",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.18493879672852",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.42621472154492e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.914023389189348",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0802451723107542",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:9b2d2ac968f225bd22ee939592ac64c4": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0065",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[10,-24,16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f84262ea494283ee11627a522f8067fc": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0066",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a7010eb90cdca5180078541caabd7ee2",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.94747877120972",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.17736739359608",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.47451242935581e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.919779784602502",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0821139058098193",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a7010eb90cdca5180078541caabd7ee2": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0066",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[48,-72,-16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:65f0d327b04aadb8425ee54a012bfd51": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0067",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:86c99915fb4938033cef1f1c79f20f26",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.93897771835327",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.17228830640617",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.50777864580398e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.923500556854135",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0829347355349478",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:86c99915fb4938033cef1f1c79f20f26": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0067",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-26,4,16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:135656545b11da25b3b9e5296a4c1583": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0068",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:124fd785f1011c77e93bf0bc0cda783f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.91353464126587",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.15704210840336",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.61197292659621e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.933994187279112",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0855746630008624",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:124fd785f1011c77e93bf0bc0cda783f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0068",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[26,18,64]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:16a0de533a153793ccdac522009f77c2": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0069",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a5edccaa1ee1e1a3cf37954dc584b2c1",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.90734338760376",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.15332192293598",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.63841617967231e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.936402129572896",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0863919526492905",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a5edccaa1ee1e1a3cf37954dc584b2c1": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0069",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[0,-22,-54]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:26852796b5d7ba6eb653315a8accd667": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0070",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:27f8457a9b46baae1a37773f8f85876a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.90487241744995",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.15183605169709",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.64909255723211e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.937347294524692",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0866104581112591",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:27f8457a9b46baae1a37773f8f85876a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0070",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[10,30,-6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:645365b733aee62b96ed5d9eb97c872a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0071",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:61461b4cb693c67119ecef5cce38f06c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.90001773834229",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.14891491710542",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.67027465689529e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.939177943711304",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0873354556109577",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:61461b4cb693c67119ecef5cce38f06c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0071",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[28,-14,10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9a917736e3d5642e34dc1a8c05d59370": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0072",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7024715a649a60cb4dc55a269c6a23a0",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.8938684463501",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.14521124011164",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.69750293880222e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.941446847291943",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0877947883186739",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7024715a649a60cb4dc55a269c6a23a0": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0072",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-50,-34,2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8e8f82ce9a9f916915f7207c051727bd": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0073",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:17584b61b2e1ba24747384b5df72b417",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.71507501602173",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.03574917489321",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.72141698914874e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.984994076694401",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.117674394049896",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:17584b61b2e1ba24747384b5df72b417": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0073",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-50,-44,-2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a67831c35816df52629ee7a7fc26dde0": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0074",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:fa7748f42b4ea105392364e1f036194b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.19112873077393",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.69339227166818",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000110641138199918",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999998036789566",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.27646623644364",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:fa7748f42b4ea105392364e1f036194b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0074",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-44,-40,2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ec5b68946bd31e836ab65ff6af1c4a12": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0075",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a8ceaa5e8f88a768a13627b2df8779f0",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.8740234375",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.13323153375862",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.78849030254558e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.948390984974567",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0906467281751595",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a8ceaa5e8f88a768a13627b2df8779f0": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0075",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[40,-58,-4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:75631318c3d0bd234d33224648039cef": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0076",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f976f8e9ff5e60139441a829e8309f5c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.85820341110229",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.12365167586169",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.86456349975384e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.953518161280421",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0931417862836213",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f976f8e9ff5e60139441a829e8309f5c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0076",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-36,-10,10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5bdba307d61986d6149f72dba439105d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0077",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e29c2a8f4f6a6f0797b978de28eba557",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.84939575195312",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.11830662564564",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.90833322246675e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.956218144422422",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.094298931343831",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e29c2a8f4f6a6f0797b978de28eba557": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0077",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[28,-94,12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2024155e74ac1cefebed8ca6401c4774": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0078",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:8ada6393b1a9a3f95ad2291994faec90",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.84849166870117",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.11775750127654",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.91288474941098e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.956489104833424",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.094298931343831",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:8ada6393b1a9a3f95ad2291994faec90": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0078",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-54,20,2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d0fc86df54e53e74dd24a6a5984cb2c6": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0079",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:9d85c6c90938d870289914c51cf481cb",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.84107542037964",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.11324969968147",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.95064001932144e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.9586686962403",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0952087356620267",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:9d85c6c90938d870289914c51cf481cb": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0079",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-14,-102,16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:25187e17b37ef5575be4d5ced78392b0": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0080",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:525dc2ad246a75dacc4a235e063563e7",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.82058572769165",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.10076479505859",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.05893469639173e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.964297185993396",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0988254126520163",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:525dc2ad246a75dacc4a235e063563e7": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0080",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-40,0,36]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6b28b7892bbd80bbf1d73a494bd4d5f5": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0081",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7c073ea600f14fd4ea899167ad505fa8",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.8377993106842",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.44169525159104",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0002890405543442",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999286",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.489947318972906",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7c073ea600f14fd4ea899167ad505fa8": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0081",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-46,6,32]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:deca705eeaa663fdf055aa9f356776a9": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0082",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6fb430ff22243bc9598fb0ac4aaf9c27",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.80269765853882",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.08982806807398",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.15846535014386e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.968751908822455",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.101323968025976",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6fb430ff22243bc9598fb0ac4aaf9c27": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0082",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-8,-2,-26]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d21f3565a424b86ffb29d622322bc1d3": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0083",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:8dccf601dcdbcf162697530c6196953f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.7697925567627",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.06961897184955",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.35450441299356e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.975886012613188",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.107275411916197",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:8dccf601dcdbcf162697530c6196953f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0083",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-54,-14,44]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e161951a5e1072e332cd915c3b62c0f7": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0084",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:5b9b9731572d08126d7aa3c59cec9305",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.66720128059387",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.31324766391278",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000461096398393313",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.635496970778773",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:5b9b9731572d08126d7aa3c59cec9305": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0084",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-46,-16,42]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2146b6f3997a0283631b40f42fa43d64": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0085",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:82214ebe8ef9b550cf4e1aa7a663349d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.76250028610229",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.0651242608467",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.40034388049315e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.977290243152968",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.108771358683944",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:82214ebe8ef9b550cf4e1aa7a663349d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0085",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[2,-48,-30]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0e6bf474e07d5b7b08647f8b148f1967": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0086",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ba7fb6c8d83c030743f5d0f254764ced",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.6519603729248",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.99626416831875",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.21749621180478e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.991944888183868",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.128446006759384",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ba7fb6c8d83c030743f5d0f254764ced": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0086",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[8,-50,-40]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d72c48f6d8afc2c9c15435f9d82418cf": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0087",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0176ea45bff6510ce2f14431bf105e73",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.10066413879395",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.63067985034096",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000141337823446053",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999883838746",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.31440196024118",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0176ea45bff6510ce2f14431bf105e73": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0087",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-6,-54,-34]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:36093115c68af5d4a10804e4c18ac4b8": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0088",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:8f6c6846bbd931f8db1b84eb92b10f53",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.71864032745361",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.03796623427238",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.69583056984324e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.984495898499825",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.117001939306263",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:8f6c6846bbd931f8db1b84eb92b10f53": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0088",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[30,26,-26]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f6438ecb7f50fccc2df09ada0b2c3936": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0089",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6f8a1c21df8a5fd72256d5fc0cfd2f29",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.44299697875977",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.86221318181419",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.61822240265908e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999504108645955",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.179991208659564",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6f8a1c21df8a5fd72256d5fc0cfd2f29": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0089",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[24,14,-26]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e92804e0ae7f8fae7ff71ce6170d001c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0090",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:12aca80540254ba38eaf72b666080df0",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.96920132637024",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.53746207311998",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000201996101466206",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999353667",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.394063237507806",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:12aca80540254ba38eaf72b666080df0": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0090",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[26,14,-18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ad38b1977ea2816b6d5129b7de2be1cc": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0091",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:2df1390cc5fce031de8c0874577cadce",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.70100975036621",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.02698888340493",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.82478512551032e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.986841070396366",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.12010902462004",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:2df1390cc5fce031de8c0874577cadce": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0091",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-28,-16,6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:381454c1e2fbda01612a05c0a4339f74": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0092",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d3ea04f828be657e6bab2138bbf28662",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.67801570892334",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.01261939052354",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.00243455383375e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.989477369969029",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.124772480459746",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d3ea04f828be657e6bab2138bbf28662": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0092",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[44,0,10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b762ee5ba6db8bfb0128b4bb42245b28": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0093",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:aebbd1158b0ede5b331c1c3f1d17b188",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.22728967666626",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.71814419332447",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000100345855709283",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999994729417339",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.257292468216432",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:aebbd1158b0ede5b331c1c3f1d17b188": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0093",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[54,0,16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:85563c1d691e946655502a1d62515133": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0094",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:bbf81c743efe445a1c97b21a8fab3e28",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.66959953308105",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.00734493617698",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.07025754018309e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.990331612042013",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.125816071886827",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:bbf81c743efe445a1c97b21a8fab3e28": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0094",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-54,-22,12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:41ddd3c253a63198d170247b8ccef29c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0095",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:921adc178a0217524216f743d14205b3",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.65595293045044",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.99877537618825",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.18355355407585e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.991599911633511",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.127861903463077",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:921adc178a0217524216f743d14205b3": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0095",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[50,50,-8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:78ffb1d7f41f1c0b6ea5119ca8935556": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0096",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:973e73a26378971ef19237f48098ed3a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.65494585037231",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.99814212312407",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.19208079492261e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.991688012376402",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.127861903463077",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:973e73a26378971ef19237f48098ed3a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0096",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-28,-94,14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d614eab5b59c47eed1084c951be2e2ac": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0097",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a580eafb1c15748fd65f50cb3130fabb",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.59036016464233",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.95728588718167",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.79030920980572e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99598096157132",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.142567282550543",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a580eafb1c15748fd65f50cb3130fabb": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0097",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[40,-8,-4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b50f8c0634d1f6225cc186049de68413": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0098",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e96da7fbc7121c5fcada2bd43aff06a1",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.11932277679443",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.64370826236287",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000134369006709489",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999978233167",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.306052577208852",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e96da7fbc7121c5fcada2bd43aff06a1": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0098",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[42,-14,-12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:37f724585a89abe98ff9f20ca03e9884": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0099",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e1a4edce029a77b4f6d92ac5806a54ec",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.9436137676239",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.51902135936471",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000216570916963699",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999802529",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.411752007254358",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e1a4edce029a77b4f6d92ac5806a54ec": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0099",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[36,-8,-12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e12a986e485026e4d146b52ea34da3ea": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0100",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c2abbc2ce0ad122a6bc9709ad15207e7",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.55580520629883",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.9352264591963",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.15591423175155e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.997392444225686",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.150878854905596",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c2abbc2ce0ad122a6bc9709ad15207e7": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0100",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-16,-36,22]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b9372af04e7acfd4ce56135b4d0536af": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0101",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4f6cf46b76ce3e5bb2f7e9293eb4e52f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.55545139312744",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.93499985843019",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.15983725905456e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.997404409483695",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.150878854905596",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4f6cf46b76ce3e5bb2f7e9293eb4e52f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0101",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[32,4,46]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:48b80f9b9e00d0859755f74a197e7295": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0102",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:245f24faf67b8c0bed06e039441f3242",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.55117416381836",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.93225931513679",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.20756089468677e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.997545471779058",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.151725570321213",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:245f24faf67b8c0bed06e039441f3242": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0102",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-66,-38,20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:911d519f5928583e1f82ac51bab14528": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0103",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:5edd83cba07a9fb55a7f38bf2a36fdfe",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.53549385070801",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.92219382792662",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.38731790728397e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.998009069005951",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.155845230235465",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:5edd83cba07a9fb55a7f38bf2a36fdfe": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0103",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[40,-40,14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b35cc4339b958823a6b0d89e47050e64": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0104",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6326326bf38f1f521effe41a32bcff8c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.53285837173462",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.92049917786993",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.41828687672841e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.998079247810657",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.156454214178493",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6326326bf38f1f521effe41a32bcff8c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0104",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[6,-40,18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:98380d632dcdfa9a6e36fc6b78b2273c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0105",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ec5c657b1f38d62cf4afaa29e7f266c0",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.52961778640747",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.91841429412832",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.45667054541632e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.998162674504785",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.156835312141954",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ec5c657b1f38d62cf4afaa29e7f266c0": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0105",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[52,-68,16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:720ed23eb6c46a721179918c28f55ffc": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0106",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f824150295332ede014a54eca9b3e037",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.52500677108765",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.91544554806561",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.51187048494672e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.998276102661289",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.156835312141954",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f824150295332ede014a54eca9b3e037": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0106",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-48,-22,-10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:06f3fa5f5a7dd43a7c83878b6daecccd": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0107",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:2e1377b54d2ffed14f657fdcc448a72b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.48953676223755",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.89252279227539",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.96035879459233e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99896686399793",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.165823318703379",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:2e1377b54d2ffed14f657fdcc448a72b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0107",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[30,52,-4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:aeae6d15ef755bd8bf17831ae1de5a8b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0108",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:45a89c69b7ea6fbf25176dea9a058957",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.45128202438354",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.8676284436992",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.49494726368449e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999431806314623",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.177705345844304",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:45a89c69b7ea6fbf25176dea9a058957": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0108",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[30,-78,12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f1c37bc22f16214c1df5f88314a215a4": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0109",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e379fe3bb7b26ed85e05da7ee6813086",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.43969058990479",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.86004968799798",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.66819856246958e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999530645129751",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.180631808606791",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e379fe3bb7b26ed85e05da7ee6813086": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0109",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[56,34,-6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:bef3273cb030511d57da83b609f7288b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0110",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:03ef48e74c3406c59a104d33ec1ced06",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.43896007537842",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.8595715019443",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.67930097867819e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999536338351379",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.180631808606791",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:03ef48e74c3406c59a104d33ec1ced06": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0110",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-26,-94,2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:95ad202473a2bf127c7926f3746acacc": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0111",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:36d1028c68af6184089ce9aee42f9174",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.43468761444092",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.85677347172615",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.74467726958128e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999568445566068",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.182003342977838",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:36d1028c68af6184089ce9aee42f9174": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0111",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-4,2,42]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0fb6745b7885bc7a34cefdeb57f43c2f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0112",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:92cf7da97869a4b83347f08dbaa11faf",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.41122913360596",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.84136995866889",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.1174774538153e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999712443776799",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.188911373544714",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:92cf7da97869a4b83347f08dbaa11faf": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0112",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[10,-46,-10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:458c984a04e6737387c5f9f56e3c0c8a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0113",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d4a64a06c03e91cda9054bed710dca42",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.40113353729248",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.83471966710863",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.28537919565852e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999760079336093",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.192447078003389",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d4a64a06c03e91cda9054bed710dca42": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0113",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-56,-28,32]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:baeb0c03f7acf106a1287e421c2742f3": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0114",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:856a6c1dbdd8ced84613dc690fc7e35e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.8069314956665",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.41880668619853",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000314481969186486",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999891",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.512736471214834",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:856a6c1dbdd8ced84613dc690fc7e35e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0114",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-48,-26,38]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ca0839c16a1a2c559d6575777eda49c0": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0115",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d5aa0acf36e1fe500e1939ac94f4df6f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.3867974281311",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.82525392537983",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.53186827229701e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999815750636743",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.197194516669469",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d5aa0acf36e1fe500e1939ac94f4df6f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0115",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-4,-10,-12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8369fa28a67eb70b3c8346f78b861cd7": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0116",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6ed010c8390266e2a02334f0871efbc1",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.38070726394653",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.82122488004205",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.6395247973916e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999835706899974",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.199147137761087",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6ed010c8390266e2a02334f0871efbc1": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0116",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-12,-84,-42]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c9919f1aac8740808b218ad44f9721a0": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0117",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0bc5e8e1b5feb1cc5e112bc5d1f0486c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.37547636032104",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.81776053049529",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.73342723619408e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999851291705404",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.200454348633431",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0bc5e8e1b5feb1cc5e112bc5d1f0486c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0117",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-40,0,0]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8e304887e697a26945a0a355426f4603": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0118",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4035e3a3b521c5cf812810100219fc74",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.36677885055542",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.8119925842216",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.8925506726436e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999874314988424",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.203206123512965",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4035e3a3b521c5cf812810100219fc74": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0118",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-28,0,2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c94747cdbcb83041515a601d983f3b27": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0119",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0aaacb97d9578ab5bbd5b285599748af",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.35107517242432",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.80155384474342",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.18957405629883e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999907978180442",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.208513005623714",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0aaacb97d9578ab5bbd5b285599748af": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0119",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-50,2,38]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e42d96aae6a120678fb678c94074a5db": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0120",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ddc582eb09610fb7b7fc6c9c6c19e864",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.33398485183716",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.79015733594979",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.52759461690733e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999935243728569",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.215680526572575",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ddc582eb09610fb7b7fc6c9c6c19e864": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0120",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-18,20,-10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d358ade24a46e28d596c4d0af691488b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0121",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:725ad5ba6d7cd65f30acf71da2d71a0b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.32422828674316",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.78363433945477",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.72774207707938e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999947322155091",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.21884755438417",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:725ad5ba6d7cd65f30acf71da2d71a0b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0121",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-54,-44,58]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8756d972087f4144374fcbc8ae52666e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0122",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b5933bbb6136fc305b2604a8d7deab9e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.26067924499512",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.74084237095966",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "9.1702262191129e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999987705149813",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.242015591352726",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b5933bbb6136fc305b2604a8d7deab9e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0122",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-20,44,-4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a89e2e80fe4388ce0ae8d072fcec1ac6": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0123",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:1a5dc642a881d6f4e4d3829a697631ac",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.18645191192627",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.69017800075158",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000112048594444025",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999998281846379",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.278031328015723",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:1a5dc642a881d6f4e4d3829a697631ac": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0123",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-14,-32,-64]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ab27403976625180dff5b30fab548263": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0124",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:397f7e230bc5b14a56fc501c4f38a3df",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.18069553375244",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.6862176534993",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00011380585323062",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999854453826",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.28014402363808",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:397f7e230bc5b14a56fc501c4f38a3df": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0124",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[46,-54,14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:46ddcc1817cf540464c279f74a62d9e4": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0125",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b89df9a7d5311e01dec9a19aebb58fad",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.16153001785278",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.67299901881211",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000119860202107414",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999174595323",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.287520254070199",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b89df9a7d5311e01dec9a19aebb58fad": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0125",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-36,-14,-24]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:bf6a4e636ece08a9573e7b57d980d23f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0126",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c78fc1593491a390909bb0e0d1c8f4c9",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.16062259674072",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.67237190318196",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00012015480804084",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999196926834",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.287520254070199",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c78fc1593491a390909bb0e0d1c8f4c9": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0126",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[16,-28,-4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2eae7c427a5a98b75646c2db0e42ffd3": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0127",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ebe690e4d7b4a7281caa9b69d4aa561e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.14985752105713",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.66492347570236",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000123706274285817",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999422317975",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.29175084353581",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ebe690e4d7b4a7281caa9b69d4aa561e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0127",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-28,14,-32]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f175b4660b0c3a112517dde55ce65ffd": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0128",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e80844385b765c376df5c5195c77c748",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.14875411987305",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.66415911467327",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000124076245730076",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999441734682",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.292006151507083",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e80844385b765c376df5c5195c77c748": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0128",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-34,-66,-12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c82901e5c8a2f2e07c026cc63680c42d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0129",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a4d26902e57a81a17208a81e72853eac",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.14285278320312",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.66006819074182",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000126074068639181",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999535656409",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.294856542429919",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a4d26902e57a81a17208a81e72853eac": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0129",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-36,-36,18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5e05a6be8ed22422ff22c365a4608304": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0130",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:211422795d75783e69bfebe075bb12ba",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.13366317749023",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.65368808789982",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000129250133878323",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999653050959",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.299778606912797",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:211422795d75783e69bfebe075bb12ba": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0130",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[48,6,-26]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e7bdd69e98dd52520a3f71978bb4d63d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0131",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0ad970416204095c686c9e26a90dd497",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.13216829299927",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.65264911070072",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000129774394504789",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999669292985",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.299778606912797",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0ad970416204095c686c9e26a90dd497": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0131",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[0,-36,68]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:cb0d453b25f613101c49b7755e158915": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0132",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:bb9c71a13ba7d3c7720ba36a40323b94",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.12954187393188",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.65082293334618",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000130700706083675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999969612074",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.300282900918552",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:bb9c71a13ba7d3c7720ba36a40323b94": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0132",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[0,-66,-32]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5e99034ea754760cb72226c0515da7cb": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0133",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c9fab48eb480bedcc91578a2698fde0a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.75143074989319",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.3772657457694",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000366051410943258",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999997",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.557036851440628",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c9fab48eb480bedcc91578a2698fde0a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0133",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-2,-72,-40]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:129852f860cbdc380fde0cefe3342420": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0134",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:205eb48ed5250d88acfbba837645bb72",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.10398292541504",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.63300080119002",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00014007207404787",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999869876426",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.313079908458167",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:205eb48ed5250d88acfbba837645bb72": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0134",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-30,-80,-44]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b0ded885245f537f83463a08809ba2e2": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0135",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6f21e9e630f7c14252e29da5be8927f7",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.09423494338989",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.62617922203425",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000143822875420141",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999906977983",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.318311758000453",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6f21e9e630f7c14252e29da5be8927f7": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0135",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-18,-58,20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:22c1d4544f394d556ce159121dad1090": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0136",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:3e383b88dff3fd247a1d4f46b429f125",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.08876514434814",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.62234556566246",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000145971878909523",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999923179458",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.320746339887158",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3e383b88dff3fd247a1d4f46b429f125": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0136",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-16,58,-4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:547427e4ab366b57aeae32169e9fa826": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0137",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:2baf888e6359dbc3d2163775f4559d85",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.06298494338989",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.60421915672313",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0001565463954466",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999969751391",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.337066691036746",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:2baf888e6359dbc3d2163775f4559d85": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0137",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-58,-64,12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b237ed83cace8461fcea11375ea64058": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0138",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ff3ac071d67ebff33f35d13e2679dac7",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.02409505844116",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.57669340248228",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000173983947479694",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999993280169",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.362069612357364",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ff3ac071d67ebff33f35d13e2679dac7": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0138",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-52,-72,0]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:eb9870892ec73e0a42bedc835e702e1e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0139",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4cb8ea570ae8e3ce83375c59900097d2",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.02128601074219",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.5746966510118",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000175317095178373",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999994000907",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.363217717063605",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4cb8ea570ae8e3ce83375c59900097d2": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0139",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-12,-28,-36]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:fcfba481a3f9e7e9b20a26684a18708e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0140",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:63bfafc8fb101ba5e644b447c56092c7",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.01868104934692",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.57284393485473",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000176562616446385",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999994603219",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.36472959583602",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:63bfafc8fb101ba5e644b447c56092c7": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0140",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[16,66,8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4a44af96f5a5a857488581ee74a760c5": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0141",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:8f1c6e77c3ba88353c96f0c53e4a0f3a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.01162719726562",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.5678220431388",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000179980416080805",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999995959358",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.368705093303964",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:8f1c6e77c3ba88353c96f0c53e4a0f3a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0141",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[38,-18,-22]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:365c37bfef2c5372b568baf1a0e25c19": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0142",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c269becdf88d5e85bf338212a81d3460",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.00135660171509",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.56049691778852",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000185076828154274",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999997368965",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.373725297443398",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c269becdf88d5e85bf338212a81d3460": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0142",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-48,-80,4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9bdf6e301bc7d332bfc69fca7860e71a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0143",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:2b1b92ad42efe2e13047dd7960aa5a24",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.00135326385498",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.56049453464796",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000185078507948022",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999997369336",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.373725297443398",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:2b1b92ad42efe2e13047dd7960aa5a24": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0143",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-58,12,-8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f154380a3618d99fcc1963b7595b12cf": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0144",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:5c37f393fae5b3f0c9757bc853b9b56e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.99607825279236",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.55672625925588",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000187752539048236",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999997897124",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.376379972172505",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:5c37f393fae5b3f0c9757bc853b9b56e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0144",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-48,-76,38]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:04b3a6d25c6f054367f9c4694052a759": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0145",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4c62a1b7a4a99ebc81422f9ad84145a8",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.98602223396301",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.54953116356185",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000192958892207273",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999998637159",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.383480923686124",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4c62a1b7a4a99ebc81422f9ad84145a8": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0145",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[36,-82,-12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:21a5865dd670800228185cc04d8fc8fb": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0146",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:bc24ed4471eb7ddcb8c465323191fbb1",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.98011517524719",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.54529763503038",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000196084993860035",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999998948156",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.387269615473322",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:bc24ed4471eb7ddcb8c465323191fbb1": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0146",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[20,54,-8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c74a4087e267c6fd39be3a397e46725a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0147",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a66466e9c70651b2e5c633b33d19f5cf",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.96872425079346",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.5371191512089",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000202258563679281",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999936744",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.394063237507806",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a66466e9c70651b2e5c633b33d19f5cf": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0147",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-14,-94,-10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b7c5013ad25e77cc226834b99a8ce972": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0148",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:74c064010533901b8404367331895a48",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.95317459106445",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.5259233176632",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0002110045706335",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999690183",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.405666580848087",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:74c064010533901b8404367331895a48": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0148",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[24,42,24]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6991f89fa4a569360c7960b2846f6a34": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0149",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4d01562ba8e7aaef06d135d4e94692d7",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.95155644416809",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.52475614968874",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000211936393588741",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999712743",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.405953632826713",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4d01562ba8e7aaef06d135d4e94692d7": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0149",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[12,-40,54]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:491aedeeb6989cc87f18a592ce6034b8": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0150",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:10d3c6a7e17f15b5c99b849bce1f4e00",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.9356153011322",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.5132366181111",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000221341529396013",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999865451",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.417114555671981",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:10d3c6a7e17f15b5c99b849bce1f4e00": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0150",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-38,-42,40]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a0e32572643e1e64ce6a2b660df410a5": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0151",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:9aa3ceab97fdd6296ca2d454a99e0236",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.9238920211792",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.50474037295824",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000228526381680583",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999924203",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.426487116823797",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:9aa3ceab97fdd6296ca2d454a99e0236": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0151",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[26,14,-42]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:eff4c7c132b2d22a84606557001ce26e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0152",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:69acdcdb685d789931e1f31b3781c116",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.92273545265198",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.50390103236879",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000229247859657944",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999928429",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.426958547295112",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:69acdcdb685d789931e1f31b3781c116": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0152",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[70,-14,-16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:bbf3d38beafaa3b95e5b56928a96bf1c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0153",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:8d526269d332e0c02c7b75355485d2f8",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.92078685760498",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.50248644225283",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000230468620522117",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999935043",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.428151423127615",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:8d526269d332e0c02c7b75355485d2f8": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0153",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[34,-76,-48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:fde7e62b6e5574c052bb9f546102d87e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0154",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:44da668a7172bf8e300266f277be8526",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.91062116622925",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.49509717797378",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000236944590689236",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999996108",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.436321106791799",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:44da668a7172bf8e300266f277be8526": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0154",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-6,-28,-38]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:fd29863328da8f073c80249fc257f355": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0155",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:986f6d2591d738e2cadb54b471af94af",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.58703351020813",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.25118905074874",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000574617057569893",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.726302359446116",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:986f6d2591d738e2cadb54b471af94af": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0155",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[0,-34,-38]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:bbfd8b6cf217d559db130a9610ba08e1": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0156",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:924ee8942f43f143db4d35b4c58fba9b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.90419101715088",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.49041501158993",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000241135489868927",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999972007",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.441724604413149",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:924ee8942f43f143db4d35b4c58fba9b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0156",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-38,-32,-20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7b9ad2de6142a99edfdc041b3923c4a7": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0157",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:436e822866e4609faf1e3f52f35d390a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.89783668518066",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.48578178709346",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00024535055301822",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999979874",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.446520868052966",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:436e822866e4609faf1e3f52f35d390a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0157",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-16,-60,-40]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:22f96a3b44837b69cbbf8a2c6235393c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0158",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f0873eb65c77e400ce4652d1321fd7dc",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.89488410949707",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.48362680959561",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000247334358895901",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999998276",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.448724783299707",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f0873eb65c77e400ce4652d1321fd7dc": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0158",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[22,-6,36]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4acde4458913098e4ee4d1c2c2fdf3e4": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0159",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ef2dcb6bf4f5fa6a95e35be037823273",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.88967633247375",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.47982255115638",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000250872994247642",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999986909",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.452045143743209",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ef2dcb6bf4f5fa6a95e35be037823273": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0159",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[70,-18,22]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d0a5abfdb9ce4fbd61ff9387b7bb7058": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0160",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ede966d1838252b4a610f64fcfdc2cde",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.88418507575989",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.47580665261676",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000254659668458612",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999990239",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.454152699790317",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ede966d1838252b4a610f64fcfdc2cde": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0160",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[30,2,6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8eb9d8849b7d8b35f84629d662d9ddce": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0161",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7074e885282a279bde925ee7cac8966c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.86606097221375",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.4625186718634",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000267572390954318",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999996381",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.470059115371888",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7074e885282a279bde925ee7cac8966c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0161",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[44,-70,10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b9ada525c8e48deb5d4ab2d7359c8cad": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0162",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:3c562f99bbe0809e80e32866c3fb4ddc",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.86296033859253",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.46024024384584",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00026984682439557",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999996958",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.472530207119252",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3c562f99bbe0809e80e32866c3fb4ddc": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0162",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[62,14,2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3858cf13f28f0ad56deb178e3014e96c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0163",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:be16a855a7da7e7571099f7d7fadf88b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.8599865436554",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.45805360223286",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000272046559771755",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999997427",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.474088026751007",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:be16a855a7da7e7571099f7d7fadf88b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0163",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-4,-36,-2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1112b9b2a26ffc98a6ff69fd57530f89": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0164",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:46892ae833db38c9bed091f4cc572d1f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.84141182899475",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.4443640186187",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000286202240919464",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999116",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.488513754339778",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:46892ae833db38c9bed091f4cc572d1f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0164",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[36,-86,0]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:774e14320ea8f360c6b0c85dfac5a6f6": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0165",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6cda172da941b8967efdbea8200c7c74",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.83968877792358",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.44309136368839",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000287552494602217",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999202",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.488629379902393",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6cda172da941b8967efdbea8200c7c74": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0165",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-22,-20,-8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:47ddc4f29769c51faebf4ea324bcbea6": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0166",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:710d166e9d667b62c67e8a53f8271d18",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.82990407943726",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.43585539262748",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000295343082936661",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999554",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.497538796190216",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:710d166e9d667b62c67e8a53f8271d18": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0166",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[28,10,-48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:294213488c1599f884797c81cb836c26": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0167",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6367c8833a918270dfd9c8b1b40ca341",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.82795763015747",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.43441413993503",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000296918082366093",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999603",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.498296237103169",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6367c8833a918270dfd9c8b1b40ca341": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0167",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[66,-50,8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5ef57e2d25150bc6ea7a27effd3f103a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0168",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:57e37097f19962e578c75dbc7bf9fd63",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.8172779083252",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.42649555500792",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000305711884475035",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999793",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.506379555477876",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:57e37097f19962e578c75dbc7bf9fd63": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0168",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[4,10,-12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0d6879c706d432096efe8532fec772d4": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0169",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:9edfb7145b03634fe426e3cb3a1f8f31",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.81648898124695",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.42590987377981",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000306371831813368",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999803",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.506469617613673",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:9edfb7145b03634fe426e3cb3a1f8f31": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0169",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-30,-76,14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ab5b8f7ed76dff5e4855a5dd6e0a6743": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0170",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4b10b660ac7ce0aa32872c923c9c69e9",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.81299877166748",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.42331762603938",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000309308734253833",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999841",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.507710079712136",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4b10b660ac7ce0aa32872c923c9c69e9": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0170",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-56,-18,36]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:764e3cd68a4e95df65e0a1e502bbd0d3": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0171",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7079336242f83a28182be4daca622d5b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.8037748336792",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.41645740843357",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000317207934866337",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999911",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.514664695786681",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7079336242f83a28182be4daca622d5b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0171",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-34,30,44]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:75596cb1506d72be9c60a786cdfeb9e9": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0172",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:dcdaa5f8f83360bc6ccfa19fcc3afbe8",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.80352520942688",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.41627156249268",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00031742451522887",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999912",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.514664695786681",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:dcdaa5f8f83360bc6ccfa19fcc3afbe8": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0172",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[18,-78,16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:cc61bb9a0e1e912d0243c40937af6d28": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0173",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:43baf4b4f25319c4535a3067412de7c0",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.79121017456055",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.40709049802208",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000328296763804747",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999999996",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.524856123968262",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:43baf4b4f25319c4535a3067412de7c0": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0173",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[52,-8,52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:32de098d3053799d0fc2c5c953ee1d3c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0174",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f56888b381f2199a57eb6f32e1b76c94",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.79016637802124",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.40631120271348",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000329235375377435",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999963",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.525348401881072",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f56888b381f2199a57eb6f32e1b76c94": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0174",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-38,-20,-18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:459d474e17bd85aec6efe07624d6ae57": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0175",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:8482429c259a3f7b13d44a7131b80d39",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.78082299232483",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.39932758559063",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000337758775393771",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999999998",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.533091122666778",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:8482429c259a3f7b13d44a7131b80d39": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0175",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-64,-16,34]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3510b1f1d6805ff05bb7b6b5d36253fa": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0176",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f5066157a094cacabacac8bdb14ecf29",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.775071144104",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.39502136510282",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000343116226298679",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999986",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.538899956377297",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f5066157a094cacabacac8bdb14ecf29": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0176",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-6,64,24]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5bf7e5d9bb601821a72345c87cedd51c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0177",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ff6a8ac356b1fcdc3ba1e0677b07ef35",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.77039766311646",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.39151850905751",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000347532341239631",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999999999",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.541509095101857",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ff6a8ac356b1fcdc3ba1e0677b07ef35": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0177",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[12,-86,2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b691067d61784029be138ffa1686adb8": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0178",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ccbf47d9d1d8eec7a8d44dfb17daf242",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.76804852485657",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.38975644066078",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000349773728989367",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999991",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.542836741004494",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ccbf47d9d1d8eec7a8d44dfb17daf242": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0178",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[56,-56,4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b2e8f0a888997bba7bfdd9f220a34d7c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0179",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:82e8ec11f93f733e88d5f02ce475eb3a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.76583623886108",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.38809619826667",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000351897876951224",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999993",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.544688226103431",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:82e8ec11f93f733e88d5f02ce475eb3a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0179",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[30,-10,-22]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:db0d54b000c98e5dee79f930e669b285": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0180",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:68a3e5e2e053a83eaa1d9e2d1081aee6",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.75574827194214",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.380515360821",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000361750154451945",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999996",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.55496612223741",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:68a3e5e2e053a83eaa1d9e2d1081aee6": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0180",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-26,22,60]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:79e2013c8aa62a779d24f56c4f7d2b61": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0181",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6ce596eae40f92939ac779652c7de352",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.75386500358582",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.37909828240956",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000363620022447164",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999997",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.55578840663352",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6ce596eae40f92939ac779652c7de352": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0181",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[8,-92,26]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:36d4e5984e645e3739eafcddd636c2a0": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0182",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6a73634a41988180ea6cdf81a21e10fd",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.74783110618591",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.37455409826951",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000369676911683547",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999998",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.559414929313896",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6a73634a41988180ea6cdf81a21e10fd": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0182",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-44,-10,-38]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ee94413a615c0ae8d638fa74a0954f38": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0183",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6d6ca80aef4904d97475b3a1a85fb36f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.73827314376831",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.36734359778017",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000379480313921432",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999999",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.568714691324852",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6d6ca80aef4904d97475b3a1a85fb36f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0183",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[32,4,8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c4ca487861e26bb6edf9d460b8c438f5": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0184",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a984ff9c1bc463c5305396b634b896d7",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.73499631881714",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.36486808622606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000382901311427597",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999999",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.57046827086113",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a984ff9c1bc463c5305396b634b896d7": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0184",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-12,-60,-28]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:74d29ddfa219f7865899d3e1aa985fad": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0185",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:862ab06c53bf7580c82758f3c5e05d0c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.71396541595459",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.34893751145887",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000405610447892446",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.593900566305716",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:862ab06c53bf7580c82758f3c5e05d0c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0185",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[26,-8,12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:02ee73aa72ad228b43c68c9f025c92c9": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0186",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:8454dc655bb35ba99f3dba0346e7316c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.71342253684998",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.34852531049968",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000406214298471763",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.593900566305716",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:8454dc655bb35ba99f3dba0346e7316c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0186",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[20,-26,14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5148a355763840d52c51745baf6d8bf1": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0187",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:022b93a52530966eb78075d6eac6ecea",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.71231603622437",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.34768500611999",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000407447880153899",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.594555117771048",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:022b93a52530966eb78075d6eac6ecea": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0187",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[8,8,44]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0799198166c4e4ec859a6d6486f90093": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0188",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:566b1ae67509d41808fda40621ca7b61",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.71084380149841",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.34656663561433",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00040909505954867",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.595665947803054",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:566b1ae67509d41808fda40621ca7b61": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0188",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-28,4,-42]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0aa10d875c9c1e35c96e247e10de57ee": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0189",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f4b96ff42be70bb2b09861757cb97da1",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.69969868659973",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.3380885246229",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00042178434593132",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.607485135007791",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f4b96ff42be70bb2b09861757cb97da1": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0189",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[22,-6,-34]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:df286e546b49998eef6184d9ae67818c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0190",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:40abce439058cc82f5d725ab26b39a04",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.69548296928406",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.33487616330673",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00042668696793946",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.610645919300431",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:40abce439058cc82f5d725ab26b39a04": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0190",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[26,46,4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b5c652713f89d13b86856e3329e60e97": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0191",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:12a1b45b727c26d17ba943ca60c4c0bd",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.68579792976379",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.32748481106661",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000438168831523034",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.620072204467785",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:12a1b45b727c26d17ba943ca60c4c0bd": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0191",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-18,-16,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:89124d4a55465ecc6580a87278eb8730": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0192",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:51cc533c8467f20d1155ffc22498abf5",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.68518376350403",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.32701556031273",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000438907358197516",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.620072204467785",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:51cc533c8467f20d1155ffc22498abf5": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0192",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-12,38,58]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7c0c361d425385fbaf81e45ac15b1add": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0193",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:8196fd95c6f6da2498153caebca81a9e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.68469381332397",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.32664117032322",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000439497416485524",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.620072204467785",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:8196fd95c6f6da2498153caebca81a9e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0193",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-20,-2,56]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a27efb8e81003403a3b728b02a0305de": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0194",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:56df4db7d539ca39549ce15b7ea50f31",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.68345642089844",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.32569544910563",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000440991199531338",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.620678594375276",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:56df4db7d539ca39549ce15b7ea50f31": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0194",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-52,28,12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f6c9002f2a33bbdcf918614062da93d1": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0195",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:51195bf8976356008123f14dcc2b8de5",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.67815756797791",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.32164266737708",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000447446096799475",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.624850402893793",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:51195bf8976356008123f14dcc2b8de5": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0195",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[22,20,-18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:273a08beef0cdedfcbf83ba358d17b4a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0196",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:bee076b1ef81a577daaacaa7c437434e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.67246556282043",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.31728385777887",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00045448607795473",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.630238922827796",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:bee076b1ef81a577daaacaa7c437434e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0196",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-16,56,-10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b8d737b346f350b24c46e795748e22fb": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0197",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f381a9b3ecc4a18b9ce6ca29376c4ff2",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.67176198959351",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.31674469325952",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00045536398943602",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.630238922827796",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f381a9b3ecc4a18b9ce6ca29376c4ff2": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0197",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-54,-22,60]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b628b10379f38e68ed5b66c336b27ce3": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0198",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4a3e07338e224062c86a093f897dd586",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.6656653881073",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.31206918161529",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000463043207802327",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.636780442381221",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4a3e07338e224062c86a093f897dd586": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0198",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[12,-26,32]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:73de5af689e2e854fa7db73a7b08e0fe": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0199",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ebdbc5b2e4abb9eaa379c70ec8dcde1e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.66424226760864",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.3109768679857",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000464854468121723",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.637917502965391",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ebdbc5b2e4abb9eaa379c70ec8dcde1e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0199",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-54,-26,20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b0085be54d5b554caf5c0c60d9943ca3": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0200",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:18a86448a493c980c8799ef2fa49927e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.65446782112122",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.30346511601015",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000477489250152452",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.649479872404913",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:18a86448a493c980c8799ef2fa49927e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0200",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[28,-26,54]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f9e69d234f36d1d73224b4a30b59f7dc": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0201",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:83afb4d3fe181c770288664feec0e8eb",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.65308904647827",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.30240419282363",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000479299143653966",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.650580107543262",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:83afb4d3fe181c770288664feec0e8eb": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0201",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[56,-12,-34]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:fdaaf45a96ab001df01c3f32cad6f0d5": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0202",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:1ab0b084d0c745086441303217bfb06a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.65141272544861",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.30111387597635",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000481508936725383",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.652085475027948",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:1ab0b084d0c745086441303217bfb06a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0202",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-32,-26,26]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:802d2977df694ebb8aa91513a51f9d09": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0203",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:efc63a148d5261c31e0939091f77ceaa",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.64412999153137",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.2955024977544",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000491229150587746",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.660471475830505",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:efc63a148d5261c31e0939091f77ceaa": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0203",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[62,-42,32]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:cd20eea678913bcc90beb6f06a1cd190": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0204",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c2889d3d5127c29f90b0ada1c993e777",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.64054799079895",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.29273918630896",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000496082327765768",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.664365976163986",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c2889d3d5127c29f90b0ada1c993e777": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0204",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-50,-34,18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:edf7c2638a60e524d92e073751527602": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0205",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:16fc3bf39c860621c7aea2f02a4dac4d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.64017224311829",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.29244918940118",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000496594212155088",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.664365976163986",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:16fc3bf39c860621c7aea2f02a4dac4d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0205",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-42,-28,2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b1acd578e7fa991204c8a410a3717560": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0206",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b25042964be10a1a50bf593da017ad14",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.63664436340332",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.28972522633498",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00050142630710126",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.668465061469917",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b25042964be10a1a50bf593da017ad14": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0206",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-12,-8,-20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:494d32a46900ee1bd2a49c4de9617108": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0207",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:2aa7ecf6ebf03a10e3d10e470e617211",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.63564610481262",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.28895405423442",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00050280219001142",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.669072337143437",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:2aa7ecf6ebf03a10e3d10e470e617211": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0207",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-30,50,-6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:16a6a4016277da6cf913ef3b2c7113db": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0208",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:416a43460ad683e7fc9bd2dc7f3d33fa",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.63432455062866",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.28793286446379",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000504629519068156",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.670129672801443",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:416a43460ad683e7fc9bd2dc7f3d33fa": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0208",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[62,6,20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5d0442cdaea493ca10a242a8af6b8b02": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0209",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:57429efabfe0638de627a0c651d9d52b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.63211607933044",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.2862256597491",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000507698146165469",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.672158308361536",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:57429efabfe0638de627a0c651d9d52b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0209",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-24,4,26]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d32c29e6c832599417bd8574e70ffe47": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0210",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f736a09b34c0dc25a9d0e7be843d9c96",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.63174819946289",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.28594119681201",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000508211131676539",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.672158308361536",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f736a09b34c0dc25a9d0e7be843d9c96": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0210",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-8,-90,-30]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1da4e83fb9b216cfbd49324f411b7060": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0211",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:9dfaa6f7572bbd0cf40dbfceb5ffab83",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.62799787521362",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.28303991621965",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00051347061762641",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.676617003024309",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:9dfaa6f7572bbd0cf40dbfceb5ffab83": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0211",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-60,-38,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d4fa6966b630445b57a0f19116a3daed": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0212",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:dfc9b625f7263d322b56af38f35b9481",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.6240873336792",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.28001207990403",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000519013209931529",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.680244967613049",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:dfc9b625f7263d322b56af38f35b9481": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0212",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[22,34,-4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ad65b31051a0c3ef755cdd2741ae415f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0213",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:82ffc6dfc401537ce52185c43cfcf147",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.62374401092529",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.2797461261145",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000519502686150974",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.680244967613049",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:82ffc6dfc401537ce52185c43cfcf147": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0213",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[46,-58,-18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5c492afc637552d22a37d356b892476b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0214",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ab90c63f449b003e4d791be7e3d0e800",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.62238955497742",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.27869670069254",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000521438278593522",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.681370246579141",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ab90c63f449b003e4d791be7e3d0e800": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0214",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-18,62,26]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f6cd2c4025ec944fe9fad4a68eeb76c3": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0215",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:edf4f82f106c671bdef81e84a01b9486",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.6151659488678",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.27309447054155",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000531884583176545",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.690041088084649",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:edf4f82f106c671bdef81e84a01b9486": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0215",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[66,-30,8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b076644097262f402af618f0521f3c6f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0216",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d46c39edd8f989ed016fc63e4e532951",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.60937356948853",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.2685956145544",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000540413261609474",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.697552180185497",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d46c39edd8f989ed016fc63e4e532951": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0216",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-10,-18,-42]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:cf314ff0f3be99903935c1888a63ccdc": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0217",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b27a4f7ac8e1c0c6c2cef33e18a16762",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.60362911224365",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.26412815526814",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000549007436707605",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.704264807188576",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b27a4f7ac8e1c0c6c2cef33e18a16762": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0217",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[32,-36,-6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:653a08ed610a534c1cf43ad67b874319": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0218",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:fef07c2b8aea1136621b0fce4d8e22f4",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.5972752571106",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.25917999430208",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000558673768633722",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.712747532197775",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:fef07c2b8aea1136621b0fce4d8e22f4": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0218",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[52,-2,40]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7132d322b3cc936428996208440f96f6": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0219",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:92f24ae50520920d9d40e416007b7466",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.58600521087646",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.25038571079181",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000576242907006641",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.727015038116334",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:92f24ae50520920d9d40e416007b7466": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0219",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[14,6,62]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0640d1c27d97d1f42ae25c516d60eb0c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0220",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:94f679f4fb0174f6de4275cf2933e45d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.58496069908142",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.24956951283845",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00057789913282269",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.727753479695118",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:94f679f4fb0174f6de4275cf2933e45d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0220",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[48,-68,-22]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:443881374484db2a28a772aefb17c81f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0221",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:abfaa93e10cd4e067aec5cce0e6988af",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.57942819595337",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.24524309204834",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00058675199606395",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.732763098510088",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:abfaa93e10cd4e067aec5cce0e6988af": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0221",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[44,6,54]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:cdca9d1394769421f403ff2c2b85319d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0222",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:af2e01b40163257b4d36aca790b9bdea",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.57787442207336",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.24402705959498",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00058926274833293",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.733379048702781",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:af2e01b40163257b4d36aca790b9bdea": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0222",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-52,-36,32]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2f89f4ddc37f465398449ec427aef8f4": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0223",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6ca8f9ce9b937a2e0b96c22dfdcf588f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.57743859291077",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.24368588864821",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000589968948020769",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.733379048702781",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6ca8f9ce9b937a2e0b96c22dfdcf588f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0223",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-40,-14,-10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:cce527c4d5173264fd0ba76367f83931": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0224",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:5f4ae25fe5269d66ca447679a1db8171",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.57096195220947",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.23861192072534",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000600564422457928",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.742283339420037",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:5f4ae25fe5269d66ca447679a1db8171": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0224",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[24,38,40]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f59eaee6cc14a37ee302a26deccb5ba8": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0225",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:df0c9b42ffecb2d8ebc2d1d89f566469",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.57036733627319",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.23814570748812",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000601546736720304",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.742311455927918",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:df0c9b42ffecb2d8ebc2d1d89f566469": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0225",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-56,8,-26]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:cbdb1c804f7d0ec340e49acbe0f59365": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0226",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b501cb0bebb39347ca92fbcfc86d2801",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.56984972953796",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.23773982240894",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000602403147547781",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.742311455927918",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b501cb0bebb39347ca92fbcfc86d2801": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0226",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-46,-76,-8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e99c458abc0e31d64f6dc46f9eb3ba86": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0227",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e87776fe0defb58e096d6889e9628b08",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.56818604469299",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.23643490706068",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000605164134718339",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.744019467604621",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e87776fe0defb58e096d6889e9628b08": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0227",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[16,40,20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ed39a62270a751bff5d29b2e4c49e7f8": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0228",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:013cdc8bc7bd75dd13e53be4e70de1e7",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.56333160400391",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.23262447936818",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000613293417818239",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.748959368128923",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:013cdc8bc7bd75dd13e53be4e70de1e7": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0228",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[48,-28,22]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b97a5c6fcb6a02f68a6fadc9cf02ba98": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0229",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:42ba35106dcd2141347921bd860ffc4f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.56151604652405",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.23119829562355",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000616361933964638",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.750918681283957",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:42ba35106dcd2141347921bd860ffc4f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0229",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[6,10,34]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3fc6abca83add3e6e871c4ba13db90d8": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0230",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:8f5014db8d06c5cb5b713b4c5644456b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.55326652526855",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.22471054262134",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000630500477415308",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.758661956634776",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:8f5014db8d06c5cb5b713b4c5644456b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0230",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[54,-46,46]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:73ff07955917113509745f126dd5bd76": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0231",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b4367bc8834e232852e1f229303575de",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.53535223007202",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.21057969685079",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000662337649990907",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.782699957189858",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b4367bc8834e232852e1f229303575de": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0231",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-60,-30,22]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3a2f1d64a861856a52cc3fa9969bc2b0": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0232",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:35d050255e7913d2871e399b6466dd0b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.53448247909546",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.20989215326664",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000663923910754316",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.783230703782876",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:35d050255e7913d2871e399b6466dd0b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0232",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-46,24,-36]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:aef2a2aecfbeec0007f227032d3cef74": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0233",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7db42b1f6fa6ef9bdf3710cab7dd6378",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.52919697761536",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.20571096990557",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000673646212453916",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.790008451230221",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7db42b1f6fa6ef9bdf3710cab7dd6378": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0233",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[18,-84,-44]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:98a88c543aab0179b9f3e245882a9203": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0234",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:640fa10a58203760c34949fdbdd4513a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.52617359161377",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.2033169804895",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000679271799107761",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.794036522733694",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:640fa10a58203760c34949fdbdd4513a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0234",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[20,-38,-52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3cec9a1c9417800f3a247e3023d0f1cb": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0235",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6343fb8cffbbeab720d14fffd9e903dd",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.52416038513184",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.20172194962906",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000683043949932127",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.796437366060161",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6343fb8cffbbeab720d14fffd9e903dd": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0235",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[58,12,24]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a7e2dfc487d0a70d1149fdf1efb30d4c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0236",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6a152f1146f43c017dc68ab8324ec605",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.51774144172668",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.19663137427302",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000695212465446571",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.806071113207381",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6a152f1146f43c017dc68ab8324ec605": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0236",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[54,-52,26]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0528a1b646839dcdd2fb0bb16a07223d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0237",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4d047343b5b28834cf69c72f874e638d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.51371550559998",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.1934347318076",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000702955576802444",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.811837038292354",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4d047343b5b28834cf69c72f874e638d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0237",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[34,12,30]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9143f6e13fe4ee9fe42fac2f81f2e676": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0238",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:9077c71eee98aae8008376a8ed7b9b4a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.50933194160461",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.18995074240404",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000711485225238007",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.818238642626287",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:9077c71eee98aae8008376a8ed7b9b4a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0238",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[62,-40,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f5a857ae39046f3db5dec63a77684c88": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0239",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6ffc03184a2b6a40feae78bfa7efbfeb",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.50692367553711",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.18803518455038",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000716215526890496",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.821370946387423",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6ffc03184a2b6a40feae78bfa7efbfeb": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0239",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[22,20,36]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c3c44bb5597ea19a830120e15048bdfc": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0240",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:2ba4588b7d24368c21cef645f387e746",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.50429320335388",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.18594166053569",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000721418444738164",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.824888687870713",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:2ba4588b7d24368c21cef645f387e746": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0240",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[0,-34,28]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a85791f58de3fb579b6358c661ed5fa2": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0241",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:573674c8cee6088a030e40b5687fd66a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.50173401832581",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.18390364686918",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00072651685008529",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.828300523267217",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:573674c8cee6088a030e40b5687fd66a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0241",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[8,54,24]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0a7bb31878e22554cbc54493045e8d7d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0242",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:cdd8504c583ff46d7c8a7b3108bd3b78",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.50026345252991",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.18273201070653",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000729462891188581",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.828979444161694",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:cdd8504c583ff46d7c8a7b3108bd3b78": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0242",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-30,-26,-30]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c5d06f34a6464f6267e87ac23872ca2e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0243",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:3599d615ec8b933bd560ca5eb76b7f21",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.49797105789185",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.18090480576431",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000734079319294478",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.831956387035011",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3599d615ec8b933bd560ca5eb76b7f21": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0243",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-42,14,-32]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:af68b1cc579ac5658c4a2293d9579639": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0244",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:19f62681d85fd0553b734d7b621b76c3",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.49039101600647",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.17485603225285",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000749554293693833",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.843983114081373",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:19f62681d85fd0553b734d7b621b76c3": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0244",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[38,20,-44]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:77af4bcf04d46e852b0206ce06555bc3": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0245",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:13a5242219aba3ab609f497a0343d2e9",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.48954701423645",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.17418187045752",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000751297535500295",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.84451741403903",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:13a5242219aba3ab609f497a0343d2e9": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0245",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-6,-16,-30]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ac4cc325bba6dd74902e4bedc227ea4d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0246",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0c0cf4fe47307d156cf82ba69ae5886e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.48527431488037",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.1707669420392",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00076018534619382",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.850048157107863",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0c0cf4fe47307d156cf82ba69ae5886e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0246",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[48,-44,-14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8bd2069b941164ec318034e819fbd415": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0247",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d9c9d3dee1810cae464cf215a3f5fe75",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.47563886642456",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.16305338543499",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000780618494857888",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.865926190191015",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d9c9d3dee1810cae464cf215a3f5fe75": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0247",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-54,8,-16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:60851992aa4e11f85611dcd9fc54b154": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0248",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:088ffb09b5d95f1915e71e6abafa1edd",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.47256183624268",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.1605864476201",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000787259372072469",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.870414106789922",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:088ffb09b5d95f1915e71e6abafa1edd": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0248",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-18,-18,-44]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e1653eb5a2319fdfa378634babb879b4": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0249",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:54ec63f77daa9a18ff3b8c3a72842a9e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.45146727561951",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.14362649041421",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000834341399658656",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.904541913018706",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:54ec63f77daa9a18ff3b8c3a72842a9e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0249",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[28,-82,-26]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d78c9899bc897947e0449b5b9372058c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0250",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:78b19072340e7131009e1d60e6925937",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.4509379863739",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.14319986465702",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000835558468664344",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.904541913018706",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:78b19072340e7131009e1d60e6925937": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0250",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[24,52,6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d36696cd084e014fe3b461011d62026c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0251",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:2f3a040be26b69350ee6668f1e953585",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.44921636581421",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.14181181124074",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000839529589309329",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.905753908911515",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:2f3a040be26b69350ee6668f1e953585": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0251",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-4,-48,-44]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c7e89f2bfb5ebb96c9943bcc727e584b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0252",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:05d9b2e1c39a81ce187b6175e51fc747",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.4477481842041",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.14062764913883",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000842931107996825",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.907476465657815",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:05d9b2e1c39a81ce187b6175e51fc747": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0252",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-18,52,-6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:abcb021cf3e7d4a1923c3e650e8f646d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0253",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c4ad197d4d9f82b6dd8bb207c1a7e8e4",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.44230937957764",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.13623741912434",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000855653022884484",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.915554421234191",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c4ad197d4d9f82b6dd8bb207c1a7e8e4": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0253",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-22,12,-26]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:798c8ad3bf29b7e6a1599d243c811ef4": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0254",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:dc041c3c37fe0c0edd7ce9841a6c74c1",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.43941974639893",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.13390260786598",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000862490493106716",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.919935328973706",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:dc041c3c37fe0c0edd7ce9841a6c74c1": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0254",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[46,-30,-6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:188e8be049871fa65f8fc1d3fd94eeea": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0255",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:241b86464efb064f25917d09147c860f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.43677449226379",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.13176386125168",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000868797847718428",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.923879718713014",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:241b86464efb064f25917d09147c860f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0255",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-20,28,8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:bd959eb0d068217ced11fd9423305a37": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0256",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:9f5778ddf03c3b5ff73110a18039e5d3",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.43498468399048",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.13031600570198",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000873091748155641",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.926238520156328",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:9f5778ddf03c3b5ff73110a18039e5d3": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0256",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[40,-70,34]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:bb3156da7e40e4feec485af3e6a32ecd": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0257",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:13eaebbb8058068078e2c653b9875caa",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.43085432052612",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.12697243929315",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000883082416866077",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.933001754616948",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:13eaebbb8058068078e2c653b9875caa": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0257",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[44,-38,-6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f8e25bc4e933ed306f46968cead64492": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0258",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a03239e65a180276f5a134d7c3ec3985",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.42879891395569",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.12530735529034",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000888096838085106",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.935884446603093",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a03239e65a180276f5a134d7c3ec3985": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0258",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[52,-6,8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b80c331bc3c013d36540ed2209e180ac": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0259",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:71fc6bdf3b69205367a0010060b137b5",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.42553544044495",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.12266195704485",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000896117338800573",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.939451992103697",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:71fc6bdf3b69205367a0010060b137b5": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0259",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[54,-72,8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4deb8dc19d6af02360fbd76e432ce8b6": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0260",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b5082c06f45ce0a2dd15d81971c68d59",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.42464590072632",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.12194053531123",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000898316119580023",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.939451992103697",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b5082c06f45ce0a2dd15d81971c68d59": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0260",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-34,-86,12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ed4d3b7d5ccc140dfba860cdd388e8ce": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0261",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:06c7a2471791b84ae3c6a36937e0e8a0",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.42428636550903",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.12164890720699",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00089920636307117",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.939451992103697",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:06c7a2471791b84ae3c6a36937e0e8a0": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0261",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-4,10,-10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b7f899e5f3760319ce8ccef45e585946": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0262",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:1a7b22ad02fe7ed75c7738a5f7ac0c62",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.4242856502533",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.12164832702029",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000899208134995888",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.939451992103697",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:1a7b22ad02fe7ed75c7738a5f7ac0c62": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0262",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-66,-32,16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:30b82d808ecbca165129f91f15eeb7d8": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0263",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:08f17e7b0d90c8d55cce1d84356b89c1",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.42256450653076",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.12025192043597",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000903482154968605",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.94172231450196",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:08f17e7b0d90c8d55cce1d84356b89c1": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0263",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-6,10,6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c0b355fc51e7cd26f5f72e9f5c550472": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0264",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4e1ed2f0db8b7a4f4d7af0bb70e715a4",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.420490026474",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.11856808830486",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000908660733561772",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.943981476602879",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4e1ed2f0db8b7a4f4d7af0bb70e715a4": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0264",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[60,22,28]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a2e099d5d8ff7d6205bb133cc5078448": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0265",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a95381a6790d557cf86a8873e91a0071",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.42032909393311",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.11843742665399",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000909063718098957",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.943981476602879",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a95381a6790d557cf86a8873e91a0071": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0265",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[6,48,-18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:cc1877ba95e403c226eac44d78215696": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0266",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f2e91580aedfda1661c00346dcfdf4a4",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.41344952583313",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.11284722900141",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000926459524586143",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.956145916250816",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f2e91580aedfda1661c00346dcfdf4a4": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0266",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[30,-66,-4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c1b25d75e61e613c55029c674539f77a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0267",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d1aefdaa8c182ce454467dd1278dd001",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.41180443763733",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.11150911429397",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00093066864036262",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.958308660309721",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d1aefdaa8c182ce454467dd1278dd001": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0267",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[62,18,8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:dd0f126c27f7ac1f0c10fd12e39bf105": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0268",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:da274ebc3923f39c33998c996c5f1b48",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.4099760055542",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.11002125556328",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000935369406583231",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.960830954574892",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:da274ebc3923f39c33998c996c5f1b48": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0268",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[22,40,38]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c91264646d693326daa65c4e49da790c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0269",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4b8ff43a5a20f4afeed513550c9779d1",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.40772676467896",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.10819008533752",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000941184775066772",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.964175735240494",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4b8ff43a5a20f4afeed513550c9779d1": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0269",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-12,-74,-32]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:85a9c11ba54c056a1c94ef036e48c7e8": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0270",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:98db87a6e1ff03f144dc1294bd88361c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.40043520927429",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.10224710205524",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000960287852612818",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.977387221974707",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:98db87a6e1ff03f144dc1294bd88361c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0270",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[36,12,8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:80417a00361d173f5c5af02c203f269c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0271",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:9ae3231161e4fa13633730f1e4660a9a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.39929604530334",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.10131769657828",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000963307318207596",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.978600787160336",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:9ae3231161e4fa13633730f1e4660a9a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0271",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[34,-64,-54]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f44f60b309d98b4839df00ce58c954d3": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0272",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c0904438f742cbf33d8af23df92769ae",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.39674377441406",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.09923447115328",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000970107026972977",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.982601015041391",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c0904438f742cbf33d8af23df92769ae": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0272",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-6,22,14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:cb93650662489dd0d5315baef5339a8f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0273",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0af8678dbadc97c6d0964c0f0dea2c02",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.39575552940369",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.09842750203846",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00097275281871112",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.983523861304105",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0af8678dbadc97c6d0964c0f0dea2c02": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0273",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[40,-70,6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8f4b30cf80d927285653473f8c169306": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0274",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:9d40e288714ed88d103be79dc9b0b58b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.39392924308777",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.09693571606088",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000977661355603399",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.986105717216079",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:9d40e288714ed88d103be79dc9b0b58b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0274",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-48,-6,-36]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4fd5e1e62237032c0a688ab5a411bfd8": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0275",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:cf60c37ac17a2f336fba57b992c85f9a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.39195704460144",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.09532401480647",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000982990005503837",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.988983887764777",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:cf60c37ac17a2f336fba57b992c85f9a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0275",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-10,-60,-38]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d3c3847d28d2438a321d68783cee6c15": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0276",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:60692ff98d1d7460d8d0977b8de1a377",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.38738560676575",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.09158527627283",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000995453939317104",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.997054018314194",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:60692ff98d1d7460d8d0977b8de1a377": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0276",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[34,-62,-16]",
+                "type": "xsd:string"
+            }
+        }
+    },
+    "activity": {
+        "niiri:9c7e245e4dcccf690110a5c2f867fe1e": {
+            "prov:type": {
+                "$": "nidm_ModelParametersEstimation:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Model parameters estimation",
+                "type": "xsd:string"
+            },
+            "nidm_withEstimationMethod:": {
+                "$": "obo_generalizedleastsquaresestimation:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e18771e5677d91f4a09d79dadf322eaf": {
+            "prov:type": {
+                "$": "nidm_ContrastEstimation:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Contrast estimation",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1d58f1ea373dca6b6777c0ae0bfc411d": {
+            "prov:type": {
+                "$": "nidm_Inference:",
+                "type": "xsd:QName"
+            },
+            "nidm_hasAlternativeHypothesis:": {
+                "$": "nidm_OneTailedTest:",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Inference",
+                "type": "xsd:string"
+            }
+        }
+    },
+    "agent": {
+        "niiri:8903ae1fa9a6ecfaa31839e8cf029c8a": {
+            "prov:type": [
+                {
+                "$": "src_SPM:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "prov:SoftwareAgent",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "SPM",
+                "type": "xsd:string"
+            },
+            "nidm_softwareVersion:": {
+                "$": "12.6906",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:331761d1abf931827633659314e96094": {
+            "prov:type": [
+                {
+                "$": "nlx_Imaginginstrument:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nlx_Magneticresonanceimagingscanner:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "MRI Scanner",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9c886fc4d02f6c8f53849090a389159d": {
+            "prov:type": {
+                "$": "prov:Person",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Person",
+                "type": "xsd:string"
+            }
+        }
+    },
+    "wasGeneratedBy": {
+        "_:wGB20": {
+            "prov:entity": "niiri:701d77588170de3f2a3a5cae849cee5b",
+            "prov:activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e"
+        },
+        "_:wGB22": {
+            "prov:entity": "niiri:2759c13e0ec7d1d95a0ecd06a3481373",
+            "prov:activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e"
+        },
+        "_:wGB26": {
+            "prov:entity": "niiri:7cfe9f21fb53f5db106ee22b82a0fe77",
+            "prov:activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e"
+        },
+        "_:wGB30": {
+            "prov:entity": "niiri:43283050484b34063061bdb16cb80c6a",
+            "prov:activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e"
+        },
+        "_:wGB34": {
+            "prov:entity": "niiri:977b0276cc808425abbde5601d66f7f1",
+            "prov:activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e"
+        },
+        "_:wGB38": {
+            "prov:entity": "niiri:ed63a46c0d2c960f86afcc856493eba3",
+            "prov:activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e"
+        },
+        "_:wGB42": {
+            "prov:entity": "niiri:0f11c4b5e831cc47e20327b9561101d1",
+            "prov:activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e"
+        },
+        "_:wGB46": {
+            "prov:entity": "niiri:48291f5a02d1cc7b2042bb3d593d7fff",
+            "prov:activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e"
+        },
+        "_:wGB50": {
+            "prov:entity": "niiri:8f783b7ccac78e3e7bdec49afe00edd2",
+            "prov:activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e"
+        },
+        "_:wGB54": {
+            "prov:entity": "niiri:242b483bd1eee1b930fc5cca16db8bd0",
+            "prov:activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e"
+        },
+        "_:wGB58": {
+            "prov:entity": "niiri:133e1e9add501047daab53a9c6301964",
+            "prov:activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e"
+        },
+        "_:wGB62": {
+            "prov:entity": "niiri:1e8ad4131b61696d7f4e8f0d62cc8247",
+            "prov:activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e"
+        },
+        "_:wGB66": {
+            "prov:entity": "niiri:21ab0f8b00a00ed52acdb49a05c615c3",
+            "prov:activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e"
+        },
+        "_:wGB70": {
+            "prov:entity": "niiri:8c85285ad275239152b5e31bdf64af12",
+            "prov:activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e"
+        },
+        "_:wGB74": {
+            "prov:entity": "niiri:2bf2dfa438b489a6f9109550ebd7bc98",
+            "prov:activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e"
+        },
+        "_:wGB78": {
+            "prov:entity": "niiri:d1214d3e1d706371966179c913755cb7",
+            "prov:activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e"
+        },
+        "_:wGB82": {
+            "prov:entity": "niiri:067750a93237f9d14c0ce7af50da4f3c",
+            "prov:activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e"
+        },
+        "_:wGB86": {
+            "prov:entity": "niiri:0d7a4762edd076ba489e5cfade96a9fc",
+            "prov:activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e"
+        },
+        "_:wGB90": {
+            "prov:entity": "niiri:239f80ca4290c616514b508515eba255",
+            "prov:activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e"
+        },
+        "_:wGB94": {
+            "prov:entity": "niiri:4e4595ea20f67bd5529f3d2e095f8043",
+            "prov:activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e"
+        },
+        "_:wGB98": {
+            "prov:entity": "niiri:069ab84a0bc77f8bbe6fbf8bb2bb80fc",
+            "prov:activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e"
+        },
+        "_:wGB102": {
+            "prov:entity": "niiri:0f888978a8a86a495939e12690e2bcf8",
+            "prov:activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e"
+        },
+        "_:wGB106": {
+            "prov:entity": "niiri:4dc9f226357a6ab7f5e304324e2bcbfd",
+            "prov:activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e"
+        },
+        "_:wGB110": {
+            "prov:entity": "niiri:d1abc868edbc84f873320116529f4be5",
+            "prov:activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e"
+        },
+        "_:wGB114": {
+            "prov:entity": "niiri:799a884fae2a161e9aadf96d9f7e36f8",
+            "prov:activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e"
+        },
+        "_:wGB146": {
+            "prov:entity": "niiri:a58ef4cb06ae0d7d8f0c14e5f016db3c",
+            "prov:activity": "niiri:e18771e5677d91f4a09d79dadf322eaf"
+        },
+        "_:wGB148": {
+            "prov:entity": "niiri:ce5a4b9b70b53160de00542203e0ef42",
+            "prov:activity": "niiri:e18771e5677d91f4a09d79dadf322eaf"
+        },
+        "_:wGB167": {
+            "prov:entity": "niiri:4f06d69ed569f568944f5c14d618d42b",
+            "prov:activity": "niiri:1d58f1ea373dca6b6777c0ae0bfc411d"
+        },
+        "_:wGB171": {
+            "prov:entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145",
+            "prov:activity": "niiri:1d58f1ea373dca6b6777c0ae0bfc411d"
+        }
+    },
+    "used": {
+        "_:u14": {
+            "prov:activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e",
+            "prov:entity": "niiri:03fe576d4676dc2c478698e09040bd38"
+        },
+        "_:u15": {
+            "prov:activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e",
+            "prov:entity": "niiri:d23b22fadb663709f46b3ab69916d020"
+        },
+        "_:u16": {
+            "prov:activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e",
+            "prov:entity": "niiri:2411622502cf663c690e37bc572df1f3"
+        },
+        "_:u118": {
+            "prov:activity": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+            "prov:entity": "niiri:701d77588170de3f2a3a5cae849cee5b"
+        },
+        "_:u119": {
+            "prov:activity": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+            "prov:entity": "niiri:d1abc868edbc84f873320116529f4be5"
+        },
+        "_:u120": {
+            "prov:activity": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+            "prov:entity": "niiri:03fe576d4676dc2c478698e09040bd38"
+        },
+        "_:u121": {
+            "prov:activity": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+            "prov:entity": "niiri:adea7750ce17c82bde1a6b2deaac6a59"
+        },
+        "_:u122": {
+            "prov:activity": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+            "prov:entity": "niiri:7cfe9f21fb53f5db106ee22b82a0fe77"
+        },
+        "_:u123": {
+            "prov:activity": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+            "prov:entity": "niiri:43283050484b34063061bdb16cb80c6a"
+        },
+        "_:u124": {
+            "prov:activity": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+            "prov:entity": "niiri:977b0276cc808425abbde5601d66f7f1"
+        },
+        "_:u125": {
+            "prov:activity": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+            "prov:entity": "niiri:ed63a46c0d2c960f86afcc856493eba3"
+        },
+        "_:u126": {
+            "prov:activity": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+            "prov:entity": "niiri:0f11c4b5e831cc47e20327b9561101d1"
+        },
+        "_:u127": {
+            "prov:activity": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+            "prov:entity": "niiri:48291f5a02d1cc7b2042bb3d593d7fff"
+        },
+        "_:u128": {
+            "prov:activity": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+            "prov:entity": "niiri:8f783b7ccac78e3e7bdec49afe00edd2"
+        },
+        "_:u129": {
+            "prov:activity": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+            "prov:entity": "niiri:242b483bd1eee1b930fc5cca16db8bd0"
+        },
+        "_:u130": {
+            "prov:activity": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+            "prov:entity": "niiri:133e1e9add501047daab53a9c6301964"
+        },
+        "_:u131": {
+            "prov:activity": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+            "prov:entity": "niiri:1e8ad4131b61696d7f4e8f0d62cc8247"
+        },
+        "_:u132": {
+            "prov:activity": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+            "prov:entity": "niiri:21ab0f8b00a00ed52acdb49a05c615c3"
+        },
+        "_:u133": {
+            "prov:activity": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+            "prov:entity": "niiri:8c85285ad275239152b5e31bdf64af12"
+        },
+        "_:u134": {
+            "prov:activity": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+            "prov:entity": "niiri:2bf2dfa438b489a6f9109550ebd7bc98"
+        },
+        "_:u135": {
+            "prov:activity": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+            "prov:entity": "niiri:d1214d3e1d706371966179c913755cb7"
+        },
+        "_:u136": {
+            "prov:activity": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+            "prov:entity": "niiri:067750a93237f9d14c0ce7af50da4f3c"
+        },
+        "_:u137": {
+            "prov:activity": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+            "prov:entity": "niiri:0d7a4762edd076ba489e5cfade96a9fc"
+        },
+        "_:u138": {
+            "prov:activity": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+            "prov:entity": "niiri:239f80ca4290c616514b508515eba255"
+        },
+        "_:u139": {
+            "prov:activity": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+            "prov:entity": "niiri:4e4595ea20f67bd5529f3d2e095f8043"
+        },
+        "_:u140": {
+            "prov:activity": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+            "prov:entity": "niiri:069ab84a0bc77f8bbe6fbf8bb2bb80fc"
+        },
+        "_:u141": {
+            "prov:activity": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+            "prov:entity": "niiri:0f888978a8a86a495939e12690e2bcf8"
+        },
+        "_:u142": {
+            "prov:activity": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+            "prov:entity": "niiri:4dc9f226357a6ab7f5e304324e2bcbfd"
+        },
+        "_:u159": {
+            "prov:activity": "niiri:1d58f1ea373dca6b6777c0ae0bfc411d",
+            "prov:entity": "niiri:3cdb938d0d98089a2daa2c42933f776f"
+        },
+        "_:u160": {
+            "prov:activity": "niiri:1d58f1ea373dca6b6777c0ae0bfc411d",
+            "prov:entity": "niiri:ec3787cbdbedf5e1c42112b88a72d8a8"
+        },
+        "_:u161": {
+            "prov:activity": "niiri:1d58f1ea373dca6b6777c0ae0bfc411d",
+            "prov:entity": "niiri:a58ef4cb06ae0d7d8f0c14e5f016db3c"
+        },
+        "_:u162": {
+            "prov:activity": "niiri:1d58f1ea373dca6b6777c0ae0bfc411d",
+            "prov:entity": "niiri:799a884fae2a161e9aadf96d9f7e36f8"
+        },
+        "_:u163": {
+            "prov:activity": "niiri:1d58f1ea373dca6b6777c0ae0bfc411d",
+            "prov:entity": "niiri:701d77588170de3f2a3a5cae849cee5b"
+        },
+        "_:u164": {
+            "prov:activity": "niiri:1d58f1ea373dca6b6777c0ae0bfc411d",
+            "prov:entity": "niiri:5f2a0985f22401ffe697c6cbad69a014"
+        },
+        "_:u165": {
+            "prov:activity": "niiri:1d58f1ea373dca6b6777c0ae0bfc411d",
+            "prov:entity": "niiri:5375a11691240712e54191f850b6a223"
+        }
+    },
+    "wasDerivedFrom": {
+        "_:wDF19": {
+            "prov:generatedEntity": "niiri:701d77588170de3f2a3a5cae849cee5b",
+            "prov:usedEntity": "niiri:68240aa5f992dd1323cc9f0c0e3a3639"
+        },
+        "_:wDF25": {
+            "prov:generatedEntity": "niiri:7cfe9f21fb53f5db106ee22b82a0fe77",
+            "prov:usedEntity": "niiri:089827f143cffa9301487e18ac4f137b"
+        },
+        "_:wDF29": {
+            "prov:generatedEntity": "niiri:43283050484b34063061bdb16cb80c6a",
+            "prov:usedEntity": "niiri:329c6968efa0ef3a9c454bf61031c775"
+        },
+        "_:wDF33": {
+            "prov:generatedEntity": "niiri:977b0276cc808425abbde5601d66f7f1",
+            "prov:usedEntity": "niiri:eb7cef4922655d41030fe942fbcf92d0"
+        },
+        "_:wDF37": {
+            "prov:generatedEntity": "niiri:ed63a46c0d2c960f86afcc856493eba3",
+            "prov:usedEntity": "niiri:4253cad80266847727bfd03c0f113481"
+        },
+        "_:wDF41": {
+            "prov:generatedEntity": "niiri:0f11c4b5e831cc47e20327b9561101d1",
+            "prov:usedEntity": "niiri:5e2edc7c4f0179e995e1d8a613e7f3f5"
+        },
+        "_:wDF45": {
+            "prov:generatedEntity": "niiri:48291f5a02d1cc7b2042bb3d593d7fff",
+            "prov:usedEntity": "niiri:a32c3f75242cd2d6bdf7364d58ecabaa"
+        },
+        "_:wDF49": {
+            "prov:generatedEntity": "niiri:8f783b7ccac78e3e7bdec49afe00edd2",
+            "prov:usedEntity": "niiri:f8a0341ad0e00972a335bb4d5abdf527"
+        },
+        "_:wDF53": {
+            "prov:generatedEntity": "niiri:242b483bd1eee1b930fc5cca16db8bd0",
+            "prov:usedEntity": "niiri:2aa65d5429266d49e3eb2223f5d00c0f"
+        },
+        "_:wDF57": {
+            "prov:generatedEntity": "niiri:133e1e9add501047daab53a9c6301964",
+            "prov:usedEntity": "niiri:d99c4966dd6f79fa35b1936be239db4a"
+        },
+        "_:wDF61": {
+            "prov:generatedEntity": "niiri:1e8ad4131b61696d7f4e8f0d62cc8247",
+            "prov:usedEntity": "niiri:3b7f58f0e40d4420da47ee38ea6e01f4"
+        },
+        "_:wDF65": {
+            "prov:generatedEntity": "niiri:21ab0f8b00a00ed52acdb49a05c615c3",
+            "prov:usedEntity": "niiri:e81af0e320d70f0c3b56e6ba69ab24b3"
+        },
+        "_:wDF69": {
+            "prov:generatedEntity": "niiri:8c85285ad275239152b5e31bdf64af12",
+            "prov:usedEntity": "niiri:e07667d489f48b12e6c861fd0f90c6b2"
+        },
+        "_:wDF73": {
+            "prov:generatedEntity": "niiri:2bf2dfa438b489a6f9109550ebd7bc98",
+            "prov:usedEntity": "niiri:7b36c6521cdd3ed1a0440a51a36ed339"
+        },
+        "_:wDF77": {
+            "prov:generatedEntity": "niiri:d1214d3e1d706371966179c913755cb7",
+            "prov:usedEntity": "niiri:9c4ae77f74400a1405d71f6f92c62e06"
+        },
+        "_:wDF81": {
+            "prov:generatedEntity": "niiri:067750a93237f9d14c0ce7af50da4f3c",
+            "prov:usedEntity": "niiri:07be9f58a9f65a0bcedc3f67a360ae25"
+        },
+        "_:wDF85": {
+            "prov:generatedEntity": "niiri:0d7a4762edd076ba489e5cfade96a9fc",
+            "prov:usedEntity": "niiri:d763714606a30881b76dbdbf13aa45f0"
+        },
+        "_:wDF89": {
+            "prov:generatedEntity": "niiri:239f80ca4290c616514b508515eba255",
+            "prov:usedEntity": "niiri:7894ca83b4d7bbe3efc917dce739071e"
+        },
+        "_:wDF93": {
+            "prov:generatedEntity": "niiri:4e4595ea20f67bd5529f3d2e095f8043",
+            "prov:usedEntity": "niiri:157eda0d89d7ceb121cc325642f884bc"
+        },
+        "_:wDF97": {
+            "prov:generatedEntity": "niiri:069ab84a0bc77f8bbe6fbf8bb2bb80fc",
+            "prov:usedEntity": "niiri:22a1c0d63f9d2cf485131f1c86148558"
+        },
+        "_:wDF101": {
+            "prov:generatedEntity": "niiri:0f888978a8a86a495939e12690e2bcf8",
+            "prov:usedEntity": "niiri:e7d4386ec97d8e529d6fde660a4adc75"
+        },
+        "_:wDF105": {
+            "prov:generatedEntity": "niiri:4dc9f226357a6ab7f5e304324e2bcbfd",
+            "prov:usedEntity": "niiri:14c8f75ed277956b9ba6f87eb9db82e8"
+        },
+        "_:wDF109": {
+            "prov:generatedEntity": "niiri:d1abc868edbc84f873320116529f4be5",
+            "prov:usedEntity": "niiri:012705be5593997e59490b3d6466d660"
+        },
+        "_:wDF113": {
+            "prov:generatedEntity": "niiri:799a884fae2a161e9aadf96d9f7e36f8",
+            "prov:usedEntity": "niiri:129241c961b40e0c62467f34d91dab7e"
+        },
+        "_:wDF145": {
+            "prov:generatedEntity": "niiri:a58ef4cb06ae0d7d8f0c14e5f016db3c",
+            "prov:usedEntity": "niiri:4a659d96c27e7d9b44774d45d04e80fe"
+        },
+        "_:wDF173": {
+            "prov:generatedEntity": "niiri:85fec2a2169d10c191c4e617a17cdba0",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF175": {
+            "prov:generatedEntity": "niiri:1aa2c5542022d8edfbe6faaf12d4ebb7",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF177": {
+            "prov:generatedEntity": "niiri:f9d722fcce853c033260a3ae532235c1",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF179": {
+            "prov:generatedEntity": "niiri:73ec267aa6e4362aa22b8bf333d9a6f3",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF181": {
+            "prov:generatedEntity": "niiri:a78547a90624868c0aef3cebdd83d669",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF183": {
+            "prov:generatedEntity": "niiri:940cf2d7b7d0eb179a5d87089cdef025",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF185": {
+            "prov:generatedEntity": "niiri:22f7499c81f2b4cfb5d9464b77334f85",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF187": {
+            "prov:generatedEntity": "niiri:313e60cc130ee5f7b46b9a70c28c95a0",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF189": {
+            "prov:generatedEntity": "niiri:5755c7b6f3b8bb9a495a80e69a7ab94e",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF191": {
+            "prov:generatedEntity": "niiri:23f5c60185b27f2be0dd455c41c3fde3",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF193": {
+            "prov:generatedEntity": "niiri:33cca310ebec4700e45b0560235f03cd",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF195": {
+            "prov:generatedEntity": "niiri:68605e1a07366f1a9aaae9f04eb3bbcf",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF197": {
+            "prov:generatedEntity": "niiri:ab91ba995acbb604c8550a19c6d56878",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF199": {
+            "prov:generatedEntity": "niiri:8ddb469ed3d8d13f9f3b41143b2bc54e",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF201": {
+            "prov:generatedEntity": "niiri:fe3d995dc2bfdeb5f29182f0558560a6",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF203": {
+            "prov:generatedEntity": "niiri:cfbb41a715a689539e32d23fa5ecf0ad",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF205": {
+            "prov:generatedEntity": "niiri:1ea775914efd19bdf7935c45c2fc61d7",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF207": {
+            "prov:generatedEntity": "niiri:c9c2075e31233972320b91bbe319e15d",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF209": {
+            "prov:generatedEntity": "niiri:184504b2959cc0300f56dbed9be3df0a",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF211": {
+            "prov:generatedEntity": "niiri:e56b27d2108b9aebc19f9ff56ac97dce",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF213": {
+            "prov:generatedEntity": "niiri:e78e0827b0a80cf9fb06ff0a74ee9600",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF215": {
+            "prov:generatedEntity": "niiri:461b922ff7bd3d15d33f54bcbd492da3",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF217": {
+            "prov:generatedEntity": "niiri:1cfc9f0a458d8852ad0759c9e8be8a6a",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF219": {
+            "prov:generatedEntity": "niiri:5bbe3c6a1630a3c2cc55aa12dfd9e286",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF221": {
+            "prov:generatedEntity": "niiri:1e1925d1a7237f41c7f4bbc7a938991e",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF223": {
+            "prov:generatedEntity": "niiri:45311fe546d4fc676e17072f500c1575",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF225": {
+            "prov:generatedEntity": "niiri:12134d971afb042d040aea6cecc0ebec",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF227": {
+            "prov:generatedEntity": "niiri:7dfc1da184d477320648da6e59dc2a7c",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF229": {
+            "prov:generatedEntity": "niiri:ff37e6b9b5486e16e27ae0fca1db545d",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF231": {
+            "prov:generatedEntity": "niiri:bfb3c58b6c12062e86b12426bbf496d9",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF233": {
+            "prov:generatedEntity": "niiri:b1059120ca68f8c294f13d22a334afc5",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF235": {
+            "prov:generatedEntity": "niiri:dd43f04c7775bf5d225a62b05a1f8275",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF237": {
+            "prov:generatedEntity": "niiri:c723d93708cb4dee84578d4dad2314df",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF239": {
+            "prov:generatedEntity": "niiri:d30171bbdc271c074a6050acb8a4d34e",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF241": {
+            "prov:generatedEntity": "niiri:ea2ed9cc4d84a345a4920b11801993b3",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF243": {
+            "prov:generatedEntity": "niiri:cf3d3e192bab8fb0febbddda2b472570",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF245": {
+            "prov:generatedEntity": "niiri:a6ee0e116834a7cbcea03e95f20dae54",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF247": {
+            "prov:generatedEntity": "niiri:e9b27c64b1591506ec57168d7dbf134f",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF249": {
+            "prov:generatedEntity": "niiri:35e614f307abb1c7215e649c0bbf0aa0",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF251": {
+            "prov:generatedEntity": "niiri:84661ae12e172546f496d4b26feacce8",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF253": {
+            "prov:generatedEntity": "niiri:b3ab45e7aaebdd6d5415f3e8fb8365d3",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF255": {
+            "prov:generatedEntity": "niiri:a9dd639eb89226977a3ede42cafc093c",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF257": {
+            "prov:generatedEntity": "niiri:01b4ff55ed7965f77f28199c98d35002",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF259": {
+            "prov:generatedEntity": "niiri:f606725494013a6004aeb7f3234c5659",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF261": {
+            "prov:generatedEntity": "niiri:d70674f2ab25c84bf1ccbf050e157cb6",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF263": {
+            "prov:generatedEntity": "niiri:d3a715b103390651d1c521ee09f466c0",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF265": {
+            "prov:generatedEntity": "niiri:3577f89d6cde1468b3bf7bab875643fa",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF267": {
+            "prov:generatedEntity": "niiri:6b28309025a8c950f906f3a74a6104c4",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF269": {
+            "prov:generatedEntity": "niiri:40f12e78ef285dbb693762e0e24f5a51",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF271": {
+            "prov:generatedEntity": "niiri:708e2b5584c9334ba1cde9334d8aee40",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF273": {
+            "prov:generatedEntity": "niiri:2ed437f95a18d4610e20aee5f5ca8ca1",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF275": {
+            "prov:generatedEntity": "niiri:c4315919bc864f2492337dd699116ee4",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF277": {
+            "prov:generatedEntity": "niiri:5ad7bfc734bce8d2e03526bbce4c1642",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF279": {
+            "prov:generatedEntity": "niiri:f28a45db3e8e726134be22dd55ada8fc",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF281": {
+            "prov:generatedEntity": "niiri:7dbd526d156c17d030cb03d4502bec48",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF283": {
+            "prov:generatedEntity": "niiri:db64bef791d519bd840c407a07274b39",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF285": {
+            "prov:generatedEntity": "niiri:261d424ff1d40e2e1212f8b47057e08d",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF287": {
+            "prov:generatedEntity": "niiri:f0b1b468bf91334fdba7c8b7612cca41",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF289": {
+            "prov:generatedEntity": "niiri:6faaad2ce4a4160eadbbce94632ec2bf",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF291": {
+            "prov:generatedEntity": "niiri:8451b5d05d4d0f88becbc68925bab4c9",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF293": {
+            "prov:generatedEntity": "niiri:e8d74786a114ffeb6114fffeeb2583da",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF295": {
+            "prov:generatedEntity": "niiri:af4cb856d066cec808680cb766e205ae",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF297": {
+            "prov:generatedEntity": "niiri:64c74f4674adc0005dffc886ffba3300",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF299": {
+            "prov:generatedEntity": "niiri:878873f431f64df4853365a578c78440",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF301": {
+            "prov:generatedEntity": "niiri:62873793384331403012ec1c900656e0",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF303": {
+            "prov:generatedEntity": "niiri:cf86c38738ff15923d1bfe58d642e526",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF305": {
+            "prov:generatedEntity": "niiri:6eb2f26421b4abdd2aff61056be6347c",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF307": {
+            "prov:generatedEntity": "niiri:464e6cc9ad8cde4967c4e8430942863e",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF309": {
+            "prov:generatedEntity": "niiri:0f59b224fb308f5b33db0b615cec440e",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF311": {
+            "prov:generatedEntity": "niiri:61f0e2e951d39892ec38816ca4ff7b91",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF313": {
+            "prov:generatedEntity": "niiri:9764501f1b27ea039a6888cad5412dc6",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF315": {
+            "prov:generatedEntity": "niiri:c4798ee5bb6817f0ac7d3d1f7cbb895d",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF317": {
+            "prov:generatedEntity": "niiri:5499ba7833a3a03073324dac7488ac06",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF319": {
+            "prov:generatedEntity": "niiri:50c6ebb589d5bdb3e362aaf8f837978b",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF321": {
+            "prov:generatedEntity": "niiri:a489f5516c417d51a01d581c1281955e",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF323": {
+            "prov:generatedEntity": "niiri:e4ff54dd97ad1e3f10b9d1c7027c4645",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF325": {
+            "prov:generatedEntity": "niiri:8de83fae7bd6e9f8380ec49cdc4829ae",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF327": {
+            "prov:generatedEntity": "niiri:85491f67ab81ddeb946caf2849c4b9f4",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF329": {
+            "prov:generatedEntity": "niiri:3e9eba22eff518f24b14c038fe2913df",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF331": {
+            "prov:generatedEntity": "niiri:2b503ca3533d10a4f1f80dad7060444a",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF333": {
+            "prov:generatedEntity": "niiri:cf6de656d89419d4ac154fd946ec6388",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF335": {
+            "prov:generatedEntity": "niiri:9c0f05c7637bc2f31d907b17584b6aa0",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF337": {
+            "prov:generatedEntity": "niiri:62e799c85533fe86208bf5e33c6a326d",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF339": {
+            "prov:generatedEntity": "niiri:7b8b805f3c10072513741773f37173a9",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF341": {
+            "prov:generatedEntity": "niiri:c8967930ef6b4850b98397e5a02cf2f7",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF343": {
+            "prov:generatedEntity": "niiri:162bab89b0c20f6474f1241e5c7169b3",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF345": {
+            "prov:generatedEntity": "niiri:91dc841836bbf5d1c0b426905fb75e01",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF347": {
+            "prov:generatedEntity": "niiri:3f463a005d2c5f82895c19639d89d232",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF349": {
+            "prov:generatedEntity": "niiri:a088e0c82151087e1bf9897ac5ca3823",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF351": {
+            "prov:generatedEntity": "niiri:321fa4b64bb46facf5ed354080dc1587",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF353": {
+            "prov:generatedEntity": "niiri:1bb068ae0340b41c3c1e0585e61ab7a2",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF355": {
+            "prov:generatedEntity": "niiri:0b5c4b3fea9afd08f274ad657436f2dd",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF357": {
+            "prov:generatedEntity": "niiri:7b0e7637357771b4e3c95b60da0daba2",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF359": {
+            "prov:generatedEntity": "niiri:b8afe5b11ecf6b25c3098ac5c67b90a0",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF361": {
+            "prov:generatedEntity": "niiri:a2a8b82493043f5593bcde950e35d4f5",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF363": {
+            "prov:generatedEntity": "niiri:13a870b0869420f093e2bf23ab79a37e",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF365": {
+            "prov:generatedEntity": "niiri:9e62040415b20939b8c829b35ac0b428",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF367": {
+            "prov:generatedEntity": "niiri:ef74f8693d6b0cc1f8f7291479877d46",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF369": {
+            "prov:generatedEntity": "niiri:b4f4a8e2b968691b39abdbd7cd10251b",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF371": {
+            "prov:generatedEntity": "niiri:b479ffd217729f45ba8e8b497543b71d",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF373": {
+            "prov:generatedEntity": "niiri:64b1c86050912153a776e757204d9bd6",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF375": {
+            "prov:generatedEntity": "niiri:2262ce46c8d9d3e44fca9d2b9991842a",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF377": {
+            "prov:generatedEntity": "niiri:03e5589e0cbf8390adc9f572f09c2111",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF379": {
+            "prov:generatedEntity": "niiri:183d033f8dc6f63dd2d370f917d30bf5",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF381": {
+            "prov:generatedEntity": "niiri:82ed6a608808b53426982c1cc66a2ec6",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF383": {
+            "prov:generatedEntity": "niiri:c38a12c7c56a4a6bcef1a3f1defaede6",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF385": {
+            "prov:generatedEntity": "niiri:b903a819026d14c010b6e3c047f2d1f1",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF387": {
+            "prov:generatedEntity": "niiri:932955007c6604e912ca88f69e4b71b2",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF389": {
+            "prov:generatedEntity": "niiri:19bb8ba20387a263ccc2a4033c4a6959",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF391": {
+            "prov:generatedEntity": "niiri:4c267352cce4185f6d8f19642a2432ea",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF393": {
+            "prov:generatedEntity": "niiri:b779ca098f1180fe09ebe0414895c731",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF395": {
+            "prov:generatedEntity": "niiri:b7385089cc22c8804fc256dff15181f6",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF397": {
+            "prov:generatedEntity": "niiri:a34044dfcf23dfe53b2945318b0397f1",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF399": {
+            "prov:generatedEntity": "niiri:e3223bf7299c1367c69b65daadf7dab4",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF401": {
+            "prov:generatedEntity": "niiri:315a3351fd67e6810a0558156faed379",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF403": {
+            "prov:generatedEntity": "niiri:956afe330511d5dec77faf29c8e66c5b",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF405": {
+            "prov:generatedEntity": "niiri:4740016eb1ce8e7ec8341eb44cf9ffa5",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF407": {
+            "prov:generatedEntity": "niiri:f956c3347b26a7454fde4d7c1ee3dfac",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF409": {
+            "prov:generatedEntity": "niiri:0306caf1c070bce484bea6d4d02ee4b9",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF411": {
+            "prov:generatedEntity": "niiri:0718df40c87e4adde0a6b31fdd007bb4",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF413": {
+            "prov:generatedEntity": "niiri:c3345fe728c02a6d54b764235fc35217",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF415": {
+            "prov:generatedEntity": "niiri:db4e8782b5b474daeb575623d11d8f36",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF417": {
+            "prov:generatedEntity": "niiri:3a7bd3c73757ad2c63a505ac44ee7de9",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF419": {
+            "prov:generatedEntity": "niiri:ca632dc1f3d6a97bb76e5a785e5f4b39",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF421": {
+            "prov:generatedEntity": "niiri:4d501ade9f45e68e86c0aef60754a9aa",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF423": {
+            "prov:generatedEntity": "niiri:4353f4b513f6d03c8ce9a7ee07ac3524",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF425": {
+            "prov:generatedEntity": "niiri:d24c03f6c5960ef050e1d0a675496464",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF427": {
+            "prov:generatedEntity": "niiri:0630bc3a96bd8ec1bd4f2dbb98bd8a68",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF429": {
+            "prov:generatedEntity": "niiri:7a6a9d89a41bce106a6e3f6b9bf39fc2",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF431": {
+            "prov:generatedEntity": "niiri:6cd9c8b1f2dc650429e50bd72f6da32d",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF433": {
+            "prov:generatedEntity": "niiri:f0caefb73eec8df07661fca6c2cc2a56",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF435": {
+            "prov:generatedEntity": "niiri:10dda0f512d376c45616527318012baa",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF437": {
+            "prov:generatedEntity": "niiri:3aeaeffb7762bacf9f1b2dc630012fe3",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF439": {
+            "prov:generatedEntity": "niiri:88ee03bc281326c9948572b0834fecf3",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF441": {
+            "prov:generatedEntity": "niiri:30868fad9324d3113736d83bd681718a",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF443": {
+            "prov:generatedEntity": "niiri:4b462b6d837ce2e27bce61ed0c368fd6",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF445": {
+            "prov:generatedEntity": "niiri:1bf97c65bec07a1317ef69c944689cf8",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF447": {
+            "prov:generatedEntity": "niiri:cd27fa26bbd5aa4fa8cfbebf1bb95ad9",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF449": {
+            "prov:generatedEntity": "niiri:31a80df97955e986f4be4839a052a5db",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF451": {
+            "prov:generatedEntity": "niiri:39fc04da006cbf70670a7f80045d0d49",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF453": {
+            "prov:generatedEntity": "niiri:a2df6515d44ea1c2de2e20cd83b43f91",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF455": {
+            "prov:generatedEntity": "niiri:9b33ff671ff0c042af89e5b1be1377da",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF457": {
+            "prov:generatedEntity": "niiri:25e2f4ca28679423b49be4329eea0bc3",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF459": {
+            "prov:generatedEntity": "niiri:0a729befa841fff84fcf2612fb2ce4a5",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF461": {
+            "prov:generatedEntity": "niiri:501da0873de972e1023817d65202130e",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF463": {
+            "prov:generatedEntity": "niiri:0336a0114f6c74e1df58148ee9b074f4",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF465": {
+            "prov:generatedEntity": "niiri:06324b32c616d4e45a79cb65a439ac48",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF467": {
+            "prov:generatedEntity": "niiri:ac9a19a2b1c9949a888ebae7d65a2399",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF469": {
+            "prov:generatedEntity": "niiri:061dca60ff6ace182bd1ebe945535ace",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF471": {
+            "prov:generatedEntity": "niiri:6242500a1c0ecfe873a2799eca21133b",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF473": {
+            "prov:generatedEntity": "niiri:62f0dcd6742c42c5c8a69829ea982b14",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF475": {
+            "prov:generatedEntity": "niiri:ed86b8af25a7303faba66f96f7427038",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF477": {
+            "prov:generatedEntity": "niiri:81c63725e4640647cd75f101cc0fc8a7",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF479": {
+            "prov:generatedEntity": "niiri:4b2e0a2531b0291df0fe5df5bc205ec9",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF481": {
+            "prov:generatedEntity": "niiri:7f91f8087c7d8ec7eda6204b5b39482d",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF483": {
+            "prov:generatedEntity": "niiri:2c7f0285c24b2b8b65a032418b15cd16",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF485": {
+            "prov:generatedEntity": "niiri:7ed3fe10280b67503b5448524a04f269",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF487": {
+            "prov:generatedEntity": "niiri:99c58e7d96cf7da6763a2e1cbba873ae",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF489": {
+            "prov:generatedEntity": "niiri:d5206500679003f5f39472159c4ad0de",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF491": {
+            "prov:generatedEntity": "niiri:0803006e1feea37abdc724f07464d7a9",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF493": {
+            "prov:generatedEntity": "niiri:abae6765a0aa40936d109b9a2fd5acbf",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF495": {
+            "prov:generatedEntity": "niiri:4b0a463a8d9ceb66a11c49348ae1f5fc",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF497": {
+            "prov:generatedEntity": "niiri:ca33d7428ff48eafbc3f213db2286c92",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF499": {
+            "prov:generatedEntity": "niiri:a2d559eeea3fd425019a74c32cb07b03",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF501": {
+            "prov:generatedEntity": "niiri:1cffc79d71ec5b44f8be32f71d15b738",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF503": {
+            "prov:generatedEntity": "niiri:08835c169510829e8effda3071bba336",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF505": {
+            "prov:generatedEntity": "niiri:d5a3f5e4133bc22e2c189ceeb5b93544",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF507": {
+            "prov:generatedEntity": "niiri:9b44436d58818f06cd48133f714e8a99",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF509": {
+            "prov:generatedEntity": "niiri:051457613c34bfa68d60b137e8c7ae17",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF511": {
+            "prov:generatedEntity": "niiri:ea9fe9402f815e54e3cef6704ebcb2e4",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF513": {
+            "prov:generatedEntity": "niiri:1dce01b8df60884c582e29243c828080",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF515": {
+            "prov:generatedEntity": "niiri:eb8a2332e6ccc41b6d1a8cca84b280fe",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF517": {
+            "prov:generatedEntity": "niiri:3ab29b7a5414afa7ee3dad94fe418d2f",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF519": {
+            "prov:generatedEntity": "niiri:de99f369510067d001dcfc78a4b7ee95",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF521": {
+            "prov:generatedEntity": "niiri:03516b1ded0c354154f06310cfeb09c0",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF523": {
+            "prov:generatedEntity": "niiri:56da6908cbe82b7569f6ca2737e51eb6",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF525": {
+            "prov:generatedEntity": "niiri:087ce96dd01c83b4336943a7df6de172",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF527": {
+            "prov:generatedEntity": "niiri:1a5540bf2e828d5e14c6001adb4f30d5",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF529": {
+            "prov:generatedEntity": "niiri:b54974658dcfd8d91a65540d01e3250b",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF531": {
+            "prov:generatedEntity": "niiri:b1012bc624cd6b3f47ff149073d0a78b",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF533": {
+            "prov:generatedEntity": "niiri:d45da63c733d96ddba5cf2fb05dc0b58",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF535": {
+            "prov:generatedEntity": "niiri:14e793643765a6fe10fb66237bee63db",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF537": {
+            "prov:generatedEntity": "niiri:a3b1937d74b3d7366255ed05df95e8dc",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF539": {
+            "prov:generatedEntity": "niiri:4f0d78d14b791c15d9759ece4ec7e6ed",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF541": {
+            "prov:generatedEntity": "niiri:f569ae7a0c44f14440097fc2492d13ab",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF543": {
+            "prov:generatedEntity": "niiri:2fd27f14078fbb1aa402a271e101e35f",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF545": {
+            "prov:generatedEntity": "niiri:5476fcd5093f7c864637efaafd42b996",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF547": {
+            "prov:generatedEntity": "niiri:10bac4ccf6049482f632adb3952c3c8c",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF549": {
+            "prov:generatedEntity": "niiri:cda273936fc980c18403b41fb8533954",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF551": {
+            "prov:generatedEntity": "niiri:89501dfa67d1d32810bbe20fd9b1fe8c",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF553": {
+            "prov:generatedEntity": "niiri:02f6f6429a8304a7731a404570cb4b94",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF555": {
+            "prov:generatedEntity": "niiri:8747a3ddd24cbd71e40672d541cefee5",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF557": {
+            "prov:generatedEntity": "niiri:c885eb98b2506b007c2d8feb2e37f08e",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF559": {
+            "prov:generatedEntity": "niiri:bd96226234de4e21627b04208c7e537f",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF561": {
+            "prov:generatedEntity": "niiri:8b7eb042176ff4b34dbab2133217acff",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF563": {
+            "prov:generatedEntity": "niiri:74aa1acb0840e11af474625bf18a205b",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF565": {
+            "prov:generatedEntity": "niiri:1f8d909cef3803a0e6a8e31c86e2cb37",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF567": {
+            "prov:generatedEntity": "niiri:d1b86bb927184d1863bf16406cbb38ef",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF569": {
+            "prov:generatedEntity": "niiri:8681fd0b6a40a88059175d0b5804a743",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF571": {
+            "prov:generatedEntity": "niiri:53d7d39a6b6a7a44a92c2cdc58facf3a",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF573": {
+            "prov:generatedEntity": "niiri:b8f303a3f6e3ffbd2a86dd99d6d873fb",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF575": {
+            "prov:generatedEntity": "niiri:555db4d96064ec58a79e6099a79dd060",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF577": {
+            "prov:generatedEntity": "niiri:df9fe6cd3c5bf212b4c85e3bd119959c",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF579": {
+            "prov:generatedEntity": "niiri:17f6f685daf3b085f3dac6c057c020c1",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF581": {
+            "prov:generatedEntity": "niiri:c5cf9af3cc2424e4b8e65eb6049706ed",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF583": {
+            "prov:generatedEntity": "niiri:24b677d8caebb84711be327c29be20b9",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF585": {
+            "prov:generatedEntity": "niiri:c9997d6b8885703c61c50e9494f01f5b",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF587": {
+            "prov:generatedEntity": "niiri:18c389e9f560a707e21a88082c18399f",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF589": {
+            "prov:generatedEntity": "niiri:4f2617299971ce7d3a16c3c37b0badbd",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF591": {
+            "prov:generatedEntity": "niiri:7ab88d893988ef5840b83076dc34632a",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF593": {
+            "prov:generatedEntity": "niiri:ad4b61cba6b4e1ac8b424d69a662357a",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF595": {
+            "prov:generatedEntity": "niiri:18172de66764cc046e57e3f71900f308",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF597": {
+            "prov:generatedEntity": "niiri:5b864821dad832cdea33cc2c71107b5d",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF599": {
+            "prov:generatedEntity": "niiri:54af2492a558bd6b541a83efffeacbc6",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF601": {
+            "prov:generatedEntity": "niiri:4c87d31930bd2a3884bfbd054121e8ea",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF603": {
+            "prov:generatedEntity": "niiri:0c1ba90c913890f99f03e9c6732b7833",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF605": {
+            "prov:generatedEntity": "niiri:7e48fd00328505ec2f7c55286029038c",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF607": {
+            "prov:generatedEntity": "niiri:fe7b7aeb5b19bcdfb6ba3b9e7bbc0530",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF609": {
+            "prov:generatedEntity": "niiri:2598e0a8af6b254c19ea1eae1c055e59",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF611": {
+            "prov:generatedEntity": "niiri:ef260aa5a1800f7a5b96c1d3f96edac0",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF613": {
+            "prov:generatedEntity": "niiri:9edfdd818d3f428259751e3a1f4426fa",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF615": {
+            "prov:generatedEntity": "niiri:1667cff121b7be39391cc74c4150a6e4",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF617": {
+            "prov:generatedEntity": "niiri:8a9dbe909430bab19de8984a30f0827c",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF619": {
+            "prov:generatedEntity": "niiri:73e5d22f5e99f7222d046e5c8b8f17e5",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF621": {
+            "prov:generatedEntity": "niiri:8015064bc0743ed13468353e18ca0971",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF623": {
+            "prov:generatedEntity": "niiri:eb612c2c1cebda064d6320c535f9294f",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF625": {
+            "prov:generatedEntity": "niiri:6369784f4c4b56deb50440d6515b981e",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF627": {
+            "prov:generatedEntity": "niiri:2147d82387f71f29a3d3dfb09b7b8d64",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF629": {
+            "prov:generatedEntity": "niiri:790465006aaf87ef2289ea019fdb0b83",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF631": {
+            "prov:generatedEntity": "niiri:730c6026b96772dd69384df78d1b3195",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF633": {
+            "prov:generatedEntity": "niiri:26bef1517140b96419bd96743968bf5a",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF635": {
+            "prov:generatedEntity": "niiri:c80e777eb02827978765763f51129026",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF637": {
+            "prov:generatedEntity": "niiri:6eb9789a31f1c0da3f5dc3fb64518f9e",
+            "prov:usedEntity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
+        },
+        "_:wDF640": {
+            "prov:generatedEntity": "niiri:6375cbd08f405cfa4aa923cd73003620",
+            "prov:usedEntity": "niiri:85fec2a2169d10c191c4e617a17cdba0"
+        },
+        "_:wDF643": {
+            "prov:generatedEntity": "niiri:f9affa16a68b7d08052caab897982f1e",
+            "prov:usedEntity": "niiri:85fec2a2169d10c191c4e617a17cdba0"
+        },
+        "_:wDF646": {
+            "prov:generatedEntity": "niiri:760b5861535d1b8d351a8ea1c8e8055e",
+            "prov:usedEntity": "niiri:85fec2a2169d10c191c4e617a17cdba0"
+        },
+        "_:wDF649": {
+            "prov:generatedEntity": "niiri:01d92dcf2decdbf979916bc117777a31",
+            "prov:usedEntity": "niiri:1aa2c5542022d8edfbe6faaf12d4ebb7"
+        },
+        "_:wDF652": {
+            "prov:generatedEntity": "niiri:85893fd2a80f9cb9a50aeeaf16aa5be0",
+            "prov:usedEntity": "niiri:1aa2c5542022d8edfbe6faaf12d4ebb7"
+        },
+        "_:wDF655": {
+            "prov:generatedEntity": "niiri:eb798644a33419afda56222bf6a4057c",
+            "prov:usedEntity": "niiri:1aa2c5542022d8edfbe6faaf12d4ebb7"
+        },
+        "_:wDF658": {
+            "prov:generatedEntity": "niiri:8b04f6c0610c61ade2031f4e0e7fd687",
+            "prov:usedEntity": "niiri:f9d722fcce853c033260a3ae532235c1"
+        },
+        "_:wDF661": {
+            "prov:generatedEntity": "niiri:8d815390449dd61ecf2635b2c7a5611c",
+            "prov:usedEntity": "niiri:f9d722fcce853c033260a3ae532235c1"
+        },
+        "_:wDF664": {
+            "prov:generatedEntity": "niiri:b2ac34a9e9c7de3ca84c442f813d01ef",
+            "prov:usedEntity": "niiri:f9d722fcce853c033260a3ae532235c1"
+        },
+        "_:wDF667": {
+            "prov:generatedEntity": "niiri:007c46c3626dce09d1207554312d2e9a",
+            "prov:usedEntity": "niiri:73ec267aa6e4362aa22b8bf333d9a6f3"
+        },
+        "_:wDF670": {
+            "prov:generatedEntity": "niiri:0f083958a49b6859e479679cb5c0b402",
+            "prov:usedEntity": "niiri:73ec267aa6e4362aa22b8bf333d9a6f3"
+        },
+        "_:wDF673": {
+            "prov:generatedEntity": "niiri:495925dd7a5c597e0b631259e27402bc",
+            "prov:usedEntity": "niiri:73ec267aa6e4362aa22b8bf333d9a6f3"
+        },
+        "_:wDF676": {
+            "prov:generatedEntity": "niiri:78d8a083c90c99f5fc07322a26f5cde9",
+            "prov:usedEntity": "niiri:a78547a90624868c0aef3cebdd83d669"
+        },
+        "_:wDF679": {
+            "prov:generatedEntity": "niiri:c53b99e7694641c31b95648ff991e8a5",
+            "prov:usedEntity": "niiri:940cf2d7b7d0eb179a5d87089cdef025"
+        },
+        "_:wDF682": {
+            "prov:generatedEntity": "niiri:b3b4ea8ddeb67b7b4031f94f6efe9a70",
+            "prov:usedEntity": "niiri:22f7499c81f2b4cfb5d9464b77334f85"
+        },
+        "_:wDF685": {
+            "prov:generatedEntity": "niiri:61b0171a6b5389bc91ab6b1f988304af",
+            "prov:usedEntity": "niiri:22f7499c81f2b4cfb5d9464b77334f85"
+        },
+        "_:wDF688": {
+            "prov:generatedEntity": "niiri:395843f5ca50db682d73ad4b552a0079",
+            "prov:usedEntity": "niiri:313e60cc130ee5f7b46b9a70c28c95a0"
+        },
+        "_:wDF691": {
+            "prov:generatedEntity": "niiri:c9497860d4fc106d2a8129f3a41c5e21",
+            "prov:usedEntity": "niiri:313e60cc130ee5f7b46b9a70c28c95a0"
+        },
+        "_:wDF694": {
+            "prov:generatedEntity": "niiri:5ecb0bf5c97b7f24045a8880831fa426",
+            "prov:usedEntity": "niiri:313e60cc130ee5f7b46b9a70c28c95a0"
+        },
+        "_:wDF697": {
+            "prov:generatedEntity": "niiri:d36f5f82de4a3b0715a81212cca9c290",
+            "prov:usedEntity": "niiri:5755c7b6f3b8bb9a495a80e69a7ab94e"
+        },
+        "_:wDF700": {
+            "prov:generatedEntity": "niiri:e00bf7ebffe936d438f170dfbba1c2bf",
+            "prov:usedEntity": "niiri:5755c7b6f3b8bb9a495a80e69a7ab94e"
+        },
+        "_:wDF703": {
+            "prov:generatedEntity": "niiri:44b0e53d8cb7cd288c880c38c3120379",
+            "prov:usedEntity": "niiri:23f5c60185b27f2be0dd455c41c3fde3"
+        },
+        "_:wDF706": {
+            "prov:generatedEntity": "niiri:ac8f339519721b314dfbcb54584abed9",
+            "prov:usedEntity": "niiri:33cca310ebec4700e45b0560235f03cd"
+        },
+        "_:wDF709": {
+            "prov:generatedEntity": "niiri:6614974273127e7f54c4cba899f3eab6",
+            "prov:usedEntity": "niiri:33cca310ebec4700e45b0560235f03cd"
+        },
+        "_:wDF712": {
+            "prov:generatedEntity": "niiri:c742243cf82a89d57a67528234343c14",
+            "prov:usedEntity": "niiri:33cca310ebec4700e45b0560235f03cd"
+        },
+        "_:wDF715": {
+            "prov:generatedEntity": "niiri:ef6c96561d3475ee3682ddd186166797",
+            "prov:usedEntity": "niiri:68605e1a07366f1a9aaae9f04eb3bbcf"
+        },
+        "_:wDF718": {
+            "prov:generatedEntity": "niiri:9f24a0581a298125f2f285b756d18966",
+            "prov:usedEntity": "niiri:68605e1a07366f1a9aaae9f04eb3bbcf"
+        },
+        "_:wDF721": {
+            "prov:generatedEntity": "niiri:9c2ce6348aeb7ede7a631d7c312619e2",
+            "prov:usedEntity": "niiri:68605e1a07366f1a9aaae9f04eb3bbcf"
+        },
+        "_:wDF724": {
+            "prov:generatedEntity": "niiri:f71d38ee9ef7cc1c310f15620e0322f1",
+            "prov:usedEntity": "niiri:ab91ba995acbb604c8550a19c6d56878"
+        },
+        "_:wDF727": {
+            "prov:generatedEntity": "niiri:bcb9b4ab7230df4bb758bc460b37e486",
+            "prov:usedEntity": "niiri:ab91ba995acbb604c8550a19c6d56878"
+        },
+        "_:wDF730": {
+            "prov:generatedEntity": "niiri:0524275a9408ea6e1dc8e1d6c4ce5393",
+            "prov:usedEntity": "niiri:ab91ba995acbb604c8550a19c6d56878"
+        },
+        "_:wDF733": {
+            "prov:generatedEntity": "niiri:1c7d7853345eae89866ead4836881a90",
+            "prov:usedEntity": "niiri:8ddb469ed3d8d13f9f3b41143b2bc54e"
+        },
+        "_:wDF736": {
+            "prov:generatedEntity": "niiri:1ed918e3e6e487b700b47936095209c4",
+            "prov:usedEntity": "niiri:fe3d995dc2bfdeb5f29182f0558560a6"
+        },
+        "_:wDF739": {
+            "prov:generatedEntity": "niiri:837348f6ba9eea5a44579dfe608168d9",
+            "prov:usedEntity": "niiri:fe3d995dc2bfdeb5f29182f0558560a6"
+        },
+        "_:wDF742": {
+            "prov:generatedEntity": "niiri:fe8cde79b36b2168ffe3f9627203cbad",
+            "prov:usedEntity": "niiri:cfbb41a715a689539e32d23fa5ecf0ad"
+        },
+        "_:wDF745": {
+            "prov:generatedEntity": "niiri:d013871b13a39a72c56c973d8d7c69ea",
+            "prov:usedEntity": "niiri:cfbb41a715a689539e32d23fa5ecf0ad"
+        },
+        "_:wDF748": {
+            "prov:generatedEntity": "niiri:4edccd0555b06c37550a7a304066b78e",
+            "prov:usedEntity": "niiri:cfbb41a715a689539e32d23fa5ecf0ad"
+        },
+        "_:wDF751": {
+            "prov:generatedEntity": "niiri:937b4c105cb8dab064d0662d01153915",
+            "prov:usedEntity": "niiri:1ea775914efd19bdf7935c45c2fc61d7"
+        },
+        "_:wDF754": {
+            "prov:generatedEntity": "niiri:5ef928ba0042c21ed23333a93026c5a5",
+            "prov:usedEntity": "niiri:c9c2075e31233972320b91bbe319e15d"
+        },
+        "_:wDF757": {
+            "prov:generatedEntity": "niiri:3b48cac23fce59fddaa73fd59df07df2",
+            "prov:usedEntity": "niiri:184504b2959cc0300f56dbed9be3df0a"
+        },
+        "_:wDF760": {
+            "prov:generatedEntity": "niiri:91271dfe97a1459e04ef73790c14a894",
+            "prov:usedEntity": "niiri:e56b27d2108b9aebc19f9ff56ac97dce"
+        },
+        "_:wDF763": {
+            "prov:generatedEntity": "niiri:bd1b4d2f824f4a7a06cbe3b08d77df91",
+            "prov:usedEntity": "niiri:e78e0827b0a80cf9fb06ff0a74ee9600"
+        },
+        "_:wDF766": {
+            "prov:generatedEntity": "niiri:d1e90a72a70964a43504b62fa88ceb97",
+            "prov:usedEntity": "niiri:461b922ff7bd3d15d33f54bcbd492da3"
+        },
+        "_:wDF769": {
+            "prov:generatedEntity": "niiri:e777d8426ec1922a9300b8c510619da9",
+            "prov:usedEntity": "niiri:461b922ff7bd3d15d33f54bcbd492da3"
+        },
+        "_:wDF772": {
+            "prov:generatedEntity": "niiri:87ad6041e36ec3077cd5b4ed5e1e763f",
+            "prov:usedEntity": "niiri:1cfc9f0a458d8852ad0759c9e8be8a6a"
+        },
+        "_:wDF775": {
+            "prov:generatedEntity": "niiri:40a241f7cfcef8552dfd5aadd9a4fbf1",
+            "prov:usedEntity": "niiri:5bbe3c6a1630a3c2cc55aa12dfd9e286"
+        },
+        "_:wDF778": {
+            "prov:generatedEntity": "niiri:8454ccb4e839a31841899dbcc90d3705",
+            "prov:usedEntity": "niiri:1e1925d1a7237f41c7f4bbc7a938991e"
+        },
+        "_:wDF781": {
+            "prov:generatedEntity": "niiri:25112a96f0a534131b06def72c92db36",
+            "prov:usedEntity": "niiri:1e1925d1a7237f41c7f4bbc7a938991e"
+        },
+        "_:wDF784": {
+            "prov:generatedEntity": "niiri:ebbe77abb440c0b57b92a0f3181bf3ef",
+            "prov:usedEntity": "niiri:45311fe546d4fc676e17072f500c1575"
+        },
+        "_:wDF787": {
+            "prov:generatedEntity": "niiri:622888501323beabd65ee1c12fd5258f",
+            "prov:usedEntity": "niiri:45311fe546d4fc676e17072f500c1575"
+        },
+        "_:wDF790": {
+            "prov:generatedEntity": "niiri:2cc303fb0baeaaf69f5c83c6ace6046d",
+            "prov:usedEntity": "niiri:12134d971afb042d040aea6cecc0ebec"
+        },
+        "_:wDF793": {
+            "prov:generatedEntity": "niiri:939c3046fadf99b92e995efdba77b780",
+            "prov:usedEntity": "niiri:12134d971afb042d040aea6cecc0ebec"
+        },
+        "_:wDF796": {
+            "prov:generatedEntity": "niiri:59954b6fbe4f7e0ee8297e3dfb447725",
+            "prov:usedEntity": "niiri:7dfc1da184d477320648da6e59dc2a7c"
+        },
+        "_:wDF799": {
+            "prov:generatedEntity": "niiri:0d75e98dbb1ee49d43d97017b2bc924f",
+            "prov:usedEntity": "niiri:ff37e6b9b5486e16e27ae0fca1db545d"
+        },
+        "_:wDF802": {
+            "prov:generatedEntity": "niiri:60e306c02d06deb6b75ca415cf7afa84",
+            "prov:usedEntity": "niiri:bfb3c58b6c12062e86b12426bbf496d9"
+        },
+        "_:wDF805": {
+            "prov:generatedEntity": "niiri:70c48b68597d17a57d7df6777d571a0d",
+            "prov:usedEntity": "niiri:bfb3c58b6c12062e86b12426bbf496d9"
+        },
+        "_:wDF808": {
+            "prov:generatedEntity": "niiri:4febc9242872f447f9f0fb6d8187edd9",
+            "prov:usedEntity": "niiri:bfb3c58b6c12062e86b12426bbf496d9"
+        },
+        "_:wDF811": {
+            "prov:generatedEntity": "niiri:6309cc2f72b3ba21a56aceea534b259c",
+            "prov:usedEntity": "niiri:b1059120ca68f8c294f13d22a334afc5"
+        },
+        "_:wDF814": {
+            "prov:generatedEntity": "niiri:3af656624dd76ed9af5b633959de57aa",
+            "prov:usedEntity": "niiri:dd43f04c7775bf5d225a62b05a1f8275"
+        },
+        "_:wDF817": {
+            "prov:generatedEntity": "niiri:6a4d1d270484e6aaf38f13bdd3037234",
+            "prov:usedEntity": "niiri:dd43f04c7775bf5d225a62b05a1f8275"
+        },
+        "_:wDF820": {
+            "prov:generatedEntity": "niiri:c6fcc1f2ec131691f25f7ea0f2e12eb7",
+            "prov:usedEntity": "niiri:c723d93708cb4dee84578d4dad2314df"
+        },
+        "_:wDF823": {
+            "prov:generatedEntity": "niiri:b749f6df0e9c14d8711813f709744b7f",
+            "prov:usedEntity": "niiri:d30171bbdc271c074a6050acb8a4d34e"
+        },
+        "_:wDF826": {
+            "prov:generatedEntity": "niiri:31f45e8d9b10c8383ebb56334d2cd5f6",
+            "prov:usedEntity": "niiri:ea2ed9cc4d84a345a4920b11801993b3"
+        },
+        "_:wDF829": {
+            "prov:generatedEntity": "niiri:daf29f6ab3520aed8f7ff3bc5e75f2ab",
+            "prov:usedEntity": "niiri:ea2ed9cc4d84a345a4920b11801993b3"
+        },
+        "_:wDF832": {
+            "prov:generatedEntity": "niiri:ad918640c79c32e0c9a09cfe39505035",
+            "prov:usedEntity": "niiri:cf3d3e192bab8fb0febbddda2b472570"
+        },
+        "_:wDF835": {
+            "prov:generatedEntity": "niiri:f84262ea494283ee11627a522f8067fc",
+            "prov:usedEntity": "niiri:a6ee0e116834a7cbcea03e95f20dae54"
+        },
+        "_:wDF838": {
+            "prov:generatedEntity": "niiri:65f0d327b04aadb8425ee54a012bfd51",
+            "prov:usedEntity": "niiri:e9b27c64b1591506ec57168d7dbf134f"
+        },
+        "_:wDF841": {
+            "prov:generatedEntity": "niiri:135656545b11da25b3b9e5296a4c1583",
+            "prov:usedEntity": "niiri:35e614f307abb1c7215e649c0bbf0aa0"
+        },
+        "_:wDF844": {
+            "prov:generatedEntity": "niiri:16a0de533a153793ccdac522009f77c2",
+            "prov:usedEntity": "niiri:84661ae12e172546f496d4b26feacce8"
+        },
+        "_:wDF847": {
+            "prov:generatedEntity": "niiri:26852796b5d7ba6eb653315a8accd667",
+            "prov:usedEntity": "niiri:b3ab45e7aaebdd6d5415f3e8fb8365d3"
+        },
+        "_:wDF850": {
+            "prov:generatedEntity": "niiri:645365b733aee62b96ed5d9eb97c872a",
+            "prov:usedEntity": "niiri:a9dd639eb89226977a3ede42cafc093c"
+        },
+        "_:wDF853": {
+            "prov:generatedEntity": "niiri:9a917736e3d5642e34dc1a8c05d59370",
+            "prov:usedEntity": "niiri:01b4ff55ed7965f77f28199c98d35002"
+        },
+        "_:wDF856": {
+            "prov:generatedEntity": "niiri:8e8f82ce9a9f916915f7207c051727bd",
+            "prov:usedEntity": "niiri:01b4ff55ed7965f77f28199c98d35002"
+        },
+        "_:wDF859": {
+            "prov:generatedEntity": "niiri:a67831c35816df52629ee7a7fc26dde0",
+            "prov:usedEntity": "niiri:01b4ff55ed7965f77f28199c98d35002"
+        },
+        "_:wDF862": {
+            "prov:generatedEntity": "niiri:ec5b68946bd31e836ab65ff6af1c4a12",
+            "prov:usedEntity": "niiri:f606725494013a6004aeb7f3234c5659"
+        },
+        "_:wDF865": {
+            "prov:generatedEntity": "niiri:75631318c3d0bd234d33224648039cef",
+            "prov:usedEntity": "niiri:d70674f2ab25c84bf1ccbf050e157cb6"
+        },
+        "_:wDF868": {
+            "prov:generatedEntity": "niiri:5bdba307d61986d6149f72dba439105d",
+            "prov:usedEntity": "niiri:d3a715b103390651d1c521ee09f466c0"
+        },
+        "_:wDF871": {
+            "prov:generatedEntity": "niiri:2024155e74ac1cefebed8ca6401c4774",
+            "prov:usedEntity": "niiri:3577f89d6cde1468b3bf7bab875643fa"
+        },
+        "_:wDF874": {
+            "prov:generatedEntity": "niiri:d0fc86df54e53e74dd24a6a5984cb2c6",
+            "prov:usedEntity": "niiri:6b28309025a8c950f906f3a74a6104c4"
+        },
+        "_:wDF877": {
+            "prov:generatedEntity": "niiri:25187e17b37ef5575be4d5ced78392b0",
+            "prov:usedEntity": "niiri:40f12e78ef285dbb693762e0e24f5a51"
+        },
+        "_:wDF880": {
+            "prov:generatedEntity": "niiri:6b28b7892bbd80bbf1d73a494bd4d5f5",
+            "prov:usedEntity": "niiri:40f12e78ef285dbb693762e0e24f5a51"
+        },
+        "_:wDF883": {
+            "prov:generatedEntity": "niiri:deca705eeaa663fdf055aa9f356776a9",
+            "prov:usedEntity": "niiri:708e2b5584c9334ba1cde9334d8aee40"
+        },
+        "_:wDF886": {
+            "prov:generatedEntity": "niiri:d21f3565a424b86ffb29d622322bc1d3",
+            "prov:usedEntity": "niiri:2ed437f95a18d4610e20aee5f5ca8ca1"
+        },
+        "_:wDF889": {
+            "prov:generatedEntity": "niiri:e161951a5e1072e332cd915c3b62c0f7",
+            "prov:usedEntity": "niiri:2ed437f95a18d4610e20aee5f5ca8ca1"
+        },
+        "_:wDF892": {
+            "prov:generatedEntity": "niiri:2146b6f3997a0283631b40f42fa43d64",
+            "prov:usedEntity": "niiri:c4315919bc864f2492337dd699116ee4"
+        },
+        "_:wDF895": {
+            "prov:generatedEntity": "niiri:0e6bf474e07d5b7b08647f8b148f1967",
+            "prov:usedEntity": "niiri:c4315919bc864f2492337dd699116ee4"
+        },
+        "_:wDF898": {
+            "prov:generatedEntity": "niiri:d72c48f6d8afc2c9c15435f9d82418cf",
+            "prov:usedEntity": "niiri:c4315919bc864f2492337dd699116ee4"
+        },
+        "_:wDF901": {
+            "prov:generatedEntity": "niiri:36093115c68af5d4a10804e4c18ac4b8",
+            "prov:usedEntity": "niiri:5ad7bfc734bce8d2e03526bbce4c1642"
+        },
+        "_:wDF904": {
+            "prov:generatedEntity": "niiri:f6438ecb7f50fccc2df09ada0b2c3936",
+            "prov:usedEntity": "niiri:5ad7bfc734bce8d2e03526bbce4c1642"
+        },
+        "_:wDF907": {
+            "prov:generatedEntity": "niiri:e92804e0ae7f8fae7ff71ce6170d001c",
+            "prov:usedEntity": "niiri:5ad7bfc734bce8d2e03526bbce4c1642"
+        },
+        "_:wDF910": {
+            "prov:generatedEntity": "niiri:ad38b1977ea2816b6d5129b7de2be1cc",
+            "prov:usedEntity": "niiri:f28a45db3e8e726134be22dd55ada8fc"
+        },
+        "_:wDF913": {
+            "prov:generatedEntity": "niiri:381454c1e2fbda01612a05c0a4339f74",
+            "prov:usedEntity": "niiri:7dbd526d156c17d030cb03d4502bec48"
+        },
+        "_:wDF916": {
+            "prov:generatedEntity": "niiri:b762ee5ba6db8bfb0128b4bb42245b28",
+            "prov:usedEntity": "niiri:7dbd526d156c17d030cb03d4502bec48"
+        },
+        "_:wDF919": {
+            "prov:generatedEntity": "niiri:85563c1d691e946655502a1d62515133",
+            "prov:usedEntity": "niiri:db64bef791d519bd840c407a07274b39"
+        },
+        "_:wDF922": {
+            "prov:generatedEntity": "niiri:41ddd3c253a63198d170247b8ccef29c",
+            "prov:usedEntity": "niiri:261d424ff1d40e2e1212f8b47057e08d"
+        },
+        "_:wDF925": {
+            "prov:generatedEntity": "niiri:78ffb1d7f41f1c0b6ea5119ca8935556",
+            "prov:usedEntity": "niiri:f0b1b468bf91334fdba7c8b7612cca41"
+        },
+        "_:wDF928": {
+            "prov:generatedEntity": "niiri:d614eab5b59c47eed1084c951be2e2ac",
+            "prov:usedEntity": "niiri:6faaad2ce4a4160eadbbce94632ec2bf"
+        },
+        "_:wDF931": {
+            "prov:generatedEntity": "niiri:b50f8c0634d1f6225cc186049de68413",
+            "prov:usedEntity": "niiri:6faaad2ce4a4160eadbbce94632ec2bf"
+        },
+        "_:wDF934": {
+            "prov:generatedEntity": "niiri:37f724585a89abe98ff9f20ca03e9884",
+            "prov:usedEntity": "niiri:6faaad2ce4a4160eadbbce94632ec2bf"
+        },
+        "_:wDF937": {
+            "prov:generatedEntity": "niiri:e12a986e485026e4d146b52ea34da3ea",
+            "prov:usedEntity": "niiri:8451b5d05d4d0f88becbc68925bab4c9"
+        },
+        "_:wDF940": {
+            "prov:generatedEntity": "niiri:b9372af04e7acfd4ce56135b4d0536af",
+            "prov:usedEntity": "niiri:e8d74786a114ffeb6114fffeeb2583da"
+        },
+        "_:wDF943": {
+            "prov:generatedEntity": "niiri:48b80f9b9e00d0859755f74a197e7295",
+            "prov:usedEntity": "niiri:af4cb856d066cec808680cb766e205ae"
+        },
+        "_:wDF946": {
+            "prov:generatedEntity": "niiri:911d519f5928583e1f82ac51bab14528",
+            "prov:usedEntity": "niiri:64c74f4674adc0005dffc886ffba3300"
+        },
+        "_:wDF949": {
+            "prov:generatedEntity": "niiri:b35cc4339b958823a6b0d89e47050e64",
+            "prov:usedEntity": "niiri:878873f431f64df4853365a578c78440"
+        },
+        "_:wDF952": {
+            "prov:generatedEntity": "niiri:98380d632dcdfa9a6e36fc6b78b2273c",
+            "prov:usedEntity": "niiri:62873793384331403012ec1c900656e0"
+        },
+        "_:wDF955": {
+            "prov:generatedEntity": "niiri:720ed23eb6c46a721179918c28f55ffc",
+            "prov:usedEntity": "niiri:cf86c38738ff15923d1bfe58d642e526"
+        },
+        "_:wDF958": {
+            "prov:generatedEntity": "niiri:06f3fa5f5a7dd43a7c83878b6daecccd",
+            "prov:usedEntity": "niiri:6eb2f26421b4abdd2aff61056be6347c"
+        },
+        "_:wDF961": {
+            "prov:generatedEntity": "niiri:aeae6d15ef755bd8bf17831ae1de5a8b",
+            "prov:usedEntity": "niiri:464e6cc9ad8cde4967c4e8430942863e"
+        },
+        "_:wDF964": {
+            "prov:generatedEntity": "niiri:f1c37bc22f16214c1df5f88314a215a4",
+            "prov:usedEntity": "niiri:0f59b224fb308f5b33db0b615cec440e"
+        },
+        "_:wDF967": {
+            "prov:generatedEntity": "niiri:bef3273cb030511d57da83b609f7288b",
+            "prov:usedEntity": "niiri:61f0e2e951d39892ec38816ca4ff7b91"
+        },
+        "_:wDF970": {
+            "prov:generatedEntity": "niiri:95ad202473a2bf127c7926f3746acacc",
+            "prov:usedEntity": "niiri:9764501f1b27ea039a6888cad5412dc6"
+        },
+        "_:wDF973": {
+            "prov:generatedEntity": "niiri:0fb6745b7885bc7a34cefdeb57f43c2f",
+            "prov:usedEntity": "niiri:c4798ee5bb6817f0ac7d3d1f7cbb895d"
+        },
+        "_:wDF976": {
+            "prov:generatedEntity": "niiri:458c984a04e6737387c5f9f56e3c0c8a",
+            "prov:usedEntity": "niiri:5499ba7833a3a03073324dac7488ac06"
+        },
+        "_:wDF979": {
+            "prov:generatedEntity": "niiri:baeb0c03f7acf106a1287e421c2742f3",
+            "prov:usedEntity": "niiri:5499ba7833a3a03073324dac7488ac06"
+        },
+        "_:wDF982": {
+            "prov:generatedEntity": "niiri:ca0839c16a1a2c559d6575777eda49c0",
+            "prov:usedEntity": "niiri:50c6ebb589d5bdb3e362aaf8f837978b"
+        },
+        "_:wDF985": {
+            "prov:generatedEntity": "niiri:8369fa28a67eb70b3c8346f78b861cd7",
+            "prov:usedEntity": "niiri:a489f5516c417d51a01d581c1281955e"
+        },
+        "_:wDF988": {
+            "prov:generatedEntity": "niiri:c9919f1aac8740808b218ad44f9721a0",
+            "prov:usedEntity": "niiri:e4ff54dd97ad1e3f10b9d1c7027c4645"
+        },
+        "_:wDF991": {
+            "prov:generatedEntity": "niiri:8e304887e697a26945a0a355426f4603",
+            "prov:usedEntity": "niiri:8de83fae7bd6e9f8380ec49cdc4829ae"
+        },
+        "_:wDF994": {
+            "prov:generatedEntity": "niiri:c94747cdbcb83041515a601d983f3b27",
+            "prov:usedEntity": "niiri:85491f67ab81ddeb946caf2849c4b9f4"
+        },
+        "_:wDF997": {
+            "prov:generatedEntity": "niiri:e42d96aae6a120678fb678c94074a5db",
+            "prov:usedEntity": "niiri:3e9eba22eff518f24b14c038fe2913df"
+        },
+        "_:wDF1000": {
+            "prov:generatedEntity": "niiri:d358ade24a46e28d596c4d0af691488b",
+            "prov:usedEntity": "niiri:2b503ca3533d10a4f1f80dad7060444a"
+        },
+        "_:wDF1003": {
+            "prov:generatedEntity": "niiri:8756d972087f4144374fcbc8ae52666e",
+            "prov:usedEntity": "niiri:cf6de656d89419d4ac154fd946ec6388"
+        },
+        "_:wDF1006": {
+            "prov:generatedEntity": "niiri:a89e2e80fe4388ce0ae8d072fcec1ac6",
+            "prov:usedEntity": "niiri:9c0f05c7637bc2f31d907b17584b6aa0"
+        },
+        "_:wDF1009": {
+            "prov:generatedEntity": "niiri:ab27403976625180dff5b30fab548263",
+            "prov:usedEntity": "niiri:62e799c85533fe86208bf5e33c6a326d"
+        },
+        "_:wDF1012": {
+            "prov:generatedEntity": "niiri:46ddcc1817cf540464c279f74a62d9e4",
+            "prov:usedEntity": "niiri:7b8b805f3c10072513741773f37173a9"
+        },
+        "_:wDF1015": {
+            "prov:generatedEntity": "niiri:bf6a4e636ece08a9573e7b57d980d23f",
+            "prov:usedEntity": "niiri:c8967930ef6b4850b98397e5a02cf2f7"
+        },
+        "_:wDF1018": {
+            "prov:generatedEntity": "niiri:2eae7c427a5a98b75646c2db0e42ffd3",
+            "prov:usedEntity": "niiri:162bab89b0c20f6474f1241e5c7169b3"
+        },
+        "_:wDF1021": {
+            "prov:generatedEntity": "niiri:f175b4660b0c3a112517dde55ce65ffd",
+            "prov:usedEntity": "niiri:91dc841836bbf5d1c0b426905fb75e01"
+        },
+        "_:wDF1024": {
+            "prov:generatedEntity": "niiri:c82901e5c8a2f2e07c026cc63680c42d",
+            "prov:usedEntity": "niiri:3f463a005d2c5f82895c19639d89d232"
+        },
+        "_:wDF1027": {
+            "prov:generatedEntity": "niiri:5e05a6be8ed22422ff22c365a4608304",
+            "prov:usedEntity": "niiri:a088e0c82151087e1bf9897ac5ca3823"
+        },
+        "_:wDF1030": {
+            "prov:generatedEntity": "niiri:e7bdd69e98dd52520a3f71978bb4d63d",
+            "prov:usedEntity": "niiri:321fa4b64bb46facf5ed354080dc1587"
+        },
+        "_:wDF1033": {
+            "prov:generatedEntity": "niiri:cb0d453b25f613101c49b7755e158915",
+            "prov:usedEntity": "niiri:1bb068ae0340b41c3c1e0585e61ab7a2"
+        },
+        "_:wDF1036": {
+            "prov:generatedEntity": "niiri:5e99034ea754760cb72226c0515da7cb",
+            "prov:usedEntity": "niiri:1bb068ae0340b41c3c1e0585e61ab7a2"
+        },
+        "_:wDF1039": {
+            "prov:generatedEntity": "niiri:129852f860cbdc380fde0cefe3342420",
+            "prov:usedEntity": "niiri:0b5c4b3fea9afd08f274ad657436f2dd"
+        },
+        "_:wDF1042": {
+            "prov:generatedEntity": "niiri:b0ded885245f537f83463a08809ba2e2",
+            "prov:usedEntity": "niiri:7b0e7637357771b4e3c95b60da0daba2"
+        },
+        "_:wDF1045": {
+            "prov:generatedEntity": "niiri:22c1d4544f394d556ce159121dad1090",
+            "prov:usedEntity": "niiri:b8afe5b11ecf6b25c3098ac5c67b90a0"
+        },
+        "_:wDF1048": {
+            "prov:generatedEntity": "niiri:547427e4ab366b57aeae32169e9fa826",
+            "prov:usedEntity": "niiri:a2a8b82493043f5593bcde950e35d4f5"
+        },
+        "_:wDF1051": {
+            "prov:generatedEntity": "niiri:b237ed83cace8461fcea11375ea64058",
+            "prov:usedEntity": "niiri:13a870b0869420f093e2bf23ab79a37e"
+        },
+        "_:wDF1054": {
+            "prov:generatedEntity": "niiri:eb9870892ec73e0a42bedc835e702e1e",
+            "prov:usedEntity": "niiri:9e62040415b20939b8c829b35ac0b428"
+        },
+        "_:wDF1057": {
+            "prov:generatedEntity": "niiri:fcfba481a3f9e7e9b20a26684a18708e",
+            "prov:usedEntity": "niiri:ef74f8693d6b0cc1f8f7291479877d46"
+        },
+        "_:wDF1060": {
+            "prov:generatedEntity": "niiri:4a44af96f5a5a857488581ee74a760c5",
+            "prov:usedEntity": "niiri:b4f4a8e2b968691b39abdbd7cd10251b"
+        },
+        "_:wDF1063": {
+            "prov:generatedEntity": "niiri:365c37bfef2c5372b568baf1a0e25c19",
+            "prov:usedEntity": "niiri:b479ffd217729f45ba8e8b497543b71d"
+        },
+        "_:wDF1066": {
+            "prov:generatedEntity": "niiri:9bdf6e301bc7d332bfc69fca7860e71a",
+            "prov:usedEntity": "niiri:64b1c86050912153a776e757204d9bd6"
+        },
+        "_:wDF1069": {
+            "prov:generatedEntity": "niiri:f154380a3618d99fcc1963b7595b12cf",
+            "prov:usedEntity": "niiri:2262ce46c8d9d3e44fca9d2b9991842a"
+        },
+        "_:wDF1072": {
+            "prov:generatedEntity": "niiri:04b3a6d25c6f054367f9c4694052a759",
+            "prov:usedEntity": "niiri:03e5589e0cbf8390adc9f572f09c2111"
+        },
+        "_:wDF1075": {
+            "prov:generatedEntity": "niiri:21a5865dd670800228185cc04d8fc8fb",
+            "prov:usedEntity": "niiri:183d033f8dc6f63dd2d370f917d30bf5"
+        },
+        "_:wDF1078": {
+            "prov:generatedEntity": "niiri:c74a4087e267c6fd39be3a397e46725a",
+            "prov:usedEntity": "niiri:82ed6a608808b53426982c1cc66a2ec6"
+        },
+        "_:wDF1081": {
+            "prov:generatedEntity": "niiri:b7c5013ad25e77cc226834b99a8ce972",
+            "prov:usedEntity": "niiri:c38a12c7c56a4a6bcef1a3f1defaede6"
+        },
+        "_:wDF1084": {
+            "prov:generatedEntity": "niiri:6991f89fa4a569360c7960b2846f6a34",
+            "prov:usedEntity": "niiri:b903a819026d14c010b6e3c047f2d1f1"
+        },
+        "_:wDF1087": {
+            "prov:generatedEntity": "niiri:491aedeeb6989cc87f18a592ce6034b8",
+            "prov:usedEntity": "niiri:932955007c6604e912ca88f69e4b71b2"
+        },
+        "_:wDF1090": {
+            "prov:generatedEntity": "niiri:a0e32572643e1e64ce6a2b660df410a5",
+            "prov:usedEntity": "niiri:19bb8ba20387a263ccc2a4033c4a6959"
+        },
+        "_:wDF1093": {
+            "prov:generatedEntity": "niiri:eff4c7c132b2d22a84606557001ce26e",
+            "prov:usedEntity": "niiri:4c267352cce4185f6d8f19642a2432ea"
+        },
+        "_:wDF1096": {
+            "prov:generatedEntity": "niiri:bbf3d38beafaa3b95e5b56928a96bf1c",
+            "prov:usedEntity": "niiri:b779ca098f1180fe09ebe0414895c731"
+        },
+        "_:wDF1099": {
+            "prov:generatedEntity": "niiri:fde7e62b6e5574c052bb9f546102d87e",
+            "prov:usedEntity": "niiri:b7385089cc22c8804fc256dff15181f6"
+        },
+        "_:wDF1102": {
+            "prov:generatedEntity": "niiri:fd29863328da8f073c80249fc257f355",
+            "prov:usedEntity": "niiri:b7385089cc22c8804fc256dff15181f6"
+        },
+        "_:wDF1105": {
+            "prov:generatedEntity": "niiri:bbfd8b6cf217d559db130a9610ba08e1",
+            "prov:usedEntity": "niiri:a34044dfcf23dfe53b2945318b0397f1"
+        },
+        "_:wDF1108": {
+            "prov:generatedEntity": "niiri:7b9ad2de6142a99edfdc041b3923c4a7",
+            "prov:usedEntity": "niiri:e3223bf7299c1367c69b65daadf7dab4"
+        },
+        "_:wDF1111": {
+            "prov:generatedEntity": "niiri:22f96a3b44837b69cbbf8a2c6235393c",
+            "prov:usedEntity": "niiri:315a3351fd67e6810a0558156faed379"
+        },
+        "_:wDF1114": {
+            "prov:generatedEntity": "niiri:4acde4458913098e4ee4d1c2c2fdf3e4",
+            "prov:usedEntity": "niiri:956afe330511d5dec77faf29c8e66c5b"
+        },
+        "_:wDF1117": {
+            "prov:generatedEntity": "niiri:d0a5abfdb9ce4fbd61ff9387b7bb7058",
+            "prov:usedEntity": "niiri:4740016eb1ce8e7ec8341eb44cf9ffa5"
+        },
+        "_:wDF1120": {
+            "prov:generatedEntity": "niiri:8eb9d8849b7d8b35f84629d662d9ddce",
+            "prov:usedEntity": "niiri:f956c3347b26a7454fde4d7c1ee3dfac"
+        },
+        "_:wDF1123": {
+            "prov:generatedEntity": "niiri:b9ada525c8e48deb5d4ab2d7359c8cad",
+            "prov:usedEntity": "niiri:0306caf1c070bce484bea6d4d02ee4b9"
+        },
+        "_:wDF1126": {
+            "prov:generatedEntity": "niiri:3858cf13f28f0ad56deb178e3014e96c",
+            "prov:usedEntity": "niiri:0718df40c87e4adde0a6b31fdd007bb4"
+        },
+        "_:wDF1129": {
+            "prov:generatedEntity": "niiri:1112b9b2a26ffc98a6ff69fd57530f89",
+            "prov:usedEntity": "niiri:c3345fe728c02a6d54b764235fc35217"
+        },
+        "_:wDF1132": {
+            "prov:generatedEntity": "niiri:774e14320ea8f360c6b0c85dfac5a6f6",
+            "prov:usedEntity": "niiri:db4e8782b5b474daeb575623d11d8f36"
+        },
+        "_:wDF1135": {
+            "prov:generatedEntity": "niiri:47ddc4f29769c51faebf4ea324bcbea6",
+            "prov:usedEntity": "niiri:3a7bd3c73757ad2c63a505ac44ee7de9"
+        },
+        "_:wDF1138": {
+            "prov:generatedEntity": "niiri:294213488c1599f884797c81cb836c26",
+            "prov:usedEntity": "niiri:ca632dc1f3d6a97bb76e5a785e5f4b39"
+        },
+        "_:wDF1141": {
+            "prov:generatedEntity": "niiri:5ef57e2d25150bc6ea7a27effd3f103a",
+            "prov:usedEntity": "niiri:4d501ade9f45e68e86c0aef60754a9aa"
+        },
+        "_:wDF1144": {
+            "prov:generatedEntity": "niiri:0d6879c706d432096efe8532fec772d4",
+            "prov:usedEntity": "niiri:4353f4b513f6d03c8ce9a7ee07ac3524"
+        },
+        "_:wDF1147": {
+            "prov:generatedEntity": "niiri:ab5b8f7ed76dff5e4855a5dd6e0a6743",
+            "prov:usedEntity": "niiri:d24c03f6c5960ef050e1d0a675496464"
+        },
+        "_:wDF1150": {
+            "prov:generatedEntity": "niiri:764e3cd68a4e95df65e0a1e502bbd0d3",
+            "prov:usedEntity": "niiri:0630bc3a96bd8ec1bd4f2dbb98bd8a68"
+        },
+        "_:wDF1153": {
+            "prov:generatedEntity": "niiri:75596cb1506d72be9c60a786cdfeb9e9",
+            "prov:usedEntity": "niiri:7a6a9d89a41bce106a6e3f6b9bf39fc2"
+        },
+        "_:wDF1156": {
+            "prov:generatedEntity": "niiri:cc61bb9a0e1e912d0243c40937af6d28",
+            "prov:usedEntity": "niiri:6cd9c8b1f2dc650429e50bd72f6da32d"
+        },
+        "_:wDF1159": {
+            "prov:generatedEntity": "niiri:32de098d3053799d0fc2c5c953ee1d3c",
+            "prov:usedEntity": "niiri:f0caefb73eec8df07661fca6c2cc2a56"
+        },
+        "_:wDF1162": {
+            "prov:generatedEntity": "niiri:459d474e17bd85aec6efe07624d6ae57",
+            "prov:usedEntity": "niiri:10dda0f512d376c45616527318012baa"
+        },
+        "_:wDF1165": {
+            "prov:generatedEntity": "niiri:3510b1f1d6805ff05bb7b6b5d36253fa",
+            "prov:usedEntity": "niiri:3aeaeffb7762bacf9f1b2dc630012fe3"
+        },
+        "_:wDF1168": {
+            "prov:generatedEntity": "niiri:5bf7e5d9bb601821a72345c87cedd51c",
+            "prov:usedEntity": "niiri:88ee03bc281326c9948572b0834fecf3"
+        },
+        "_:wDF1171": {
+            "prov:generatedEntity": "niiri:b691067d61784029be138ffa1686adb8",
+            "prov:usedEntity": "niiri:30868fad9324d3113736d83bd681718a"
+        },
+        "_:wDF1174": {
+            "prov:generatedEntity": "niiri:b2e8f0a888997bba7bfdd9f220a34d7c",
+            "prov:usedEntity": "niiri:4b462b6d837ce2e27bce61ed0c368fd6"
+        },
+        "_:wDF1177": {
+            "prov:generatedEntity": "niiri:db0d54b000c98e5dee79f930e669b285",
+            "prov:usedEntity": "niiri:1bf97c65bec07a1317ef69c944689cf8"
+        },
+        "_:wDF1180": {
+            "prov:generatedEntity": "niiri:79e2013c8aa62a779d24f56c4f7d2b61",
+            "prov:usedEntity": "niiri:cd27fa26bbd5aa4fa8cfbebf1bb95ad9"
+        },
+        "_:wDF1183": {
+            "prov:generatedEntity": "niiri:36d4e5984e645e3739eafcddd636c2a0",
+            "prov:usedEntity": "niiri:31a80df97955e986f4be4839a052a5db"
+        },
+        "_:wDF1186": {
+            "prov:generatedEntity": "niiri:ee94413a615c0ae8d638fa74a0954f38",
+            "prov:usedEntity": "niiri:39fc04da006cbf70670a7f80045d0d49"
+        },
+        "_:wDF1189": {
+            "prov:generatedEntity": "niiri:c4ca487861e26bb6edf9d460b8c438f5",
+            "prov:usedEntity": "niiri:a2df6515d44ea1c2de2e20cd83b43f91"
+        },
+        "_:wDF1192": {
+            "prov:generatedEntity": "niiri:74d29ddfa219f7865899d3e1aa985fad",
+            "prov:usedEntity": "niiri:9b33ff671ff0c042af89e5b1be1377da"
+        },
+        "_:wDF1195": {
+            "prov:generatedEntity": "niiri:02ee73aa72ad228b43c68c9f025c92c9",
+            "prov:usedEntity": "niiri:25e2f4ca28679423b49be4329eea0bc3"
+        },
+        "_:wDF1198": {
+            "prov:generatedEntity": "niiri:5148a355763840d52c51745baf6d8bf1",
+            "prov:usedEntity": "niiri:0a729befa841fff84fcf2612fb2ce4a5"
+        },
+        "_:wDF1201": {
+            "prov:generatedEntity": "niiri:0799198166c4e4ec859a6d6486f90093",
+            "prov:usedEntity": "niiri:501da0873de972e1023817d65202130e"
+        },
+        "_:wDF1204": {
+            "prov:generatedEntity": "niiri:0aa10d875c9c1e35c96e247e10de57ee",
+            "prov:usedEntity": "niiri:0336a0114f6c74e1df58148ee9b074f4"
+        },
+        "_:wDF1207": {
+            "prov:generatedEntity": "niiri:df286e546b49998eef6184d9ae67818c",
+            "prov:usedEntity": "niiri:06324b32c616d4e45a79cb65a439ac48"
+        },
+        "_:wDF1210": {
+            "prov:generatedEntity": "niiri:b5c652713f89d13b86856e3329e60e97",
+            "prov:usedEntity": "niiri:ac9a19a2b1c9949a888ebae7d65a2399"
+        },
+        "_:wDF1213": {
+            "prov:generatedEntity": "niiri:89124d4a55465ecc6580a87278eb8730",
+            "prov:usedEntity": "niiri:061dca60ff6ace182bd1ebe945535ace"
+        },
+        "_:wDF1216": {
+            "prov:generatedEntity": "niiri:7c0c361d425385fbaf81e45ac15b1add",
+            "prov:usedEntity": "niiri:6242500a1c0ecfe873a2799eca21133b"
+        },
+        "_:wDF1219": {
+            "prov:generatedEntity": "niiri:a27efb8e81003403a3b728b02a0305de",
+            "prov:usedEntity": "niiri:62f0dcd6742c42c5c8a69829ea982b14"
+        },
+        "_:wDF1222": {
+            "prov:generatedEntity": "niiri:f6c9002f2a33bbdcf918614062da93d1",
+            "prov:usedEntity": "niiri:ed86b8af25a7303faba66f96f7427038"
+        },
+        "_:wDF1225": {
+            "prov:generatedEntity": "niiri:273a08beef0cdedfcbf83ba358d17b4a",
+            "prov:usedEntity": "niiri:81c63725e4640647cd75f101cc0fc8a7"
+        },
+        "_:wDF1228": {
+            "prov:generatedEntity": "niiri:b8d737b346f350b24c46e795748e22fb",
+            "prov:usedEntity": "niiri:4b2e0a2531b0291df0fe5df5bc205ec9"
+        },
+        "_:wDF1231": {
+            "prov:generatedEntity": "niiri:b628b10379f38e68ed5b66c336b27ce3",
+            "prov:usedEntity": "niiri:7f91f8087c7d8ec7eda6204b5b39482d"
+        },
+        "_:wDF1234": {
+            "prov:generatedEntity": "niiri:73de5af689e2e854fa7db73a7b08e0fe",
+            "prov:usedEntity": "niiri:2c7f0285c24b2b8b65a032418b15cd16"
+        },
+        "_:wDF1237": {
+            "prov:generatedEntity": "niiri:b0085be54d5b554caf5c0c60d9943ca3",
+            "prov:usedEntity": "niiri:7ed3fe10280b67503b5448524a04f269"
+        },
+        "_:wDF1240": {
+            "prov:generatedEntity": "niiri:f9e69d234f36d1d73224b4a30b59f7dc",
+            "prov:usedEntity": "niiri:99c58e7d96cf7da6763a2e1cbba873ae"
+        },
+        "_:wDF1243": {
+            "prov:generatedEntity": "niiri:fdaaf45a96ab001df01c3f32cad6f0d5",
+            "prov:usedEntity": "niiri:d5206500679003f5f39472159c4ad0de"
+        },
+        "_:wDF1246": {
+            "prov:generatedEntity": "niiri:802d2977df694ebb8aa91513a51f9d09",
+            "prov:usedEntity": "niiri:0803006e1feea37abdc724f07464d7a9"
+        },
+        "_:wDF1249": {
+            "prov:generatedEntity": "niiri:cd20eea678913bcc90beb6f06a1cd190",
+            "prov:usedEntity": "niiri:abae6765a0aa40936d109b9a2fd5acbf"
+        },
+        "_:wDF1252": {
+            "prov:generatedEntity": "niiri:edf7c2638a60e524d92e073751527602",
+            "prov:usedEntity": "niiri:4b0a463a8d9ceb66a11c49348ae1f5fc"
+        },
+        "_:wDF1255": {
+            "prov:generatedEntity": "niiri:b1acd578e7fa991204c8a410a3717560",
+            "prov:usedEntity": "niiri:ca33d7428ff48eafbc3f213db2286c92"
+        },
+        "_:wDF1258": {
+            "prov:generatedEntity": "niiri:494d32a46900ee1bd2a49c4de9617108",
+            "prov:usedEntity": "niiri:a2d559eeea3fd425019a74c32cb07b03"
+        },
+        "_:wDF1261": {
+            "prov:generatedEntity": "niiri:16a6a4016277da6cf913ef3b2c7113db",
+            "prov:usedEntity": "niiri:1cffc79d71ec5b44f8be32f71d15b738"
+        },
+        "_:wDF1264": {
+            "prov:generatedEntity": "niiri:5d0442cdaea493ca10a242a8af6b8b02",
+            "prov:usedEntity": "niiri:08835c169510829e8effda3071bba336"
+        },
+        "_:wDF1267": {
+            "prov:generatedEntity": "niiri:d32c29e6c832599417bd8574e70ffe47",
+            "prov:usedEntity": "niiri:d5a3f5e4133bc22e2c189ceeb5b93544"
+        },
+        "_:wDF1270": {
+            "prov:generatedEntity": "niiri:1da4e83fb9b216cfbd49324f411b7060",
+            "prov:usedEntity": "niiri:9b44436d58818f06cd48133f714e8a99"
+        },
+        "_:wDF1273": {
+            "prov:generatedEntity": "niiri:d4fa6966b630445b57a0f19116a3daed",
+            "prov:usedEntity": "niiri:051457613c34bfa68d60b137e8c7ae17"
+        },
+        "_:wDF1276": {
+            "prov:generatedEntity": "niiri:ad65b31051a0c3ef755cdd2741ae415f",
+            "prov:usedEntity": "niiri:ea9fe9402f815e54e3cef6704ebcb2e4"
+        },
+        "_:wDF1279": {
+            "prov:generatedEntity": "niiri:5c492afc637552d22a37d356b892476b",
+            "prov:usedEntity": "niiri:1dce01b8df60884c582e29243c828080"
+        },
+        "_:wDF1282": {
+            "prov:generatedEntity": "niiri:f6cd2c4025ec944fe9fad4a68eeb76c3",
+            "prov:usedEntity": "niiri:eb8a2332e6ccc41b6d1a8cca84b280fe"
+        },
+        "_:wDF1285": {
+            "prov:generatedEntity": "niiri:b076644097262f402af618f0521f3c6f",
+            "prov:usedEntity": "niiri:3ab29b7a5414afa7ee3dad94fe418d2f"
+        },
+        "_:wDF1288": {
+            "prov:generatedEntity": "niiri:cf314ff0f3be99903935c1888a63ccdc",
+            "prov:usedEntity": "niiri:de99f369510067d001dcfc78a4b7ee95"
+        },
+        "_:wDF1291": {
+            "prov:generatedEntity": "niiri:653a08ed610a534c1cf43ad67b874319",
+            "prov:usedEntity": "niiri:03516b1ded0c354154f06310cfeb09c0"
+        },
+        "_:wDF1294": {
+            "prov:generatedEntity": "niiri:7132d322b3cc936428996208440f96f6",
+            "prov:usedEntity": "niiri:56da6908cbe82b7569f6ca2737e51eb6"
+        },
+        "_:wDF1297": {
+            "prov:generatedEntity": "niiri:0640d1c27d97d1f42ae25c516d60eb0c",
+            "prov:usedEntity": "niiri:087ce96dd01c83b4336943a7df6de172"
+        },
+        "_:wDF1300": {
+            "prov:generatedEntity": "niiri:443881374484db2a28a772aefb17c81f",
+            "prov:usedEntity": "niiri:1a5540bf2e828d5e14c6001adb4f30d5"
+        },
+        "_:wDF1303": {
+            "prov:generatedEntity": "niiri:cdca9d1394769421f403ff2c2b85319d",
+            "prov:usedEntity": "niiri:b54974658dcfd8d91a65540d01e3250b"
+        },
+        "_:wDF1306": {
+            "prov:generatedEntity": "niiri:2f89f4ddc37f465398449ec427aef8f4",
+            "prov:usedEntity": "niiri:b1012bc624cd6b3f47ff149073d0a78b"
+        },
+        "_:wDF1309": {
+            "prov:generatedEntity": "niiri:cce527c4d5173264fd0ba76367f83931",
+            "prov:usedEntity": "niiri:d45da63c733d96ddba5cf2fb05dc0b58"
+        },
+        "_:wDF1312": {
+            "prov:generatedEntity": "niiri:f59eaee6cc14a37ee302a26deccb5ba8",
+            "prov:usedEntity": "niiri:14e793643765a6fe10fb66237bee63db"
+        },
+        "_:wDF1315": {
+            "prov:generatedEntity": "niiri:cbdb1c804f7d0ec340e49acbe0f59365",
+            "prov:usedEntity": "niiri:a3b1937d74b3d7366255ed05df95e8dc"
+        },
+        "_:wDF1318": {
+            "prov:generatedEntity": "niiri:e99c458abc0e31d64f6dc46f9eb3ba86",
+            "prov:usedEntity": "niiri:4f0d78d14b791c15d9759ece4ec7e6ed"
+        },
+        "_:wDF1321": {
+            "prov:generatedEntity": "niiri:ed39a62270a751bff5d29b2e4c49e7f8",
+            "prov:usedEntity": "niiri:f569ae7a0c44f14440097fc2492d13ab"
+        },
+        "_:wDF1324": {
+            "prov:generatedEntity": "niiri:b97a5c6fcb6a02f68a6fadc9cf02ba98",
+            "prov:usedEntity": "niiri:2fd27f14078fbb1aa402a271e101e35f"
+        },
+        "_:wDF1327": {
+            "prov:generatedEntity": "niiri:3fc6abca83add3e6e871c4ba13db90d8",
+            "prov:usedEntity": "niiri:5476fcd5093f7c864637efaafd42b996"
+        },
+        "_:wDF1330": {
+            "prov:generatedEntity": "niiri:73ff07955917113509745f126dd5bd76",
+            "prov:usedEntity": "niiri:10bac4ccf6049482f632adb3952c3c8c"
+        },
+        "_:wDF1333": {
+            "prov:generatedEntity": "niiri:3a2f1d64a861856a52cc3fa9969bc2b0",
+            "prov:usedEntity": "niiri:cda273936fc980c18403b41fb8533954"
+        },
+        "_:wDF1336": {
+            "prov:generatedEntity": "niiri:aef2a2aecfbeec0007f227032d3cef74",
+            "prov:usedEntity": "niiri:89501dfa67d1d32810bbe20fd9b1fe8c"
+        },
+        "_:wDF1339": {
+            "prov:generatedEntity": "niiri:98a88c543aab0179b9f3e245882a9203",
+            "prov:usedEntity": "niiri:02f6f6429a8304a7731a404570cb4b94"
+        },
+        "_:wDF1342": {
+            "prov:generatedEntity": "niiri:3cec9a1c9417800f3a247e3023d0f1cb",
+            "prov:usedEntity": "niiri:8747a3ddd24cbd71e40672d541cefee5"
+        },
+        "_:wDF1345": {
+            "prov:generatedEntity": "niiri:a7e2dfc487d0a70d1149fdf1efb30d4c",
+            "prov:usedEntity": "niiri:c885eb98b2506b007c2d8feb2e37f08e"
+        },
+        "_:wDF1348": {
+            "prov:generatedEntity": "niiri:0528a1b646839dcdd2fb0bb16a07223d",
+            "prov:usedEntity": "niiri:bd96226234de4e21627b04208c7e537f"
+        },
+        "_:wDF1351": {
+            "prov:generatedEntity": "niiri:9143f6e13fe4ee9fe42fac2f81f2e676",
+            "prov:usedEntity": "niiri:8b7eb042176ff4b34dbab2133217acff"
+        },
+        "_:wDF1354": {
+            "prov:generatedEntity": "niiri:f5a857ae39046f3db5dec63a77684c88",
+            "prov:usedEntity": "niiri:74aa1acb0840e11af474625bf18a205b"
+        },
+        "_:wDF1357": {
+            "prov:generatedEntity": "niiri:c3c44bb5597ea19a830120e15048bdfc",
+            "prov:usedEntity": "niiri:1f8d909cef3803a0e6a8e31c86e2cb37"
+        },
+        "_:wDF1360": {
+            "prov:generatedEntity": "niiri:a85791f58de3fb579b6358c661ed5fa2",
+            "prov:usedEntity": "niiri:d1b86bb927184d1863bf16406cbb38ef"
+        },
+        "_:wDF1363": {
+            "prov:generatedEntity": "niiri:0a7bb31878e22554cbc54493045e8d7d",
+            "prov:usedEntity": "niiri:8681fd0b6a40a88059175d0b5804a743"
+        },
+        "_:wDF1366": {
+            "prov:generatedEntity": "niiri:c5d06f34a6464f6267e87ac23872ca2e",
+            "prov:usedEntity": "niiri:53d7d39a6b6a7a44a92c2cdc58facf3a"
+        },
+        "_:wDF1369": {
+            "prov:generatedEntity": "niiri:af68b1cc579ac5658c4a2293d9579639",
+            "prov:usedEntity": "niiri:b8f303a3f6e3ffbd2a86dd99d6d873fb"
+        },
+        "_:wDF1372": {
+            "prov:generatedEntity": "niiri:77af4bcf04d46e852b0206ce06555bc3",
+            "prov:usedEntity": "niiri:555db4d96064ec58a79e6099a79dd060"
+        },
+        "_:wDF1375": {
+            "prov:generatedEntity": "niiri:ac4cc325bba6dd74902e4bedc227ea4d",
+            "prov:usedEntity": "niiri:df9fe6cd3c5bf212b4c85e3bd119959c"
+        },
+        "_:wDF1378": {
+            "prov:generatedEntity": "niiri:8bd2069b941164ec318034e819fbd415",
+            "prov:usedEntity": "niiri:17f6f685daf3b085f3dac6c057c020c1"
+        },
+        "_:wDF1381": {
+            "prov:generatedEntity": "niiri:60851992aa4e11f85611dcd9fc54b154",
+            "prov:usedEntity": "niiri:c5cf9af3cc2424e4b8e65eb6049706ed"
+        },
+        "_:wDF1384": {
+            "prov:generatedEntity": "niiri:e1653eb5a2319fdfa378634babb879b4",
+            "prov:usedEntity": "niiri:24b677d8caebb84711be327c29be20b9"
+        },
+        "_:wDF1387": {
+            "prov:generatedEntity": "niiri:d78c9899bc897947e0449b5b9372058c",
+            "prov:usedEntity": "niiri:c9997d6b8885703c61c50e9494f01f5b"
+        },
+        "_:wDF1390": {
+            "prov:generatedEntity": "niiri:d36696cd084e014fe3b461011d62026c",
+            "prov:usedEntity": "niiri:18c389e9f560a707e21a88082c18399f"
+        },
+        "_:wDF1393": {
+            "prov:generatedEntity": "niiri:c7e89f2bfb5ebb96c9943bcc727e584b",
+            "prov:usedEntity": "niiri:4f2617299971ce7d3a16c3c37b0badbd"
+        },
+        "_:wDF1396": {
+            "prov:generatedEntity": "niiri:abcb021cf3e7d4a1923c3e650e8f646d",
+            "prov:usedEntity": "niiri:7ab88d893988ef5840b83076dc34632a"
+        },
+        "_:wDF1399": {
+            "prov:generatedEntity": "niiri:798c8ad3bf29b7e6a1599d243c811ef4",
+            "prov:usedEntity": "niiri:ad4b61cba6b4e1ac8b424d69a662357a"
+        },
+        "_:wDF1402": {
+            "prov:generatedEntity": "niiri:188e8be049871fa65f8fc1d3fd94eeea",
+            "prov:usedEntity": "niiri:18172de66764cc046e57e3f71900f308"
+        },
+        "_:wDF1405": {
+            "prov:generatedEntity": "niiri:bd959eb0d068217ced11fd9423305a37",
+            "prov:usedEntity": "niiri:5b864821dad832cdea33cc2c71107b5d"
+        },
+        "_:wDF1408": {
+            "prov:generatedEntity": "niiri:bb3156da7e40e4feec485af3e6a32ecd",
+            "prov:usedEntity": "niiri:54af2492a558bd6b541a83efffeacbc6"
+        },
+        "_:wDF1411": {
+            "prov:generatedEntity": "niiri:f8e25bc4e933ed306f46968cead64492",
+            "prov:usedEntity": "niiri:4c87d31930bd2a3884bfbd054121e8ea"
+        },
+        "_:wDF1414": {
+            "prov:generatedEntity": "niiri:b80c331bc3c013d36540ed2209e180ac",
+            "prov:usedEntity": "niiri:0c1ba90c913890f99f03e9c6732b7833"
+        },
+        "_:wDF1417": {
+            "prov:generatedEntity": "niiri:4deb8dc19d6af02360fbd76e432ce8b6",
+            "prov:usedEntity": "niiri:7e48fd00328505ec2f7c55286029038c"
+        },
+        "_:wDF1420": {
+            "prov:generatedEntity": "niiri:ed4d3b7d5ccc140dfba860cdd388e8ce",
+            "prov:usedEntity": "niiri:fe7b7aeb5b19bcdfb6ba3b9e7bbc0530"
+        },
+        "_:wDF1423": {
+            "prov:generatedEntity": "niiri:b7f899e5f3760319ce8ccef45e585946",
+            "prov:usedEntity": "niiri:2598e0a8af6b254c19ea1eae1c055e59"
+        },
+        "_:wDF1426": {
+            "prov:generatedEntity": "niiri:30b82d808ecbca165129f91f15eeb7d8",
+            "prov:usedEntity": "niiri:ef260aa5a1800f7a5b96c1d3f96edac0"
+        },
+        "_:wDF1429": {
+            "prov:generatedEntity": "niiri:c0b355fc51e7cd26f5f72e9f5c550472",
+            "prov:usedEntity": "niiri:9edfdd818d3f428259751e3a1f4426fa"
+        },
+        "_:wDF1432": {
+            "prov:generatedEntity": "niiri:a2e099d5d8ff7d6205bb133cc5078448",
+            "prov:usedEntity": "niiri:1667cff121b7be39391cc74c4150a6e4"
+        },
+        "_:wDF1435": {
+            "prov:generatedEntity": "niiri:cc1877ba95e403c226eac44d78215696",
+            "prov:usedEntity": "niiri:8a9dbe909430bab19de8984a30f0827c"
+        },
+        "_:wDF1438": {
+            "prov:generatedEntity": "niiri:c1b25d75e61e613c55029c674539f77a",
+            "prov:usedEntity": "niiri:73e5d22f5e99f7222d046e5c8b8f17e5"
+        },
+        "_:wDF1441": {
+            "prov:generatedEntity": "niiri:dd0f126c27f7ac1f0c10fd12e39bf105",
+            "prov:usedEntity": "niiri:8015064bc0743ed13468353e18ca0971"
+        },
+        "_:wDF1444": {
+            "prov:generatedEntity": "niiri:c91264646d693326daa65c4e49da790c",
+            "prov:usedEntity": "niiri:eb612c2c1cebda064d6320c535f9294f"
+        },
+        "_:wDF1447": {
+            "prov:generatedEntity": "niiri:85a9c11ba54c056a1c94ef036e48c7e8",
+            "prov:usedEntity": "niiri:6369784f4c4b56deb50440d6515b981e"
+        },
+        "_:wDF1450": {
+            "prov:generatedEntity": "niiri:80417a00361d173f5c5af02c203f269c",
+            "prov:usedEntity": "niiri:2147d82387f71f29a3d3dfb09b7b8d64"
+        },
+        "_:wDF1453": {
+            "prov:generatedEntity": "niiri:f44f60b309d98b4839df00ce58c954d3",
+            "prov:usedEntity": "niiri:790465006aaf87ef2289ea019fdb0b83"
+        },
+        "_:wDF1456": {
+            "prov:generatedEntity": "niiri:cb93650662489dd0d5315baef5339a8f",
+            "prov:usedEntity": "niiri:730c6026b96772dd69384df78d1b3195"
+        },
+        "_:wDF1459": {
+            "prov:generatedEntity": "niiri:8f4b30cf80d927285653473f8c169306",
+            "prov:usedEntity": "niiri:26bef1517140b96419bd96743968bf5a"
+        },
+        "_:wDF1462": {
+            "prov:generatedEntity": "niiri:4fd5e1e62237032c0a688ab5a411bfd8",
+            "prov:usedEntity": "niiri:c80e777eb02827978765763f51129026"
+        },
+        "_:wDF1465": {
+            "prov:generatedEntity": "niiri:d3c3847d28d2438a321d68783cee6c15",
+            "prov:usedEntity": "niiri:6eb9789a31f1c0da3f5dc3fb64518f9e"
+        }
+    },
+    "wasAttributedTo": {
+        "_:wAT6": {
+            "prov:entity": "niiri:d23b22fadb663709f46b3ab69916d020",
+            "prov:agent": "niiri:331761d1abf931827633659314e96094"
+        },
+        "_:wAT7": {
+            "prov:entity": "niiri:d23b22fadb663709f46b3ab69916d020",
+            "prov:agent": "niiri:9c886fc4d02f6c8f53849090a389159d"
+        }
+    },
+    "wasAssociatedWith": {
+        "_:wAW13": {
+            "prov:activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e",
+            "prov:agent": "niiri:8903ae1fa9a6ecfaa31839e8cf029c8a"
+        },
+        "_:wAW117": {
+            "prov:activity": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+            "prov:agent": "niiri:8903ae1fa9a6ecfaa31839e8cf029c8a"
+        },
+        "_:wAW158": {
+            "prov:activity": "niiri:1d58f1ea373dca6b6777c0ae0bfc411d",
+            "prov:agent": "niiri:8903ae1fa9a6ecfaa31839e8cf029c8a"
+        }
+    }
+    }
+  }
+}

--- a/spmexport/ex_spm_hrf_fir/nidm.jsonld
+++ b/spmexport/ex_spm_hrf_fir/nidm.jsonld
@@ -7,7 +7,7 @@
       "niiri": "http://iri.nidash.org/",
       "spm": "http://purl.org/nidash/spm#",
       "neurolex": "http://neurolex.org/wiki/",
-      "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#",
+      "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/",
       "dct": "http://purl.org/dc/terms/",
       "nfo": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#",
       "dc": "http://purl.org/dc/elements/1.1/",
@@ -22,32 +22,32 @@
   ],
   "@graph": [
     {
-      "@id": "niiri:9b16a6ffae33f71c3473e2fb802b8ee7",
-      "@type": ["prov:Entity","prov:Bundle","nidm_NIDMResults:"],
+      "@id": "niiri:36c29725f6c7f64a0ab322716c073611",
+      "@type": ["prov:Entity","prov:Bundle","nidm_NIDMResults"],
       "rdfs:label": "NIDM-Results",
-      "nidm_version:": {"@type": "xsd:string", "@value": "1.3.0"}
+      "nidm_version": {"@type": "xsd:string", "@value": "1.3.0"}
     },
     {
-      "@id": "niiri:c784b095fb75ef28778f34c027010e66",
-      "@type": ["prov:Agent","nidm_spm_results_nidm:","prov:SoftwareAgent"],
+      "@id": "niiri:dd800a501694fa49759a45e9b9e77f27",
+      "@type": ["prov:Agent","nidm_spm_results_nidm","prov:SoftwareAgent"],
       "rdfs:label": "spm_results_nidm",
-      "nidm_softwareVersion:": {"@type": "xsd:string", "@value": "12.6903"}
+      "nidm_softwareVersion": {"@type": "xsd:string", "@value": "12.7057"}
     },
     {
-      "@id": "niiri:c3cf94f5f02593a936b43c8b6e9b6d5d",
-      "@type": ["prov:Activity","nidm_NIDMResultsExport:"],
+      "@id": "niiri:de4cf047e6d9cda522f7ec10c3c92475",
+      "@type": ["prov:Activity","nidm_NIDMResultsExport"],
       "rdfs:label": "NIDM-Results export"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:c3cf94f5f02593a936b43c8b6e9b6d5d",
-      "agent": "niiri:c784b095fb75ef28778f34c027010e66"
+      "activity_associated": "niiri:de4cf047e6d9cda522f7ec10c3c92475",
+      "agent": "niiri:dd800a501694fa49759a45e9b9e77f27"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:9b16a6ffae33f71c3473e2fb802b8ee7",
-      "activity": "niiri:c3cf94f5f02593a936b43c8b6e9b6d5d",
-      "atTime": "2016-12-07T16:08:48"
+      "entity_generated": "niiri:36c29725f6c7f64a0ab322716c073611",
+      "activity": "niiri:de4cf047e6d9cda522f7ec10c3c92475",
+      "atTime": "2017-04-19T12:18:24"
     }
   ]
 },
@@ -157,1120 +157,1120 @@
       "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
     }
   ],
-  "@id": "niiri:9b16a6ffae33f71c3473e2fb802b8ee7",
+  "@id": "niiri:36c29725f6c7f64a0ab322716c073611",
   "@graph": [
     {
-      "@id": "niiri:2b8ccd681cfa7e7efa195046c80d4149",
-      "@type": ["prov:Agent","src_SPM:","prov:SoftwareAgent"],
+      "@id": "niiri:8903ae1fa9a6ecfaa31839e8cf029c8a",
+      "@type": ["prov:Agent","src_SPM","prov:SoftwareAgent"],
       "rdfs:label": "SPM",
-      "nidm_softwareVersion:": {"@type": "xsd:string", "@value": "12.12.2"}
+      "nidm_softwareVersion": {"@type": "xsd:string", "@value": "12.6906"}
     },
     {
-      "@id": "niiri:a0df09e94db6f8ac04096ab9e62f03e3",
-      "@type": ["prov:Entity","nidm_CoordinateSpace:"],
+      "@id": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c",
+      "@type": ["prov:Entity","nidm_CoordinateSpace"],
       "rdfs:label": "Coordinate space 1",
-      "nidm_voxelToWorldMapping:": {"@type": "xsd:string", "@value": "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"},
-      "nidm_voxelUnits:": {"@type": "xsd:string", "@value": "[\"mm\", \"mm\", \"mm\"]"},
-      "nidm_voxelSize:": {"@type": "xsd:string", "@value": "[2, 2, 2]"},
-      "nidm_inWorldCoordinateSystem:": {"@id": "nidm_Ixi549CoordinateSystem:"},
-      "nidm_numberOfDimensions:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_dimensionsInVoxels:": {"@type": "xsd:string", "@value": "[79,95,79]"}
+      "nidm_voxelToWorldMapping": {"@type": "xsd:string", "@value": "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"},
+      "nidm_voxelUnits": {"@type": "xsd:string", "@value": "[\"mm\", \"mm\", \"mm\"]"},
+      "nidm_voxelSize": {"@type": "xsd:string", "@value": "[2, 2, 2]"},
+      "nidm_inWorldCoordinateSystem": {"@id": "nidm_Ixi549CoordinateSystem"},
+      "nidm_numberOfDimensions": {"@type": "xsd:int", "@value": "3"},
+      "nidm_dimensionsInVoxels": {"@type": "xsd:string", "@value": "[79,95,79]"}
     },
     {
-      "@id": "niiri:346e097f10a52ec316e54b49edc38cdd",
-      "@type": ["prov:Agent","nlx_Imaginginstrument:","nlx_Magneticresonanceimagingscanner:"],
+      "@id": "niiri:331761d1abf931827633659314e96094",
+      "@type": ["prov:Agent","nlx_Imaginginstrument","nlx_Magneticresonanceimagingscanner"],
       "rdfs:label": "MRI Scanner"
     },
     {
-      "@id": "niiri:334e15e19418b7788d794c8c723b4944",
+      "@id": "niiri:9c886fc4d02f6c8f53849090a389159d",
       "@type": ["prov:Agent","prov:Person"],
       "rdfs:label": "Person"
     },
     {
-      "@id": "niiri:bedc0c126056eed53855a4140c25cc80",
-      "@type": ["prov:Entity","prov:Collection","nidm_Data:"],
+      "@id": "niiri:d23b22fadb663709f46b3ab69916d020",
+      "@type": ["prov:Entity","prov:Collection","nidm_Data"],
       "rdfs:label": "Data",
-      "nidm_grandMeanScaling:": {"@type": "xsd:boolean", "@value": "true"},
-      "nidm_targetIntensity:": {"@type": "xsd:float", "@value": "100"},
-      "nidm_hasMRIProtocol:": {"@id": "nlx_FunctionalMRIprotocol:"}
+      "nidm_grandMeanScaling": {"@type": "xsd:boolean", "@value": "true"},
+      "nidm_targetIntensity": {"@type": "xsd:float", "@value": "100"},
+      "nidm_hasMRIProtocol": {"@id": "nlx_FunctionalMRIprotocol"}
     },
     {
       "@type": "prov:Attribution",
-      "entity_attributed": "niiri:bedc0c126056eed53855a4140c25cc80",
-      "agent": "niiri:346e097f10a52ec316e54b49edc38cdd"
+      "entity_attributed": "niiri:d23b22fadb663709f46b3ab69916d020",
+      "agent": "niiri:331761d1abf931827633659314e96094"
     },
     {
       "@type": "prov:Attribution",
-      "entity_attributed": "niiri:bedc0c126056eed53855a4140c25cc80",
-      "agent": "niiri:334e15e19418b7788d794c8c723b4944"
+      "entity_attributed": "niiri:d23b22fadb663709f46b3ab69916d020",
+      "agent": "niiri:9c886fc4d02f6c8f53849090a389159d"
     },
     {
-      "@id": "niiri:db710ed0e5b8ef3b436af166cc200864",
-      "@type": ["prov:Entity","spm_DCTDriftModel:"],
+      "@id": "niiri:470096f779b79da44b4d0df59add54c2",
+      "@type": ["prov:Entity","spm_DCTDriftModel"],
       "rdfs:label": "SPM's DCT Drift Model",
-      "spm_SPMsDriftCutoffPeriod:": {"@type": "xsd:float", "@value": "128"}
+      "spm_SPMsDriftCutoffPeriod": {"@type": "xsd:float", "@value": "128"}
     },
     {
-      "@id": "niiri:7f6fc22ede14f7eb59e1c96c8768b797",
-      "@type": ["prov:Entity","nidm_DesignMatrix:"],
+      "@id": "niiri:03fe576d4676dc2c478698e09040bd38",
+      "@type": ["prov:Entity","nidm_DesignMatrix"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "DesignMatrix.csv"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "DesignMatrix.csv"},
       "dct:format": {"@type": "xsd:string", "@value": "text/csv"},
-      "dc:description": {"@id": "niiri:6b09f6c2a7fc57a3fd917b8b6edac3e8"},
+      "dc:description": {"@id": "niiri:e87650be9879dfa4463aee62d8f91cb6"},
       "rdfs:label": "Design Matrix",
-      "nidm_regressorNames:": {"@type": "xsd:string", "@value": "[\"Sn(1) to*bf(1)\", \"Sn(1) to*bf(2)\", \"Sn(1) to*bf(3)\", \"Sn(1) to*bf(4)\", \"Sn(1) to*bf(5)\", \"Sn(1) to*bf(6)\", \"Sn(1) to*bf(7)\", \"Sn(1) to*bf(8)\", \"Sn(1) to*bf(9)\", \"Sn(1) to*bf(10)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) \ntask001 co*bf(2)\", \"Sn(1) \ntask001 co*bf(3)\", \"Sn(1) \ntask001 co*bf(4)\", \"Sn(1) \ntask001 co*bf(5)\", \"Sn(1) \ntask001 co*bf(6)\", \"Sn(1) \ntask001 co*bf(7)\", \"Sn(1) \ntask001 co*bf(8)\", \"Sn(1) \ntask001 co*bf(9)\", \"Sn(1) \ntask001 co*bf(10)\", \"Sn(1) constant\"]"},
-      "nidm_hasDriftModel:": {"@id": "niiri:db710ed0e5b8ef3b436af166cc200864"},
-      "nidm_hasHRFBasis:": {"@id": "nidm_FiniteImpulseResponseBasisSet:"}
+      "nidm_regressorNames": {"@type": "xsd:string", "@value": "[\"Sn(1) to*bf(1)\", \"Sn(1) to*bf(2)\", \"Sn(1) to*bf(3)\", \"Sn(1) to*bf(4)\", \"Sn(1) to*bf(5)\", \"Sn(1) to*bf(6)\", \"Sn(1) to*bf(7)\", \"Sn(1) to*bf(8)\", \"Sn(1) to*bf(9)\", \"Sn(1) to*bf(10)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) \ntask001 co*bf(2)\", \"Sn(1) \ntask001 co*bf(3)\", \"Sn(1) \ntask001 co*bf(4)\", \"Sn(1) \ntask001 co*bf(5)\", \"Sn(1) \ntask001 co*bf(6)\", \"Sn(1) \ntask001 co*bf(7)\", \"Sn(1) \ntask001 co*bf(8)\", \"Sn(1) \ntask001 co*bf(9)\", \"Sn(1) \ntask001 co*bf(10)\", \"Sn(1) constant\"]"},
+      "nidm_hasDriftModel": {"@id": "niiri:470096f779b79da44b4d0df59add54c2"},
+      "nidm_hasHRFBasis": {"@id": "nidm_FiniteImpulseResponseBasisSet"}
     },
     {
-      "@id": "niiri:6b09f6c2a7fc57a3fd917b8b6edac3e8",
+      "@id": "niiri:e87650be9879dfa4463aee62d8f91cb6",
       "@type": ["prov:Entity","dctype:Image"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "DesignMatrix.png"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "DesignMatrix.png"},
       "dct:format": {"@type": "xsd:string", "@value": "image/png"}
     },
     {
-      "@id": "niiri:f10b5d59de57808aedc01bf8e699b5bb",
-      "@type": ["prov:Entity","nidm_ErrorModel:"],
-      "nidm_hasErrorDistribution:": {"@id": "obo_normaldistribution:"},
-      "nidm_hasErrorDependence:": {"@id": "obo_Toeplitzcovariancestructure:"},
-      "nidm_dependenceMapWiseDependence:": {"@id": "nidm_ConstantParameter:"},
-      "nidm_errorVarianceHomogeneous:": {"@type": "xsd:boolean", "@value": "true"},
-      "nidm_varianceMapWiseDependence:": {"@id": "nidm_IndependentParameter:"}
+      "@id": "niiri:2411622502cf663c690e37bc572df1f3",
+      "@type": ["prov:Entity","nidm_ErrorModel"],
+      "nidm_hasErrorDistribution": {"@id": "obo_normaldistribution"},
+      "nidm_hasErrorDependence": {"@id": "obo_Toeplitzcovariancestructure"},
+      "nidm_dependenceMapWiseDependence": {"@id": "nidm_ConstantParameter"},
+      "nidm_errorVarianceHomogeneous": {"@type": "xsd:boolean", "@value": "true"},
+      "nidm_varianceMapWiseDependence": {"@id": "nidm_IndependentParameter"}
     },
     {
-      "@id": "niiri:16bb24a73948c11f2d5fd7d31856731c",
-      "@type": ["prov:Activity","nidm_ModelParametersEstimation:"],
+      "@id": "niiri:9c7e245e4dcccf690110a5c2f867fe1e",
+      "@type": ["prov:Activity","nidm_ModelParametersEstimation"],
       "rdfs:label": "Model parameters estimation",
-      "nidm_withEstimationMethod:": {"@id": "obo_generalizedleastsquaresestimation:"}
+      "nidm_withEstimationMethod": {"@id": "obo_generalizedleastsquaresestimation"}
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:16bb24a73948c11f2d5fd7d31856731c",
-      "agent": "niiri:2b8ccd681cfa7e7efa195046c80d4149"
+      "activity_associated": "niiri:9c7e245e4dcccf690110a5c2f867fe1e",
+      "agent": "niiri:8903ae1fa9a6ecfaa31839e8cf029c8a"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:16bb24a73948c11f2d5fd7d31856731c",
-      "entity": "niiri:7f6fc22ede14f7eb59e1c96c8768b797"
+      "activity_using": "niiri:9c7e245e4dcccf690110a5c2f867fe1e",
+      "entity": "niiri:03fe576d4676dc2c478698e09040bd38"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:16bb24a73948c11f2d5fd7d31856731c",
-      "entity": "niiri:bedc0c126056eed53855a4140c25cc80"
+      "activity_using": "niiri:9c7e245e4dcccf690110a5c2f867fe1e",
+      "entity": "niiri:d23b22fadb663709f46b3ab69916d020"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:16bb24a73948c11f2d5fd7d31856731c",
-      "entity": "niiri:f10b5d59de57808aedc01bf8e699b5bb"
+      "activity_using": "niiri:9c7e245e4dcccf690110a5c2f867fe1e",
+      "entity": "niiri:2411622502cf663c690e37bc572df1f3"
     },
     {
-      "@id": "niiri:76fcf8996a7e7792184e6dbb3548dddd",
-      "@type": ["prov:Entity","nidm_MaskMap:"],
+      "@id": "niiri:701d77588170de3f2a3a5cae849cee5b",
+      "@type": ["prov:Entity","nidm_MaskMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "Mask.nii.gz"},
-      "nidm_isUserDefined:": {"@type": "xsd:boolean", "@value": "false"},
+      "nidm_isUserDefined": {"@type": "xsd:boolean", "@value": "false"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "Mask.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Mask",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:a0df09e94db6f8ac04096ab9e62f03e3"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876"}
     },
     {
-      "@id": "niiri:0748d0b5cd6cfe017e2f94a333b5eb11",
-      "@type": ["prov:Entity","nidm_MaskMap:"],
+      "@id": "niiri:68240aa5f992dd1323cc9f0c0e3a3639",
+      "@type": ["prov:Entity","nidm_MaskMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "mask.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "36929e1f5f4143bd9cc818cd896a25f129961fab208c3a4438555f40444c08347b359142ee8c53ece6e8cca1627f49db0788a1fd3b9e2ecaef61999c6c6c67ac"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:76fcf8996a7e7792184e6dbb3548dddd",
-      "entity": "niiri:0748d0b5cd6cfe017e2f94a333b5eb11"
+      "entity_derived": "niiri:701d77588170de3f2a3a5cae849cee5b",
+      "entity": "niiri:68240aa5f992dd1323cc9f0c0e3a3639"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:76fcf8996a7e7792184e6dbb3548dddd",
-      "activity": "niiri:16bb24a73948c11f2d5fd7d31856731c"
+      "entity_generated": "niiri:701d77588170de3f2a3a5cae849cee5b",
+      "activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e"
     },
     {
-      "@id": "niiri:b00802b292f9cbac2cc85093367f010c",
-      "@type": ["prov:Entity","nidm_GrandMeanMap:"],
+      "@id": "niiri:2759c13e0ec7d1d95a0ecd06a3481373",
+      "@type": ["prov:Entity","nidm_GrandMeanMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "GrandMean.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "GrandMean.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Grand Mean Map",
-      "nidm_maskedMedian:": {"@type": "xsd:float", "@value": "116.759864807129"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:a0df09e94db6f8ac04096ab9e62f03e3"},
+      "nidm_maskedMedian": {"@type": "xsd:float", "@value": "116.759864807129"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "c9f870cdec14d68f6155f69fff57c713e04ba77396008f146de034a59019081d730f36a8d3da8abed1888f20ec50b2fef12d42f65398b47980f3c8f4f9621e30"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:b00802b292f9cbac2cc85093367f010c",
-      "activity": "niiri:16bb24a73948c11f2d5fd7d31856731c"
+      "entity_generated": "niiri:2759c13e0ec7d1d95a0ecd06a3481373",
+      "activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e"
     },
     {
-      "@id": "niiri:ee988293f4c9ba01ab8220c738ce6c57",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:7cfe9f21fb53f5db106ee22b82a0fe77",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0001.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0001.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 1",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:a0df09e94db6f8ac04096ab9e62f03e3"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "ab4f341fdc6bb61ed1858ac74fedbac74fcc7d8bb81ad62df8362a733702555296077259ebdbc9255f7fbfdcbf3818802601d04117f70115bb7b2dec0508ad33"}
     },
     {
-      "@id": "niiri:f808b564206d0605cceca7a0bef47627",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:089827f143cffa9301487e18ac4f137b",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0001.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "ab4f341fdc6bb61ed1858ac74fedbac74fcc7d8bb81ad62df8362a733702555296077259ebdbc9255f7fbfdcbf3818802601d04117f70115bb7b2dec0508ad33"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ee988293f4c9ba01ab8220c738ce6c57",
-      "entity": "niiri:f808b564206d0605cceca7a0bef47627"
+      "entity_derived": "niiri:7cfe9f21fb53f5db106ee22b82a0fe77",
+      "entity": "niiri:089827f143cffa9301487e18ac4f137b"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:ee988293f4c9ba01ab8220c738ce6c57",
-      "activity": "niiri:16bb24a73948c11f2d5fd7d31856731c"
+      "entity_generated": "niiri:7cfe9f21fb53f5db106ee22b82a0fe77",
+      "activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e"
     },
     {
-      "@id": "niiri:08b2f0e7adb342474b1ecdc6fb347df9",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:43283050484b34063061bdb16cb80c6a",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0002.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0002.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 2",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:a0df09e94db6f8ac04096ab9e62f03e3"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "553b1841b724f521f7df6a39860f8d936fd47b0d9050cc0d11514571198520a4748f95110e809e16801cb8541c0d3f11db5515b9be6a335cc7a32c4cb4bff458"}
     },
     {
-      "@id": "niiri:40596b70cf44f0b23c77498d34443fd1",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:329c6968efa0ef3a9c454bf61031c775",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0002.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "553b1841b724f521f7df6a39860f8d936fd47b0d9050cc0d11514571198520a4748f95110e809e16801cb8541c0d3f11db5515b9be6a335cc7a32c4cb4bff458"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:08b2f0e7adb342474b1ecdc6fb347df9",
-      "entity": "niiri:40596b70cf44f0b23c77498d34443fd1"
+      "entity_derived": "niiri:43283050484b34063061bdb16cb80c6a",
+      "entity": "niiri:329c6968efa0ef3a9c454bf61031c775"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:08b2f0e7adb342474b1ecdc6fb347df9",
-      "activity": "niiri:16bb24a73948c11f2d5fd7d31856731c"
+      "entity_generated": "niiri:43283050484b34063061bdb16cb80c6a",
+      "activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e"
     },
     {
-      "@id": "niiri:b43b6c5f15dd6da1f95e2c9295f696ea",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:977b0276cc808425abbde5601d66f7f1",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0003.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0003.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 3",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:a0df09e94db6f8ac04096ab9e62f03e3"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "8b865f4a40e90f00870f1fb7ef2c526ed19dff1736129d20b7fb0f56bc0b3e5765fbe25ac2011fcc9a0dfb0a1fdee3c9a0cb4208d575eff4ea1e60b0a1248c89"}
     },
     {
-      "@id": "niiri:ca4ead196043e20fde835aa43c6ea138",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:eb7cef4922655d41030fe942fbcf92d0",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0003.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "8b865f4a40e90f00870f1fb7ef2c526ed19dff1736129d20b7fb0f56bc0b3e5765fbe25ac2011fcc9a0dfb0a1fdee3c9a0cb4208d575eff4ea1e60b0a1248c89"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b43b6c5f15dd6da1f95e2c9295f696ea",
-      "entity": "niiri:ca4ead196043e20fde835aa43c6ea138"
+      "entity_derived": "niiri:977b0276cc808425abbde5601d66f7f1",
+      "entity": "niiri:eb7cef4922655d41030fe942fbcf92d0"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:b43b6c5f15dd6da1f95e2c9295f696ea",
-      "activity": "niiri:16bb24a73948c11f2d5fd7d31856731c"
+      "entity_generated": "niiri:977b0276cc808425abbde5601d66f7f1",
+      "activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e"
     },
     {
-      "@id": "niiri:72b5623932c79270073e16410388a14e",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:ed63a46c0d2c960f86afcc856493eba3",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0004.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0004.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 4",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:a0df09e94db6f8ac04096ab9e62f03e3"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "66f8b072dd8b6311a71e1da755c6e878723be8030f3cced7e61d9de0455ddd357733cece45530571e955093c1611ff50161a398ca59bc4f5d412ae9beff68b1d"}
     },
     {
-      "@id": "niiri:4e706ef24c8a0e0f11c39703e5e13bb5",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:4253cad80266847727bfd03c0f113481",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0004.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "66f8b072dd8b6311a71e1da755c6e878723be8030f3cced7e61d9de0455ddd357733cece45530571e955093c1611ff50161a398ca59bc4f5d412ae9beff68b1d"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:72b5623932c79270073e16410388a14e",
-      "entity": "niiri:4e706ef24c8a0e0f11c39703e5e13bb5"
+      "entity_derived": "niiri:ed63a46c0d2c960f86afcc856493eba3",
+      "entity": "niiri:4253cad80266847727bfd03c0f113481"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:72b5623932c79270073e16410388a14e",
-      "activity": "niiri:16bb24a73948c11f2d5fd7d31856731c"
+      "entity_generated": "niiri:ed63a46c0d2c960f86afcc856493eba3",
+      "activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e"
     },
     {
-      "@id": "niiri:d49f6378df8608464ae61aa8917485a4",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:0f11c4b5e831cc47e20327b9561101d1",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0005.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0005.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 5",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:a0df09e94db6f8ac04096ab9e62f03e3"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "8cc9e95e7a8fed19b960048ee106a347b1f19de664cce72ef19eeddcfb99fb83f2c47d9042a1b2ebd035ebbe53e156bdfa991586d61633f1bf8683d68749c581"}
     },
     {
-      "@id": "niiri:b72754ccc46f4560aa4d457918639078",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:5e2edc7c4f0179e995e1d8a613e7f3f5",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0005.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "8cc9e95e7a8fed19b960048ee106a347b1f19de664cce72ef19eeddcfb99fb83f2c47d9042a1b2ebd035ebbe53e156bdfa991586d61633f1bf8683d68749c581"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d49f6378df8608464ae61aa8917485a4",
-      "entity": "niiri:b72754ccc46f4560aa4d457918639078"
+      "entity_derived": "niiri:0f11c4b5e831cc47e20327b9561101d1",
+      "entity": "niiri:5e2edc7c4f0179e995e1d8a613e7f3f5"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:d49f6378df8608464ae61aa8917485a4",
-      "activity": "niiri:16bb24a73948c11f2d5fd7d31856731c"
+      "entity_generated": "niiri:0f11c4b5e831cc47e20327b9561101d1",
+      "activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e"
     },
     {
-      "@id": "niiri:5b4a4fc6079e7ec827225bd783e5df60",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:48291f5a02d1cc7b2042bb3d593d7fff",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0006.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0006.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 6",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:a0df09e94db6f8ac04096ab9e62f03e3"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "62c235f5803befb467c0e211761d3969a92708699589dca1e61f45abeee452c3aeff7b0654acc13df518a73251efcfc5ce54b68b351f282f7240a3e200cece00"}
     },
     {
-      "@id": "niiri:8ecd1284340b06c1fc5cdd9ea6088cec",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:a32c3f75242cd2d6bdf7364d58ecabaa",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0006.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "62c235f5803befb467c0e211761d3969a92708699589dca1e61f45abeee452c3aeff7b0654acc13df518a73251efcfc5ce54b68b351f282f7240a3e200cece00"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5b4a4fc6079e7ec827225bd783e5df60",
-      "entity": "niiri:8ecd1284340b06c1fc5cdd9ea6088cec"
+      "entity_derived": "niiri:48291f5a02d1cc7b2042bb3d593d7fff",
+      "entity": "niiri:a32c3f75242cd2d6bdf7364d58ecabaa"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:5b4a4fc6079e7ec827225bd783e5df60",
-      "activity": "niiri:16bb24a73948c11f2d5fd7d31856731c"
+      "entity_generated": "niiri:48291f5a02d1cc7b2042bb3d593d7fff",
+      "activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e"
     },
     {
-      "@id": "niiri:4610816ff722cb10c0691d600ac85b87",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:8f783b7ccac78e3e7bdec49afe00edd2",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0007.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0007.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 7",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:a0df09e94db6f8ac04096ab9e62f03e3"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "503eac361a50d582f783868de851f17396fdaede65faabc382b3ed8794bc42d4a6b1a0192cd1646145777fff9ba3f1fc14610fac5616a4e8a49e801fe50c1fb0"}
     },
     {
-      "@id": "niiri:d0d01d6d9e71220497fac7fa1e09e6cd",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:f8a0341ad0e00972a335bb4d5abdf527",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0007.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "503eac361a50d582f783868de851f17396fdaede65faabc382b3ed8794bc42d4a6b1a0192cd1646145777fff9ba3f1fc14610fac5616a4e8a49e801fe50c1fb0"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4610816ff722cb10c0691d600ac85b87",
-      "entity": "niiri:d0d01d6d9e71220497fac7fa1e09e6cd"
+      "entity_derived": "niiri:8f783b7ccac78e3e7bdec49afe00edd2",
+      "entity": "niiri:f8a0341ad0e00972a335bb4d5abdf527"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:4610816ff722cb10c0691d600ac85b87",
-      "activity": "niiri:16bb24a73948c11f2d5fd7d31856731c"
+      "entity_generated": "niiri:8f783b7ccac78e3e7bdec49afe00edd2",
+      "activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e"
     },
     {
-      "@id": "niiri:dc2118ccd0863d65cab02ef9ba996ffa",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:242b483bd1eee1b930fc5cca16db8bd0",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0008.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0008.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 8",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:a0df09e94db6f8ac04096ab9e62f03e3"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "7ff16e915edd22e3b69ad9337a39e81470000b43b3e01582dadd95ac6b75e4dae59468d1ee28423da6a5b6e61f8ce4a56016da8b37b0b3b5896adad675ad8bf0"}
     },
     {
-      "@id": "niiri:aa502560b662bb6fdc607bf1856a892b",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:2aa65d5429266d49e3eb2223f5d00c0f",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0008.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "7ff16e915edd22e3b69ad9337a39e81470000b43b3e01582dadd95ac6b75e4dae59468d1ee28423da6a5b6e61f8ce4a56016da8b37b0b3b5896adad675ad8bf0"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:dc2118ccd0863d65cab02ef9ba996ffa",
-      "entity": "niiri:aa502560b662bb6fdc607bf1856a892b"
+      "entity_derived": "niiri:242b483bd1eee1b930fc5cca16db8bd0",
+      "entity": "niiri:2aa65d5429266d49e3eb2223f5d00c0f"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:dc2118ccd0863d65cab02ef9ba996ffa",
-      "activity": "niiri:16bb24a73948c11f2d5fd7d31856731c"
+      "entity_generated": "niiri:242b483bd1eee1b930fc5cca16db8bd0",
+      "activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e"
     },
     {
-      "@id": "niiri:aa34f275343373ad637d2bc6dbfc90ba",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:133e1e9add501047daab53a9c6301964",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0009.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0009.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 9",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:a0df09e94db6f8ac04096ab9e62f03e3"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "e470031c887654d88c3720ca80d430fb890ed6eb50f06947ccfcf5add371f10f5f0264fa29314da1b1860d8f9c46fd0d5d348d34ae430c918129e28dc687d941"}
     },
     {
-      "@id": "niiri:74e55be2faffbf58f0469004e3506ee2",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:d99c4966dd6f79fa35b1936be239db4a",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0009.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "e470031c887654d88c3720ca80d430fb890ed6eb50f06947ccfcf5add371f10f5f0264fa29314da1b1860d8f9c46fd0d5d348d34ae430c918129e28dc687d941"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:aa34f275343373ad637d2bc6dbfc90ba",
-      "entity": "niiri:74e55be2faffbf58f0469004e3506ee2"
+      "entity_derived": "niiri:133e1e9add501047daab53a9c6301964",
+      "entity": "niiri:d99c4966dd6f79fa35b1936be239db4a"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:aa34f275343373ad637d2bc6dbfc90ba",
-      "activity": "niiri:16bb24a73948c11f2d5fd7d31856731c"
+      "entity_generated": "niiri:133e1e9add501047daab53a9c6301964",
+      "activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e"
     },
     {
-      "@id": "niiri:06fc994e05054a0d86d4ae675034b9fd",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:1e8ad4131b61696d7f4e8f0d62cc8247",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0010.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0010.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 10",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:a0df09e94db6f8ac04096ab9e62f03e3"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "84a21319af5843da90c9a80cce510a3ce962d9cf5c17e9aae6c9f68caf849b2a48554dc0edaf4bc6869e139a83a40a1241598e5c3eaf850c1877cd7d89092772"}
     },
     {
-      "@id": "niiri:1161e9a860d132b4d918bb8f03db4bc5",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:3b7f58f0e40d4420da47ee38ea6e01f4",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0010.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "84a21319af5843da90c9a80cce510a3ce962d9cf5c17e9aae6c9f68caf849b2a48554dc0edaf4bc6869e139a83a40a1241598e5c3eaf850c1877cd7d89092772"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:06fc994e05054a0d86d4ae675034b9fd",
-      "entity": "niiri:1161e9a860d132b4d918bb8f03db4bc5"
+      "entity_derived": "niiri:1e8ad4131b61696d7f4e8f0d62cc8247",
+      "entity": "niiri:3b7f58f0e40d4420da47ee38ea6e01f4"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:06fc994e05054a0d86d4ae675034b9fd",
-      "activity": "niiri:16bb24a73948c11f2d5fd7d31856731c"
+      "entity_generated": "niiri:1e8ad4131b61696d7f4e8f0d62cc8247",
+      "activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e"
     },
     {
-      "@id": "niiri:722ecde813a148bb553937e9a852c5fb",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:21ab0f8b00a00ed52acdb49a05c615c3",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0011.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0011.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 11",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:a0df09e94db6f8ac04096ab9e62f03e3"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "79c5038da96f3fa6f62a85fc10874a19b8def87cdf22be32b896a4cb1816aab1123e4fde54cdbfe4d92bb2e86f1af66cce152604df2f617db594def52e10975b"}
     },
     {
-      "@id": "niiri:cf2dd477d370f5e2e75d743f101b2542",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:e81af0e320d70f0c3b56e6ba69ab24b3",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0011.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "79c5038da96f3fa6f62a85fc10874a19b8def87cdf22be32b896a4cb1816aab1123e4fde54cdbfe4d92bb2e86f1af66cce152604df2f617db594def52e10975b"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:722ecde813a148bb553937e9a852c5fb",
-      "entity": "niiri:cf2dd477d370f5e2e75d743f101b2542"
+      "entity_derived": "niiri:21ab0f8b00a00ed52acdb49a05c615c3",
+      "entity": "niiri:e81af0e320d70f0c3b56e6ba69ab24b3"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:722ecde813a148bb553937e9a852c5fb",
-      "activity": "niiri:16bb24a73948c11f2d5fd7d31856731c"
+      "entity_generated": "niiri:21ab0f8b00a00ed52acdb49a05c615c3",
+      "activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e"
     },
     {
-      "@id": "niiri:2a5e8f6c192c564c4fdf245159e6d259",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:8c85285ad275239152b5e31bdf64af12",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0012.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0012.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 12",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:a0df09e94db6f8ac04096ab9e62f03e3"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "aa63e2b2dc5c82b5de51c5dbf288e74e2135aa59df78d8e9c42d29c54bd1091a6e2d7d19a0f3f5b2bc38e620ff705cb51d12904557f23880d0d6ea5920e8774c"}
     },
     {
-      "@id": "niiri:c155d23b8e2a64f5da27157b2c193db1",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:e07667d489f48b12e6c861fd0f90c6b2",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0012.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "aa63e2b2dc5c82b5de51c5dbf288e74e2135aa59df78d8e9c42d29c54bd1091a6e2d7d19a0f3f5b2bc38e620ff705cb51d12904557f23880d0d6ea5920e8774c"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2a5e8f6c192c564c4fdf245159e6d259",
-      "entity": "niiri:c155d23b8e2a64f5da27157b2c193db1"
+      "entity_derived": "niiri:8c85285ad275239152b5e31bdf64af12",
+      "entity": "niiri:e07667d489f48b12e6c861fd0f90c6b2"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:2a5e8f6c192c564c4fdf245159e6d259",
-      "activity": "niiri:16bb24a73948c11f2d5fd7d31856731c"
+      "entity_generated": "niiri:8c85285ad275239152b5e31bdf64af12",
+      "activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e"
     },
     {
-      "@id": "niiri:def186a6565313c3633d33a821beccd2",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:2bf2dfa438b489a6f9109550ebd7bc98",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0013.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0013.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 13",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:a0df09e94db6f8ac04096ab9e62f03e3"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "aad291cd77ce0f4c11b7e90f630400d464d26a3e83e751f811a0f077617d9770bf67d9746d1932ec1d83fde054cefd0d9a8e01d600369da1042d1925bb5f9c01"}
     },
     {
-      "@id": "niiri:ff0d71c967b8d13cea4c07057efbb1c3",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:7b36c6521cdd3ed1a0440a51a36ed339",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0013.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "aad291cd77ce0f4c11b7e90f630400d464d26a3e83e751f811a0f077617d9770bf67d9746d1932ec1d83fde054cefd0d9a8e01d600369da1042d1925bb5f9c01"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:def186a6565313c3633d33a821beccd2",
-      "entity": "niiri:ff0d71c967b8d13cea4c07057efbb1c3"
+      "entity_derived": "niiri:2bf2dfa438b489a6f9109550ebd7bc98",
+      "entity": "niiri:7b36c6521cdd3ed1a0440a51a36ed339"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:def186a6565313c3633d33a821beccd2",
-      "activity": "niiri:16bb24a73948c11f2d5fd7d31856731c"
+      "entity_generated": "niiri:2bf2dfa438b489a6f9109550ebd7bc98",
+      "activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e"
     },
     {
-      "@id": "niiri:fdd3ba21d27a5f3e3e9d70843484c806",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:d1214d3e1d706371966179c913755cb7",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0014.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0014.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 14",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:a0df09e94db6f8ac04096ab9e62f03e3"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "129cbf53f40e0f17148e0f2b09a9fc69043e42e71c5ad30362034660c39e4bddbdab423b5ab3b1ba828d335d714f93e1ad6aef35eb18b77c28c675d33d9eacf6"}
     },
     {
-      "@id": "niiri:e93073b0f1d7b523837d306a39918289",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:9c4ae77f74400a1405d71f6f92c62e06",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0014.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "129cbf53f40e0f17148e0f2b09a9fc69043e42e71c5ad30362034660c39e4bddbdab423b5ab3b1ba828d335d714f93e1ad6aef35eb18b77c28c675d33d9eacf6"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:fdd3ba21d27a5f3e3e9d70843484c806",
-      "entity": "niiri:e93073b0f1d7b523837d306a39918289"
+      "entity_derived": "niiri:d1214d3e1d706371966179c913755cb7",
+      "entity": "niiri:9c4ae77f74400a1405d71f6f92c62e06"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:fdd3ba21d27a5f3e3e9d70843484c806",
-      "activity": "niiri:16bb24a73948c11f2d5fd7d31856731c"
+      "entity_generated": "niiri:d1214d3e1d706371966179c913755cb7",
+      "activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e"
     },
     {
-      "@id": "niiri:db0185dff2a8f093bf4501edb86172ec",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:067750a93237f9d14c0ce7af50da4f3c",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0015.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0015.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 15",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:a0df09e94db6f8ac04096ab9e62f03e3"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "71639fb3c9115d83f377228cc11bfda9f4deb51c53b79094baccc446213cb5e197e7eb63479d1bfc2a5dfde9ca5f6e330b1e477d02448d829010715f72c32e22"}
     },
     {
-      "@id": "niiri:b8910a680a66db347a837f43192abe3a",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:07be9f58a9f65a0bcedc3f67a360ae25",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0015.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "71639fb3c9115d83f377228cc11bfda9f4deb51c53b79094baccc446213cb5e197e7eb63479d1bfc2a5dfde9ca5f6e330b1e477d02448d829010715f72c32e22"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:db0185dff2a8f093bf4501edb86172ec",
-      "entity": "niiri:b8910a680a66db347a837f43192abe3a"
+      "entity_derived": "niiri:067750a93237f9d14c0ce7af50da4f3c",
+      "entity": "niiri:07be9f58a9f65a0bcedc3f67a360ae25"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:db0185dff2a8f093bf4501edb86172ec",
-      "activity": "niiri:16bb24a73948c11f2d5fd7d31856731c"
+      "entity_generated": "niiri:067750a93237f9d14c0ce7af50da4f3c",
+      "activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e"
     },
     {
-      "@id": "niiri:e6c1f12f4ed83708faa17eb0c97001fc",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:0d7a4762edd076ba489e5cfade96a9fc",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0016.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0016.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 16",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:a0df09e94db6f8ac04096ab9e62f03e3"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "a4359da69efe29d916afa7cbb9e7c021c354b4fe3623b6a4547216a5aff27e75cefc94f99d1d4fb5151523b0de3b221a6c949be59dc01fea3554e872ff8318f0"}
     },
     {
-      "@id": "niiri:af1132dc3ba7571fea70b4857c7d13b9",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:d763714606a30881b76dbdbf13aa45f0",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0016.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "a4359da69efe29d916afa7cbb9e7c021c354b4fe3623b6a4547216a5aff27e75cefc94f99d1d4fb5151523b0de3b221a6c949be59dc01fea3554e872ff8318f0"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e6c1f12f4ed83708faa17eb0c97001fc",
-      "entity": "niiri:af1132dc3ba7571fea70b4857c7d13b9"
+      "entity_derived": "niiri:0d7a4762edd076ba489e5cfade96a9fc",
+      "entity": "niiri:d763714606a30881b76dbdbf13aa45f0"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:e6c1f12f4ed83708faa17eb0c97001fc",
-      "activity": "niiri:16bb24a73948c11f2d5fd7d31856731c"
+      "entity_generated": "niiri:0d7a4762edd076ba489e5cfade96a9fc",
+      "activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e"
     },
     {
-      "@id": "niiri:41870d89f5dcfe8abd864989bd6ee1cf",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:239f80ca4290c616514b508515eba255",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0017.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0017.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 17",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:a0df09e94db6f8ac04096ab9e62f03e3"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "d3641c92698032f2ac880b84a2450f16e837354e289fb3b1190d6a37cd6d144c44f6b546d2990768bb7a55827cd2149f0fe4bb8b5b657c1e875fb979e25b55ff"}
     },
     {
-      "@id": "niiri:ccd69ba74567be40d9386cfcd40147a0",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:7894ca83b4d7bbe3efc917dce739071e",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0017.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "d3641c92698032f2ac880b84a2450f16e837354e289fb3b1190d6a37cd6d144c44f6b546d2990768bb7a55827cd2149f0fe4bb8b5b657c1e875fb979e25b55ff"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:41870d89f5dcfe8abd864989bd6ee1cf",
-      "entity": "niiri:ccd69ba74567be40d9386cfcd40147a0"
+      "entity_derived": "niiri:239f80ca4290c616514b508515eba255",
+      "entity": "niiri:7894ca83b4d7bbe3efc917dce739071e"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:41870d89f5dcfe8abd864989bd6ee1cf",
-      "activity": "niiri:16bb24a73948c11f2d5fd7d31856731c"
+      "entity_generated": "niiri:239f80ca4290c616514b508515eba255",
+      "activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e"
     },
     {
-      "@id": "niiri:c62c63e9de3ddec4af7084778f1f0a65",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:4e4595ea20f67bd5529f3d2e095f8043",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0018.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0018.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 18",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:a0df09e94db6f8ac04096ab9e62f03e3"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "11bb520f059bbf675e597a18a69fbe20d2c00ad4f2e4048e662f1e50d466ebece3285602c7737b32b2dc7177cb06b964053a133789f60b8c6a117a2887946f43"}
     },
     {
-      "@id": "niiri:682a254dac785c2a1985170a04f36faf",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:157eda0d89d7ceb121cc325642f884bc",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0018.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "11bb520f059bbf675e597a18a69fbe20d2c00ad4f2e4048e662f1e50d466ebece3285602c7737b32b2dc7177cb06b964053a133789f60b8c6a117a2887946f43"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c62c63e9de3ddec4af7084778f1f0a65",
-      "entity": "niiri:682a254dac785c2a1985170a04f36faf"
+      "entity_derived": "niiri:4e4595ea20f67bd5529f3d2e095f8043",
+      "entity": "niiri:157eda0d89d7ceb121cc325642f884bc"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:c62c63e9de3ddec4af7084778f1f0a65",
-      "activity": "niiri:16bb24a73948c11f2d5fd7d31856731c"
+      "entity_generated": "niiri:4e4595ea20f67bd5529f3d2e095f8043",
+      "activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e"
     },
     {
-      "@id": "niiri:87d33654f4af56e37c48ada547612e29",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:069ab84a0bc77f8bbe6fbf8bb2bb80fc",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0019.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0019.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 19",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:a0df09e94db6f8ac04096ab9e62f03e3"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "7265ca9b2713d334013587196872999038d4b9a1aa18d4a28daa1e14c509a555ef5cae893952d60604f7ce19c0e72ce33c0e11374e1802bae57d858aee9bf47e"}
     },
     {
-      "@id": "niiri:22abe292447474a270706b548436c88a",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:22a1c0d63f9d2cf485131f1c86148558",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0019.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "7265ca9b2713d334013587196872999038d4b9a1aa18d4a28daa1e14c509a555ef5cae893952d60604f7ce19c0e72ce33c0e11374e1802bae57d858aee9bf47e"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:87d33654f4af56e37c48ada547612e29",
-      "entity": "niiri:22abe292447474a270706b548436c88a"
+      "entity_derived": "niiri:069ab84a0bc77f8bbe6fbf8bb2bb80fc",
+      "entity": "niiri:22a1c0d63f9d2cf485131f1c86148558"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:87d33654f4af56e37c48ada547612e29",
-      "activity": "niiri:16bb24a73948c11f2d5fd7d31856731c"
+      "entity_generated": "niiri:069ab84a0bc77f8bbe6fbf8bb2bb80fc",
+      "activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e"
     },
     {
-      "@id": "niiri:ce9c3abc019a371896731fd76d85d617",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:0f888978a8a86a495939e12690e2bcf8",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0020.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0020.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 20",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:a0df09e94db6f8ac04096ab9e62f03e3"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "3f2e9de942f81adf736fbdee718b1708a1b2e978482dbe0fc68141fc59f7f59cc66191bf4c59e48d5850ffd708527ff0a1ec1835c76e7466466841f349bb793e"}
     },
     {
-      "@id": "niiri:cc893415abb7a4682e5cc9e460136e1c",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:e7d4386ec97d8e529d6fde660a4adc75",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0020.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "3f2e9de942f81adf736fbdee718b1708a1b2e978482dbe0fc68141fc59f7f59cc66191bf4c59e48d5850ffd708527ff0a1ec1835c76e7466466841f349bb793e"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ce9c3abc019a371896731fd76d85d617",
-      "entity": "niiri:cc893415abb7a4682e5cc9e460136e1c"
+      "entity_derived": "niiri:0f888978a8a86a495939e12690e2bcf8",
+      "entity": "niiri:e7d4386ec97d8e529d6fde660a4adc75"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:ce9c3abc019a371896731fd76d85d617",
-      "activity": "niiri:16bb24a73948c11f2d5fd7d31856731c"
+      "entity_generated": "niiri:0f888978a8a86a495939e12690e2bcf8",
+      "activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e"
     },
     {
-      "@id": "niiri:936bb6e7dc82f81ac536ffdc8670e558",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:4dc9f226357a6ab7f5e304324e2bcbfd",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0021.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0021.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 21",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:a0df09e94db6f8ac04096ab9e62f03e3"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "0e2c3b4b5e08e5167d4e7ef3dd3f8e2c2f7bb3d0d530889dceeb306f67758558be8cd1531caab46240406285577babef37c24d49567c4c0410ded0cd3aca0e47"}
     },
     {
-      "@id": "niiri:708fdd2e6bbd0ebe611c01a8aade288c",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:14c8f75ed277956b9ba6f87eb9db82e8",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0021.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "0e2c3b4b5e08e5167d4e7ef3dd3f8e2c2f7bb3d0d530889dceeb306f67758558be8cd1531caab46240406285577babef37c24d49567c4c0410ded0cd3aca0e47"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:936bb6e7dc82f81ac536ffdc8670e558",
-      "entity": "niiri:708fdd2e6bbd0ebe611c01a8aade288c"
+      "entity_derived": "niiri:4dc9f226357a6ab7f5e304324e2bcbfd",
+      "entity": "niiri:14c8f75ed277956b9ba6f87eb9db82e8"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:936bb6e7dc82f81ac536ffdc8670e558",
-      "activity": "niiri:16bb24a73948c11f2d5fd7d31856731c"
+      "entity_generated": "niiri:4dc9f226357a6ab7f5e304324e2bcbfd",
+      "activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e"
     },
     {
-      "@id": "niiri:afff1faf703e5a9a815b740a33dbb8b9",
-      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap:"],
+      "@id": "niiri:d1abc868edbc84f873320116529f4be5",
+      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ResidualMeanSquares.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ResidualMeanSquares.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Residual Mean Squares Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:a0df09e94db6f8ac04096ab9e62f03e3"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "9992ae2923012fed54b3812708cd3b60f75373d57ff1adc2205155139f1320943649e7830fd0cef48fb9364ceec9ffb18ab458c47fab082783d8262d0a5b7e4e"}
     },
     {
-      "@id": "niiri:f1c6088a2ea2360d8f585f84225d553f",
-      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap:"],
+      "@id": "niiri:012705be5593997e59490b3d6466d660",
+      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "ResMS.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "29e0870b07948253df9f088ac41fd14172c0ce0fb0838c6c32f399622f75ba05856cfae66041c4ecc8dadd513e7bc4402f6a6dc371f62a58a2565dee13b1b853"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:afff1faf703e5a9a815b740a33dbb8b9",
-      "entity": "niiri:f1c6088a2ea2360d8f585f84225d553f"
+      "entity_derived": "niiri:d1abc868edbc84f873320116529f4be5",
+      "entity": "niiri:012705be5593997e59490b3d6466d660"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:afff1faf703e5a9a815b740a33dbb8b9",
-      "activity": "niiri:16bb24a73948c11f2d5fd7d31856731c"
+      "entity_generated": "niiri:d1abc868edbc84f873320116529f4be5",
+      "activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e"
     },
     {
-      "@id": "niiri:32c639a78085600f8a705a697ed06aed",
-      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap:"],
+      "@id": "niiri:799a884fae2a161e9aadf96d9f7e36f8",
+      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ReselsPerVoxel.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ReselsPerVoxel.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Resels per Voxel Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:a0df09e94db6f8ac04096ab9e62f03e3"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "e4cc508a935582c9626e9e67fbe3c169a6ba856c20047bb79af4fbdfbd0eddf56b6068e4e54a09ff62c3c7d3c63ddaa6d1d4b213ae65b506447addc8a957ca36"}
     },
     {
-      "@id": "niiri:bd7187db2557e26a813cb7f1d1bc0fa1",
-      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap:"],
+      "@id": "niiri:129241c961b40e0c62467f34d91dab7e",
+      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "RPV.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "2f28d80ced43971006071cce9126ba56245647cd4f0f5f47497c25660d144b19e30b9868bcefc3786b1d2459986e17cdb8cd37fe515839dd062fa6277e369bce"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:32c639a78085600f8a705a697ed06aed",
-      "entity": "niiri:bd7187db2557e26a813cb7f1d1bc0fa1"
+      "entity_derived": "niiri:799a884fae2a161e9aadf96d9f7e36f8",
+      "entity": "niiri:129241c961b40e0c62467f34d91dab7e"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:32c639a78085600f8a705a697ed06aed",
-      "activity": "niiri:16bb24a73948c11f2d5fd7d31856731c"
+      "entity_generated": "niiri:799a884fae2a161e9aadf96d9f7e36f8",
+      "activity": "niiri:9c7e245e4dcccf690110a5c2f867fe1e"
     },
     {
-      "@id": "niiri:71f495a64a87dd58b1cc74f1383c228a",
-      "@type": ["prov:Entity","obo_contrastweightmatrix:"],
-      "nidm_statisticType:": {"@id": "obo_Fstatistic:"},
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "Tone Counting vs Baseline"},
+      "@id": "niiri:adea7750ce17c82bde1a6b2deaac6a59",
+      "@type": ["prov:Entity","obo_contrastweightmatrix"],
+      "nidm_statisticType": {"@id": "obo_Fstatistic"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "Tone Counting vs Baseline"},
       "rdfs:label": "Contrast: Tone Counting vs Baseline",
       "prov:value": {"@type": "xsd:string", "@value": "[[1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],[0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],[0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],[0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],[0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],[0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],[0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],[0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],[0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],[0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]]"}
     },
     {
-      "@id": "niiri:c823c79a04cd1f35b594684f46e488b1",
-      "@type": ["prov:Activity","nidm_ContrastEstimation:"],
+      "@id": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+      "@type": ["prov:Activity","nidm_ContrastEstimation"],
       "rdfs:label": "Contrast estimation"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:c823c79a04cd1f35b594684f46e488b1",
-      "agent": "niiri:2b8ccd681cfa7e7efa195046c80d4149"
+      "activity_associated": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+      "agent": "niiri:8903ae1fa9a6ecfaa31839e8cf029c8a"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:c823c79a04cd1f35b594684f46e488b1",
-      "entity": "niiri:76fcf8996a7e7792184e6dbb3548dddd"
+      "activity_using": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+      "entity": "niiri:701d77588170de3f2a3a5cae849cee5b"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:c823c79a04cd1f35b594684f46e488b1",
-      "entity": "niiri:afff1faf703e5a9a815b740a33dbb8b9"
+      "activity_using": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+      "entity": "niiri:d1abc868edbc84f873320116529f4be5"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:c823c79a04cd1f35b594684f46e488b1",
-      "entity": "niiri:7f6fc22ede14f7eb59e1c96c8768b797"
+      "activity_using": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+      "entity": "niiri:03fe576d4676dc2c478698e09040bd38"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:c823c79a04cd1f35b594684f46e488b1",
-      "entity": "niiri:71f495a64a87dd58b1cc74f1383c228a"
+      "activity_using": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+      "entity": "niiri:adea7750ce17c82bde1a6b2deaac6a59"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:c823c79a04cd1f35b594684f46e488b1",
-      "entity": "niiri:ee988293f4c9ba01ab8220c738ce6c57"
+      "activity_using": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+      "entity": "niiri:7cfe9f21fb53f5db106ee22b82a0fe77"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:c823c79a04cd1f35b594684f46e488b1",
-      "entity": "niiri:08b2f0e7adb342474b1ecdc6fb347df9"
+      "activity_using": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+      "entity": "niiri:43283050484b34063061bdb16cb80c6a"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:c823c79a04cd1f35b594684f46e488b1",
-      "entity": "niiri:b43b6c5f15dd6da1f95e2c9295f696ea"
+      "activity_using": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+      "entity": "niiri:977b0276cc808425abbde5601d66f7f1"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:c823c79a04cd1f35b594684f46e488b1",
-      "entity": "niiri:72b5623932c79270073e16410388a14e"
+      "activity_using": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+      "entity": "niiri:ed63a46c0d2c960f86afcc856493eba3"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:c823c79a04cd1f35b594684f46e488b1",
-      "entity": "niiri:d49f6378df8608464ae61aa8917485a4"
+      "activity_using": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+      "entity": "niiri:0f11c4b5e831cc47e20327b9561101d1"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:c823c79a04cd1f35b594684f46e488b1",
-      "entity": "niiri:5b4a4fc6079e7ec827225bd783e5df60"
+      "activity_using": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+      "entity": "niiri:48291f5a02d1cc7b2042bb3d593d7fff"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:c823c79a04cd1f35b594684f46e488b1",
-      "entity": "niiri:4610816ff722cb10c0691d600ac85b87"
+      "activity_using": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+      "entity": "niiri:8f783b7ccac78e3e7bdec49afe00edd2"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:c823c79a04cd1f35b594684f46e488b1",
-      "entity": "niiri:dc2118ccd0863d65cab02ef9ba996ffa"
+      "activity_using": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+      "entity": "niiri:242b483bd1eee1b930fc5cca16db8bd0"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:c823c79a04cd1f35b594684f46e488b1",
-      "entity": "niiri:aa34f275343373ad637d2bc6dbfc90ba"
+      "activity_using": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+      "entity": "niiri:133e1e9add501047daab53a9c6301964"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:c823c79a04cd1f35b594684f46e488b1",
-      "entity": "niiri:06fc994e05054a0d86d4ae675034b9fd"
+      "activity_using": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+      "entity": "niiri:1e8ad4131b61696d7f4e8f0d62cc8247"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:c823c79a04cd1f35b594684f46e488b1",
-      "entity": "niiri:722ecde813a148bb553937e9a852c5fb"
+      "activity_using": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+      "entity": "niiri:21ab0f8b00a00ed52acdb49a05c615c3"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:c823c79a04cd1f35b594684f46e488b1",
-      "entity": "niiri:2a5e8f6c192c564c4fdf245159e6d259"
+      "activity_using": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+      "entity": "niiri:8c85285ad275239152b5e31bdf64af12"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:c823c79a04cd1f35b594684f46e488b1",
-      "entity": "niiri:def186a6565313c3633d33a821beccd2"
+      "activity_using": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+      "entity": "niiri:2bf2dfa438b489a6f9109550ebd7bc98"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:c823c79a04cd1f35b594684f46e488b1",
-      "entity": "niiri:fdd3ba21d27a5f3e3e9d70843484c806"
+      "activity_using": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+      "entity": "niiri:d1214d3e1d706371966179c913755cb7"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:c823c79a04cd1f35b594684f46e488b1",
-      "entity": "niiri:db0185dff2a8f093bf4501edb86172ec"
+      "activity_using": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+      "entity": "niiri:067750a93237f9d14c0ce7af50da4f3c"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:c823c79a04cd1f35b594684f46e488b1",
-      "entity": "niiri:e6c1f12f4ed83708faa17eb0c97001fc"
+      "activity_using": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+      "entity": "niiri:0d7a4762edd076ba489e5cfade96a9fc"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:c823c79a04cd1f35b594684f46e488b1",
-      "entity": "niiri:41870d89f5dcfe8abd864989bd6ee1cf"
+      "activity_using": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+      "entity": "niiri:239f80ca4290c616514b508515eba255"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:c823c79a04cd1f35b594684f46e488b1",
-      "entity": "niiri:c62c63e9de3ddec4af7084778f1f0a65"
+      "activity_using": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+      "entity": "niiri:4e4595ea20f67bd5529f3d2e095f8043"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:c823c79a04cd1f35b594684f46e488b1",
-      "entity": "niiri:87d33654f4af56e37c48ada547612e29"
+      "activity_using": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+      "entity": "niiri:069ab84a0bc77f8bbe6fbf8bb2bb80fc"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:c823c79a04cd1f35b594684f46e488b1",
-      "entity": "niiri:ce9c3abc019a371896731fd76d85d617"
+      "activity_using": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+      "entity": "niiri:0f888978a8a86a495939e12690e2bcf8"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:c823c79a04cd1f35b594684f46e488b1",
-      "entity": "niiri:936bb6e7dc82f81ac536ffdc8670e558"
+      "activity_using": "niiri:e18771e5677d91f4a09d79dadf322eaf",
+      "entity": "niiri:4dc9f226357a6ab7f5e304324e2bcbfd"
     },
     {
-      "@id": "niiri:677d89c0518fd97cb9d8725ef4cde38f",
-      "@type": ["prov:Entity","nidm_StatisticMap:"],
+      "@id": "niiri:a58ef4cb06ae0d7d8f0c14e5f016db3c",
+      "@type": ["prov:Entity","nidm_StatisticMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "FStatistic.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "FStatistic.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "F-Statistic Map: Tone Counting vs Baseline",
-      "nidm_statisticType:": {"@id": "obo_Fstatistic:"},
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "Tone Counting vs Baseline"},
-      "nidm_errorDegreesOfFreedom:": {"@type": "xsd:float", "@value": "79.9999999999727"},
-      "nidm_effectDegreesOfFreedom:": {"@type": "xsd:float", "@value": "9.99999999999902"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:a0df09e94db6f8ac04096ab9e62f03e3"},
+      "nidm_statisticType": {"@id": "obo_Fstatistic"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "Tone Counting vs Baseline"},
+      "nidm_errorDegreesOfFreedom": {"@type": "xsd:float", "@value": "79.9999999999727"},
+      "nidm_effectDegreesOfFreedom": {"@type": "xsd:float", "@value": "9.99999999999902"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "d929be872bc4e50522f425af19834ae0fdffb717909e441f01354d5d49fa33db0b86fb6054d74fdfaaf5288288f3b827eca9c06969bf5ca07da368b9c2983331"}
     },
     {
-      "@id": "niiri:bdad181146cee1f1221b950807842891",
-      "@type": ["prov:Entity","nidm_StatisticMap:"],
+      "@id": "niiri:4a659d96c27e7d9b44774d45d04e80fe",
+      "@type": ["prov:Entity","nidm_StatisticMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "spmF_0001.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "fc863f9f5a0f55d3013a44bc04c0144d78238bb193d7176caebb1fd666c4f342ae1e4f7f89a379811e06eefc054d74e6cf610556bf8e4942c82ea36ed4acf8be"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:677d89c0518fd97cb9d8725ef4cde38f",
-      "entity": "niiri:bdad181146cee1f1221b950807842891"
+      "entity_derived": "niiri:a58ef4cb06ae0d7d8f0c14e5f016db3c",
+      "entity": "niiri:4a659d96c27e7d9b44774d45d04e80fe"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:677d89c0518fd97cb9d8725ef4cde38f",
-      "activity": "niiri:c823c79a04cd1f35b594684f46e488b1"
+      "entity_generated": "niiri:a58ef4cb06ae0d7d8f0c14e5f016db3c",
+      "activity": "niiri:e18771e5677d91f4a09d79dadf322eaf"
     },
     {
-      "@id": "niiri:7d1875e35bad8956747e03da1bfa4d33",
-      "@type": ["prov:Entity","nidm_ContrastExplainedMeanSquareMap:"],
+      "@id": "niiri:ce5a4b9b70b53160de00542203e0ef42",
+      "@type": ["prov:Entity","nidm_ContrastExplainedMeanSquareMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ContrastExplainedMeanSquare.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ContrastExplainedMeanSquare.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Contrast Explained Mean Square Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:a0df09e94db6f8ac04096ab9e62f03e3"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "413ba8ccbb0f2a6d28833434d74e7c0e86ba02e18e6b4a3ce9cd4f6261d96fcc6a469adbde0bdca4367446a5857cd90bfd495cbd432064288b12cb5a456ceb32"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:7d1875e35bad8956747e03da1bfa4d33",
-      "activity": "niiri:c823c79a04cd1f35b594684f46e488b1"
+      "entity_generated": "niiri:ce5a4b9b70b53160de00542203e0ef42",
+      "activity": "niiri:e18771e5677d91f4a09d79dadf322eaf"
     },
     {
-      "@id": "niiri:f27f8fd0daf37ac0c325511449336820",
-      "@type": ["prov:Entity","nidm_HeightThreshold:","nidm_PValueUncorrected:"],
-      "rdfs:label": "Height Threshold: p<0.001000 (unc.)",
+      "@id": "niiri:3cdb938d0d98089a2daa2c42933f776f",
+      "@type": ["prov:Entity","nidm_HeightThreshold","nidm_PValueUncorrected"],
+      "rdfs:label": "Height Threshold: p<0.001 (unc.)",
       "prov:value": {"@type": "xsd:float", "@value": "0.000999500040298695"},
-      "nidm_equivalentThreshold:": [{"@id": "niiri:7a4585c8214149c879402d2b7df09e7c"},{"@id": "niiri:1eea923c1d8ed4ac6662ccee6bfd3bdb"}]
+      "nidm_equivalentThreshold": [{"@id": "niiri:b32341380b98d15b8fd2009d71b54406"},{"@id": "niiri:0700cb52ae8c414bd0981a1a1b41108c"}]
     },
     {
-      "@id": "niiri:7a4585c8214149c879402d2b7df09e7c",
-      "@type": ["prov:Entity","nidm_HeightThreshold:","obo_statistic:"],
-      "rdfs:label": "Height Threshold",
+      "@id": "niiri:b32341380b98d15b8fd2009d71b54406",
+      "@type": ["prov:Entity","nidm_HeightThreshold","obo_statistic"],
+      "rdfs:label": "Height Threshold: F=3.385914)",
       "prov:value": {"@type": "xsd:float", "@value": "3.38591395681668"}
     },
     {
-      "@id": "niiri:1eea923c1d8ed4ac6662ccee6bfd3bdb",
-      "@type": ["prov:Entity","nidm_HeightThreshold:","obo_FWERadjustedpvalue:"],
-      "rdfs:label": "Height Threshold",
+      "@id": "niiri:0700cb52ae8c414bd0981a1a1b41108c",
+      "@type": ["prov:Entity","nidm_HeightThreshold","obo_FWERadjustedpvalue"],
+      "rdfs:label": "Height Threshold: p<1.000000 (FWE)",
       "prov:value": {"@type": "xsd:float", "@value": "1"}
     },
     {
-      "@id": "niiri:ab66f11f59d7ca7bb62046e8d9133e17",
-      "@type": ["prov:Entity","nidm_ExtentThreshold:","obo_statistic:"],
+      "@id": "niiri:ec3787cbdbedf5e1c42112b88a72d8a8",
+      "@type": ["prov:Entity","nidm_ExtentThreshold","obo_statistic"],
       "rdfs:label": "Extent Threshold: k>=0",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "0"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0"},
-      "nidm_equivalentThreshold:": [{"@id": "niiri:9d8ba071d9e49621d6c2b99e2d0e741b"},{"@id": "niiri:c86d2d896fd0f90b14834da61b1c2140"}]
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "0"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0"},
+      "nidm_equivalentThreshold": [{"@id": "niiri:db0a4cdd3410e9ced5166eed42dc1593"},{"@id": "niiri:1a26121240ec6092679db261d7ef1d67"}]
     },
     {
-      "@id": "niiri:9d8ba071d9e49621d6c2b99e2d0e741b",
-      "@type": ["prov:Entity","nidm_ExtentThreshold:","obo_FWERadjustedpvalue:"],
+      "@id": "niiri:db0a4cdd3410e9ced5166eed42dc1593",
+      "@type": ["prov:Entity","nidm_ExtentThreshold","obo_FWERadjustedpvalue"],
       "rdfs:label": "Extent Threshold",
       "prov:value": {"@type": "xsd:float", "@value": "1"}
     },
     {
-      "@id": "niiri:c86d2d896fd0f90b14834da61b1c2140",
-      "@type": ["prov:Entity","nidm_ExtentThreshold:","nidm_PValueUncorrected:"],
+      "@id": "niiri:1a26121240ec6092679db261d7ef1d67",
+      "@type": ["prov:Entity","nidm_ExtentThreshold","nidm_PValueUncorrected"],
       "rdfs:label": "Extent Threshold",
       "prov:value": {"@type": "xsd:float", "@value": "1"}
     },
     {
-      "@id": "niiri:83b43f87517e0312723714e057e27393",
-      "@type": ["prov:Entity","nidm_PeakDefinitionCriteria:"],
+      "@id": "niiri:5f2a0985f22401ffe697c6cbad69a014",
+      "@type": ["prov:Entity","nidm_PeakDefinitionCriteria"],
       "rdfs:label": "Peak Definition Criteria",
-      "nidm_maxNumberOfPeaksPerCluster:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_minDistanceBetweenPeaks:": {"@type": "xsd:float", "@value": "8"}
+      "nidm_maxNumberOfPeaksPerCluster": {"@type": "xsd:int", "@value": "3"},
+      "nidm_minDistanceBetweenPeaks": {"@type": "xsd:float", "@value": "8"}
     },
     {
-      "@id": "niiri:92c2b0e166865683bdf335e4295612b0",
-      "@type": ["prov:Entity","nidm_ClusterDefinitionCriteria:"],
+      "@id": "niiri:5375a11691240712e54191f850b6a223",
+      "@type": ["prov:Entity","nidm_ClusterDefinitionCriteria"],
       "rdfs:label": "Cluster Connectivity Criterion: 18",
-      "nidm_hasConnectivityCriterion:": {"@id": "nidm_voxel18connected:"}
+      "nidm_hasConnectivityCriterion": {"@id": "nidm_voxel18connected"}
     },
     {
-      "@id": "niiri:5d50bfe60bcdf32579cf9c2bb73605e2",
-      "@type": ["prov:Activity","nidm_Inference:"],
-      "nidm_hasAlternativeHypothesis:": {"@id": "nidm_OneTailedTest:"},
+      "@id": "niiri:1d58f1ea373dca6b6777c0ae0bfc411d",
+      "@type": ["prov:Activity","nidm_Inference"],
+      "nidm_hasAlternativeHypothesis": {"@id": "nidm_OneTailedTest"},
       "rdfs:label": "Inference"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:5d50bfe60bcdf32579cf9c2bb73605e2",
-      "agent": "niiri:2b8ccd681cfa7e7efa195046c80d4149"
+      "activity_associated": "niiri:1d58f1ea373dca6b6777c0ae0bfc411d",
+      "agent": "niiri:8903ae1fa9a6ecfaa31839e8cf029c8a"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:5d50bfe60bcdf32579cf9c2bb73605e2",
-      "entity": "niiri:f27f8fd0daf37ac0c325511449336820"
+      "activity_using": "niiri:1d58f1ea373dca6b6777c0ae0bfc411d",
+      "entity": "niiri:3cdb938d0d98089a2daa2c42933f776f"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:5d50bfe60bcdf32579cf9c2bb73605e2",
-      "entity": "niiri:ab66f11f59d7ca7bb62046e8d9133e17"
+      "activity_using": "niiri:1d58f1ea373dca6b6777c0ae0bfc411d",
+      "entity": "niiri:ec3787cbdbedf5e1c42112b88a72d8a8"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:5d50bfe60bcdf32579cf9c2bb73605e2",
-      "entity": "niiri:677d89c0518fd97cb9d8725ef4cde38f"
+      "activity_using": "niiri:1d58f1ea373dca6b6777c0ae0bfc411d",
+      "entity": "niiri:a58ef4cb06ae0d7d8f0c14e5f016db3c"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:5d50bfe60bcdf32579cf9c2bb73605e2",
-      "entity": "niiri:32c639a78085600f8a705a697ed06aed"
+      "activity_using": "niiri:1d58f1ea373dca6b6777c0ae0bfc411d",
+      "entity": "niiri:799a884fae2a161e9aadf96d9f7e36f8"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:5d50bfe60bcdf32579cf9c2bb73605e2",
-      "entity": "niiri:76fcf8996a7e7792184e6dbb3548dddd"
+      "activity_using": "niiri:1d58f1ea373dca6b6777c0ae0bfc411d",
+      "entity": "niiri:701d77588170de3f2a3a5cae849cee5b"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:5d50bfe60bcdf32579cf9c2bb73605e2",
-      "entity": "niiri:83b43f87517e0312723714e057e27393"
+      "activity_using": "niiri:1d58f1ea373dca6b6777c0ae0bfc411d",
+      "entity": "niiri:5f2a0985f22401ffe697c6cbad69a014"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:5d50bfe60bcdf32579cf9c2bb73605e2",
-      "entity": "niiri:92c2b0e166865683bdf335e4295612b0"
+      "activity_using": "niiri:1d58f1ea373dca6b6777c0ae0bfc411d",
+      "entity": "niiri:5375a11691240712e54191f850b6a223"
     },
     {
-      "@id": "niiri:3e2b41a23244c3a3a86c37dd2d4d47bf",
-      "@type": ["prov:Entity","nidm_SearchSpaceMaskMap:"],
+      "@id": "niiri:4f06d69ed569f568944f5c14d618d42b",
+      "@type": ["prov:Entity","nidm_SearchSpaceMaskMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "SearchSpaceMask.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "SearchSpaceMask.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Search Space Mask Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:a0df09e94db6f8ac04096ab9e62f03e3"},
-      "nidm_searchVolumeInVoxels:": {"@type": "xsd:int", "@value": "223057"},
-      "nidm_searchVolumeInUnits:": {"@type": "xsd:float", "@value": "1784456"},
-      "nidm_reselSizeInVoxels:": {"@type": "xsd:float", "@value": "61.0192089405672"},
-      "nidm_searchVolumeInResels:": {"@type": "xsd:float", "@value": "3391.65327760272"},
-      "spm_searchVolumeReselsGeometry:": {"@type": "xsd:string", "@value": "[6, 100.17222995762, 1013.43634591138, 3391.65327760272]"},
-      "nidm_noiseFWHMInVoxels:": {"@type": "xsd:string", "@value": "[3.98580588901192, 3.92965863532102, 3.89579058084751]"},
-      "nidm_noiseFWHMInUnits:": {"@type": "xsd:string", "@value": "[7.97161177802383, 7.85931727064203, 7.79158116169502]"},
-      "nidm_randomFieldStationarity:": {"@type": "xsd:boolean", "@value": "true"},
-      "nidm_expectedNumberOfVoxelsPerCluster:": {"@type": "xsd:float", "@value": "3.28593722598409"},
-      "nidm_expectedNumberOfClusters:": {"@type": "xsd:float", "@value": "71.0755433009035"},
-      "nidm_heightCriticalThresholdFWE05:": {"@type": "xsd:float", "@value": "6.60490273485611"},
-      "nidm_heightCriticalThresholdFDR05:": {"@type": "xsd:float", "@value": "5.22679281234741"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c"},
+      "nidm_searchVolumeInVoxels": {"@type": "xsd:int", "@value": "223057"},
+      "nidm_searchVolumeInUnits": {"@type": "xsd:float", "@value": "1784456"},
+      "nidm_reselSizeInVoxels": {"@type": "xsd:float", "@value": "61.0192089405672"},
+      "nidm_searchVolumeInResels": {"@type": "xsd:float", "@value": "3391.65327760272"},
+      "spm_searchVolumeReselsGeometry": {"@type": "xsd:string", "@value": "[6, 100.17222995762, 1013.43634591138, 3391.65327760272]"},
+      "nidm_noiseFWHMInVoxels": {"@type": "xsd:string", "@value": "[3.98580588901192, 3.92965863532102, 3.89579058084751]"},
+      "nidm_noiseFWHMInUnits": {"@type": "xsd:string", "@value": "[7.97161177802383, 7.85931727064203, 7.79158116169502]"},
+      "nidm_randomFieldStationarity": {"@type": "xsd:boolean", "@value": "true"},
+      "nidm_expectedNumberOfVoxelsPerCluster": {"@type": "xsd:float", "@value": "3.28593722598409"},
+      "nidm_expectedNumberOfClusters": {"@type": "xsd:float", "@value": "71.0755433009035"},
+      "nidm_heightCriticalThresholdFWE05": {"@type": "xsd:float", "@value": "6.60490273485611"},
+      "nidm_heightCriticalThresholdFDR05": {"@type": "xsd:float", "@value": "5.22679281234741"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876"},
-      "spm_smallestSignificantClusterSizeInVoxelsFWE05:": {"@type": "xsd:int", "@value": "50"},
-      "spm_smallestSignificantClusterSizeInVoxelsFDR05:": {"@type": "xsd:int", "@value": "27"}
+      "spm_smallestSignificantClusterSizeInVoxelsFWE05": {"@type": "xsd:int", "@value": "50"},
+      "spm_smallestSignificantClusterSizeInVoxelsFDR05": {"@type": "xsd:int", "@value": "27"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:3e2b41a23244c3a3a86c37dd2d4d47bf",
-      "activity": "niiri:5d50bfe60bcdf32579cf9c2bb73605e2"
+      "entity_generated": "niiri:4f06d69ed569f568944f5c14d618d42b",
+      "activity": "niiri:1d58f1ea373dca6b6777c0ae0bfc411d"
     },
     {
-      "@id": "niiri:fec8545d1e39630ce18d7eddddd0aaa4",
-      "@type": ["prov:Entity","nidm_ExcursionSetMap:"],
+      "@id": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145",
+      "@type": ["prov:Entity","nidm_ExcursionSetMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ExcursionSet.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ExcursionSet.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Excursion Set Map",
-      "nidm_numberOfSupraThresholdClusters:": {"@type": "xsd:int", "@value": "233"},
-      "nidm_pValue:": {"@type": "xsd:float", "@value": "0"},
-      "nidm_hasClusterLabelsMap:": {"@id": "niiri:3a2cebaff9a491bcb49fbe38aff03e5e"},
-      "nidm_hasMaximumIntensityProjection:": {"@id": "niiri:51fc0014bcdab3e46d21c5d9574d0c00"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:a0df09e94db6f8ac04096ab9e62f03e3"},
+      "nidm_numberOfSupraThresholdClusters": {"@type": "xsd:int", "@value": "233"},
+      "nidm_pValue": {"@type": "xsd:float", "@value": "0"},
+      "nidm_hasClusterLabelsMap": {"@id": "niiri:0bc71c587ee079ccd7e9e7c78d309612"},
+      "nidm_hasMaximumIntensityProjection": {"@id": "niiri:ff39a18fca2ad1e06ab58e61826a6e4e"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "2c020948d33abb498f0c56063da36e748988840af6d965454a32bb8eb7eaf376b82773a26e325acb6da10cc41fbee4e1a4c8cec6e5f335e3ca9d5e01bec47cec"}
     },
     {
-      "@id": "niiri:3a2cebaff9a491bcb49fbe38aff03e5e",
-      "@type": ["prov:Entity","nidm_ClusterLabelsMap:"],
+      "@id": "niiri:0bc71c587ee079ccd7e9e7c78d309612",
+      "@type": ["prov:Entity","nidm_ClusterLabelsMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ClusterLabels.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ClusterLabels.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Cluster Labels Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:a0df09e94db6f8ac04096ab9e62f03e3"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b6feb3b8e24120e8ddf1cf9eae080e8c"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "6a4279ff424d9aee83ff86b3a7fbe1c99f15bfbfda56cf88ca167390de958eb1fce4cf5c82cd12818a6f0e3cc06e0a3b49d6e7491992d21e7047633059b0b333"}
     },
     {
-      "@id": "niiri:51fc0014bcdab3e46d21c5d9574d0c00",
+      "@id": "niiri:ff39a18fca2ad1e06ab58e61826a6e4e",
       "@type": ["prov:Entity","dctype:Image"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "MaximumIntensityProjection.png"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "MaximumIntensityProjection.png"},
@@ -1278,9808 +1278,9808 @@
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:fec8545d1e39630ce18d7eddddd0aaa4",
-      "activity": "niiri:5d50bfe60bcdf32579cf9c2bb73605e2"
+      "entity_generated": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145",
+      "activity": "niiri:1d58f1ea373dca6b6777c0ae0bfc411d"
     },
     {
-      "@id": "niiri:ba835f71b6ca8a486d7c5f7379bd662f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:85fec2a2169d10c191c4e617a17cdba0",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0001",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "29439"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "482.454632092554"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.22840660865927e-227"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "7.5221873981761e-225"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "1"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "29439"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "482.454632092554"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.22840660865927e-227"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "7.5221873981761e-225"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "1"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ba835f71b6ca8a486d7c5f7379bd662f",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:85fec2a2169d10c191c4e617a17cdba0",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:887840e0df0dde27ca60bb3a5eed1fdb",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:1aa2c5542022d8edfbe6faaf12d4ebb7",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0002",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "125"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "2.04853524275856"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.15095913141277e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "8.18016996407822e-05"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "3.35216847023969e-05"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "2"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "125"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "2.04853524275856"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.15095913141277e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "8.18016996407822e-05"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "3.35216847023969e-05"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "2"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:887840e0df0dde27ca60bb3a5eed1fdb",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:1aa2c5542022d8edfbe6faaf12d4ebb7",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:14b137956e5e00ffd0fdc43f5c22f5c4",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f9d722fcce853c033260a3ae532235c1",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0003",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1968"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "32.2521388619908"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.93628745979793e-38"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "5.75077489066459e-36"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "3"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1968"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "32.2521388619908"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.93628745979793e-38"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "5.75077489066459e-36"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "3"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:14b137956e5e00ffd0fdc43f5c22f5c4",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:f9d722fcce853c033260a3ae532235c1",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:0549497fa62a1d5511dea65e5ef2cf1b",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:73ec267aa6e4362aa22b8bf333d9a6f3",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0004",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "170"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "2.78600793015164"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.12715600843801e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "3.64414734899121e-06"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "2.12665981162699e-06"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "4"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "170"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "2.78600793015164"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.12715600843801e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "3.64414734899121e-06"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "2.12665981162699e-06"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "4"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0549497fa62a1d5511dea65e5ef2cf1b",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:73ec267aa6e4362aa22b8bf333d9a6f3",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:3fbaffdfe735b9ae40c349431f693073",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:a78547a90624868c0aef3cebdd83d669",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0005",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "131"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "2.14686493441097"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.45594393969356e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "5.29921225013164e-05"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "2.48176419706943e-05"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "5"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "131"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "2.14686493441097"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.45594393969356e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "5.29921225013164e-05"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "2.48176419706943e-05"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "5"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3fbaffdfe735b9ae40c349431f693073",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:a78547a90624868c0aef3cebdd83d669",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:6380e74b916ddbf1a024a72c065d623f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:940cf2d7b7d0eb179a5d87089cdef025",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0006",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "13"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.21304766524689"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0485956620121857"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.968379925135842"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.164098394910714"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "6"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "13"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.21304766524689"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0485956620121857"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.968379925135842"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.164098394910714"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "6"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6380e74b916ddbf1a024a72c065d623f",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:940cf2d7b7d0eb179a5d87089cdef025",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:4cab3569c0af76ee151f4e707fdd3538",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:22f7499c81f2b4cfb5d9464b77334f85",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0007",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "51"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.835802379045492"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000540755081088917"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0377052296641641"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00629979669468589"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "7"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "51"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.835802379045492"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000540755081088917"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0377052296641641"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00629979669468589"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "7"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4cab3569c0af76ee151f4e707fdd3538",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:22f7499c81f2b4cfb5d9464b77334f85",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:9a4cbf3c4b4b3511dfc9fd1435a8a28b",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:313e60cc130ee5f7b46b9a70c28c95a0",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0008",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "507"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "8.30885894462871"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.86063251674991e-16"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "5.58442181386454e-14"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "6.10509125467576e-14"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "8"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "507"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "8.30885894462871"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.86063251674991e-16"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "5.58442181386454e-14"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "6.10509125467576e-14"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "8"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9a4cbf3c4b4b3511dfc9fd1435a8a28b",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:313e60cc130ee5f7b46b9a70c28c95a0",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:c8ec1ca234b9bf8d2809bf619534b056",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:5755c7b6f3b8bb9a495a80e69a7ab94e",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0009",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "37"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.606366431856533"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00230266652416726"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.150972136700134"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0178840433376991"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "9"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "37"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.606366431856533"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00230266652416726"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.150972136700134"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0178840433376991"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "9"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c8ec1ca234b9bf8d2809bf619534b056",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:5755c7b6f3b8bb9a495a80e69a7ab94e",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:1b47349b306df45c874f7c947b149652",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:23f5c60185b27f2be0dd455c41c3fde3",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0010",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "39"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.63914299574067"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00185358588005153"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.123435179427901"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0154244825018574"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "10"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "39"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.63914299574067"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00185358588005153"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.123435179427901"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0154244825018574"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "10"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1b47349b306df45c874f7c947b149652",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:23f5c60185b27f2be0dd455c41c3fde3",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:c4b71b38ef4c3be049827afa9e8143bc",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:33cca310ebec4700e45b0560235f03cd",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0011",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "265"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "4.34289471464814"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.58159348981872e-10"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1.12412615882462e-08"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "9.21278207819405e-09"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "11"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "265"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "4.34289471464814"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.58159348981872e-10"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1.12412615882462e-08"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "9.21278207819405e-09"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "11"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c4b71b38ef4c3be049827afa9e8143bc",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:33cca310ebec4700e45b0560235f03cd",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:3e28cae2b2981677b6365484975e315d",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:68605e1a07366f1a9aaae9f04eb3bbcf",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0012",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "61"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.999685198466177"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000208355503966508"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0146998669750764"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00303417702651228"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "12"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "61"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.999685198466177"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000208355503966508"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0146998669750764"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00303417702651228"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "12"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3e28cae2b2981677b6365484975e315d",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:68605e1a07366f1a9aaae9f04eb3bbcf",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:f362fb2acc0fecc902d53e2682b7f919",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:ab91ba995acbb604c8550a19c6d56878",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0013",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "103"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.68799304003305"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.02727767740283e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.000428300288780381"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000156039522092762"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "13"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "103"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.68799304003305"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.02727767740283e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.000428300288780381"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000156039522092762"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "13"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f362fb2acc0fecc902d53e2682b7f919",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:ab91ba995acbb604c8550a19c6d56878",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:f20977e52a75b5fa007a387cc6824614",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:8ddb469ed3d8d13f9f3b41143b2bc54e",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0014",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "54"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.884967224871697"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00040374512099407"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0282885724424913"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00553368312891872"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "14"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "54"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.884967224871697"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00040374512099407"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0282885724424913"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00553368312891872"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "14"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f20977e52a75b5fa007a387cc6824614",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:8ddb469ed3d8d13f9f3b41143b2bc54e",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:27140d3dcc60dbdda794838cc4910ac1",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:fe3d995dc2bfdeb5f29182f0558560a6",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0015",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "50"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.819414097103423"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000596825369072588"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0415325605221553"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00632092322699605"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "15"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "50"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.819414097103423"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000596825369072588"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0415325605221553"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00632092322699605"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "15"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:27140d3dcc60dbdda794838cc4910ac1",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:fe3d995dc2bfdeb5f29182f0558560a6",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:292c1d14e546541ab02c17303b03d0d1",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:cfbb41a715a689539e32d23fa5ecf0ad",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0016",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "50"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.819414097103423"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000596825369072588"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0415325605221553"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00632092322699605"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "16"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "50"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.819414097103423"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000596825369072588"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0415325605221553"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00632092322699605"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "16"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:292c1d14e546541ab02c17303b03d0d1",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:cfbb41a715a689539e32d23fa5ecf0ad",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:3d59b7c113f7b19df2458e17b2f822e9",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:1ea775914efd19bdf7935c45c2fc61d7",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0017",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "69"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.13079145400272"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000100833701130562"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00714118974936662"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00167816088310149"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "17"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "69"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.13079145400272"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000100833701130562"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00714118974936662"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00167816088310149"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "17"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3d59b7c113f7b19df2458e17b2f822e9",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:1ea775914efd19bdf7935c45c2fc61d7",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:444ae882759bc4fc11d5ae4c9e6cb1e1",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c9c2075e31233972320b91bbe319e15d",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0018",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "43"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.704696123508944"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00121413216251589"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0826765137219736"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.010880492071777"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "18"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "43"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.704696123508944"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00121413216251589"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0826765137219736"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.010880492071777"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "18"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:444ae882759bc4fc11d5ae4c9e6cb1e1",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:c9c2075e31233972320b91bbe319e15d",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:59566dcbed59d8991aa0141444f7d8ea",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:184504b2959cc0300f56dbed9be3df0a",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0019",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "48"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.786637533219287"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000728464342132796"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0504584586207069"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00737966050943224"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "19"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "48"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.786637533219287"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000728464342132796"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0504584586207069"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00737966050943224"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "19"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:59566dcbed59d8991aa0141444f7d8ea",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:184504b2959cc0300f56dbed9be3df0a",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:2b54a24f6a0f9527c8816d93199577eb",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:e56b27d2108b9aebc19f9ff56ac97dce",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0020",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "15"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.245824229131027"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0359026634119283"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.922058856524574"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.141785094491174"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "20"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "15"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.245824229131027"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0359026634119283"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.922058856524574"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.141785094491174"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "20"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2b54a24f6a0f9527c8816d93199577eb",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:e56b27d2108b9aebc19f9ff56ac97dce",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:678898fc201808d0072b6bbbea15acd2",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:e78e0827b0a80cf9fb06ff0a74ee9600",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0021",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "28"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.458871894377917"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00644928550392363"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.367696937875251"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0429338149261202"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "21"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "28"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.458871894377917"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00644928550392363"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.367696937875251"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0429338149261202"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "21"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:678898fc201808d0072b6bbbea15acd2",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:e78e0827b0a80cf9fb06ff0a74ee9600",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:5a11d9bb922c3f53cb59978d26e7d5b0",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:461b922ff7bd3d15d33f54bcbd492da3",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0022",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "52"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.85219066098756"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000490267487593057"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.034245896140666"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0060122276110096"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "22"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "52"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.85219066098756"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000490267487593057"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.034245896140666"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0060122276110096"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "22"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5a11d9bb922c3f53cb59978d26e7d5b0",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:461b922ff7bd3d15d33f54bcbd492da3",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:64a43fe12cd19a1e197d1e7627a3bda5",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:1cfc9f0a458d8852ad0759c9e8be8a6a",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0023",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "15"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.245824229131027"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0359026634119283"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.922058856524574"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.141785094491174"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "23"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "15"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.245824229131027"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0359026634119283"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.922058856524574"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.141785094491174"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "23"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:64a43fe12cd19a1e197d1e7627a3bda5",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:1cfc9f0a458d8852ad0759c9e8be8a6a",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:df9def02f0fbb31e7bb7de54da832bdb",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:5bbe3c6a1630a3c2cc55aa12dfd9e286",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0024",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "17"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.278600793015164"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0268776015038201"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.851969971349154"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.120432329815194"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "24"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "17"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.278600793015164"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0268776015038201"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.851969971349154"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.120432329815194"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "24"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:df9def02f0fbb31e7bb7de54da832bdb",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:5bbe3c6a1630a3c2cc55aa12dfd9e286",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:49955533f78bc4787cee05a051461dcf",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:1e1925d1a7237f41c7f4bbc7a938991e",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0025",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "45"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.737472687393081"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000987511938850411"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0677814047796702"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00920361127008583"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "25"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "45"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.737472687393081"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000987511938850411"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0677814047796702"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00920361127008583"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "25"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:49955533f78bc4787cee05a051461dcf",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:1e1925d1a7237f41c7f4bbc7a938991e",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:49c6aebff31b5e29c05f3709fd4ca0c7",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:45311fe546d4fc676e17072f500c1575",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0026",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "22"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.360542202725506"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0136406300322587"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.620733134284922"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0739131813375881"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "26"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "22"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.360542202725506"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0136406300322587"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.620733134284922"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0739131813375881"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "26"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:49c6aebff31b5e29c05f3709fd4ca0c7",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:45311fe546d4fc676e17072f500c1575",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:9315b753bce8ecc349364143d90f1ad9",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:12134d971afb042d040aea6cecc0ebec",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0027",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "98"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.60605163032271"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.92167500672803e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.000633911891162686"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000207875027656763"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "27"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "98"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.60605163032271"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.92167500672803e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.000633911891162686"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000207875027656763"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "27"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9315b753bce8ecc349364143d90f1ad9",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:12134d971afb042d040aea6cecc0ebec",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:c92570bdb9c49bf92cb00c5c23880685",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:7dfc1da184d477320648da6e59dc2a7c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0028",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "16"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.262212511073096"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0310172463051921"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.889701795682265"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.13140033434745"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "28"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "16"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.262212511073096"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0310172463051921"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.889701795682265"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.13140033434745"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "28"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c92570bdb9c49bf92cb00c5c23880685",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:7dfc1da184d477320648da6e59dc2a7c",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:e491d13c4d524178ac2c358bfec8b0ab",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:ff37e6b9b5486e16e27ae0fca1db545d",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0029",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "38"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.622754713798602"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00206497707345811"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.136506895887386"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0165910226936462"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "29"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "38"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.622754713798602"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00206497707345811"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.136506895887386"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0165910226936462"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "29"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e491d13c4d524178ac2c358bfec8b0ab",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:ff37e6b9b5486e16e27ae0fca1db545d",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:605ecba3a006393b32ebef7f5177a299",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:bfb3c58b6c12062e86b12426bbf496d9",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0030",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "169"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "2.76961964820957"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.47637719732272e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "3.89235727094039e-06"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "2.12665981162699e-06"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "30"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "169"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "2.76961964820957"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.47637719732272e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "3.89235727094039e-06"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "2.12665981162699e-06"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "30"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:605ecba3a006393b32ebef7f5177a299",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:bfb3c58b6c12062e86b12426bbf496d9",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:792e740d5505df540f825e8630189126",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:b1059120ca68f8c294f13d22a334afc5",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0031",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "22"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.360542202725506"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0136406300322587"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.620733134284922"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0739131813375881"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "31"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "22"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.360542202725506"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0136406300322587"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.620733134284922"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0739131813375881"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "31"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:792e740d5505df540f825e8630189126",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:b1059120ca68f8c294f13d22a334afc5",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:5b18eef1ef74501ea55e4ac7f04163eb",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:dd43f04c7775bf5d225a62b05a1f8275",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0032",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "53"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.868578942929629"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000444772158654789"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0311179741203415"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00575732849814255"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "32"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "53"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.868578942929629"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000444772158654789"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0311179741203415"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00575732849814255"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "32"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5b18eef1ef74501ea55e4ac7f04163eb",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:dd43f04c7775bf5d225a62b05a1f8275",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:2a0d5cd5e741995710fe2bdd14adb005",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c723d93708cb4dee84578d4dad2314df",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0033",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "20"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.327765638841369"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0177689026939896"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.717177111469273"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.090003354949991"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "33"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "20"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.327765638841369"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0177689026939896"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.717177111469273"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.090003354949991"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "33"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2a0d5cd5e741995710fe2bdd14adb005",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:c723d93708cb4dee84578d4dad2314df",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:adca675d0dc4660fb2170e6ead12a50a",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:d30171bbdc271c074a6050acb8a4d34e",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0034",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "22"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.360542202725506"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0136406300322587"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.620733134284922"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0739131813375881"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "34"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "22"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.360542202725506"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0136406300322587"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.620733134284922"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0739131813375881"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "34"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:adca675d0dc4660fb2170e6ead12a50a",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:d30171bbdc271c074a6050acb8a4d34e",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:5e628c0b7abb6a720a8a91ae5f6c769c",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:ea2ed9cc4d84a345a4920b11801993b3",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0035",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "47"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.770249251277218"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000805635676899239"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0556524313184183"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00782137969656345"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "35"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "47"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.770249251277218"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000805635676899239"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0556524313184183"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00782137969656345"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "35"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5e628c0b7abb6a720a8a91ae5f6c769c",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:ea2ed9cc4d84a345a4920b11801993b3",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:e8494b3e58d9094d2cc21652c223abe4",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:cf3d3e192bab8fb0febbddda2b472570",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0036",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "7"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.114717973594479"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.135115167401345"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999932500065553"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.317998323277913"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "36"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "7"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.114717973594479"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.135115167401345"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999932500065553"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.317998323277913"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "36"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e8494b3e58d9094d2cc21652c223abe4",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:cf3d3e192bab8fb0febbddda2b472570",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:2a3839763db274e8b4cae9d895b6483d",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:a6ee0e116834a7cbcea03e95f20dae54",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0037",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "27"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.442483612435849"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00727748912325509"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.403843160672682"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0458285125869847"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "37"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "27"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.442483612435849"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00727748912325509"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.403843160672682"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0458285125869847"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "37"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2a3839763db274e8b4cae9d895b6483d",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:a6ee0e116834a7cbcea03e95f20dae54",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:d2c4ecdb2f17a5fa414bc38579edb8f3",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:e9b27c64b1591506ec57168d7dbf134f",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0038",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "14"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.229435947188959"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0416945009118955"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.948360030569285"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.15179404238237"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "38"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "14"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.229435947188959"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0416945009118955"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.948360030569285"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.15179404238237"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "38"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d2c4ecdb2f17a5fa414bc38579edb8f3",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:e9b27c64b1591506ec57168d7dbf134f",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:770d3b226608026413a9c2a34b0a1793",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:35e614f307abb1c7215e649c0bbf0aa0",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0039",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "13"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.21304766524689"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0485956620121857"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.968379925135842"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.164098394910714"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "39"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "13"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.21304766524689"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0485956620121857"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.968379925135842"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.164098394910714"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "39"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:770d3b226608026413a9c2a34b0a1793",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:35e614f307abb1c7215e649c0bbf0aa0",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:16b9e50b259cea22c334cdb43404b9b4",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:84661ae12e172546f496d4b26feacce8",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0040",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "12"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.196659383304822"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0568651131936359"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.982432748406332"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.181500977727632"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "40"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "12"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.196659383304822"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0568651131936359"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.982432748406332"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.181500977727632"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "40"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:16b9e50b259cea22c334cdb43404b9b4",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:84661ae12e172546f496d4b26feacce8",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:8d690e036ac0c4f773f14d063bc26982",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:b3ab45e7aaebdd6d5415f3e8fb8365d3",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0041",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "22"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.360542202725506"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0136406300322587"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.620733134284922"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0739131813375881"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "41"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "22"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.360542202725506"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0136406300322587"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.620733134284922"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0739131813375881"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "41"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8d690e036ac0c4f773f14d063bc26982",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:b3ab45e7aaebdd6d5415f3e8fb8365d3",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:871bd0030276be32c9682273d65be8a4",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:a9dd639eb89226977a3ede42cafc093c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0042",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "28"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.458871894377917"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00644928550392363"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.367696937875251"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0429338149261202"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "42"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "28"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.458871894377917"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00644928550392363"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.367696937875251"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0429338149261202"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "42"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:871bd0030276be32c9682273d65be8a4",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:a9dd639eb89226977a3ede42cafc093c",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:fd8207df6ecd8a6e5899191a7d1b9cec",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:01b4ff55ed7965f77f28199c98d35002",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0043",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "77"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.26189770953927"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.01633443149056e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00355903850604589"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00106255083867027"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "43"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "77"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.26189770953927"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.01633443149056e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00355903850604589"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00106255083867027"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "43"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:fd8207df6ecd8a6e5899191a7d1b9cec",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:01b4ff55ed7965f77f28199c98d35002",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:a16c4a98c7239f14c74af90c58802252",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f606725494013a6004aeb7f3234c5659",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0044",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "20"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.327765638841369"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0177689026939896"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.717177111469273"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.090003354949991"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "44"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "20"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.327765638841369"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0177689026939896"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.717177111469273"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.090003354949991"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "44"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a16c4a98c7239f14c74af90c58802252",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:f606725494013a6004aeb7f3234c5659",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:beba83b8e0b597cc72900977cf176cf6",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:d70674f2ab25c84bf1ccbf050e157cb6",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0045",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "10"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0789505715685566"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.996344252777198"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.232854217411059"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "45"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "10"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0789505715685566"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.996344252777198"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.232854217411059"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "45"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:beba83b8e0b597cc72900977cf176cf6",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:d70674f2ab25c84bf1ccbf050e157cb6",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:2ea9c77f7d859bb390de800ff7c12bdd",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:d3a715b103390651d1c521ee09f466c0",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0046",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "17"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.278600793015164"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0268776015038201"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.851969971349154"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.120432329815194"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "46"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "17"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.278600793015164"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0268776015038201"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.851969971349154"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.120432329815194"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "46"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2ea9c77f7d859bb390de800ff7c12bdd",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:d3a715b103390651d1c521ee09f466c0",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:667ab285deac3f27ecbbdbc71424991f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:3577f89d6cde1468b3bf7bab875643fa",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0047",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "35"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.573589867972396"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00287186075767805"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.18463471494823"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0215852760173866"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "47"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "35"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.573589867972396"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00287186075767805"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.18463471494823"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0215852760173866"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "47"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:667ab285deac3f27ecbbdbc71424991f",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:3577f89d6cde1468b3bf7bab875643fa",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:92c97d83326e6179be7fa554d9ed568a",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:6b28309025a8c950f906f3a74a6104c4",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0048",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "19"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.311377356899301"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0203471033691263"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.764532275661737"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0987682309376339"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "48"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "19"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.311377356899301"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0203471033691263"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.764532275661737"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0987682309376339"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "48"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:92c97d83326e6179be7fa554d9ed568a",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:6b28309025a8c950f906f3a74a6104c4",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:e0f12d9993b033a238dd61773dca28e9",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:40f12e78ef285dbb693762e0e24f5a51",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0049",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "27"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.442483612435849"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00727748912325509"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.403843160672682"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0458285125869847"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "49"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "27"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.442483612435849"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00727748912325509"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.403843160672682"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0458285125869847"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "49"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e0f12d9993b033a238dd61773dca28e9",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:40f12e78ef285dbb693762e0e24f5a51",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:3aa56bca1824bde9b5cb4c7830b65b84",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:708e2b5584c9334ba1cde9334d8aee40",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0050",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "15"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.245824229131027"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0359026634119283"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.922058856524574"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.141785094491174"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "50"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "15"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.245824229131027"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0359026634119283"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.922058856524574"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.141785094491174"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "50"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3aa56bca1824bde9b5cb4c7830b65b84",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:708e2b5584c9334ba1cde9334d8aee40",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:e6016935099bef709428b50f891e4418",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:2ed437f95a18d4610e20aee5f5ca8ca1",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0051",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "33"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.540813304088259"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00359701038553917"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.225594365748219"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0261907318697071"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "51"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "33"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.540813304088259"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00359701038553917"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.225594365748219"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0261907318697071"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "51"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e6016935099bef709428b50f891e4418",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:2ed437f95a18d4610e20aee5f5ca8ca1",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:75040581b4eec5ea4766cc6aef47a8db",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c4315919bc864f2492337dd699116ee4",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0052",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "75"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.22912114565514"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.95888146608574e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00422635111103054"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00106801490892152"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "52"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "75"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.22912114565514"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.95888146608574e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00422635111103054"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00106801490892152"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "52"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:75040581b4eec5ea4766cc6aef47a8db",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:c4315919bc864f2492337dd699116ee4",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:1b5b284497e39b90fa934f2eaa2c5bbd",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:5ad7bfc734bce8d2e03526bbce4c1642",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0053",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "75"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.22912114565514"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.95888146608574e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00422635111103054"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00106801490892152"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "53"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "75"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.22912114565514"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.95888146608574e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00422635111103054"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00106801490892152"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "53"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1b5b284497e39b90fa934f2eaa2c5bbd",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:5ad7bfc734bce8d2e03526bbce4c1642",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:9f190d80d4f3c866def066aba31dc20c",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f28a45db3e8e726134be22dd55ada8fc",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0054",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "16"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.262212511073096"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0310172463051921"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.889701795682265"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.13140033434745"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "54"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "16"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.262212511073096"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0310172463051921"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.889701795682265"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.13140033434745"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "54"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9f190d80d4f3c866def066aba31dc20c",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:f28a45db3e8e726134be22dd55ada8fc",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:bad61a3ace8cf7e7c8c50e40ccf98bd4",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:7dbd526d156c17d030cb03d4502bec48",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0055",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "66"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.08162660817652"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000131916545650145"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00933222214140361"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00204910367576558"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "55"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "66"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.08162660817652"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000131916545650145"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00933222214140361"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00204910367576558"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "55"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:bad61a3ace8cf7e7c8c50e40ccf98bd4",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:7dbd526d156c17d030cb03d4502bec48",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:189c6d65cca27efc776c3691b2470738",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:db64bef791d519bd840c407a07274b39",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0056",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "14"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.229435947188959"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0416945009118955"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.948360030569285"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.15179404238237"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "56"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "14"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.229435947188959"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0416945009118955"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.948360030569285"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.15179404238237"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "56"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:189c6d65cca27efc776c3691b2470738",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:db64bef791d519bd840c407a07274b39",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:f29da53849f4d24538d6a069a467c443",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:261d424ff1d40e2e1212f8b47057e08d",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0057",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "9"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.147494537478616"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0937881444422454"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.998726572661126"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.257089854765214"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "57"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "9"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.147494537478616"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0937881444422454"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.998726572661126"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.257089854765214"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "57"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f29da53849f4d24538d6a069a467c443",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:261d424ff1d40e2e1212f8b47057e08d",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:735d11dd0407b58704c0622c1bf21ceb",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f0b1b468bf91334fdba7c8b7612cca41",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0058",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "16"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.262212511073096"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0310172463051921"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.889701795682265"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.13140033434745"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "58"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "16"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.262212511073096"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0310172463051921"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.889701795682265"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.13140033434745"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "58"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:735d11dd0407b58704c0622c1bf21ceb",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:f0b1b468bf91334fdba7c8b7612cca41",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:1cab13530af314ae698e165a85ca2de5",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:6faaad2ce4a4160eadbbce94632ec2bf",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0059",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "41"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.671919559624807"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00149758703167023"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.100972640681538"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0129236214214505"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "59"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "41"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.671919559624807"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00149758703167023"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.100972640681538"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0129236214214505"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "59"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1cab13530af314ae698e165a85ca2de5",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:6faaad2ce4a4160eadbbce94632ec2bf",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:e0728affe728b03b571bb0da5a24b81e",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:8451b5d05d4d0f88becbc68925bab4c9",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0060",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "15"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.245824229131027"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0359026634119283"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.922058856524574"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.141785094491174"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "60"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "15"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.245824229131027"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0359026634119283"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.922058856524574"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.141785094491174"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "60"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e0728affe728b03b571bb0da5a24b81e",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:8451b5d05d4d0f88becbc68925bab4c9",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:2ac5440f1a62a883d86fc94f89789599",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:e8d74786a114ffeb6114fffeeb2583da",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0061",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "19"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.311377356899301"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0203471033691263"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.764532275661737"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0987682309376339"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "61"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "19"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.311377356899301"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0203471033691263"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.764532275661737"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0987682309376339"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "61"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2ac5440f1a62a883d86fc94f89789599",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:e8d74786a114ffeb6114fffeeb2583da",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:04a64b18655d556b397f88a52d983f34",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:af4cb856d066cec808680cb766e205ae",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0062",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "7"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.114717973594479"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.135115167401345"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999932500065553"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.317998323277913"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "62"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "7"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.114717973594479"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.135115167401345"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999932500065553"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.317998323277913"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "62"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:04a64b18655d556b397f88a52d983f34",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:af4cb856d066cec808680cb766e205ae",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:e07163703600f62c37c81aed00f51b7a",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:64c74f4674adc0005dffc886ffba3300",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0063",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "8"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.131106255536548"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.112142332373161"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999654520482601"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.296922311851664"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "63"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "8"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.131106255536548"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.112142332373161"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999654520482601"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.296922311851664"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "63"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e07163703600f62c37c81aed00f51b7a",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:64c74f4674adc0005dffc886ffba3300",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:f4159609553afd6154652d5027b6e84a",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:878873f431f64df4853365a578c78440",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0064",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "6"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0983296916524108"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.164286574579321"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999991511154457"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.361120489405488"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "64"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "6"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0983296916524108"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.164286574579321"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999991511154457"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.361120489405488"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "64"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f4159609553afd6154652d5027b6e84a",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:878873f431f64df4853365a578c78440",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:f4231c3f6d55163a61e855e3bf8e3cc5",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:62873793384331403012ec1c900656e0",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0065",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "29"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.475260176319986"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00572351378979088"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.334223900698014"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0404114761521598"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "65"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "29"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.475260176319986"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00572351378979088"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.334223900698014"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0404114761521598"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "65"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f4231c3f6d55163a61e855e3bf8e3cc5",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:62873793384331403012ec1c900656e0",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:f3fc51b4027adc2167b7ea4fb36f64e9",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:cf86c38738ff15923d1bfe58d642e526",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0066",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0655531277682739"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.251995246521365"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999983347393"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.477356849101447"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "66"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0655531277682739"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.251995246521365"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999983347393"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.477356849101447"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "66"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f3fc51b4027adc2167b7ea4fb36f64e9",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:cf86c38738ff15923d1bfe58d642e526",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:89485ab1dfdfe29164103a5f95597953",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:6eb2f26421b4abdd2aff61056be6347c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0067",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "67"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "67"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:89485ab1dfdfe29164103a5f95597953",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:6eb2f26421b4abdd2aff61056be6347c",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:38d55629def18240731e2415b3581423",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:464e6cc9ad8cde4967c4e8430942863e",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0068",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "12"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.196659383304822"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0568651131936359"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.982432748406332"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.181500977727632"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "68"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "12"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.196659383304822"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0568651131936359"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.982432748406332"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.181500977727632"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "68"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:38d55629def18240731e2415b3581423",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:464e6cc9ad8cde4967c4e8430942863e",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:911e248e1a4789966b6c9e185a7126b1",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:0f59b224fb308f5b33db0b615cec440e",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0069",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "9"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.147494537478616"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0937881444422454"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.998726572661126"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.257089854765214"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "69"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "9"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.147494537478616"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0937881444422454"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.998726572661126"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.257089854765214"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "69"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:911e248e1a4789966b6c9e185a7126b1",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:0f59b224fb308f5b33db0b615cec440e",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:6110880bd543820677cd9c2981bb03f1",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:61f0e2e951d39892ec38816ca4ff7b91",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0070",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "13"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.21304766524689"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0485956620121857"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.968379925135842"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.164098394910714"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "70"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "13"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.21304766524689"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0485956620121857"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.968379925135842"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.164098394910714"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "70"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6110880bd543820677cd9c2981bb03f1",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:61f0e2e951d39892ec38816ca4ff7b91",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:17de67442fe88be7d5065d079743540f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:9764501f1b27ea039a6888cad5412dc6",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0071",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "7"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.114717973594479"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.135115167401345"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999932500065553"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.317998323277913"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "71"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "7"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.114717973594479"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.135115167401345"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999932500065553"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.317998323277913"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "71"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:17de67442fe88be7d5065d079743540f",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:9764501f1b27ea039a6888cad5412dc6",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:8cbc3782d81e0868d376f120a4236af9",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c4798ee5bb6817f0ac7d3d1f7cbb895d",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0072",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "14"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.229435947188959"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0416945009118955"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.948360030569285"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.15179404238237"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "72"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "14"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.229435947188959"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0416945009118955"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.948360030569285"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.15179404238237"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "72"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8cbc3782d81e0868d376f120a4236af9",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:c4798ee5bb6817f0ac7d3d1f7cbb895d",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:2f3eeaca715cc267ad827fccd2f2f34b",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:5499ba7833a3a03073324dac7488ac06",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0073",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "20"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.327765638841369"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0177689026939896"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.717177111469273"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.090003354949991"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "73"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "20"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.327765638841369"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0177689026939896"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.717177111469273"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.090003354949991"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "73"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2f3eeaca715cc267ad827fccd2f2f34b",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:5499ba7833a3a03073324dac7488ac06",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:de6850a6407354dfd567970141571681",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:50c6ebb589d5bdb3e362aaf8f837978b",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0074",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "7"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.114717973594479"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.135115167401345"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999932500065553"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.317998323277913"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "74"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "7"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.114717973594479"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.135115167401345"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999932500065553"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.317998323277913"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "74"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:de6850a6407354dfd567970141571681",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:50c6ebb589d5bdb3e362aaf8f837978b",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:fd0c869c2731be1d9fa597f20662d444",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:a489f5516c417d51a01d581c1281955e",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0075",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "11"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.180271101362753"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.066837364763348"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.991352646973414"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.204909289340264"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "75"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "11"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.180271101362753"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.066837364763348"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.991352646973414"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.204909289340264"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "75"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:fd0c869c2731be1d9fa597f20662d444",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:a489f5516c417d51a01d581c1281955e",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:9558c05bc184bbae76bf2776b13f3613",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:e4ff54dd97ad1e3f10b9d1c7027c4645",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0076",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "24"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.393318766609643"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0105545831208163"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.527715031910996"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0647162596618474"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "76"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "24"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.393318766609643"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0105545831208163"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.527715031910996"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0647162596618474"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "76"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9558c05bc184bbae76bf2776b13f3613",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:e4ff54dd97ad1e3f10b9d1c7027c4645",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:a46d73eae3d12dd1da0f67fbeb4a1a72",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:8de83fae7bd6e9f8380ec49cdc4829ae",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0077",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "13"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.21304766524689"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0485956620121857"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.968379925135842"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.164098394910714"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "77"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "13"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.21304766524689"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0485956620121857"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.968379925135842"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.164098394910714"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "77"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a46d73eae3d12dd1da0f67fbeb4a1a72",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:8de83fae7bd6e9f8380ec49cdc4829ae",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:7635d7da2581ae0e3d9df35c569ea093",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:85491f67ab81ddeb946caf2849c4b9f4",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0078",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "6"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0983296916524108"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.164286574579321"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999991511154457"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.361120489405488"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "78"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "6"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0983296916524108"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.164286574579321"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999991511154457"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.361120489405488"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "78"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7635d7da2581ae0e3d9df35c569ea093",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:85491f67ab81ddeb946caf2849c4b9f4",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:19a7c772a61f72e1d78af974571971cd",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:3e9eba22eff518f24b14c038fe2913df",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0079",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "13"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.21304766524689"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0485956620121857"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.968379925135842"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.164098394910714"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "79"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "13"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.21304766524689"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0485956620121857"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.968379925135842"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.164098394910714"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "79"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:19a7c772a61f72e1d78af974571971cd",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:3e9eba22eff518f24b14c038fe2913df",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:843d6a80a917e6d0bba5298ced57aba0",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:2b503ca3533d10a4f1f80dad7060444a",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0080",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "8"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.131106255536548"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.112142332373161"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999654520482601"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.296922311851664"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "80"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "8"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.131106255536548"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.112142332373161"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999654520482601"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.296922311851664"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "80"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:843d6a80a917e6d0bba5298ced57aba0",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:2b503ca3533d10a4f1f80dad7060444a",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:81a5a2e83d586c873f45bcbeacbd725e",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:cf6de656d89419d4ac154fd946ec6388",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0081",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "14"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.229435947188959"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0416945009118955"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.948360030569285"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.15179404238237"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "81"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "14"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.229435947188959"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0416945009118955"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.948360030569285"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.15179404238237"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "81"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:81a5a2e83d586c873f45bcbeacbd725e",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:cf6de656d89419d4ac154fd946ec6388",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:0dba3e406159d31dec269bb22b1b416a",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:9c0f05c7637bc2f31d907b17584b6aa0",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0082",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0491648458262054"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.320523791287721"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999872308"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.529659882057015"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "82"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0491648458262054"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.320523791287721"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999872308"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.529659882057015"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "82"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0dba3e406159d31dec269bb22b1b416a",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:9c0f05c7637bc2f31d907b17584b6aa0",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:3d62634be01e822042b85fbe2f4b57a5",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:62e799c85533fe86208bf5e33c6a326d",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0083",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "18"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.294989074957232"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0233553599209337"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.809860049306577"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.111057119624032"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "83"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "18"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.294989074957232"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0233553599209337"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.809860049306577"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.111057119624032"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "83"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3d62634be01e822042b85fbe2f4b57a5",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:62e799c85533fe86208bf5e33c6a326d",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:4d27ad0557a85357aebf8d3cb8a18d20",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:7b8b805f3c10072513741773f37173a9",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0084",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "9"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.147494537478616"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0937881444422454"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.998726572661126"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.257089854765214"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "84"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "9"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.147494537478616"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0937881444422454"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.998726572661126"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.257089854765214"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "84"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4d27ad0557a85357aebf8d3cb8a18d20",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:7b8b805f3c10072513741773f37173a9",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:259f577b521fb0d31342d69e79678fd8",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c8967930ef6b4850b98397e5a02cf2f7",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0085",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0655531277682739"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.251995246521365"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999983347393"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.477356849101447"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "85"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0655531277682739"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.251995246521365"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999983347393"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.477356849101447"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "85"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:259f577b521fb0d31342d69e79678fd8",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:c8967930ef6b4850b98397e5a02cf2f7",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:73ea65987d6ff092b8032a7897f236dc",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:162bab89b0c20f6474f1241e5c7169b3",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0086",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0655531277682739"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.251995246521365"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999983347393"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.477356849101447"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "86"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0655531277682739"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.251995246521365"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999983347393"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.477356849101447"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "86"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:73ea65987d6ff092b8032a7897f236dc",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:162bab89b0c20f6474f1241e5c7169b3",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:ba34aadcbdfb22bb96b240c5d8d71cb7",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:91dc841836bbf5d1c0b426905fb75e01",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0087",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "7"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.114717973594479"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.135115167401345"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999932500065553"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.317998323277913"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "87"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "7"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.114717973594479"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.135115167401345"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999932500065553"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.317998323277913"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "87"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ba34aadcbdfb22bb96b240c5d8d71cb7",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:91dc841836bbf5d1c0b426905fb75e01",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:3a163a0cb084881b83df7fb4539004cf",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:3f463a005d2c5f82895c19639d89d232",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0088",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "17"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.278600793015164"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0268776015038201"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.851969971349154"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.120432329815194"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "88"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "17"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.278600793015164"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0268776015038201"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.851969971349154"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.120432329815194"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "88"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3a163a0cb084881b83df7fb4539004cf",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:3f463a005d2c5f82895c19639d89d232",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:43f0fb5e7c19214fdedd18472535c15a",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:a088e0c82151087e1bf9897ac5ca3823",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0089",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "7"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.114717973594479"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.135115167401345"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999932500065553"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.317998323277913"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "89"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "7"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.114717973594479"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.135115167401345"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999932500065553"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.317998323277913"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "89"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:43f0fb5e7c19214fdedd18472535c15a",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:a088e0c82151087e1bf9897ac5ca3823",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:2eda6a0e1bdd1c9e5ed07632d4ecdc2f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:321fa4b64bb46facf5ed354080dc1587",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0090",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "6"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0983296916524108"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.164286574579321"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999991511154457"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.361120489405488"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "90"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "6"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0983296916524108"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.164286574579321"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999991511154457"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.361120489405488"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "90"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2eda6a0e1bdd1c9e5ed07632d4ecdc2f",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:321fa4b64bb46facf5ed354080dc1587",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:69803a9c56c9a9477742ef1bd9b5db35",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:1bb068ae0340b41c3c1e0585e61ab7a2",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0091",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "23"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.376930484667575"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0119876489573956"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.573451269803323"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0716185181300816"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "91"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "23"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.376930484667575"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0119876489573956"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.573451269803323"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0716185181300816"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "91"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:69803a9c56c9a9477742ef1bd9b5db35",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:1bb068ae0340b41c3c1e0585e61ab7a2",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:01e79de738160252561a3797aff0be46",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:0b5c4b3fea9afd08f274ad657436f2dd",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0092",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "10"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0789505715685566"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.996344252777198"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.232854217411059"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "92"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "10"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0789505715685566"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.996344252777198"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.232854217411059"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "92"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:01e79de738160252561a3797aff0be46",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:0b5c4b3fea9afd08f274ad657436f2dd",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:f41790cbed14abdecac7977440cc0bb6",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:7b0e7637357771b4e3c95b60da0daba2",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0093",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "5"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0819414097103423"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.202012085605038"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999418769679"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.427898326781582"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "93"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "5"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0819414097103423"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.202012085605038"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999418769679"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.427898326781582"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "93"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f41790cbed14abdecac7977440cc0bb6",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:7b0e7637357771b4e3c95b60da0daba2",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:9cce28d22165f03a477a1d52851070af",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:b8afe5b11ecf6b25c3098ac5c67b90a0",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0094",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0327765638841369"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.419663124449093"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999889"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.552437898286094"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "94"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0327765638841369"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.419663124449093"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999889"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.552437898286094"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "94"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9cce28d22165f03a477a1d52851070af",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:b8afe5b11ecf6b25c3098ac5c67b90a0",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:cc59f8e2a9544b3ce2e7c770bd643f84",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:a2a8b82493043f5593bcde950e35d4f5",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0095",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "12"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.196659383304822"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0568651131936359"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.982432748406332"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.181500977727632"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "95"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "12"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.196659383304822"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0568651131936359"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.982432748406332"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.181500977727632"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "95"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cc59f8e2a9544b3ce2e7c770bd643f84",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:a2a8b82493043f5593bcde950e35d4f5",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:1057dce00f5bb5fa3cfe47e76eb89cbb",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:13a870b0869420f093e2bf23ab79a37e",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0096",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "96"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "96"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1057dce00f5bb5fa3cfe47e76eb89cbb",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:13a870b0869420f093e2bf23ab79a37e",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:60ab79a3ea3afc698ecd6cf745ac195d",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:9e62040415b20939b8c829b35ac0b428",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0097",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0327765638841369"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.419663124449093"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999889"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.552437898286094"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "97"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0327765638841369"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.419663124449093"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999889"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.552437898286094"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "97"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:60ab79a3ea3afc698ecd6cf745ac195d",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:9e62040415b20939b8c829b35ac0b428",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:5f6f6b54a9f90d5bb626fde29fa6b1fd",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:ef74f8693d6b0cc1f8f7291479877d46",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0098",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0491648458262054"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.320523791287721"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999872308"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.529659882057015"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "98"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0491648458262054"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.320523791287721"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999872308"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.529659882057015"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "98"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5f6f6b54a9f90d5bb626fde29fa6b1fd",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:ef74f8693d6b0cc1f8f7291479877d46",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:d2932453ed5d06805f9a2af83c52d15a",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:b4f4a8e2b968691b39abdbd7cd10251b",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0099",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "99"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "99"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d2932453ed5d06805f9a2af83c52d15a",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:b4f4a8e2b968691b39abdbd7cd10251b",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:3fa7a66071d2b8d3530bef533d52b63d",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:b479ffd217729f45ba8e8b497543b71d",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0100",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0491648458262054"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.320523791287721"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999872308"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.529659882057015"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "100"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0491648458262054"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.320523791287721"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999872308"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.529659882057015"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "100"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3fa7a66071d2b8d3530bef533d52b63d",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:b479ffd217729f45ba8e8b497543b71d",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:b3bc50a19f719b2fefee16f3b146e23d",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:64b1c86050912153a776e757204d9bd6",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0101",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0327765638841369"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.419663124449093"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999889"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.552437898286094"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "101"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0327765638841369"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.419663124449093"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999889"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.552437898286094"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "101"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b3bc50a19f719b2fefee16f3b146e23d",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:64b1c86050912153a776e757204d9bd6",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:ae4a511d54b76b35f1462db6d3370c9c",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:2262ce46c8d9d3e44fca9d2b9991842a",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0102",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "9"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.147494537478616"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0937881444422454"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.998726572661126"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.257089854765214"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "102"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "9"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.147494537478616"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0937881444422454"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.998726572661126"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.257089854765214"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "102"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ae4a511d54b76b35f1462db6d3370c9c",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:2262ce46c8d9d3e44fca9d2b9991842a",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:d9f9aff87a34b9c5479d4873772dd0ed",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:03e5589e0cbf8390adc9f572f09c2111",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0103",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "11"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.180271101362753"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.066837364763348"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.991352646973414"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.204909289340264"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "103"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "11"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.180271101362753"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.066837364763348"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.991352646973414"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.204909289340264"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "103"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d9f9aff87a34b9c5479d4873772dd0ed",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:03e5589e0cbf8390adc9f572f09c2111",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:8bfeeb8b866911a137111a38c272b615",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:183d033f8dc6f63dd2d370f917d30bf5",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0104",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "104"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "104"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8bfeeb8b866911a137111a38c272b615",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:183d033f8dc6f63dd2d370f917d30bf5",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:ac52eb589b96f34cb8f8a5bc4d179c34",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:82ed6a608808b53426982c1cc66a2ec6",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0105",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "11"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.180271101362753"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.066837364763348"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.991352646973414"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.204909289340264"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "105"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "11"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.180271101362753"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.066837364763348"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.991352646973414"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.204909289340264"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "105"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ac52eb589b96f34cb8f8a5bc4d179c34",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:82ed6a608808b53426982c1cc66a2ec6",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:3355d697f188c4ca897d5bfbad88c46c",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c38a12c7c56a4a6bcef1a3f1defaede6",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0106",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "14"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.229435947188959"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0416945009118955"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.948360030569285"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.15179404238237"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "106"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "14"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.229435947188959"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0416945009118955"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.948360030569285"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.15179404238237"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "106"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3355d697f188c4ca897d5bfbad88c46c",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:c38a12c7c56a4a6bcef1a3f1defaede6",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:868f4263fbce64aac9db6a0fc1959caf",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:b903a819026d14c010b6e3c047f2d1f1",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0107",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "7"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.114717973594479"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.135115167401345"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999932500065553"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.317998323277913"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "107"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "7"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.114717973594479"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.135115167401345"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999932500065553"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.317998323277913"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "107"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:868f4263fbce64aac9db6a0fc1959caf",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:b903a819026d14c010b6e3c047f2d1f1",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:f20ed18d19c8f3654c783f3c512348b3",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:932955007c6604e912ca88f69e4b71b2",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0108",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0655531277682739"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.251995246521365"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999983347393"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.477356849101447"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "108"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0655531277682739"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.251995246521365"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999983347393"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.477356849101447"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "108"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f20ed18d19c8f3654c783f3c512348b3",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:932955007c6604e912ca88f69e4b71b2",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:05512cf6085c8d2b74ae7737861092c8",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:19bb8ba20387a263ccc2a4033c4a6959",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0109",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0655531277682739"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.251995246521365"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999983347393"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.477356849101447"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "109"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0655531277682739"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.251995246521365"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999983347393"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.477356849101447"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "109"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:05512cf6085c8d2b74ae7737861092c8",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:19bb8ba20387a263ccc2a4033c4a6959",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:f695aae9ae02bed79ba9e19f8af0adb8",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:4c267352cce4185f6d8f19642a2432ea",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0110",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0327765638841369"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.419663124449093"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999889"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.552437898286094"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "110"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0327765638841369"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.419663124449093"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999889"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.552437898286094"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "110"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f695aae9ae02bed79ba9e19f8af0adb8",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:4c267352cce4185f6d8f19642a2432ea",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:d1fc4fee78d95536f89feb63f14c968c",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:b779ca098f1180fe09ebe0414895c731",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0111",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "6"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0983296916524108"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.164286574579321"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999991511154457"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.361120489405488"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "111"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "6"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0983296916524108"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.164286574579321"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999991511154457"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.361120489405488"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "111"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d1fc4fee78d95536f89feb63f14c968c",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:b779ca098f1180fe09ebe0414895c731",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:e1f20b806abf584189fd37df83ae5f02",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:b7385089cc22c8804fc256dff15181f6",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0112",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "12"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.196659383304822"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0568651131936359"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.982432748406332"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.181500977727632"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "112"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "12"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.196659383304822"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0568651131936359"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.982432748406332"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.181500977727632"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "112"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e1f20b806abf584189fd37df83ae5f02",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:b7385089cc22c8804fc256dff15181f6",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:f4343a9252d96448237743dc7620b82d",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:a34044dfcf23dfe53b2945318b0397f1",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0113",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0327765638841369"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.419663124449093"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999889"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.552437898286094"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "113"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0327765638841369"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.419663124449093"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999889"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.552437898286094"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "113"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f4343a9252d96448237743dc7620b82d",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:a34044dfcf23dfe53b2945318b0397f1",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:f74cf4fd744cb5d2223e69c6b86d72ca",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:e3223bf7299c1367c69b65daadf7dab4",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0114",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "9"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.147494537478616"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0937881444422454"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.998726572661126"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.257089854765214"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "114"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "9"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.147494537478616"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0937881444422454"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.998726572661126"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.257089854765214"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "114"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f74cf4fd744cb5d2223e69c6b86d72ca",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:e3223bf7299c1367c69b65daadf7dab4",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:2c8ba22e270c2ab78bc2767742ff87f1",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:315a3351fd67e6810a0558156faed379",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0115",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "5"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0819414097103423"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.202012085605038"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999418769679"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.427898326781582"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "115"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "5"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0819414097103423"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.202012085605038"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999418769679"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.427898326781582"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "115"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2c8ba22e270c2ab78bc2767742ff87f1",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:315a3351fd67e6810a0558156faed379",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:ffa25ea15473af14a67c3205bbe9f983",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:956afe330511d5dec77faf29c8e66c5b",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0116",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0655531277682739"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.251995246521365"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999983347393"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.477356849101447"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "116"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0655531277682739"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.251995246521365"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999983347393"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.477356849101447"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "116"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ffa25ea15473af14a67c3205bbe9f983",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:956afe330511d5dec77faf29c8e66c5b",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:bc830c332ebaee861ca402fa60321dce",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:4740016eb1ce8e7ec8341eb44cf9ffa5",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0117",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "8"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.131106255536548"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.112142332373161"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999654520482601"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.296922311851664"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "117"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "8"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.131106255536548"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.112142332373161"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999654520482601"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.296922311851664"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "117"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:bc830c332ebaee861ca402fa60321dce",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:4740016eb1ce8e7ec8341eb44cf9ffa5",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:47f7311fc1a64f3bf47cf50b4561aabc",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f956c3347b26a7454fde4d7c1ee3dfac",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0118",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "6"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0983296916524108"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.164286574579321"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999991511154457"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.361120489405488"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "118"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "6"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0983296916524108"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.164286574579321"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999991511154457"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.361120489405488"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "118"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:47f7311fc1a64f3bf47cf50b4561aabc",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:f956c3347b26a7454fde4d7c1ee3dfac",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:b8ae2b4592f8a2f04be965b5829712bf",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:0306caf1c070bce484bea6d4d02ee4b9",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0119",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "6"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0983296916524108"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.164286574579321"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999991511154457"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.361120489405488"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "119"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "6"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0983296916524108"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.164286574579321"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999991511154457"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.361120489405488"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "119"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b8ae2b4592f8a2f04be965b5829712bf",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:0306caf1c070bce484bea6d4d02ee4b9",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:a0e10a7c0fca0a0252e91da150ff7c73",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:0718df40c87e4adde0a6b31fdd007bb4",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0120",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0327765638841369"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.419663124449093"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999889"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.552437898286094"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "120"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0327765638841369"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.419663124449093"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999889"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.552437898286094"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "120"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a0e10a7c0fca0a0252e91da150ff7c73",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:0718df40c87e4adde0a6b31fdd007bb4",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:7ce8d10a760980abe8a87f7a79f378c2",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c3345fe728c02a6d54b764235fc35217",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0121",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0491648458262054"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.320523791287721"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999872308"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.529659882057015"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "121"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0491648458262054"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.320523791287721"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999872308"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.529659882057015"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "121"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7ce8d10a760980abe8a87f7a79f378c2",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:c3345fe728c02a6d54b764235fc35217",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:4dd100dcaaa90bf1aaa604fdff0ba9ff",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:db4e8782b5b474daeb575623d11d8f36",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0122",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0491648458262054"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.320523791287721"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999872308"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.529659882057015"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "122"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0491648458262054"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.320523791287721"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999872308"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.529659882057015"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "122"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4dd100dcaaa90bf1aaa604fdff0ba9ff",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:db4e8782b5b474daeb575623d11d8f36",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:ac00e8055c4355ec5762be8458693242",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:3a7bd3c73757ad2c63a505ac44ee7de9",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0123",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0655531277682739"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.251995246521365"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999983347393"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.477356849101447"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "123"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0655531277682739"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.251995246521365"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999983347393"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.477356849101447"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "123"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ac00e8055c4355ec5762be8458693242",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:3a7bd3c73757ad2c63a505ac44ee7de9",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:0c01d3025f9ac35ecf95f50b6ad70473",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:ca632dc1f3d6a97bb76e5a785e5f4b39",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0124",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0491648458262054"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.320523791287721"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999872308"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.529659882057015"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "124"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0491648458262054"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.320523791287721"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999872308"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.529659882057015"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "124"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0c01d3025f9ac35ecf95f50b6ad70473",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:ca632dc1f3d6a97bb76e5a785e5f4b39",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:6f3664cedc79fb9f59b11be01c396b26",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:4d501ade9f45e68e86c0aef60754a9aa",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0125",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0491648458262054"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.320523791287721"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999872308"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.529659882057015"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "125"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0491648458262054"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.320523791287721"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999872308"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.529659882057015"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "125"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6f3664cedc79fb9f59b11be01c396b26",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:4d501ade9f45e68e86c0aef60754a9aa",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:c89efa8381d6b8fd6a264562898c049a",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:4353f4b513f6d03c8ce9a7ee07ac3524",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0126",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0327765638841369"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.419663124449093"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999889"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.552437898286094"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "126"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0327765638841369"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.419663124449093"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999889"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.552437898286094"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "126"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c89efa8381d6b8fd6a264562898c049a",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:4353f4b513f6d03c8ce9a7ee07ac3524",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:601f2b2d65ca5573b797e7fb5ea7c122",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:d24c03f6c5960ef050e1d0a675496464",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0127",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "10"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0789505715685566"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.996344252777198"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.232854217411059"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "127"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "10"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0789505715685566"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.996344252777198"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.232854217411059"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "127"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:601f2b2d65ca5573b797e7fb5ea7c122",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:d24c03f6c5960ef050e1d0a675496464",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:41706195949bd303e398c4c6246c9da1",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:0630bc3a96bd8ec1bd4f2dbb98bd8a68",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0128",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "9"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.147494537478616"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0937881444422454"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.998726572661126"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.257089854765214"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "128"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "9"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.147494537478616"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0937881444422454"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.998726572661126"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.257089854765214"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "128"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:41706195949bd303e398c4c6246c9da1",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:0630bc3a96bd8ec1bd4f2dbb98bd8a68",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:3f5bc238b154db411923ec0d520212a5",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:7a6a9d89a41bce106a6e3f6b9bf39fc2",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0129",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0491648458262054"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.320523791287721"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999872308"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.529659882057015"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "129"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0491648458262054"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.320523791287721"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999872308"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.529659882057015"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "129"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3f5bc238b154db411923ec0d520212a5",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:7a6a9d89a41bce106a6e3f6b9bf39fc2",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:d61c2e3334e7afb034ac8b3a50d8eefd",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:6cd9c8b1f2dc650429e50bd72f6da32d",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0130",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0327765638841369"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.419663124449093"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999889"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.552437898286094"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "130"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0327765638841369"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.419663124449093"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999889"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.552437898286094"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "130"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d61c2e3334e7afb034ac8b3a50d8eefd",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:6cd9c8b1f2dc650429e50bd72f6da32d",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:c7f0899e68a33117259a0776f3fbd712",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f0caefb73eec8df07661fca6c2cc2a56",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0131",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0327765638841369"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.419663124449093"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999889"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.552437898286094"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "131"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0327765638841369"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.419663124449093"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999889"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.552437898286094"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "131"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c7f0899e68a33117259a0776f3fbd712",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:f0caefb73eec8df07661fca6c2cc2a56",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:acf0099ad05f52f7740833ae0513f2c4",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:10dda0f512d376c45616527318012baa",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0132",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0491648458262054"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.320523791287721"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999872308"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.529659882057015"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "132"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0491648458262054"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.320523791287721"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999872308"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.529659882057015"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "132"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:acf0099ad05f52f7740833ae0513f2c4",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:10dda0f512d376c45616527318012baa",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:d639d06c89e7a7987cc7beee7f6eebde",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:3aeaeffb7762bacf9f1b2dc630012fe3",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0133",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0491648458262054"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.320523791287721"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999872308"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.529659882057015"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "133"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0491648458262054"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.320523791287721"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999872308"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.529659882057015"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "133"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d639d06c89e7a7987cc7beee7f6eebde",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:3aeaeffb7762bacf9f1b2dc630012fe3",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:019db96efd3f0d5a9f077d436d990e65",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:88ee03bc281326c9948572b0834fecf3",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0134",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0655531277682739"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.251995246521365"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999983347393"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.477356849101447"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "134"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0655531277682739"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.251995246521365"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999983347393"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.477356849101447"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "134"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:019db96efd3f0d5a9f077d436d990e65",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:88ee03bc281326c9948572b0834fecf3",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:3589dce5a9f2dacdad11e4fc0348fe0f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:30868fad9324d3113736d83bd681718a",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0135",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "6"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0983296916524108"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.164286574579321"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999991511154457"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.361120489405488"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "135"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "6"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0983296916524108"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.164286574579321"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999991511154457"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.361120489405488"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "135"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3589dce5a9f2dacdad11e4fc0348fe0f",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:30868fad9324d3113736d83bd681718a",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:6c2ff806101a3ff739a426037285f4f7",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:4b462b6d837ce2e27bce61ed0c368fd6",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0136",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0655531277682739"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.251995246521365"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999983347393"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.477356849101447"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "136"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0655531277682739"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.251995246521365"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999983347393"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.477356849101447"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "136"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6c2ff806101a3ff739a426037285f4f7",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:4b462b6d837ce2e27bce61ed0c368fd6",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:700ddae2d53d6ba003ce7aef4c34cf8c",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:1bf97c65bec07a1317ef69c944689cf8",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0137",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0327765638841369"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.419663124449093"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999889"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.552437898286094"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "137"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0327765638841369"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.419663124449093"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999889"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.552437898286094"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "137"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:700ddae2d53d6ba003ce7aef4c34cf8c",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:1bf97c65bec07a1317ef69c944689cf8",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:c226e28f1c7d1bb6df56af26165cf368",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:cd27fa26bbd5aa4fa8cfbebf1bb95ad9",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0138",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0327765638841369"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.419663124449093"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999889"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.552437898286094"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "138"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0327765638841369"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.419663124449093"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999889"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.552437898286094"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "138"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c226e28f1c7d1bb6df56af26165cf368",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:cd27fa26bbd5aa4fa8cfbebf1bb95ad9",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:d349e89efbf6c30897c6f74aaef9e81f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:31a80df97955e986f4be4839a052a5db",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0139",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "7"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.114717973594479"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.135115167401345"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999932500065553"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.317998323277913"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "139"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "7"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.114717973594479"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.135115167401345"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999932500065553"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.317998323277913"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "139"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d349e89efbf6c30897c6f74aaef9e81f",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:31a80df97955e986f4be4839a052a5db",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:cd868dac3ef78cde76ebbceb4543715e",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:39fc04da006cbf70670a7f80045d0d49",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0140",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "140"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "140"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cd868dac3ef78cde76ebbceb4543715e",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:39fc04da006cbf70670a7f80045d0d49",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:2b8a556886785a97e170fa36a82a529d",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:a2df6515d44ea1c2de2e20cd83b43f91",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0141",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0655531277682739"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.251995246521365"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999983347393"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.477356849101447"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "141"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0655531277682739"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.251995246521365"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999983347393"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.477356849101447"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "141"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2b8a556886785a97e170fa36a82a529d",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:a2df6515d44ea1c2de2e20cd83b43f91",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:cbd1c61d5f72e84539faeac10377a620",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:9b33ff671ff0c042af89e5b1be1377da",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0142",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "142"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "142"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cbd1c61d5f72e84539faeac10377a620",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:9b33ff671ff0c042af89e5b1be1377da",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:08bad01c6e1b7035d226d8f83114d9d4",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:25e2f4ca28679423b49be4329eea0bc3",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0143",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0491648458262054"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.320523791287721"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999872308"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.529659882057015"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "143"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0491648458262054"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.320523791287721"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999872308"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.529659882057015"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "143"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:08bad01c6e1b7035d226d8f83114d9d4",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:25e2f4ca28679423b49be4329eea0bc3",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:dbd29bbddcbce1e02e18bedcb8b3c4b3",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:0a729befa841fff84fcf2612fb2ce4a5",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0144",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "7"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.114717973594479"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.135115167401345"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999932500065553"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.317998323277913"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "144"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "7"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.114717973594479"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.135115167401345"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999932500065553"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.317998323277913"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "144"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:dbd29bbddcbce1e02e18bedcb8b3c4b3",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:0a729befa841fff84fcf2612fb2ce4a5",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:1d73a20f9c8bfb47867f2c59ae3c13b5",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:501da0873de972e1023817d65202130e",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0145",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "5"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0819414097103423"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.202012085605038"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999418769679"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.427898326781582"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "145"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "5"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0819414097103423"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.202012085605038"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999418769679"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.427898326781582"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "145"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1d73a20f9c8bfb47867f2c59ae3c13b5",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:501da0873de972e1023817d65202130e",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:b25e28979a447c1cd5093c9afae92781",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:0336a0114f6c74e1df58148ee9b074f4",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0146",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0327765638841369"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.419663124449093"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999889"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.552437898286094"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "146"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0327765638841369"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.419663124449093"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999889"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.552437898286094"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "146"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b25e28979a447c1cd5093c9afae92781",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:0336a0114f6c74e1df58148ee9b074f4",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:e52574eea0816040ab22d41230ea518c",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:06324b32c616d4e45a79cb65a439ac48",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0147",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0327765638841369"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.419663124449093"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999889"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.552437898286094"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "147"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0327765638841369"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.419663124449093"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999889"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.552437898286094"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "147"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e52574eea0816040ab22d41230ea518c",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:06324b32c616d4e45a79cb65a439ac48",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:cac2f6c0cd35c2d53ed1689d1f149a53",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:ac9a19a2b1c9949a888ebae7d65a2399",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0148",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0327765638841369"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.419663124449093"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999889"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.552437898286094"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "148"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0327765638841369"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.419663124449093"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999889"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.552437898286094"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "148"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cac2f6c0cd35c2d53ed1689d1f149a53",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:ac9a19a2b1c9949a888ebae7d65a2399",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:78cef26d38b3c686cc371fc53f23b0b0",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:061dca60ff6ace182bd1ebe945535ace",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0149",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "149"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "149"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:78cef26d38b3c686cc371fc53f23b0b0",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:061dca60ff6ace182bd1ebe945535ace",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:ee1be7d7191fe1d0a268751891c07368",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:6242500a1c0ecfe873a2799eca21133b",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0150",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "150"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "150"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ee1be7d7191fe1d0a268751891c07368",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:6242500a1c0ecfe873a2799eca21133b",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:460199221aa05d5f8655df003b9ba5e5",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:62f0dcd6742c42c5c8a69829ea982b14",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0151",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "151"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "151"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:460199221aa05d5f8655df003b9ba5e5",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:62f0dcd6742c42c5c8a69829ea982b14",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:13c65c64199df9d15af3dcaef046e358",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:ed86b8af25a7303faba66f96f7427038",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0152",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "152"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "152"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:13c65c64199df9d15af3dcaef046e358",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:ed86b8af25a7303faba66f96f7427038",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:7a0a564d5df4aedd6daf83ea5ff89179",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:81c63725e4640647cd75f101cc0fc8a7",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0153",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0491648458262054"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.320523791287721"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999872308"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.529659882057015"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "153"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0491648458262054"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.320523791287721"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999872308"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.529659882057015"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "153"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7a0a564d5df4aedd6daf83ea5ff89179",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:81c63725e4640647cd75f101cc0fc8a7",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:64296118b766a08ff9a1b3331ff3a8be",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:4b2e0a2531b0291df0fe5df5bc205ec9",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0154",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0327765638841369"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.419663124449093"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999889"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.552437898286094"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "154"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0327765638841369"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.419663124449093"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999889"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.552437898286094"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "154"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:64296118b766a08ff9a1b3331ff3a8be",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:4b2e0a2531b0291df0fe5df5bc205ec9",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:2d05298a2bfc1bad012eb9c5a6636ad4",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:7f91f8087c7d8ec7eda6204b5b39482d",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0155",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0327765638841369"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.419663124449093"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999889"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.552437898286094"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "155"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0327765638841369"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.419663124449093"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999889"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.552437898286094"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "155"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2d05298a2bfc1bad012eb9c5a6636ad4",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:7f91f8087c7d8ec7eda6204b5b39482d",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:5675ac9e2a66ba888afe627ebfc89ba2",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:2c7f0285c24b2b8b65a032418b15cd16",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0156",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "7"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.114717973594479"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.135115167401345"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999932500065553"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.317998323277913"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "156"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "7"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.114717973594479"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.135115167401345"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999932500065553"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.317998323277913"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "156"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5675ac9e2a66ba888afe627ebfc89ba2",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:2c7f0285c24b2b8b65a032418b15cd16",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:ec3de522ea3b2037df66f6245f038d27",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:7ed3fe10280b67503b5448524a04f269",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0157",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "7"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.114717973594479"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.135115167401345"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999932500065553"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.317998323277913"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "157"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "7"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.114717973594479"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.135115167401345"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999932500065553"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.317998323277913"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "157"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ec3de522ea3b2037df66f6245f038d27",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:7ed3fe10280b67503b5448524a04f269",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:d912332211df7778d8d01732fe94c592",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:99c58e7d96cf7da6763a2e1cbba873ae",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0158",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "158"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "158"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d912332211df7778d8d01732fe94c592",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:99c58e7d96cf7da6763a2e1cbba873ae",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:7b7bea73949631fa11f1e655bc82c0ca",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:d5206500679003f5f39472159c4ad0de",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0159",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0491648458262054"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.320523791287721"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999872308"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.529659882057015"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "159"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0491648458262054"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.320523791287721"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999872308"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.529659882057015"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "159"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7b7bea73949631fa11f1e655bc82c0ca",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:d5206500679003f5f39472159c4ad0de",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:522c28dd4e63e1c775b1ebd75bb4c8b3",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:0803006e1feea37abdc724f07464d7a9",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0160",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "160"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "160"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:522c28dd4e63e1c775b1ebd75bb4c8b3",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:0803006e1feea37abdc724f07464d7a9",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:18abb51402bd1a96024eebcb51fe2cea",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:abae6765a0aa40936d109b9a2fd5acbf",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0161",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0327765638841369"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.419663124449093"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999889"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.552437898286094"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "161"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0327765638841369"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.419663124449093"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999889"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.552437898286094"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "161"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:18abb51402bd1a96024eebcb51fe2cea",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:abae6765a0aa40936d109b9a2fd5acbf",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:f22d5a21f3420379ca338b596714d6c3",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:4b0a463a8d9ceb66a11c49348ae1f5fc",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0162",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0327765638841369"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.419663124449093"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999889"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.552437898286094"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "162"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0327765638841369"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.419663124449093"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999889"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.552437898286094"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "162"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f22d5a21f3420379ca338b596714d6c3",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:4b0a463a8d9ceb66a11c49348ae1f5fc",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:3ee311b3e36564f263d2f8b333315cbe",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:ca33d7428ff48eafbc3f213db2286c92",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0163",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0327765638841369"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.419663124449093"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999889"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.552437898286094"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "163"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0327765638841369"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.419663124449093"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999889"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.552437898286094"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "163"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3ee311b3e36564f263d2f8b333315cbe",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:ca33d7428ff48eafbc3f213db2286c92",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:1f3adbf2a65a904404950a1b8c6598ab",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:a2d559eeea3fd425019a74c32cb07b03",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0164",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0655531277682739"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.251995246521365"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999983347393"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.477356849101447"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "164"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0655531277682739"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.251995246521365"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999983347393"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.477356849101447"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "164"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1f3adbf2a65a904404950a1b8c6598ab",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:a2d559eeea3fd425019a74c32cb07b03",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:acdbdf918b46bc8c7e5f5f71c88555a8",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:1cffc79d71ec5b44f8be32f71d15b738",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0165",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0491648458262054"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.320523791287721"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999872308"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.529659882057015"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "165"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0491648458262054"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.320523791287721"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999872308"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.529659882057015"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "165"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:acdbdf918b46bc8c7e5f5f71c88555a8",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:1cffc79d71ec5b44f8be32f71d15b738",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:57bb8e63228982c179f16eb42319da97",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:08835c169510829e8effda3071bba336",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0166",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0327765638841369"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.419663124449093"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999889"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.552437898286094"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "166"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0327765638841369"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.419663124449093"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999889"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.552437898286094"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "166"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:57bb8e63228982c179f16eb42319da97",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:08835c169510829e8effda3071bba336",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:47b4c3e270c9cefea83aa0b99207cb4e",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:d5a3f5e4133bc22e2c189ceeb5b93544",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0167",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0327765638841369"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.419663124449093"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999889"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.552437898286094"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "167"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0327765638841369"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.419663124449093"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999889"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.552437898286094"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "167"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:47b4c3e270c9cefea83aa0b99207cb4e",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:d5a3f5e4133bc22e2c189ceeb5b93544",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:1e1daff291581e1187737e0f917dcaf2",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:9b44436d58818f06cd48133f714e8a99",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0168",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "168"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "168"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1e1daff291581e1187737e0f917dcaf2",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:9b44436d58818f06cd48133f714e8a99",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:6847174e062f3a379b5888fc4135c73f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:051457613c34bfa68d60b137e8c7ae17",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0169",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0491648458262054"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.320523791287721"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999872308"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.529659882057015"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "169"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0491648458262054"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.320523791287721"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999872308"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.529659882057015"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "169"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6847174e062f3a379b5888fc4135c73f",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:051457613c34bfa68d60b137e8c7ae17",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:a9473168659cdf2b1a2073210ee27791",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:ea9fe9402f815e54e3cef6704ebcb2e4",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0170",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0327765638841369"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.419663124449093"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999889"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.552437898286094"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "170"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0327765638841369"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.419663124449093"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999889"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.552437898286094"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "170"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a9473168659cdf2b1a2073210ee27791",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:ea9fe9402f815e54e3cef6704ebcb2e4",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:907753cf0dfe053ffac4e74053c771f4",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:1dce01b8df60884c582e29243c828080",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0171",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0327765638841369"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.419663124449093"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999889"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.552437898286094"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "171"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0327765638841369"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.419663124449093"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999889"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.552437898286094"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "171"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:907753cf0dfe053ffac4e74053c771f4",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:1dce01b8df60884c582e29243c828080",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:7a7fab37bd67ec2dae91a58e4367079a",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:eb8a2332e6ccc41b6d1a8cca84b280fe",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0172",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0327765638841369"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.419663124449093"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999889"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.552437898286094"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "172"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0327765638841369"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.419663124449093"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999889"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.552437898286094"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "172"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7a7fab37bd67ec2dae91a58e4367079a",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:eb8a2332e6ccc41b6d1a8cca84b280fe",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:6b0e32c53f8491486992e204b6c885ee",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:3ab29b7a5414afa7ee3dad94fe418d2f",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0173",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "173"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "173"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6b0e32c53f8491486992e204b6c885ee",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:3ab29b7a5414afa7ee3dad94fe418d2f",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:437362f1f721e7635eb6c8e7a49eacc8",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:de99f369510067d001dcfc78a4b7ee95",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0174",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0491648458262054"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.320523791287721"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999872308"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.529659882057015"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "174"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0491648458262054"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.320523791287721"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999872308"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.529659882057015"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "174"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:437362f1f721e7635eb6c8e7a49eacc8",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:de99f369510067d001dcfc78a4b7ee95",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:f3e52b5df75745e99bcb5f824b5d95a7",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:03516b1ded0c354154f06310cfeb09c0",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0175",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "175"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "175"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f3e52b5df75745e99bcb5f824b5d95a7",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:03516b1ded0c354154f06310cfeb09c0",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:e240445d6ab5dec28910648113069e56",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:56da6908cbe82b7569f6ca2737e51eb6",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0176",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "5"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0819414097103423"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.202012085605038"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999418769679"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.427898326781582"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "176"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "5"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0819414097103423"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.202012085605038"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999418769679"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.427898326781582"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "176"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e240445d6ab5dec28910648113069e56",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:56da6908cbe82b7569f6ca2737e51eb6",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:e075542d829a72554ead327c95c2e9d8",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:087ce96dd01c83b4336943a7df6de172",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0177",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "177"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "177"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e075542d829a72554ead327c95c2e9d8",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:087ce96dd01c83b4336943a7df6de172",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:d9aa2f1b33b774438046f98fe3595e09",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:1a5540bf2e828d5e14c6001adb4f30d5",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0178",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0327765638841369"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.419663124449093"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999889"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.552437898286094"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "178"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0327765638841369"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.419663124449093"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999889"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.552437898286094"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "178"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d9aa2f1b33b774438046f98fe3595e09",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:1a5540bf2e828d5e14c6001adb4f30d5",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:13bffc90c8fd1625b76f45711dc4d490",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:b54974658dcfd8d91a65540d01e3250b",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0179",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "179"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "179"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:13bffc90c8fd1625b76f45711dc4d490",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:b54974658dcfd8d91a65540d01e3250b",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:226cf1d14e58a618a7ed1bfe9c594e24",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:b1012bc624cd6b3f47ff149073d0a78b",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0180",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "180"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "180"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:226cf1d14e58a618a7ed1bfe9c594e24",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:b1012bc624cd6b3f47ff149073d0a78b",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:54f50d5bf9097a354105a3150da68b70",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:d45da63c733d96ddba5cf2fb05dc0b58",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0181",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "181"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "181"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:54f50d5bf9097a354105a3150da68b70",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:d45da63c733d96ddba5cf2fb05dc0b58",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:6f1dfc43277961fa3ac9af2851b18b10",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:14e793643765a6fe10fb66237bee63db",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0182",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0491648458262054"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.320523791287721"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999872308"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.529659882057015"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "182"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0491648458262054"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.320523791287721"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999872308"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.529659882057015"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "182"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6f1dfc43277961fa3ac9af2851b18b10",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:14e793643765a6fe10fb66237bee63db",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:eac8fe1980d2f8fa464fc76d2251099d",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:a3b1937d74b3d7366255ed05df95e8dc",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0183",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0655531277682739"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.251995246521365"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999983347393"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.477356849101447"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "183"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0655531277682739"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.251995246521365"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999983347393"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.477356849101447"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "183"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:eac8fe1980d2f8fa464fc76d2251099d",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:a3b1937d74b3d7366255ed05df95e8dc",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:79433ea0eb0eb190e621fa615f0bf51e",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:4f0d78d14b791c15d9759ece4ec7e6ed",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0184",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "184"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "184"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:79433ea0eb0eb190e621fa615f0bf51e",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:4f0d78d14b791c15d9759ece4ec7e6ed",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:7d479ec4ba5d64002174656bfdc52de9",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f569ae7a0c44f14440097fc2492d13ab",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0185",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "185"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "185"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7d479ec4ba5d64002174656bfdc52de9",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:f569ae7a0c44f14440097fc2492d13ab",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:f6e5caa15217c51ffb3a70b27c4655de",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:2fd27f14078fbb1aa402a271e101e35f",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0186",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0327765638841369"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.419663124449093"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999889"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.552437898286094"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "186"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0327765638841369"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.419663124449093"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999889"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.552437898286094"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "186"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f6e5caa15217c51ffb3a70b27c4655de",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:2fd27f14078fbb1aa402a271e101e35f",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:a1d3eda99ed34e2358f8113bd4e39dbf",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:5476fcd5093f7c864637efaafd42b996",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0187",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "187"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "187"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a1d3eda99ed34e2358f8113bd4e39dbf",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:5476fcd5093f7c864637efaafd42b996",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:51e730ef4a2f4f6093b5ca4c2b56ea0f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:10bac4ccf6049482f632adb3952c3c8c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0188",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "188"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "188"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:51e730ef4a2f4f6093b5ca4c2b56ea0f",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:10bac4ccf6049482f632adb3952c3c8c",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:3352f1f91f74dc735e788278eb1bed90",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:cda273936fc980c18403b41fb8533954",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0189",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "189"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "189"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3352f1f91f74dc735e788278eb1bed90",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:cda273936fc980c18403b41fb8533954",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:46cfb09d58d7bccc0bf22049c6888ca9",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:89501dfa67d1d32810bbe20fd9b1fe8c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0190",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0327765638841369"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.419663124449093"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999889"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.552437898286094"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "190"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0327765638841369"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.419663124449093"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999889"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.552437898286094"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "190"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:46cfb09d58d7bccc0bf22049c6888ca9",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:89501dfa67d1d32810bbe20fd9b1fe8c",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:0abf2e69a6c22d3820c2671d957d5cb6",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:02f6f6429a8304a7731a404570cb4b94",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0191",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0655531277682739"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.251995246521365"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999983347393"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.477356849101447"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "191"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0655531277682739"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.251995246521365"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999983347393"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.477356849101447"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "191"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0abf2e69a6c22d3820c2671d957d5cb6",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:02f6f6429a8304a7731a404570cb4b94",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:a4c707ed5e61e6afca1d519a13e265d1",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:8747a3ddd24cbd71e40672d541cefee5",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0192",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0327765638841369"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.419663124449093"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999889"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.552437898286094"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "192"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0327765638841369"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.419663124449093"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999889"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.552437898286094"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "192"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a4c707ed5e61e6afca1d519a13e265d1",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:8747a3ddd24cbd71e40672d541cefee5",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:b664590e2a12ae3f5b1c7bfc738917c9",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c885eb98b2506b007c2d8feb2e37f08e",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0193",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "193"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "193"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b664590e2a12ae3f5b1c7bfc738917c9",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:c885eb98b2506b007c2d8feb2e37f08e",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:6abd89dfa06bba6341117a3456f77a35",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:bd96226234de4e21627b04208c7e537f",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0194",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0327765638841369"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.419663124449093"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999889"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.552437898286094"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "194"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0327765638841369"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.419663124449093"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999889"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.552437898286094"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "194"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6abd89dfa06bba6341117a3456f77a35",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:bd96226234de4e21627b04208c7e537f",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:fe9517cb56f6cb1662031dc08caaf182",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:8b7eb042176ff4b34dbab2133217acff",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0195",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "195"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "195"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:fe9517cb56f6cb1662031dc08caaf182",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:8b7eb042176ff4b34dbab2133217acff",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:50be4fbb838d8e155b244eced8a52d48",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:74aa1acb0840e11af474625bf18a205b",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0196",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "196"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "196"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:50be4fbb838d8e155b244eced8a52d48",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:74aa1acb0840e11af474625bf18a205b",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:7625dcfd9f93b74584752753153c19ec",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:1f8d909cef3803a0e6a8e31c86e2cb37",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0197",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "197"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "197"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7625dcfd9f93b74584752753153c19ec",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:1f8d909cef3803a0e6a8e31c86e2cb37",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:1ac5aaf4d3242e8406a5e8348658d29b",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:d1b86bb927184d1863bf16406cbb38ef",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0198",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "198"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "198"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1ac5aaf4d3242e8406a5e8348658d29b",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:d1b86bb927184d1863bf16406cbb38ef",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:453feff4ca6cc36089bf9e9576cad723",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:8681fd0b6a40a88059175d0b5804a743",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0199",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "199"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "199"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:453feff4ca6cc36089bf9e9576cad723",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:8681fd0b6a40a88059175d0b5804a743",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:a36937f0bb3343166a85a624c7a5008c",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:53d7d39a6b6a7a44a92c2cdc58facf3a",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0200",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "200"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "200"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a36937f0bb3343166a85a624c7a5008c",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:53d7d39a6b6a7a44a92c2cdc58facf3a",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:9539fad3df2122c0c1d221ba62c93b1e",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:b8f303a3f6e3ffbd2a86dd99d6d873fb",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0201",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "201"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "201"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9539fad3df2122c0c1d221ba62c93b1e",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:b8f303a3f6e3ffbd2a86dd99d6d873fb",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:0703f60bbede2cd4ff08171910c78742",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:555db4d96064ec58a79e6099a79dd060",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0202",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0327765638841369"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.419663124449093"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999889"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.552437898286094"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "202"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0327765638841369"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.419663124449093"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999889"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.552437898286094"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "202"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0703f60bbede2cd4ff08171910c78742",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:555db4d96064ec58a79e6099a79dd060",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:2192d0176864a609d1f99aeb7606bb20",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:df9fe6cd3c5bf212b4c85e3bd119959c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0203",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0491648458262054"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.320523791287721"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999872308"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.529659882057015"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "203"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0491648458262054"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.320523791287721"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999872308"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.529659882057015"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "203"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2192d0176864a609d1f99aeb7606bb20",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:df9fe6cd3c5bf212b4c85e3bd119959c",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:c7815fda00367a584b0eaef5d2a3a8d3",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:17f6f685daf3b085f3dac6c057c020c1",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0204",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "204"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "204"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c7815fda00367a584b0eaef5d2a3a8d3",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:17f6f685daf3b085f3dac6c057c020c1",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:0298b7fe38f8161533f229d225028815",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c5cf9af3cc2424e4b8e65eb6049706ed",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0205",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0327765638841369"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.419663124449093"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999889"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.552437898286094"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "205"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0327765638841369"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.419663124449093"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999889"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.552437898286094"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "205"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0298b7fe38f8161533f229d225028815",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:c5cf9af3cc2424e4b8e65eb6049706ed",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:0c1cd6f0700636298b473906a5e51975",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:24b677d8caebb84711be327c29be20b9",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0206",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "206"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "206"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0c1cd6f0700636298b473906a5e51975",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:24b677d8caebb84711be327c29be20b9",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:a6a6f1a505d5a404d9c028c325bee223",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c9997d6b8885703c61c50e9494f01f5b",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0207",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "207"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "207"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a6a6f1a505d5a404d9c028c325bee223",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:c9997d6b8885703c61c50e9494f01f5b",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:f5f7ac01c1435f2b1a5663ae0f9a4c7f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:18c389e9f560a707e21a88082c18399f",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0208",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0327765638841369"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.419663124449093"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999889"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.552437898286094"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "208"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0327765638841369"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.419663124449093"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999889"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.552437898286094"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "208"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f5f7ac01c1435f2b1a5663ae0f9a4c7f",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:18c389e9f560a707e21a88082c18399f",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:ef1841157cd24be39b9b725e1c39ab72",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:4f2617299971ce7d3a16c3c37b0badbd",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0209",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "209"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "209"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ef1841157cd24be39b9b725e1c39ab72",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:4f2617299971ce7d3a16c3c37b0badbd",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:e4109f0f0f898a32d7f3ac2462582221",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:7ab88d893988ef5840b83076dc34632a",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0210",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "210"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "210"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e4109f0f0f898a32d7f3ac2462582221",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:7ab88d893988ef5840b83076dc34632a",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:4525ab0c75413bf2c98a4586a5abcc36",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:ad4b61cba6b4e1ac8b424d69a662357a",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0211",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0327765638841369"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.419663124449093"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999889"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.552437898286094"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "211"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0327765638841369"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.419663124449093"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999889"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.552437898286094"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "211"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4525ab0c75413bf2c98a4586a5abcc36",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:ad4b61cba6b4e1ac8b424d69a662357a",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:4eaf48754995dc5302632344b8135db1",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:18172de66764cc046e57e3f71900f308",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0212",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "212"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "212"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4eaf48754995dc5302632344b8135db1",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:18172de66764cc046e57e3f71900f308",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:4424249ed6c1cf6688e8d9a01e38e149",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:5b864821dad832cdea33cc2c71107b5d",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0213",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "213"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "213"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4424249ed6c1cf6688e8d9a01e38e149",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:5b864821dad832cdea33cc2c71107b5d",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:a39115f19cda212439112978c2f429df",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:54af2492a558bd6b541a83efffeacbc6",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0214",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0327765638841369"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.419663124449093"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999889"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.552437898286094"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "214"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0327765638841369"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.419663124449093"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999889"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.552437898286094"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "214"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a39115f19cda212439112978c2f429df",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:54af2492a558bd6b541a83efffeacbc6",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:d5f28f9ef79dc06baf5860f0239ca3e7",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:4c87d31930bd2a3884bfbd054121e8ea",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0215",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "215"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "215"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d5f28f9ef79dc06baf5860f0239ca3e7",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:4c87d31930bd2a3884bfbd054121e8ea",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:5079e994cd9f24fc30fe92efa7493c57",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:0c1ba90c913890f99f03e9c6732b7833",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0216",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "216"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "216"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5079e994cd9f24fc30fe92efa7493c57",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:0c1ba90c913890f99f03e9c6732b7833",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:686ed6dbd2ea21d312152f2e4e96f435",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:7e48fd00328505ec2f7c55286029038c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0217",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "217"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "217"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:686ed6dbd2ea21d312152f2e4e96f435",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:7e48fd00328505ec2f7c55286029038c",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:91f65776f22ca4ee422c8dcd4c4c4459",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:fe7b7aeb5b19bcdfb6ba3b9e7bbc0530",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0218",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0327765638841369"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.419663124449093"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999889"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.552437898286094"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "218"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0327765638841369"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.419663124449093"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999889"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.552437898286094"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "218"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:91f65776f22ca4ee422c8dcd4c4c4459",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:fe7b7aeb5b19bcdfb6ba3b9e7bbc0530",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:4e1ee3ae277085cca25ed575c4d6c732",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:2598e0a8af6b254c19ea1eae1c055e59",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0219",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "219"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "219"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4e1ee3ae277085cca25ed575c4d6c732",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:2598e0a8af6b254c19ea1eae1c055e59",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:21ba06ef00e16e74fa2aac38752b9ad5",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:ef260aa5a1800f7a5b96c1d3f96edac0",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0220",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "220"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "220"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:21ba06ef00e16e74fa2aac38752b9ad5",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:ef260aa5a1800f7a5b96c1d3f96edac0",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:cb15ce5ea75dc27ee8c68d6f25317137",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:9edfdd818d3f428259751e3a1f4426fa",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0221",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "221"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "221"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cb15ce5ea75dc27ee8c68d6f25317137",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:9edfdd818d3f428259751e3a1f4426fa",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:9c56529ebb0bf4259a9c564b06624446",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:1667cff121b7be39391cc74c4150a6e4",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0222",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "222"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "222"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9c56529ebb0bf4259a9c564b06624446",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:1667cff121b7be39391cc74c4150a6e4",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:58cc34c1cf71d6fb92343373483bc627",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:8a9dbe909430bab19de8984a30f0827c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0223",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "223"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "223"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:58cc34c1cf71d6fb92343373483bc627",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:8a9dbe909430bab19de8984a30f0827c",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:ef7aa42532c9d5d3093cbb6f46af6456",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:73e5d22f5e99f7222d046e5c8b8f17e5",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0224",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "224"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "224"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ef7aa42532c9d5d3093cbb6f46af6456",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:73e5d22f5e99f7222d046e5c8b8f17e5",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:4948e1f6d55a77b68ff8403a3b1cc6a9",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:8015064bc0743ed13468353e18ca0971",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0225",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "225"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "225"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4948e1f6d55a77b68ff8403a3b1cc6a9",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:8015064bc0743ed13468353e18ca0971",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:d51ac19a940490ccb81c778042e6d07f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:eb612c2c1cebda064d6320c535f9294f",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0226",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "226"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "226"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d51ac19a940490ccb81c778042e6d07f",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:eb612c2c1cebda064d6320c535f9294f",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:dd6abaee8e1238ee75ff4cc3940af16c",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:6369784f4c4b56deb50440d6515b981e",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0227",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "227"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "227"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:dd6abaee8e1238ee75ff4cc3940af16c",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:6369784f4c4b56deb50440d6515b981e",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:dec8b0ace647b4ba45c324b0822a7d07",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:2147d82387f71f29a3d3dfb09b7b8d64",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0228",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0327765638841369"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.419663124449093"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999889"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.552437898286094"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "228"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0327765638841369"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.419663124449093"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999889"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.552437898286094"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "228"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:dec8b0ace647b4ba45c324b0822a7d07",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:2147d82387f71f29a3d3dfb09b7b8d64",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:e77710d04eb08640d5c1d3f18d42d3fa",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:790465006aaf87ef2289ea019fdb0b83",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0229",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "229"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "229"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e77710d04eb08640d5c1d3f18d42d3fa",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:790465006aaf87ef2289ea019fdb0b83",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:cce35d82d42e6ed7353ce989b716eb03",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:730c6026b96772dd69384df78d1b3195",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0230",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "230"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "230"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cce35d82d42e6ed7353ce989b716eb03",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:730c6026b96772dd69384df78d1b3195",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:34d4adf23d9292a19ec442ef839b2cff",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:26bef1517140b96419bd96743968bf5a",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0231",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "231"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "231"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:34d4adf23d9292a19ec442ef839b2cff",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:26bef1517140b96419bd96743968bf5a",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:bbd6c18fcbc3934b6a6db033becc5ed1",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c80e777eb02827978765763f51129026",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0232",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "232"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "232"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:bbd6c18fcbc3934b6a6db033becc5ed1",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:c80e777eb02827978765763f51129026",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:88f0354a46364a076e3c319e275ba3dd",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:6eb9789a31f1c0da3f5dc3fb64518f9e",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0233",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0163882819420685"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.578685227694606"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "233"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0163882819420685"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.578685227694606"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "233"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:88f0354a46364a076e3c319e275ba3dd",
-      "entity": "niiri:fec8545d1e39630ce18d7eddddd0aaa4"
+      "entity_derived": "niiri:6eb9789a31f1c0da3f5dc3fb64518f9e",
+      "entity": "niiri:8c8ad5dc532e1fc2320f4c3356bdd145"
     },
     {
-      "@id": "niiri:5c0c5cf6ffa6776f5d5c6bfcb665dd1e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:6375cbd08f405cfa4aa923cd73003620",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0001",
-      "prov:atLocation": {"@id": "niiri:cb3d5a3b64d7d0b319db57a508c6999d"},
+      "prov:atLocation": {"@id": "niiri:ce4a406feff03df1c1bc96f3bb8b1a6a"},
       "prov:value": {"@type": "xsd:float", "@value": "12.195366859436"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "6.97053078023572"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.57873714101697e-12"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "3.52098841860382e-07"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1.32821571221074e-05"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "6.97053078023572"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.57873714101697e-12"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "3.52098841860382e-07"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1.32821571221074e-05"}
     },
     {
-      "@id": "niiri:cb3d5a3b64d7d0b319db57a508c6999d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ce4a406feff03df1c1bc96f3bb8b1a6a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0001",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-12,-20,80]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-12,-20,80]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5c0c5cf6ffa6776f5d5c6bfcb665dd1e",
-      "entity": "niiri:ba835f71b6ca8a486d7c5f7379bd662f"
+      "entity_derived": "niiri:6375cbd08f405cfa4aa923cd73003620",
+      "entity": "niiri:85fec2a2169d10c191c4e617a17cdba0"
     },
     {
-      "@id": "niiri:63f85dd41ea53558df62bbac4b19011a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f9affa16a68b7d08052caab897982f1e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0002",
-      "prov:atLocation": {"@id": "niiri:91a30c7c26a8209cc335eee3b9c316a1"},
+      "prov:atLocation": {"@id": "niiri:948e4a7ef33c3baa7c4f2617243129ae"},
       "prov:value": {"@type": "xsd:float", "@value": "12.0285215377808"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "6.92667949448921"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.15416573468019e-12"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "4.80452217677119e-07"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1.32821571221074e-05"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "6.92667949448921"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.15416573468019e-12"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "4.80452217677119e-07"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1.32821571221074e-05"}
     },
     {
-      "@id": "niiri:91a30c7c26a8209cc335eee3b9c316a1",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:948e4a7ef33c3baa7c4f2617243129ae",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0002",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-2,48,28]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-2,48,28]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:63f85dd41ea53558df62bbac4b19011a",
-      "entity": "niiri:ba835f71b6ca8a486d7c5f7379bd662f"
+      "entity_derived": "niiri:f9affa16a68b7d08052caab897982f1e",
+      "entity": "niiri:85fec2a2169d10c191c4e617a17cdba0"
     },
     {
-      "@id": "niiri:043b3733fcb562e9d588c9fd302ed9d0",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:760b5861535d1b8d351a8ea1c8e8055e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0003",
-      "prov:atLocation": {"@id": "niiri:bd2cd838267a5f71e2ace6da2ab746f5"},
+      "prov:atLocation": {"@id": "niiri:2981f98fafc6bbd2a22c1698fffaeee3"},
       "prov:value": {"@type": "xsd:float", "@value": "11.1319952011108"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "6.68038320254177"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.19159127009993e-11"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "2.65787821074337e-06"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "2.57057234849773e-05"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "6.68038320254177"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.19159127009993e-11"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "2.65787821074337e-06"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "2.57057234849773e-05"}
     },
     {
-      "@id": "niiri:bd2cd838267a5f71e2ace6da2ab746f5",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:2981f98fafc6bbd2a22c1698fffaeee3",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0003",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[28,-82,-34]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[28,-82,-34]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:043b3733fcb562e9d588c9fd302ed9d0",
-      "entity": "niiri:ba835f71b6ca8a486d7c5f7379bd662f"
+      "entity_derived": "niiri:760b5861535d1b8d351a8ea1c8e8055e",
+      "entity": "niiri:85fec2a2169d10c191c4e617a17cdba0"
     },
     {
-      "@id": "niiri:a7cb6c5aa7c44e8e1412e7e097d894b0",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:01d92dcf2decdbf979916bc117777a31",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0004",
-      "prov:atLocation": {"@id": "niiri:f85513c7e4de5695128e247715538d6e"},
+      "prov:atLocation": {"@id": "niiri:991de64484a40e2c43025eb986c3aeb0"},
       "prov:value": {"@type": "xsd:float", "@value": "11.1767311096191"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "6.69312218368378"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.09229292277746e-11"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "2.43638629615628e-06"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "2.57057234849773e-05"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "6.69312218368378"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.09229292277746e-11"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "2.43638629615628e-06"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "2.57057234849773e-05"}
     },
     {
-      "@id": "niiri:f85513c7e4de5695128e247715538d6e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:991de64484a40e2c43025eb986c3aeb0",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0004",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[16,-18,24]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[16,-18,24]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a7cb6c5aa7c44e8e1412e7e097d894b0",
-      "entity": "niiri:887840e0df0dde27ca60bb3a5eed1fdb"
+      "entity_derived": "niiri:01d92dcf2decdbf979916bc117777a31",
+      "entity": "niiri:1aa2c5542022d8edfbe6faaf12d4ebb7"
     },
     {
-      "@id": "niiri:335d8ea52be5d20d7d7c4db4a1e9f490",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:85893fd2a80f9cb9a50aeeaf16aa5be0",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0005",
-      "prov:atLocation": {"@id": "niiri:0b3a3ff41571307909ae084a77734d61"},
+      "prov:atLocation": {"@id": "niiri:50a673aee12d5977c697358610b82f93"},
       "prov:value": {"@type": "xsd:float", "@value": "8.21963119506836"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.72404476343991"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.20086618216453e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00116008955846647"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000453192860238723"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.72404476343991"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.20086618216453e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00116008955846647"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000453192860238723"}
     },
     {
-      "@id": "niiri:0b3a3ff41571307909ae084a77734d61",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:50a673aee12d5977c697358610b82f93",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0005",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[10,0,22]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[10,0,22]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:335d8ea52be5d20d7d7c4db4a1e9f490",
-      "entity": "niiri:887840e0df0dde27ca60bb3a5eed1fdb"
+      "entity_derived": "niiri:85893fd2a80f9cb9a50aeeaf16aa5be0",
+      "entity": "niiri:1aa2c5542022d8edfbe6faaf12d4ebb7"
     },
     {
-      "@id": "niiri:31ea480a04178c3333f50a26da706158",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:eb798644a33419afda56222bf6a4057c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0006",
-      "prov:atLocation": {"@id": "niiri:5b1ee14770955263f940e2b7de273b8d"},
+      "prov:atLocation": {"@id": "niiri:79715caa4b342489144deaf29cf8907b"},
       "prov:value": {"@type": "xsd:float", "@value": "7.89727067947388"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.59926411112285"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.0763181346185e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00240080291677169"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000683233949888892"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.59926411112285"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.0763181346185e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00240080291677169"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000683233949888892"}
     },
     {
-      "@id": "niiri:5b1ee14770955263f940e2b7de273b8d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:79715caa4b342489144deaf29cf8907b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0006",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[18,-32,20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[18,-32,20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:31ea480a04178c3333f50a26da706158",
-      "entity": "niiri:887840e0df0dde27ca60bb3a5eed1fdb"
+      "entity_derived": "niiri:eb798644a33419afda56222bf6a4057c",
+      "entity": "niiri:1aa2c5542022d8edfbe6faaf12d4ebb7"
     },
     {
-      "@id": "niiri:56e7922f255bf5d2132f359b9c588696",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:8b04f6c0610c61ade2031f4e0e7fd687",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0007",
-      "prov:atLocation": {"@id": "niiri:e03f6d67aaf69387b86b6ab3759b5050"},
+      "prov:atLocation": {"@id": "niiri:df7b218fff7e31a0a6a4a8706cdb282e"},
       "prov:value": {"@type": "xsd:float", "@value": "9.78486633300781"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "6.27176668468128"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.7848711397761e-10"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "3.98127506539003e-05"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "6.33393663622056e-05"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "6.27176668468128"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.7848711397761e-10"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "3.98127506539003e-05"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "6.33393663622056e-05"}
     },
     {
-      "@id": "niiri:e03f6d67aaf69387b86b6ab3759b5050",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:df7b218fff7e31a0a6a4a8706cdb282e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0007",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-36,46,-14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-36,46,-14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:56e7922f255bf5d2132f359b9c588696",
-      "entity": "niiri:14b137956e5e00ffd0fdc43f5c22f5c4"
+      "entity_derived": "niiri:8b04f6c0610c61ade2031f4e0e7fd687",
+      "entity": "niiri:f9d722fcce853c033260a3ae532235c1"
     },
     {
-      "@id": "niiri:0c9f929cb0bda7f416c985174ac20abe",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:8d815390449dd61ecf2635b2c7a5611c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0008",
-      "prov:atLocation": {"@id": "niiri:d1f7a38b1a290c6904abb4788697c9fb"},
+      "prov:atLocation": {"@id": "niiri:31d492f86d25c7bb3c9b9d2dae269db3"},
       "prov:value": {"@type": "xsd:float", "@value": "8.99272632598877"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "6.00574234084408"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "9.52292245059994e-10"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.000212415401777744"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000159959987970191"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "6.00574234084408"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "9.52292245059994e-10"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.000212415401777744"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000159959987970191"}
     },
     {
-      "@id": "niiri:d1f7a38b1a290c6904abb4788697c9fb",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:31d492f86d25c7bb3c9b9d2dae269db3",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0008",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-36,52,8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-36,52,8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0c9f929cb0bda7f416c985174ac20abe",
-      "entity": "niiri:14b137956e5e00ffd0fdc43f5c22f5c4"
+      "entity_derived": "niiri:8d815390449dd61ecf2635b2c7a5611c",
+      "entity": "niiri:f9d722fcce853c033260a3ae532235c1"
     },
     {
-      "@id": "niiri:b95534360919178485fc50f77c7bd4da",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b2ac34a9e9c7de3ca84c442f813d01ef",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0009",
-      "prov:atLocation": {"@id": "niiri:2df5663e63cac7f2cb548fc9206a9dae"},
+      "prov:atLocation": {"@id": "niiri:a9d3837fe2e1545ff57eec0afa450f12"},
       "prov:value": {"@type": "xsd:float", "@value": "8.32958316802979"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.76557366261307"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.06902733729453e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.000907624981246302"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000384701368615494"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.76557366261307"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.06902733729453e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.000907624981246302"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000384701368615494"}
     },
     {
-      "@id": "niiri:2df5663e63cac7f2cb548fc9206a9dae",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a9d3837fe2e1545ff57eec0afa450f12",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0009",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-30,26,0]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-30,26,0]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b95534360919178485fc50f77c7bd4da",
-      "entity": "niiri:14b137956e5e00ffd0fdc43f5c22f5c4"
+      "entity_derived": "niiri:b2ac34a9e9c7de3ca84c442f813d01ef",
+      "entity": "niiri:f9d722fcce853c033260a3ae532235c1"
     },
     {
-      "@id": "niiri:66811a129b32873beb2504cce8ad8717",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:007c46c3626dce09d1207554312d2e9a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0010",
-      "prov:atLocation": {"@id": "niiri:92d2b37c2416217857129de0b058e63a"},
+      "prov:atLocation": {"@id": "niiri:8d8e9e0f9f2b81a67a6a5db0d0d20327"},
       "prov:value": {"@type": "xsd:float", "@value": "7.92342185974121"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.60956000685145"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.01420828402254e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00226226252256356"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000660665293349347"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.60956000685145"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.01420828402254e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00226226252256356"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000660665293349347"}
     },
     {
-      "@id": "niiri:92d2b37c2416217857129de0b058e63a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:8d8e9e0f9f2b81a67a6a5db0d0d20327",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0010",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[34,24,58]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[34,24,58]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:66811a129b32873beb2504cce8ad8717",
-      "entity": "niiri:0549497fa62a1d5511dea65e5ef2cf1b"
+      "entity_derived": "niiri:007c46c3626dce09d1207554312d2e9a",
+      "entity": "niiri:73ec267aa6e4362aa22b8bf333d9a6f3"
     },
     {
-      "@id": "niiri:df12430f8ed7eaeca494b008dc535752",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0f083958a49b6859e479679cb5c0b402",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0011",
-      "prov:atLocation": {"@id": "niiri:8e5b024ac3052224dc9ffa33ae7fade3"},
+      "prov:atLocation": {"@id": "niiri:6d5d48b7c274665475b2ca71cbe88e23"},
       "prov:value": {"@type": "xsd:float", "@value": "5.66889333724976"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.58322220042275"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.28932521062486e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.405319777142171"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0228998003891751"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.58322220042275"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.28932521062486e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.405319777142171"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0228998003891751"}
     },
     {
-      "@id": "niiri:8e5b024ac3052224dc9ffa33ae7fade3",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6d5d48b7c274665475b2ca71cbe88e23",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0011",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[42,22,52]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[42,22,52]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:df12430f8ed7eaeca494b008dc535752",
-      "entity": "niiri:0549497fa62a1d5511dea65e5ef2cf1b"
+      "entity_derived": "niiri:0f083958a49b6859e479679cb5c0b402",
+      "entity": "niiri:73ec267aa6e4362aa22b8bf333d9a6f3"
     },
     {
-      "@id": "niiri:f5c619ed9e6dd0204defbd4b15bc8109",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:495925dd7a5c597e0b631259e27402bc",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0012",
-      "prov:atLocation": {"@id": "niiri:d188fd57db2ddba3a2a392b9f0d0cb74"},
+      "prov:atLocation": {"@id": "niiri:95d95856a6aad86946eb9d81f7bf0673"},
       "prov:value": {"@type": "xsd:float", "@value": "4.58756303787231"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.95550547589705"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.81864993630465e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.996114645664071"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.142799623959245"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.95550547589705"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.81864993630465e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.996114645664071"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.142799623959245"}
     },
     {
-      "@id": "niiri:d188fd57db2ddba3a2a392b9f0d0cb74",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:95d95856a6aad86946eb9d81f7bf0673",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0012",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[30,18,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[30,18,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f5c619ed9e6dd0204defbd4b15bc8109",
-      "entity": "niiri:0549497fa62a1d5511dea65e5ef2cf1b"
+      "entity_derived": "niiri:495925dd7a5c597e0b631259e27402bc",
+      "entity": "niiri:73ec267aa6e4362aa22b8bf333d9a6f3"
     },
     {
-      "@id": "niiri:fb6772cae4af8b4a38943fef6eee4a4f",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:78d8a083c90c99f5fc07322a26f5cde9",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0013",
-      "prov:atLocation": {"@id": "niiri:26e38f0ca58479e2d682d41398175b05"},
+      "prov:atLocation": {"@id": "niiri:34d2ae37ad9642bcc041fa8361a900ea"},
       "prov:value": {"@type": "xsd:float", "@value": "7.39782667160034"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.39638585124024"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.3998318493822e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00758356300256935"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00138047262763128"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.39638585124024"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.3998318493822e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00758356300256935"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00138047262763128"}
     },
     {
-      "@id": "niiri:26e38f0ca58479e2d682d41398175b05",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:34d2ae37ad9642bcc041fa8361a900ea",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0013",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-30,52,-44]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-30,52,-44]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:fb6772cae4af8b4a38943fef6eee4a4f",
-      "entity": "niiri:3fbaffdfe735b9ae40c349431f693073"
+      "entity_derived": "niiri:78d8a083c90c99f5fc07322a26f5cde9",
+      "entity": "niiri:a78547a90624868c0aef3cebdd83d669"
     },
     {
-      "@id": "niiri:c7940f154ecbf906db93616a70093838",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c53b99e7694641c31b95648ff991e8a5",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0014",
-      "prov:atLocation": {"@id": "niiri:8a7fa5f1b493388fdbb4584ea50c85e9"},
+      "prov:atLocation": {"@id": "niiri:c234452f63bb3ac27195fdeb47ad40bf"},
       "prov:value": {"@type": "xsd:float", "@value": "7.36954021453857"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.38452514941599"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.6318073992625e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00810100072963016"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00145261378503197"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.38452514941599"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.6318073992625e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00810100072963016"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00145261378503197"}
     },
     {
-      "@id": "niiri:8a7fa5f1b493388fdbb4584ea50c85e9",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c234452f63bb3ac27195fdeb47ad40bf",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0014",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[20,62,4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[20,62,4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c7940f154ecbf906db93616a70093838",
-      "entity": "niiri:6380e74b916ddbf1a024a72c065d623f"
+      "entity_derived": "niiri:c53b99e7694641c31b95648ff991e8a5",
+      "entity": "niiri:940cf2d7b7d0eb179a5d87089cdef025"
     },
     {
-      "@id": "niiri:e6113f1f4ded222b9b9bef4484db8a83",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b3b4ea8ddeb67b7b4031f94f6efe9a70",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0015",
-      "prov:atLocation": {"@id": "niiri:9caff916aa89e9fa97320bec7a7c2d3d"},
+      "prov:atLocation": {"@id": "niiri:7a54b5ab9f0eb5be2d355ab612b3e8dc"},
       "prov:value": {"@type": "xsd:float", "@value": "7.21618938446045"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.31949501913396"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.20278310434108e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0116051721566931"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00179005739670645"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.31949501913396"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.20278310434108e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0116051721566931"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00179005739670645"}
     },
     {
-      "@id": "niiri:9caff916aa89e9fa97320bec7a7c2d3d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7a54b5ab9f0eb5be2d355ab612b3e8dc",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0015",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[52,-72,2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[52,-72,2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e6113f1f4ded222b9b9bef4484db8a83",
-      "entity": "niiri:4cab3569c0af76ee151f4e707fdd3538"
+      "entity_derived": "niiri:b3b4ea8ddeb67b7b4031f94f6efe9a70",
+      "entity": "niiri:22f7499c81f2b4cfb5d9464b77334f85"
     },
     {
-      "@id": "niiri:0c75a687b07e3c7153b0b87d7c9a4327",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:61b0171a6b5389bc91ab6b1f988304af",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0016",
-      "prov:atLocation": {"@id": "niiri:f71c1df1bb3b72c456181bee0b8f6a08"},
+      "prov:atLocation": {"@id": "niiri:210a02ccb07cf88b19c88732436048e4"},
       "prov:value": {"@type": "xsd:float", "@value": "3.82430219650269"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.43170583345079"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000299898886572558"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999682"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.500860780805665"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.43170583345079"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000299898886572558"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999682"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.500860780805665"}
     },
     {
-      "@id": "niiri:f71c1df1bb3b72c456181bee0b8f6a08",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:210a02ccb07cf88b19c88732436048e4",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0016",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[40,-72,0]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[40,-72,0]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0c75a687b07e3c7153b0b87d7c9a4327",
-      "entity": "niiri:4cab3569c0af76ee151f4e707fdd3538"
+      "entity_derived": "niiri:61b0171a6b5389bc91ab6b1f988304af",
+      "entity": "niiri:22f7499c81f2b4cfb5d9464b77334f85"
     },
     {
-      "@id": "niiri:321e136dac6f6ac382096bc280a03820",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:395843f5ca50db682d73ad4b552a0079",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0017",
-      "prov:atLocation": {"@id": "niiri:3dd0e206f22f076ea2fd011ec3a7a774"},
+      "prov:atLocation": {"@id": "niiri:8cde37036aee8f9ea450e67d6b4737cf"},
       "prov:value": {"@type": "xsd:float", "@value": "7.19049739837646"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.30847761867744"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.52723281588285e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0123288799992954"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00187574777550428"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.30847761867744"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.52723281588285e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0123288799992954"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00187574777550428"}
     },
     {
-      "@id": "niiri:3dd0e206f22f076ea2fd011ec3a7a774",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:8cde37036aee8f9ea450e67d6b4737cf",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0017",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-40,-72,26]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-40,-72,26]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:321e136dac6f6ac382096bc280a03820",
-      "entity": "niiri:9a4cbf3c4b4b3511dfc9fd1435a8a28b"
+      "entity_derived": "niiri:395843f5ca50db682d73ad4b552a0079",
+      "entity": "niiri:313e60cc130ee5f7b46b9a70c28c95a0"
     },
     {
-      "@id": "niiri:f86e12cb13946301e2b16671980e7500",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c9497860d4fc106d2a8129f3a41c5e21",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0018",
-      "prov:atLocation": {"@id": "niiri:42057404ebcba19e98071b95ffa176ea"},
+      "prov:atLocation": {"@id": "niiri:3ed159a6a6e2cc0ca8d0aa8e7ada491e"},
       "prov:value": {"@type": "xsd:float", "@value": "6.70591068267822"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.09372181887081"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.75550912029365e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0391578631772435"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00399264077980742"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.09372181887081"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.75550912029365e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0391578631772435"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00399264077980742"}
     },
     {
-      "@id": "niiri:42057404ebcba19e98071b95ffa176ea",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:3ed159a6a6e2cc0ca8d0aa8e7ada491e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0018",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-40,-86,14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-40,-86,14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f86e12cb13946301e2b16671980e7500",
-      "entity": "niiri:9a4cbf3c4b4b3511dfc9fd1435a8a28b"
+      "entity_derived": "niiri:c9497860d4fc106d2a8129f3a41c5e21",
+      "entity": "niiri:313e60cc130ee5f7b46b9a70c28c95a0"
     },
     {
-      "@id": "niiri:287402136891386317b6f87e0a44e89d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5ecb0bf5c97b7f24045a8880831fa426",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0019",
-      "prov:atLocation": {"@id": "niiri:0cf98f3330e4f9dd301c2b0197f4d9c0"},
+      "prov:atLocation": {"@id": "niiri:81b9cf871bc6bec3e655da3ee187b454"},
       "prov:value": {"@type": "xsd:float", "@value": "6.08404064178467"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.79678082629552"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.06179272005991e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.179824002311423"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0113500948707688"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.79678082629552"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.06179272005991e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.179824002311423"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0113500948707688"}
     },
     {
-      "@id": "niiri:0cf98f3330e4f9dd301c2b0197f4d9c0",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:81b9cf871bc6bec3e655da3ee187b454",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0019",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-48,-60,30]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-48,-60,30]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:287402136891386317b6f87e0a44e89d",
-      "entity": "niiri:9a4cbf3c4b4b3511dfc9fd1435a8a28b"
+      "entity_derived": "niiri:5ecb0bf5c97b7f24045a8880831fa426",
+      "entity": "niiri:313e60cc130ee5f7b46b9a70c28c95a0"
     },
     {
-      "@id": "niiri:aaf51ee731a9babf836bcdfda837d8d0",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d36f5f82de4a3b0715a81212cca9c290",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0020",
-      "prov:atLocation": {"@id": "niiri:80673cb23b518aa4ccec855e14143052"},
+      "prov:atLocation": {"@id": "niiri:c6a5ddbf6aa7d460ec508fd316db2784"},
       "prov:value": {"@type": "xsd:float", "@value": "6.76158666610718"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.1190933210259"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.53504013944428e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0342401474138896"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0036643210853873"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.1190933210259"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.53504013944428e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0342401474138896"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0036643210853873"}
     },
     {
-      "@id": "niiri:80673cb23b518aa4ccec855e14143052",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c6a5ddbf6aa7d460ec508fd316db2784",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0020",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-28,60,8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-28,60,8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:aaf51ee731a9babf836bcdfda837d8d0",
-      "entity": "niiri:c8ec1ca234b9bf8d2809bf619534b056"
+      "entity_derived": "niiri:d36f5f82de4a3b0715a81212cca9c290",
+      "entity": "niiri:5755c7b6f3b8bb9a495a80e69a7ab94e"
     },
     {
-      "@id": "niiri:d5585e5d68779ecc1ab83b84159e3fec",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e00bf7ebffe936d438f170dfbba1c2bf",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0021",
-      "prov:atLocation": {"@id": "niiri:5afc2361eccb1b40a736066c043f264b"},
+      "prov:atLocation": {"@id": "niiri:837aa2fe6f0b45ab2a10036c63a7f241"},
       "prov:value": {"@type": "xsd:float", "@value": "4.00573968887329"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.56362489977281"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000182884266391126"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999996836787"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.371800092457092"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.56362489977281"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000182884266391126"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999996836787"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.371800092457092"}
     },
     {
-      "@id": "niiri:5afc2361eccb1b40a736066c043f264b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:837aa2fe6f0b45ab2a10036c63a7f241",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0021",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-22,54,4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-22,54,4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d5585e5d68779ecc1ab83b84159e3fec",
-      "entity": "niiri:c8ec1ca234b9bf8d2809bf619534b056"
+      "entity_derived": "niiri:e00bf7ebffe936d438f170dfbba1c2bf",
+      "entity": "niiri:5755c7b6f3b8bb9a495a80e69a7ab94e"
     },
     {
-      "@id": "niiri:c713fd7a7f587cba755142fa7241d988",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:44b0e53d8cb7cd288c880c38c3120379",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0022",
-      "prov:atLocation": {"@id": "niiri:a3909652f4fd7511ddc3e9a198e184d8"},
+      "prov:atLocation": {"@id": "niiri:3cec1451f5427e2546489737253c024b"},
       "prov:value": {"@type": "xsd:float", "@value": "6.5752739906311"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.03344180146668"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.40875558610298e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0537289858908915"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00495708453245008"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.03344180146668"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.40875558610298e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0537289858908915"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00495708453245008"}
     },
     {
-      "@id": "niiri:a3909652f4fd7511ddc3e9a198e184d8",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:3cec1451f5427e2546489737253c024b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0022",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[60,-54,18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[60,-54,18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c713fd7a7f587cba755142fa7241d988",
-      "entity": "niiri:1b47349b306df45c874f7c947b149652"
+      "entity_derived": "niiri:44b0e53d8cb7cd288c880c38c3120379",
+      "entity": "niiri:23f5c60185b27f2be0dd455c41c3fde3"
     },
     {
-      "@id": "niiri:239a985d1cb8543140006f195c647529",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ac8f339519721b314dfbcb54584abed9",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0023",
-      "prov:atLocation": {"@id": "niiri:1916113714afbab2779bc8a84e11182b"},
+      "prov:atLocation": {"@id": "niiri:78a873ea8d79ec4f3f6fe4d0cab6817d"},
       "prov:value": {"@type": "xsd:float", "@value": "6.51905012130737"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.00716804962526"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.76183492853299e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0616046698347695"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00529817216776537"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.00716804962526"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.76183492853299e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0616046698347695"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00529817216776537"}
     },
     {
-      "@id": "niiri:1916113714afbab2779bc8a84e11182b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:78a873ea8d79ec4f3f6fe4d0cab6817d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0023",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[0,-22,-20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[0,-22,-20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:239a985d1cb8543140006f195c647529",
-      "entity": "niiri:c4b71b38ef4c3be049827afa9e8143bc"
+      "entity_derived": "niiri:ac8f339519721b314dfbcb54584abed9",
+      "entity": "niiri:33cca310ebec4700e45b0560235f03cd"
     },
     {
-      "@id": "niiri:b39a8730b974d3d418866558a505f890",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:6614974273127e7f54c4cba899f3eab6",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0024",
-      "prov:atLocation": {"@id": "niiri:dc3c1d39354b031307bce5f1134c7020"},
+      "prov:atLocation": {"@id": "niiri:333c34b3d2f8aaf1993c6b604235f256"},
       "prov:value": {"@type": "xsd:float", "@value": "6.48744344711304"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.99230910659331"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.98308350576981e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0665397756356061"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00561544623172705"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.99230910659331"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.98308350576981e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0665397756356061"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00561544623172705"}
     },
     {
-      "@id": "niiri:dc3c1d39354b031307bce5f1134c7020",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:333c34b3d2f8aaf1993c6b604235f256",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0024",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[10,-30,-36]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[10,-30,-36]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b39a8730b974d3d418866558a505f890",
-      "entity": "niiri:c4b71b38ef4c3be049827afa9e8143bc"
+      "entity_derived": "niiri:6614974273127e7f54c4cba899f3eab6",
+      "entity": "niiri:33cca310ebec4700e45b0560235f03cd"
     },
     {
-      "@id": "niiri:bfab7cd9c76924ed918dc2594d430185",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c742243cf82a89d57a67528234343c14",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0025",
-      "prov:atLocation": {"@id": "niiri:8197277fb6c32f0ca5bb1556d1e0b520"},
+      "prov:atLocation": {"@id": "niiri:97130dd3e85c7fe87b1fd88f3a5aca5b"},
       "prov:value": {"@type": "xsd:float", "@value": "5.05579805374146"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.24143816665454"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.11046039252827e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.863212474362956"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.06785188529979"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.24143816665454"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.11046039252827e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.863212474362956"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.06785188529979"}
     },
     {
-      "@id": "niiri:8197277fb6c32f0ca5bb1556d1e0b520",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:97130dd3e85c7fe87b1fd88f3a5aca5b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0025",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-10,-24,-18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-10,-24,-18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:bfab7cd9c76924ed918dc2594d430185",
-      "entity": "niiri:c4b71b38ef4c3be049827afa9e8143bc"
+      "entity_derived": "niiri:c742243cf82a89d57a67528234343c14",
+      "entity": "niiri:33cca310ebec4700e45b0560235f03cd"
     },
     {
-      "@id": "niiri:53f49ba357cbeee85f0a61174bddd487",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ef6c96561d3475ee3682ddd186166797",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0026",
-      "prov:atLocation": {"@id": "niiri:f423394a04ebdebfb2028e8f9b17d928"},
+      "prov:atLocation": {"@id": "niiri:d05de1a91aa11cafd11ee52e4c03f599"},
       "prov:value": {"@type": "xsd:float", "@value": "6.43919801712036"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.96950298960416"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.35623679514896e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0748632235875265"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00602839301790402"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.96950298960416"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.35623679514896e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0748632235875265"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00602839301790402"}
     },
     {
-      "@id": "niiri:f423394a04ebdebfb2028e8f9b17d928",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d05de1a91aa11cafd11ee52e4c03f599",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0026",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[32,38,50]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[32,38,50]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:53f49ba357cbeee85f0a61174bddd487",
-      "entity": "niiri:3e28cae2b2981677b6365484975e315d"
+      "entity_derived": "niiri:ef6c96561d3475ee3682ddd186166797",
+      "entity": "niiri:68605e1a07366f1a9aaae9f04eb3bbcf"
     },
     {
-      "@id": "niiri:7ba2af05d5e9e578cccafc1483313e5d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:9f24a0581a298125f2f285b756d18966",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0027",
-      "prov:atLocation": {"@id": "niiri:34bd4a587ba081babf303862fb8f698b"},
+      "prov:atLocation": {"@id": "niiri:e0fd94a7bd3607684a684406ed869b37"},
       "prov:value": {"@type": "xsd:float", "@value": "4.89343357086182"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.14494916695648"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.69944550607593e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.941605195071017"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0877947883186739"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.14494916695648"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.69944550607593e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.941605195071017"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0877947883186739"}
     },
     {
-      "@id": "niiri:34bd4a587ba081babf303862fb8f698b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e0fd94a7bd3607684a684406ed869b37",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0027",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[38,36,44]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[38,36,44]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7ba2af05d5e9e578cccafc1483313e5d",
-      "entity": "niiri:3e28cae2b2981677b6365484975e315d"
+      "entity_derived": "niiri:9f24a0581a298125f2f285b756d18966",
+      "entity": "niiri:68605e1a07366f1a9aaae9f04eb3bbcf"
     },
     {
-      "@id": "niiri:5452eb6143fd236e41565163ab9cab9b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:9c2ce6348aeb7ede7a631d7c312619e2",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0028",
-      "prov:atLocation": {"@id": "niiri:2c879e07b9a014e64f418264d4cd2b4b"},
+      "prov:atLocation": {"@id": "niiri:ad04211aace9e5e98ebb27cbef6f70cf"},
       "prov:value": {"@type": "xsd:float", "@value": "3.84852504730225"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.44961290393203"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000280695459907387"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999998663"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.483436985514074"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.44961290393203"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000280695459907387"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999998663"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.483436985514074"}
     },
     {
-      "@id": "niiri:2c879e07b9a014e64f418264d4cd2b4b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ad04211aace9e5e98ebb27cbef6f70cf",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0028",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[28,48,42]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[28,48,42]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5452eb6143fd236e41565163ab9cab9b",
-      "entity": "niiri:3e28cae2b2981677b6365484975e315d"
+      "entity_derived": "niiri:9c2ce6348aeb7ede7a631d7c312619e2",
+      "entity": "niiri:68605e1a07366f1a9aaae9f04eb3bbcf"
     },
     {
-      "@id": "niiri:7b039d9637d091dc6000d12a8a71393d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f71d38ee9ef7cc1c310f15620e0322f1",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0029",
-      "prov:atLocation": {"@id": "niiri:d8e96f4e78306b64f2369e65ebafa356"},
+      "prov:atLocation": {"@id": "niiri:bd832f486ff152b465d631cc0a7e77e4"},
       "prov:value": {"@type": "xsd:float", "@value": "6.41994762420654"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.96036060921301"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.51812182386446e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.078474183710761"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00622569915917693"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.96036060921301"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.51812182386446e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.078474183710761"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00622569915917693"}
     },
     {
-      "@id": "niiri:d8e96f4e78306b64f2369e65ebafa356",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:bd832f486ff152b465d631cc0a7e77e4",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0029",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-50,26,32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-50,26,32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7b039d9637d091dc6000d12a8a71393d",
-      "entity": "niiri:f362fb2acc0fecc902d53e2682b7f919"
+      "entity_derived": "niiri:f71d38ee9ef7cc1c310f15620e0322f1",
+      "entity": "niiri:ab91ba995acbb604c8550a19c6d56878"
     },
     {
-      "@id": "niiri:e1eec2c9ab22a771157b63f96f4e3648",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:bcb9b4ab7230df4bb758bc460b37e486",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0030",
-      "prov:atLocation": {"@id": "niiri:1a34585964e4aaa6e9b5c0537b167afa"},
+      "prov:atLocation": {"@id": "niiri:ef55d50c8d316e7518f786ea262cdb42"},
       "prov:value": {"@type": "xsd:float", "@value": "4.49974060058594"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.89913272010445"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.82689255971724e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.998798077640618"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.163634540984241"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.89913272010445"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.82689255971724e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.998798077640618"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.163634540984241"}
     },
     {
-      "@id": "niiri:1a34585964e4aaa6e9b5c0537b167afa",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ef55d50c8d316e7518f786ea262cdb42",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0030",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-40,22,36]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-40,22,36]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e1eec2c9ab22a771157b63f96f4e3648",
-      "entity": "niiri:f362fb2acc0fecc902d53e2682b7f919"
+      "entity_derived": "niiri:bcb9b4ab7230df4bb758bc460b37e486",
+      "entity": "niiri:ab91ba995acbb604c8550a19c6d56878"
     },
     {
-      "@id": "niiri:e747655ed61c067dcc187b824030be00",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0524275a9408ea6e1dc8e1d6c4ce5393",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0031",
-      "prov:atLocation": {"@id": "niiri:ac00c2bb2f5a70ea6b4a186793a8bf03"},
+      "prov:atLocation": {"@id": "niiri:cd88feb0442eabffbada9c5ef879e111"},
       "prov:value": {"@type": "xsd:float", "@value": "4.05374956130981"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.59770236066326"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000160520349498539"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999978604915"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.342543683213877"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.59770236066326"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000160520349498539"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999978604915"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.342543683213877"}
     },
     {
-      "@id": "niiri:ac00c2bb2f5a70ea6b4a186793a8bf03",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:cd88feb0442eabffbada9c5ef879e111",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0031",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-42,32,42]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-42,32,42]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e747655ed61c067dcc187b824030be00",
-      "entity": "niiri:f362fb2acc0fecc902d53e2682b7f919"
+      "entity_derived": "niiri:0524275a9408ea6e1dc8e1d6c4ce5393",
+      "entity": "niiri:ab91ba995acbb604c8550a19c6d56878"
     },
     {
-      "@id": "niiri:f9a205dcd7cddda455c20d193be8f9a1",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:1c7d7853345eae89866ead4836881a90",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0032",
-      "prov:atLocation": {"@id": "niiri:ed84b842109dd31c89ba5074de99ffda"},
+      "prov:atLocation": {"@id": "niiri:c4b770507a4d7626f6271474d76c97b2"},
       "prov:value": {"@type": "xsd:float", "@value": "6.25023365020752"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.87868788208187"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.339695245965e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.119105671995756"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00839771733178921"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.87868788208187"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.339695245965e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.119105671995756"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00839771733178921"}
     },
     {
-      "@id": "niiri:ed84b842109dd31c89ba5074de99ffda",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c4b770507a4d7626f6271474d76c97b2",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0032",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[52,-6,-34]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[52,-6,-34]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f9a205dcd7cddda455c20d193be8f9a1",
-      "entity": "niiri:f20977e52a75b5fa007a387cc6824614"
+      "entity_derived": "niiri:1c7d7853345eae89866ead4836881a90",
+      "entity": "niiri:8ddb469ed3d8d13f9f3b41143b2bc54e"
     },
     {
-      "@id": "niiri:618cb5bac8ece1d66da8a6ea46d30c75",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:1ed918e3e6e487b700b47936095209c4",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0033",
-      "prov:atLocation": {"@id": "niiri:24a8a59b616d44392b530e6b1da0fce3"},
+      "prov:atLocation": {"@id": "niiri:ae31349ed28884159eb4d5d66d33e3e3"},
       "prov:value": {"@type": "xsd:float", "@value": "6.18567895889282"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.84710419253793"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.26383204971326e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.139719202260282"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00953069985592431"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.84710419253793"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.26383204971326e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.139719202260282"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00953069985592431"}
     },
     {
-      "@id": "niiri:24a8a59b616d44392b530e6b1da0fce3",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ae31349ed28884159eb4d5d66d33e3e3",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0033",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-4,-46,-52]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-4,-46,-52]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:618cb5bac8ece1d66da8a6ea46d30c75",
-      "entity": "niiri:27140d3dcc60dbdda794838cc4910ac1"
+      "entity_derived": "niiri:1ed918e3e6e487b700b47936095209c4",
+      "entity": "niiri:fe3d995dc2bfdeb5f29182f0558560a6"
     },
     {
-      "@id": "niiri:1810e8b3f7e7bb68b4fd9164eee54e41",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:837348f6ba9eea5a44579dfe608168d9",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0034",
-      "prov:atLocation": {"@id": "niiri:5208b01a8c2a9ecc7648b9ea277e99fc"},
+      "prov:atLocation": {"@id": "niiri:ef98480f2fd69f2c61f22a53502771c8"},
       "prov:value": {"@type": "xsd:float", "@value": "3.76085114479065"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.38435212152789"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00035673219891208"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999995"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.549736132547086"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.38435212152789"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00035673219891208"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999995"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.549736132547086"}
     },
     {
-      "@id": "niiri:5208b01a8c2a9ecc7648b9ea277e99fc",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ef98480f2fd69f2c61f22a53502771c8",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0034",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[2,-40,-56]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[2,-40,-56]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1810e8b3f7e7bb68b4fd9164eee54e41",
-      "entity": "niiri:27140d3dcc60dbdda794838cc4910ac1"
+      "entity_derived": "niiri:837348f6ba9eea5a44579dfe608168d9",
+      "entity": "niiri:fe3d995dc2bfdeb5f29182f0558560a6"
     },
     {
-      "@id": "niiri:88759cfcfb7edbbfa0e528b9a0d1ccf9",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:fe8cde79b36b2168ffe3f9627203cbad",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0035",
-      "prov:atLocation": {"@id": "niiri:bb8e7291db54bb637d362bda5237f841"},
+      "prov:atLocation": {"@id": "niiri:aa376e8ac8714d8b18eae18d6a4283b5"},
       "prov:value": {"@type": "xsd:float", "@value": "6.11011409759521"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.80976084297033"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.55554926290536e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.168531878813079"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0108578016540005"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.80976084297033"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.55554926290536e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.168531878813079"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0108578016540005"}
     },
     {
-      "@id": "niiri:bb8e7291db54bb637d362bda5237f841",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:aa376e8ac8714d8b18eae18d6a4283b5",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0035",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-16,-22,24]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-16,-22,24]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:88759cfcfb7edbbfa0e528b9a0d1ccf9",
-      "entity": "niiri:292c1d14e546541ab02c17303b03d0d1"
+      "entity_derived": "niiri:fe8cde79b36b2168ffe3f9627203cbad",
+      "entity": "niiri:cfbb41a715a689539e32d23fa5ecf0ad"
     },
     {
-      "@id": "niiri:434621bd13567d9a2c5fd1d79530ac72",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d013871b13a39a72c56c973d8d7c69ea",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0036",
-      "prov:atLocation": {"@id": "niiri:55ed9d66b9acb7e80a3a7daeb1566934"},
+      "prov:atLocation": {"@id": "niiri:a0b4f6af10f809dffb754718d563928f"},
       "prov:value": {"@type": "xsd:float", "@value": "4.73779535293579"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.04985330158103"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.56248750450938e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.981601010330499"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.113611991025762"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.04985330158103"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.56248750450938e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.981601010330499"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.113611991025762"}
     },
     {
-      "@id": "niiri:55ed9d66b9acb7e80a3a7daeb1566934",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a0b4f6af10f809dffb754718d563928f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0036",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-16,-12,22]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-16,-12,22]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:434621bd13567d9a2c5fd1d79530ac72",
-      "entity": "niiri:292c1d14e546541ab02c17303b03d0d1"
+      "entity_derived": "niiri:d013871b13a39a72c56c973d8d7c69ea",
+      "entity": "niiri:cfbb41a715a689539e32d23fa5ecf0ad"
     },
     {
-      "@id": "niiri:f8d8c714270ee525d22b4519d40c655c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:4edccd0555b06c37550a7a304066b78e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0037",
-      "prov:atLocation": {"@id": "niiri:b1f69678ec21b54e036ca349f7c9fef8"},
+      "prov:atLocation": {"@id": "niiri:0199c0fccb5983aad9bd979030e607bb"},
       "prov:value": {"@type": "xsd:float", "@value": "3.99648928642273"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.55702003485366"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000187542779954697"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999997859921"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.376379972172505"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.55702003485366"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000187542779954697"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999997859921"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.376379972172505"}
     },
     {
-      "@id": "niiri:b1f69678ec21b54e036ca349f7c9fef8",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0199c0fccb5983aad9bd979030e607bb",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0037",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-12,0,12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-12,0,12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f8d8c714270ee525d22b4519d40c655c",
-      "entity": "niiri:292c1d14e546541ab02c17303b03d0d1"
+      "entity_derived": "niiri:4edccd0555b06c37550a7a304066b78e",
+      "entity": "niiri:cfbb41a715a689539e32d23fa5ecf0ad"
     },
     {
-      "@id": "niiri:b3925f274a8e224e7e058e06bbbb5536",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:937b4c105cb8dab064d0662d01153915",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0038",
-      "prov:atLocation": {"@id": "niiri:287f19134cc5d5770e57e4075b079a00"},
+      "prov:atLocation": {"@id": "niiri:ec598d9792349b28137d53c0e27bdcc9"},
       "prov:value": {"@type": "xsd:float", "@value": "6.04269409179688"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.77609641444734"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.9365362176963e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.199335784938733"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0122656272857256"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.77609641444734"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.9365362176963e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.199335784938733"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0122656272857256"}
     },
     {
-      "@id": "niiri:287f19134cc5d5770e57e4075b079a00",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ec598d9792349b28137d53c0e27bdcc9",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0038",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[60,-26,-26]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[60,-26,-26]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b3925f274a8e224e7e058e06bbbb5536",
-      "entity": "niiri:3d59b7c113f7b19df2458e17b2f822e9"
+      "entity_derived": "niiri:937b4c105cb8dab064d0662d01153915",
+      "entity": "niiri:1ea775914efd19bdf7935c45c2fc61d7"
     },
     {
-      "@id": "niiri:ff174d7c6db7e32869e0a99f614e8289",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5ef928ba0042c21ed23333a93026c5a5",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0039",
-      "prov:atLocation": {"@id": "niiri:5d0da4517d62b229280cd6b0d4d6e34e"},
+      "prov:atLocation": {"@id": "niiri:8d5aa4270374437a601d634b8fcd9627"},
       "prov:value": {"@type": "xsd:float", "@value": "5.89026117324829"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.69874511544533"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.3088244658066e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.274583699216449"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0161783507049903"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.69874511544533"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.3088244658066e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.274583699216449"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0161783507049903"}
     },
     {
-      "@id": "niiri:5d0da4517d62b229280cd6b0d4d6e34e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:8d5aa4270374437a601d634b8fcd9627",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0039",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-28,-58,-58]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-28,-58,-58]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ff174d7c6db7e32869e0a99f614e8289",
-      "entity": "niiri:444ae882759bc4fc11d5ae4c9e6cb1e1"
+      "entity_derived": "niiri:5ef928ba0042c21ed23333a93026c5a5",
+      "entity": "niiri:c9c2075e31233972320b91bbe319e15d"
     },
     {
-      "@id": "niiri:95f6abe9a06f549319a6f783851d4741",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3b48cac23fce59fddaa73fd59df07df2",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0040",
-      "prov:atLocation": {"@id": "niiri:b992b62e7d34f8d6d167804ed9010892"},
+      "prov:atLocation": {"@id": "niiri:e622a01f345c7734af0c378f60d34ee8"},
       "prov:value": {"@type": "xsd:float", "@value": "5.82566070556641"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.6654316334069"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.5398494003227e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.308848975990721"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0177557080539423"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.6654316334069"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.5398494003227e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.308848975990721"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0177557080539423"}
     },
     {
-      "@id": "niiri:b992b62e7d34f8d6d167804ed9010892",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e622a01f345c7734af0c378f60d34ee8",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0040",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-48,8,-34]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-48,8,-34]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:95f6abe9a06f549319a6f783851d4741",
-      "entity": "niiri:59566dcbed59d8991aa0141444f7d8ea"
+      "entity_derived": "niiri:3b48cac23fce59fddaa73fd59df07df2",
+      "entity": "niiri:184504b2959cc0300f56dbed9be3df0a"
     },
     {
-      "@id": "niiri:1cd030f56932f43287bc263768741843",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:91271dfe97a1459e04ef73790c14a894",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0041",
-      "prov:atLocation": {"@id": "niiri:e0590c1970f672da2d3ed4d649408a02"},
+      "prov:atLocation": {"@id": "niiri:666e30cb3b16d69e841f24335d524041"},
       "prov:value": {"@type": "xsd:float", "@value": "5.81330108642578"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.65902103562978"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.58858368881631e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.315770599808423"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0181106043668944"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.65902103562978"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.58858368881631e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.315770599808423"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0181106043668944"}
     },
     {
-      "@id": "niiri:e0590c1970f672da2d3ed4d649408a02",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:666e30cb3b16d69e841f24335d524041",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0041",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[42,-62,30]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[42,-62,30]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1cd030f56932f43287bc263768741843",
-      "entity": "niiri:2b54a24f6a0f9527c8816d93199577eb"
+      "entity_derived": "niiri:91271dfe97a1459e04ef73790c14a894",
+      "entity": "niiri:e56b27d2108b9aebc19f9ff56ac97dce"
     },
     {
-      "@id": "niiri:2316dc76081bf4b6ff88390be287a132",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:bd1b4d2f824f4a7a06cbe3b08d77df91",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0042",
-      "prov:atLocation": {"@id": "niiri:7f4f6eb0725a3a678b5a07c736d94088"},
+      "prov:atLocation": {"@id": "niiri:305ee930a25a4859579df48853fbc995"},
       "prov:value": {"@type": "xsd:float", "@value": "5.74564361572266"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.62371573654215"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.8846316389709e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.355751628578317"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0201990755486958"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.62371573654215"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.8846316389709e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.355751628578317"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0201990755486958"}
     },
     {
-      "@id": "niiri:7f4f6eb0725a3a678b5a07c736d94088",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:305ee930a25a4859579df48853fbc995",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0042",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-66,-34,6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-66,-34,6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2316dc76081bf4b6ff88390be287a132",
-      "entity": "niiri:678898fc201808d0072b6bbbea15acd2"
+      "entity_derived": "niiri:bd1b4d2f824f4a7a06cbe3b08d77df91",
+      "entity": "niiri:e78e0827b0a80cf9fb06ff0a74ee9600"
     },
     {
-      "@id": "niiri:ecd8db6806e25d3beb542ce98d7ffd31",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d1e90a72a70964a43504b62fa88ceb97",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0043",
-      "prov:atLocation": {"@id": "niiri:67e74bebb3aef324bdfbb1927c4102ab"},
+      "prov:atLocation": {"@id": "niiri:7a6d9d5ba64d3a00dfc724e8fda92efd"},
       "prov:value": {"@type": "xsd:float", "@value": "5.72459840774536"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.61265957667344"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.98774558690662e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.368904498827799"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0207237790143809"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.61265957667344"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.98774558690662e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.368904498827799"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0207237790143809"}
     },
     {
-      "@id": "niiri:67e74bebb3aef324bdfbb1927c4102ab",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7a6d9d5ba64d3a00dfc724e8fda92efd",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0043",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[36,-10,-30]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[36,-10,-30]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ecd8db6806e25d3beb542ce98d7ffd31",
-      "entity": "niiri:5a11d9bb922c3f53cb59978d26e7d5b0"
+      "entity_derived": "niiri:d1e90a72a70964a43504b62fa88ceb97",
+      "entity": "niiri:461b922ff7bd3d15d33f54bcbd492da3"
     },
     {
-      "@id": "niiri:c1eb9061ff68199e554a258e7d2b3eba",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e777d8426ec1922a9300b8c510619da9",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0044",
-      "prov:atLocation": {"@id": "niiri:76ece82011b84afeaa2a5a7ab1a920e2"},
+      "prov:atLocation": {"@id": "niiri:23b0f724f37361cf3634731181e5dc78"},
       "prov:value": {"@type": "xsd:float", "@value": "5.54388046264648"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.51622836043788"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.14753889907315e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.494815113923139"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0284655212355184"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.51622836043788"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.14753889907315e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.494815113923139"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0284655212355184"}
     },
     {
-      "@id": "niiri:76ece82011b84afeaa2a5a7ab1a920e2",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:23b0f724f37361cf3634731181e5dc78",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0044",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[30,-8,-36]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[30,-8,-36]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c1eb9061ff68199e554a258e7d2b3eba",
-      "entity": "niiri:5a11d9bb922c3f53cb59978d26e7d5b0"
+      "entity_derived": "niiri:e777d8426ec1922a9300b8c510619da9",
+      "entity": "niiri:461b922ff7bd3d15d33f54bcbd492da3"
     },
     {
-      "@id": "niiri:c631dd7b156f3726c21b6d299ced2524",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:87ad6041e36ec3077cd5b4ed5e1e763f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0045",
-      "prov:atLocation": {"@id": "niiri:b4729d5f2dbaa1349314ed4fd23e3d51"},
+      "prov:atLocation": {"@id": "niiri:3e3954b4c6a217ea807c8782412311d6"},
       "prov:value": {"@type": "xsd:float", "@value": "5.70221662521362"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.60086214528593"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.10372912945456e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.38325974300236"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0216156089926179"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.60086214528593"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.10372912945456e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.38325974300236"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0216156089926179"}
     },
     {
-      "@id": "niiri:b4729d5f2dbaa1349314ed4fd23e3d51",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:3e3954b4c6a217ea807c8782412311d6",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0045",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[20,-12,-32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[20,-12,-32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c631dd7b156f3726c21b6d299ced2524",
-      "entity": "niiri:64a43fe12cd19a1e197d1e7627a3bda5"
+      "entity_derived": "niiri:87ad6041e36ec3077cd5b4ed5e1e763f",
+      "entity": "niiri:1cfc9f0a458d8852ad0759c9e8be8a6a"
     },
     {
-      "@id": "niiri:3aad84992ebacde3d10bfadda38ecb1b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:40a241f7cfcef8552dfd5aadd9a4fbf1",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0046",
-      "prov:atLocation": {"@id": "niiri:22be3a17e239ca461f954ab69657d740"},
+      "prov:atLocation": {"@id": "niiri:02ae91295919dd56e833cd7a1878872d"},
       "prov:value": {"@type": "xsd:float", "@value": "5.64641094207764"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.57126970388676"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.42388931537274e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.420654930029894"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0237830877156679"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.57126970388676"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.42388931537274e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.420654930029894"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0237830877156679"}
     },
     {
-      "@id": "niiri:22be3a17e239ca461f954ab69657d740",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:02ae91295919dd56e833cd7a1878872d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0046",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-18,40,-18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-18,40,-18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3aad84992ebacde3d10bfadda38ecb1b",
-      "entity": "niiri:df9def02f0fbb31e7bb7de54da832bdb"
+      "entity_derived": "niiri:40a241f7cfcef8552dfd5aadd9a4fbf1",
+      "entity": "niiri:5bbe3c6a1630a3c2cc55aa12dfd9e286"
     },
     {
-      "@id": "niiri:23f0c7d741cd7bdec521d4d47f46057c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:8454ccb4e839a31841899dbcc90d3705",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0047",
-      "prov:atLocation": {"@id": "niiri:b72f4dabd901390b9eb5c1e2d7942d1e"},
+      "prov:atLocation": {"@id": "niiri:c1b0358ca9a48ab3254cdf0336ad4a33"},
       "prov:value": {"@type": "xsd:float", "@value": "5.51601076126099"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.50111380137384"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.37991495569234e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.516023728324697"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0299758857250781"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.50111380137384"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.37991495569234e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.516023728324697"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0299758857250781"}
     },
     {
-      "@id": "niiri:b72f4dabd901390b9eb5c1e2d7942d1e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c1b0358ca9a48ab3254cdf0336ad4a33",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0047",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-64,-22,18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-64,-22,18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:23f0c7d741cd7bdec521d4d47f46057c",
-      "entity": "niiri:49955533f78bc4787cee05a051461dcf"
+      "entity_derived": "niiri:8454ccb4e839a31841899dbcc90d3705",
+      "entity": "niiri:1e1925d1a7237f41c7f4bbc7a938991e"
     },
     {
-      "@id": "niiri:e19773c350b50b7d8a3b47d9447196f0",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:25112a96f0a534131b06def72c92db36",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0048",
-      "prov:atLocation": {"@id": "niiri:57c89bd677e305f56190bb3e4f5f0746"},
+      "prov:atLocation": {"@id": "niiri:a8ffc84bd049668e67aacf1f8dd72e50"},
       "prov:value": {"@type": "xsd:float", "@value": "3.82918906211853"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.43532602661172"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000295920667697569"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999572"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.497645692606821"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.43532602661172"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000295920667697569"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999572"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.497645692606821"}
     },
     {
-      "@id": "niiri:57c89bd677e305f56190bb3e4f5f0746",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a8ffc84bd049668e67aacf1f8dd72e50",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0048",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-66,-14,12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-66,-14,12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e19773c350b50b7d8a3b47d9447196f0",
-      "entity": "niiri:49955533f78bc4787cee05a051461dcf"
+      "entity_derived": "niiri:25112a96f0a534131b06def72c92db36",
+      "entity": "niiri:1e1925d1a7237f41c7f4bbc7a938991e"
     },
     {
-      "@id": "niiri:640f907d4e61a8f0b64c49cee18c2868",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ebbe77abb440c0b57b92a0f3181bf3ef",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0049",
-      "prov:atLocation": {"@id": "niiri:ab8587778455781253a54329b5806379"},
+      "prov:atLocation": {"@id": "niiri:3157cc359f1512741beefb7f95680def"},
       "prov:value": {"@type": "xsd:float", "@value": "5.50570774078369"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.49550933866504"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.47018059765336e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.523959489710639"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0302612822408903"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.49550933866504"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.47018059765336e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.523959489710639"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0302612822408903"}
     },
     {
-      "@id": "niiri:ab8587778455781253a54329b5806379",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:3157cc359f1512741beefb7f95680def",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0049",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-66,-48,6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-66,-48,6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:640f907d4e61a8f0b64c49cee18c2868",
-      "entity": "niiri:49c6aebff31b5e29c05f3709fd4ca0c7"
+      "entity_derived": "niiri:ebbe77abb440c0b57b92a0f3181bf3ef",
+      "entity": "niiri:45311fe546d4fc676e17072f500c1575"
     },
     {
-      "@id": "niiri:457d426bed2f68f96d1cc2ade09a557d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:622888501323beabd65ee1c12fd5258f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0050",
-      "prov:atLocation": {"@id": "niiri:65ad2c6de94a4d6574aad746874fefe6"},
+      "prov:atLocation": {"@id": "niiri:fb270858fb08b357c3467e4870a4a457"},
       "prov:value": {"@type": "xsd:float", "@value": "3.62412595748901"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.28004199841764"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00051895817294012"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.680244967613049"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.28004199841764"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00051895817294012"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.680244967613049"}
     },
     {
-      "@id": "niiri:65ad2c6de94a4d6574aad746874fefe6",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:fb270858fb08b357c3467e4870a4a457",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0050",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-62,-54,12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-62,-54,12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:457d426bed2f68f96d1cc2ade09a557d",
-      "entity": "niiri:49c6aebff31b5e29c05f3709fd4ca0c7"
+      "entity_derived": "niiri:622888501323beabd65ee1c12fd5258f",
+      "entity": "niiri:45311fe546d4fc676e17072f500c1575"
     },
     {
-      "@id": "niiri:2485eb0ee3130f59d77b5ba61c12caa6",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:2cc303fb0baeaaf69f5c83c6ace6046d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0051",
-      "prov:atLocation": {"@id": "niiri:49d9626964e1b0feb5d3db997a02912c"},
+      "prov:atLocation": {"@id": "niiri:607064945943841f97401329f5ca9097"},
       "prov:value": {"@type": "xsd:float", "@value": "5.30499839782715"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.38447219630665"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.81336653915354e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.683924483063057"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0434545575886298"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.38447219630665"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.81336653915354e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.683924483063057"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0434545575886298"}
     },
     {
-      "@id": "niiri:49d9626964e1b0feb5d3db997a02912c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:607064945943841f97401329f5ca9097",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0051",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[60,-24,12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[60,-24,12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2485eb0ee3130f59d77b5ba61c12caa6",
-      "entity": "niiri:9315b753bce8ecc349364143d90f1ad9"
+      "entity_derived": "niiri:2cc303fb0baeaaf69f5c83c6ace6046d",
+      "entity": "niiri:12134d971afb042d040aea6cecc0ebec"
     },
     {
-      "@id": "niiri:599c58cb1c715550934270309e5d92c4",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:939c3046fadf99b92e995efdba77b780",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0052",
-      "prov:atLocation": {"@id": "niiri:a0c806bb16f366f2daaa00a3103409fd"},
+      "prov:atLocation": {"@id": "niiri:614cae25fc7f61eac2167c4d17908165"},
       "prov:value": {"@type": "xsd:float", "@value": "4.79114770889282"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.08274799068102"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.22531390113856e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.971408745964108"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.103697297505344"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.08274799068102"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.22531390113856e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.971408745964108"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.103697297505344"}
     },
     {
-      "@id": "niiri:a0c806bb16f366f2daaa00a3103409fd",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:614cae25fc7f61eac2167c4d17908165",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0052",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[52,-26,14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[52,-26,14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:599c58cb1c715550934270309e5d92c4",
-      "entity": "niiri:9315b753bce8ecc349364143d90f1ad9"
+      "entity_derived": "niiri:939c3046fadf99b92e995efdba77b780",
+      "entity": "niiri:12134d971afb042d040aea6cecc0ebec"
     },
     {
-      "@id": "niiri:487f02ddfb3f9e916ad2e5e486ad070e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:59954b6fbe4f7e0ee8297e3dfb447725",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0053",
-      "prov:atLocation": {"@id": "niiri:b51b562218e70b9f595fed09e9dfe68d"},
+      "prov:atLocation": {"@id": "niiri:e83fc68807e48503e867fd7c663330c0"},
       "prov:value": {"@type": "xsd:float", "@value": "5.23910284042358"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.34722318758447"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.89359534200573e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.735719811343891"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0492439815526957"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.34722318758447"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.89359534200573e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.735719811343891"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0492439815526957"}
     },
     {
-      "@id": "niiri:b51b562218e70b9f595fed09e9dfe68d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e83fc68807e48503e867fd7c663330c0",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0053",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-6,-76,-44]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-6,-76,-44]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:487f02ddfb3f9e916ad2e5e486ad070e",
-      "entity": "niiri:c92570bdb9c49bf92cb00c5c23880685"
+      "entity_derived": "niiri:59954b6fbe4f7e0ee8297e3dfb447725",
+      "entity": "niiri:7dfc1da184d477320648da6e59dc2a7c"
     },
     {
-      "@id": "niiri:a789d5825fdbfdf588b010bc726bf710",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0d75e98dbb1ee49d43d97017b2bc924f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0054",
-      "prov:atLocation": {"@id": "niiri:77a56c3036c4e2f799d7939c9fdb2eb0"},
+      "prov:atLocation": {"@id": "niiri:26be6593f3f57b0aed0ef977c3e0e360"},
       "prov:value": {"@type": "xsd:float", "@value": "5.23777103424072"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.34646618864733"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.91741829794701e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.736746205981572"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0492530384603998"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.34646618864733"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.91741829794701e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.736746205981572"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0492530384603998"}
     },
     {
-      "@id": "niiri:77a56c3036c4e2f799d7939c9fdb2eb0",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:26be6593f3f57b0aed0ef977c3e0e360",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0054",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-46,16,42]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-46,16,42]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a789d5825fdbfdf588b010bc726bf710",
-      "entity": "niiri:e491d13c4d524178ac2c358bfec8b0ab"
+      "entity_derived": "niiri:0d75e98dbb1ee49d43d97017b2bc924f",
+      "entity": "niiri:ff37e6b9b5486e16e27ae0fca1db545d"
     },
     {
-      "@id": "niiri:7574da76f3b81c35aa42c65a792b9e10",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:60e306c02d06deb6b75ca415cf7afa84",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0055",
-      "prov:atLocation": {"@id": "niiri:1c0aecab207d856680c4d50f3ed33f2b"},
+      "prov:atLocation": {"@id": "niiri:a44a17f66a85b8599debb783042f342d"},
       "prov:value": {"@type": "xsd:float", "@value": "5.16541767120361"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.30508875032236"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.34594019494261e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.79072771323468"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0554020873789584"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.30508875032236"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.34594019494261e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.79072771323468"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0554020873789584"}
     },
     {
-      "@id": "niiri:1c0aecab207d856680c4d50f3ed33f2b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a44a17f66a85b8599debb783042f342d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0055",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[48,-16,14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[48,-16,14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7574da76f3b81c35aa42c65a792b9e10",
-      "entity": "niiri:605ecba3a006393b32ebef7f5177a299"
+      "entity_derived": "niiri:60e306c02d06deb6b75ca415cf7afa84",
+      "entity": "niiri:bfb3c58b6c12062e86b12426bbf496d9"
     },
     {
-      "@id": "niiri:032951392e18253dfc74a1d2b1c12f10",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:70c48b68597d17a57d7df6777d571a0d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0056",
-      "prov:atLocation": {"@id": "niiri:e898e2d82d24df225f1127a92e31f65c"},
+      "prov:atLocation": {"@id": "niiri:63c92f8e694fff1184419aacd9378eaa"},
       "prov:value": {"@type": "xsd:float", "@value": "5.04228210449219"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.23350816985445"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.1503691013437e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.871162148697437"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0694084780297125"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.23350816985445"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.1503691013437e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.871162148697437"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0694084780297125"}
     },
     {
-      "@id": "niiri:e898e2d82d24df225f1127a92e31f65c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:63c92f8e694fff1184419aacd9378eaa",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0056",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[56,-14,10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[56,-14,10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:032951392e18253dfc74a1d2b1c12f10",
-      "entity": "niiri:605ecba3a006393b32ebef7f5177a299"
+      "entity_derived": "niiri:70c48b68597d17a57d7df6777d571a0d",
+      "entity": "niiri:bfb3c58b6c12062e86b12426bbf496d9"
     },
     {
-      "@id": "niiri:520bcf676a06a4ca52471b03575e7a6b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:4febc9242872f447f9f0fb6d8187edd9",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0057",
-      "prov:atLocation": {"@id": "niiri:4bda8b7619e4fc3b50623978723a468a"},
+      "prov:atLocation": {"@id": "niiri:9cc744b2ef0b321a73a7c3ffc643b63c"},
       "prov:value": {"@type": "xsd:float", "@value": "4.93621253967285"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.17063459410943"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.51876293638109e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.924687668878693"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0829690614620754"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.17063459410943"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.51876293638109e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.924687668878693"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0829690614620754"}
     },
     {
-      "@id": "niiri:4bda8b7619e4fc3b50623978723a468a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:9cc744b2ef0b321a73a7c3ffc643b63c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0057",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[40,-12,14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[40,-12,14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:520bcf676a06a4ca52471b03575e7a6b",
-      "entity": "niiri:605ecba3a006393b32ebef7f5177a299"
+      "entity_derived": "niiri:4febc9242872f447f9f0fb6d8187edd9",
+      "entity": "niiri:bfb3c58b6c12062e86b12426bbf496d9"
     },
     {
-      "@id": "niiri:5825afe4f8d264d3a86abf8a8143bb86",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:6309cc2f72b3ba21a56aceea534b259c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0058",
-      "prov:atLocation": {"@id": "niiri:2de1e40f79c81991b212d1351dd8c9ed"},
+      "prov:atLocation": {"@id": "niiri:16fe50f2d483d0250919ca566d224a60"},
       "prov:value": {"@type": "xsd:float", "@value": "5.16341876983643"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.30393854152611"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.38941134995164e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.792161008528185"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0554020873789584"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.30393854152611"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.38941134995164e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.792161008528185"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0554020873789584"}
     },
     {
-      "@id": "niiri:2de1e40f79c81991b212d1351dd8c9ed",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:16fe50f2d483d0250919ca566d224a60",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0058",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-28,6,62]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-28,6,62]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5825afe4f8d264d3a86abf8a8143bb86",
-      "entity": "niiri:792e740d5505df540f825e8630189126"
+      "entity_derived": "niiri:6309cc2f72b3ba21a56aceea534b259c",
+      "entity": "niiri:b1059120ca68f8c294f13d22a334afc5"
     },
     {
-      "@id": "niiri:8e9b9a00f7fe8891b1220f3ba0ae6380",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3af656624dd76ed9af5b633959de57aa",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0059",
-      "prov:atLocation": {"@id": "niiri:69e0772e7dad7498a8a5df57e5d5d24b"},
+      "prov:atLocation": {"@id": "niiri:2207a1786e7e1335381eca0ad553a27d"},
       "prov:value": {"@type": "xsd:float", "@value": "5.15367984771729"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.29832907222195"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.60452684559032e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.799092501739318"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0561583848310698"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.29832907222195"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.60452684559032e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.799092501739318"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0561583848310698"}
     },
     {
-      "@id": "niiri:69e0772e7dad7498a8a5df57e5d5d24b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:2207a1786e7e1335381eca0ad553a27d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0059",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-60,8,0]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-60,8,0]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8e9b9a00f7fe8891b1220f3ba0ae6380",
-      "entity": "niiri:5b18eef1ef74501ea55e4ac7f04163eb"
+      "entity_derived": "niiri:3af656624dd76ed9af5b633959de57aa",
+      "entity": "niiri:dd43f04c7775bf5d225a62b05a1f8275"
     },
     {
-      "@id": "niiri:a669ed7f0ef590d607b0c01700cce297",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:6a4d1d270484e6aaf38f13bdd3037234",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0060",
-      "prov:atLocation": {"@id": "niiri:0bb9b8c6033b015bb085e1cc50c5394d"},
+      "prov:atLocation": {"@id": "niiri:f9bd5a66fb8e6af654b99e17a2115983"},
       "prov:value": {"@type": "xsd:float", "@value": "4.63001489639282"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.98242834282796"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.41073475436104e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.993645272304345"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.133707794797061"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.98242834282796"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.41073475436104e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.993645272304345"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.133707794797061"}
     },
     {
-      "@id": "niiri:0bb9b8c6033b015bb085e1cc50c5394d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f9bd5a66fb8e6af654b99e17a2115983",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0060",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-58,0,2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-58,0,2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a669ed7f0ef590d607b0c01700cce297",
-      "entity": "niiri:5b18eef1ef74501ea55e4ac7f04163eb"
+      "entity_derived": "niiri:6a4d1d270484e6aaf38f13bdd3037234",
+      "entity": "niiri:dd43f04c7775bf5d225a62b05a1f8275"
     },
     {
-      "@id": "niiri:a7eeea51c2bb4172feef3e0ba9a0d435",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c6fcc1f2ec131691f25f7ea0f2e12eb7",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0061",
-      "prov:atLocation": {"@id": "niiri:f0e35547f105243131eff4949ac7ede8"},
+      "prov:atLocation": {"@id": "niiri:d28f87df7e33ffced1cd1c65433f6dd9"},
       "prov:value": {"@type": "xsd:float", "@value": "5.13582944869995"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.28802377033811"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "9.01349028958887e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.811564040895531"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0582499630192324"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.28802377033811"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "9.01349028958887e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.811564040895531"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0582499630192324"}
     },
     {
-      "@id": "niiri:f0e35547f105243131eff4949ac7ede8",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d28f87df7e33ffced1cd1c65433f6dd9",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0061",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[62,-4,-18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[62,-4,-18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a7eeea51c2bb4172feef3e0ba9a0d435",
-      "entity": "niiri:2a0d5cd5e741995710fe2bdd14adb005"
+      "entity_derived": "niiri:c6fcc1f2ec131691f25f7ea0f2e12eb7",
+      "entity": "niiri:c723d93708cb4dee84578d4dad2314df"
     },
     {
-      "@id": "niiri:7e4c23daaec9d9eb36d437eb5c9342e6",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b749f6df0e9c14d8711813f709744b7f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0062",
-      "prov:atLocation": {"@id": "niiri:83c77d8d93a7158eef0cf81da673f1a3"},
+      "prov:atLocation": {"@id": "niiri:ffb706fd0bf0d0619cb3999481194ffb"},
       "prov:value": {"@type": "xsd:float", "@value": "5.06757831573486"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.24833497375142"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.07682603029957e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.856090469899599"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0664563384555011"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.24833497375142"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.07682603029957e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.856090469899599"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0664563384555011"}
     },
     {
-      "@id": "niiri:83c77d8d93a7158eef0cf81da673f1a3",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ffb706fd0bf0d0619cb3999481194ffb",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0062",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[30,54,-44]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[30,54,-44]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7e4c23daaec9d9eb36d437eb5c9342e6",
-      "entity": "niiri:adca675d0dc4660fb2170e6ead12a50a"
+      "entity_derived": "niiri:b749f6df0e9c14d8711813f709744b7f",
+      "entity": "niiri:d30171bbdc271c074a6050acb8a4d34e"
     },
     {
-      "@id": "niiri:a3660ec9bcd34f5cb6da9ae0b4066109",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:31f45e8d9b10c8383ebb56334d2cd5f6",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0063",
-      "prov:atLocation": {"@id": "niiri:9c631d906d5287aff564998ecc4f8cce"},
+      "prov:atLocation": {"@id": "niiri:eea3a5acdf27e2de2dab85015bbaea23"},
       "prov:value": {"@type": "xsd:float", "@value": "5.02421474456787"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.2228792447941"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.20600532134141e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.881407445915171"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.071813553261658"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.2228792447941"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.20600532134141e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.881407445915171"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.071813553261658"}
     },
     {
-      "@id": "niiri:9c631d906d5287aff564998ecc4f8cce",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:eea3a5acdf27e2de2dab85015bbaea23",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0063",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-30,-16,-20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-30,-16,-20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a3660ec9bcd34f5cb6da9ae0b4066109",
-      "entity": "niiri:5e628c0b7abb6a720a8a91ae5f6c769c"
+      "entity_derived": "niiri:31f45e8d9b10c8383ebb56334d2cd5f6",
+      "entity": "niiri:ea2ed9cc4d84a345a4920b11801993b3"
     },
     {
-      "@id": "niiri:8a18e9844ab6e1afcb094f9b9fe9ade8",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:daf29f6ab3520aed8f7ff3bc5e75f2ab",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0064",
-      "prov:atLocation": {"@id": "niiri:c7fdf91a09e1f605b6f0a86b17fb7ba2"},
+      "prov:atLocation": {"@id": "niiri:7f8295ad4df78742c62a26488eb8fad3"},
       "prov:value": {"@type": "xsd:float", "@value": "4.74015760421753"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.05131641531498"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.54651392115335e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.981217661454756"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.113611991025762"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.05131641531498"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.54651392115335e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.981217661454756"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.113611991025762"}
     },
     {
-      "@id": "niiri:c7fdf91a09e1f605b6f0a86b17fb7ba2",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7f8295ad4df78742c62a26488eb8fad3",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0064",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-22,-18,-20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-22,-18,-20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8a18e9844ab6e1afcb094f9b9fe9ade8",
-      "entity": "niiri:5e628c0b7abb6a720a8a91ae5f6c769c"
+      "entity_derived": "niiri:daf29f6ab3520aed8f7ff3bc5e75f2ab",
+      "entity": "niiri:ea2ed9cc4d84a345a4920b11801993b3"
     },
     {
-      "@id": "niiri:d6c89785a0b95f8bffbed2ff4cb64851",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ad918640c79c32e0c9a09cfe39505035",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0065",
-      "prov:atLocation": {"@id": "niiri:97cf8d3c545623e4d9dd1de2c4904514"},
+      "prov:atLocation": {"@id": "niiri:9b2d2ac968f225bd22ee939592ac64c4"},
       "prov:value": {"@type": "xsd:float", "@value": "4.96017456054688"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.18493879672852"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.42621472154492e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.914023389189348"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0802451723107542"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.18493879672852"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.42621472154492e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.914023389189348"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0802451723107542"}
     },
     {
-      "@id": "niiri:97cf8d3c545623e4d9dd1de2c4904514",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:9b2d2ac968f225bd22ee939592ac64c4",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0065",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[10,-24,16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[10,-24,16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d6c89785a0b95f8bffbed2ff4cb64851",
-      "entity": "niiri:e8494b3e58d9094d2cc21652c223abe4"
+      "entity_derived": "niiri:ad918640c79c32e0c9a09cfe39505035",
+      "entity": "niiri:cf3d3e192bab8fb0febbddda2b472570"
     },
     {
-      "@id": "niiri:39aea2637649c51f04ef88233664ec2c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f84262ea494283ee11627a522f8067fc",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0066",
-      "prov:atLocation": {"@id": "niiri:25c72afe587c80bdc78a40751fe14148"},
+      "prov:atLocation": {"@id": "niiri:a7010eb90cdca5180078541caabd7ee2"},
       "prov:value": {"@type": "xsd:float", "@value": "4.94747877120972"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.17736739359608"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.47451242935581e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.919779784602502"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0821139058098193"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.17736739359608"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.47451242935581e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.919779784602502"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0821139058098193"}
     },
     {
-      "@id": "niiri:25c72afe587c80bdc78a40751fe14148",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a7010eb90cdca5180078541caabd7ee2",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0066",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[48,-72,-16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[48,-72,-16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:39aea2637649c51f04ef88233664ec2c",
-      "entity": "niiri:2a3839763db274e8b4cae9d895b6483d"
+      "entity_derived": "niiri:f84262ea494283ee11627a522f8067fc",
+      "entity": "niiri:a6ee0e116834a7cbcea03e95f20dae54"
     },
     {
-      "@id": "niiri:d4f9b70d314c8c6f922cf7bd9fb1fe30",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:65f0d327b04aadb8425ee54a012bfd51",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0067",
-      "prov:atLocation": {"@id": "niiri:ecb155ab41b55d6238b7afc06b2e2b26"},
+      "prov:atLocation": {"@id": "niiri:86c99915fb4938033cef1f1c79f20f26"},
       "prov:value": {"@type": "xsd:float", "@value": "4.93897771835327"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.17228830640617"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.50777864580398e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.923500556854135"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0829347355349478"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.17228830640617"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.50777864580398e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.923500556854135"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0829347355349478"}
     },
     {
-      "@id": "niiri:ecb155ab41b55d6238b7afc06b2e2b26",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:86c99915fb4938033cef1f1c79f20f26",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0067",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-26,4,16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-26,4,16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d4f9b70d314c8c6f922cf7bd9fb1fe30",
-      "entity": "niiri:d2c4ecdb2f17a5fa414bc38579edb8f3"
+      "entity_derived": "niiri:65f0d327b04aadb8425ee54a012bfd51",
+      "entity": "niiri:e9b27c64b1591506ec57168d7dbf134f"
     },
     {
-      "@id": "niiri:b4d2481c57ef30b25fbeea3702d7b949",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:135656545b11da25b3b9e5296a4c1583",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0068",
-      "prov:atLocation": {"@id": "niiri:e6a4cafa8e5684c22383551c2dbe5bdd"},
+      "prov:atLocation": {"@id": "niiri:124fd785f1011c77e93bf0bc0cda783f"},
       "prov:value": {"@type": "xsd:float", "@value": "4.91353464126587"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.15704210840336"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.61197292659621e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.933994187279112"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0855746630008624"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.15704210840336"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.61197292659621e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.933994187279112"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0855746630008624"}
     },
     {
-      "@id": "niiri:e6a4cafa8e5684c22383551c2dbe5bdd",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:124fd785f1011c77e93bf0bc0cda783f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0068",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[26,18,64]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[26,18,64]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b4d2481c57ef30b25fbeea3702d7b949",
-      "entity": "niiri:770d3b226608026413a9c2a34b0a1793"
+      "entity_derived": "niiri:135656545b11da25b3b9e5296a4c1583",
+      "entity": "niiri:35e614f307abb1c7215e649c0bbf0aa0"
     },
     {
-      "@id": "niiri:0c29f95be682b4f5566f488c8cdf0854",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:16a0de533a153793ccdac522009f77c2",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0069",
-      "prov:atLocation": {"@id": "niiri:47021cde688fadb5d9941d8b66a02b77"},
+      "prov:atLocation": {"@id": "niiri:a5edccaa1ee1e1a3cf37954dc584b2c1"},
       "prov:value": {"@type": "xsd:float", "@value": "4.90734338760376"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.15332192293598"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.63841617967231e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.936402129572896"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0863919526492905"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.15332192293598"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.63841617967231e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.936402129572896"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0863919526492905"}
     },
     {
-      "@id": "niiri:47021cde688fadb5d9941d8b66a02b77",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a5edccaa1ee1e1a3cf37954dc584b2c1",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0069",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[0,-22,-54]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[0,-22,-54]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0c29f95be682b4f5566f488c8cdf0854",
-      "entity": "niiri:16b9e50b259cea22c334cdb43404b9b4"
+      "entity_derived": "niiri:16a0de533a153793ccdac522009f77c2",
+      "entity": "niiri:84661ae12e172546f496d4b26feacce8"
     },
     {
-      "@id": "niiri:6538d60d100cfda9910f74b7a0eb57aa",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:26852796b5d7ba6eb653315a8accd667",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0070",
-      "prov:atLocation": {"@id": "niiri:5e8c23f6e73edc168f9d581e8cd4eb29"},
+      "prov:atLocation": {"@id": "niiri:27f8457a9b46baae1a37773f8f85876a"},
       "prov:value": {"@type": "xsd:float", "@value": "4.90487241744995"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.15183605169709"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.64909255723211e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.937347294524692"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0866104581112591"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.15183605169709"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.64909255723211e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.937347294524692"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0866104581112591"}
     },
     {
-      "@id": "niiri:5e8c23f6e73edc168f9d581e8cd4eb29",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:27f8457a9b46baae1a37773f8f85876a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0070",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[10,30,-6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[10,30,-6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6538d60d100cfda9910f74b7a0eb57aa",
-      "entity": "niiri:8d690e036ac0c4f773f14d063bc26982"
+      "entity_derived": "niiri:26852796b5d7ba6eb653315a8accd667",
+      "entity": "niiri:b3ab45e7aaebdd6d5415f3e8fb8365d3"
     },
     {
-      "@id": "niiri:e3a4a5c00a5b127c22c7a90646c37e59",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:645365b733aee62b96ed5d9eb97c872a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0071",
-      "prov:atLocation": {"@id": "niiri:552fdebe80de450291edea3e1259b2d9"},
+      "prov:atLocation": {"@id": "niiri:61461b4cb693c67119ecef5cce38f06c"},
       "prov:value": {"@type": "xsd:float", "@value": "4.90001773834229"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.14891491710542"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.67027465689529e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.939177943711304"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0873354556109577"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.14891491710542"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.67027465689529e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.939177943711304"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0873354556109577"}
     },
     {
-      "@id": "niiri:552fdebe80de450291edea3e1259b2d9",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:61461b4cb693c67119ecef5cce38f06c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0071",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[28,-14,10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[28,-14,10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e3a4a5c00a5b127c22c7a90646c37e59",
-      "entity": "niiri:871bd0030276be32c9682273d65be8a4"
+      "entity_derived": "niiri:645365b733aee62b96ed5d9eb97c872a",
+      "entity": "niiri:a9dd639eb89226977a3ede42cafc093c"
     },
     {
-      "@id": "niiri:66599b6396ec5d3d776eea1f305bf4bf",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:9a917736e3d5642e34dc1a8c05d59370",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0072",
-      "prov:atLocation": {"@id": "niiri:7bc7da5422c076be933244c4657cfdcb"},
+      "prov:atLocation": {"@id": "niiri:7024715a649a60cb4dc55a269c6a23a0"},
       "prov:value": {"@type": "xsd:float", "@value": "4.8938684463501"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.14521124011164"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.69750293880222e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.941446847291943"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0877947883186739"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.14521124011164"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.69750293880222e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.941446847291943"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0877947883186739"}
     },
     {
-      "@id": "niiri:7bc7da5422c076be933244c4657cfdcb",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7024715a649a60cb4dc55a269c6a23a0",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0072",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-50,-34,2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-50,-34,2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:66599b6396ec5d3d776eea1f305bf4bf",
-      "entity": "niiri:fd8207df6ecd8a6e5899191a7d1b9cec"
+      "entity_derived": "niiri:9a917736e3d5642e34dc1a8c05d59370",
+      "entity": "niiri:01b4ff55ed7965f77f28199c98d35002"
     },
     {
-      "@id": "niiri:1b91ec1d915124abfb7102f075ee114f",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:8e8f82ce9a9f916915f7207c051727bd",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0073",
-      "prov:atLocation": {"@id": "niiri:af0eca1f60ac2e58cb6fec62f9982c26"},
+      "prov:atLocation": {"@id": "niiri:17584b61b2e1ba24747384b5df72b417"},
       "prov:value": {"@type": "xsd:float", "@value": "4.71507501602173"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.03574917489321"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.72141698914874e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.984994076694401"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.117674394049896"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.03574917489321"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.72141698914874e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.984994076694401"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.117674394049896"}
     },
     {
-      "@id": "niiri:af0eca1f60ac2e58cb6fec62f9982c26",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:17584b61b2e1ba24747384b5df72b417",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0073",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-50,-44,-2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-50,-44,-2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1b91ec1d915124abfb7102f075ee114f",
-      "entity": "niiri:fd8207df6ecd8a6e5899191a7d1b9cec"
+      "entity_derived": "niiri:8e8f82ce9a9f916915f7207c051727bd",
+      "entity": "niiri:01b4ff55ed7965f77f28199c98d35002"
     },
     {
-      "@id": "niiri:8aa3b01ee444af495e69be10cbf53286",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a67831c35816df52629ee7a7fc26dde0",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0074",
-      "prov:atLocation": {"@id": "niiri:60a7e5e2fff4cfad3b1011063fd34696"},
+      "prov:atLocation": {"@id": "niiri:fa7748f42b4ea105392364e1f036194b"},
       "prov:value": {"@type": "xsd:float", "@value": "4.19112873077393"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.69339227166818"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000110641138199918"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999998036789566"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.27646623644364"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.69339227166818"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000110641138199918"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999998036789566"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.27646623644364"}
     },
     {
-      "@id": "niiri:60a7e5e2fff4cfad3b1011063fd34696",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:fa7748f42b4ea105392364e1f036194b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0074",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-44,-40,2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-44,-40,2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8aa3b01ee444af495e69be10cbf53286",
-      "entity": "niiri:fd8207df6ecd8a6e5899191a7d1b9cec"
+      "entity_derived": "niiri:a67831c35816df52629ee7a7fc26dde0",
+      "entity": "niiri:01b4ff55ed7965f77f28199c98d35002"
     },
     {
-      "@id": "niiri:865e5d11fa910596d62e40eef5609628",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ec5b68946bd31e836ab65ff6af1c4a12",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0075",
-      "prov:atLocation": {"@id": "niiri:c5d99e9f2b535ec03ddcfcba79492a57"},
+      "prov:atLocation": {"@id": "niiri:a8ceaa5e8f88a768a13627b2df8779f0"},
       "prov:value": {"@type": "xsd:float", "@value": "4.8740234375"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.13323153375862"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.78849030254558e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.948390984974567"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0906467281751595"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.13323153375862"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.78849030254558e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.948390984974567"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0906467281751595"}
     },
     {
-      "@id": "niiri:c5d99e9f2b535ec03ddcfcba79492a57",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a8ceaa5e8f88a768a13627b2df8779f0",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0075",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[40,-58,-4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[40,-58,-4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:865e5d11fa910596d62e40eef5609628",
-      "entity": "niiri:a16c4a98c7239f14c74af90c58802252"
+      "entity_derived": "niiri:ec5b68946bd31e836ab65ff6af1c4a12",
+      "entity": "niiri:f606725494013a6004aeb7f3234c5659"
     },
     {
-      "@id": "niiri:bcad430042f16dff1ed83ae431c070f8",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:75631318c3d0bd234d33224648039cef",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0076",
-      "prov:atLocation": {"@id": "niiri:cb75f4ff2f63215ca951256bcc00b832"},
+      "prov:atLocation": {"@id": "niiri:f976f8e9ff5e60139441a829e8309f5c"},
       "prov:value": {"@type": "xsd:float", "@value": "4.85820341110229"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.12365167586169"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.86456349975384e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.953518161280421"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0931417862836213"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.12365167586169"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.86456349975384e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.953518161280421"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0931417862836213"}
     },
     {
-      "@id": "niiri:cb75f4ff2f63215ca951256bcc00b832",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f976f8e9ff5e60139441a829e8309f5c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0076",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-36,-10,10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-36,-10,10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:bcad430042f16dff1ed83ae431c070f8",
-      "entity": "niiri:beba83b8e0b597cc72900977cf176cf6"
+      "entity_derived": "niiri:75631318c3d0bd234d33224648039cef",
+      "entity": "niiri:d70674f2ab25c84bf1ccbf050e157cb6"
     },
     {
-      "@id": "niiri:fc8dc33bc5b91c4e94e461f6322f0c13",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5bdba307d61986d6149f72dba439105d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0077",
-      "prov:atLocation": {"@id": "niiri:9d9806f8b9a398fd82beb787328c55a5"},
+      "prov:atLocation": {"@id": "niiri:e29c2a8f4f6a6f0797b978de28eba557"},
       "prov:value": {"@type": "xsd:float", "@value": "4.84939575195312"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.11830662564564"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.90833322246675e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.956218144422422"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.094298931343831"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.11830662564564"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.90833322246675e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.956218144422422"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.094298931343831"}
     },
     {
-      "@id": "niiri:9d9806f8b9a398fd82beb787328c55a5",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e29c2a8f4f6a6f0797b978de28eba557",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0077",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[28,-94,12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[28,-94,12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:fc8dc33bc5b91c4e94e461f6322f0c13",
-      "entity": "niiri:2ea9c77f7d859bb390de800ff7c12bdd"
+      "entity_derived": "niiri:5bdba307d61986d6149f72dba439105d",
+      "entity": "niiri:d3a715b103390651d1c521ee09f466c0"
     },
     {
-      "@id": "niiri:fc582bcab54e2cf79907d707a9f51f8b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:2024155e74ac1cefebed8ca6401c4774",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0078",
-      "prov:atLocation": {"@id": "niiri:5a86e856ce68104f53c7247952f527fe"},
+      "prov:atLocation": {"@id": "niiri:8ada6393b1a9a3f95ad2291994faec90"},
       "prov:value": {"@type": "xsd:float", "@value": "4.84849166870117"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.11775750127654"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.91288474941098e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.956489104833424"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.094298931343831"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.11775750127654"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.91288474941098e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.956489104833424"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.094298931343831"}
     },
     {
-      "@id": "niiri:5a86e856ce68104f53c7247952f527fe",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:8ada6393b1a9a3f95ad2291994faec90",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0078",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-54,20,2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-54,20,2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:fc582bcab54e2cf79907d707a9f51f8b",
-      "entity": "niiri:667ab285deac3f27ecbbdbc71424991f"
+      "entity_derived": "niiri:2024155e74ac1cefebed8ca6401c4774",
+      "entity": "niiri:3577f89d6cde1468b3bf7bab875643fa"
     },
     {
-      "@id": "niiri:8322def335da2dc4240f9ca8f3c7a08f",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d0fc86df54e53e74dd24a6a5984cb2c6",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0079",
-      "prov:atLocation": {"@id": "niiri:171f4c43a47bbc3a756c4a635afbc53d"},
+      "prov:atLocation": {"@id": "niiri:9d85c6c90938d870289914c51cf481cb"},
       "prov:value": {"@type": "xsd:float", "@value": "4.84107542037964"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.11324969968147"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.95064001932144e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.9586686962403"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0952087356620267"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.11324969968147"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.95064001932144e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.9586686962403"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0952087356620267"}
     },
     {
-      "@id": "niiri:171f4c43a47bbc3a756c4a635afbc53d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:9d85c6c90938d870289914c51cf481cb",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0079",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-14,-102,16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-14,-102,16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8322def335da2dc4240f9ca8f3c7a08f",
-      "entity": "niiri:92c97d83326e6179be7fa554d9ed568a"
+      "entity_derived": "niiri:d0fc86df54e53e74dd24a6a5984cb2c6",
+      "entity": "niiri:6b28309025a8c950f906f3a74a6104c4"
     },
     {
-      "@id": "niiri:d34f512e7dd790b3abd0cc3ba064804d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:25187e17b37ef5575be4d5ced78392b0",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0080",
-      "prov:atLocation": {"@id": "niiri:b3238f9ed6739c9e50ac5b7649903780"},
+      "prov:atLocation": {"@id": "niiri:525dc2ad246a75dacc4a235e063563e7"},
       "prov:value": {"@type": "xsd:float", "@value": "4.82058572769165"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.10076479505859"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.05893469639173e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.964297185993396"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0988254126520163"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.10076479505859"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.05893469639173e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.964297185993396"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0988254126520163"}
     },
     {
-      "@id": "niiri:b3238f9ed6739c9e50ac5b7649903780",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:525dc2ad246a75dacc4a235e063563e7",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0080",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-40,0,36]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-40,0,36]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d34f512e7dd790b3abd0cc3ba064804d",
-      "entity": "niiri:e0f12d9993b033a238dd61773dca28e9"
+      "entity_derived": "niiri:25187e17b37ef5575be4d5ced78392b0",
+      "entity": "niiri:40f12e78ef285dbb693762e0e24f5a51"
     },
     {
-      "@id": "niiri:eae613ff67937874de777c199fc0e712",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:6b28b7892bbd80bbf1d73a494bd4d5f5",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0081",
-      "prov:atLocation": {"@id": "niiri:96fa4565771d09092e8365fbd19c3a42"},
+      "prov:atLocation": {"@id": "niiri:7c073ea600f14fd4ea899167ad505fa8"},
       "prov:value": {"@type": "xsd:float", "@value": "3.8377993106842"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.44169525159104"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0002890405543442"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999286"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.489947318972906"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.44169525159104"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0002890405543442"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999286"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.489947318972906"}
     },
     {
-      "@id": "niiri:96fa4565771d09092e8365fbd19c3a42",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7c073ea600f14fd4ea899167ad505fa8",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0081",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-46,6,32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-46,6,32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:eae613ff67937874de777c199fc0e712",
-      "entity": "niiri:e0f12d9993b033a238dd61773dca28e9"
+      "entity_derived": "niiri:6b28b7892bbd80bbf1d73a494bd4d5f5",
+      "entity": "niiri:40f12e78ef285dbb693762e0e24f5a51"
     },
     {
-      "@id": "niiri:0c2d986077e4a5c4aa9243c25fe32a93",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:deca705eeaa663fdf055aa9f356776a9",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0082",
-      "prov:atLocation": {"@id": "niiri:a71770e9738ba7be97b5499c771ee18f"},
+      "prov:atLocation": {"@id": "niiri:6fb430ff22243bc9598fb0ac4aaf9c27"},
       "prov:value": {"@type": "xsd:float", "@value": "4.80269765853882"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.08982806807398"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.15846535014386e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.968751908822455"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.101323968025976"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.08982806807398"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.15846535014386e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.968751908822455"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.101323968025976"}
     },
     {
-      "@id": "niiri:a71770e9738ba7be97b5499c771ee18f",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6fb430ff22243bc9598fb0ac4aaf9c27",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0082",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-8,-2,-26]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-8,-2,-26]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0c2d986077e4a5c4aa9243c25fe32a93",
-      "entity": "niiri:3aa56bca1824bde9b5cb4c7830b65b84"
+      "entity_derived": "niiri:deca705eeaa663fdf055aa9f356776a9",
+      "entity": "niiri:708e2b5584c9334ba1cde9334d8aee40"
     },
     {
-      "@id": "niiri:17f6b9ca0ecafb202e10381cdfc8d5c7",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d21f3565a424b86ffb29d622322bc1d3",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0083",
-      "prov:atLocation": {"@id": "niiri:716a2e8bbf82fdbc3ed38760e208b812"},
+      "prov:atLocation": {"@id": "niiri:8dccf601dcdbcf162697530c6196953f"},
       "prov:value": {"@type": "xsd:float", "@value": "4.7697925567627"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.06961897184955"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.35450441299356e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.975886012613188"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.107275411916197"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.06961897184955"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.35450441299356e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.975886012613188"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.107275411916197"}
     },
     {
-      "@id": "niiri:716a2e8bbf82fdbc3ed38760e208b812",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:8dccf601dcdbcf162697530c6196953f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0083",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-54,-14,44]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-54,-14,44]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:17f6b9ca0ecafb202e10381cdfc8d5c7",
-      "entity": "niiri:e6016935099bef709428b50f891e4418"
+      "entity_derived": "niiri:d21f3565a424b86ffb29d622322bc1d3",
+      "entity": "niiri:2ed437f95a18d4610e20aee5f5ca8ca1"
     },
     {
-      "@id": "niiri:e6f78a3bf29d25e68f593050b5f02d21",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e161951a5e1072e332cd915c3b62c0f7",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0084",
-      "prov:atLocation": {"@id": "niiri:5d633af9dca77359bea07159f4ee2500"},
+      "prov:atLocation": {"@id": "niiri:5b9b9731572d08126d7aa3c59cec9305"},
       "prov:value": {"@type": "xsd:float", "@value": "3.66720128059387"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.31324766391278"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000461096398393313"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.635496970778773"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.31324766391278"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000461096398393313"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.635496970778773"}
     },
     {
-      "@id": "niiri:5d633af9dca77359bea07159f4ee2500",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:5b9b9731572d08126d7aa3c59cec9305",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0084",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-46,-16,42]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-46,-16,42]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e6f78a3bf29d25e68f593050b5f02d21",
-      "entity": "niiri:e6016935099bef709428b50f891e4418"
+      "entity_derived": "niiri:e161951a5e1072e332cd915c3b62c0f7",
+      "entity": "niiri:2ed437f95a18d4610e20aee5f5ca8ca1"
     },
     {
-      "@id": "niiri:4fd872970ed44df708416742f907dd60",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:2146b6f3997a0283631b40f42fa43d64",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0085",
-      "prov:atLocation": {"@id": "niiri:ac6e1aa6b3c9b2ffafefc7993bbdb3d5"},
+      "prov:atLocation": {"@id": "niiri:82214ebe8ef9b550cf4e1aa7a663349d"},
       "prov:value": {"@type": "xsd:float", "@value": "4.76250028610229"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.0651242608467"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.40034388049315e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.977290243152968"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.108771358683944"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.0651242608467"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.40034388049315e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.977290243152968"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.108771358683944"}
     },
     {
-      "@id": "niiri:ac6e1aa6b3c9b2ffafefc7993bbdb3d5",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:82214ebe8ef9b550cf4e1aa7a663349d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0085",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[2,-48,-30]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[2,-48,-30]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4fd872970ed44df708416742f907dd60",
-      "entity": "niiri:75040581b4eec5ea4766cc6aef47a8db"
+      "entity_derived": "niiri:2146b6f3997a0283631b40f42fa43d64",
+      "entity": "niiri:c4315919bc864f2492337dd699116ee4"
     },
     {
-      "@id": "niiri:2ca5a6be3c35afb1d8b31cda31292b35",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0e6bf474e07d5b7b08647f8b148f1967",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0086",
-      "prov:atLocation": {"@id": "niiri:77f0590f945a9f0fa5288494ddd17b52"},
+      "prov:atLocation": {"@id": "niiri:ba7fb6c8d83c030743f5d0f254764ced"},
       "prov:value": {"@type": "xsd:float", "@value": "4.6519603729248"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.99626416831875"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.21749621180478e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.991944888183868"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.128446006759384"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.99626416831875"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.21749621180478e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.991944888183868"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.128446006759384"}
     },
     {
-      "@id": "niiri:77f0590f945a9f0fa5288494ddd17b52",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ba7fb6c8d83c030743f5d0f254764ced",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0086",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[8,-50,-40]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[8,-50,-40]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2ca5a6be3c35afb1d8b31cda31292b35",
-      "entity": "niiri:75040581b4eec5ea4766cc6aef47a8db"
+      "entity_derived": "niiri:0e6bf474e07d5b7b08647f8b148f1967",
+      "entity": "niiri:c4315919bc864f2492337dd699116ee4"
     },
     {
-      "@id": "niiri:a38570bac87c06908a31a54a84c167b1",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d72c48f6d8afc2c9c15435f9d82418cf",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0087",
-      "prov:atLocation": {"@id": "niiri:2996faba5ee172677f1c883f4f96df84"},
+      "prov:atLocation": {"@id": "niiri:0176ea45bff6510ce2f14431bf105e73"},
       "prov:value": {"@type": "xsd:float", "@value": "4.10066413879395"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.63067985034096"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000141337823446053"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999883838746"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.31440196024118"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.63067985034096"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000141337823446053"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999883838746"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.31440196024118"}
     },
     {
-      "@id": "niiri:2996faba5ee172677f1c883f4f96df84",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0176ea45bff6510ce2f14431bf105e73",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0087",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-6,-54,-34]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-6,-54,-34]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a38570bac87c06908a31a54a84c167b1",
-      "entity": "niiri:75040581b4eec5ea4766cc6aef47a8db"
+      "entity_derived": "niiri:d72c48f6d8afc2c9c15435f9d82418cf",
+      "entity": "niiri:c4315919bc864f2492337dd699116ee4"
     },
     {
-      "@id": "niiri:0fd4ff744da0e82ccc15307e98485e12",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:36093115c68af5d4a10804e4c18ac4b8",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0088",
-      "prov:atLocation": {"@id": "niiri:27ad17410385cf16531ede1f0e7f92fb"},
+      "prov:atLocation": {"@id": "niiri:8f6c6846bbd931f8db1b84eb92b10f53"},
       "prov:value": {"@type": "xsd:float", "@value": "4.71864032745361"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.03796623427238"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.69583056984324e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.984495898499825"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.117001939306263"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.03796623427238"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.69583056984324e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.984495898499825"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.117001939306263"}
     },
     {
-      "@id": "niiri:27ad17410385cf16531ede1f0e7f92fb",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:8f6c6846bbd931f8db1b84eb92b10f53",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0088",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[30,26,-26]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[30,26,-26]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0fd4ff744da0e82ccc15307e98485e12",
-      "entity": "niiri:1b5b284497e39b90fa934f2eaa2c5bbd"
+      "entity_derived": "niiri:36093115c68af5d4a10804e4c18ac4b8",
+      "entity": "niiri:5ad7bfc734bce8d2e03526bbce4c1642"
     },
     {
-      "@id": "niiri:306c809d5c32a2c41d8f9887cf2c9b9b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f6438ecb7f50fccc2df09ada0b2c3936",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0089",
-      "prov:atLocation": {"@id": "niiri:a2b2f239e523f6379f3634d3ebaf876a"},
+      "prov:atLocation": {"@id": "niiri:6f8a1c21df8a5fd72256d5fc0cfd2f29"},
       "prov:value": {"@type": "xsd:float", "@value": "4.44299697875977"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.86221318181419"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.61822240265908e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999504108645955"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.179991208659564"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.86221318181419"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.61822240265908e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999504108645955"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.179991208659564"}
     },
     {
-      "@id": "niiri:a2b2f239e523f6379f3634d3ebaf876a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6f8a1c21df8a5fd72256d5fc0cfd2f29",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0089",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[24,14,-26]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[24,14,-26]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:306c809d5c32a2c41d8f9887cf2c9b9b",
-      "entity": "niiri:1b5b284497e39b90fa934f2eaa2c5bbd"
+      "entity_derived": "niiri:f6438ecb7f50fccc2df09ada0b2c3936",
+      "entity": "niiri:5ad7bfc734bce8d2e03526bbce4c1642"
     },
     {
-      "@id": "niiri:f8547bd151dbdbbc5ba877786e167f7e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e92804e0ae7f8fae7ff71ce6170d001c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0090",
-      "prov:atLocation": {"@id": "niiri:f29b9f4b46a5244c6a5198760cd3bf04"},
+      "prov:atLocation": {"@id": "niiri:12aca80540254ba38eaf72b666080df0"},
       "prov:value": {"@type": "xsd:float", "@value": "3.96920132637024"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.53746207311998"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000201996101466206"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999353667"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.394063237507806"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.53746207311998"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000201996101466206"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999353667"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.394063237507806"}
     },
     {
-      "@id": "niiri:f29b9f4b46a5244c6a5198760cd3bf04",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:12aca80540254ba38eaf72b666080df0",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0090",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[26,14,-18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[26,14,-18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f8547bd151dbdbbc5ba877786e167f7e",
-      "entity": "niiri:1b5b284497e39b90fa934f2eaa2c5bbd"
+      "entity_derived": "niiri:e92804e0ae7f8fae7ff71ce6170d001c",
+      "entity": "niiri:5ad7bfc734bce8d2e03526bbce4c1642"
     },
     {
-      "@id": "niiri:42a50c3eb244dfe091f5c23c2704835b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ad38b1977ea2816b6d5129b7de2be1cc",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0091",
-      "prov:atLocation": {"@id": "niiri:26c0c7e4309cea859082f50525cd45ba"},
+      "prov:atLocation": {"@id": "niiri:2df1390cc5fce031de8c0874577cadce"},
       "prov:value": {"@type": "xsd:float", "@value": "4.70100975036621"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.02698888340493"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.82478512551032e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.986841070396366"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.12010902462004"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.02698888340493"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.82478512551032e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.986841070396366"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.12010902462004"}
     },
     {
-      "@id": "niiri:26c0c7e4309cea859082f50525cd45ba",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:2df1390cc5fce031de8c0874577cadce",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0091",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-28,-16,6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-28,-16,6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:42a50c3eb244dfe091f5c23c2704835b",
-      "entity": "niiri:9f190d80d4f3c866def066aba31dc20c"
+      "entity_derived": "niiri:ad38b1977ea2816b6d5129b7de2be1cc",
+      "entity": "niiri:f28a45db3e8e726134be22dd55ada8fc"
     },
     {
-      "@id": "niiri:5f6ab64bc5653e5c1c69b4d7e59e56c0",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:381454c1e2fbda01612a05c0a4339f74",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0092",
-      "prov:atLocation": {"@id": "niiri:0437c6eb17d20933f6823a9b6151ab98"},
+      "prov:atLocation": {"@id": "niiri:d3ea04f828be657e6bab2138bbf28662"},
       "prov:value": {"@type": "xsd:float", "@value": "4.67801570892334"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.01261939052354"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.00243455383375e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.989477369969029"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.124772480459746"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.01261939052354"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.00243455383375e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.989477369969029"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.124772480459746"}
     },
     {
-      "@id": "niiri:0437c6eb17d20933f6823a9b6151ab98",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d3ea04f828be657e6bab2138bbf28662",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0092",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[44,0,10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[44,0,10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5f6ab64bc5653e5c1c69b4d7e59e56c0",
-      "entity": "niiri:bad61a3ace8cf7e7c8c50e40ccf98bd4"
+      "entity_derived": "niiri:381454c1e2fbda01612a05c0a4339f74",
+      "entity": "niiri:7dbd526d156c17d030cb03d4502bec48"
     },
     {
-      "@id": "niiri:85d77ed1bf9f8388298bfe7a77494333",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b762ee5ba6db8bfb0128b4bb42245b28",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0093",
-      "prov:atLocation": {"@id": "niiri:1cf182c70d175685bf729d5057b31022"},
+      "prov:atLocation": {"@id": "niiri:aebbd1158b0ede5b331c1c3f1d17b188"},
       "prov:value": {"@type": "xsd:float", "@value": "4.22728967666626"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.71814419332447"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000100345855709283"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999994729417339"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.257292468216432"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.71814419332447"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000100345855709283"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999994729417339"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.257292468216432"}
     },
     {
-      "@id": "niiri:1cf182c70d175685bf729d5057b31022",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:aebbd1158b0ede5b331c1c3f1d17b188",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0093",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[54,0,16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[54,0,16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:85d77ed1bf9f8388298bfe7a77494333",
-      "entity": "niiri:bad61a3ace8cf7e7c8c50e40ccf98bd4"
+      "entity_derived": "niiri:b762ee5ba6db8bfb0128b4bb42245b28",
+      "entity": "niiri:7dbd526d156c17d030cb03d4502bec48"
     },
     {
-      "@id": "niiri:c30a7b8bf86a990343f6528dc86c8da6",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:85563c1d691e946655502a1d62515133",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0094",
-      "prov:atLocation": {"@id": "niiri:d54e01ce6cebb1fe89926a726c90eab7"},
+      "prov:atLocation": {"@id": "niiri:bbf81c743efe445a1c97b21a8fab3e28"},
       "prov:value": {"@type": "xsd:float", "@value": "4.66959953308105"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.00734493617698"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.07025754018309e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.990331612042013"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.125816071886827"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.00734493617698"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.07025754018309e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.990331612042013"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.125816071886827"}
     },
     {
-      "@id": "niiri:d54e01ce6cebb1fe89926a726c90eab7",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:bbf81c743efe445a1c97b21a8fab3e28",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0094",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-54,-22,12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-54,-22,12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c30a7b8bf86a990343f6528dc86c8da6",
-      "entity": "niiri:189c6d65cca27efc776c3691b2470738"
+      "entity_derived": "niiri:85563c1d691e946655502a1d62515133",
+      "entity": "niiri:db64bef791d519bd840c407a07274b39"
     },
     {
-      "@id": "niiri:1088eceb72998c0658f10b30358f8dee",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:41ddd3c253a63198d170247b8ccef29c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0095",
-      "prov:atLocation": {"@id": "niiri:3cc9446da6d6c70a4656d02b32801137"},
+      "prov:atLocation": {"@id": "niiri:921adc178a0217524216f743d14205b3"},
       "prov:value": {"@type": "xsd:float", "@value": "4.65595293045044"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.99877537618825"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.18355355407585e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.991599911633511"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.127861903463077"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.99877537618825"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.18355355407585e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.991599911633511"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.127861903463077"}
     },
     {
-      "@id": "niiri:3cc9446da6d6c70a4656d02b32801137",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:921adc178a0217524216f743d14205b3",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0095",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[50,50,-8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[50,50,-8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1088eceb72998c0658f10b30358f8dee",
-      "entity": "niiri:f29da53849f4d24538d6a069a467c443"
+      "entity_derived": "niiri:41ddd3c253a63198d170247b8ccef29c",
+      "entity": "niiri:261d424ff1d40e2e1212f8b47057e08d"
     },
     {
-      "@id": "niiri:671ae43880d238d19d2d2be2b6209076",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:78ffb1d7f41f1c0b6ea5119ca8935556",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0096",
-      "prov:atLocation": {"@id": "niiri:660d6fc3b3ea3e4b958c93bafb20a666"},
+      "prov:atLocation": {"@id": "niiri:973e73a26378971ef19237f48098ed3a"},
       "prov:value": {"@type": "xsd:float", "@value": "4.65494585037231"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.99814212312407"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.19208079492261e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.991688012376402"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.127861903463077"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.99814212312407"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.19208079492261e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.991688012376402"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.127861903463077"}
     },
     {
-      "@id": "niiri:660d6fc3b3ea3e4b958c93bafb20a666",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:973e73a26378971ef19237f48098ed3a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0096",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-28,-94,14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-28,-94,14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:671ae43880d238d19d2d2be2b6209076",
-      "entity": "niiri:735d11dd0407b58704c0622c1bf21ceb"
+      "entity_derived": "niiri:78ffb1d7f41f1c0b6ea5119ca8935556",
+      "entity": "niiri:f0b1b468bf91334fdba7c8b7612cca41"
     },
     {
-      "@id": "niiri:b597b068893e960609d27315716990e2",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d614eab5b59c47eed1084c951be2e2ac",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0097",
-      "prov:atLocation": {"@id": "niiri:50f893947a270f5af66c2cbd6585e809"},
+      "prov:atLocation": {"@id": "niiri:a580eafb1c15748fd65f50cb3130fabb"},
       "prov:value": {"@type": "xsd:float", "@value": "4.59036016464233"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.95728588718167"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.79030920980572e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99598096157132"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.142567282550543"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.95728588718167"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.79030920980572e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99598096157132"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.142567282550543"}
     },
     {
-      "@id": "niiri:50f893947a270f5af66c2cbd6585e809",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a580eafb1c15748fd65f50cb3130fabb",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0097",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[40,-8,-4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[40,-8,-4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b597b068893e960609d27315716990e2",
-      "entity": "niiri:1cab13530af314ae698e165a85ca2de5"
+      "entity_derived": "niiri:d614eab5b59c47eed1084c951be2e2ac",
+      "entity": "niiri:6faaad2ce4a4160eadbbce94632ec2bf"
     },
     {
-      "@id": "niiri:d0425a54d68a26b09e3b868f56d2f0f0",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b50f8c0634d1f6225cc186049de68413",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0098",
-      "prov:atLocation": {"@id": "niiri:f433850395b5c2c86bd5e11b3805dc73"},
+      "prov:atLocation": {"@id": "niiri:e96da7fbc7121c5fcada2bd43aff06a1"},
       "prov:value": {"@type": "xsd:float", "@value": "4.11932277679443"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.64370826236287"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000134369006709489"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999978233167"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.306052577208852"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.64370826236287"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000134369006709489"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999978233167"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.306052577208852"}
     },
     {
-      "@id": "niiri:f433850395b5c2c86bd5e11b3805dc73",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e96da7fbc7121c5fcada2bd43aff06a1",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0098",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[42,-14,-12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[42,-14,-12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d0425a54d68a26b09e3b868f56d2f0f0",
-      "entity": "niiri:1cab13530af314ae698e165a85ca2de5"
+      "entity_derived": "niiri:b50f8c0634d1f6225cc186049de68413",
+      "entity": "niiri:6faaad2ce4a4160eadbbce94632ec2bf"
     },
     {
-      "@id": "niiri:4366c702fcc58810550566b4e4d23534",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:37f724585a89abe98ff9f20ca03e9884",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0099",
-      "prov:atLocation": {"@id": "niiri:895f20dcc2031d58bc886785a482f1b5"},
+      "prov:atLocation": {"@id": "niiri:e1a4edce029a77b4f6d92ac5806a54ec"},
       "prov:value": {"@type": "xsd:float", "@value": "3.9436137676239"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.51902135936471"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000216570916963699"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999802529"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.411752007254358"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.51902135936471"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000216570916963699"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999802529"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.411752007254358"}
     },
     {
-      "@id": "niiri:895f20dcc2031d58bc886785a482f1b5",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e1a4edce029a77b4f6d92ac5806a54ec",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0099",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[36,-8,-12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[36,-8,-12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4366c702fcc58810550566b4e4d23534",
-      "entity": "niiri:1cab13530af314ae698e165a85ca2de5"
+      "entity_derived": "niiri:37f724585a89abe98ff9f20ca03e9884",
+      "entity": "niiri:6faaad2ce4a4160eadbbce94632ec2bf"
     },
     {
-      "@id": "niiri:87643e96d74b14a2c024309920c3827b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e12a986e485026e4d146b52ea34da3ea",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0100",
-      "prov:atLocation": {"@id": "niiri:49337bb4cea94fc97b5fb6f4ef8286e1"},
+      "prov:atLocation": {"@id": "niiri:c2abbc2ce0ad122a6bc9709ad15207e7"},
       "prov:value": {"@type": "xsd:float", "@value": "4.55580520629883"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.9352264591963"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.15591423175155e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.997392444225686"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.150878854905596"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.9352264591963"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.15591423175155e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.997392444225686"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.150878854905596"}
     },
     {
-      "@id": "niiri:49337bb4cea94fc97b5fb6f4ef8286e1",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c2abbc2ce0ad122a6bc9709ad15207e7",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0100",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-16,-36,22]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-16,-36,22]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:87643e96d74b14a2c024309920c3827b",
-      "entity": "niiri:e0728affe728b03b571bb0da5a24b81e"
+      "entity_derived": "niiri:e12a986e485026e4d146b52ea34da3ea",
+      "entity": "niiri:8451b5d05d4d0f88becbc68925bab4c9"
     },
     {
-      "@id": "niiri:aba73c7bf694c726dd1a62029c95a89d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b9372af04e7acfd4ce56135b4d0536af",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0101",
-      "prov:atLocation": {"@id": "niiri:74374695e7cee91acee321fbeb220133"},
+      "prov:atLocation": {"@id": "niiri:4f6cf46b76ce3e5bb2f7e9293eb4e52f"},
       "prov:value": {"@type": "xsd:float", "@value": "4.55545139312744"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.93499985843019"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.15983725905456e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.997404409483695"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.150878854905596"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.93499985843019"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.15983725905456e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.997404409483695"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.150878854905596"}
     },
     {
-      "@id": "niiri:74374695e7cee91acee321fbeb220133",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4f6cf46b76ce3e5bb2f7e9293eb4e52f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0101",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[32,4,46]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[32,4,46]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:aba73c7bf694c726dd1a62029c95a89d",
-      "entity": "niiri:2ac5440f1a62a883d86fc94f89789599"
+      "entity_derived": "niiri:b9372af04e7acfd4ce56135b4d0536af",
+      "entity": "niiri:e8d74786a114ffeb6114fffeeb2583da"
     },
     {
-      "@id": "niiri:1ced12f966574e6914952926c04a3a91",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:48b80f9b9e00d0859755f74a197e7295",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0102",
-      "prov:atLocation": {"@id": "niiri:e42ccaa79df168a0e41d6ed1ca039dcf"},
+      "prov:atLocation": {"@id": "niiri:245f24faf67b8c0bed06e039441f3242"},
       "prov:value": {"@type": "xsd:float", "@value": "4.55117416381836"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.93225931513679"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.20756089468677e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.997545471779058"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.151725570321213"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.93225931513679"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.20756089468677e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.997545471779058"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.151725570321213"}
     },
     {
-      "@id": "niiri:e42ccaa79df168a0e41d6ed1ca039dcf",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:245f24faf67b8c0bed06e039441f3242",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0102",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-66,-38,20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-66,-38,20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1ced12f966574e6914952926c04a3a91",
-      "entity": "niiri:04a64b18655d556b397f88a52d983f34"
+      "entity_derived": "niiri:48b80f9b9e00d0859755f74a197e7295",
+      "entity": "niiri:af4cb856d066cec808680cb766e205ae"
     },
     {
-      "@id": "niiri:260f9b244d05e2c1dc6d321bb88eb14e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:911d519f5928583e1f82ac51bab14528",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0103",
-      "prov:atLocation": {"@id": "niiri:3ee349d2ae3fd31b84b1b3a515f9770a"},
+      "prov:atLocation": {"@id": "niiri:5edd83cba07a9fb55a7f38bf2a36fdfe"},
       "prov:value": {"@type": "xsd:float", "@value": "4.53549385070801"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.92219382792662"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.38731790728397e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.998009069005951"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.155845230235465"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.92219382792662"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.38731790728397e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.998009069005951"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.155845230235465"}
     },
     {
-      "@id": "niiri:3ee349d2ae3fd31b84b1b3a515f9770a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:5edd83cba07a9fb55a7f38bf2a36fdfe",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0103",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[40,-40,14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[40,-40,14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:260f9b244d05e2c1dc6d321bb88eb14e",
-      "entity": "niiri:e07163703600f62c37c81aed00f51b7a"
+      "entity_derived": "niiri:911d519f5928583e1f82ac51bab14528",
+      "entity": "niiri:64c74f4674adc0005dffc886ffba3300"
     },
     {
-      "@id": "niiri:4bf2c17eaf5e2b6a6bc490e00bf4f4d0",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b35cc4339b958823a6b0d89e47050e64",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0104",
-      "prov:atLocation": {"@id": "niiri:cec3e23ba7dfca18d4fd168450ff18ff"},
+      "prov:atLocation": {"@id": "niiri:6326326bf38f1f521effe41a32bcff8c"},
       "prov:value": {"@type": "xsd:float", "@value": "4.53285837173462"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.92049917786993"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.41828687672841e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.998079247810657"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.156454214178493"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.92049917786993"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.41828687672841e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.998079247810657"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.156454214178493"}
     },
     {
-      "@id": "niiri:cec3e23ba7dfca18d4fd168450ff18ff",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6326326bf38f1f521effe41a32bcff8c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0104",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[6,-40,18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[6,-40,18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4bf2c17eaf5e2b6a6bc490e00bf4f4d0",
-      "entity": "niiri:f4159609553afd6154652d5027b6e84a"
+      "entity_derived": "niiri:b35cc4339b958823a6b0d89e47050e64",
+      "entity": "niiri:878873f431f64df4853365a578c78440"
     },
     {
-      "@id": "niiri:96efd99f3a78d60684b5b316a0c19cc2",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:98380d632dcdfa9a6e36fc6b78b2273c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0105",
-      "prov:atLocation": {"@id": "niiri:4a2715da0d82ada4545208a80cab2511"},
+      "prov:atLocation": {"@id": "niiri:ec5c657b1f38d62cf4afaa29e7f266c0"},
       "prov:value": {"@type": "xsd:float", "@value": "4.52961778640747"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.91841429412832"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.45667054541632e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.998162674504785"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.156835312141954"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.91841429412832"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.45667054541632e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.998162674504785"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.156835312141954"}
     },
     {
-      "@id": "niiri:4a2715da0d82ada4545208a80cab2511",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ec5c657b1f38d62cf4afaa29e7f266c0",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0105",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[52,-68,16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[52,-68,16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:96efd99f3a78d60684b5b316a0c19cc2",
-      "entity": "niiri:f4231c3f6d55163a61e855e3bf8e3cc5"
+      "entity_derived": "niiri:98380d632dcdfa9a6e36fc6b78b2273c",
+      "entity": "niiri:62873793384331403012ec1c900656e0"
     },
     {
-      "@id": "niiri:0c3cc5af988e7da86a56270c9c96f8c7",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:720ed23eb6c46a721179918c28f55ffc",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0106",
-      "prov:atLocation": {"@id": "niiri:460d184d093c1173982c3b1976da2688"},
+      "prov:atLocation": {"@id": "niiri:f824150295332ede014a54eca9b3e037"},
       "prov:value": {"@type": "xsd:float", "@value": "4.52500677108765"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.91544554806561"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.51187048494672e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.998276102661289"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.156835312141954"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.91544554806561"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.51187048494672e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.998276102661289"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.156835312141954"}
     },
     {
-      "@id": "niiri:460d184d093c1173982c3b1976da2688",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f824150295332ede014a54eca9b3e037",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0106",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-48,-22,-10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-48,-22,-10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0c3cc5af988e7da86a56270c9c96f8c7",
-      "entity": "niiri:f3fc51b4027adc2167b7ea4fb36f64e9"
+      "entity_derived": "niiri:720ed23eb6c46a721179918c28f55ffc",
+      "entity": "niiri:cf86c38738ff15923d1bfe58d642e526"
     },
     {
-      "@id": "niiri:7fbb194cd2d6fb1d9d1d16abadf4d2be",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:06f3fa5f5a7dd43a7c83878b6daecccd",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0107",
-      "prov:atLocation": {"@id": "niiri:f38864f25cb61f37ffed64c3e17672dc"},
+      "prov:atLocation": {"@id": "niiri:2e1377b54d2ffed14f657fdcc448a72b"},
       "prov:value": {"@type": "xsd:float", "@value": "4.48953676223755"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.89252279227539"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.96035879459233e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99896686399793"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.165823318703379"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.89252279227539"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.96035879459233e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99896686399793"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.165823318703379"}
     },
     {
-      "@id": "niiri:f38864f25cb61f37ffed64c3e17672dc",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:2e1377b54d2ffed14f657fdcc448a72b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0107",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[30,52,-4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[30,52,-4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7fbb194cd2d6fb1d9d1d16abadf4d2be",
-      "entity": "niiri:89485ab1dfdfe29164103a5f95597953"
+      "entity_derived": "niiri:06f3fa5f5a7dd43a7c83878b6daecccd",
+      "entity": "niiri:6eb2f26421b4abdd2aff61056be6347c"
     },
     {
-      "@id": "niiri:2c3112f14d52846a4e846057968ffc37",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:aeae6d15ef755bd8bf17831ae1de5a8b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0108",
-      "prov:atLocation": {"@id": "niiri:0f84a5df8e7af60bd0dd46befca71596"},
+      "prov:atLocation": {"@id": "niiri:45a89c69b7ea6fbf25176dea9a058957"},
       "prov:value": {"@type": "xsd:float", "@value": "4.45128202438354"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.8676284436992"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.49494726368449e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999431806314623"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.177705345844304"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.8676284436992"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.49494726368449e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999431806314623"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.177705345844304"}
     },
     {
-      "@id": "niiri:0f84a5df8e7af60bd0dd46befca71596",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:45a89c69b7ea6fbf25176dea9a058957",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0108",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[30,-78,12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[30,-78,12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2c3112f14d52846a4e846057968ffc37",
-      "entity": "niiri:38d55629def18240731e2415b3581423"
+      "entity_derived": "niiri:aeae6d15ef755bd8bf17831ae1de5a8b",
+      "entity": "niiri:464e6cc9ad8cde4967c4e8430942863e"
     },
     {
-      "@id": "niiri:f0ccedd5fce18281ce4d2341d24ffe8e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f1c37bc22f16214c1df5f88314a215a4",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0109",
-      "prov:atLocation": {"@id": "niiri:8c6052a4b3fd6e34fcd86c593825af20"},
+      "prov:atLocation": {"@id": "niiri:e379fe3bb7b26ed85e05da7ee6813086"},
       "prov:value": {"@type": "xsd:float", "@value": "4.43969058990479"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.86004968799798"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.66819856246958e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999530645129751"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.180631808606791"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.86004968799798"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.66819856246958e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999530645129751"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.180631808606791"}
     },
     {
-      "@id": "niiri:8c6052a4b3fd6e34fcd86c593825af20",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e379fe3bb7b26ed85e05da7ee6813086",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0109",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[56,34,-6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[56,34,-6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f0ccedd5fce18281ce4d2341d24ffe8e",
-      "entity": "niiri:911e248e1a4789966b6c9e185a7126b1"
+      "entity_derived": "niiri:f1c37bc22f16214c1df5f88314a215a4",
+      "entity": "niiri:0f59b224fb308f5b33db0b615cec440e"
     },
     {
-      "@id": "niiri:72d1c291678d22f2bd98eedf3b4f80e1",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:bef3273cb030511d57da83b609f7288b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0110",
-      "prov:atLocation": {"@id": "niiri:e050ac6a4efbe8f0a7222ba8c092f08d"},
+      "prov:atLocation": {"@id": "niiri:03ef48e74c3406c59a104d33ec1ced06"},
       "prov:value": {"@type": "xsd:float", "@value": "4.43896007537842"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.8595715019443"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.67930097867819e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999536338351379"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.180631808606791"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.8595715019443"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.67930097867819e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999536338351379"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.180631808606791"}
     },
     {
-      "@id": "niiri:e050ac6a4efbe8f0a7222ba8c092f08d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:03ef48e74c3406c59a104d33ec1ced06",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0110",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-26,-94,2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-26,-94,2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:72d1c291678d22f2bd98eedf3b4f80e1",
-      "entity": "niiri:6110880bd543820677cd9c2981bb03f1"
+      "entity_derived": "niiri:bef3273cb030511d57da83b609f7288b",
+      "entity": "niiri:61f0e2e951d39892ec38816ca4ff7b91"
     },
     {
-      "@id": "niiri:3305c63dcf3abdaff650b7191ec8d6b0",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:95ad202473a2bf127c7926f3746acacc",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0111",
-      "prov:atLocation": {"@id": "niiri:c6d08c08c9f530820ca2c9f56a4d6448"},
+      "prov:atLocation": {"@id": "niiri:36d1028c68af6184089ce9aee42f9174"},
       "prov:value": {"@type": "xsd:float", "@value": "4.43468761444092"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.85677347172615"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.74467726958128e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999568445566068"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.182003342977838"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.85677347172615"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.74467726958128e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999568445566068"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.182003342977838"}
     },
     {
-      "@id": "niiri:c6d08c08c9f530820ca2c9f56a4d6448",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:36d1028c68af6184089ce9aee42f9174",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0111",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-4,2,42]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-4,2,42]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3305c63dcf3abdaff650b7191ec8d6b0",
-      "entity": "niiri:17de67442fe88be7d5065d079743540f"
+      "entity_derived": "niiri:95ad202473a2bf127c7926f3746acacc",
+      "entity": "niiri:9764501f1b27ea039a6888cad5412dc6"
     },
     {
-      "@id": "niiri:77ba8da0f7e4f5aab68f081161fa1bea",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0fb6745b7885bc7a34cefdeb57f43c2f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0112",
-      "prov:atLocation": {"@id": "niiri:83d5b3ee5bd86eb620c993b83ea0caa6"},
+      "prov:atLocation": {"@id": "niiri:92cf7da97869a4b83347f08dbaa11faf"},
       "prov:value": {"@type": "xsd:float", "@value": "4.41122913360596"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.84136995866889"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.1174774538153e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999712443776799"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.188911373544714"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.84136995866889"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.1174774538153e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999712443776799"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.188911373544714"}
     },
     {
-      "@id": "niiri:83d5b3ee5bd86eb620c993b83ea0caa6",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:92cf7da97869a4b83347f08dbaa11faf",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0112",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[10,-46,-10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[10,-46,-10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:77ba8da0f7e4f5aab68f081161fa1bea",
-      "entity": "niiri:8cbc3782d81e0868d376f120a4236af9"
+      "entity_derived": "niiri:0fb6745b7885bc7a34cefdeb57f43c2f",
+      "entity": "niiri:c4798ee5bb6817f0ac7d3d1f7cbb895d"
     },
     {
-      "@id": "niiri:ff0dbdfc84bb05fe5679f7b179ee11f0",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:458c984a04e6737387c5f9f56e3c0c8a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0113",
-      "prov:atLocation": {"@id": "niiri:cc552590c3f29a42d9a6610fe218b7e6"},
+      "prov:atLocation": {"@id": "niiri:d4a64a06c03e91cda9054bed710dca42"},
       "prov:value": {"@type": "xsd:float", "@value": "4.40113353729248"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.83471966710863"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.28537919565852e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999760079336093"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.192447078003389"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.83471966710863"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.28537919565852e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999760079336093"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.192447078003389"}
     },
     {
-      "@id": "niiri:cc552590c3f29a42d9a6610fe218b7e6",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d4a64a06c03e91cda9054bed710dca42",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0113",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-56,-28,32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-56,-28,32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ff0dbdfc84bb05fe5679f7b179ee11f0",
-      "entity": "niiri:2f3eeaca715cc267ad827fccd2f2f34b"
+      "entity_derived": "niiri:458c984a04e6737387c5f9f56e3c0c8a",
+      "entity": "niiri:5499ba7833a3a03073324dac7488ac06"
     },
     {
-      "@id": "niiri:527d0d830812700e62c40d9a6100d315",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:baeb0c03f7acf106a1287e421c2742f3",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0114",
-      "prov:atLocation": {"@id": "niiri:9ddaaf7b2ea49bfd8c516120cdaf8904"},
+      "prov:atLocation": {"@id": "niiri:856a6c1dbdd8ced84613dc690fc7e35e"},
       "prov:value": {"@type": "xsd:float", "@value": "3.8069314956665"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.41880668619853"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000314481969186486"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999891"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.512736471214834"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.41880668619853"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000314481969186486"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999891"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.512736471214834"}
     },
     {
-      "@id": "niiri:9ddaaf7b2ea49bfd8c516120cdaf8904",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:856a6c1dbdd8ced84613dc690fc7e35e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0114",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-48,-26,38]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-48,-26,38]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:527d0d830812700e62c40d9a6100d315",
-      "entity": "niiri:2f3eeaca715cc267ad827fccd2f2f34b"
+      "entity_derived": "niiri:baeb0c03f7acf106a1287e421c2742f3",
+      "entity": "niiri:5499ba7833a3a03073324dac7488ac06"
     },
     {
-      "@id": "niiri:c3a082504bc195d9e4d777deea4e6d17",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ca0839c16a1a2c559d6575777eda49c0",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0115",
-      "prov:atLocation": {"@id": "niiri:94196d9f29b0dd9b11a8162f03bc6f80"},
+      "prov:atLocation": {"@id": "niiri:d5aa0acf36e1fe500e1939ac94f4df6f"},
       "prov:value": {"@type": "xsd:float", "@value": "4.3867974281311"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.82525392537983"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.53186827229701e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999815750636743"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.197194516669469"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.82525392537983"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.53186827229701e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999815750636743"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.197194516669469"}
     },
     {
-      "@id": "niiri:94196d9f29b0dd9b11a8162f03bc6f80",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d5aa0acf36e1fe500e1939ac94f4df6f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0115",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-4,-10,-12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-4,-10,-12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c3a082504bc195d9e4d777deea4e6d17",
-      "entity": "niiri:de6850a6407354dfd567970141571681"
+      "entity_derived": "niiri:ca0839c16a1a2c559d6575777eda49c0",
+      "entity": "niiri:50c6ebb589d5bdb3e362aaf8f837978b"
     },
     {
-      "@id": "niiri:cc6a58fe2921e4ac22cebe6c90dd0ba6",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:8369fa28a67eb70b3c8346f78b861cd7",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0116",
-      "prov:atLocation": {"@id": "niiri:8830be0395520c67acf02a3152e0f4d4"},
+      "prov:atLocation": {"@id": "niiri:6ed010c8390266e2a02334f0871efbc1"},
       "prov:value": {"@type": "xsd:float", "@value": "4.38070726394653"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.82122488004205"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.6395247973916e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999835706899974"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.199147137761087"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.82122488004205"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.6395247973916e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999835706899974"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.199147137761087"}
     },
     {
-      "@id": "niiri:8830be0395520c67acf02a3152e0f4d4",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6ed010c8390266e2a02334f0871efbc1",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0116",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-12,-84,-42]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-12,-84,-42]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cc6a58fe2921e4ac22cebe6c90dd0ba6",
-      "entity": "niiri:fd0c869c2731be1d9fa597f20662d444"
+      "entity_derived": "niiri:8369fa28a67eb70b3c8346f78b861cd7",
+      "entity": "niiri:a489f5516c417d51a01d581c1281955e"
     },
     {
-      "@id": "niiri:c1032fc39d6b775cc9b9991bf5fd94f9",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c9919f1aac8740808b218ad44f9721a0",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0117",
-      "prov:atLocation": {"@id": "niiri:5dba11cc47d82ed9a5828d75f4d25abd"},
+      "prov:atLocation": {"@id": "niiri:0bc5e8e1b5feb1cc5e112bc5d1f0486c"},
       "prov:value": {"@type": "xsd:float", "@value": "4.37547636032104"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.81776053049529"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.73342723619408e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999851291705404"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.200454348633431"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.81776053049529"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.73342723619408e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999851291705404"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.200454348633431"}
     },
     {
-      "@id": "niiri:5dba11cc47d82ed9a5828d75f4d25abd",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0bc5e8e1b5feb1cc5e112bc5d1f0486c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0117",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-40,0,0]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-40,0,0]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c1032fc39d6b775cc9b9991bf5fd94f9",
-      "entity": "niiri:9558c05bc184bbae76bf2776b13f3613"
+      "entity_derived": "niiri:c9919f1aac8740808b218ad44f9721a0",
+      "entity": "niiri:e4ff54dd97ad1e3f10b9d1c7027c4645"
     },
     {
-      "@id": "niiri:1649a7f3e9a2410af3d8e4ef6fd303e2",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:8e304887e697a26945a0a355426f4603",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0118",
-      "prov:atLocation": {"@id": "niiri:165dd2fac7105a73a7b80e22b60705b4"},
+      "prov:atLocation": {"@id": "niiri:4035e3a3b521c5cf812810100219fc74"},
       "prov:value": {"@type": "xsd:float", "@value": "4.36677885055542"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.8119925842216"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.8925506726436e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999874314988424"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.203206123512965"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.8119925842216"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.8925506726436e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999874314988424"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.203206123512965"}
     },
     {
-      "@id": "niiri:165dd2fac7105a73a7b80e22b60705b4",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4035e3a3b521c5cf812810100219fc74",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0118",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-28,0,2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-28,0,2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1649a7f3e9a2410af3d8e4ef6fd303e2",
-      "entity": "niiri:a46d73eae3d12dd1da0f67fbeb4a1a72"
+      "entity_derived": "niiri:8e304887e697a26945a0a355426f4603",
+      "entity": "niiri:8de83fae7bd6e9f8380ec49cdc4829ae"
     },
     {
-      "@id": "niiri:7f5d7505bc741dd7d5b391adf234196c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c94747cdbcb83041515a601d983f3b27",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0119",
-      "prov:atLocation": {"@id": "niiri:e59f57cd9f06987b6f61377b25632cc9"},
+      "prov:atLocation": {"@id": "niiri:0aaacb97d9578ab5bbd5b285599748af"},
       "prov:value": {"@type": "xsd:float", "@value": "4.35107517242432"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.80155384474342"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.18957405629883e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999907978180442"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.208513005623714"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.80155384474342"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.18957405629883e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999907978180442"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.208513005623714"}
     },
     {
-      "@id": "niiri:e59f57cd9f06987b6f61377b25632cc9",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0aaacb97d9578ab5bbd5b285599748af",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0119",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-50,2,38]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-50,2,38]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7f5d7505bc741dd7d5b391adf234196c",
-      "entity": "niiri:7635d7da2581ae0e3d9df35c569ea093"
+      "entity_derived": "niiri:c94747cdbcb83041515a601d983f3b27",
+      "entity": "niiri:85491f67ab81ddeb946caf2849c4b9f4"
     },
     {
-      "@id": "niiri:2dc919c851ba7755dbe18a26809b75a0",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e42d96aae6a120678fb678c94074a5db",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0120",
-      "prov:atLocation": {"@id": "niiri:c15ccc6718f3a15d89f19043f5addb5b"},
+      "prov:atLocation": {"@id": "niiri:ddc582eb09610fb7b7fc6c9c6c19e864"},
       "prov:value": {"@type": "xsd:float", "@value": "4.33398485183716"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.79015733594979"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.52759461690733e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999935243728569"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.215680526572575"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.79015733594979"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.52759461690733e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999935243728569"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.215680526572575"}
     },
     {
-      "@id": "niiri:c15ccc6718f3a15d89f19043f5addb5b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ddc582eb09610fb7b7fc6c9c6c19e864",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0120",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-18,20,-10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-18,20,-10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2dc919c851ba7755dbe18a26809b75a0",
-      "entity": "niiri:19a7c772a61f72e1d78af974571971cd"
+      "entity_derived": "niiri:e42d96aae6a120678fb678c94074a5db",
+      "entity": "niiri:3e9eba22eff518f24b14c038fe2913df"
     },
     {
-      "@id": "niiri:65ae58a9c810213d5e645d1a5efc43b5",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d358ade24a46e28d596c4d0af691488b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0121",
-      "prov:atLocation": {"@id": "niiri:041c46e2b4d312223fdbb6ad7f6756e2"},
+      "prov:atLocation": {"@id": "niiri:725ad5ba6d7cd65f30acf71da2d71a0b"},
       "prov:value": {"@type": "xsd:float", "@value": "4.32422828674316"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.78363433945477"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.72774207707938e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999947322155091"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.21884755438417"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.78363433945477"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.72774207707938e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999947322155091"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.21884755438417"}
     },
     {
-      "@id": "niiri:041c46e2b4d312223fdbb6ad7f6756e2",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:725ad5ba6d7cd65f30acf71da2d71a0b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0121",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-54,-44,58]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-54,-44,58]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:65ae58a9c810213d5e645d1a5efc43b5",
-      "entity": "niiri:843d6a80a917e6d0bba5298ced57aba0"
+      "entity_derived": "niiri:d358ade24a46e28d596c4d0af691488b",
+      "entity": "niiri:2b503ca3533d10a4f1f80dad7060444a"
     },
     {
-      "@id": "niiri:011104b1119694f29047c0d121fc1cda",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:8756d972087f4144374fcbc8ae52666e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0122",
-      "prov:atLocation": {"@id": "niiri:87e8f34b8f412c36edb736b17b6dcecf"},
+      "prov:atLocation": {"@id": "niiri:b5933bbb6136fc305b2604a8d7deab9e"},
       "prov:value": {"@type": "xsd:float", "@value": "4.26067924499512"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.74084237095966"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "9.1702262191129e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999987705149813"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.242015591352726"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.74084237095966"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "9.1702262191129e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999987705149813"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.242015591352726"}
     },
     {
-      "@id": "niiri:87e8f34b8f412c36edb736b17b6dcecf",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b5933bbb6136fc305b2604a8d7deab9e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0122",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-20,44,-4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-20,44,-4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:011104b1119694f29047c0d121fc1cda",
-      "entity": "niiri:81a5a2e83d586c873f45bcbeacbd725e"
+      "entity_derived": "niiri:8756d972087f4144374fcbc8ae52666e",
+      "entity": "niiri:cf6de656d89419d4ac154fd946ec6388"
     },
     {
-      "@id": "niiri:2d1ce2b3b7314391e10ed799a9f28906",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a89e2e80fe4388ce0ae8d072fcec1ac6",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0123",
-      "prov:atLocation": {"@id": "niiri:d0729914d5e3c4bac1a31c4f58bc59e7"},
+      "prov:atLocation": {"@id": "niiri:1a5dc642a881d6f4e4d3829a697631ac"},
       "prov:value": {"@type": "xsd:float", "@value": "4.18645191192627"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.69017800075158"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000112048594444025"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999998281846379"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.278031328015723"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.69017800075158"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000112048594444025"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999998281846379"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.278031328015723"}
     },
     {
-      "@id": "niiri:d0729914d5e3c4bac1a31c4f58bc59e7",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:1a5dc642a881d6f4e4d3829a697631ac",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0123",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-14,-32,-64]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-14,-32,-64]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2d1ce2b3b7314391e10ed799a9f28906",
-      "entity": "niiri:0dba3e406159d31dec269bb22b1b416a"
+      "entity_derived": "niiri:a89e2e80fe4388ce0ae8d072fcec1ac6",
+      "entity": "niiri:9c0f05c7637bc2f31d907b17584b6aa0"
     },
     {
-      "@id": "niiri:a5a2448865b51f8e6018dd6e5c69e2cc",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ab27403976625180dff5b30fab548263",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0124",
-      "prov:atLocation": {"@id": "niiri:1785b6d6129a2cc148fe835d0e08dd0b"},
+      "prov:atLocation": {"@id": "niiri:397f7e230bc5b14a56fc501c4f38a3df"},
       "prov:value": {"@type": "xsd:float", "@value": "4.18069553375244"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.6862176534993"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00011380585323062"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999854453826"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.28014402363808"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.6862176534993"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00011380585323062"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999854453826"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.28014402363808"}
     },
     {
-      "@id": "niiri:1785b6d6129a2cc148fe835d0e08dd0b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:397f7e230bc5b14a56fc501c4f38a3df",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0124",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[46,-54,14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[46,-54,14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a5a2448865b51f8e6018dd6e5c69e2cc",
-      "entity": "niiri:3d62634be01e822042b85fbe2f4b57a5"
+      "entity_derived": "niiri:ab27403976625180dff5b30fab548263",
+      "entity": "niiri:62e799c85533fe86208bf5e33c6a326d"
     },
     {
-      "@id": "niiri:8d1da7a81194cb3115ff73028d763837",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:46ddcc1817cf540464c279f74a62d9e4",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0125",
-      "prov:atLocation": {"@id": "niiri:8c9a1cdbde509d06bc9249e524560204"},
+      "prov:atLocation": {"@id": "niiri:b89df9a7d5311e01dec9a19aebb58fad"},
       "prov:value": {"@type": "xsd:float", "@value": "4.16153001785278"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.67299901881211"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000119860202107414"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999174595323"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.287520254070199"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.67299901881211"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000119860202107414"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999174595323"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.287520254070199"}
     },
     {
-      "@id": "niiri:8c9a1cdbde509d06bc9249e524560204",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b89df9a7d5311e01dec9a19aebb58fad",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0125",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-36,-14,-24]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-36,-14,-24]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8d1da7a81194cb3115ff73028d763837",
-      "entity": "niiri:4d27ad0557a85357aebf8d3cb8a18d20"
+      "entity_derived": "niiri:46ddcc1817cf540464c279f74a62d9e4",
+      "entity": "niiri:7b8b805f3c10072513741773f37173a9"
     },
     {
-      "@id": "niiri:e74db54412c4a302b69fece9334e85e0",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:bf6a4e636ece08a9573e7b57d980d23f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0126",
-      "prov:atLocation": {"@id": "niiri:97f8b327ff6eca1c45f4c9b893a6f549"},
+      "prov:atLocation": {"@id": "niiri:c78fc1593491a390909bb0e0d1c8f4c9"},
       "prov:value": {"@type": "xsd:float", "@value": "4.16062259674072"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.67237190318196"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00012015480804084"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999196926834"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.287520254070199"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.67237190318196"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00012015480804084"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999196926834"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.287520254070199"}
     },
     {
-      "@id": "niiri:97f8b327ff6eca1c45f4c9b893a6f549",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c78fc1593491a390909bb0e0d1c8f4c9",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0126",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[16,-28,-4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[16,-28,-4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e74db54412c4a302b69fece9334e85e0",
-      "entity": "niiri:259f577b521fb0d31342d69e79678fd8"
+      "entity_derived": "niiri:bf6a4e636ece08a9573e7b57d980d23f",
+      "entity": "niiri:c8967930ef6b4850b98397e5a02cf2f7"
     },
     {
-      "@id": "niiri:baf9880dde22b6bd57633d511c3fbdee",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:2eae7c427a5a98b75646c2db0e42ffd3",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0127",
-      "prov:atLocation": {"@id": "niiri:10f6661f422c4d5e128c60d8bbf34483"},
+      "prov:atLocation": {"@id": "niiri:ebe690e4d7b4a7281caa9b69d4aa561e"},
       "prov:value": {"@type": "xsd:float", "@value": "4.14985752105713"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.66492347570236"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000123706274285817"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999422317975"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.29175084353581"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.66492347570236"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000123706274285817"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999422317975"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.29175084353581"}
     },
     {
-      "@id": "niiri:10f6661f422c4d5e128c60d8bbf34483",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ebe690e4d7b4a7281caa9b69d4aa561e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0127",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-28,14,-32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-28,14,-32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:baf9880dde22b6bd57633d511c3fbdee",
-      "entity": "niiri:73ea65987d6ff092b8032a7897f236dc"
+      "entity_derived": "niiri:2eae7c427a5a98b75646c2db0e42ffd3",
+      "entity": "niiri:162bab89b0c20f6474f1241e5c7169b3"
     },
     {
-      "@id": "niiri:ff7cbfb80e98a99ece15374712d7bbf3",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f175b4660b0c3a112517dde55ce65ffd",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0128",
-      "prov:atLocation": {"@id": "niiri:48c56e1cff6258befee2079ac974cdfe"},
+      "prov:atLocation": {"@id": "niiri:e80844385b765c376df5c5195c77c748"},
       "prov:value": {"@type": "xsd:float", "@value": "4.14875411987305"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.66415911467327"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000124076245730076"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999441734682"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.292006151507083"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.66415911467327"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000124076245730076"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999441734682"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.292006151507083"}
     },
     {
-      "@id": "niiri:48c56e1cff6258befee2079ac974cdfe",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e80844385b765c376df5c5195c77c748",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0128",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-34,-66,-12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-34,-66,-12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ff7cbfb80e98a99ece15374712d7bbf3",
-      "entity": "niiri:ba34aadcbdfb22bb96b240c5d8d71cb7"
+      "entity_derived": "niiri:f175b4660b0c3a112517dde55ce65ffd",
+      "entity": "niiri:91dc841836bbf5d1c0b426905fb75e01"
     },
     {
-      "@id": "niiri:e5ae6607ef1f74d17740d67cbd30f3cc",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c82901e5c8a2f2e07c026cc63680c42d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0129",
-      "prov:atLocation": {"@id": "niiri:8fe3962f98ed6ef4a016041bccb3decd"},
+      "prov:atLocation": {"@id": "niiri:a4d26902e57a81a17208a81e72853eac"},
       "prov:value": {"@type": "xsd:float", "@value": "4.14285278320312"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.66006819074182"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000126074068639181"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999535656409"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.294856542429919"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.66006819074182"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000126074068639181"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999535656409"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.294856542429919"}
     },
     {
-      "@id": "niiri:8fe3962f98ed6ef4a016041bccb3decd",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a4d26902e57a81a17208a81e72853eac",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0129",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-36,-36,18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-36,-36,18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e5ae6607ef1f74d17740d67cbd30f3cc",
-      "entity": "niiri:3a163a0cb084881b83df7fb4539004cf"
+      "entity_derived": "niiri:c82901e5c8a2f2e07c026cc63680c42d",
+      "entity": "niiri:3f463a005d2c5f82895c19639d89d232"
     },
     {
-      "@id": "niiri:f27f6c548b20f347c59293da9f535803",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5e05a6be8ed22422ff22c365a4608304",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0130",
-      "prov:atLocation": {"@id": "niiri:74dd8128a505045e9137cbd31e31f66c"},
+      "prov:atLocation": {"@id": "niiri:211422795d75783e69bfebe075bb12ba"},
       "prov:value": {"@type": "xsd:float", "@value": "4.13366317749023"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.65368808789982"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000129250133878323"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999653050959"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.299778606912797"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.65368808789982"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000129250133878323"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999653050959"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.299778606912797"}
     },
     {
-      "@id": "niiri:74dd8128a505045e9137cbd31e31f66c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:211422795d75783e69bfebe075bb12ba",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0130",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[48,6,-26]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[48,6,-26]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f27f6c548b20f347c59293da9f535803",
-      "entity": "niiri:43f0fb5e7c19214fdedd18472535c15a"
+      "entity_derived": "niiri:5e05a6be8ed22422ff22c365a4608304",
+      "entity": "niiri:a088e0c82151087e1bf9897ac5ca3823"
     },
     {
-      "@id": "niiri:f756b6f61da1646cc690af7d01487191",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e7bdd69e98dd52520a3f71978bb4d63d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0131",
-      "prov:atLocation": {"@id": "niiri:80aeef67e3ae8218a0930deda8754a8e"},
+      "prov:atLocation": {"@id": "niiri:0ad970416204095c686c9e26a90dd497"},
       "prov:value": {"@type": "xsd:float", "@value": "4.13216829299927"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.65264911070072"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000129774394504789"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999669292985"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.299778606912797"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.65264911070072"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000129774394504789"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999669292985"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.299778606912797"}
     },
     {
-      "@id": "niiri:80aeef67e3ae8218a0930deda8754a8e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0ad970416204095c686c9e26a90dd497",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0131",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[0,-36,68]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[0,-36,68]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f756b6f61da1646cc690af7d01487191",
-      "entity": "niiri:2eda6a0e1bdd1c9e5ed07632d4ecdc2f"
+      "entity_derived": "niiri:e7bdd69e98dd52520a3f71978bb4d63d",
+      "entity": "niiri:321fa4b64bb46facf5ed354080dc1587"
     },
     {
-      "@id": "niiri:4bd4142b1e187a6f1547307275a6b64a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:cb0d453b25f613101c49b7755e158915",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0132",
-      "prov:atLocation": {"@id": "niiri:214c5b9a5b733e0a2b01aa0370c70317"},
+      "prov:atLocation": {"@id": "niiri:bb9c71a13ba7d3c7720ba36a40323b94"},
       "prov:value": {"@type": "xsd:float", "@value": "4.12954187393188"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.65082293334618"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000130700706083675"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999969612074"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.300282900918552"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.65082293334618"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000130700706083675"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999969612074"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.300282900918552"}
     },
     {
-      "@id": "niiri:214c5b9a5b733e0a2b01aa0370c70317",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:bb9c71a13ba7d3c7720ba36a40323b94",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0132",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[0,-66,-32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[0,-66,-32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4bd4142b1e187a6f1547307275a6b64a",
-      "entity": "niiri:69803a9c56c9a9477742ef1bd9b5db35"
+      "entity_derived": "niiri:cb0d453b25f613101c49b7755e158915",
+      "entity": "niiri:1bb068ae0340b41c3c1e0585e61ab7a2"
     },
     {
-      "@id": "niiri:82e7078422f0b3937478956ca2843ed9",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5e99034ea754760cb72226c0515da7cb",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0133",
-      "prov:atLocation": {"@id": "niiri:7f935a6b2fe8e680c5275698f3711d68"},
+      "prov:atLocation": {"@id": "niiri:c9fab48eb480bedcc91578a2698fde0a"},
       "prov:value": {"@type": "xsd:float", "@value": "3.75143074989319"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.3772657457694"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000366051410943258"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999997"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.557036851440628"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.3772657457694"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000366051410943258"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999997"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.557036851440628"}
     },
     {
-      "@id": "niiri:7f935a6b2fe8e680c5275698f3711d68",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c9fab48eb480bedcc91578a2698fde0a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0133",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-2,-72,-40]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-2,-72,-40]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:82e7078422f0b3937478956ca2843ed9",
-      "entity": "niiri:69803a9c56c9a9477742ef1bd9b5db35"
+      "entity_derived": "niiri:5e99034ea754760cb72226c0515da7cb",
+      "entity": "niiri:1bb068ae0340b41c3c1e0585e61ab7a2"
     },
     {
-      "@id": "niiri:9041224ff70fb80d80372bf6cee64f1c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:129852f860cbdc380fde0cefe3342420",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0134",
-      "prov:atLocation": {"@id": "niiri:818d6163412bc763dcff14dee617a7e4"},
+      "prov:atLocation": {"@id": "niiri:205eb48ed5250d88acfbba837645bb72"},
       "prov:value": {"@type": "xsd:float", "@value": "4.10398292541504"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.63300080119002"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00014007207404787"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999869876426"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.313079908458167"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.63300080119002"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00014007207404787"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999869876426"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.313079908458167"}
     },
     {
-      "@id": "niiri:818d6163412bc763dcff14dee617a7e4",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:205eb48ed5250d88acfbba837645bb72",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0134",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-30,-80,-44]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-30,-80,-44]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9041224ff70fb80d80372bf6cee64f1c",
-      "entity": "niiri:01e79de738160252561a3797aff0be46"
+      "entity_derived": "niiri:129852f860cbdc380fde0cefe3342420",
+      "entity": "niiri:0b5c4b3fea9afd08f274ad657436f2dd"
     },
     {
-      "@id": "niiri:382c7b65c86868f2d1114949721c8c8b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b0ded885245f537f83463a08809ba2e2",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0135",
-      "prov:atLocation": {"@id": "niiri:a69cfd9529da5843d6391826ca8aa710"},
+      "prov:atLocation": {"@id": "niiri:6f21e9e630f7c14252e29da5be8927f7"},
       "prov:value": {"@type": "xsd:float", "@value": "4.09423494338989"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.62617922203425"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000143822875420141"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999906977983"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.318311758000453"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.62617922203425"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000143822875420141"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999906977983"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.318311758000453"}
     },
     {
-      "@id": "niiri:a69cfd9529da5843d6391826ca8aa710",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6f21e9e630f7c14252e29da5be8927f7",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0135",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-18,-58,20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-18,-58,20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:382c7b65c86868f2d1114949721c8c8b",
-      "entity": "niiri:f41790cbed14abdecac7977440cc0bb6"
+      "entity_derived": "niiri:b0ded885245f537f83463a08809ba2e2",
+      "entity": "niiri:7b0e7637357771b4e3c95b60da0daba2"
     },
     {
-      "@id": "niiri:0ff9790b1632fd8dc7c026079b7e404b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:22c1d4544f394d556ce159121dad1090",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0136",
-      "prov:atLocation": {"@id": "niiri:b391b16f30fa5bb91a81e95ad82f83a8"},
+      "prov:atLocation": {"@id": "niiri:3e383b88dff3fd247a1d4f46b429f125"},
       "prov:value": {"@type": "xsd:float", "@value": "4.08876514434814"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.62234556566246"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000145971878909523"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999923179458"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.320746339887158"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.62234556566246"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000145971878909523"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999923179458"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.320746339887158"}
     },
     {
-      "@id": "niiri:b391b16f30fa5bb91a81e95ad82f83a8",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:3e383b88dff3fd247a1d4f46b429f125",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0136",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-16,58,-4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-16,58,-4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0ff9790b1632fd8dc7c026079b7e404b",
-      "entity": "niiri:9cce28d22165f03a477a1d52851070af"
+      "entity_derived": "niiri:22c1d4544f394d556ce159121dad1090",
+      "entity": "niiri:b8afe5b11ecf6b25c3098ac5c67b90a0"
     },
     {
-      "@id": "niiri:46679ca6343d1a573a12b3267334ccae",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:547427e4ab366b57aeae32169e9fa826",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0137",
-      "prov:atLocation": {"@id": "niiri:4fc24b19e3f4073fc98c2cf157a77815"},
+      "prov:atLocation": {"@id": "niiri:2baf888e6359dbc3d2163775f4559d85"},
       "prov:value": {"@type": "xsd:float", "@value": "4.06298494338989"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.60421915672313"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0001565463954466"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999969751391"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.337066691036746"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.60421915672313"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0001565463954466"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999969751391"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.337066691036746"}
     },
     {
-      "@id": "niiri:4fc24b19e3f4073fc98c2cf157a77815",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:2baf888e6359dbc3d2163775f4559d85",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0137",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-58,-64,12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-58,-64,12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:46679ca6343d1a573a12b3267334ccae",
-      "entity": "niiri:cc59f8e2a9544b3ce2e7c770bd643f84"
+      "entity_derived": "niiri:547427e4ab366b57aeae32169e9fa826",
+      "entity": "niiri:a2a8b82493043f5593bcde950e35d4f5"
     },
     {
-      "@id": "niiri:e505d9f08efe295d66ff7d2729598e62",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b237ed83cace8461fcea11375ea64058",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0138",
-      "prov:atLocation": {"@id": "niiri:f6cac4d82fa45980bce788671b68c796"},
+      "prov:atLocation": {"@id": "niiri:ff3ac071d67ebff33f35d13e2679dac7"},
       "prov:value": {"@type": "xsd:float", "@value": "4.02409505844116"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.57669340248228"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000173983947479694"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999993280169"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.362069612357364"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.57669340248228"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000173983947479694"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999993280169"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.362069612357364"}
     },
     {
-      "@id": "niiri:f6cac4d82fa45980bce788671b68c796",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ff3ac071d67ebff33f35d13e2679dac7",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0138",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-52,-72,0]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-52,-72,0]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e505d9f08efe295d66ff7d2729598e62",
-      "entity": "niiri:1057dce00f5bb5fa3cfe47e76eb89cbb"
+      "entity_derived": "niiri:b237ed83cace8461fcea11375ea64058",
+      "entity": "niiri:13a870b0869420f093e2bf23ab79a37e"
     },
     {
-      "@id": "niiri:0befb71a96e196f1aecb2eefd51a6d97",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:eb9870892ec73e0a42bedc835e702e1e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0139",
-      "prov:atLocation": {"@id": "niiri:55f1bc9fb2977b7990ae8bce10083d5e"},
+      "prov:atLocation": {"@id": "niiri:4cb8ea570ae8e3ce83375c59900097d2"},
       "prov:value": {"@type": "xsd:float", "@value": "4.02128601074219"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.5746966510118"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000175317095178373"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999994000907"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.363217717063605"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.5746966510118"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000175317095178373"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999994000907"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.363217717063605"}
     },
     {
-      "@id": "niiri:55f1bc9fb2977b7990ae8bce10083d5e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4cb8ea570ae8e3ce83375c59900097d2",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0139",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-12,-28,-36]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-12,-28,-36]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0befb71a96e196f1aecb2eefd51a6d97",
-      "entity": "niiri:60ab79a3ea3afc698ecd6cf745ac195d"
+      "entity_derived": "niiri:eb9870892ec73e0a42bedc835e702e1e",
+      "entity": "niiri:9e62040415b20939b8c829b35ac0b428"
     },
     {
-      "@id": "niiri:98c13d4a8425e483950ba8ece5bf4a9f",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:fcfba481a3f9e7e9b20a26684a18708e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0140",
-      "prov:atLocation": {"@id": "niiri:48b17d888a4a392b84acb2d5b67ccb59"},
+      "prov:atLocation": {"@id": "niiri:63bfafc8fb101ba5e644b447c56092c7"},
       "prov:value": {"@type": "xsd:float", "@value": "4.01868104934692"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.57284393485473"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000176562616446385"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999994603219"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.36472959583602"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.57284393485473"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000176562616446385"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999994603219"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.36472959583602"}
     },
     {
-      "@id": "niiri:48b17d888a4a392b84acb2d5b67ccb59",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:63bfafc8fb101ba5e644b447c56092c7",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0140",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[16,66,8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[16,66,8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:98c13d4a8425e483950ba8ece5bf4a9f",
-      "entity": "niiri:5f6f6b54a9f90d5bb626fde29fa6b1fd"
+      "entity_derived": "niiri:fcfba481a3f9e7e9b20a26684a18708e",
+      "entity": "niiri:ef74f8693d6b0cc1f8f7291479877d46"
     },
     {
-      "@id": "niiri:6ad0d5c98c6831dc1f952295b4caf89e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:4a44af96f5a5a857488581ee74a760c5",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0141",
-      "prov:atLocation": {"@id": "niiri:021f6bacb46f04b2ef69b6934db45bcb"},
+      "prov:atLocation": {"@id": "niiri:8f1c6e77c3ba88353c96f0c53e4a0f3a"},
       "prov:value": {"@type": "xsd:float", "@value": "4.01162719726562"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.5678220431388"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000179980416080805"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999995959358"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.368705093303964"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.5678220431388"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000179980416080805"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999995959358"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.368705093303964"}
     },
     {
-      "@id": "niiri:021f6bacb46f04b2ef69b6934db45bcb",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:8f1c6e77c3ba88353c96f0c53e4a0f3a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0141",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[38,-18,-22]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[38,-18,-22]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6ad0d5c98c6831dc1f952295b4caf89e",
-      "entity": "niiri:d2932453ed5d06805f9a2af83c52d15a"
+      "entity_derived": "niiri:4a44af96f5a5a857488581ee74a760c5",
+      "entity": "niiri:b4f4a8e2b968691b39abdbd7cd10251b"
     },
     {
-      "@id": "niiri:c0f6e7b4644cfb60af16d459f0abf3d9",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:365c37bfef2c5372b568baf1a0e25c19",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0142",
-      "prov:atLocation": {"@id": "niiri:3e5fa4a1c3a10b594eed4892e0711540"},
+      "prov:atLocation": {"@id": "niiri:c269becdf88d5e85bf338212a81d3460"},
       "prov:value": {"@type": "xsd:float", "@value": "4.00135660171509"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.56049691778852"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000185076828154274"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999997368965"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.373725297443398"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.56049691778852"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000185076828154274"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999997368965"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.373725297443398"}
     },
     {
-      "@id": "niiri:3e5fa4a1c3a10b594eed4892e0711540",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c269becdf88d5e85bf338212a81d3460",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0142",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-48,-80,4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-48,-80,4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c0f6e7b4644cfb60af16d459f0abf3d9",
-      "entity": "niiri:3fa7a66071d2b8d3530bef533d52b63d"
+      "entity_derived": "niiri:365c37bfef2c5372b568baf1a0e25c19",
+      "entity": "niiri:b479ffd217729f45ba8e8b497543b71d"
     },
     {
-      "@id": "niiri:af4a6524016fc118e255dc42f2f9c362",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:9bdf6e301bc7d332bfc69fca7860e71a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0143",
-      "prov:atLocation": {"@id": "niiri:1486cf66d9de1dbe26612b03f0e6a4c9"},
+      "prov:atLocation": {"@id": "niiri:2b1b92ad42efe2e13047dd7960aa5a24"},
       "prov:value": {"@type": "xsd:float", "@value": "4.00135326385498"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.56049453464796"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000185078507948022"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999997369336"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.373725297443398"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.56049453464796"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000185078507948022"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999997369336"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.373725297443398"}
     },
     {
-      "@id": "niiri:1486cf66d9de1dbe26612b03f0e6a4c9",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:2b1b92ad42efe2e13047dd7960aa5a24",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0143",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-58,12,-8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-58,12,-8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:af4a6524016fc118e255dc42f2f9c362",
-      "entity": "niiri:b3bc50a19f719b2fefee16f3b146e23d"
+      "entity_derived": "niiri:9bdf6e301bc7d332bfc69fca7860e71a",
+      "entity": "niiri:64b1c86050912153a776e757204d9bd6"
     },
     {
-      "@id": "niiri:bf2797ace2e53c69a0cfe47803eb943e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f154380a3618d99fcc1963b7595b12cf",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0144",
-      "prov:atLocation": {"@id": "niiri:74fd89207afdcbd8909359b1cd2137af"},
+      "prov:atLocation": {"@id": "niiri:5c37f393fae5b3f0c9757bc853b9b56e"},
       "prov:value": {"@type": "xsd:float", "@value": "3.99607825279236"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.55672625925588"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000187752539048236"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999997897124"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.376379972172505"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.55672625925588"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000187752539048236"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999997897124"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.376379972172505"}
     },
     {
-      "@id": "niiri:74fd89207afdcbd8909359b1cd2137af",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:5c37f393fae5b3f0c9757bc853b9b56e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0144",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-48,-76,38]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-48,-76,38]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:bf2797ace2e53c69a0cfe47803eb943e",
-      "entity": "niiri:ae4a511d54b76b35f1462db6d3370c9c"
+      "entity_derived": "niiri:f154380a3618d99fcc1963b7595b12cf",
+      "entity": "niiri:2262ce46c8d9d3e44fca9d2b9991842a"
     },
     {
-      "@id": "niiri:68eb2bb6428cb7fb60f9cc6b4b70731c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:04b3a6d25c6f054367f9c4694052a759",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0145",
-      "prov:atLocation": {"@id": "niiri:9b177c1403c3d72642752ce1fd26ffc0"},
+      "prov:atLocation": {"@id": "niiri:4c62a1b7a4a99ebc81422f9ad84145a8"},
       "prov:value": {"@type": "xsd:float", "@value": "3.98602223396301"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.54953116356185"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000192958892207273"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999998637159"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.383480923686124"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.54953116356185"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000192958892207273"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999998637159"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.383480923686124"}
     },
     {
-      "@id": "niiri:9b177c1403c3d72642752ce1fd26ffc0",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4c62a1b7a4a99ebc81422f9ad84145a8",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0145",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[36,-82,-12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[36,-82,-12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:68eb2bb6428cb7fb60f9cc6b4b70731c",
-      "entity": "niiri:d9f9aff87a34b9c5479d4873772dd0ed"
+      "entity_derived": "niiri:04b3a6d25c6f054367f9c4694052a759",
+      "entity": "niiri:03e5589e0cbf8390adc9f572f09c2111"
     },
     {
-      "@id": "niiri:89aca1530216702056d8baaf5e96f3b9",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:21a5865dd670800228185cc04d8fc8fb",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0146",
-      "prov:atLocation": {"@id": "niiri:4210b934a7686b52ab673b65b6237b92"},
+      "prov:atLocation": {"@id": "niiri:bc24ed4471eb7ddcb8c465323191fbb1"},
       "prov:value": {"@type": "xsd:float", "@value": "3.98011517524719"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.54529763503038"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000196084993860035"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999998948156"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.387269615473322"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.54529763503038"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000196084993860035"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999998948156"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.387269615473322"}
     },
     {
-      "@id": "niiri:4210b934a7686b52ab673b65b6237b92",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:bc24ed4471eb7ddcb8c465323191fbb1",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0146",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[20,54,-8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[20,54,-8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:89aca1530216702056d8baaf5e96f3b9",
-      "entity": "niiri:8bfeeb8b866911a137111a38c272b615"
+      "entity_derived": "niiri:21a5865dd670800228185cc04d8fc8fb",
+      "entity": "niiri:183d033f8dc6f63dd2d370f917d30bf5"
     },
     {
-      "@id": "niiri:ae28de6778d667095f89372fc3a550d2",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c74a4087e267c6fd39be3a397e46725a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0147",
-      "prov:atLocation": {"@id": "niiri:f435575022c6f9a3cd038c9698277abc"},
+      "prov:atLocation": {"@id": "niiri:a66466e9c70651b2e5c633b33d19f5cf"},
       "prov:value": {"@type": "xsd:float", "@value": "3.96872425079346"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.5371191512089"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000202258563679281"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999936744"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.394063237507806"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.5371191512089"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000202258563679281"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999936744"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.394063237507806"}
     },
     {
-      "@id": "niiri:f435575022c6f9a3cd038c9698277abc",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a66466e9c70651b2e5c633b33d19f5cf",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0147",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-14,-94,-10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-14,-94,-10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ae28de6778d667095f89372fc3a550d2",
-      "entity": "niiri:ac52eb589b96f34cb8f8a5bc4d179c34"
+      "entity_derived": "niiri:c74a4087e267c6fd39be3a397e46725a",
+      "entity": "niiri:82ed6a608808b53426982c1cc66a2ec6"
     },
     {
-      "@id": "niiri:19444cfcec8df5e62fbbfd91a32d5ed2",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b7c5013ad25e77cc226834b99a8ce972",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0148",
-      "prov:atLocation": {"@id": "niiri:675e1f4fa7e363a599b247e3927ecc92"},
+      "prov:atLocation": {"@id": "niiri:74c064010533901b8404367331895a48"},
       "prov:value": {"@type": "xsd:float", "@value": "3.95317459106445"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.5259233176632"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0002110045706335"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999690183"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.405666580848087"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.5259233176632"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0002110045706335"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999690183"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.405666580848087"}
     },
     {
-      "@id": "niiri:675e1f4fa7e363a599b247e3927ecc92",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:74c064010533901b8404367331895a48",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0148",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[24,42,24]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[24,42,24]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:19444cfcec8df5e62fbbfd91a32d5ed2",
-      "entity": "niiri:3355d697f188c4ca897d5bfbad88c46c"
+      "entity_derived": "niiri:b7c5013ad25e77cc226834b99a8ce972",
+      "entity": "niiri:c38a12c7c56a4a6bcef1a3f1defaede6"
     },
     {
-      "@id": "niiri:7053ec26e42de608655ed244474068db",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:6991f89fa4a569360c7960b2846f6a34",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0149",
-      "prov:atLocation": {"@id": "niiri:0e60e10eda1b6196de171edf4835a00b"},
+      "prov:atLocation": {"@id": "niiri:4d01562ba8e7aaef06d135d4e94692d7"},
       "prov:value": {"@type": "xsd:float", "@value": "3.95155644416809"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.52475614968874"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000211936393588741"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999712743"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.405953632826713"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.52475614968874"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000211936393588741"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999712743"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.405953632826713"}
     },
     {
-      "@id": "niiri:0e60e10eda1b6196de171edf4835a00b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4d01562ba8e7aaef06d135d4e94692d7",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0149",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[12,-40,54]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[12,-40,54]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7053ec26e42de608655ed244474068db",
-      "entity": "niiri:868f4263fbce64aac9db6a0fc1959caf"
+      "entity_derived": "niiri:6991f89fa4a569360c7960b2846f6a34",
+      "entity": "niiri:b903a819026d14c010b6e3c047f2d1f1"
     },
     {
-      "@id": "niiri:5d90a7e798fc989106dcd7e3f700063d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:491aedeeb6989cc87f18a592ce6034b8",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0150",
-      "prov:atLocation": {"@id": "niiri:03b46eda33433662aeba61fcc011b88a"},
+      "prov:atLocation": {"@id": "niiri:10d3c6a7e17f15b5c99b849bce1f4e00"},
       "prov:value": {"@type": "xsd:float", "@value": "3.9356153011322"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.5132366181111"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000221341529396013"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999865451"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.417114555671981"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.5132366181111"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000221341529396013"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999865451"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.417114555671981"}
     },
     {
-      "@id": "niiri:03b46eda33433662aeba61fcc011b88a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:10d3c6a7e17f15b5c99b849bce1f4e00",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0150",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-38,-42,40]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-38,-42,40]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5d90a7e798fc989106dcd7e3f700063d",
-      "entity": "niiri:f20ed18d19c8f3654c783f3c512348b3"
+      "entity_derived": "niiri:491aedeeb6989cc87f18a592ce6034b8",
+      "entity": "niiri:932955007c6604e912ca88f69e4b71b2"
     },
     {
-      "@id": "niiri:8b40dfda892474fa41abb58fde74a407",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a0e32572643e1e64ce6a2b660df410a5",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0151",
-      "prov:atLocation": {"@id": "niiri:a347bbd053fb913e14b1f7c3a3bd8e7a"},
+      "prov:atLocation": {"@id": "niiri:9aa3ceab97fdd6296ca2d454a99e0236"},
       "prov:value": {"@type": "xsd:float", "@value": "3.9238920211792"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.50474037295824"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000228526381680583"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999924203"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.426487116823797"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.50474037295824"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000228526381680583"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999924203"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.426487116823797"}
     },
     {
-      "@id": "niiri:a347bbd053fb913e14b1f7c3a3bd8e7a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:9aa3ceab97fdd6296ca2d454a99e0236",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0151",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[26,14,-42]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[26,14,-42]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8b40dfda892474fa41abb58fde74a407",
-      "entity": "niiri:05512cf6085c8d2b74ae7737861092c8"
+      "entity_derived": "niiri:a0e32572643e1e64ce6a2b660df410a5",
+      "entity": "niiri:19bb8ba20387a263ccc2a4033c4a6959"
     },
     {
-      "@id": "niiri:f980d09473ea1db06a5ae15757b63531",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:eff4c7c132b2d22a84606557001ce26e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0152",
-      "prov:atLocation": {"@id": "niiri:ac45277c6c3e4f5e91852754529d4adf"},
+      "prov:atLocation": {"@id": "niiri:69acdcdb685d789931e1f31b3781c116"},
       "prov:value": {"@type": "xsd:float", "@value": "3.92273545265198"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.50390103236879"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000229247859657944"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999928429"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.426958547295112"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.50390103236879"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000229247859657944"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999928429"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.426958547295112"}
     },
     {
-      "@id": "niiri:ac45277c6c3e4f5e91852754529d4adf",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:69acdcdb685d789931e1f31b3781c116",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0152",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[70,-14,-16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[70,-14,-16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f980d09473ea1db06a5ae15757b63531",
-      "entity": "niiri:f695aae9ae02bed79ba9e19f8af0adb8"
+      "entity_derived": "niiri:eff4c7c132b2d22a84606557001ce26e",
+      "entity": "niiri:4c267352cce4185f6d8f19642a2432ea"
     },
     {
-      "@id": "niiri:689291c6ba42ba2ac5cad972a5fef404",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:bbf3d38beafaa3b95e5b56928a96bf1c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0153",
-      "prov:atLocation": {"@id": "niiri:b78b7f1eb50166ff54fb5604ca6337ed"},
+      "prov:atLocation": {"@id": "niiri:8d526269d332e0c02c7b75355485d2f8"},
       "prov:value": {"@type": "xsd:float", "@value": "3.92078685760498"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.50248644225283"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000230468620522117"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999935043"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.428151423127615"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.50248644225283"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000230468620522117"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999935043"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.428151423127615"}
     },
     {
-      "@id": "niiri:b78b7f1eb50166ff54fb5604ca6337ed",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:8d526269d332e0c02c7b75355485d2f8",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0153",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[34,-76,-48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[34,-76,-48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:689291c6ba42ba2ac5cad972a5fef404",
-      "entity": "niiri:d1fc4fee78d95536f89feb63f14c968c"
+      "entity_derived": "niiri:bbf3d38beafaa3b95e5b56928a96bf1c",
+      "entity": "niiri:b779ca098f1180fe09ebe0414895c731"
     },
     {
-      "@id": "niiri:17883bb686073f5e839d5a2c56455e56",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:fde7e62b6e5574c052bb9f546102d87e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0154",
-      "prov:atLocation": {"@id": "niiri:c664cfa73dad97e74074295ac43ea93e"},
+      "prov:atLocation": {"@id": "niiri:44da668a7172bf8e300266f277be8526"},
       "prov:value": {"@type": "xsd:float", "@value": "3.91062116622925"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.49509717797378"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000236944590689236"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999996108"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.436321106791799"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.49509717797378"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000236944590689236"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999996108"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.436321106791799"}
     },
     {
-      "@id": "niiri:c664cfa73dad97e74074295ac43ea93e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:44da668a7172bf8e300266f277be8526",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0154",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-6,-28,-38]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-6,-28,-38]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:17883bb686073f5e839d5a2c56455e56",
-      "entity": "niiri:e1f20b806abf584189fd37df83ae5f02"
+      "entity_derived": "niiri:fde7e62b6e5574c052bb9f546102d87e",
+      "entity": "niiri:b7385089cc22c8804fc256dff15181f6"
     },
     {
-      "@id": "niiri:a8eb2fd9a2816c1854b916c6d05cc3de",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:fd29863328da8f073c80249fc257f355",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0155",
-      "prov:atLocation": {"@id": "niiri:605067a9ffda41ab1a46d83048f971b3"},
+      "prov:atLocation": {"@id": "niiri:986f6d2591d738e2cadb54b471af94af"},
       "prov:value": {"@type": "xsd:float", "@value": "3.58703351020813"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.25118905074874"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000574617057569893"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.726302359446116"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.25118905074874"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000574617057569893"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.726302359446116"}
     },
     {
-      "@id": "niiri:605067a9ffda41ab1a46d83048f971b3",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:986f6d2591d738e2cadb54b471af94af",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0155",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[0,-34,-38]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[0,-34,-38]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a8eb2fd9a2816c1854b916c6d05cc3de",
-      "entity": "niiri:e1f20b806abf584189fd37df83ae5f02"
+      "entity_derived": "niiri:fd29863328da8f073c80249fc257f355",
+      "entity": "niiri:b7385089cc22c8804fc256dff15181f6"
     },
     {
-      "@id": "niiri:9e2bf19e1e6e723e7ef6ef9189c04fe4",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:bbfd8b6cf217d559db130a9610ba08e1",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0156",
-      "prov:atLocation": {"@id": "niiri:835c4fe7a0877e34b674425316a351e8"},
+      "prov:atLocation": {"@id": "niiri:924ee8942f43f143db4d35b4c58fba9b"},
       "prov:value": {"@type": "xsd:float", "@value": "3.90419101715088"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.49041501158993"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000241135489868927"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999972007"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.441724604413149"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.49041501158993"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000241135489868927"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999972007"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.441724604413149"}
     },
     {
-      "@id": "niiri:835c4fe7a0877e34b674425316a351e8",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:924ee8942f43f143db4d35b4c58fba9b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0156",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-38,-32,-20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-38,-32,-20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9e2bf19e1e6e723e7ef6ef9189c04fe4",
-      "entity": "niiri:f4343a9252d96448237743dc7620b82d"
+      "entity_derived": "niiri:bbfd8b6cf217d559db130a9610ba08e1",
+      "entity": "niiri:a34044dfcf23dfe53b2945318b0397f1"
     },
     {
-      "@id": "niiri:9226f674cf9b761e0a9ecfd66d3a398f",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:7b9ad2de6142a99edfdc041b3923c4a7",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0157",
-      "prov:atLocation": {"@id": "niiri:8986fe3ec63b2150128b1ebc207fe996"},
+      "prov:atLocation": {"@id": "niiri:436e822866e4609faf1e3f52f35d390a"},
       "prov:value": {"@type": "xsd:float", "@value": "3.89783668518066"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.48578178709346"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00024535055301822"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999979874"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.446520868052966"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.48578178709346"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00024535055301822"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999979874"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.446520868052966"}
     },
     {
-      "@id": "niiri:8986fe3ec63b2150128b1ebc207fe996",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:436e822866e4609faf1e3f52f35d390a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0157",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-16,-60,-40]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-16,-60,-40]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9226f674cf9b761e0a9ecfd66d3a398f",
-      "entity": "niiri:f74cf4fd744cb5d2223e69c6b86d72ca"
+      "entity_derived": "niiri:7b9ad2de6142a99edfdc041b3923c4a7",
+      "entity": "niiri:e3223bf7299c1367c69b65daadf7dab4"
     },
     {
-      "@id": "niiri:35761cafae22ec77ae8236d4705d8cf2",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:22f96a3b44837b69cbbf8a2c6235393c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0158",
-      "prov:atLocation": {"@id": "niiri:85a13da6c36c15780f819fee23c0e3db"},
+      "prov:atLocation": {"@id": "niiri:f0873eb65c77e400ce4652d1321fd7dc"},
       "prov:value": {"@type": "xsd:float", "@value": "3.89488410949707"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.48362680959561"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000247334358895901"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999998276"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.448724783299707"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.48362680959561"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000247334358895901"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999998276"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.448724783299707"}
     },
     {
-      "@id": "niiri:85a13da6c36c15780f819fee23c0e3db",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f0873eb65c77e400ce4652d1321fd7dc",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0158",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[22,-6,36]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[22,-6,36]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:35761cafae22ec77ae8236d4705d8cf2",
-      "entity": "niiri:2c8ba22e270c2ab78bc2767742ff87f1"
+      "entity_derived": "niiri:22f96a3b44837b69cbbf8a2c6235393c",
+      "entity": "niiri:315a3351fd67e6810a0558156faed379"
     },
     {
-      "@id": "niiri:ff502a8d909d3c3fb263e7bba8857ee2",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:4acde4458913098e4ee4d1c2c2fdf3e4",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0159",
-      "prov:atLocation": {"@id": "niiri:99e931bccfddb88b417478c52ad364a1"},
+      "prov:atLocation": {"@id": "niiri:ef2dcb6bf4f5fa6a95e35be037823273"},
       "prov:value": {"@type": "xsd:float", "@value": "3.88967633247375"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.47982255115638"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000250872994247642"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999986909"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.452045143743209"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.47982255115638"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000250872994247642"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999986909"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.452045143743209"}
     },
     {
-      "@id": "niiri:99e931bccfddb88b417478c52ad364a1",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ef2dcb6bf4f5fa6a95e35be037823273",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0159",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[70,-18,22]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[70,-18,22]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ff502a8d909d3c3fb263e7bba8857ee2",
-      "entity": "niiri:ffa25ea15473af14a67c3205bbe9f983"
+      "entity_derived": "niiri:4acde4458913098e4ee4d1c2c2fdf3e4",
+      "entity": "niiri:956afe330511d5dec77faf29c8e66c5b"
     },
     {
-      "@id": "niiri:78f7bb979686e7d99e73f8e3bcdeb29f",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d0a5abfdb9ce4fbd61ff9387b7bb7058",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0160",
-      "prov:atLocation": {"@id": "niiri:262ada1ef00daebfcc5a3f15081faf81"},
+      "prov:atLocation": {"@id": "niiri:ede966d1838252b4a610f64fcfdc2cde"},
       "prov:value": {"@type": "xsd:float", "@value": "3.88418507575989"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.47580665261676"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000254659668458612"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999990239"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.454152699790317"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.47580665261676"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000254659668458612"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999990239"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.454152699790317"}
     },
     {
-      "@id": "niiri:262ada1ef00daebfcc5a3f15081faf81",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ede966d1838252b4a610f64fcfdc2cde",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0160",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[30,2,6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[30,2,6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:78f7bb979686e7d99e73f8e3bcdeb29f",
-      "entity": "niiri:bc830c332ebaee861ca402fa60321dce"
+      "entity_derived": "niiri:d0a5abfdb9ce4fbd61ff9387b7bb7058",
+      "entity": "niiri:4740016eb1ce8e7ec8341eb44cf9ffa5"
     },
     {
-      "@id": "niiri:d7d1e168a257cc2a8098d5c4990334fc",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:8eb9d8849b7d8b35f84629d662d9ddce",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0161",
-      "prov:atLocation": {"@id": "niiri:6113b83ffc7f18d4a0cd5ff52a9e1dfc"},
+      "prov:atLocation": {"@id": "niiri:7074e885282a279bde925ee7cac8966c"},
       "prov:value": {"@type": "xsd:float", "@value": "3.86606097221375"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.4625186718634"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000267572390954318"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999996381"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.470059115371888"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.4625186718634"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000267572390954318"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999996381"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.470059115371888"}
     },
     {
-      "@id": "niiri:6113b83ffc7f18d4a0cd5ff52a9e1dfc",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7074e885282a279bde925ee7cac8966c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0161",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[44,-70,10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[44,-70,10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d7d1e168a257cc2a8098d5c4990334fc",
-      "entity": "niiri:47f7311fc1a64f3bf47cf50b4561aabc"
+      "entity_derived": "niiri:8eb9d8849b7d8b35f84629d662d9ddce",
+      "entity": "niiri:f956c3347b26a7454fde4d7c1ee3dfac"
     },
     {
-      "@id": "niiri:ebb9c3a475d66ccb16fb19d9f0d3ce14",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b9ada525c8e48deb5d4ab2d7359c8cad",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0162",
-      "prov:atLocation": {"@id": "niiri:46f7f2bdccb029792eb1f98b5b5baef1"},
+      "prov:atLocation": {"@id": "niiri:3c562f99bbe0809e80e32866c3fb4ddc"},
       "prov:value": {"@type": "xsd:float", "@value": "3.86296033859253"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.46024024384584"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00026984682439557"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999996958"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.472530207119252"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.46024024384584"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00026984682439557"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999996958"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.472530207119252"}
     },
     {
-      "@id": "niiri:46f7f2bdccb029792eb1f98b5b5baef1",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:3c562f99bbe0809e80e32866c3fb4ddc",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0162",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[62,14,2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[62,14,2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ebb9c3a475d66ccb16fb19d9f0d3ce14",
-      "entity": "niiri:b8ae2b4592f8a2f04be965b5829712bf"
+      "entity_derived": "niiri:b9ada525c8e48deb5d4ab2d7359c8cad",
+      "entity": "niiri:0306caf1c070bce484bea6d4d02ee4b9"
     },
     {
-      "@id": "niiri:234f15c91bb1376fd18666ea14553917",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3858cf13f28f0ad56deb178e3014e96c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0163",
-      "prov:atLocation": {"@id": "niiri:81fa678cb829b598f9461c5b13e08eeb"},
+      "prov:atLocation": {"@id": "niiri:be16a855a7da7e7571099f7d7fadf88b"},
       "prov:value": {"@type": "xsd:float", "@value": "3.8599865436554"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.45805360223286"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000272046559771755"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999997427"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.474088026751007"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.45805360223286"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000272046559771755"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999997427"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.474088026751007"}
     },
     {
-      "@id": "niiri:81fa678cb829b598f9461c5b13e08eeb",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:be16a855a7da7e7571099f7d7fadf88b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0163",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-4,-36,-2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-4,-36,-2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:234f15c91bb1376fd18666ea14553917",
-      "entity": "niiri:a0e10a7c0fca0a0252e91da150ff7c73"
+      "entity_derived": "niiri:3858cf13f28f0ad56deb178e3014e96c",
+      "entity": "niiri:0718df40c87e4adde0a6b31fdd007bb4"
     },
     {
-      "@id": "niiri:7850b2964ab00633dad17748772a65f3",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:1112b9b2a26ffc98a6ff69fd57530f89",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0164",
-      "prov:atLocation": {"@id": "niiri:1111921aa18c82a39e80343596bc0094"},
+      "prov:atLocation": {"@id": "niiri:46892ae833db38c9bed091f4cc572d1f"},
       "prov:value": {"@type": "xsd:float", "@value": "3.84141182899475"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.4443640186187"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000286202240919464"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999116"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.488513754339778"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.4443640186187"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000286202240919464"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999116"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.488513754339778"}
     },
     {
-      "@id": "niiri:1111921aa18c82a39e80343596bc0094",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:46892ae833db38c9bed091f4cc572d1f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0164",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[36,-86,0]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[36,-86,0]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7850b2964ab00633dad17748772a65f3",
-      "entity": "niiri:7ce8d10a760980abe8a87f7a79f378c2"
+      "entity_derived": "niiri:1112b9b2a26ffc98a6ff69fd57530f89",
+      "entity": "niiri:c3345fe728c02a6d54b764235fc35217"
     },
     {
-      "@id": "niiri:7b821f21d097cc8be558a6d09355f235",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:774e14320ea8f360c6b0c85dfac5a6f6",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0165",
-      "prov:atLocation": {"@id": "niiri:4fce38511ab679beeca0106d265285e3"},
+      "prov:atLocation": {"@id": "niiri:6cda172da941b8967efdbea8200c7c74"},
       "prov:value": {"@type": "xsd:float", "@value": "3.83968877792358"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.44309136368839"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000287552494602217"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999202"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.488629379902393"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.44309136368839"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000287552494602217"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999202"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.488629379902393"}
     },
     {
-      "@id": "niiri:4fce38511ab679beeca0106d265285e3",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6cda172da941b8967efdbea8200c7c74",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0165",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-22,-20,-8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-22,-20,-8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7b821f21d097cc8be558a6d09355f235",
-      "entity": "niiri:4dd100dcaaa90bf1aaa604fdff0ba9ff"
+      "entity_derived": "niiri:774e14320ea8f360c6b0c85dfac5a6f6",
+      "entity": "niiri:db4e8782b5b474daeb575623d11d8f36"
     },
     {
-      "@id": "niiri:0ed5fd3b050787ec334d9240417cc86b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:47ddc4f29769c51faebf4ea324bcbea6",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0166",
-      "prov:atLocation": {"@id": "niiri:7e187bd41f06a2ac9b65071b34db4f4d"},
+      "prov:atLocation": {"@id": "niiri:710d166e9d667b62c67e8a53f8271d18"},
       "prov:value": {"@type": "xsd:float", "@value": "3.82990407943726"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.43585539262748"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000295343082936661"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999554"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.497538796190216"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.43585539262748"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000295343082936661"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999554"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.497538796190216"}
     },
     {
-      "@id": "niiri:7e187bd41f06a2ac9b65071b34db4f4d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:710d166e9d667b62c67e8a53f8271d18",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0166",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[28,10,-48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[28,10,-48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0ed5fd3b050787ec334d9240417cc86b",
-      "entity": "niiri:ac00e8055c4355ec5762be8458693242"
+      "entity_derived": "niiri:47ddc4f29769c51faebf4ea324bcbea6",
+      "entity": "niiri:3a7bd3c73757ad2c63a505ac44ee7de9"
     },
     {
-      "@id": "niiri:917c3a971b74e494332c12b9d38f5f02",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:294213488c1599f884797c81cb836c26",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0167",
-      "prov:atLocation": {"@id": "niiri:1e214330c1ac605ba9e2a36127308d66"},
+      "prov:atLocation": {"@id": "niiri:6367c8833a918270dfd9c8b1b40ca341"},
       "prov:value": {"@type": "xsd:float", "@value": "3.82795763015747"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.43441413993503"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000296918082366093"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999603"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.498296237103169"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.43441413993503"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000296918082366093"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999603"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.498296237103169"}
     },
     {
-      "@id": "niiri:1e214330c1ac605ba9e2a36127308d66",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6367c8833a918270dfd9c8b1b40ca341",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0167",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[66,-50,8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[66,-50,8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:917c3a971b74e494332c12b9d38f5f02",
-      "entity": "niiri:0c01d3025f9ac35ecf95f50b6ad70473"
+      "entity_derived": "niiri:294213488c1599f884797c81cb836c26",
+      "entity": "niiri:ca632dc1f3d6a97bb76e5a785e5f4b39"
     },
     {
-      "@id": "niiri:ed7bf2f4d7ab358d6ef3f9319bccd007",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5ef57e2d25150bc6ea7a27effd3f103a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0168",
-      "prov:atLocation": {"@id": "niiri:c1024294630358228bcebd260db7bf8f"},
+      "prov:atLocation": {"@id": "niiri:57e37097f19962e578c75dbc7bf9fd63"},
       "prov:value": {"@type": "xsd:float", "@value": "3.8172779083252"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.42649555500792"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000305711884475035"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999793"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.506379555477876"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.42649555500792"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000305711884475035"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999793"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.506379555477876"}
     },
     {
-      "@id": "niiri:c1024294630358228bcebd260db7bf8f",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:57e37097f19962e578c75dbc7bf9fd63",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0168",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[4,10,-12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[4,10,-12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ed7bf2f4d7ab358d6ef3f9319bccd007",
-      "entity": "niiri:6f3664cedc79fb9f59b11be01c396b26"
+      "entity_derived": "niiri:5ef57e2d25150bc6ea7a27effd3f103a",
+      "entity": "niiri:4d501ade9f45e68e86c0aef60754a9aa"
     },
     {
-      "@id": "niiri:b24c5cd9b910fa054ebf0fa0aa6bed8d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0d6879c706d432096efe8532fec772d4",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0169",
-      "prov:atLocation": {"@id": "niiri:fa58bdddec43dbb6066752da57561818"},
+      "prov:atLocation": {"@id": "niiri:9edfb7145b03634fe426e3cb3a1f8f31"},
       "prov:value": {"@type": "xsd:float", "@value": "3.81648898124695"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.42590987377981"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000306371831813368"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999803"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.506469617613673"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.42590987377981"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000306371831813368"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999803"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.506469617613673"}
     },
     {
-      "@id": "niiri:fa58bdddec43dbb6066752da57561818",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:9edfb7145b03634fe426e3cb3a1f8f31",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0169",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-30,-76,14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-30,-76,14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b24c5cd9b910fa054ebf0fa0aa6bed8d",
-      "entity": "niiri:c89efa8381d6b8fd6a264562898c049a"
+      "entity_derived": "niiri:0d6879c706d432096efe8532fec772d4",
+      "entity": "niiri:4353f4b513f6d03c8ce9a7ee07ac3524"
     },
     {
-      "@id": "niiri:76656100d047e2ed713b22fc387c3ac1",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ab5b8f7ed76dff5e4855a5dd6e0a6743",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0170",
-      "prov:atLocation": {"@id": "niiri:b5f3dd3509c4c369cab07cfc6b263d4c"},
+      "prov:atLocation": {"@id": "niiri:4b10b660ac7ce0aa32872c923c9c69e9"},
       "prov:value": {"@type": "xsd:float", "@value": "3.81299877166748"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.42331762603938"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000309308734253833"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999841"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.507710079712136"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.42331762603938"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000309308734253833"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999841"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.507710079712136"}
     },
     {
-      "@id": "niiri:b5f3dd3509c4c369cab07cfc6b263d4c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4b10b660ac7ce0aa32872c923c9c69e9",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0170",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-56,-18,36]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-56,-18,36]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:76656100d047e2ed713b22fc387c3ac1",
-      "entity": "niiri:601f2b2d65ca5573b797e7fb5ea7c122"
+      "entity_derived": "niiri:ab5b8f7ed76dff5e4855a5dd6e0a6743",
+      "entity": "niiri:d24c03f6c5960ef050e1d0a675496464"
     },
     {
-      "@id": "niiri:3583b9c4fc0171a190e35241951dba8c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:764e3cd68a4e95df65e0a1e502bbd0d3",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0171",
-      "prov:atLocation": {"@id": "niiri:ad35dabfe3f4302f7aa5d78104dc9595"},
+      "prov:atLocation": {"@id": "niiri:7079336242f83a28182be4daca622d5b"},
       "prov:value": {"@type": "xsd:float", "@value": "3.8037748336792"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.41645740843357"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000317207934866337"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999911"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.514664695786681"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.41645740843357"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000317207934866337"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999911"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.514664695786681"}
     },
     {
-      "@id": "niiri:ad35dabfe3f4302f7aa5d78104dc9595",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7079336242f83a28182be4daca622d5b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0171",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-34,30,44]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-34,30,44]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3583b9c4fc0171a190e35241951dba8c",
-      "entity": "niiri:41706195949bd303e398c4c6246c9da1"
+      "entity_derived": "niiri:764e3cd68a4e95df65e0a1e502bbd0d3",
+      "entity": "niiri:0630bc3a96bd8ec1bd4f2dbb98bd8a68"
     },
     {
-      "@id": "niiri:439481b3a0012f61306105bf2a9e776e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:75596cb1506d72be9c60a786cdfeb9e9",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0172",
-      "prov:atLocation": {"@id": "niiri:d64db3448b2d0408bc9c2ba27b8954bc"},
+      "prov:atLocation": {"@id": "niiri:dcdaa5f8f83360bc6ccfa19fcc3afbe8"},
       "prov:value": {"@type": "xsd:float", "@value": "3.80352520942688"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.41627156249268"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00031742451522887"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999912"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.514664695786681"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.41627156249268"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00031742451522887"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999912"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.514664695786681"}
     },
     {
-      "@id": "niiri:d64db3448b2d0408bc9c2ba27b8954bc",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:dcdaa5f8f83360bc6ccfa19fcc3afbe8",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0172",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[18,-78,16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[18,-78,16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:439481b3a0012f61306105bf2a9e776e",
-      "entity": "niiri:3f5bc238b154db411923ec0d520212a5"
+      "entity_derived": "niiri:75596cb1506d72be9c60a786cdfeb9e9",
+      "entity": "niiri:7a6a9d89a41bce106a6e3f6b9bf39fc2"
     },
     {
-      "@id": "niiri:1556c414fb66f9ab6cc43df03318b6c0",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:cc61bb9a0e1e912d0243c40937af6d28",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0173",
-      "prov:atLocation": {"@id": "niiri:4ee0e9d25b9437d0ab31e8dd4484d4a0"},
+      "prov:atLocation": {"@id": "niiri:43baf4b4f25319c4535a3067412de7c0"},
       "prov:value": {"@type": "xsd:float", "@value": "3.79121017456055"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.40709049802208"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000328296763804747"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999999996"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.524856123968262"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.40709049802208"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000328296763804747"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999999996"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.524856123968262"}
     },
     {
-      "@id": "niiri:4ee0e9d25b9437d0ab31e8dd4484d4a0",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:43baf4b4f25319c4535a3067412de7c0",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0173",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[52,-8,52]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[52,-8,52]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1556c414fb66f9ab6cc43df03318b6c0",
-      "entity": "niiri:d61c2e3334e7afb034ac8b3a50d8eefd"
+      "entity_derived": "niiri:cc61bb9a0e1e912d0243c40937af6d28",
+      "entity": "niiri:6cd9c8b1f2dc650429e50bd72f6da32d"
     },
     {
-      "@id": "niiri:01f5f6d1e678860e3ba5ed96a8b9c5d9",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:32de098d3053799d0fc2c5c953ee1d3c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0174",
-      "prov:atLocation": {"@id": "niiri:1f2be2e88f5e869401b6058392d3f8d3"},
+      "prov:atLocation": {"@id": "niiri:f56888b381f2199a57eb6f32e1b76c94"},
       "prov:value": {"@type": "xsd:float", "@value": "3.79016637802124"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.40631120271348"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000329235375377435"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999963"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.525348401881072"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.40631120271348"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000329235375377435"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999963"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.525348401881072"}
     },
     {
-      "@id": "niiri:1f2be2e88f5e869401b6058392d3f8d3",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f56888b381f2199a57eb6f32e1b76c94",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0174",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-38,-20,-18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-38,-20,-18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:01f5f6d1e678860e3ba5ed96a8b9c5d9",
-      "entity": "niiri:c7f0899e68a33117259a0776f3fbd712"
+      "entity_derived": "niiri:32de098d3053799d0fc2c5c953ee1d3c",
+      "entity": "niiri:f0caefb73eec8df07661fca6c2cc2a56"
     },
     {
-      "@id": "niiri:0ec9533ffbb4d7f4726270a2944b2dbb",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:459d474e17bd85aec6efe07624d6ae57",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0175",
-      "prov:atLocation": {"@id": "niiri:c23f591fda8160c477941d2116809c5e"},
+      "prov:atLocation": {"@id": "niiri:8482429c259a3f7b13d44a7131b80d39"},
       "prov:value": {"@type": "xsd:float", "@value": "3.78082299232483"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.39932758559063"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000337758775393771"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999999998"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.533091122666778"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.39932758559063"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000337758775393771"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999999998"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.533091122666778"}
     },
     {
-      "@id": "niiri:c23f591fda8160c477941d2116809c5e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:8482429c259a3f7b13d44a7131b80d39",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0175",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-64,-16,34]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-64,-16,34]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0ec9533ffbb4d7f4726270a2944b2dbb",
-      "entity": "niiri:acf0099ad05f52f7740833ae0513f2c4"
+      "entity_derived": "niiri:459d474e17bd85aec6efe07624d6ae57",
+      "entity": "niiri:10dda0f512d376c45616527318012baa"
     },
     {
-      "@id": "niiri:e64bebd118b0a946836ec84aa101efaf",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3510b1f1d6805ff05bb7b6b5d36253fa",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0176",
-      "prov:atLocation": {"@id": "niiri:3168c610fa4db5fbc7d85dd821868324"},
+      "prov:atLocation": {"@id": "niiri:f5066157a094cacabacac8bdb14ecf29"},
       "prov:value": {"@type": "xsd:float", "@value": "3.775071144104"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.39502136510282"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000343116226298679"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999986"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.538899956377297"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.39502136510282"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000343116226298679"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999986"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.538899956377297"}
     },
     {
-      "@id": "niiri:3168c610fa4db5fbc7d85dd821868324",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f5066157a094cacabacac8bdb14ecf29",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0176",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-6,64,24]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-6,64,24]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e64bebd118b0a946836ec84aa101efaf",
-      "entity": "niiri:d639d06c89e7a7987cc7beee7f6eebde"
+      "entity_derived": "niiri:3510b1f1d6805ff05bb7b6b5d36253fa",
+      "entity": "niiri:3aeaeffb7762bacf9f1b2dc630012fe3"
     },
     {
-      "@id": "niiri:b79bfb24284bb783de7becea3d6c7594",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5bf7e5d9bb601821a72345c87cedd51c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0177",
-      "prov:atLocation": {"@id": "niiri:9cb273c27cdca162dbac06aef6a6ce6f"},
+      "prov:atLocation": {"@id": "niiri:ff6a8ac356b1fcdc3ba1e0677b07ef35"},
       "prov:value": {"@type": "xsd:float", "@value": "3.77039766311646"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.39151850905751"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000347532341239631"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999999999"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.541509095101857"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.39151850905751"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000347532341239631"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999999999"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.541509095101857"}
     },
     {
-      "@id": "niiri:9cb273c27cdca162dbac06aef6a6ce6f",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ff6a8ac356b1fcdc3ba1e0677b07ef35",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0177",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[12,-86,2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[12,-86,2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b79bfb24284bb783de7becea3d6c7594",
-      "entity": "niiri:019db96efd3f0d5a9f077d436d990e65"
+      "entity_derived": "niiri:5bf7e5d9bb601821a72345c87cedd51c",
+      "entity": "niiri:88ee03bc281326c9948572b0834fecf3"
     },
     {
-      "@id": "niiri:e79401d06adc37ee4b78d19978f78585",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b691067d61784029be138ffa1686adb8",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0178",
-      "prov:atLocation": {"@id": "niiri:4400c98a34340b7d55bd1142aa8e430c"},
+      "prov:atLocation": {"@id": "niiri:ccbf47d9d1d8eec7a8d44dfb17daf242"},
       "prov:value": {"@type": "xsd:float", "@value": "3.76804852485657"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.38975644066078"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000349773728989367"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999991"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.542836741004494"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.38975644066078"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000349773728989367"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999991"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.542836741004494"}
     },
     {
-      "@id": "niiri:4400c98a34340b7d55bd1142aa8e430c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ccbf47d9d1d8eec7a8d44dfb17daf242",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0178",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[56,-56,4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[56,-56,4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e79401d06adc37ee4b78d19978f78585",
-      "entity": "niiri:3589dce5a9f2dacdad11e4fc0348fe0f"
+      "entity_derived": "niiri:b691067d61784029be138ffa1686adb8",
+      "entity": "niiri:30868fad9324d3113736d83bd681718a"
     },
     {
-      "@id": "niiri:ff37da2a4f0c0a6297a5db8ab30945c5",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b2e8f0a888997bba7bfdd9f220a34d7c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0179",
-      "prov:atLocation": {"@id": "niiri:e51b409400bc4492b1ae033d7bd19085"},
+      "prov:atLocation": {"@id": "niiri:82e8ec11f93f733e88d5f02ce475eb3a"},
       "prov:value": {"@type": "xsd:float", "@value": "3.76583623886108"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.38809619826667"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000351897876951224"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999993"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.544688226103431"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.38809619826667"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000351897876951224"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999993"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.544688226103431"}
     },
     {
-      "@id": "niiri:e51b409400bc4492b1ae033d7bd19085",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:82e8ec11f93f733e88d5f02ce475eb3a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0179",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[30,-10,-22]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[30,-10,-22]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ff37da2a4f0c0a6297a5db8ab30945c5",
-      "entity": "niiri:6c2ff806101a3ff739a426037285f4f7"
+      "entity_derived": "niiri:b2e8f0a888997bba7bfdd9f220a34d7c",
+      "entity": "niiri:4b462b6d837ce2e27bce61ed0c368fd6"
     },
     {
-      "@id": "niiri:dd610c86903a2b65db4e265608c060f9",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:db0d54b000c98e5dee79f930e669b285",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0180",
-      "prov:atLocation": {"@id": "niiri:c1fe9a6ef838b0b4038c116cc3740cd9"},
+      "prov:atLocation": {"@id": "niiri:68a3e5e2e053a83eaa1d9e2d1081aee6"},
       "prov:value": {"@type": "xsd:float", "@value": "3.75574827194214"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.380515360821"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000361750154451945"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999996"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.55496612223741"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.380515360821"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000361750154451945"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999996"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.55496612223741"}
     },
     {
-      "@id": "niiri:c1fe9a6ef838b0b4038c116cc3740cd9",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:68a3e5e2e053a83eaa1d9e2d1081aee6",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0180",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-26,22,60]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-26,22,60]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:dd610c86903a2b65db4e265608c060f9",
-      "entity": "niiri:700ddae2d53d6ba003ce7aef4c34cf8c"
+      "entity_derived": "niiri:db0d54b000c98e5dee79f930e669b285",
+      "entity": "niiri:1bf97c65bec07a1317ef69c944689cf8"
     },
     {
-      "@id": "niiri:57dd52ee4f0d1d9c03506ff39479c584",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:79e2013c8aa62a779d24f56c4f7d2b61",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0181",
-      "prov:atLocation": {"@id": "niiri:93ba4fa3b7b3768e6fdc0a9f6444fd2c"},
+      "prov:atLocation": {"@id": "niiri:6ce596eae40f92939ac779652c7de352"},
       "prov:value": {"@type": "xsd:float", "@value": "3.75386500358582"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.37909828240956"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000363620022447164"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999997"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.55578840663352"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.37909828240956"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000363620022447164"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999997"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.55578840663352"}
     },
     {
-      "@id": "niiri:93ba4fa3b7b3768e6fdc0a9f6444fd2c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6ce596eae40f92939ac779652c7de352",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0181",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[8,-92,26]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[8,-92,26]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:57dd52ee4f0d1d9c03506ff39479c584",
-      "entity": "niiri:c226e28f1c7d1bb6df56af26165cf368"
+      "entity_derived": "niiri:79e2013c8aa62a779d24f56c4f7d2b61",
+      "entity": "niiri:cd27fa26bbd5aa4fa8cfbebf1bb95ad9"
     },
     {
-      "@id": "niiri:e2871ebca726df5053d77d25385e3099",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:36d4e5984e645e3739eafcddd636c2a0",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0182",
-      "prov:atLocation": {"@id": "niiri:ae350c0ae9ee4d2393cec54aac49bf5b"},
+      "prov:atLocation": {"@id": "niiri:6a73634a41988180ea6cdf81a21e10fd"},
       "prov:value": {"@type": "xsd:float", "@value": "3.74783110618591"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.37455409826951"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000369676911683547"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999998"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.559414929313896"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.37455409826951"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000369676911683547"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999998"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.559414929313896"}
     },
     {
-      "@id": "niiri:ae350c0ae9ee4d2393cec54aac49bf5b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6a73634a41988180ea6cdf81a21e10fd",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0182",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-44,-10,-38]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-44,-10,-38]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e2871ebca726df5053d77d25385e3099",
-      "entity": "niiri:d349e89efbf6c30897c6f74aaef9e81f"
+      "entity_derived": "niiri:36d4e5984e645e3739eafcddd636c2a0",
+      "entity": "niiri:31a80df97955e986f4be4839a052a5db"
     },
     {
-      "@id": "niiri:12aa07f0139d12698164fc38fa4f2cbf",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ee94413a615c0ae8d638fa74a0954f38",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0183",
-      "prov:atLocation": {"@id": "niiri:a429b7a35674e2fa4bd9eddbcf7eac1e"},
+      "prov:atLocation": {"@id": "niiri:6d6ca80aef4904d97475b3a1a85fb36f"},
       "prov:value": {"@type": "xsd:float", "@value": "3.73827314376831"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.36734359778017"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000379480313921432"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999999"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.568714691324852"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.36734359778017"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000379480313921432"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999999"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.568714691324852"}
     },
     {
-      "@id": "niiri:a429b7a35674e2fa4bd9eddbcf7eac1e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6d6ca80aef4904d97475b3a1a85fb36f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0183",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[32,4,8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[32,4,8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:12aa07f0139d12698164fc38fa4f2cbf",
-      "entity": "niiri:cd868dac3ef78cde76ebbceb4543715e"
+      "entity_derived": "niiri:ee94413a615c0ae8d638fa74a0954f38",
+      "entity": "niiri:39fc04da006cbf70670a7f80045d0d49"
     },
     {
-      "@id": "niiri:6d82ef6c5b79ee21f49f61c4144c77b2",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c4ca487861e26bb6edf9d460b8c438f5",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0184",
-      "prov:atLocation": {"@id": "niiri:aff3accbbd76f14d658937fd03eba12c"},
+      "prov:atLocation": {"@id": "niiri:a984ff9c1bc463c5305396b634b896d7"},
       "prov:value": {"@type": "xsd:float", "@value": "3.73499631881714"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.36486808622606"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000382901311427597"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999999"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.57046827086113"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.36486808622606"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000382901311427597"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999999"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.57046827086113"}
     },
     {
-      "@id": "niiri:aff3accbbd76f14d658937fd03eba12c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a984ff9c1bc463c5305396b634b896d7",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0184",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-12,-60,-28]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-12,-60,-28]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6d82ef6c5b79ee21f49f61c4144c77b2",
-      "entity": "niiri:2b8a556886785a97e170fa36a82a529d"
+      "entity_derived": "niiri:c4ca487861e26bb6edf9d460b8c438f5",
+      "entity": "niiri:a2df6515d44ea1c2de2e20cd83b43f91"
     },
     {
-      "@id": "niiri:09a0686f4010b14f74f873bb9e5859b4",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:74d29ddfa219f7865899d3e1aa985fad",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0185",
-      "prov:atLocation": {"@id": "niiri:d2df05b7efca297f96a55dfd94e9b231"},
+      "prov:atLocation": {"@id": "niiri:862ab06c53bf7580c82758f3c5e05d0c"},
       "prov:value": {"@type": "xsd:float", "@value": "3.71396541595459"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.34893751145887"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000405610447892446"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.593900566305716"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.34893751145887"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000405610447892446"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.593900566305716"}
     },
     {
-      "@id": "niiri:d2df05b7efca297f96a55dfd94e9b231",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:862ab06c53bf7580c82758f3c5e05d0c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0185",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[26,-8,12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[26,-8,12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:09a0686f4010b14f74f873bb9e5859b4",
-      "entity": "niiri:cbd1c61d5f72e84539faeac10377a620"
+      "entity_derived": "niiri:74d29ddfa219f7865899d3e1aa985fad",
+      "entity": "niiri:9b33ff671ff0c042af89e5b1be1377da"
     },
     {
-      "@id": "niiri:81e790cfa9ebe0580ac21e4679031d54",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:02ee73aa72ad228b43c68c9f025c92c9",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0186",
-      "prov:atLocation": {"@id": "niiri:6d8f75af4a6e97ca5cde4a4c2d77f2d1"},
+      "prov:atLocation": {"@id": "niiri:8454dc655bb35ba99f3dba0346e7316c"},
       "prov:value": {"@type": "xsd:float", "@value": "3.71342253684998"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.34852531049968"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000406214298471763"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.593900566305716"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.34852531049968"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000406214298471763"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.593900566305716"}
     },
     {
-      "@id": "niiri:6d8f75af4a6e97ca5cde4a4c2d77f2d1",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:8454dc655bb35ba99f3dba0346e7316c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0186",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[20,-26,14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[20,-26,14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:81e790cfa9ebe0580ac21e4679031d54",
-      "entity": "niiri:08bad01c6e1b7035d226d8f83114d9d4"
+      "entity_derived": "niiri:02ee73aa72ad228b43c68c9f025c92c9",
+      "entity": "niiri:25e2f4ca28679423b49be4329eea0bc3"
     },
     {
-      "@id": "niiri:756c3bd1589a6a1a93f8e9b0426d30da",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5148a355763840d52c51745baf6d8bf1",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0187",
-      "prov:atLocation": {"@id": "niiri:eafbe6430229fd9295b4ed3d5265d179"},
+      "prov:atLocation": {"@id": "niiri:022b93a52530966eb78075d6eac6ecea"},
       "prov:value": {"@type": "xsd:float", "@value": "3.71231603622437"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.34768500611999"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000407447880153899"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.594555117771048"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.34768500611999"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000407447880153899"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.594555117771048"}
     },
     {
-      "@id": "niiri:eafbe6430229fd9295b4ed3d5265d179",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:022b93a52530966eb78075d6eac6ecea",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0187",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[8,8,44]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[8,8,44]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:756c3bd1589a6a1a93f8e9b0426d30da",
-      "entity": "niiri:dbd29bbddcbce1e02e18bedcb8b3c4b3"
+      "entity_derived": "niiri:5148a355763840d52c51745baf6d8bf1",
+      "entity": "niiri:0a729befa841fff84fcf2612fb2ce4a5"
     },
     {
-      "@id": "niiri:e6c2bfa55531294a2a6810f1e2499f7e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0799198166c4e4ec859a6d6486f90093",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0188",
-      "prov:atLocation": {"@id": "niiri:ba8be61c20624edab79b352cbc6c0c3f"},
+      "prov:atLocation": {"@id": "niiri:566b1ae67509d41808fda40621ca7b61"},
       "prov:value": {"@type": "xsd:float", "@value": "3.71084380149841"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.34656663561433"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00040909505954867"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.595665947803054"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.34656663561433"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00040909505954867"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.595665947803054"}
     },
     {
-      "@id": "niiri:ba8be61c20624edab79b352cbc6c0c3f",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:566b1ae67509d41808fda40621ca7b61",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0188",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-28,4,-42]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-28,4,-42]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e6c2bfa55531294a2a6810f1e2499f7e",
-      "entity": "niiri:1d73a20f9c8bfb47867f2c59ae3c13b5"
+      "entity_derived": "niiri:0799198166c4e4ec859a6d6486f90093",
+      "entity": "niiri:501da0873de972e1023817d65202130e"
     },
     {
-      "@id": "niiri:588e6085420a80bcd1e10a6dde764a47",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0aa10d875c9c1e35c96e247e10de57ee",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0189",
-      "prov:atLocation": {"@id": "niiri:8bfdd226c46a87c2b9fb259bd51e8cd3"},
+      "prov:atLocation": {"@id": "niiri:f4b96ff42be70bb2b09861757cb97da1"},
       "prov:value": {"@type": "xsd:float", "@value": "3.69969868659973"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.3380885246229"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00042178434593132"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.607485135007791"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.3380885246229"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00042178434593132"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.607485135007791"}
     },
     {
-      "@id": "niiri:8bfdd226c46a87c2b9fb259bd51e8cd3",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f4b96ff42be70bb2b09861757cb97da1",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0189",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[22,-6,-34]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[22,-6,-34]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:588e6085420a80bcd1e10a6dde764a47",
-      "entity": "niiri:b25e28979a447c1cd5093c9afae92781"
+      "entity_derived": "niiri:0aa10d875c9c1e35c96e247e10de57ee",
+      "entity": "niiri:0336a0114f6c74e1df58148ee9b074f4"
     },
     {
-      "@id": "niiri:b28414ca025b0ceb35fc0a166285b480",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:df286e546b49998eef6184d9ae67818c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0190",
-      "prov:atLocation": {"@id": "niiri:86ef3b9c9e4f7a9b0c7ff381015d0d5c"},
+      "prov:atLocation": {"@id": "niiri:40abce439058cc82f5d725ab26b39a04"},
       "prov:value": {"@type": "xsd:float", "@value": "3.69548296928406"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.33487616330673"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00042668696793946"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.610645919300431"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.33487616330673"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00042668696793946"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.610645919300431"}
     },
     {
-      "@id": "niiri:86ef3b9c9e4f7a9b0c7ff381015d0d5c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:40abce439058cc82f5d725ab26b39a04",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0190",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[26,46,4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[26,46,4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b28414ca025b0ceb35fc0a166285b480",
-      "entity": "niiri:e52574eea0816040ab22d41230ea518c"
+      "entity_derived": "niiri:df286e546b49998eef6184d9ae67818c",
+      "entity": "niiri:06324b32c616d4e45a79cb65a439ac48"
     },
     {
-      "@id": "niiri:17632dec077de6a4b5e6f11b977be3f4",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b5c652713f89d13b86856e3329e60e97",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0191",
-      "prov:atLocation": {"@id": "niiri:88f83b15542c493d543d7dba15131255"},
+      "prov:atLocation": {"@id": "niiri:12a1b45b727c26d17ba943ca60c4c0bd"},
       "prov:value": {"@type": "xsd:float", "@value": "3.68579792976379"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.32748481106661"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000438168831523034"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.620072204467785"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.32748481106661"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000438168831523034"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.620072204467785"}
     },
     {
-      "@id": "niiri:88f83b15542c493d543d7dba15131255",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:12a1b45b727c26d17ba943ca60c4c0bd",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0191",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-18,-16,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-18,-16,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:17632dec077de6a4b5e6f11b977be3f4",
-      "entity": "niiri:cac2f6c0cd35c2d53ed1689d1f149a53"
+      "entity_derived": "niiri:b5c652713f89d13b86856e3329e60e97",
+      "entity": "niiri:ac9a19a2b1c9949a888ebae7d65a2399"
     },
     {
-      "@id": "niiri:d32bfab4ca3777f99408b23496062f21",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:89124d4a55465ecc6580a87278eb8730",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0192",
-      "prov:atLocation": {"@id": "niiri:7222e0c3ef89b9c8becc19dbb85e4b22"},
+      "prov:atLocation": {"@id": "niiri:51cc533c8467f20d1155ffc22498abf5"},
       "prov:value": {"@type": "xsd:float", "@value": "3.68518376350403"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.32701556031273"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000438907358197516"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.620072204467785"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.32701556031273"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000438907358197516"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.620072204467785"}
     },
     {
-      "@id": "niiri:7222e0c3ef89b9c8becc19dbb85e4b22",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:51cc533c8467f20d1155ffc22498abf5",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0192",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-12,38,58]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-12,38,58]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d32bfab4ca3777f99408b23496062f21",
-      "entity": "niiri:78cef26d38b3c686cc371fc53f23b0b0"
+      "entity_derived": "niiri:89124d4a55465ecc6580a87278eb8730",
+      "entity": "niiri:061dca60ff6ace182bd1ebe945535ace"
     },
     {
-      "@id": "niiri:c72de2624c07eaf74d6e92bb473ec21c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:7c0c361d425385fbaf81e45ac15b1add",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0193",
-      "prov:atLocation": {"@id": "niiri:72fcaf12715d23476f7fc2f3eeea64a0"},
+      "prov:atLocation": {"@id": "niiri:8196fd95c6f6da2498153caebca81a9e"},
       "prov:value": {"@type": "xsd:float", "@value": "3.68469381332397"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.32664117032322"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000439497416485524"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.620072204467785"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.32664117032322"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000439497416485524"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.620072204467785"}
     },
     {
-      "@id": "niiri:72fcaf12715d23476f7fc2f3eeea64a0",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:8196fd95c6f6da2498153caebca81a9e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0193",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-20,-2,56]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-20,-2,56]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c72de2624c07eaf74d6e92bb473ec21c",
-      "entity": "niiri:ee1be7d7191fe1d0a268751891c07368"
+      "entity_derived": "niiri:7c0c361d425385fbaf81e45ac15b1add",
+      "entity": "niiri:6242500a1c0ecfe873a2799eca21133b"
     },
     {
-      "@id": "niiri:e722df44ac69d464af27624984f0bb4c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a27efb8e81003403a3b728b02a0305de",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0194",
-      "prov:atLocation": {"@id": "niiri:66ab321f4a5e82659cb5370912d91ed9"},
+      "prov:atLocation": {"@id": "niiri:56df4db7d539ca39549ce15b7ea50f31"},
       "prov:value": {"@type": "xsd:float", "@value": "3.68345642089844"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.32569544910563"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000440991199531338"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.620678594375276"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.32569544910563"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000440991199531338"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.620678594375276"}
     },
     {
-      "@id": "niiri:66ab321f4a5e82659cb5370912d91ed9",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:56df4db7d539ca39549ce15b7ea50f31",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0194",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-52,28,12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-52,28,12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e722df44ac69d464af27624984f0bb4c",
-      "entity": "niiri:460199221aa05d5f8655df003b9ba5e5"
+      "entity_derived": "niiri:a27efb8e81003403a3b728b02a0305de",
+      "entity": "niiri:62f0dcd6742c42c5c8a69829ea982b14"
     },
     {
-      "@id": "niiri:8a4fa46722b6ec4fe67c5c55b72df858",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f6c9002f2a33bbdcf918614062da93d1",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0195",
-      "prov:atLocation": {"@id": "niiri:1cc0115a9ae6b0efd554881e1b94c5ac"},
+      "prov:atLocation": {"@id": "niiri:51195bf8976356008123f14dcc2b8de5"},
       "prov:value": {"@type": "xsd:float", "@value": "3.67815756797791"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.32164266737708"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000447446096799475"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.624850402893793"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.32164266737708"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000447446096799475"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.624850402893793"}
     },
     {
-      "@id": "niiri:1cc0115a9ae6b0efd554881e1b94c5ac",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:51195bf8976356008123f14dcc2b8de5",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0195",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[22,20,-18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[22,20,-18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8a4fa46722b6ec4fe67c5c55b72df858",
-      "entity": "niiri:13c65c64199df9d15af3dcaef046e358"
+      "entity_derived": "niiri:f6c9002f2a33bbdcf918614062da93d1",
+      "entity": "niiri:ed86b8af25a7303faba66f96f7427038"
     },
     {
-      "@id": "niiri:1c981200507bd3ef3c96df12ef94ef8b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:273a08beef0cdedfcbf83ba358d17b4a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0196",
-      "prov:atLocation": {"@id": "niiri:18a1ba4f4b46f198e48a8fab512606d1"},
+      "prov:atLocation": {"@id": "niiri:bee076b1ef81a577daaacaa7c437434e"},
       "prov:value": {"@type": "xsd:float", "@value": "3.67246556282043"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.31728385777887"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00045448607795473"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.630238922827796"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.31728385777887"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00045448607795473"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.630238922827796"}
     },
     {
-      "@id": "niiri:18a1ba4f4b46f198e48a8fab512606d1",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:bee076b1ef81a577daaacaa7c437434e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0196",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-16,56,-10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-16,56,-10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1c981200507bd3ef3c96df12ef94ef8b",
-      "entity": "niiri:7a0a564d5df4aedd6daf83ea5ff89179"
+      "entity_derived": "niiri:273a08beef0cdedfcbf83ba358d17b4a",
+      "entity": "niiri:81c63725e4640647cd75f101cc0fc8a7"
     },
     {
-      "@id": "niiri:d41c01e2a940202811c21be7e2a39cf8",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b8d737b346f350b24c46e795748e22fb",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0197",
-      "prov:atLocation": {"@id": "niiri:279d26e2f8d06421d06ac330815fd880"},
+      "prov:atLocation": {"@id": "niiri:f381a9b3ecc4a18b9ce6ca29376c4ff2"},
       "prov:value": {"@type": "xsd:float", "@value": "3.67176198959351"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.31674469325952"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00045536398943602"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.630238922827796"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.31674469325952"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00045536398943602"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.630238922827796"}
     },
     {
-      "@id": "niiri:279d26e2f8d06421d06ac330815fd880",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f381a9b3ecc4a18b9ce6ca29376c4ff2",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0197",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-54,-22,60]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-54,-22,60]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d41c01e2a940202811c21be7e2a39cf8",
-      "entity": "niiri:64296118b766a08ff9a1b3331ff3a8be"
+      "entity_derived": "niiri:b8d737b346f350b24c46e795748e22fb",
+      "entity": "niiri:4b2e0a2531b0291df0fe5df5bc205ec9"
     },
     {
-      "@id": "niiri:cb5e4a08e9400a334eb9b747b16de07b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b628b10379f38e68ed5b66c336b27ce3",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0198",
-      "prov:atLocation": {"@id": "niiri:e0cb2ac4803ebf6432fbaf9d8664003a"},
+      "prov:atLocation": {"@id": "niiri:4a3e07338e224062c86a093f897dd586"},
       "prov:value": {"@type": "xsd:float", "@value": "3.6656653881073"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.31206918161529"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000463043207802327"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.636780442381221"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.31206918161529"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000463043207802327"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.636780442381221"}
     },
     {
-      "@id": "niiri:e0cb2ac4803ebf6432fbaf9d8664003a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4a3e07338e224062c86a093f897dd586",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0198",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[12,-26,32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[12,-26,32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cb5e4a08e9400a334eb9b747b16de07b",
-      "entity": "niiri:2d05298a2bfc1bad012eb9c5a6636ad4"
+      "entity_derived": "niiri:b628b10379f38e68ed5b66c336b27ce3",
+      "entity": "niiri:7f91f8087c7d8ec7eda6204b5b39482d"
     },
     {
-      "@id": "niiri:4bde4d943d26283fb187a7fbdf7f3b4d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:73de5af689e2e854fa7db73a7b08e0fe",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0199",
-      "prov:atLocation": {"@id": "niiri:74cb0e81cf74220bc3cb9f57860c8561"},
+      "prov:atLocation": {"@id": "niiri:ebdbc5b2e4abb9eaa379c70ec8dcde1e"},
       "prov:value": {"@type": "xsd:float", "@value": "3.66424226760864"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.3109768679857"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000464854468121723"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.637917502965391"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.3109768679857"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000464854468121723"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.637917502965391"}
     },
     {
-      "@id": "niiri:74cb0e81cf74220bc3cb9f57860c8561",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ebdbc5b2e4abb9eaa379c70ec8dcde1e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0199",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-54,-26,20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-54,-26,20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4bde4d943d26283fb187a7fbdf7f3b4d",
-      "entity": "niiri:5675ac9e2a66ba888afe627ebfc89ba2"
+      "entity_derived": "niiri:73de5af689e2e854fa7db73a7b08e0fe",
+      "entity": "niiri:2c7f0285c24b2b8b65a032418b15cd16"
     },
     {
-      "@id": "niiri:c266692d1c80522485c97cc3ea18c3ac",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b0085be54d5b554caf5c0c60d9943ca3",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0200",
-      "prov:atLocation": {"@id": "niiri:4bfce0fa1e9dd94ba7fafbc441dbac24"},
+      "prov:atLocation": {"@id": "niiri:18a86448a493c980c8799ef2fa49927e"},
       "prov:value": {"@type": "xsd:float", "@value": "3.65446782112122"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.30346511601015"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000477489250152452"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.649479872404913"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.30346511601015"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000477489250152452"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.649479872404913"}
     },
     {
-      "@id": "niiri:4bfce0fa1e9dd94ba7fafbc441dbac24",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:18a86448a493c980c8799ef2fa49927e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0200",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[28,-26,54]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[28,-26,54]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c266692d1c80522485c97cc3ea18c3ac",
-      "entity": "niiri:ec3de522ea3b2037df66f6245f038d27"
+      "entity_derived": "niiri:b0085be54d5b554caf5c0c60d9943ca3",
+      "entity": "niiri:7ed3fe10280b67503b5448524a04f269"
     },
     {
-      "@id": "niiri:6f7481789f1fc90fd34d16d386705c4c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f9e69d234f36d1d73224b4a30b59f7dc",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0201",
-      "prov:atLocation": {"@id": "niiri:220598619807b214635f463c83541c39"},
+      "prov:atLocation": {"@id": "niiri:83afb4d3fe181c770288664feec0e8eb"},
       "prov:value": {"@type": "xsd:float", "@value": "3.65308904647827"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.30240419282363"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000479299143653966"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.650580107543262"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.30240419282363"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000479299143653966"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.650580107543262"}
     },
     {
-      "@id": "niiri:220598619807b214635f463c83541c39",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:83afb4d3fe181c770288664feec0e8eb",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0201",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[56,-12,-34]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[56,-12,-34]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6f7481789f1fc90fd34d16d386705c4c",
-      "entity": "niiri:d912332211df7778d8d01732fe94c592"
+      "entity_derived": "niiri:f9e69d234f36d1d73224b4a30b59f7dc",
+      "entity": "niiri:99c58e7d96cf7da6763a2e1cbba873ae"
     },
     {
-      "@id": "niiri:ef8c6bdb39c721b0f2cdfe89bdda3461",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:fdaaf45a96ab001df01c3f32cad6f0d5",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0202",
-      "prov:atLocation": {"@id": "niiri:3a559a209510f1661bacc06353f06b68"},
+      "prov:atLocation": {"@id": "niiri:1ab0b084d0c745086441303217bfb06a"},
       "prov:value": {"@type": "xsd:float", "@value": "3.65141272544861"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.30111387597635"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000481508936725383"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.652085475027948"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.30111387597635"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000481508936725383"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.652085475027948"}
     },
     {
-      "@id": "niiri:3a559a209510f1661bacc06353f06b68",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:1ab0b084d0c745086441303217bfb06a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0202",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-32,-26,26]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-32,-26,26]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ef8c6bdb39c721b0f2cdfe89bdda3461",
-      "entity": "niiri:7b7bea73949631fa11f1e655bc82c0ca"
+      "entity_derived": "niiri:fdaaf45a96ab001df01c3f32cad6f0d5",
+      "entity": "niiri:d5206500679003f5f39472159c4ad0de"
     },
     {
-      "@id": "niiri:3559a82551b51293a26321ba3f63be57",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:802d2977df694ebb8aa91513a51f9d09",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0203",
-      "prov:atLocation": {"@id": "niiri:47fb39b4708b604798b7097271b8722b"},
+      "prov:atLocation": {"@id": "niiri:efc63a148d5261c31e0939091f77ceaa"},
       "prov:value": {"@type": "xsd:float", "@value": "3.64412999153137"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.2955024977544"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000491229150587746"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.660471475830505"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.2955024977544"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000491229150587746"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.660471475830505"}
     },
     {
-      "@id": "niiri:47fb39b4708b604798b7097271b8722b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:efc63a148d5261c31e0939091f77ceaa",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0203",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[62,-42,32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[62,-42,32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3559a82551b51293a26321ba3f63be57",
-      "entity": "niiri:522c28dd4e63e1c775b1ebd75bb4c8b3"
+      "entity_derived": "niiri:802d2977df694ebb8aa91513a51f9d09",
+      "entity": "niiri:0803006e1feea37abdc724f07464d7a9"
     },
     {
-      "@id": "niiri:292337cfe50250e8c1b9e0526394644c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:cd20eea678913bcc90beb6f06a1cd190",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0204",
-      "prov:atLocation": {"@id": "niiri:8d49632298c713cfe3e4f7c0b8b81748"},
+      "prov:atLocation": {"@id": "niiri:c2889d3d5127c29f90b0ada1c993e777"},
       "prov:value": {"@type": "xsd:float", "@value": "3.64054799079895"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.29273918630896"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000496082327765768"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.664365976163986"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.29273918630896"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000496082327765768"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.664365976163986"}
     },
     {
-      "@id": "niiri:8d49632298c713cfe3e4f7c0b8b81748",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c2889d3d5127c29f90b0ada1c993e777",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0204",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-50,-34,18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-50,-34,18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:292337cfe50250e8c1b9e0526394644c",
-      "entity": "niiri:18abb51402bd1a96024eebcb51fe2cea"
+      "entity_derived": "niiri:cd20eea678913bcc90beb6f06a1cd190",
+      "entity": "niiri:abae6765a0aa40936d109b9a2fd5acbf"
     },
     {
-      "@id": "niiri:faff79bf09b47b4ddc5d0086a7dca9ee",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:edf7c2638a60e524d92e073751527602",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0205",
-      "prov:atLocation": {"@id": "niiri:4cc001e6714eaf0b08158ebe69c8a6dd"},
+      "prov:atLocation": {"@id": "niiri:16fc3bf39c860621c7aea2f02a4dac4d"},
       "prov:value": {"@type": "xsd:float", "@value": "3.64017224311829"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.29244918940118"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000496594212155088"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.664365976163986"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.29244918940118"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000496594212155088"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.664365976163986"}
     },
     {
-      "@id": "niiri:4cc001e6714eaf0b08158ebe69c8a6dd",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:16fc3bf39c860621c7aea2f02a4dac4d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0205",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-42,-28,2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-42,-28,2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:faff79bf09b47b4ddc5d0086a7dca9ee",
-      "entity": "niiri:f22d5a21f3420379ca338b596714d6c3"
+      "entity_derived": "niiri:edf7c2638a60e524d92e073751527602",
+      "entity": "niiri:4b0a463a8d9ceb66a11c49348ae1f5fc"
     },
     {
-      "@id": "niiri:7cc3828aff43a6e5dbc4d120d5f6bdc8",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b1acd578e7fa991204c8a410a3717560",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0206",
-      "prov:atLocation": {"@id": "niiri:9ca80a13007830e4af8ec0c80ce72261"},
+      "prov:atLocation": {"@id": "niiri:b25042964be10a1a50bf593da017ad14"},
       "prov:value": {"@type": "xsd:float", "@value": "3.63664436340332"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.28972522633498"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00050142630710126"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.668465061469917"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.28972522633498"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00050142630710126"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.668465061469917"}
     },
     {
-      "@id": "niiri:9ca80a13007830e4af8ec0c80ce72261",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b25042964be10a1a50bf593da017ad14",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0206",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-12,-8,-20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-12,-8,-20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7cc3828aff43a6e5dbc4d120d5f6bdc8",
-      "entity": "niiri:3ee311b3e36564f263d2f8b333315cbe"
+      "entity_derived": "niiri:b1acd578e7fa991204c8a410a3717560",
+      "entity": "niiri:ca33d7428ff48eafbc3f213db2286c92"
     },
     {
-      "@id": "niiri:019054c49f79d7f10b47b2f5163689a6",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:494d32a46900ee1bd2a49c4de9617108",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0207",
-      "prov:atLocation": {"@id": "niiri:a78b382b048dce4b6bc0c858dbdcf1dd"},
+      "prov:atLocation": {"@id": "niiri:2aa7ecf6ebf03a10e3d10e470e617211"},
       "prov:value": {"@type": "xsd:float", "@value": "3.63564610481262"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.28895405423442"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00050280219001142"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.669072337143437"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.28895405423442"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00050280219001142"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.669072337143437"}
     },
     {
-      "@id": "niiri:a78b382b048dce4b6bc0c858dbdcf1dd",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:2aa7ecf6ebf03a10e3d10e470e617211",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0207",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-30,50,-6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-30,50,-6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:019054c49f79d7f10b47b2f5163689a6",
-      "entity": "niiri:1f3adbf2a65a904404950a1b8c6598ab"
+      "entity_derived": "niiri:494d32a46900ee1bd2a49c4de9617108",
+      "entity": "niiri:a2d559eeea3fd425019a74c32cb07b03"
     },
     {
-      "@id": "niiri:b155904b83343b83a14963ed3f06f9f6",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:16a6a4016277da6cf913ef3b2c7113db",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0208",
-      "prov:atLocation": {"@id": "niiri:d23dad6368353e03c133e7a880da352b"},
+      "prov:atLocation": {"@id": "niiri:416a43460ad683e7fc9bd2dc7f3d33fa"},
       "prov:value": {"@type": "xsd:float", "@value": "3.63432455062866"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.28793286446379"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000504629519068156"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.670129672801443"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.28793286446379"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000504629519068156"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.670129672801443"}
     },
     {
-      "@id": "niiri:d23dad6368353e03c133e7a880da352b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:416a43460ad683e7fc9bd2dc7f3d33fa",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0208",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[62,6,20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[62,6,20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b155904b83343b83a14963ed3f06f9f6",
-      "entity": "niiri:acdbdf918b46bc8c7e5f5f71c88555a8"
+      "entity_derived": "niiri:16a6a4016277da6cf913ef3b2c7113db",
+      "entity": "niiri:1cffc79d71ec5b44f8be32f71d15b738"
     },
     {
-      "@id": "niiri:b43cb35e3ab74cca689fe5d3597cafd2",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5d0442cdaea493ca10a242a8af6b8b02",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0209",
-      "prov:atLocation": {"@id": "niiri:62b3808db084d9d452adf57c4d857090"},
+      "prov:atLocation": {"@id": "niiri:57429efabfe0638de627a0c651d9d52b"},
       "prov:value": {"@type": "xsd:float", "@value": "3.63211607933044"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.2862256597491"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000507698146165469"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.672158308361536"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.2862256597491"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000507698146165469"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.672158308361536"}
     },
     {
-      "@id": "niiri:62b3808db084d9d452adf57c4d857090",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:57429efabfe0638de627a0c651d9d52b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0209",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-24,4,26]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-24,4,26]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b43cb35e3ab74cca689fe5d3597cafd2",
-      "entity": "niiri:57bb8e63228982c179f16eb42319da97"
+      "entity_derived": "niiri:5d0442cdaea493ca10a242a8af6b8b02",
+      "entity": "niiri:08835c169510829e8effda3071bba336"
     },
     {
-      "@id": "niiri:ba85cdf66b0935d9c26a3d8fb4ec076e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d32c29e6c832599417bd8574e70ffe47",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0210",
-      "prov:atLocation": {"@id": "niiri:ddec368c647bb9a5d779d908f8c0039d"},
+      "prov:atLocation": {"@id": "niiri:f736a09b34c0dc25a9d0e7be843d9c96"},
       "prov:value": {"@type": "xsd:float", "@value": "3.63174819946289"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.28594119681201"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000508211131676539"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.672158308361536"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.28594119681201"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000508211131676539"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.672158308361536"}
     },
     {
-      "@id": "niiri:ddec368c647bb9a5d779d908f8c0039d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f736a09b34c0dc25a9d0e7be843d9c96",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0210",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-8,-90,-30]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-8,-90,-30]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ba85cdf66b0935d9c26a3d8fb4ec076e",
-      "entity": "niiri:47b4c3e270c9cefea83aa0b99207cb4e"
+      "entity_derived": "niiri:d32c29e6c832599417bd8574e70ffe47",
+      "entity": "niiri:d5a3f5e4133bc22e2c189ceeb5b93544"
     },
     {
-      "@id": "niiri:6b06034302166fca25722f73014f1fa5",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:1da4e83fb9b216cfbd49324f411b7060",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0211",
-      "prov:atLocation": {"@id": "niiri:017514c19df3110d9738f725acf3a6e7"},
+      "prov:atLocation": {"@id": "niiri:9dfaa6f7572bbd0cf40dbfceb5ffab83"},
       "prov:value": {"@type": "xsd:float", "@value": "3.62799787521362"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.28303991621965"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00051347061762641"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.676617003024309"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.28303991621965"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00051347061762641"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.676617003024309"}
     },
     {
-      "@id": "niiri:017514c19df3110d9738f725acf3a6e7",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:9dfaa6f7572bbd0cf40dbfceb5ffab83",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0211",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-60,-38,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-60,-38,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6b06034302166fca25722f73014f1fa5",
-      "entity": "niiri:1e1daff291581e1187737e0f917dcaf2"
+      "entity_derived": "niiri:1da4e83fb9b216cfbd49324f411b7060",
+      "entity": "niiri:9b44436d58818f06cd48133f714e8a99"
     },
     {
-      "@id": "niiri:5dce25241470c9335c4e8e5e763a7dac",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d4fa6966b630445b57a0f19116a3daed",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0212",
-      "prov:atLocation": {"@id": "niiri:b6979185cf28e4a8bc80b8086532974e"},
+      "prov:atLocation": {"@id": "niiri:dfc9b625f7263d322b56af38f35b9481"},
       "prov:value": {"@type": "xsd:float", "@value": "3.6240873336792"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.28001207990403"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000519013209931529"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.680244967613049"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.28001207990403"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000519013209931529"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.680244967613049"}
     },
     {
-      "@id": "niiri:b6979185cf28e4a8bc80b8086532974e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:dfc9b625f7263d322b56af38f35b9481",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0212",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[22,34,-4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[22,34,-4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5dce25241470c9335c4e8e5e763a7dac",
-      "entity": "niiri:6847174e062f3a379b5888fc4135c73f"
+      "entity_derived": "niiri:d4fa6966b630445b57a0f19116a3daed",
+      "entity": "niiri:051457613c34bfa68d60b137e8c7ae17"
     },
     {
-      "@id": "niiri:d105282f9defe267a465f045b1dd0e7d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ad65b31051a0c3ef755cdd2741ae415f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0213",
-      "prov:atLocation": {"@id": "niiri:b08f821c14963d93c313967a3a447f63"},
+      "prov:atLocation": {"@id": "niiri:82ffc6dfc401537ce52185c43cfcf147"},
       "prov:value": {"@type": "xsd:float", "@value": "3.62374401092529"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.2797461261145"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000519502686150974"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.680244967613049"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.2797461261145"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000519502686150974"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.680244967613049"}
     },
     {
-      "@id": "niiri:b08f821c14963d93c313967a3a447f63",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:82ffc6dfc401537ce52185c43cfcf147",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0213",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[46,-58,-18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[46,-58,-18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d105282f9defe267a465f045b1dd0e7d",
-      "entity": "niiri:a9473168659cdf2b1a2073210ee27791"
+      "entity_derived": "niiri:ad65b31051a0c3ef755cdd2741ae415f",
+      "entity": "niiri:ea9fe9402f815e54e3cef6704ebcb2e4"
     },
     {
-      "@id": "niiri:a8289ab936d15b8fb58bbc9bf05aeaf5",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5c492afc637552d22a37d356b892476b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0214",
-      "prov:atLocation": {"@id": "niiri:7091211174c94f71cb8e6c4ee1b395fd"},
+      "prov:atLocation": {"@id": "niiri:ab90c63f449b003e4d791be7e3d0e800"},
       "prov:value": {"@type": "xsd:float", "@value": "3.62238955497742"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.27869670069254"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000521438278593522"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.681370246579141"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.27869670069254"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000521438278593522"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.681370246579141"}
     },
     {
-      "@id": "niiri:7091211174c94f71cb8e6c4ee1b395fd",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ab90c63f449b003e4d791be7e3d0e800",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0214",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-18,62,26]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-18,62,26]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a8289ab936d15b8fb58bbc9bf05aeaf5",
-      "entity": "niiri:907753cf0dfe053ffac4e74053c771f4"
+      "entity_derived": "niiri:5c492afc637552d22a37d356b892476b",
+      "entity": "niiri:1dce01b8df60884c582e29243c828080"
     },
     {
-      "@id": "niiri:8acb818b9bd4064fdb974a1bdda6017f",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f6cd2c4025ec944fe9fad4a68eeb76c3",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0215",
-      "prov:atLocation": {"@id": "niiri:de20fca34aead465553cd2a0d7c00538"},
+      "prov:atLocation": {"@id": "niiri:edf4f82f106c671bdef81e84a01b9486"},
       "prov:value": {"@type": "xsd:float", "@value": "3.6151659488678"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.27309447054155"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000531884583176545"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.690041088084649"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.27309447054155"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000531884583176545"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.690041088084649"}
     },
     {
-      "@id": "niiri:de20fca34aead465553cd2a0d7c00538",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:edf4f82f106c671bdef81e84a01b9486",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0215",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[66,-30,8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[66,-30,8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8acb818b9bd4064fdb974a1bdda6017f",
-      "entity": "niiri:7a7fab37bd67ec2dae91a58e4367079a"
+      "entity_derived": "niiri:f6cd2c4025ec944fe9fad4a68eeb76c3",
+      "entity": "niiri:eb8a2332e6ccc41b6d1a8cca84b280fe"
     },
     {
-      "@id": "niiri:01a05158b8b9d9a48af9806cf6f174e6",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b076644097262f402af618f0521f3c6f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0216",
-      "prov:atLocation": {"@id": "niiri:5a939851cab3866cd5a4cdc829e6d175"},
+      "prov:atLocation": {"@id": "niiri:d46c39edd8f989ed016fc63e4e532951"},
       "prov:value": {"@type": "xsd:float", "@value": "3.60937356948853"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.2685956145544"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000540413261609474"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.697552180185497"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.2685956145544"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000540413261609474"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.697552180185497"}
     },
     {
-      "@id": "niiri:5a939851cab3866cd5a4cdc829e6d175",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d46c39edd8f989ed016fc63e4e532951",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0216",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-10,-18,-42]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-10,-18,-42]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:01a05158b8b9d9a48af9806cf6f174e6",
-      "entity": "niiri:6b0e32c53f8491486992e204b6c885ee"
+      "entity_derived": "niiri:b076644097262f402af618f0521f3c6f",
+      "entity": "niiri:3ab29b7a5414afa7ee3dad94fe418d2f"
     },
     {
-      "@id": "niiri:480ccf452d0de5c8338c4bd8561fc873",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:cf314ff0f3be99903935c1888a63ccdc",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0217",
-      "prov:atLocation": {"@id": "niiri:455bc90906fca2efee367054943bcd10"},
+      "prov:atLocation": {"@id": "niiri:b27a4f7ac8e1c0c6c2cef33e18a16762"},
       "prov:value": {"@type": "xsd:float", "@value": "3.60362911224365"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.26412815526814"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000549007436707605"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.704264807188576"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.26412815526814"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000549007436707605"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.704264807188576"}
     },
     {
-      "@id": "niiri:455bc90906fca2efee367054943bcd10",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b27a4f7ac8e1c0c6c2cef33e18a16762",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0217",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[32,-36,-6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[32,-36,-6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:480ccf452d0de5c8338c4bd8561fc873",
-      "entity": "niiri:437362f1f721e7635eb6c8e7a49eacc8"
+      "entity_derived": "niiri:cf314ff0f3be99903935c1888a63ccdc",
+      "entity": "niiri:de99f369510067d001dcfc78a4b7ee95"
     },
     {
-      "@id": "niiri:fd777c497dbb657fd82823b623d2dd3a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:653a08ed610a534c1cf43ad67b874319",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0218",
-      "prov:atLocation": {"@id": "niiri:37981ea26664efc9fd6743ab0a7b732d"},
+      "prov:atLocation": {"@id": "niiri:fef07c2b8aea1136621b0fce4d8e22f4"},
       "prov:value": {"@type": "xsd:float", "@value": "3.5972752571106"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.25917999430208"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000558673768633722"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.712747532197775"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.25917999430208"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000558673768633722"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.712747532197775"}
     },
     {
-      "@id": "niiri:37981ea26664efc9fd6743ab0a7b732d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:fef07c2b8aea1136621b0fce4d8e22f4",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0218",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[52,-2,40]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[52,-2,40]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:fd777c497dbb657fd82823b623d2dd3a",
-      "entity": "niiri:f3e52b5df75745e99bcb5f824b5d95a7"
+      "entity_derived": "niiri:653a08ed610a534c1cf43ad67b874319",
+      "entity": "niiri:03516b1ded0c354154f06310cfeb09c0"
     },
     {
-      "@id": "niiri:28a10bfe7a2c092a96599336d5aca46e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:7132d322b3cc936428996208440f96f6",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0219",
-      "prov:atLocation": {"@id": "niiri:b080ece0eb3b899aebcecbbc322ff3a5"},
+      "prov:atLocation": {"@id": "niiri:92f24ae50520920d9d40e416007b7466"},
       "prov:value": {"@type": "xsd:float", "@value": "3.58600521087646"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.25038571079181"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000576242907006641"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.727015038116334"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.25038571079181"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000576242907006641"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.727015038116334"}
     },
     {
-      "@id": "niiri:b080ece0eb3b899aebcecbbc322ff3a5",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:92f24ae50520920d9d40e416007b7466",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0219",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[14,6,62]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[14,6,62]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:28a10bfe7a2c092a96599336d5aca46e",
-      "entity": "niiri:e240445d6ab5dec28910648113069e56"
+      "entity_derived": "niiri:7132d322b3cc936428996208440f96f6",
+      "entity": "niiri:56da6908cbe82b7569f6ca2737e51eb6"
     },
     {
-      "@id": "niiri:e0fcd11eb8654c7e340d7090beac46a8",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0640d1c27d97d1f42ae25c516d60eb0c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0220",
-      "prov:atLocation": {"@id": "niiri:03c0e1db52d4c6987426275b18a9744c"},
+      "prov:atLocation": {"@id": "niiri:94f679f4fb0174f6de4275cf2933e45d"},
       "prov:value": {"@type": "xsd:float", "@value": "3.58496069908142"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.24956951283845"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00057789913282269"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.727753479695118"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.24956951283845"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00057789913282269"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.727753479695118"}
     },
     {
-      "@id": "niiri:03c0e1db52d4c6987426275b18a9744c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:94f679f4fb0174f6de4275cf2933e45d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0220",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[48,-68,-22]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[48,-68,-22]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e0fcd11eb8654c7e340d7090beac46a8",
-      "entity": "niiri:e075542d829a72554ead327c95c2e9d8"
+      "entity_derived": "niiri:0640d1c27d97d1f42ae25c516d60eb0c",
+      "entity": "niiri:087ce96dd01c83b4336943a7df6de172"
     },
     {
-      "@id": "niiri:527afb8ff80e9a0230db0cf6e8759c40",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:443881374484db2a28a772aefb17c81f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0221",
-      "prov:atLocation": {"@id": "niiri:49382e7805f43abd72df482d6bc18041"},
+      "prov:atLocation": {"@id": "niiri:abfaa93e10cd4e067aec5cce0e6988af"},
       "prov:value": {"@type": "xsd:float", "@value": "3.57942819595337"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.24524309204834"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00058675199606395"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.732763098510088"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.24524309204834"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00058675199606395"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.732763098510088"}
     },
     {
-      "@id": "niiri:49382e7805f43abd72df482d6bc18041",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:abfaa93e10cd4e067aec5cce0e6988af",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0221",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[44,6,54]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[44,6,54]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:527afb8ff80e9a0230db0cf6e8759c40",
-      "entity": "niiri:d9aa2f1b33b774438046f98fe3595e09"
+      "entity_derived": "niiri:443881374484db2a28a772aefb17c81f",
+      "entity": "niiri:1a5540bf2e828d5e14c6001adb4f30d5"
     },
     {
-      "@id": "niiri:29dcb764295a638c24e4c54f67953660",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:cdca9d1394769421f403ff2c2b85319d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0222",
-      "prov:atLocation": {"@id": "niiri:d2550b01b7638d57eafdd91089b16e0c"},
+      "prov:atLocation": {"@id": "niiri:af2e01b40163257b4d36aca790b9bdea"},
       "prov:value": {"@type": "xsd:float", "@value": "3.57787442207336"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.24402705959498"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00058926274833293"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.733379048702781"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.24402705959498"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00058926274833293"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.733379048702781"}
     },
     {
-      "@id": "niiri:d2550b01b7638d57eafdd91089b16e0c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:af2e01b40163257b4d36aca790b9bdea",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0222",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-52,-36,32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-52,-36,32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:29dcb764295a638c24e4c54f67953660",
-      "entity": "niiri:13bffc90c8fd1625b76f45711dc4d490"
+      "entity_derived": "niiri:cdca9d1394769421f403ff2c2b85319d",
+      "entity": "niiri:b54974658dcfd8d91a65540d01e3250b"
     },
     {
-      "@id": "niiri:9507d455b653afa82e174377053b32fd",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:2f89f4ddc37f465398449ec427aef8f4",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0223",
-      "prov:atLocation": {"@id": "niiri:da226d86fa055a7f70f8595d6b0e32fc"},
+      "prov:atLocation": {"@id": "niiri:6ca8f9ce9b937a2e0b96c22dfdcf588f"},
       "prov:value": {"@type": "xsd:float", "@value": "3.57743859291077"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.24368588864821"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000589968948020769"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.733379048702781"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.24368588864821"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000589968948020769"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.733379048702781"}
     },
     {
-      "@id": "niiri:da226d86fa055a7f70f8595d6b0e32fc",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6ca8f9ce9b937a2e0b96c22dfdcf588f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0223",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-40,-14,-10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-40,-14,-10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9507d455b653afa82e174377053b32fd",
-      "entity": "niiri:226cf1d14e58a618a7ed1bfe9c594e24"
+      "entity_derived": "niiri:2f89f4ddc37f465398449ec427aef8f4",
+      "entity": "niiri:b1012bc624cd6b3f47ff149073d0a78b"
     },
     {
-      "@id": "niiri:338ef1aad0eba02b52b18a5ccccf64b9",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:cce527c4d5173264fd0ba76367f83931",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0224",
-      "prov:atLocation": {"@id": "niiri:1880442a1afa1ae0be72cb6517fdad6b"},
+      "prov:atLocation": {"@id": "niiri:5f4ae25fe5269d66ca447679a1db8171"},
       "prov:value": {"@type": "xsd:float", "@value": "3.57096195220947"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.23861192072534"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000600564422457928"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.742283339420037"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.23861192072534"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000600564422457928"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.742283339420037"}
     },
     {
-      "@id": "niiri:1880442a1afa1ae0be72cb6517fdad6b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:5f4ae25fe5269d66ca447679a1db8171",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0224",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[24,38,40]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[24,38,40]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:338ef1aad0eba02b52b18a5ccccf64b9",
-      "entity": "niiri:54f50d5bf9097a354105a3150da68b70"
+      "entity_derived": "niiri:cce527c4d5173264fd0ba76367f83931",
+      "entity": "niiri:d45da63c733d96ddba5cf2fb05dc0b58"
     },
     {
-      "@id": "niiri:0069a554e0ca9a3376528d1782229337",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f59eaee6cc14a37ee302a26deccb5ba8",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0225",
-      "prov:atLocation": {"@id": "niiri:f142855532e38b46b9133355a9e881a5"},
+      "prov:atLocation": {"@id": "niiri:df0c9b42ffecb2d8ebc2d1d89f566469"},
       "prov:value": {"@type": "xsd:float", "@value": "3.57036733627319"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.23814570748812"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000601546736720304"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.742311455927918"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.23814570748812"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000601546736720304"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.742311455927918"}
     },
     {
-      "@id": "niiri:f142855532e38b46b9133355a9e881a5",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:df0c9b42ffecb2d8ebc2d1d89f566469",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0225",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-56,8,-26]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-56,8,-26]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0069a554e0ca9a3376528d1782229337",
-      "entity": "niiri:6f1dfc43277961fa3ac9af2851b18b10"
+      "entity_derived": "niiri:f59eaee6cc14a37ee302a26deccb5ba8",
+      "entity": "niiri:14e793643765a6fe10fb66237bee63db"
     },
     {
-      "@id": "niiri:d818c67e5dec2eb6ae6952cb1d8e6490",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:cbdb1c804f7d0ec340e49acbe0f59365",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0226",
-      "prov:atLocation": {"@id": "niiri:b3c58dbeeecd1d714e31c6df16eca605"},
+      "prov:atLocation": {"@id": "niiri:b501cb0bebb39347ca92fbcfc86d2801"},
       "prov:value": {"@type": "xsd:float", "@value": "3.56984972953796"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.23773982240894"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000602403147547781"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.742311455927918"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.23773982240894"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000602403147547781"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.742311455927918"}
     },
     {
-      "@id": "niiri:b3c58dbeeecd1d714e31c6df16eca605",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b501cb0bebb39347ca92fbcfc86d2801",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0226",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-46,-76,-8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-46,-76,-8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d818c67e5dec2eb6ae6952cb1d8e6490",
-      "entity": "niiri:eac8fe1980d2f8fa464fc76d2251099d"
+      "entity_derived": "niiri:cbdb1c804f7d0ec340e49acbe0f59365",
+      "entity": "niiri:a3b1937d74b3d7366255ed05df95e8dc"
     },
     {
-      "@id": "niiri:944b10d72b78402dcab8a595815ad03c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e99c458abc0e31d64f6dc46f9eb3ba86",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0227",
-      "prov:atLocation": {"@id": "niiri:ec89e9bf6e3a6ec013492213a7f95ead"},
+      "prov:atLocation": {"@id": "niiri:e87776fe0defb58e096d6889e9628b08"},
       "prov:value": {"@type": "xsd:float", "@value": "3.56818604469299"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.23643490706068"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000605164134718339"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.744019467604621"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.23643490706068"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000605164134718339"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.744019467604621"}
     },
     {
-      "@id": "niiri:ec89e9bf6e3a6ec013492213a7f95ead",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e87776fe0defb58e096d6889e9628b08",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0227",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[16,40,20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[16,40,20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:944b10d72b78402dcab8a595815ad03c",
-      "entity": "niiri:79433ea0eb0eb190e621fa615f0bf51e"
+      "entity_derived": "niiri:e99c458abc0e31d64f6dc46f9eb3ba86",
+      "entity": "niiri:4f0d78d14b791c15d9759ece4ec7e6ed"
     },
     {
-      "@id": "niiri:a5224cc9e0429dfa9daa5f454afbd587",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ed39a62270a751bff5d29b2e4c49e7f8",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0228",
-      "prov:atLocation": {"@id": "niiri:ca94df6b6797b235fbc04993cc66f9b0"},
+      "prov:atLocation": {"@id": "niiri:013cdc8bc7bd75dd13e53be4e70de1e7"},
       "prov:value": {"@type": "xsd:float", "@value": "3.56333160400391"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.23262447936818"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000613293417818239"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.748959368128923"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.23262447936818"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000613293417818239"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.748959368128923"}
     },
     {
-      "@id": "niiri:ca94df6b6797b235fbc04993cc66f9b0",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:013cdc8bc7bd75dd13e53be4e70de1e7",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0228",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[48,-28,22]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[48,-28,22]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a5224cc9e0429dfa9daa5f454afbd587",
-      "entity": "niiri:7d479ec4ba5d64002174656bfdc52de9"
+      "entity_derived": "niiri:ed39a62270a751bff5d29b2e4c49e7f8",
+      "entity": "niiri:f569ae7a0c44f14440097fc2492d13ab"
     },
     {
-      "@id": "niiri:c76cc26051f5bea1921fc20516474612",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b97a5c6fcb6a02f68a6fadc9cf02ba98",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0229",
-      "prov:atLocation": {"@id": "niiri:2952751017cef1359932bf3336bfd01e"},
+      "prov:atLocation": {"@id": "niiri:42ba35106dcd2141347921bd860ffc4f"},
       "prov:value": {"@type": "xsd:float", "@value": "3.56151604652405"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.23119829562355"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000616361933964638"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.750918681283957"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.23119829562355"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000616361933964638"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.750918681283957"}
     },
     {
-      "@id": "niiri:2952751017cef1359932bf3336bfd01e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:42ba35106dcd2141347921bd860ffc4f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0229",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[6,10,34]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[6,10,34]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c76cc26051f5bea1921fc20516474612",
-      "entity": "niiri:f6e5caa15217c51ffb3a70b27c4655de"
+      "entity_derived": "niiri:b97a5c6fcb6a02f68a6fadc9cf02ba98",
+      "entity": "niiri:2fd27f14078fbb1aa402a271e101e35f"
     },
     {
-      "@id": "niiri:93e7f5eeb92cbfe69494e25162c848aa",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3fc6abca83add3e6e871c4ba13db90d8",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0230",
-      "prov:atLocation": {"@id": "niiri:2a4ecae66ef702055e93059d47a60ff3"},
+      "prov:atLocation": {"@id": "niiri:8f5014db8d06c5cb5b713b4c5644456b"},
       "prov:value": {"@type": "xsd:float", "@value": "3.55326652526855"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.22471054262134"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000630500477415308"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.758661956634776"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.22471054262134"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000630500477415308"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.758661956634776"}
     },
     {
-      "@id": "niiri:2a4ecae66ef702055e93059d47a60ff3",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:8f5014db8d06c5cb5b713b4c5644456b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0230",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[54,-46,46]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[54,-46,46]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:93e7f5eeb92cbfe69494e25162c848aa",
-      "entity": "niiri:a1d3eda99ed34e2358f8113bd4e39dbf"
+      "entity_derived": "niiri:3fc6abca83add3e6e871c4ba13db90d8",
+      "entity": "niiri:5476fcd5093f7c864637efaafd42b996"
     },
     {
-      "@id": "niiri:b04bd6e704bb70e3bce09b8a874d7043",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:73ff07955917113509745f126dd5bd76",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0231",
-      "prov:atLocation": {"@id": "niiri:c4517b6615dcf1a6b867a80de4baba62"},
+      "prov:atLocation": {"@id": "niiri:b4367bc8834e232852e1f229303575de"},
       "prov:value": {"@type": "xsd:float", "@value": "3.53535223007202"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.21057969685079"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000662337649990907"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.782699957189858"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.21057969685079"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000662337649990907"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.782699957189858"}
     },
     {
-      "@id": "niiri:c4517b6615dcf1a6b867a80de4baba62",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b4367bc8834e232852e1f229303575de",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0231",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-60,-30,22]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-60,-30,22]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b04bd6e704bb70e3bce09b8a874d7043",
-      "entity": "niiri:51e730ef4a2f4f6093b5ca4c2b56ea0f"
+      "entity_derived": "niiri:73ff07955917113509745f126dd5bd76",
+      "entity": "niiri:10bac4ccf6049482f632adb3952c3c8c"
     },
     {
-      "@id": "niiri:bba858fce100c5682da038ec3346309c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3a2f1d64a861856a52cc3fa9969bc2b0",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0232",
-      "prov:atLocation": {"@id": "niiri:d38e96f5e40921d4793395a28aa6619f"},
+      "prov:atLocation": {"@id": "niiri:35d050255e7913d2871e399b6466dd0b"},
       "prov:value": {"@type": "xsd:float", "@value": "3.53448247909546"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.20989215326664"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000663923910754316"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.783230703782876"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.20989215326664"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000663923910754316"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.783230703782876"}
     },
     {
-      "@id": "niiri:d38e96f5e40921d4793395a28aa6619f",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:35d050255e7913d2871e399b6466dd0b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0232",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-46,24,-36]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-46,24,-36]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:bba858fce100c5682da038ec3346309c",
-      "entity": "niiri:3352f1f91f74dc735e788278eb1bed90"
+      "entity_derived": "niiri:3a2f1d64a861856a52cc3fa9969bc2b0",
+      "entity": "niiri:cda273936fc980c18403b41fb8533954"
     },
     {
-      "@id": "niiri:373a5f68e73fe5d0fd97dda23ea05d83",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:aef2a2aecfbeec0007f227032d3cef74",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0233",
-      "prov:atLocation": {"@id": "niiri:199516b49cfb38533e880834a47a3d66"},
+      "prov:atLocation": {"@id": "niiri:7db42b1f6fa6ef9bdf3710cab7dd6378"},
       "prov:value": {"@type": "xsd:float", "@value": "3.52919697761536"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.20571096990557"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000673646212453916"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.790008451230221"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.20571096990557"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000673646212453916"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.790008451230221"}
     },
     {
-      "@id": "niiri:199516b49cfb38533e880834a47a3d66",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7db42b1f6fa6ef9bdf3710cab7dd6378",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0233",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[18,-84,-44]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[18,-84,-44]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:373a5f68e73fe5d0fd97dda23ea05d83",
-      "entity": "niiri:46cfb09d58d7bccc0bf22049c6888ca9"
+      "entity_derived": "niiri:aef2a2aecfbeec0007f227032d3cef74",
+      "entity": "niiri:89501dfa67d1d32810bbe20fd9b1fe8c"
     },
     {
-      "@id": "niiri:3986f2091cccc89f019b6bd69b8aa1d9",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:98a88c543aab0179b9f3e245882a9203",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0234",
-      "prov:atLocation": {"@id": "niiri:8670ccf5666cbe8c30249913aec0bd81"},
+      "prov:atLocation": {"@id": "niiri:640fa10a58203760c34949fdbdd4513a"},
       "prov:value": {"@type": "xsd:float", "@value": "3.52617359161377"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.2033169804895"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000679271799107761"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.794036522733694"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.2033169804895"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000679271799107761"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.794036522733694"}
     },
     {
-      "@id": "niiri:8670ccf5666cbe8c30249913aec0bd81",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:640fa10a58203760c34949fdbdd4513a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0234",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[20,-38,-52]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[20,-38,-52]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3986f2091cccc89f019b6bd69b8aa1d9",
-      "entity": "niiri:0abf2e69a6c22d3820c2671d957d5cb6"
+      "entity_derived": "niiri:98a88c543aab0179b9f3e245882a9203",
+      "entity": "niiri:02f6f6429a8304a7731a404570cb4b94"
     },
     {
-      "@id": "niiri:3829d4f4c6c77ddc79a1e18c412aea42",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3cec9a1c9417800f3a247e3023d0f1cb",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0235",
-      "prov:atLocation": {"@id": "niiri:a716b80861e7d3cbc66f5a3d9dc5fe81"},
+      "prov:atLocation": {"@id": "niiri:6343fb8cffbbeab720d14fffd9e903dd"},
       "prov:value": {"@type": "xsd:float", "@value": "3.52416038513184"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.20172194962906"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000683043949932127"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.796437366060161"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.20172194962906"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000683043949932127"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.796437366060161"}
     },
     {
-      "@id": "niiri:a716b80861e7d3cbc66f5a3d9dc5fe81",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6343fb8cffbbeab720d14fffd9e903dd",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0235",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[58,12,24]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[58,12,24]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3829d4f4c6c77ddc79a1e18c412aea42",
-      "entity": "niiri:a4c707ed5e61e6afca1d519a13e265d1"
+      "entity_derived": "niiri:3cec9a1c9417800f3a247e3023d0f1cb",
+      "entity": "niiri:8747a3ddd24cbd71e40672d541cefee5"
     },
     {
-      "@id": "niiri:b1ed886d825af536568af317a4173477",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a7e2dfc487d0a70d1149fdf1efb30d4c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0236",
-      "prov:atLocation": {"@id": "niiri:276690ec03e527307d636c6fb0b3aa43"},
+      "prov:atLocation": {"@id": "niiri:6a152f1146f43c017dc68ab8324ec605"},
       "prov:value": {"@type": "xsd:float", "@value": "3.51774144172668"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.19663137427302"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000695212465446571"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.806071113207381"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.19663137427302"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000695212465446571"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.806071113207381"}
     },
     {
-      "@id": "niiri:276690ec03e527307d636c6fb0b3aa43",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6a152f1146f43c017dc68ab8324ec605",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0236",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[54,-52,26]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[54,-52,26]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b1ed886d825af536568af317a4173477",
-      "entity": "niiri:b664590e2a12ae3f5b1c7bfc738917c9"
+      "entity_derived": "niiri:a7e2dfc487d0a70d1149fdf1efb30d4c",
+      "entity": "niiri:c885eb98b2506b007c2d8feb2e37f08e"
     },
     {
-      "@id": "niiri:67f347e7a204c93a10d706891c560791",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0528a1b646839dcdd2fb0bb16a07223d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0237",
-      "prov:atLocation": {"@id": "niiri:574feb78f5d86bfde1e62fe3cca0590f"},
+      "prov:atLocation": {"@id": "niiri:4d047343b5b28834cf69c72f874e638d"},
       "prov:value": {"@type": "xsd:float", "@value": "3.51371550559998"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.1934347318076"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000702955576802444"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.811837038292354"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.1934347318076"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000702955576802444"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.811837038292354"}
     },
     {
-      "@id": "niiri:574feb78f5d86bfde1e62fe3cca0590f",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4d047343b5b28834cf69c72f874e638d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0237",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[34,12,30]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[34,12,30]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:67f347e7a204c93a10d706891c560791",
-      "entity": "niiri:6abd89dfa06bba6341117a3456f77a35"
+      "entity_derived": "niiri:0528a1b646839dcdd2fb0bb16a07223d",
+      "entity": "niiri:bd96226234de4e21627b04208c7e537f"
     },
     {
-      "@id": "niiri:4f96fec959af5ccb3aa99ac5756d95c7",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:9143f6e13fe4ee9fe42fac2f81f2e676",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0238",
-      "prov:atLocation": {"@id": "niiri:08b492b6468d9a2e69ce8d6e8919afb4"},
+      "prov:atLocation": {"@id": "niiri:9077c71eee98aae8008376a8ed7b9b4a"},
       "prov:value": {"@type": "xsd:float", "@value": "3.50933194160461"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.18995074240404"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000711485225238007"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.818238642626287"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.18995074240404"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000711485225238007"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.818238642626287"}
     },
     {
-      "@id": "niiri:08b492b6468d9a2e69ce8d6e8919afb4",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:9077c71eee98aae8008376a8ed7b9b4a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0238",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[62,-40,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[62,-40,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4f96fec959af5ccb3aa99ac5756d95c7",
-      "entity": "niiri:fe9517cb56f6cb1662031dc08caaf182"
+      "entity_derived": "niiri:9143f6e13fe4ee9fe42fac2f81f2e676",
+      "entity": "niiri:8b7eb042176ff4b34dbab2133217acff"
     },
     {
-      "@id": "niiri:157af58a6279ef51fcf9a28e1c0664a1",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f5a857ae39046f3db5dec63a77684c88",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0239",
-      "prov:atLocation": {"@id": "niiri:66e93f1739e6835f643b310d93ed007e"},
+      "prov:atLocation": {"@id": "niiri:6ffc03184a2b6a40feae78bfa7efbfeb"},
       "prov:value": {"@type": "xsd:float", "@value": "3.50692367553711"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.18803518455038"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000716215526890496"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.821370946387423"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.18803518455038"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000716215526890496"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.821370946387423"}
     },
     {
-      "@id": "niiri:66e93f1739e6835f643b310d93ed007e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6ffc03184a2b6a40feae78bfa7efbfeb",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0239",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[22,20,36]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[22,20,36]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:157af58a6279ef51fcf9a28e1c0664a1",
-      "entity": "niiri:50be4fbb838d8e155b244eced8a52d48"
+      "entity_derived": "niiri:f5a857ae39046f3db5dec63a77684c88",
+      "entity": "niiri:74aa1acb0840e11af474625bf18a205b"
     },
     {
-      "@id": "niiri:267a6a1b74c53063e90f02d4c08b6215",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c3c44bb5597ea19a830120e15048bdfc",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0240",
-      "prov:atLocation": {"@id": "niiri:e755754abc11613c85cdfa1dca5b4593"},
+      "prov:atLocation": {"@id": "niiri:2ba4588b7d24368c21cef645f387e746"},
       "prov:value": {"@type": "xsd:float", "@value": "3.50429320335388"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.18594166053569"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000721418444738164"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.824888687870713"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.18594166053569"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000721418444738164"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.824888687870713"}
     },
     {
-      "@id": "niiri:e755754abc11613c85cdfa1dca5b4593",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:2ba4588b7d24368c21cef645f387e746",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0240",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[0,-34,28]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[0,-34,28]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:267a6a1b74c53063e90f02d4c08b6215",
-      "entity": "niiri:7625dcfd9f93b74584752753153c19ec"
+      "entity_derived": "niiri:c3c44bb5597ea19a830120e15048bdfc",
+      "entity": "niiri:1f8d909cef3803a0e6a8e31c86e2cb37"
     },
     {
-      "@id": "niiri:43b6938758516893593f4cdf20f34340",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a85791f58de3fb579b6358c661ed5fa2",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0241",
-      "prov:atLocation": {"@id": "niiri:aa75268c91b8da02bba871a4a3597032"},
+      "prov:atLocation": {"@id": "niiri:573674c8cee6088a030e40b5687fd66a"},
       "prov:value": {"@type": "xsd:float", "@value": "3.50173401832581"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.18390364686918"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00072651685008529"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.828300523267217"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.18390364686918"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00072651685008529"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.828300523267217"}
     },
     {
-      "@id": "niiri:aa75268c91b8da02bba871a4a3597032",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:573674c8cee6088a030e40b5687fd66a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0241",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[8,54,24]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[8,54,24]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:43b6938758516893593f4cdf20f34340",
-      "entity": "niiri:1ac5aaf4d3242e8406a5e8348658d29b"
+      "entity_derived": "niiri:a85791f58de3fb579b6358c661ed5fa2",
+      "entity": "niiri:d1b86bb927184d1863bf16406cbb38ef"
     },
     {
-      "@id": "niiri:a410f5da2b153bf301f1cdab68dd0ea6",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0a7bb31878e22554cbc54493045e8d7d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0242",
-      "prov:atLocation": {"@id": "niiri:b19569c59cdc8ee8931a601d53971753"},
+      "prov:atLocation": {"@id": "niiri:cdd8504c583ff46d7c8a7b3108bd3b78"},
       "prov:value": {"@type": "xsd:float", "@value": "3.50026345252991"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.18273201070653"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000729462891188581"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.828979444161694"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.18273201070653"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000729462891188581"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.828979444161694"}
     },
     {
-      "@id": "niiri:b19569c59cdc8ee8931a601d53971753",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:cdd8504c583ff46d7c8a7b3108bd3b78",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0242",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-30,-26,-30]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-30,-26,-30]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a410f5da2b153bf301f1cdab68dd0ea6",
-      "entity": "niiri:453feff4ca6cc36089bf9e9576cad723"
+      "entity_derived": "niiri:0a7bb31878e22554cbc54493045e8d7d",
+      "entity": "niiri:8681fd0b6a40a88059175d0b5804a743"
     },
     {
-      "@id": "niiri:3927113e0ec7a1af308fa162e99437f9",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c5d06f34a6464f6267e87ac23872ca2e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0243",
-      "prov:atLocation": {"@id": "niiri:7227da02604055c63b55c7955bdcac46"},
+      "prov:atLocation": {"@id": "niiri:3599d615ec8b933bd560ca5eb76b7f21"},
       "prov:value": {"@type": "xsd:float", "@value": "3.49797105789185"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.18090480576431"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000734079319294478"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.831956387035011"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.18090480576431"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000734079319294478"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.831956387035011"}
     },
     {
-      "@id": "niiri:7227da02604055c63b55c7955bdcac46",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:3599d615ec8b933bd560ca5eb76b7f21",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0243",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-42,14,-32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-42,14,-32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3927113e0ec7a1af308fa162e99437f9",
-      "entity": "niiri:a36937f0bb3343166a85a624c7a5008c"
+      "entity_derived": "niiri:c5d06f34a6464f6267e87ac23872ca2e",
+      "entity": "niiri:53d7d39a6b6a7a44a92c2cdc58facf3a"
     },
     {
-      "@id": "niiri:30674defc26774c78cfb710cf49f9ffc",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:af68b1cc579ac5658c4a2293d9579639",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0244",
-      "prov:atLocation": {"@id": "niiri:70a31d5933b342a728070af7348068dd"},
+      "prov:atLocation": {"@id": "niiri:19f62681d85fd0553b734d7b621b76c3"},
       "prov:value": {"@type": "xsd:float", "@value": "3.49039101600647"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.17485603225285"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000749554293693833"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.843983114081373"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.17485603225285"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000749554293693833"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.843983114081373"}
     },
     {
-      "@id": "niiri:70a31d5933b342a728070af7348068dd",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:19f62681d85fd0553b734d7b621b76c3",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0244",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[38,20,-44]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[38,20,-44]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:30674defc26774c78cfb710cf49f9ffc",
-      "entity": "niiri:9539fad3df2122c0c1d221ba62c93b1e"
+      "entity_derived": "niiri:af68b1cc579ac5658c4a2293d9579639",
+      "entity": "niiri:b8f303a3f6e3ffbd2a86dd99d6d873fb"
     },
     {
-      "@id": "niiri:02a8e47c9b68ca96830e1c4b0a1bdfb2",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:77af4bcf04d46e852b0206ce06555bc3",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0245",
-      "prov:atLocation": {"@id": "niiri:f2a576427c49aaaa3109a5f7bfe93fce"},
+      "prov:atLocation": {"@id": "niiri:13a5242219aba3ab609f497a0343d2e9"},
       "prov:value": {"@type": "xsd:float", "@value": "3.48954701423645"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.17418187045752"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000751297535500295"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.84451741403903"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.17418187045752"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000751297535500295"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.84451741403903"}
     },
     {
-      "@id": "niiri:f2a576427c49aaaa3109a5f7bfe93fce",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:13a5242219aba3ab609f497a0343d2e9",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0245",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-6,-16,-30]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-6,-16,-30]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:02a8e47c9b68ca96830e1c4b0a1bdfb2",
-      "entity": "niiri:0703f60bbede2cd4ff08171910c78742"
+      "entity_derived": "niiri:77af4bcf04d46e852b0206ce06555bc3",
+      "entity": "niiri:555db4d96064ec58a79e6099a79dd060"
     },
     {
-      "@id": "niiri:92e850c4ae029b98ce8e37ccf5c2a489",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ac4cc325bba6dd74902e4bedc227ea4d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0246",
-      "prov:atLocation": {"@id": "niiri:147054d7a3545b678bac792fdbf68064"},
+      "prov:atLocation": {"@id": "niiri:0c0cf4fe47307d156cf82ba69ae5886e"},
       "prov:value": {"@type": "xsd:float", "@value": "3.48527431488037"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.1707669420392"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00076018534619382"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.850048157107863"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.1707669420392"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00076018534619382"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.850048157107863"}
     },
     {
-      "@id": "niiri:147054d7a3545b678bac792fdbf68064",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0c0cf4fe47307d156cf82ba69ae5886e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0246",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[48,-44,-14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[48,-44,-14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:92e850c4ae029b98ce8e37ccf5c2a489",
-      "entity": "niiri:2192d0176864a609d1f99aeb7606bb20"
+      "entity_derived": "niiri:ac4cc325bba6dd74902e4bedc227ea4d",
+      "entity": "niiri:df9fe6cd3c5bf212b4c85e3bd119959c"
     },
     {
-      "@id": "niiri:b391a9b61ff1a3cc97f6a81f1bd22c2f",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:8bd2069b941164ec318034e819fbd415",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0247",
-      "prov:atLocation": {"@id": "niiri:12426e86e0fb00d146ffbe8336f59e85"},
+      "prov:atLocation": {"@id": "niiri:d9c9d3dee1810cae464cf215a3f5fe75"},
       "prov:value": {"@type": "xsd:float", "@value": "3.47563886642456"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.16305338543499"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000780618494857888"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.865926190191015"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.16305338543499"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000780618494857888"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.865926190191015"}
     },
     {
-      "@id": "niiri:12426e86e0fb00d146ffbe8336f59e85",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d9c9d3dee1810cae464cf215a3f5fe75",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0247",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-54,8,-16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-54,8,-16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b391a9b61ff1a3cc97f6a81f1bd22c2f",
-      "entity": "niiri:c7815fda00367a584b0eaef5d2a3a8d3"
+      "entity_derived": "niiri:8bd2069b941164ec318034e819fbd415",
+      "entity": "niiri:17f6f685daf3b085f3dac6c057c020c1"
     },
     {
-      "@id": "niiri:101beaa5b254b0a2495d8e9dd1a668e3",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:60851992aa4e11f85611dcd9fc54b154",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0248",
-      "prov:atLocation": {"@id": "niiri:6fa32114266a66be0893771476327949"},
+      "prov:atLocation": {"@id": "niiri:088ffb09b5d95f1915e71e6abafa1edd"},
       "prov:value": {"@type": "xsd:float", "@value": "3.47256183624268"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.1605864476201"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000787259372072469"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.870414106789922"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.1605864476201"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000787259372072469"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.870414106789922"}
     },
     {
-      "@id": "niiri:6fa32114266a66be0893771476327949",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:088ffb09b5d95f1915e71e6abafa1edd",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0248",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-18,-18,-44]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-18,-18,-44]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:101beaa5b254b0a2495d8e9dd1a668e3",
-      "entity": "niiri:0298b7fe38f8161533f229d225028815"
+      "entity_derived": "niiri:60851992aa4e11f85611dcd9fc54b154",
+      "entity": "niiri:c5cf9af3cc2424e4b8e65eb6049706ed"
     },
     {
-      "@id": "niiri:694563d3fce7b1050b91f872cd711ac0",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e1653eb5a2319fdfa378634babb879b4",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0249",
-      "prov:atLocation": {"@id": "niiri:ade2cec4e2e3f6c89578a933442f3f44"},
+      "prov:atLocation": {"@id": "niiri:54ec63f77daa9a18ff3b8c3a72842a9e"},
       "prov:value": {"@type": "xsd:float", "@value": "3.45146727561951"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.14362649041421"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000834341399658656"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.904541913018706"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.14362649041421"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000834341399658656"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.904541913018706"}
     },
     {
-      "@id": "niiri:ade2cec4e2e3f6c89578a933442f3f44",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:54ec63f77daa9a18ff3b8c3a72842a9e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0249",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[28,-82,-26]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[28,-82,-26]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:694563d3fce7b1050b91f872cd711ac0",
-      "entity": "niiri:0c1cd6f0700636298b473906a5e51975"
+      "entity_derived": "niiri:e1653eb5a2319fdfa378634babb879b4",
+      "entity": "niiri:24b677d8caebb84711be327c29be20b9"
     },
     {
-      "@id": "niiri:1b6d45bbf74835aa70c91401c2c5223a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d78c9899bc897947e0449b5b9372058c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0250",
-      "prov:atLocation": {"@id": "niiri:ff861d2d96bb938a5cbcba9162b7eacd"},
+      "prov:atLocation": {"@id": "niiri:78b19072340e7131009e1d60e6925937"},
       "prov:value": {"@type": "xsd:float", "@value": "3.4509379863739"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.14319986465702"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000835558468664344"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.904541913018706"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.14319986465702"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000835558468664344"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.904541913018706"}
     },
     {
-      "@id": "niiri:ff861d2d96bb938a5cbcba9162b7eacd",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:78b19072340e7131009e1d60e6925937",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0250",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[24,52,6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[24,52,6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1b6d45bbf74835aa70c91401c2c5223a",
-      "entity": "niiri:a6a6f1a505d5a404d9c028c325bee223"
+      "entity_derived": "niiri:d78c9899bc897947e0449b5b9372058c",
+      "entity": "niiri:c9997d6b8885703c61c50e9494f01f5b"
     },
     {
-      "@id": "niiri:f52f8140fe70249f4f25786ac572993f",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d36696cd084e014fe3b461011d62026c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0251",
-      "prov:atLocation": {"@id": "niiri:1f5a8eeeec0087009c35d2fce6e99d5f"},
+      "prov:atLocation": {"@id": "niiri:2f3a040be26b69350ee6668f1e953585"},
       "prov:value": {"@type": "xsd:float", "@value": "3.44921636581421"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.14181181124074"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000839529589309329"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.905753908911515"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.14181181124074"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000839529589309329"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.905753908911515"}
     },
     {
-      "@id": "niiri:1f5a8eeeec0087009c35d2fce6e99d5f",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:2f3a040be26b69350ee6668f1e953585",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0251",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-4,-48,-44]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-4,-48,-44]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f52f8140fe70249f4f25786ac572993f",
-      "entity": "niiri:f5f7ac01c1435f2b1a5663ae0f9a4c7f"
+      "entity_derived": "niiri:d36696cd084e014fe3b461011d62026c",
+      "entity": "niiri:18c389e9f560a707e21a88082c18399f"
     },
     {
-      "@id": "niiri:36306c6f527c2b06a1045359517fac9c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c7e89f2bfb5ebb96c9943bcc727e584b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0252",
-      "prov:atLocation": {"@id": "niiri:2612ada677eed159584b95ffb1f4b1d8"},
+      "prov:atLocation": {"@id": "niiri:05d9b2e1c39a81ce187b6175e51fc747"},
       "prov:value": {"@type": "xsd:float", "@value": "3.4477481842041"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.14062764913883"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000842931107996825"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.907476465657815"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.14062764913883"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000842931107996825"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.907476465657815"}
     },
     {
-      "@id": "niiri:2612ada677eed159584b95ffb1f4b1d8",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:05d9b2e1c39a81ce187b6175e51fc747",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0252",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-18,52,-6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-18,52,-6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:36306c6f527c2b06a1045359517fac9c",
-      "entity": "niiri:ef1841157cd24be39b9b725e1c39ab72"
+      "entity_derived": "niiri:c7e89f2bfb5ebb96c9943bcc727e584b",
+      "entity": "niiri:4f2617299971ce7d3a16c3c37b0badbd"
     },
     {
-      "@id": "niiri:b9346fe11034c44bddb0b55793b205a4",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:abcb021cf3e7d4a1923c3e650e8f646d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0253",
-      "prov:atLocation": {"@id": "niiri:29f23c71781634f66978e21da8d51baf"},
+      "prov:atLocation": {"@id": "niiri:c4ad197d4d9f82b6dd8bb207c1a7e8e4"},
       "prov:value": {"@type": "xsd:float", "@value": "3.44230937957764"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.13623741912434"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000855653022884484"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.915554421234191"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.13623741912434"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000855653022884484"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.915554421234191"}
     },
     {
-      "@id": "niiri:29f23c71781634f66978e21da8d51baf",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c4ad197d4d9f82b6dd8bb207c1a7e8e4",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0253",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-22,12,-26]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-22,12,-26]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b9346fe11034c44bddb0b55793b205a4",
-      "entity": "niiri:e4109f0f0f898a32d7f3ac2462582221"
+      "entity_derived": "niiri:abcb021cf3e7d4a1923c3e650e8f646d",
+      "entity": "niiri:7ab88d893988ef5840b83076dc34632a"
     },
     {
-      "@id": "niiri:cf29c1a8bb918b6e5d5ad13958131a43",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:798c8ad3bf29b7e6a1599d243c811ef4",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0254",
-      "prov:atLocation": {"@id": "niiri:0e2cf2a8e5c5493529071dbf9ca69a3b"},
+      "prov:atLocation": {"@id": "niiri:dc041c3c37fe0c0edd7ce9841a6c74c1"},
       "prov:value": {"@type": "xsd:float", "@value": "3.43941974639893"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.13390260786598"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000862490493106716"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.919935328973706"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.13390260786598"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000862490493106716"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.919935328973706"}
     },
     {
-      "@id": "niiri:0e2cf2a8e5c5493529071dbf9ca69a3b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:dc041c3c37fe0c0edd7ce9841a6c74c1",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0254",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[46,-30,-6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[46,-30,-6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cf29c1a8bb918b6e5d5ad13958131a43",
-      "entity": "niiri:4525ab0c75413bf2c98a4586a5abcc36"
+      "entity_derived": "niiri:798c8ad3bf29b7e6a1599d243c811ef4",
+      "entity": "niiri:ad4b61cba6b4e1ac8b424d69a662357a"
     },
     {
-      "@id": "niiri:9c8de8c17d4a738e981a9e95cb8bea2a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:188e8be049871fa65f8fc1d3fd94eeea",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0255",
-      "prov:atLocation": {"@id": "niiri:b6904e54dc6f210f5f59a30a1bcfc54a"},
+      "prov:atLocation": {"@id": "niiri:241b86464efb064f25917d09147c860f"},
       "prov:value": {"@type": "xsd:float", "@value": "3.43677449226379"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.13176386125168"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000868797847718428"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.923879718713014"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.13176386125168"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000868797847718428"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.923879718713014"}
     },
     {
-      "@id": "niiri:b6904e54dc6f210f5f59a30a1bcfc54a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:241b86464efb064f25917d09147c860f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0255",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-20,28,8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-20,28,8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9c8de8c17d4a738e981a9e95cb8bea2a",
-      "entity": "niiri:4eaf48754995dc5302632344b8135db1"
+      "entity_derived": "niiri:188e8be049871fa65f8fc1d3fd94eeea",
+      "entity": "niiri:18172de66764cc046e57e3f71900f308"
     },
     {
-      "@id": "niiri:0b01472586a4b0c4f8825be66c755556",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:bd959eb0d068217ced11fd9423305a37",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0256",
-      "prov:atLocation": {"@id": "niiri:3120560a320757e9467244f3b855e1cf"},
+      "prov:atLocation": {"@id": "niiri:9f5778ddf03c3b5ff73110a18039e5d3"},
       "prov:value": {"@type": "xsd:float", "@value": "3.43498468399048"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.13031600570198"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000873091748155641"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.926238520156328"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.13031600570198"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000873091748155641"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.926238520156328"}
     },
     {
-      "@id": "niiri:3120560a320757e9467244f3b855e1cf",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:9f5778ddf03c3b5ff73110a18039e5d3",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0256",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[40,-70,34]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[40,-70,34]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0b01472586a4b0c4f8825be66c755556",
-      "entity": "niiri:4424249ed6c1cf6688e8d9a01e38e149"
+      "entity_derived": "niiri:bd959eb0d068217ced11fd9423305a37",
+      "entity": "niiri:5b864821dad832cdea33cc2c71107b5d"
     },
     {
-      "@id": "niiri:38ceb79f3c1ba8a4e6956ba24de4d11a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:bb3156da7e40e4feec485af3e6a32ecd",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0257",
-      "prov:atLocation": {"@id": "niiri:5f8a387c461b3148ad13494d71bda1d1"},
+      "prov:atLocation": {"@id": "niiri:13eaebbb8058068078e2c653b9875caa"},
       "prov:value": {"@type": "xsd:float", "@value": "3.43085432052612"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.12697243929315"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000883082416866077"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.933001754616948"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.12697243929315"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000883082416866077"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.933001754616948"}
     },
     {
-      "@id": "niiri:5f8a387c461b3148ad13494d71bda1d1",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:13eaebbb8058068078e2c653b9875caa",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0257",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[44,-38,-6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[44,-38,-6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:38ceb79f3c1ba8a4e6956ba24de4d11a",
-      "entity": "niiri:a39115f19cda212439112978c2f429df"
+      "entity_derived": "niiri:bb3156da7e40e4feec485af3e6a32ecd",
+      "entity": "niiri:54af2492a558bd6b541a83efffeacbc6"
     },
     {
-      "@id": "niiri:27594401c561929af8d24f6405f4deba",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f8e25bc4e933ed306f46968cead64492",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0258",
-      "prov:atLocation": {"@id": "niiri:82eaf07b78957dbaab11aef1baa80aa2"},
+      "prov:atLocation": {"@id": "niiri:a03239e65a180276f5a134d7c3ec3985"},
       "prov:value": {"@type": "xsd:float", "@value": "3.42879891395569"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.12530735529034"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000888096838085106"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.935884446603093"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.12530735529034"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000888096838085106"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.935884446603093"}
     },
     {
-      "@id": "niiri:82eaf07b78957dbaab11aef1baa80aa2",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a03239e65a180276f5a134d7c3ec3985",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0258",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[52,-6,8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[52,-6,8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:27594401c561929af8d24f6405f4deba",
-      "entity": "niiri:d5f28f9ef79dc06baf5860f0239ca3e7"
+      "entity_derived": "niiri:f8e25bc4e933ed306f46968cead64492",
+      "entity": "niiri:4c87d31930bd2a3884bfbd054121e8ea"
     },
     {
-      "@id": "niiri:58a735d123722a7558bcc09250d992d7",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b80c331bc3c013d36540ed2209e180ac",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0259",
-      "prov:atLocation": {"@id": "niiri:2f3e93c7676b5a0e2805bebee1f9d179"},
+      "prov:atLocation": {"@id": "niiri:71fc6bdf3b69205367a0010060b137b5"},
       "prov:value": {"@type": "xsd:float", "@value": "3.42553544044495"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.12266195704485"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000896117338800573"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.939451992103697"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.12266195704485"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000896117338800573"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.939451992103697"}
     },
     {
-      "@id": "niiri:2f3e93c7676b5a0e2805bebee1f9d179",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:71fc6bdf3b69205367a0010060b137b5",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0259",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[54,-72,8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[54,-72,8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:58a735d123722a7558bcc09250d992d7",
-      "entity": "niiri:5079e994cd9f24fc30fe92efa7493c57"
+      "entity_derived": "niiri:b80c331bc3c013d36540ed2209e180ac",
+      "entity": "niiri:0c1ba90c913890f99f03e9c6732b7833"
     },
     {
-      "@id": "niiri:e8969dceee58b2b20f0b988472c9653e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:4deb8dc19d6af02360fbd76e432ce8b6",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0260",
-      "prov:atLocation": {"@id": "niiri:a04078d9882464053185059f803d1d26"},
+      "prov:atLocation": {"@id": "niiri:b5082c06f45ce0a2dd15d81971c68d59"},
       "prov:value": {"@type": "xsd:float", "@value": "3.42464590072632"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.12194053531123"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000898316119580023"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.939451992103697"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.12194053531123"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000898316119580023"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.939451992103697"}
     },
     {
-      "@id": "niiri:a04078d9882464053185059f803d1d26",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b5082c06f45ce0a2dd15d81971c68d59",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0260",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-34,-86,12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-34,-86,12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e8969dceee58b2b20f0b988472c9653e",
-      "entity": "niiri:686ed6dbd2ea21d312152f2e4e96f435"
+      "entity_derived": "niiri:4deb8dc19d6af02360fbd76e432ce8b6",
+      "entity": "niiri:7e48fd00328505ec2f7c55286029038c"
     },
     {
-      "@id": "niiri:767a71267bbe9178e3b5840ace1525ad",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ed4d3b7d5ccc140dfba860cdd388e8ce",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0261",
-      "prov:atLocation": {"@id": "niiri:140badd68f365dee0f7ca11dddf2e2d4"},
+      "prov:atLocation": {"@id": "niiri:06c7a2471791b84ae3c6a36937e0e8a0"},
       "prov:value": {"@type": "xsd:float", "@value": "3.42428636550903"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.12164890720699"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00089920636307117"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.939451992103697"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.12164890720699"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00089920636307117"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.939451992103697"}
     },
     {
-      "@id": "niiri:140badd68f365dee0f7ca11dddf2e2d4",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:06c7a2471791b84ae3c6a36937e0e8a0",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0261",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-4,10,-10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-4,10,-10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:767a71267bbe9178e3b5840ace1525ad",
-      "entity": "niiri:91f65776f22ca4ee422c8dcd4c4c4459"
+      "entity_derived": "niiri:ed4d3b7d5ccc140dfba860cdd388e8ce",
+      "entity": "niiri:fe7b7aeb5b19bcdfb6ba3b9e7bbc0530"
     },
     {
-      "@id": "niiri:bc6ae74fd4bd5212ee4a36a237f3490e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b7f899e5f3760319ce8ccef45e585946",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0262",
-      "prov:atLocation": {"@id": "niiri:4059198b6c549aa31f9f5cf29e45af3c"},
+      "prov:atLocation": {"@id": "niiri:1a7b22ad02fe7ed75c7738a5f7ac0c62"},
       "prov:value": {"@type": "xsd:float", "@value": "3.4242856502533"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.12164832702029"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000899208134995888"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.939451992103697"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.12164832702029"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000899208134995888"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.939451992103697"}
     },
     {
-      "@id": "niiri:4059198b6c549aa31f9f5cf29e45af3c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:1a7b22ad02fe7ed75c7738a5f7ac0c62",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0262",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-66,-32,16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-66,-32,16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:bc6ae74fd4bd5212ee4a36a237f3490e",
-      "entity": "niiri:4e1ee3ae277085cca25ed575c4d6c732"
+      "entity_derived": "niiri:b7f899e5f3760319ce8ccef45e585946",
+      "entity": "niiri:2598e0a8af6b254c19ea1eae1c055e59"
     },
     {
-      "@id": "niiri:fbf29cced919e01bc4d870031c5b9664",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:30b82d808ecbca165129f91f15eeb7d8",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0263",
-      "prov:atLocation": {"@id": "niiri:057ceabe371a11b3e54a00c7b3846412"},
+      "prov:atLocation": {"@id": "niiri:08f17e7b0d90c8d55cce1d84356b89c1"},
       "prov:value": {"@type": "xsd:float", "@value": "3.42256450653076"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.12025192043597"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000903482154968605"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.94172231450196"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.12025192043597"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000903482154968605"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.94172231450196"}
     },
     {
-      "@id": "niiri:057ceabe371a11b3e54a00c7b3846412",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:08f17e7b0d90c8d55cce1d84356b89c1",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0263",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-6,10,6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-6,10,6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:fbf29cced919e01bc4d870031c5b9664",
-      "entity": "niiri:21ba06ef00e16e74fa2aac38752b9ad5"
+      "entity_derived": "niiri:30b82d808ecbca165129f91f15eeb7d8",
+      "entity": "niiri:ef260aa5a1800f7a5b96c1d3f96edac0"
     },
     {
-      "@id": "niiri:ad6ebc4267abca02b3f648b13a2bc7e8",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c0b355fc51e7cd26f5f72e9f5c550472",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0264",
-      "prov:atLocation": {"@id": "niiri:9f50af5738d295fb4c112818e8ed812b"},
+      "prov:atLocation": {"@id": "niiri:4e1ed2f0db8b7a4f4d7af0bb70e715a4"},
       "prov:value": {"@type": "xsd:float", "@value": "3.420490026474"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.11856808830486"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000908660733561772"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.943981476602879"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.11856808830486"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000908660733561772"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.943981476602879"}
     },
     {
-      "@id": "niiri:9f50af5738d295fb4c112818e8ed812b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4e1ed2f0db8b7a4f4d7af0bb70e715a4",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0264",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[60,22,28]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[60,22,28]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ad6ebc4267abca02b3f648b13a2bc7e8",
-      "entity": "niiri:cb15ce5ea75dc27ee8c68d6f25317137"
+      "entity_derived": "niiri:c0b355fc51e7cd26f5f72e9f5c550472",
+      "entity": "niiri:9edfdd818d3f428259751e3a1f4426fa"
     },
     {
-      "@id": "niiri:76b0a16db9e2cdc644577f7cb27f8e45",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a2e099d5d8ff7d6205bb133cc5078448",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0265",
-      "prov:atLocation": {"@id": "niiri:cfc6412303e2e50ffef9b795c9b0ed40"},
+      "prov:atLocation": {"@id": "niiri:a95381a6790d557cf86a8873e91a0071"},
       "prov:value": {"@type": "xsd:float", "@value": "3.42032909393311"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.11843742665399"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000909063718098957"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.943981476602879"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.11843742665399"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000909063718098957"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.943981476602879"}
     },
     {
-      "@id": "niiri:cfc6412303e2e50ffef9b795c9b0ed40",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a95381a6790d557cf86a8873e91a0071",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0265",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[6,48,-18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[6,48,-18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:76b0a16db9e2cdc644577f7cb27f8e45",
-      "entity": "niiri:9c56529ebb0bf4259a9c564b06624446"
+      "entity_derived": "niiri:a2e099d5d8ff7d6205bb133cc5078448",
+      "entity": "niiri:1667cff121b7be39391cc74c4150a6e4"
     },
     {
-      "@id": "niiri:60aade6cd640aed73151491f62f81cc5",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:cc1877ba95e403c226eac44d78215696",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0266",
-      "prov:atLocation": {"@id": "niiri:d567defdeffdbaabcdc8fcccb18582e6"},
+      "prov:atLocation": {"@id": "niiri:f2e91580aedfda1661c00346dcfdf4a4"},
       "prov:value": {"@type": "xsd:float", "@value": "3.41344952583313"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.11284722900141"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000926459524586143"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.956145916250816"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.11284722900141"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000926459524586143"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.956145916250816"}
     },
     {
-      "@id": "niiri:d567defdeffdbaabcdc8fcccb18582e6",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f2e91580aedfda1661c00346dcfdf4a4",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0266",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[30,-66,-4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[30,-66,-4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:60aade6cd640aed73151491f62f81cc5",
-      "entity": "niiri:58cc34c1cf71d6fb92343373483bc627"
+      "entity_derived": "niiri:cc1877ba95e403c226eac44d78215696",
+      "entity": "niiri:8a9dbe909430bab19de8984a30f0827c"
     },
     {
-      "@id": "niiri:bcdbc0d0bede0ed614966d0971fab082",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c1b25d75e61e613c55029c674539f77a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0267",
-      "prov:atLocation": {"@id": "niiri:7828d22e6f7c800b3de1d100a72aeaa6"},
+      "prov:atLocation": {"@id": "niiri:d1aefdaa8c182ce454467dd1278dd001"},
       "prov:value": {"@type": "xsd:float", "@value": "3.41180443763733"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.11150911429397"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00093066864036262"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.958308660309721"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.11150911429397"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00093066864036262"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.958308660309721"}
     },
     {
-      "@id": "niiri:7828d22e6f7c800b3de1d100a72aeaa6",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d1aefdaa8c182ce454467dd1278dd001",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0267",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[62,18,8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[62,18,8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:bcdbc0d0bede0ed614966d0971fab082",
-      "entity": "niiri:ef7aa42532c9d5d3093cbb6f46af6456"
+      "entity_derived": "niiri:c1b25d75e61e613c55029c674539f77a",
+      "entity": "niiri:73e5d22f5e99f7222d046e5c8b8f17e5"
     },
     {
-      "@id": "niiri:53cd36dd64f896620fc190ddbd15ac00",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:dd0f126c27f7ac1f0c10fd12e39bf105",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0268",
-      "prov:atLocation": {"@id": "niiri:0a9b35f95a04802e6be14f473e26dcbc"},
+      "prov:atLocation": {"@id": "niiri:da274ebc3923f39c33998c996c5f1b48"},
       "prov:value": {"@type": "xsd:float", "@value": "3.4099760055542"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.11002125556328"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000935369406583231"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.960830954574892"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.11002125556328"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000935369406583231"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.960830954574892"}
     },
     {
-      "@id": "niiri:0a9b35f95a04802e6be14f473e26dcbc",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:da274ebc3923f39c33998c996c5f1b48",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0268",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[22,40,38]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[22,40,38]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:53cd36dd64f896620fc190ddbd15ac00",
-      "entity": "niiri:4948e1f6d55a77b68ff8403a3b1cc6a9"
+      "entity_derived": "niiri:dd0f126c27f7ac1f0c10fd12e39bf105",
+      "entity": "niiri:8015064bc0743ed13468353e18ca0971"
     },
     {
-      "@id": "niiri:a14fcf9ccb355d41569e0f3c6507e437",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c91264646d693326daa65c4e49da790c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0269",
-      "prov:atLocation": {"@id": "niiri:8aa7b35f567fe23cf02e5c132ec2259e"},
+      "prov:atLocation": {"@id": "niiri:4b8ff43a5a20f4afeed513550c9779d1"},
       "prov:value": {"@type": "xsd:float", "@value": "3.40772676467896"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.10819008533752"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000941184775066772"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.964175735240494"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.10819008533752"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000941184775066772"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.964175735240494"}
     },
     {
-      "@id": "niiri:8aa7b35f567fe23cf02e5c132ec2259e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4b8ff43a5a20f4afeed513550c9779d1",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0269",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-12,-74,-32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-12,-74,-32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a14fcf9ccb355d41569e0f3c6507e437",
-      "entity": "niiri:d51ac19a940490ccb81c778042e6d07f"
+      "entity_derived": "niiri:c91264646d693326daa65c4e49da790c",
+      "entity": "niiri:eb612c2c1cebda064d6320c535f9294f"
     },
     {
-      "@id": "niiri:50aa138335b817fa5d80de192f3e56fe",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:85a9c11ba54c056a1c94ef036e48c7e8",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0270",
-      "prov:atLocation": {"@id": "niiri:b8782b5412b610e9e02c8ae2f51f811e"},
+      "prov:atLocation": {"@id": "niiri:98db87a6e1ff03f144dc1294bd88361c"},
       "prov:value": {"@type": "xsd:float", "@value": "3.40043520927429"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.10224710205524"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000960287852612818"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.977387221974707"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.10224710205524"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000960287852612818"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.977387221974707"}
     },
     {
-      "@id": "niiri:b8782b5412b610e9e02c8ae2f51f811e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:98db87a6e1ff03f144dc1294bd88361c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0270",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[36,12,8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[36,12,8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:50aa138335b817fa5d80de192f3e56fe",
-      "entity": "niiri:dd6abaee8e1238ee75ff4cc3940af16c"
+      "entity_derived": "niiri:85a9c11ba54c056a1c94ef036e48c7e8",
+      "entity": "niiri:6369784f4c4b56deb50440d6515b981e"
     },
     {
-      "@id": "niiri:dce605d65d09289a881eb04b284924f2",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:80417a00361d173f5c5af02c203f269c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0271",
-      "prov:atLocation": {"@id": "niiri:b0621d155d49ef8642896e35363eaa9e"},
+      "prov:atLocation": {"@id": "niiri:9ae3231161e4fa13633730f1e4660a9a"},
       "prov:value": {"@type": "xsd:float", "@value": "3.39929604530334"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.10131769657828"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000963307318207596"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.978600787160336"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.10131769657828"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000963307318207596"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.978600787160336"}
     },
     {
-      "@id": "niiri:b0621d155d49ef8642896e35363eaa9e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:9ae3231161e4fa13633730f1e4660a9a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0271",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[34,-64,-54]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[34,-64,-54]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:dce605d65d09289a881eb04b284924f2",
-      "entity": "niiri:dec8b0ace647b4ba45c324b0822a7d07"
+      "entity_derived": "niiri:80417a00361d173f5c5af02c203f269c",
+      "entity": "niiri:2147d82387f71f29a3d3dfb09b7b8d64"
     },
     {
-      "@id": "niiri:50c70741ba2247ba187b32228ba5cb8a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f44f60b309d98b4839df00ce58c954d3",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0272",
-      "prov:atLocation": {"@id": "niiri:659216a0abb9cfa83ba297653940b95a"},
+      "prov:atLocation": {"@id": "niiri:c0904438f742cbf33d8af23df92769ae"},
       "prov:value": {"@type": "xsd:float", "@value": "3.39674377441406"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.09923447115328"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000970107026972977"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.982601015041391"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.09923447115328"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000970107026972977"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.982601015041391"}
     },
     {
-      "@id": "niiri:659216a0abb9cfa83ba297653940b95a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c0904438f742cbf33d8af23df92769ae",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0272",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-6,22,14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-6,22,14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:50c70741ba2247ba187b32228ba5cb8a",
-      "entity": "niiri:e77710d04eb08640d5c1d3f18d42d3fa"
+      "entity_derived": "niiri:f44f60b309d98b4839df00ce58c954d3",
+      "entity": "niiri:790465006aaf87ef2289ea019fdb0b83"
     },
     {
-      "@id": "niiri:0518f540beb04f2487d45a5646104e9f",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:cb93650662489dd0d5315baef5339a8f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0273",
-      "prov:atLocation": {"@id": "niiri:a671673494c6b11b49c6a4b64a206b75"},
+      "prov:atLocation": {"@id": "niiri:0af8678dbadc97c6d0964c0f0dea2c02"},
       "prov:value": {"@type": "xsd:float", "@value": "3.39575552940369"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.09842750203846"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00097275281871112"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.983523861304105"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.09842750203846"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00097275281871112"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.983523861304105"}
     },
     {
-      "@id": "niiri:a671673494c6b11b49c6a4b64a206b75",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0af8678dbadc97c6d0964c0f0dea2c02",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0273",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[40,-70,6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[40,-70,6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0518f540beb04f2487d45a5646104e9f",
-      "entity": "niiri:cce35d82d42e6ed7353ce989b716eb03"
+      "entity_derived": "niiri:cb93650662489dd0d5315baef5339a8f",
+      "entity": "niiri:730c6026b96772dd69384df78d1b3195"
     },
     {
-      "@id": "niiri:f26539aa4d229b93e34c0c42786c0216",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:8f4b30cf80d927285653473f8c169306",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0274",
-      "prov:atLocation": {"@id": "niiri:d93c3861611074088693299ee91310c7"},
+      "prov:atLocation": {"@id": "niiri:9d40e288714ed88d103be79dc9b0b58b"},
       "prov:value": {"@type": "xsd:float", "@value": "3.39392924308777"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.09693571606088"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000977661355603399"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.986105717216079"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.09693571606088"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000977661355603399"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.986105717216079"}
     },
     {
-      "@id": "niiri:d93c3861611074088693299ee91310c7",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:9d40e288714ed88d103be79dc9b0b58b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0274",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-48,-6,-36]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-48,-6,-36]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f26539aa4d229b93e34c0c42786c0216",
-      "entity": "niiri:34d4adf23d9292a19ec442ef839b2cff"
+      "entity_derived": "niiri:8f4b30cf80d927285653473f8c169306",
+      "entity": "niiri:26bef1517140b96419bd96743968bf5a"
     },
     {
-      "@id": "niiri:1b79f8647d5740efff59a55996d73b9f",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:4fd5e1e62237032c0a688ab5a411bfd8",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0275",
-      "prov:atLocation": {"@id": "niiri:fa62ad323338a942257e78fcff0bfde7"},
+      "prov:atLocation": {"@id": "niiri:cf60c37ac17a2f336fba57b992c85f9a"},
       "prov:value": {"@type": "xsd:float", "@value": "3.39195704460144"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.09532401480647"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000982990005503837"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.988983887764777"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.09532401480647"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000982990005503837"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.988983887764777"}
     },
     {
-      "@id": "niiri:fa62ad323338a942257e78fcff0bfde7",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:cf60c37ac17a2f336fba57b992c85f9a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0275",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-10,-60,-38]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-10,-60,-38]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1b79f8647d5740efff59a55996d73b9f",
-      "entity": "niiri:bbd6c18fcbc3934b6a6db033becc5ed1"
+      "entity_derived": "niiri:4fd5e1e62237032c0a688ab5a411bfd8",
+      "entity": "niiri:c80e777eb02827978765763f51129026"
     },
     {
-      "@id": "niiri:6a69aee9cf777be919ff8795f24f3290",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d3c3847d28d2438a321d68783cee6c15",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0276",
-      "prov:atLocation": {"@id": "niiri:c7b4a32e49dcd80ca13733878f9df03d"},
+      "prov:atLocation": {"@id": "niiri:60692ff98d1d7460d8d0977b8de1a377"},
       "prov:value": {"@type": "xsd:float", "@value": "3.38738560676575"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.09158527627283"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000995453939317104"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.997054018314194"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.09158527627283"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000995453939317104"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.997054018314194"}
     },
     {
-      "@id": "niiri:c7b4a32e49dcd80ca13733878f9df03d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:60692ff98d1d7460d8d0977b8de1a377",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0276",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[34,-62,-16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[34,-62,-16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6a69aee9cf777be919ff8795f24f3290",
-      "entity": "niiri:88f0354a46364a076e3c319e275ba3dd"
+      "entity_derived": "niiri:d3c3847d28d2438a321d68783cee6c15",
+      "entity": "niiri:6eb9789a31f1c0da3f5dc3fb64518f9e"
     }
   ]
 }

--- a/spmexport/ex_spm_hrf_fir/nidm.ttl
+++ b/spmexport/ex_spm_hrf_fir/nidm.ttl
@@ -4,7 +4,7 @@
 @prefix niiri: <http://iri.nidash.org/> .
 @prefix spm: <http://purl.org/nidash/spm#> .
 @prefix neurolex: <http://neurolex.org/wiki/> .
-@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#> .
+@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
@@ -17,27 +17,27 @@
 @prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-niiri:9b16a6ffae33f71c3473e2fb802b8ee7
+niiri:36c29725f6c7f64a0ab322716c073611
   a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
   rdfs:label "NIDM-Results" ;
   nidm_version: "1.3.0"^^xsd:string .
 
-niiri:c784b095fb75ef28778f34c027010e66
+niiri:dd800a501694fa49759a45e9b9e77f27
   a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
   rdfs:label "spm_results_nidm" ;
-  nidm_softwareVersion: "12.6903"^^xsd:string .
+  nidm_softwareVersion: "12.7057"^^xsd:string .
 
-niiri:c3cf94f5f02593a936b43c8b6e9b6d5d
+niiri:de4cf047e6d9cda522f7ec10c3c92475
   a prov:Activity, nidm_NIDMResultsExport: ; 
   rdfs:label "NIDM-Results export" .
 
-niiri:c3cf94f5f02593a936b43c8b6e9b6d5d prov:wasAssociatedWith niiri:c784b095fb75ef28778f34c027010e66 .
+niiri:de4cf047e6d9cda522f7ec10c3c92475 prov:wasAssociatedWith niiri:dd800a501694fa49759a45e9b9e77f27 .
 
 _:blank5 a prov:Generation .
 
-niiri:9b16a6ffae33f71c3473e2fb802b8ee7 prov:qualifiedGeneration _:blank5 .
+niiri:36c29725f6c7f64a0ab322716c073611 prov:qualifiedGeneration _:blank5 .
 
-_:blank5 prov:atTime "2016-12-07T16:08:48"^^xsd:dateTime .
+_:blank5 prov:atTime "2017-04-19T12:18:24"^^xsd:dateTime .
 
 @prefix nidm_Ixi549CoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000050> .
 @prefix src_SPM: <http://scicrunch.org/resolver/SCR_007037> .
@@ -141,12 +141,12 @@ _:blank5 prov:atTime "2016-12-07T16:08:48"^^xsd:dateTime .
 @prefix nidm_Coordinate: <http://purl.org/nidash/nidm#NIDM_0000015> .
 @prefix nidm_coordinateVector: <http://purl.org/nidash/nidm#NIDM_0000086> .
 
-niiri:2b8ccd681cfa7e7efa195046c80d4149
+niiri:8903ae1fa9a6ecfaa31839e8cf029c8a
     a prov:Agent, src_SPM:, prov:SoftwareAgent ; 
     rdfs:label "SPM" ;
-    nidm_softwareVersion: "12.12.2"^^xsd:string .
+    nidm_softwareVersion: "12.6906"^^xsd:string .
 
-niiri:a0df09e94db6f8ac04096ab9e62f03e3
+niiri:b6feb3b8e24120e8ddf1cf9eae080e8c
     a prov:Entity, nidm_CoordinateSpace: ; 
     rdfs:label "Coordinate space 1" ;
     nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
@@ -156,48 +156,48 @@ niiri:a0df09e94db6f8ac04096ab9e62f03e3
     nidm_numberOfDimensions: "3"^^xsd:int ;
     nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
 
-niiri:346e097f10a52ec316e54b49edc38cdd
+niiri:331761d1abf931827633659314e96094
     a prov:Agent, nlx_Imaginginstrument:, nlx_Magneticresonanceimagingscanner: ; 
     rdfs:label "MRI Scanner" .
 
-niiri:334e15e19418b7788d794c8c723b4944
+niiri:9c886fc4d02f6c8f53849090a389159d
     a prov:Agent, prov:Person ; 
     rdfs:label "Person" .
 
-niiri:bedc0c126056eed53855a4140c25cc80
+niiri:d23b22fadb663709f46b3ab69916d020
     a prov:Entity, prov:Collection, nidm_Data: ; 
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "true"^^xsd:boolean ;
     nidm_targetIntensity: "100"^^xsd:float ;
     nidm_hasMRIProtocol: nlx_FunctionalMRIprotocol: .
 
-niiri:bedc0c126056eed53855a4140c25cc80 prov:wasAttributedTo niiri:346e097f10a52ec316e54b49edc38cdd .
+niiri:d23b22fadb663709f46b3ab69916d020 prov:wasAttributedTo niiri:331761d1abf931827633659314e96094 .
 
-niiri:bedc0c126056eed53855a4140c25cc80 prov:wasAttributedTo niiri:334e15e19418b7788d794c8c723b4944 .
+niiri:d23b22fadb663709f46b3ab69916d020 prov:wasAttributedTo niiri:9c886fc4d02f6c8f53849090a389159d .
 
-niiri:db710ed0e5b8ef3b436af166cc200864
+niiri:470096f779b79da44b4d0df59add54c2
     a prov:Entity, spm_DCTDriftModel: ; 
     rdfs:label "SPM's DCT Drift Model" ;
     spm_SPMsDriftCutoffPeriod: "128"^^xsd:float .
 
-niiri:7f6fc22ede14f7eb59e1c96c8768b797
+niiri:03fe576d4676dc2c478698e09040bd38
     a prov:Entity, nidm_DesignMatrix: ; 
     prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.csv"^^xsd:string ;
     dct:format "text/csv"^^xsd:string ;
-    dc:description niiri:6b09f6c2a7fc57a3fd917b8b6edac3e8 ;
+    dc:description niiri:e87650be9879dfa4463aee62d8f91cb6 ;
     rdfs:label "Design Matrix" ;
     nidm_regressorNames: "[\"Sn(1) to*bf(1)\", \"Sn(1) to*bf(2)\", \"Sn(1) to*bf(3)\", \"Sn(1) to*bf(4)\", \"Sn(1) to*bf(5)\", \"Sn(1) to*bf(6)\", \"Sn(1) to*bf(7)\", \"Sn(1) to*bf(8)\", \"Sn(1) to*bf(9)\", \"Sn(1) to*bf(10)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) \ntask001 co*bf(2)\", \"Sn(1) \ntask001 co*bf(3)\", \"Sn(1) \ntask001 co*bf(4)\", \"Sn(1) \ntask001 co*bf(5)\", \"Sn(1) \ntask001 co*bf(6)\", \"Sn(1) \ntask001 co*bf(7)\", \"Sn(1) \ntask001 co*bf(8)\", \"Sn(1) \ntask001 co*bf(9)\", \"Sn(1) \ntask001 co*bf(10)\", \"Sn(1) constant\"]"^^xsd:string ;
-    nidm_hasDriftModel: niiri:db710ed0e5b8ef3b436af166cc200864 ;
+    nidm_hasDriftModel: niiri:470096f779b79da44b4d0df59add54c2 ;
     nidm_hasHRFBasis: nidm_FiniteImpulseResponseBasisSet: .
 
-niiri:6b09f6c2a7fc57a3fd917b8b6edac3e8
+niiri:e87650be9879dfa4463aee62d8f91cb6
     a prov:Entity, dctype:Image ; 
     prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:f10b5d59de57808aedc01bf8e699b5bb
+niiri:2411622502cf663c690e37bc572df1f3
     a prov:Entity, nidm_ErrorModel: ; 
     nidm_hasErrorDistribution: obo_normaldistribution: ;
     nidm_hasErrorDependence: obo_Toeplitzcovariancestructure: ;
@@ -205,552 +205,552 @@ niiri:f10b5d59de57808aedc01bf8e699b5bb
     nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
     nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
 
-niiri:16bb24a73948c11f2d5fd7d31856731c
+niiri:9c7e245e4dcccf690110a5c2f867fe1e
     a prov:Activity, nidm_ModelParametersEstimation: ; 
     rdfs:label "Model parameters estimation" ;
     nidm_withEstimationMethod: obo_generalizedleastsquaresestimation: .
 
-niiri:16bb24a73948c11f2d5fd7d31856731c prov:wasAssociatedWith niiri:2b8ccd681cfa7e7efa195046c80d4149 .
+niiri:9c7e245e4dcccf690110a5c2f867fe1e prov:wasAssociatedWith niiri:8903ae1fa9a6ecfaa31839e8cf029c8a .
 
-niiri:16bb24a73948c11f2d5fd7d31856731c prov:used niiri:7f6fc22ede14f7eb59e1c96c8768b797 .
+niiri:9c7e245e4dcccf690110a5c2f867fe1e prov:used niiri:03fe576d4676dc2c478698e09040bd38 .
 
-niiri:16bb24a73948c11f2d5fd7d31856731c prov:used niiri:bedc0c126056eed53855a4140c25cc80 .
+niiri:9c7e245e4dcccf690110a5c2f867fe1e prov:used niiri:d23b22fadb663709f46b3ab69916d020 .
 
-niiri:16bb24a73948c11f2d5fd7d31856731c prov:used niiri:f10b5d59de57808aedc01bf8e699b5bb .
+niiri:9c7e245e4dcccf690110a5c2f867fe1e prov:used niiri:2411622502cf663c690e37bc572df1f3 .
 
-niiri:76fcf8996a7e7792184e6dbb3548dddd
+niiri:701d77588170de3f2a3a5cae849cee5b
     a prov:Entity, nidm_MaskMap: ; 
     prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
     nidm_isUserDefined: "false"^^xsd:boolean ;
     nfo:fileName "Mask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Mask" ;
-    nidm_inCoordinateSpace: niiri:a0df09e94db6f8ac04096ab9e62f03e3 ;
+    nidm_inCoordinateSpace: niiri:b6feb3b8e24120e8ddf1cf9eae080e8c ;
     crypto:sha512 "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876"^^xsd:string .
 
-niiri:0748d0b5cd6cfe017e2f94a333b5eb11
+niiri:68240aa5f992dd1323cc9f0c0e3a3639
     a prov:Entity, nidm_MaskMap: ; 
     nfo:fileName "mask.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "36929e1f5f4143bd9cc818cd896a25f129961fab208c3a4438555f40444c08347b359142ee8c53ece6e8cca1627f49db0788a1fd3b9e2ecaef61999c6c6c67ac"^^xsd:string .
 
-niiri:76fcf8996a7e7792184e6dbb3548dddd prov:wasDerivedFrom niiri:0748d0b5cd6cfe017e2f94a333b5eb11 .
+niiri:701d77588170de3f2a3a5cae849cee5b prov:wasDerivedFrom niiri:68240aa5f992dd1323cc9f0c0e3a3639 .
 
-niiri:76fcf8996a7e7792184e6dbb3548dddd prov:wasGeneratedBy niiri:16bb24a73948c11f2d5fd7d31856731c .
+niiri:701d77588170de3f2a3a5cae849cee5b prov:wasGeneratedBy niiri:9c7e245e4dcccf690110a5c2f867fe1e .
 
-niiri:b00802b292f9cbac2cc85093367f010c
+niiri:2759c13e0ec7d1d95a0ecd06a3481373
     a prov:Entity, nidm_GrandMeanMap: ; 
     prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
     nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Grand Mean Map" ;
     nidm_maskedMedian: "116.759864807129"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:a0df09e94db6f8ac04096ab9e62f03e3 ;
+    nidm_inCoordinateSpace: niiri:b6feb3b8e24120e8ddf1cf9eae080e8c ;
     crypto:sha512 "c9f870cdec14d68f6155f69fff57c713e04ba77396008f146de034a59019081d730f36a8d3da8abed1888f20ec50b2fef12d42f65398b47980f3c8f4f9621e30"^^xsd:string .
 
-niiri:b00802b292f9cbac2cc85093367f010c prov:wasGeneratedBy niiri:16bb24a73948c11f2d5fd7d31856731c .
+niiri:2759c13e0ec7d1d95a0ecd06a3481373 prov:wasGeneratedBy niiri:9c7e245e4dcccf690110a5c2f867fe1e .
 
-niiri:ee988293f4c9ba01ab8220c738ce6c57
+niiri:7cfe9f21fb53f5db106ee22b82a0fe77
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0001.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0001.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 1" ;
-    nidm_inCoordinateSpace: niiri:a0df09e94db6f8ac04096ab9e62f03e3 ;
+    nidm_inCoordinateSpace: niiri:b6feb3b8e24120e8ddf1cf9eae080e8c ;
     crypto:sha512 "ab4f341fdc6bb61ed1858ac74fedbac74fcc7d8bb81ad62df8362a733702555296077259ebdbc9255f7fbfdcbf3818802601d04117f70115bb7b2dec0508ad33"^^xsd:string .
 
-niiri:f808b564206d0605cceca7a0bef47627
+niiri:089827f143cffa9301487e18ac4f137b
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "ab4f341fdc6bb61ed1858ac74fedbac74fcc7d8bb81ad62df8362a733702555296077259ebdbc9255f7fbfdcbf3818802601d04117f70115bb7b2dec0508ad33"^^xsd:string .
 
-niiri:ee988293f4c9ba01ab8220c738ce6c57 prov:wasDerivedFrom niiri:f808b564206d0605cceca7a0bef47627 .
+niiri:7cfe9f21fb53f5db106ee22b82a0fe77 prov:wasDerivedFrom niiri:089827f143cffa9301487e18ac4f137b .
 
-niiri:ee988293f4c9ba01ab8220c738ce6c57 prov:wasGeneratedBy niiri:16bb24a73948c11f2d5fd7d31856731c .
+niiri:7cfe9f21fb53f5db106ee22b82a0fe77 prov:wasGeneratedBy niiri:9c7e245e4dcccf690110a5c2f867fe1e .
 
-niiri:08b2f0e7adb342474b1ecdc6fb347df9
+niiri:43283050484b34063061bdb16cb80c6a
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0002.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0002.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 2" ;
-    nidm_inCoordinateSpace: niiri:a0df09e94db6f8ac04096ab9e62f03e3 ;
+    nidm_inCoordinateSpace: niiri:b6feb3b8e24120e8ddf1cf9eae080e8c ;
     crypto:sha512 "553b1841b724f521f7df6a39860f8d936fd47b0d9050cc0d11514571198520a4748f95110e809e16801cb8541c0d3f11db5515b9be6a335cc7a32c4cb4bff458"^^xsd:string .
 
-niiri:40596b70cf44f0b23c77498d34443fd1
+niiri:329c6968efa0ef3a9c454bf61031c775
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0002.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "553b1841b724f521f7df6a39860f8d936fd47b0d9050cc0d11514571198520a4748f95110e809e16801cb8541c0d3f11db5515b9be6a335cc7a32c4cb4bff458"^^xsd:string .
 
-niiri:08b2f0e7adb342474b1ecdc6fb347df9 prov:wasDerivedFrom niiri:40596b70cf44f0b23c77498d34443fd1 .
+niiri:43283050484b34063061bdb16cb80c6a prov:wasDerivedFrom niiri:329c6968efa0ef3a9c454bf61031c775 .
 
-niiri:08b2f0e7adb342474b1ecdc6fb347df9 prov:wasGeneratedBy niiri:16bb24a73948c11f2d5fd7d31856731c .
+niiri:43283050484b34063061bdb16cb80c6a prov:wasGeneratedBy niiri:9c7e245e4dcccf690110a5c2f867fe1e .
 
-niiri:b43b6c5f15dd6da1f95e2c9295f696ea
+niiri:977b0276cc808425abbde5601d66f7f1
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0003.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0003.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 3" ;
-    nidm_inCoordinateSpace: niiri:a0df09e94db6f8ac04096ab9e62f03e3 ;
+    nidm_inCoordinateSpace: niiri:b6feb3b8e24120e8ddf1cf9eae080e8c ;
     crypto:sha512 "8b865f4a40e90f00870f1fb7ef2c526ed19dff1736129d20b7fb0f56bc0b3e5765fbe25ac2011fcc9a0dfb0a1fdee3c9a0cb4208d575eff4ea1e60b0a1248c89"^^xsd:string .
 
-niiri:ca4ead196043e20fde835aa43c6ea138
+niiri:eb7cef4922655d41030fe942fbcf92d0
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0003.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "8b865f4a40e90f00870f1fb7ef2c526ed19dff1736129d20b7fb0f56bc0b3e5765fbe25ac2011fcc9a0dfb0a1fdee3c9a0cb4208d575eff4ea1e60b0a1248c89"^^xsd:string .
 
-niiri:b43b6c5f15dd6da1f95e2c9295f696ea prov:wasDerivedFrom niiri:ca4ead196043e20fde835aa43c6ea138 .
+niiri:977b0276cc808425abbde5601d66f7f1 prov:wasDerivedFrom niiri:eb7cef4922655d41030fe942fbcf92d0 .
 
-niiri:b43b6c5f15dd6da1f95e2c9295f696ea prov:wasGeneratedBy niiri:16bb24a73948c11f2d5fd7d31856731c .
+niiri:977b0276cc808425abbde5601d66f7f1 prov:wasGeneratedBy niiri:9c7e245e4dcccf690110a5c2f867fe1e .
 
-niiri:72b5623932c79270073e16410388a14e
+niiri:ed63a46c0d2c960f86afcc856493eba3
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0004.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0004.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 4" ;
-    nidm_inCoordinateSpace: niiri:a0df09e94db6f8ac04096ab9e62f03e3 ;
+    nidm_inCoordinateSpace: niiri:b6feb3b8e24120e8ddf1cf9eae080e8c ;
     crypto:sha512 "66f8b072dd8b6311a71e1da755c6e878723be8030f3cced7e61d9de0455ddd357733cece45530571e955093c1611ff50161a398ca59bc4f5d412ae9beff68b1d"^^xsd:string .
 
-niiri:4e706ef24c8a0e0f11c39703e5e13bb5
+niiri:4253cad80266847727bfd03c0f113481
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0004.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "66f8b072dd8b6311a71e1da755c6e878723be8030f3cced7e61d9de0455ddd357733cece45530571e955093c1611ff50161a398ca59bc4f5d412ae9beff68b1d"^^xsd:string .
 
-niiri:72b5623932c79270073e16410388a14e prov:wasDerivedFrom niiri:4e706ef24c8a0e0f11c39703e5e13bb5 .
+niiri:ed63a46c0d2c960f86afcc856493eba3 prov:wasDerivedFrom niiri:4253cad80266847727bfd03c0f113481 .
 
-niiri:72b5623932c79270073e16410388a14e prov:wasGeneratedBy niiri:16bb24a73948c11f2d5fd7d31856731c .
+niiri:ed63a46c0d2c960f86afcc856493eba3 prov:wasGeneratedBy niiri:9c7e245e4dcccf690110a5c2f867fe1e .
 
-niiri:d49f6378df8608464ae61aa8917485a4
+niiri:0f11c4b5e831cc47e20327b9561101d1
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0005.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0005.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 5" ;
-    nidm_inCoordinateSpace: niiri:a0df09e94db6f8ac04096ab9e62f03e3 ;
+    nidm_inCoordinateSpace: niiri:b6feb3b8e24120e8ddf1cf9eae080e8c ;
     crypto:sha512 "8cc9e95e7a8fed19b960048ee106a347b1f19de664cce72ef19eeddcfb99fb83f2c47d9042a1b2ebd035ebbe53e156bdfa991586d61633f1bf8683d68749c581"^^xsd:string .
 
-niiri:b72754ccc46f4560aa4d457918639078
+niiri:5e2edc7c4f0179e995e1d8a613e7f3f5
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0005.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "8cc9e95e7a8fed19b960048ee106a347b1f19de664cce72ef19eeddcfb99fb83f2c47d9042a1b2ebd035ebbe53e156bdfa991586d61633f1bf8683d68749c581"^^xsd:string .
 
-niiri:d49f6378df8608464ae61aa8917485a4 prov:wasDerivedFrom niiri:b72754ccc46f4560aa4d457918639078 .
+niiri:0f11c4b5e831cc47e20327b9561101d1 prov:wasDerivedFrom niiri:5e2edc7c4f0179e995e1d8a613e7f3f5 .
 
-niiri:d49f6378df8608464ae61aa8917485a4 prov:wasGeneratedBy niiri:16bb24a73948c11f2d5fd7d31856731c .
+niiri:0f11c4b5e831cc47e20327b9561101d1 prov:wasGeneratedBy niiri:9c7e245e4dcccf690110a5c2f867fe1e .
 
-niiri:5b4a4fc6079e7ec827225bd783e5df60
+niiri:48291f5a02d1cc7b2042bb3d593d7fff
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0006.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0006.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 6" ;
-    nidm_inCoordinateSpace: niiri:a0df09e94db6f8ac04096ab9e62f03e3 ;
+    nidm_inCoordinateSpace: niiri:b6feb3b8e24120e8ddf1cf9eae080e8c ;
     crypto:sha512 "62c235f5803befb467c0e211761d3969a92708699589dca1e61f45abeee452c3aeff7b0654acc13df518a73251efcfc5ce54b68b351f282f7240a3e200cece00"^^xsd:string .
 
-niiri:8ecd1284340b06c1fc5cdd9ea6088cec
+niiri:a32c3f75242cd2d6bdf7364d58ecabaa
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0006.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "62c235f5803befb467c0e211761d3969a92708699589dca1e61f45abeee452c3aeff7b0654acc13df518a73251efcfc5ce54b68b351f282f7240a3e200cece00"^^xsd:string .
 
-niiri:5b4a4fc6079e7ec827225bd783e5df60 prov:wasDerivedFrom niiri:8ecd1284340b06c1fc5cdd9ea6088cec .
+niiri:48291f5a02d1cc7b2042bb3d593d7fff prov:wasDerivedFrom niiri:a32c3f75242cd2d6bdf7364d58ecabaa .
 
-niiri:5b4a4fc6079e7ec827225bd783e5df60 prov:wasGeneratedBy niiri:16bb24a73948c11f2d5fd7d31856731c .
+niiri:48291f5a02d1cc7b2042bb3d593d7fff prov:wasGeneratedBy niiri:9c7e245e4dcccf690110a5c2f867fe1e .
 
-niiri:4610816ff722cb10c0691d600ac85b87
+niiri:8f783b7ccac78e3e7bdec49afe00edd2
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0007.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0007.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 7" ;
-    nidm_inCoordinateSpace: niiri:a0df09e94db6f8ac04096ab9e62f03e3 ;
+    nidm_inCoordinateSpace: niiri:b6feb3b8e24120e8ddf1cf9eae080e8c ;
     crypto:sha512 "503eac361a50d582f783868de851f17396fdaede65faabc382b3ed8794bc42d4a6b1a0192cd1646145777fff9ba3f1fc14610fac5616a4e8a49e801fe50c1fb0"^^xsd:string .
 
-niiri:d0d01d6d9e71220497fac7fa1e09e6cd
+niiri:f8a0341ad0e00972a335bb4d5abdf527
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0007.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "503eac361a50d582f783868de851f17396fdaede65faabc382b3ed8794bc42d4a6b1a0192cd1646145777fff9ba3f1fc14610fac5616a4e8a49e801fe50c1fb0"^^xsd:string .
 
-niiri:4610816ff722cb10c0691d600ac85b87 prov:wasDerivedFrom niiri:d0d01d6d9e71220497fac7fa1e09e6cd .
+niiri:8f783b7ccac78e3e7bdec49afe00edd2 prov:wasDerivedFrom niiri:f8a0341ad0e00972a335bb4d5abdf527 .
 
-niiri:4610816ff722cb10c0691d600ac85b87 prov:wasGeneratedBy niiri:16bb24a73948c11f2d5fd7d31856731c .
+niiri:8f783b7ccac78e3e7bdec49afe00edd2 prov:wasGeneratedBy niiri:9c7e245e4dcccf690110a5c2f867fe1e .
 
-niiri:dc2118ccd0863d65cab02ef9ba996ffa
+niiri:242b483bd1eee1b930fc5cca16db8bd0
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0008.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0008.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 8" ;
-    nidm_inCoordinateSpace: niiri:a0df09e94db6f8ac04096ab9e62f03e3 ;
+    nidm_inCoordinateSpace: niiri:b6feb3b8e24120e8ddf1cf9eae080e8c ;
     crypto:sha512 "7ff16e915edd22e3b69ad9337a39e81470000b43b3e01582dadd95ac6b75e4dae59468d1ee28423da6a5b6e61f8ce4a56016da8b37b0b3b5896adad675ad8bf0"^^xsd:string .
 
-niiri:aa502560b662bb6fdc607bf1856a892b
+niiri:2aa65d5429266d49e3eb2223f5d00c0f
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0008.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "7ff16e915edd22e3b69ad9337a39e81470000b43b3e01582dadd95ac6b75e4dae59468d1ee28423da6a5b6e61f8ce4a56016da8b37b0b3b5896adad675ad8bf0"^^xsd:string .
 
-niiri:dc2118ccd0863d65cab02ef9ba996ffa prov:wasDerivedFrom niiri:aa502560b662bb6fdc607bf1856a892b .
+niiri:242b483bd1eee1b930fc5cca16db8bd0 prov:wasDerivedFrom niiri:2aa65d5429266d49e3eb2223f5d00c0f .
 
-niiri:dc2118ccd0863d65cab02ef9ba996ffa prov:wasGeneratedBy niiri:16bb24a73948c11f2d5fd7d31856731c .
+niiri:242b483bd1eee1b930fc5cca16db8bd0 prov:wasGeneratedBy niiri:9c7e245e4dcccf690110a5c2f867fe1e .
 
-niiri:aa34f275343373ad637d2bc6dbfc90ba
+niiri:133e1e9add501047daab53a9c6301964
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0009.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0009.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 9" ;
-    nidm_inCoordinateSpace: niiri:a0df09e94db6f8ac04096ab9e62f03e3 ;
+    nidm_inCoordinateSpace: niiri:b6feb3b8e24120e8ddf1cf9eae080e8c ;
     crypto:sha512 "e470031c887654d88c3720ca80d430fb890ed6eb50f06947ccfcf5add371f10f5f0264fa29314da1b1860d8f9c46fd0d5d348d34ae430c918129e28dc687d941"^^xsd:string .
 
-niiri:74e55be2faffbf58f0469004e3506ee2
+niiri:d99c4966dd6f79fa35b1936be239db4a
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0009.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "e470031c887654d88c3720ca80d430fb890ed6eb50f06947ccfcf5add371f10f5f0264fa29314da1b1860d8f9c46fd0d5d348d34ae430c918129e28dc687d941"^^xsd:string .
 
-niiri:aa34f275343373ad637d2bc6dbfc90ba prov:wasDerivedFrom niiri:74e55be2faffbf58f0469004e3506ee2 .
+niiri:133e1e9add501047daab53a9c6301964 prov:wasDerivedFrom niiri:d99c4966dd6f79fa35b1936be239db4a .
 
-niiri:aa34f275343373ad637d2bc6dbfc90ba prov:wasGeneratedBy niiri:16bb24a73948c11f2d5fd7d31856731c .
+niiri:133e1e9add501047daab53a9c6301964 prov:wasGeneratedBy niiri:9c7e245e4dcccf690110a5c2f867fe1e .
 
-niiri:06fc994e05054a0d86d4ae675034b9fd
+niiri:1e8ad4131b61696d7f4e8f0d62cc8247
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0010.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0010.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 10" ;
-    nidm_inCoordinateSpace: niiri:a0df09e94db6f8ac04096ab9e62f03e3 ;
+    nidm_inCoordinateSpace: niiri:b6feb3b8e24120e8ddf1cf9eae080e8c ;
     crypto:sha512 "84a21319af5843da90c9a80cce510a3ce962d9cf5c17e9aae6c9f68caf849b2a48554dc0edaf4bc6869e139a83a40a1241598e5c3eaf850c1877cd7d89092772"^^xsd:string .
 
-niiri:1161e9a860d132b4d918bb8f03db4bc5
+niiri:3b7f58f0e40d4420da47ee38ea6e01f4
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0010.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "84a21319af5843da90c9a80cce510a3ce962d9cf5c17e9aae6c9f68caf849b2a48554dc0edaf4bc6869e139a83a40a1241598e5c3eaf850c1877cd7d89092772"^^xsd:string .
 
-niiri:06fc994e05054a0d86d4ae675034b9fd prov:wasDerivedFrom niiri:1161e9a860d132b4d918bb8f03db4bc5 .
+niiri:1e8ad4131b61696d7f4e8f0d62cc8247 prov:wasDerivedFrom niiri:3b7f58f0e40d4420da47ee38ea6e01f4 .
 
-niiri:06fc994e05054a0d86d4ae675034b9fd prov:wasGeneratedBy niiri:16bb24a73948c11f2d5fd7d31856731c .
+niiri:1e8ad4131b61696d7f4e8f0d62cc8247 prov:wasGeneratedBy niiri:9c7e245e4dcccf690110a5c2f867fe1e .
 
-niiri:722ecde813a148bb553937e9a852c5fb
+niiri:21ab0f8b00a00ed52acdb49a05c615c3
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0011.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0011.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 11" ;
-    nidm_inCoordinateSpace: niiri:a0df09e94db6f8ac04096ab9e62f03e3 ;
+    nidm_inCoordinateSpace: niiri:b6feb3b8e24120e8ddf1cf9eae080e8c ;
     crypto:sha512 "79c5038da96f3fa6f62a85fc10874a19b8def87cdf22be32b896a4cb1816aab1123e4fde54cdbfe4d92bb2e86f1af66cce152604df2f617db594def52e10975b"^^xsd:string .
 
-niiri:cf2dd477d370f5e2e75d743f101b2542
+niiri:e81af0e320d70f0c3b56e6ba69ab24b3
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0011.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "79c5038da96f3fa6f62a85fc10874a19b8def87cdf22be32b896a4cb1816aab1123e4fde54cdbfe4d92bb2e86f1af66cce152604df2f617db594def52e10975b"^^xsd:string .
 
-niiri:722ecde813a148bb553937e9a852c5fb prov:wasDerivedFrom niiri:cf2dd477d370f5e2e75d743f101b2542 .
+niiri:21ab0f8b00a00ed52acdb49a05c615c3 prov:wasDerivedFrom niiri:e81af0e320d70f0c3b56e6ba69ab24b3 .
 
-niiri:722ecde813a148bb553937e9a852c5fb prov:wasGeneratedBy niiri:16bb24a73948c11f2d5fd7d31856731c .
+niiri:21ab0f8b00a00ed52acdb49a05c615c3 prov:wasGeneratedBy niiri:9c7e245e4dcccf690110a5c2f867fe1e .
 
-niiri:2a5e8f6c192c564c4fdf245159e6d259
+niiri:8c85285ad275239152b5e31bdf64af12
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0012.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0012.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 12" ;
-    nidm_inCoordinateSpace: niiri:a0df09e94db6f8ac04096ab9e62f03e3 ;
+    nidm_inCoordinateSpace: niiri:b6feb3b8e24120e8ddf1cf9eae080e8c ;
     crypto:sha512 "aa63e2b2dc5c82b5de51c5dbf288e74e2135aa59df78d8e9c42d29c54bd1091a6e2d7d19a0f3f5b2bc38e620ff705cb51d12904557f23880d0d6ea5920e8774c"^^xsd:string .
 
-niiri:c155d23b8e2a64f5da27157b2c193db1
+niiri:e07667d489f48b12e6c861fd0f90c6b2
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0012.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "aa63e2b2dc5c82b5de51c5dbf288e74e2135aa59df78d8e9c42d29c54bd1091a6e2d7d19a0f3f5b2bc38e620ff705cb51d12904557f23880d0d6ea5920e8774c"^^xsd:string .
 
-niiri:2a5e8f6c192c564c4fdf245159e6d259 prov:wasDerivedFrom niiri:c155d23b8e2a64f5da27157b2c193db1 .
+niiri:8c85285ad275239152b5e31bdf64af12 prov:wasDerivedFrom niiri:e07667d489f48b12e6c861fd0f90c6b2 .
 
-niiri:2a5e8f6c192c564c4fdf245159e6d259 prov:wasGeneratedBy niiri:16bb24a73948c11f2d5fd7d31856731c .
+niiri:8c85285ad275239152b5e31bdf64af12 prov:wasGeneratedBy niiri:9c7e245e4dcccf690110a5c2f867fe1e .
 
-niiri:def186a6565313c3633d33a821beccd2
+niiri:2bf2dfa438b489a6f9109550ebd7bc98
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0013.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0013.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 13" ;
-    nidm_inCoordinateSpace: niiri:a0df09e94db6f8ac04096ab9e62f03e3 ;
+    nidm_inCoordinateSpace: niiri:b6feb3b8e24120e8ddf1cf9eae080e8c ;
     crypto:sha512 "aad291cd77ce0f4c11b7e90f630400d464d26a3e83e751f811a0f077617d9770bf67d9746d1932ec1d83fde054cefd0d9a8e01d600369da1042d1925bb5f9c01"^^xsd:string .
 
-niiri:ff0d71c967b8d13cea4c07057efbb1c3
+niiri:7b36c6521cdd3ed1a0440a51a36ed339
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0013.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "aad291cd77ce0f4c11b7e90f630400d464d26a3e83e751f811a0f077617d9770bf67d9746d1932ec1d83fde054cefd0d9a8e01d600369da1042d1925bb5f9c01"^^xsd:string .
 
-niiri:def186a6565313c3633d33a821beccd2 prov:wasDerivedFrom niiri:ff0d71c967b8d13cea4c07057efbb1c3 .
+niiri:2bf2dfa438b489a6f9109550ebd7bc98 prov:wasDerivedFrom niiri:7b36c6521cdd3ed1a0440a51a36ed339 .
 
-niiri:def186a6565313c3633d33a821beccd2 prov:wasGeneratedBy niiri:16bb24a73948c11f2d5fd7d31856731c .
+niiri:2bf2dfa438b489a6f9109550ebd7bc98 prov:wasGeneratedBy niiri:9c7e245e4dcccf690110a5c2f867fe1e .
 
-niiri:fdd3ba21d27a5f3e3e9d70843484c806
+niiri:d1214d3e1d706371966179c913755cb7
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0014.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0014.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 14" ;
-    nidm_inCoordinateSpace: niiri:a0df09e94db6f8ac04096ab9e62f03e3 ;
+    nidm_inCoordinateSpace: niiri:b6feb3b8e24120e8ddf1cf9eae080e8c ;
     crypto:sha512 "129cbf53f40e0f17148e0f2b09a9fc69043e42e71c5ad30362034660c39e4bddbdab423b5ab3b1ba828d335d714f93e1ad6aef35eb18b77c28c675d33d9eacf6"^^xsd:string .
 
-niiri:e93073b0f1d7b523837d306a39918289
+niiri:9c4ae77f74400a1405d71f6f92c62e06
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0014.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "129cbf53f40e0f17148e0f2b09a9fc69043e42e71c5ad30362034660c39e4bddbdab423b5ab3b1ba828d335d714f93e1ad6aef35eb18b77c28c675d33d9eacf6"^^xsd:string .
 
-niiri:fdd3ba21d27a5f3e3e9d70843484c806 prov:wasDerivedFrom niiri:e93073b0f1d7b523837d306a39918289 .
+niiri:d1214d3e1d706371966179c913755cb7 prov:wasDerivedFrom niiri:9c4ae77f74400a1405d71f6f92c62e06 .
 
-niiri:fdd3ba21d27a5f3e3e9d70843484c806 prov:wasGeneratedBy niiri:16bb24a73948c11f2d5fd7d31856731c .
+niiri:d1214d3e1d706371966179c913755cb7 prov:wasGeneratedBy niiri:9c7e245e4dcccf690110a5c2f867fe1e .
 
-niiri:db0185dff2a8f093bf4501edb86172ec
+niiri:067750a93237f9d14c0ce7af50da4f3c
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0015.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0015.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 15" ;
-    nidm_inCoordinateSpace: niiri:a0df09e94db6f8ac04096ab9e62f03e3 ;
+    nidm_inCoordinateSpace: niiri:b6feb3b8e24120e8ddf1cf9eae080e8c ;
     crypto:sha512 "71639fb3c9115d83f377228cc11bfda9f4deb51c53b79094baccc446213cb5e197e7eb63479d1bfc2a5dfde9ca5f6e330b1e477d02448d829010715f72c32e22"^^xsd:string .
 
-niiri:b8910a680a66db347a837f43192abe3a
+niiri:07be9f58a9f65a0bcedc3f67a360ae25
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0015.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "71639fb3c9115d83f377228cc11bfda9f4deb51c53b79094baccc446213cb5e197e7eb63479d1bfc2a5dfde9ca5f6e330b1e477d02448d829010715f72c32e22"^^xsd:string .
 
-niiri:db0185dff2a8f093bf4501edb86172ec prov:wasDerivedFrom niiri:b8910a680a66db347a837f43192abe3a .
+niiri:067750a93237f9d14c0ce7af50da4f3c prov:wasDerivedFrom niiri:07be9f58a9f65a0bcedc3f67a360ae25 .
 
-niiri:db0185dff2a8f093bf4501edb86172ec prov:wasGeneratedBy niiri:16bb24a73948c11f2d5fd7d31856731c .
+niiri:067750a93237f9d14c0ce7af50da4f3c prov:wasGeneratedBy niiri:9c7e245e4dcccf690110a5c2f867fe1e .
 
-niiri:e6c1f12f4ed83708faa17eb0c97001fc
+niiri:0d7a4762edd076ba489e5cfade96a9fc
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0016.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0016.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 16" ;
-    nidm_inCoordinateSpace: niiri:a0df09e94db6f8ac04096ab9e62f03e3 ;
+    nidm_inCoordinateSpace: niiri:b6feb3b8e24120e8ddf1cf9eae080e8c ;
     crypto:sha512 "a4359da69efe29d916afa7cbb9e7c021c354b4fe3623b6a4547216a5aff27e75cefc94f99d1d4fb5151523b0de3b221a6c949be59dc01fea3554e872ff8318f0"^^xsd:string .
 
-niiri:af1132dc3ba7571fea70b4857c7d13b9
+niiri:d763714606a30881b76dbdbf13aa45f0
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0016.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "a4359da69efe29d916afa7cbb9e7c021c354b4fe3623b6a4547216a5aff27e75cefc94f99d1d4fb5151523b0de3b221a6c949be59dc01fea3554e872ff8318f0"^^xsd:string .
 
-niiri:e6c1f12f4ed83708faa17eb0c97001fc prov:wasDerivedFrom niiri:af1132dc3ba7571fea70b4857c7d13b9 .
+niiri:0d7a4762edd076ba489e5cfade96a9fc prov:wasDerivedFrom niiri:d763714606a30881b76dbdbf13aa45f0 .
 
-niiri:e6c1f12f4ed83708faa17eb0c97001fc prov:wasGeneratedBy niiri:16bb24a73948c11f2d5fd7d31856731c .
+niiri:0d7a4762edd076ba489e5cfade96a9fc prov:wasGeneratedBy niiri:9c7e245e4dcccf690110a5c2f867fe1e .
 
-niiri:41870d89f5dcfe8abd864989bd6ee1cf
+niiri:239f80ca4290c616514b508515eba255
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0017.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0017.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 17" ;
-    nidm_inCoordinateSpace: niiri:a0df09e94db6f8ac04096ab9e62f03e3 ;
+    nidm_inCoordinateSpace: niiri:b6feb3b8e24120e8ddf1cf9eae080e8c ;
     crypto:sha512 "d3641c92698032f2ac880b84a2450f16e837354e289fb3b1190d6a37cd6d144c44f6b546d2990768bb7a55827cd2149f0fe4bb8b5b657c1e875fb979e25b55ff"^^xsd:string .
 
-niiri:ccd69ba74567be40d9386cfcd40147a0
+niiri:7894ca83b4d7bbe3efc917dce739071e
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0017.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "d3641c92698032f2ac880b84a2450f16e837354e289fb3b1190d6a37cd6d144c44f6b546d2990768bb7a55827cd2149f0fe4bb8b5b657c1e875fb979e25b55ff"^^xsd:string .
 
-niiri:41870d89f5dcfe8abd864989bd6ee1cf prov:wasDerivedFrom niiri:ccd69ba74567be40d9386cfcd40147a0 .
+niiri:239f80ca4290c616514b508515eba255 prov:wasDerivedFrom niiri:7894ca83b4d7bbe3efc917dce739071e .
 
-niiri:41870d89f5dcfe8abd864989bd6ee1cf prov:wasGeneratedBy niiri:16bb24a73948c11f2d5fd7d31856731c .
+niiri:239f80ca4290c616514b508515eba255 prov:wasGeneratedBy niiri:9c7e245e4dcccf690110a5c2f867fe1e .
 
-niiri:c62c63e9de3ddec4af7084778f1f0a65
+niiri:4e4595ea20f67bd5529f3d2e095f8043
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0018.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0018.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 18" ;
-    nidm_inCoordinateSpace: niiri:a0df09e94db6f8ac04096ab9e62f03e3 ;
+    nidm_inCoordinateSpace: niiri:b6feb3b8e24120e8ddf1cf9eae080e8c ;
     crypto:sha512 "11bb520f059bbf675e597a18a69fbe20d2c00ad4f2e4048e662f1e50d466ebece3285602c7737b32b2dc7177cb06b964053a133789f60b8c6a117a2887946f43"^^xsd:string .
 
-niiri:682a254dac785c2a1985170a04f36faf
+niiri:157eda0d89d7ceb121cc325642f884bc
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0018.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "11bb520f059bbf675e597a18a69fbe20d2c00ad4f2e4048e662f1e50d466ebece3285602c7737b32b2dc7177cb06b964053a133789f60b8c6a117a2887946f43"^^xsd:string .
 
-niiri:c62c63e9de3ddec4af7084778f1f0a65 prov:wasDerivedFrom niiri:682a254dac785c2a1985170a04f36faf .
+niiri:4e4595ea20f67bd5529f3d2e095f8043 prov:wasDerivedFrom niiri:157eda0d89d7ceb121cc325642f884bc .
 
-niiri:c62c63e9de3ddec4af7084778f1f0a65 prov:wasGeneratedBy niiri:16bb24a73948c11f2d5fd7d31856731c .
+niiri:4e4595ea20f67bd5529f3d2e095f8043 prov:wasGeneratedBy niiri:9c7e245e4dcccf690110a5c2f867fe1e .
 
-niiri:87d33654f4af56e37c48ada547612e29
+niiri:069ab84a0bc77f8bbe6fbf8bb2bb80fc
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0019.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0019.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 19" ;
-    nidm_inCoordinateSpace: niiri:a0df09e94db6f8ac04096ab9e62f03e3 ;
+    nidm_inCoordinateSpace: niiri:b6feb3b8e24120e8ddf1cf9eae080e8c ;
     crypto:sha512 "7265ca9b2713d334013587196872999038d4b9a1aa18d4a28daa1e14c509a555ef5cae893952d60604f7ce19c0e72ce33c0e11374e1802bae57d858aee9bf47e"^^xsd:string .
 
-niiri:22abe292447474a270706b548436c88a
+niiri:22a1c0d63f9d2cf485131f1c86148558
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0019.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "7265ca9b2713d334013587196872999038d4b9a1aa18d4a28daa1e14c509a555ef5cae893952d60604f7ce19c0e72ce33c0e11374e1802bae57d858aee9bf47e"^^xsd:string .
 
-niiri:87d33654f4af56e37c48ada547612e29 prov:wasDerivedFrom niiri:22abe292447474a270706b548436c88a .
+niiri:069ab84a0bc77f8bbe6fbf8bb2bb80fc prov:wasDerivedFrom niiri:22a1c0d63f9d2cf485131f1c86148558 .
 
-niiri:87d33654f4af56e37c48ada547612e29 prov:wasGeneratedBy niiri:16bb24a73948c11f2d5fd7d31856731c .
+niiri:069ab84a0bc77f8bbe6fbf8bb2bb80fc prov:wasGeneratedBy niiri:9c7e245e4dcccf690110a5c2f867fe1e .
 
-niiri:ce9c3abc019a371896731fd76d85d617
+niiri:0f888978a8a86a495939e12690e2bcf8
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0020.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0020.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 20" ;
-    nidm_inCoordinateSpace: niiri:a0df09e94db6f8ac04096ab9e62f03e3 ;
+    nidm_inCoordinateSpace: niiri:b6feb3b8e24120e8ddf1cf9eae080e8c ;
     crypto:sha512 "3f2e9de942f81adf736fbdee718b1708a1b2e978482dbe0fc68141fc59f7f59cc66191bf4c59e48d5850ffd708527ff0a1ec1835c76e7466466841f349bb793e"^^xsd:string .
 
-niiri:cc893415abb7a4682e5cc9e460136e1c
+niiri:e7d4386ec97d8e529d6fde660a4adc75
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0020.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "3f2e9de942f81adf736fbdee718b1708a1b2e978482dbe0fc68141fc59f7f59cc66191bf4c59e48d5850ffd708527ff0a1ec1835c76e7466466841f349bb793e"^^xsd:string .
 
-niiri:ce9c3abc019a371896731fd76d85d617 prov:wasDerivedFrom niiri:cc893415abb7a4682e5cc9e460136e1c .
+niiri:0f888978a8a86a495939e12690e2bcf8 prov:wasDerivedFrom niiri:e7d4386ec97d8e529d6fde660a4adc75 .
 
-niiri:ce9c3abc019a371896731fd76d85d617 prov:wasGeneratedBy niiri:16bb24a73948c11f2d5fd7d31856731c .
+niiri:0f888978a8a86a495939e12690e2bcf8 prov:wasGeneratedBy niiri:9c7e245e4dcccf690110a5c2f867fe1e .
 
-niiri:936bb6e7dc82f81ac536ffdc8670e558
+niiri:4dc9f226357a6ab7f5e304324e2bcbfd
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0021.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0021.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 21" ;
-    nidm_inCoordinateSpace: niiri:a0df09e94db6f8ac04096ab9e62f03e3 ;
+    nidm_inCoordinateSpace: niiri:b6feb3b8e24120e8ddf1cf9eae080e8c ;
     crypto:sha512 "0e2c3b4b5e08e5167d4e7ef3dd3f8e2c2f7bb3d0d530889dceeb306f67758558be8cd1531caab46240406285577babef37c24d49567c4c0410ded0cd3aca0e47"^^xsd:string .
 
-niiri:708fdd2e6bbd0ebe611c01a8aade288c
+niiri:14c8f75ed277956b9ba6f87eb9db82e8
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0021.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "0e2c3b4b5e08e5167d4e7ef3dd3f8e2c2f7bb3d0d530889dceeb306f67758558be8cd1531caab46240406285577babef37c24d49567c4c0410ded0cd3aca0e47"^^xsd:string .
 
-niiri:936bb6e7dc82f81ac536ffdc8670e558 prov:wasDerivedFrom niiri:708fdd2e6bbd0ebe611c01a8aade288c .
+niiri:4dc9f226357a6ab7f5e304324e2bcbfd prov:wasDerivedFrom niiri:14c8f75ed277956b9ba6f87eb9db82e8 .
 
-niiri:936bb6e7dc82f81ac536ffdc8670e558 prov:wasGeneratedBy niiri:16bb24a73948c11f2d5fd7d31856731c .
+niiri:4dc9f226357a6ab7f5e304324e2bcbfd prov:wasGeneratedBy niiri:9c7e245e4dcccf690110a5c2f867fe1e .
 
-niiri:afff1faf703e5a9a815b740a33dbb8b9
+niiri:d1abc868edbc84f873320116529f4be5
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Residual Mean Squares Map" ;
-    nidm_inCoordinateSpace: niiri:a0df09e94db6f8ac04096ab9e62f03e3 ;
+    nidm_inCoordinateSpace: niiri:b6feb3b8e24120e8ddf1cf9eae080e8c ;
     crypto:sha512 "9992ae2923012fed54b3812708cd3b60f75373d57ff1adc2205155139f1320943649e7830fd0cef48fb9364ceec9ffb18ab458c47fab082783d8262d0a5b7e4e"^^xsd:string .
 
-niiri:f1c6088a2ea2360d8f585f84225d553f
+niiri:012705be5593997e59490b3d6466d660
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     nfo:fileName "ResMS.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "29e0870b07948253df9f088ac41fd14172c0ce0fb0838c6c32f399622f75ba05856cfae66041c4ecc8dadd513e7bc4402f6a6dc371f62a58a2565dee13b1b853"^^xsd:string .
 
-niiri:afff1faf703e5a9a815b740a33dbb8b9 prov:wasDerivedFrom niiri:f1c6088a2ea2360d8f585f84225d553f .
+niiri:d1abc868edbc84f873320116529f4be5 prov:wasDerivedFrom niiri:012705be5593997e59490b3d6466d660 .
 
-niiri:afff1faf703e5a9a815b740a33dbb8b9 prov:wasGeneratedBy niiri:16bb24a73948c11f2d5fd7d31856731c .
+niiri:d1abc868edbc84f873320116529f4be5 prov:wasGeneratedBy niiri:9c7e245e4dcccf690110a5c2f867fe1e .
 
-niiri:32c639a78085600f8a705a697ed06aed
+niiri:799a884fae2a161e9aadf96d9f7e36f8
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Resels per Voxel Map" ;
-    nidm_inCoordinateSpace: niiri:a0df09e94db6f8ac04096ab9e62f03e3 ;
+    nidm_inCoordinateSpace: niiri:b6feb3b8e24120e8ddf1cf9eae080e8c ;
     crypto:sha512 "e4cc508a935582c9626e9e67fbe3c169a6ba856c20047bb79af4fbdfbd0eddf56b6068e4e54a09ff62c3c7d3c63ddaa6d1d4b213ae65b506447addc8a957ca36"^^xsd:string .
 
-niiri:bd7187db2557e26a813cb7f1d1bc0fa1
+niiri:129241c961b40e0c62467f34d91dab7e
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     nfo:fileName "RPV.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "2f28d80ced43971006071cce9126ba56245647cd4f0f5f47497c25660d144b19e30b9868bcefc3786b1d2459986e17cdb8cd37fe515839dd062fa6277e369bce"^^xsd:string .
 
-niiri:32c639a78085600f8a705a697ed06aed prov:wasDerivedFrom niiri:bd7187db2557e26a813cb7f1d1bc0fa1 .
+niiri:799a884fae2a161e9aadf96d9f7e36f8 prov:wasDerivedFrom niiri:129241c961b40e0c62467f34d91dab7e .
 
-niiri:32c639a78085600f8a705a697ed06aed prov:wasGeneratedBy niiri:16bb24a73948c11f2d5fd7d31856731c .
+niiri:799a884fae2a161e9aadf96d9f7e36f8 prov:wasGeneratedBy niiri:9c7e245e4dcccf690110a5c2f867fe1e .
 
-niiri:71f495a64a87dd58b1cc74f1383c228a
+niiri:adea7750ce17c82bde1a6b2deaac6a59
     a prov:Entity, obo_contrastweightmatrix: ; 
     nidm_statisticType: obo_Fstatistic: ;
     nidm_contrastName: "Tone Counting vs Baseline"^^xsd:string ;
     rdfs:label "Contrast: Tone Counting vs Baseline" ;
     prov:value "[[1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],[0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],[0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],[0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],[0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],[0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],[0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],[0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],[0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],[0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]]"^^xsd:string .
 
-niiri:c823c79a04cd1f35b594684f46e488b1
+niiri:e18771e5677d91f4a09d79dadf322eaf
     a prov:Activity, nidm_ContrastEstimation: ; 
     rdfs:label "Contrast estimation" .
 
-niiri:c823c79a04cd1f35b594684f46e488b1 prov:wasAssociatedWith niiri:2b8ccd681cfa7e7efa195046c80d4149 .
+niiri:e18771e5677d91f4a09d79dadf322eaf prov:wasAssociatedWith niiri:8903ae1fa9a6ecfaa31839e8cf029c8a .
 
-niiri:c823c79a04cd1f35b594684f46e488b1 prov:used niiri:76fcf8996a7e7792184e6dbb3548dddd .
+niiri:e18771e5677d91f4a09d79dadf322eaf prov:used niiri:701d77588170de3f2a3a5cae849cee5b .
 
-niiri:c823c79a04cd1f35b594684f46e488b1 prov:used niiri:afff1faf703e5a9a815b740a33dbb8b9 .
+niiri:e18771e5677d91f4a09d79dadf322eaf prov:used niiri:d1abc868edbc84f873320116529f4be5 .
 
-niiri:c823c79a04cd1f35b594684f46e488b1 prov:used niiri:7f6fc22ede14f7eb59e1c96c8768b797 .
+niiri:e18771e5677d91f4a09d79dadf322eaf prov:used niiri:03fe576d4676dc2c478698e09040bd38 .
 
-niiri:c823c79a04cd1f35b594684f46e488b1 prov:used niiri:71f495a64a87dd58b1cc74f1383c228a .
+niiri:e18771e5677d91f4a09d79dadf322eaf prov:used niiri:adea7750ce17c82bde1a6b2deaac6a59 .
 
-niiri:c823c79a04cd1f35b594684f46e488b1 prov:used niiri:ee988293f4c9ba01ab8220c738ce6c57 .
+niiri:e18771e5677d91f4a09d79dadf322eaf prov:used niiri:7cfe9f21fb53f5db106ee22b82a0fe77 .
 
-niiri:c823c79a04cd1f35b594684f46e488b1 prov:used niiri:08b2f0e7adb342474b1ecdc6fb347df9 .
+niiri:e18771e5677d91f4a09d79dadf322eaf prov:used niiri:43283050484b34063061bdb16cb80c6a .
 
-niiri:c823c79a04cd1f35b594684f46e488b1 prov:used niiri:b43b6c5f15dd6da1f95e2c9295f696ea .
+niiri:e18771e5677d91f4a09d79dadf322eaf prov:used niiri:977b0276cc808425abbde5601d66f7f1 .
 
-niiri:c823c79a04cd1f35b594684f46e488b1 prov:used niiri:72b5623932c79270073e16410388a14e .
+niiri:e18771e5677d91f4a09d79dadf322eaf prov:used niiri:ed63a46c0d2c960f86afcc856493eba3 .
 
-niiri:c823c79a04cd1f35b594684f46e488b1 prov:used niiri:d49f6378df8608464ae61aa8917485a4 .
+niiri:e18771e5677d91f4a09d79dadf322eaf prov:used niiri:0f11c4b5e831cc47e20327b9561101d1 .
 
-niiri:c823c79a04cd1f35b594684f46e488b1 prov:used niiri:5b4a4fc6079e7ec827225bd783e5df60 .
+niiri:e18771e5677d91f4a09d79dadf322eaf prov:used niiri:48291f5a02d1cc7b2042bb3d593d7fff .
 
-niiri:c823c79a04cd1f35b594684f46e488b1 prov:used niiri:4610816ff722cb10c0691d600ac85b87 .
+niiri:e18771e5677d91f4a09d79dadf322eaf prov:used niiri:8f783b7ccac78e3e7bdec49afe00edd2 .
 
-niiri:c823c79a04cd1f35b594684f46e488b1 prov:used niiri:dc2118ccd0863d65cab02ef9ba996ffa .
+niiri:e18771e5677d91f4a09d79dadf322eaf prov:used niiri:242b483bd1eee1b930fc5cca16db8bd0 .
 
-niiri:c823c79a04cd1f35b594684f46e488b1 prov:used niiri:aa34f275343373ad637d2bc6dbfc90ba .
+niiri:e18771e5677d91f4a09d79dadf322eaf prov:used niiri:133e1e9add501047daab53a9c6301964 .
 
-niiri:c823c79a04cd1f35b594684f46e488b1 prov:used niiri:06fc994e05054a0d86d4ae675034b9fd .
+niiri:e18771e5677d91f4a09d79dadf322eaf prov:used niiri:1e8ad4131b61696d7f4e8f0d62cc8247 .
 
-niiri:c823c79a04cd1f35b594684f46e488b1 prov:used niiri:722ecde813a148bb553937e9a852c5fb .
+niiri:e18771e5677d91f4a09d79dadf322eaf prov:used niiri:21ab0f8b00a00ed52acdb49a05c615c3 .
 
-niiri:c823c79a04cd1f35b594684f46e488b1 prov:used niiri:2a5e8f6c192c564c4fdf245159e6d259 .
+niiri:e18771e5677d91f4a09d79dadf322eaf prov:used niiri:8c85285ad275239152b5e31bdf64af12 .
 
-niiri:c823c79a04cd1f35b594684f46e488b1 prov:used niiri:def186a6565313c3633d33a821beccd2 .
+niiri:e18771e5677d91f4a09d79dadf322eaf prov:used niiri:2bf2dfa438b489a6f9109550ebd7bc98 .
 
-niiri:c823c79a04cd1f35b594684f46e488b1 prov:used niiri:fdd3ba21d27a5f3e3e9d70843484c806 .
+niiri:e18771e5677d91f4a09d79dadf322eaf prov:used niiri:d1214d3e1d706371966179c913755cb7 .
 
-niiri:c823c79a04cd1f35b594684f46e488b1 prov:used niiri:db0185dff2a8f093bf4501edb86172ec .
+niiri:e18771e5677d91f4a09d79dadf322eaf prov:used niiri:067750a93237f9d14c0ce7af50da4f3c .
 
-niiri:c823c79a04cd1f35b594684f46e488b1 prov:used niiri:e6c1f12f4ed83708faa17eb0c97001fc .
+niiri:e18771e5677d91f4a09d79dadf322eaf prov:used niiri:0d7a4762edd076ba489e5cfade96a9fc .
 
-niiri:c823c79a04cd1f35b594684f46e488b1 prov:used niiri:41870d89f5dcfe8abd864989bd6ee1cf .
+niiri:e18771e5677d91f4a09d79dadf322eaf prov:used niiri:239f80ca4290c616514b508515eba255 .
 
-niiri:c823c79a04cd1f35b594684f46e488b1 prov:used niiri:c62c63e9de3ddec4af7084778f1f0a65 .
+niiri:e18771e5677d91f4a09d79dadf322eaf prov:used niiri:4e4595ea20f67bd5529f3d2e095f8043 .
 
-niiri:c823c79a04cd1f35b594684f46e488b1 prov:used niiri:87d33654f4af56e37c48ada547612e29 .
+niiri:e18771e5677d91f4a09d79dadf322eaf prov:used niiri:069ab84a0bc77f8bbe6fbf8bb2bb80fc .
 
-niiri:c823c79a04cd1f35b594684f46e488b1 prov:used niiri:ce9c3abc019a371896731fd76d85d617 .
+niiri:e18771e5677d91f4a09d79dadf322eaf prov:used niiri:0f888978a8a86a495939e12690e2bcf8 .
 
-niiri:c823c79a04cd1f35b594684f46e488b1 prov:used niiri:936bb6e7dc82f81ac536ffdc8670e558 .
+niiri:e18771e5677d91f4a09d79dadf322eaf prov:used niiri:4dc9f226357a6ab7f5e304324e2bcbfd .
 
-niiri:677d89c0518fd97cb9d8725ef4cde38f
+niiri:a58ef4cb06ae0d7d8f0c14e5f016db3c
     a prov:Entity, nidm_StatisticMap: ; 
     prov:atLocation "FStatistic.nii.gz"^^xsd:anyURI ;
     nfo:fileName "FStatistic.nii.gz"^^xsd:string ;
@@ -760,104 +760,104 @@ niiri:677d89c0518fd97cb9d8725ef4cde38f
     nidm_contrastName: "Tone Counting vs Baseline"^^xsd:string ;
     nidm_errorDegreesOfFreedom: "79.9999999999727"^^xsd:float ;
     nidm_effectDegreesOfFreedom: "9.99999999999902"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:a0df09e94db6f8ac04096ab9e62f03e3 ;
+    nidm_inCoordinateSpace: niiri:b6feb3b8e24120e8ddf1cf9eae080e8c ;
     crypto:sha512 "d929be872bc4e50522f425af19834ae0fdffb717909e441f01354d5d49fa33db0b86fb6054d74fdfaaf5288288f3b827eca9c06969bf5ca07da368b9c2983331"^^xsd:string .
 
-niiri:bdad181146cee1f1221b950807842891
+niiri:4a659d96c27e7d9b44774d45d04e80fe
     a prov:Entity, nidm_StatisticMap: ; 
     nfo:fileName "spmF_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "fc863f9f5a0f55d3013a44bc04c0144d78238bb193d7176caebb1fd666c4f342ae1e4f7f89a379811e06eefc054d74e6cf610556bf8e4942c82ea36ed4acf8be"^^xsd:string .
 
-niiri:677d89c0518fd97cb9d8725ef4cde38f prov:wasDerivedFrom niiri:bdad181146cee1f1221b950807842891 .
+niiri:a58ef4cb06ae0d7d8f0c14e5f016db3c prov:wasDerivedFrom niiri:4a659d96c27e7d9b44774d45d04e80fe .
 
-niiri:677d89c0518fd97cb9d8725ef4cde38f prov:wasGeneratedBy niiri:c823c79a04cd1f35b594684f46e488b1 .
+niiri:a58ef4cb06ae0d7d8f0c14e5f016db3c prov:wasGeneratedBy niiri:e18771e5677d91f4a09d79dadf322eaf .
 
-niiri:7d1875e35bad8956747e03da1bfa4d33
+niiri:ce5a4b9b70b53160de00542203e0ef42
     a prov:Entity, nidm_ContrastExplainedMeanSquareMap: ; 
     prov:atLocation "ContrastExplainedMeanSquare.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ContrastExplainedMeanSquare.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Explained Mean Square Map" ;
-    nidm_inCoordinateSpace: niiri:a0df09e94db6f8ac04096ab9e62f03e3 ;
+    nidm_inCoordinateSpace: niiri:b6feb3b8e24120e8ddf1cf9eae080e8c ;
     crypto:sha512 "413ba8ccbb0f2a6d28833434d74e7c0e86ba02e18e6b4a3ce9cd4f6261d96fcc6a469adbde0bdca4367446a5857cd90bfd495cbd432064288b12cb5a456ceb32"^^xsd:string .
 
-niiri:7d1875e35bad8956747e03da1bfa4d33 prov:wasGeneratedBy niiri:c823c79a04cd1f35b594684f46e488b1 .
+niiri:ce5a4b9b70b53160de00542203e0ef42 prov:wasGeneratedBy niiri:e18771e5677d91f4a09d79dadf322eaf .
 
-niiri:f27f8fd0daf37ac0c325511449336820
+niiri:3cdb938d0d98089a2daa2c42933f776f
     a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
-    rdfs:label "Height Threshold: p<0.001000 (unc.)" ;
+    rdfs:label "Height Threshold: p<0.001 (unc.)" ;
     prov:value "0.000999500040298695"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:7a4585c8214149c879402d2b7df09e7c ;
-    nidm_equivalentThreshold: niiri:1eea923c1d8ed4ac6662ccee6bfd3bdb .
+    nidm_equivalentThreshold: niiri:b32341380b98d15b8fd2009d71b54406 ;
+    nidm_equivalentThreshold: niiri:0700cb52ae8c414bd0981a1a1b41108c .
 
-niiri:7a4585c8214149c879402d2b7df09e7c
+niiri:b32341380b98d15b8fd2009d71b54406
     a prov:Entity, nidm_HeightThreshold:, obo_statistic: ; 
-    rdfs:label "Height Threshold" ;
+    rdfs:label "Height Threshold: F=3.385914)" ;
     prov:value "3.38591395681668"^^xsd:float .
 
-niiri:1eea923c1d8ed4ac6662ccee6bfd3bdb
+niiri:0700cb52ae8c414bd0981a1a1b41108c
     a prov:Entity, nidm_HeightThreshold:, obo_FWERadjustedpvalue: ; 
-    rdfs:label "Height Threshold" ;
+    rdfs:label "Height Threshold: p<1.000000 (FWE)" ;
     prov:value "1"^^xsd:float .
 
-niiri:ab66f11f59d7ca7bb62046e8d9133e17
+niiri:ec3787cbdbedf5e1c42112b88a72d8a8
     a prov:Entity, nidm_ExtentThreshold:, obo_statistic: ; 
     rdfs:label "Extent Threshold: k>=0" ;
     nidm_clusterSizeInVoxels: "0"^^xsd:int ;
     nidm_clusterSizeInResels: "0"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:9d8ba071d9e49621d6c2b99e2d0e741b ;
-    nidm_equivalentThreshold: niiri:c86d2d896fd0f90b14834da61b1c2140 .
+    nidm_equivalentThreshold: niiri:db0a4cdd3410e9ced5166eed42dc1593 ;
+    nidm_equivalentThreshold: niiri:1a26121240ec6092679db261d7ef1d67 .
 
-niiri:9d8ba071d9e49621d6c2b99e2d0e741b
+niiri:db0a4cdd3410e9ced5166eed42dc1593
     a prov:Entity, nidm_ExtentThreshold:, obo_FWERadjustedpvalue: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:c86d2d896fd0f90b14834da61b1c2140
+niiri:1a26121240ec6092679db261d7ef1d67
     a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:83b43f87517e0312723714e057e27393
+niiri:5f2a0985f22401ffe697c6cbad69a014
     a prov:Entity, nidm_PeakDefinitionCriteria: ; 
     rdfs:label "Peak Definition Criteria" ;
     nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
     nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
 
-niiri:92c2b0e166865683bdf335e4295612b0
+niiri:5375a11691240712e54191f850b6a223
     a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
     rdfs:label "Cluster Connectivity Criterion: 18" ;
     nidm_hasConnectivityCriterion: nidm_voxel18connected: .
 
-niiri:5d50bfe60bcdf32579cf9c2bb73605e2
+niiri:1d58f1ea373dca6b6777c0ae0bfc411d
     a prov:Activity, nidm_Inference: ; 
     nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
     rdfs:label "Inference" .
 
-niiri:5d50bfe60bcdf32579cf9c2bb73605e2 prov:wasAssociatedWith niiri:2b8ccd681cfa7e7efa195046c80d4149 .
+niiri:1d58f1ea373dca6b6777c0ae0bfc411d prov:wasAssociatedWith niiri:8903ae1fa9a6ecfaa31839e8cf029c8a .
 
-niiri:5d50bfe60bcdf32579cf9c2bb73605e2 prov:used niiri:f27f8fd0daf37ac0c325511449336820 .
+niiri:1d58f1ea373dca6b6777c0ae0bfc411d prov:used niiri:3cdb938d0d98089a2daa2c42933f776f .
 
-niiri:5d50bfe60bcdf32579cf9c2bb73605e2 prov:used niiri:ab66f11f59d7ca7bb62046e8d9133e17 .
+niiri:1d58f1ea373dca6b6777c0ae0bfc411d prov:used niiri:ec3787cbdbedf5e1c42112b88a72d8a8 .
 
-niiri:5d50bfe60bcdf32579cf9c2bb73605e2 prov:used niiri:677d89c0518fd97cb9d8725ef4cde38f .
+niiri:1d58f1ea373dca6b6777c0ae0bfc411d prov:used niiri:a58ef4cb06ae0d7d8f0c14e5f016db3c .
 
-niiri:5d50bfe60bcdf32579cf9c2bb73605e2 prov:used niiri:32c639a78085600f8a705a697ed06aed .
+niiri:1d58f1ea373dca6b6777c0ae0bfc411d prov:used niiri:799a884fae2a161e9aadf96d9f7e36f8 .
 
-niiri:5d50bfe60bcdf32579cf9c2bb73605e2 prov:used niiri:76fcf8996a7e7792184e6dbb3548dddd .
+niiri:1d58f1ea373dca6b6777c0ae0bfc411d prov:used niiri:701d77588170de3f2a3a5cae849cee5b .
 
-niiri:5d50bfe60bcdf32579cf9c2bb73605e2 prov:used niiri:83b43f87517e0312723714e057e27393 .
+niiri:1d58f1ea373dca6b6777c0ae0bfc411d prov:used niiri:5f2a0985f22401ffe697c6cbad69a014 .
 
-niiri:5d50bfe60bcdf32579cf9c2bb73605e2 prov:used niiri:92c2b0e166865683bdf335e4295612b0 .
+niiri:1d58f1ea373dca6b6777c0ae0bfc411d prov:used niiri:5375a11691240712e54191f850b6a223 .
 
-niiri:3e2b41a23244c3a3a86c37dd2d4d47bf
+niiri:4f06d69ed569f568944f5c14d618d42b
     a prov:Entity, nidm_SearchSpaceMaskMap: ; 
     prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
     nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Search Space Mask Map" ;
-    nidm_inCoordinateSpace: niiri:a0df09e94db6f8ac04096ab9e62f03e3 ;
+    nidm_inCoordinateSpace: niiri:b6feb3b8e24120e8ddf1cf9eae080e8c ;
     nidm_searchVolumeInVoxels: "223057"^^xsd:int ;
     nidm_searchVolumeInUnits: "1784456"^^xsd:float ;
     nidm_reselSizeInVoxels: "61.0192089405672"^^xsd:float ;
@@ -874,9 +874,9 @@ niiri:3e2b41a23244c3a3a86c37dd2d4d47bf
     spm_smallestSignificantClusterSizeInVoxelsFWE05: "50"^^xsd:int ;
     spm_smallestSignificantClusterSizeInVoxelsFDR05: "27"^^xsd:int .
 
-niiri:3e2b41a23244c3a3a86c37dd2d4d47bf prov:wasGeneratedBy niiri:5d50bfe60bcdf32579cf9c2bb73605e2 .
+niiri:4f06d69ed569f568944f5c14d618d42b prov:wasGeneratedBy niiri:1d58f1ea373dca6b6777c0ae0bfc411d .
 
-niiri:fec8545d1e39630ce18d7eddddd0aaa4
+niiri:8c8ad5dc532e1fc2320f4c3356bdd145
     a prov:Entity, nidm_ExcursionSetMap: ; 
     prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
@@ -884,29 +884,29 @@ niiri:fec8545d1e39630ce18d7eddddd0aaa4
     rdfs:label "Excursion Set Map" ;
     nidm_numberOfSupraThresholdClusters: "233"^^xsd:int ;
     nidm_pValue: "0"^^xsd:float ;
-    nidm_hasClusterLabelsMap: niiri:3a2cebaff9a491bcb49fbe38aff03e5e ;
-    nidm_hasMaximumIntensityProjection: niiri:51fc0014bcdab3e46d21c5d9574d0c00 ;
-    nidm_inCoordinateSpace: niiri:a0df09e94db6f8ac04096ab9e62f03e3 ;
+    nidm_hasClusterLabelsMap: niiri:0bc71c587ee079ccd7e9e7c78d309612 ;
+    nidm_hasMaximumIntensityProjection: niiri:ff39a18fca2ad1e06ab58e61826a6e4e ;
+    nidm_inCoordinateSpace: niiri:b6feb3b8e24120e8ddf1cf9eae080e8c ;
     crypto:sha512 "2c020948d33abb498f0c56063da36e748988840af6d965454a32bb8eb7eaf376b82773a26e325acb6da10cc41fbee4e1a4c8cec6e5f335e3ca9d5e01bec47cec"^^xsd:string .
 
-niiri:3a2cebaff9a491bcb49fbe38aff03e5e
+niiri:0bc71c587ee079ccd7e9e7c78d309612
     a prov:Entity, nidm_ClusterLabelsMap: ; 
     prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Cluster Labels Map" ;
-    nidm_inCoordinateSpace: niiri:a0df09e94db6f8ac04096ab9e62f03e3 ;
+    nidm_inCoordinateSpace: niiri:b6feb3b8e24120e8ddf1cf9eae080e8c ;
     crypto:sha512 "6a4279ff424d9aee83ff86b3a7fbe1c99f15bfbfda56cf88ca167390de958eb1fce4cf5c82cd12818a6f0e3cc06e0a3b49d6e7491992d21e7047633059b0b333"^^xsd:string .
 
-niiri:51fc0014bcdab3e46d21c5d9574d0c00
+niiri:ff39a18fca2ad1e06ab58e61826a6e4e
     a prov:Entity, dctype:Image ; 
     prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
     nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:fec8545d1e39630ce18d7eddddd0aaa4 prov:wasGeneratedBy niiri:5d50bfe60bcdf32579cf9c2bb73605e2 .
+niiri:8c8ad5dc532e1fc2320f4c3356bdd145 prov:wasGeneratedBy niiri:1d58f1ea373dca6b6777c0ae0bfc411d .
 
-niiri:ba835f71b6ca8a486d7c5f7379bd662f
+niiri:85fec2a2169d10c191c4e617a17cdba0
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0001" ;
     nidm_clusterSizeInVoxels: "29439"^^xsd:int ;
@@ -916,9 +916,9 @@ niiri:ba835f71b6ca8a486d7c5f7379bd662f
     nidm_qValueFDR: "7.5221873981761e-225"^^xsd:float ;
     nidm_clusterLabelId: "1"^^xsd:int .
 
-niiri:ba835f71b6ca8a486d7c5f7379bd662f prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:85fec2a2169d10c191c4e617a17cdba0 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:887840e0df0dde27ca60bb3a5eed1fdb
+niiri:1aa2c5542022d8edfbe6faaf12d4ebb7
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0002" ;
     nidm_clusterSizeInVoxels: "125"^^xsd:int ;
@@ -928,9 +928,9 @@ niiri:887840e0df0dde27ca60bb3a5eed1fdb
     nidm_qValueFDR: "3.35216847023969e-05"^^xsd:float ;
     nidm_clusterLabelId: "2"^^xsd:int .
 
-niiri:887840e0df0dde27ca60bb3a5eed1fdb prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:1aa2c5542022d8edfbe6faaf12d4ebb7 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:14b137956e5e00ffd0fdc43f5c22f5c4
+niiri:f9d722fcce853c033260a3ae532235c1
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0003" ;
     nidm_clusterSizeInVoxels: "1968"^^xsd:int ;
@@ -940,9 +940,9 @@ niiri:14b137956e5e00ffd0fdc43f5c22f5c4
     nidm_qValueFDR: "5.75077489066459e-36"^^xsd:float ;
     nidm_clusterLabelId: "3"^^xsd:int .
 
-niiri:14b137956e5e00ffd0fdc43f5c22f5c4 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:f9d722fcce853c033260a3ae532235c1 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:0549497fa62a1d5511dea65e5ef2cf1b
+niiri:73ec267aa6e4362aa22b8bf333d9a6f3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0004" ;
     nidm_clusterSizeInVoxels: "170"^^xsd:int ;
@@ -952,9 +952,9 @@ niiri:0549497fa62a1d5511dea65e5ef2cf1b
     nidm_qValueFDR: "2.12665981162699e-06"^^xsd:float ;
     nidm_clusterLabelId: "4"^^xsd:int .
 
-niiri:0549497fa62a1d5511dea65e5ef2cf1b prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:73ec267aa6e4362aa22b8bf333d9a6f3 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:3fbaffdfe735b9ae40c349431f693073
+niiri:a78547a90624868c0aef3cebdd83d669
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0005" ;
     nidm_clusterSizeInVoxels: "131"^^xsd:int ;
@@ -964,9 +964,9 @@ niiri:3fbaffdfe735b9ae40c349431f693073
     nidm_qValueFDR: "2.48176419706943e-05"^^xsd:float ;
     nidm_clusterLabelId: "5"^^xsd:int .
 
-niiri:3fbaffdfe735b9ae40c349431f693073 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:a78547a90624868c0aef3cebdd83d669 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:6380e74b916ddbf1a024a72c065d623f
+niiri:940cf2d7b7d0eb179a5d87089cdef025
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0006" ;
     nidm_clusterSizeInVoxels: "13"^^xsd:int ;
@@ -976,9 +976,9 @@ niiri:6380e74b916ddbf1a024a72c065d623f
     nidm_qValueFDR: "0.164098394910714"^^xsd:float ;
     nidm_clusterLabelId: "6"^^xsd:int .
 
-niiri:6380e74b916ddbf1a024a72c065d623f prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:940cf2d7b7d0eb179a5d87089cdef025 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:4cab3569c0af76ee151f4e707fdd3538
+niiri:22f7499c81f2b4cfb5d9464b77334f85
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0007" ;
     nidm_clusterSizeInVoxels: "51"^^xsd:int ;
@@ -988,9 +988,9 @@ niiri:4cab3569c0af76ee151f4e707fdd3538
     nidm_qValueFDR: "0.00629979669468589"^^xsd:float ;
     nidm_clusterLabelId: "7"^^xsd:int .
 
-niiri:4cab3569c0af76ee151f4e707fdd3538 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:22f7499c81f2b4cfb5d9464b77334f85 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:9a4cbf3c4b4b3511dfc9fd1435a8a28b
+niiri:313e60cc130ee5f7b46b9a70c28c95a0
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0008" ;
     nidm_clusterSizeInVoxels: "507"^^xsd:int ;
@@ -1000,9 +1000,9 @@ niiri:9a4cbf3c4b4b3511dfc9fd1435a8a28b
     nidm_qValueFDR: "6.10509125467576e-14"^^xsd:float ;
     nidm_clusterLabelId: "8"^^xsd:int .
 
-niiri:9a4cbf3c4b4b3511dfc9fd1435a8a28b prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:313e60cc130ee5f7b46b9a70c28c95a0 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:c8ec1ca234b9bf8d2809bf619534b056
+niiri:5755c7b6f3b8bb9a495a80e69a7ab94e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0009" ;
     nidm_clusterSizeInVoxels: "37"^^xsd:int ;
@@ -1012,9 +1012,9 @@ niiri:c8ec1ca234b9bf8d2809bf619534b056
     nidm_qValueFDR: "0.0178840433376991"^^xsd:float ;
     nidm_clusterLabelId: "9"^^xsd:int .
 
-niiri:c8ec1ca234b9bf8d2809bf619534b056 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:5755c7b6f3b8bb9a495a80e69a7ab94e prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:1b47349b306df45c874f7c947b149652
+niiri:23f5c60185b27f2be0dd455c41c3fde3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0010" ;
     nidm_clusterSizeInVoxels: "39"^^xsd:int ;
@@ -1024,9 +1024,9 @@ niiri:1b47349b306df45c874f7c947b149652
     nidm_qValueFDR: "0.0154244825018574"^^xsd:float ;
     nidm_clusterLabelId: "10"^^xsd:int .
 
-niiri:1b47349b306df45c874f7c947b149652 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:23f5c60185b27f2be0dd455c41c3fde3 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:c4b71b38ef4c3be049827afa9e8143bc
+niiri:33cca310ebec4700e45b0560235f03cd
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0011" ;
     nidm_clusterSizeInVoxels: "265"^^xsd:int ;
@@ -1036,9 +1036,9 @@ niiri:c4b71b38ef4c3be049827afa9e8143bc
     nidm_qValueFDR: "9.21278207819405e-09"^^xsd:float ;
     nidm_clusterLabelId: "11"^^xsd:int .
 
-niiri:c4b71b38ef4c3be049827afa9e8143bc prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:33cca310ebec4700e45b0560235f03cd prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:3e28cae2b2981677b6365484975e315d
+niiri:68605e1a07366f1a9aaae9f04eb3bbcf
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0012" ;
     nidm_clusterSizeInVoxels: "61"^^xsd:int ;
@@ -1048,9 +1048,9 @@ niiri:3e28cae2b2981677b6365484975e315d
     nidm_qValueFDR: "0.00303417702651228"^^xsd:float ;
     nidm_clusterLabelId: "12"^^xsd:int .
 
-niiri:3e28cae2b2981677b6365484975e315d prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:68605e1a07366f1a9aaae9f04eb3bbcf prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:f362fb2acc0fecc902d53e2682b7f919
+niiri:ab91ba995acbb604c8550a19c6d56878
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0013" ;
     nidm_clusterSizeInVoxels: "103"^^xsd:int ;
@@ -1060,9 +1060,9 @@ niiri:f362fb2acc0fecc902d53e2682b7f919
     nidm_qValueFDR: "0.000156039522092762"^^xsd:float ;
     nidm_clusterLabelId: "13"^^xsd:int .
 
-niiri:f362fb2acc0fecc902d53e2682b7f919 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:ab91ba995acbb604c8550a19c6d56878 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:f20977e52a75b5fa007a387cc6824614
+niiri:8ddb469ed3d8d13f9f3b41143b2bc54e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0014" ;
     nidm_clusterSizeInVoxels: "54"^^xsd:int ;
@@ -1072,9 +1072,9 @@ niiri:f20977e52a75b5fa007a387cc6824614
     nidm_qValueFDR: "0.00553368312891872"^^xsd:float ;
     nidm_clusterLabelId: "14"^^xsd:int .
 
-niiri:f20977e52a75b5fa007a387cc6824614 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:8ddb469ed3d8d13f9f3b41143b2bc54e prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:27140d3dcc60dbdda794838cc4910ac1
+niiri:fe3d995dc2bfdeb5f29182f0558560a6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0015" ;
     nidm_clusterSizeInVoxels: "50"^^xsd:int ;
@@ -1084,9 +1084,9 @@ niiri:27140d3dcc60dbdda794838cc4910ac1
     nidm_qValueFDR: "0.00632092322699605"^^xsd:float ;
     nidm_clusterLabelId: "15"^^xsd:int .
 
-niiri:27140d3dcc60dbdda794838cc4910ac1 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:fe3d995dc2bfdeb5f29182f0558560a6 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:292c1d14e546541ab02c17303b03d0d1
+niiri:cfbb41a715a689539e32d23fa5ecf0ad
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0016" ;
     nidm_clusterSizeInVoxels: "50"^^xsd:int ;
@@ -1096,9 +1096,9 @@ niiri:292c1d14e546541ab02c17303b03d0d1
     nidm_qValueFDR: "0.00632092322699605"^^xsd:float ;
     nidm_clusterLabelId: "16"^^xsd:int .
 
-niiri:292c1d14e546541ab02c17303b03d0d1 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:cfbb41a715a689539e32d23fa5ecf0ad prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:3d59b7c113f7b19df2458e17b2f822e9
+niiri:1ea775914efd19bdf7935c45c2fc61d7
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0017" ;
     nidm_clusterSizeInVoxels: "69"^^xsd:int ;
@@ -1108,9 +1108,9 @@ niiri:3d59b7c113f7b19df2458e17b2f822e9
     nidm_qValueFDR: "0.00167816088310149"^^xsd:float ;
     nidm_clusterLabelId: "17"^^xsd:int .
 
-niiri:3d59b7c113f7b19df2458e17b2f822e9 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:1ea775914efd19bdf7935c45c2fc61d7 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:444ae882759bc4fc11d5ae4c9e6cb1e1
+niiri:c9c2075e31233972320b91bbe319e15d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0018" ;
     nidm_clusterSizeInVoxels: "43"^^xsd:int ;
@@ -1120,9 +1120,9 @@ niiri:444ae882759bc4fc11d5ae4c9e6cb1e1
     nidm_qValueFDR: "0.010880492071777"^^xsd:float ;
     nidm_clusterLabelId: "18"^^xsd:int .
 
-niiri:444ae882759bc4fc11d5ae4c9e6cb1e1 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:c9c2075e31233972320b91bbe319e15d prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:59566dcbed59d8991aa0141444f7d8ea
+niiri:184504b2959cc0300f56dbed9be3df0a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0019" ;
     nidm_clusterSizeInVoxels: "48"^^xsd:int ;
@@ -1132,9 +1132,9 @@ niiri:59566dcbed59d8991aa0141444f7d8ea
     nidm_qValueFDR: "0.00737966050943224"^^xsd:float ;
     nidm_clusterLabelId: "19"^^xsd:int .
 
-niiri:59566dcbed59d8991aa0141444f7d8ea prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:184504b2959cc0300f56dbed9be3df0a prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:2b54a24f6a0f9527c8816d93199577eb
+niiri:e56b27d2108b9aebc19f9ff56ac97dce
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0020" ;
     nidm_clusterSizeInVoxels: "15"^^xsd:int ;
@@ -1144,9 +1144,9 @@ niiri:2b54a24f6a0f9527c8816d93199577eb
     nidm_qValueFDR: "0.141785094491174"^^xsd:float ;
     nidm_clusterLabelId: "20"^^xsd:int .
 
-niiri:2b54a24f6a0f9527c8816d93199577eb prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:e56b27d2108b9aebc19f9ff56ac97dce prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:678898fc201808d0072b6bbbea15acd2
+niiri:e78e0827b0a80cf9fb06ff0a74ee9600
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0021" ;
     nidm_clusterSizeInVoxels: "28"^^xsd:int ;
@@ -1156,9 +1156,9 @@ niiri:678898fc201808d0072b6bbbea15acd2
     nidm_qValueFDR: "0.0429338149261202"^^xsd:float ;
     nidm_clusterLabelId: "21"^^xsd:int .
 
-niiri:678898fc201808d0072b6bbbea15acd2 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:e78e0827b0a80cf9fb06ff0a74ee9600 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:5a11d9bb922c3f53cb59978d26e7d5b0
+niiri:461b922ff7bd3d15d33f54bcbd492da3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0022" ;
     nidm_clusterSizeInVoxels: "52"^^xsd:int ;
@@ -1168,9 +1168,9 @@ niiri:5a11d9bb922c3f53cb59978d26e7d5b0
     nidm_qValueFDR: "0.0060122276110096"^^xsd:float ;
     nidm_clusterLabelId: "22"^^xsd:int .
 
-niiri:5a11d9bb922c3f53cb59978d26e7d5b0 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:461b922ff7bd3d15d33f54bcbd492da3 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:64a43fe12cd19a1e197d1e7627a3bda5
+niiri:1cfc9f0a458d8852ad0759c9e8be8a6a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0023" ;
     nidm_clusterSizeInVoxels: "15"^^xsd:int ;
@@ -1180,9 +1180,9 @@ niiri:64a43fe12cd19a1e197d1e7627a3bda5
     nidm_qValueFDR: "0.141785094491174"^^xsd:float ;
     nidm_clusterLabelId: "23"^^xsd:int .
 
-niiri:64a43fe12cd19a1e197d1e7627a3bda5 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:1cfc9f0a458d8852ad0759c9e8be8a6a prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:df9def02f0fbb31e7bb7de54da832bdb
+niiri:5bbe3c6a1630a3c2cc55aa12dfd9e286
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0024" ;
     nidm_clusterSizeInVoxels: "17"^^xsd:int ;
@@ -1192,9 +1192,9 @@ niiri:df9def02f0fbb31e7bb7de54da832bdb
     nidm_qValueFDR: "0.120432329815194"^^xsd:float ;
     nidm_clusterLabelId: "24"^^xsd:int .
 
-niiri:df9def02f0fbb31e7bb7de54da832bdb prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:5bbe3c6a1630a3c2cc55aa12dfd9e286 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:49955533f78bc4787cee05a051461dcf
+niiri:1e1925d1a7237f41c7f4bbc7a938991e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0025" ;
     nidm_clusterSizeInVoxels: "45"^^xsd:int ;
@@ -1204,9 +1204,9 @@ niiri:49955533f78bc4787cee05a051461dcf
     nidm_qValueFDR: "0.00920361127008583"^^xsd:float ;
     nidm_clusterLabelId: "25"^^xsd:int .
 
-niiri:49955533f78bc4787cee05a051461dcf prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:1e1925d1a7237f41c7f4bbc7a938991e prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:49c6aebff31b5e29c05f3709fd4ca0c7
+niiri:45311fe546d4fc676e17072f500c1575
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0026" ;
     nidm_clusterSizeInVoxels: "22"^^xsd:int ;
@@ -1216,9 +1216,9 @@ niiri:49c6aebff31b5e29c05f3709fd4ca0c7
     nidm_qValueFDR: "0.0739131813375881"^^xsd:float ;
     nidm_clusterLabelId: "26"^^xsd:int .
 
-niiri:49c6aebff31b5e29c05f3709fd4ca0c7 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:45311fe546d4fc676e17072f500c1575 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:9315b753bce8ecc349364143d90f1ad9
+niiri:12134d971afb042d040aea6cecc0ebec
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0027" ;
     nidm_clusterSizeInVoxels: "98"^^xsd:int ;
@@ -1228,9 +1228,9 @@ niiri:9315b753bce8ecc349364143d90f1ad9
     nidm_qValueFDR: "0.000207875027656763"^^xsd:float ;
     nidm_clusterLabelId: "27"^^xsd:int .
 
-niiri:9315b753bce8ecc349364143d90f1ad9 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:12134d971afb042d040aea6cecc0ebec prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:c92570bdb9c49bf92cb00c5c23880685
+niiri:7dfc1da184d477320648da6e59dc2a7c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0028" ;
     nidm_clusterSizeInVoxels: "16"^^xsd:int ;
@@ -1240,9 +1240,9 @@ niiri:c92570bdb9c49bf92cb00c5c23880685
     nidm_qValueFDR: "0.13140033434745"^^xsd:float ;
     nidm_clusterLabelId: "28"^^xsd:int .
 
-niiri:c92570bdb9c49bf92cb00c5c23880685 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:7dfc1da184d477320648da6e59dc2a7c prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:e491d13c4d524178ac2c358bfec8b0ab
+niiri:ff37e6b9b5486e16e27ae0fca1db545d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0029" ;
     nidm_clusterSizeInVoxels: "38"^^xsd:int ;
@@ -1252,9 +1252,9 @@ niiri:e491d13c4d524178ac2c358bfec8b0ab
     nidm_qValueFDR: "0.0165910226936462"^^xsd:float ;
     nidm_clusterLabelId: "29"^^xsd:int .
 
-niiri:e491d13c4d524178ac2c358bfec8b0ab prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:ff37e6b9b5486e16e27ae0fca1db545d prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:605ecba3a006393b32ebef7f5177a299
+niiri:bfb3c58b6c12062e86b12426bbf496d9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0030" ;
     nidm_clusterSizeInVoxels: "169"^^xsd:int ;
@@ -1264,9 +1264,9 @@ niiri:605ecba3a006393b32ebef7f5177a299
     nidm_qValueFDR: "2.12665981162699e-06"^^xsd:float ;
     nidm_clusterLabelId: "30"^^xsd:int .
 
-niiri:605ecba3a006393b32ebef7f5177a299 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:bfb3c58b6c12062e86b12426bbf496d9 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:792e740d5505df540f825e8630189126
+niiri:b1059120ca68f8c294f13d22a334afc5
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0031" ;
     nidm_clusterSizeInVoxels: "22"^^xsd:int ;
@@ -1276,9 +1276,9 @@ niiri:792e740d5505df540f825e8630189126
     nidm_qValueFDR: "0.0739131813375881"^^xsd:float ;
     nidm_clusterLabelId: "31"^^xsd:int .
 
-niiri:792e740d5505df540f825e8630189126 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:b1059120ca68f8c294f13d22a334afc5 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:5b18eef1ef74501ea55e4ac7f04163eb
+niiri:dd43f04c7775bf5d225a62b05a1f8275
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0032" ;
     nidm_clusterSizeInVoxels: "53"^^xsd:int ;
@@ -1288,9 +1288,9 @@ niiri:5b18eef1ef74501ea55e4ac7f04163eb
     nidm_qValueFDR: "0.00575732849814255"^^xsd:float ;
     nidm_clusterLabelId: "32"^^xsd:int .
 
-niiri:5b18eef1ef74501ea55e4ac7f04163eb prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:dd43f04c7775bf5d225a62b05a1f8275 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:2a0d5cd5e741995710fe2bdd14adb005
+niiri:c723d93708cb4dee84578d4dad2314df
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0033" ;
     nidm_clusterSizeInVoxels: "20"^^xsd:int ;
@@ -1300,9 +1300,9 @@ niiri:2a0d5cd5e741995710fe2bdd14adb005
     nidm_qValueFDR: "0.090003354949991"^^xsd:float ;
     nidm_clusterLabelId: "33"^^xsd:int .
 
-niiri:2a0d5cd5e741995710fe2bdd14adb005 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:c723d93708cb4dee84578d4dad2314df prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:adca675d0dc4660fb2170e6ead12a50a
+niiri:d30171bbdc271c074a6050acb8a4d34e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0034" ;
     nidm_clusterSizeInVoxels: "22"^^xsd:int ;
@@ -1312,9 +1312,9 @@ niiri:adca675d0dc4660fb2170e6ead12a50a
     nidm_qValueFDR: "0.0739131813375881"^^xsd:float ;
     nidm_clusterLabelId: "34"^^xsd:int .
 
-niiri:adca675d0dc4660fb2170e6ead12a50a prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:d30171bbdc271c074a6050acb8a4d34e prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:5e628c0b7abb6a720a8a91ae5f6c769c
+niiri:ea2ed9cc4d84a345a4920b11801993b3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0035" ;
     nidm_clusterSizeInVoxels: "47"^^xsd:int ;
@@ -1324,9 +1324,9 @@ niiri:5e628c0b7abb6a720a8a91ae5f6c769c
     nidm_qValueFDR: "0.00782137969656345"^^xsd:float ;
     nidm_clusterLabelId: "35"^^xsd:int .
 
-niiri:5e628c0b7abb6a720a8a91ae5f6c769c prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:ea2ed9cc4d84a345a4920b11801993b3 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:e8494b3e58d9094d2cc21652c223abe4
+niiri:cf3d3e192bab8fb0febbddda2b472570
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0036" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -1336,9 +1336,9 @@ niiri:e8494b3e58d9094d2cc21652c223abe4
     nidm_qValueFDR: "0.317998323277913"^^xsd:float ;
     nidm_clusterLabelId: "36"^^xsd:int .
 
-niiri:e8494b3e58d9094d2cc21652c223abe4 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:cf3d3e192bab8fb0febbddda2b472570 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:2a3839763db274e8b4cae9d895b6483d
+niiri:a6ee0e116834a7cbcea03e95f20dae54
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0037" ;
     nidm_clusterSizeInVoxels: "27"^^xsd:int ;
@@ -1348,9 +1348,9 @@ niiri:2a3839763db274e8b4cae9d895b6483d
     nidm_qValueFDR: "0.0458285125869847"^^xsd:float ;
     nidm_clusterLabelId: "37"^^xsd:int .
 
-niiri:2a3839763db274e8b4cae9d895b6483d prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:a6ee0e116834a7cbcea03e95f20dae54 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:d2c4ecdb2f17a5fa414bc38579edb8f3
+niiri:e9b27c64b1591506ec57168d7dbf134f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0038" ;
     nidm_clusterSizeInVoxels: "14"^^xsd:int ;
@@ -1360,9 +1360,9 @@ niiri:d2c4ecdb2f17a5fa414bc38579edb8f3
     nidm_qValueFDR: "0.15179404238237"^^xsd:float ;
     nidm_clusterLabelId: "38"^^xsd:int .
 
-niiri:d2c4ecdb2f17a5fa414bc38579edb8f3 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:e9b27c64b1591506ec57168d7dbf134f prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:770d3b226608026413a9c2a34b0a1793
+niiri:35e614f307abb1c7215e649c0bbf0aa0
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0039" ;
     nidm_clusterSizeInVoxels: "13"^^xsd:int ;
@@ -1372,9 +1372,9 @@ niiri:770d3b226608026413a9c2a34b0a1793
     nidm_qValueFDR: "0.164098394910714"^^xsd:float ;
     nidm_clusterLabelId: "39"^^xsd:int .
 
-niiri:770d3b226608026413a9c2a34b0a1793 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:35e614f307abb1c7215e649c0bbf0aa0 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:16b9e50b259cea22c334cdb43404b9b4
+niiri:84661ae12e172546f496d4b26feacce8
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0040" ;
     nidm_clusterSizeInVoxels: "12"^^xsd:int ;
@@ -1384,9 +1384,9 @@ niiri:16b9e50b259cea22c334cdb43404b9b4
     nidm_qValueFDR: "0.181500977727632"^^xsd:float ;
     nidm_clusterLabelId: "40"^^xsd:int .
 
-niiri:16b9e50b259cea22c334cdb43404b9b4 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:84661ae12e172546f496d4b26feacce8 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:8d690e036ac0c4f773f14d063bc26982
+niiri:b3ab45e7aaebdd6d5415f3e8fb8365d3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0041" ;
     nidm_clusterSizeInVoxels: "22"^^xsd:int ;
@@ -1396,9 +1396,9 @@ niiri:8d690e036ac0c4f773f14d063bc26982
     nidm_qValueFDR: "0.0739131813375881"^^xsd:float ;
     nidm_clusterLabelId: "41"^^xsd:int .
 
-niiri:8d690e036ac0c4f773f14d063bc26982 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:b3ab45e7aaebdd6d5415f3e8fb8365d3 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:871bd0030276be32c9682273d65be8a4
+niiri:a9dd639eb89226977a3ede42cafc093c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0042" ;
     nidm_clusterSizeInVoxels: "28"^^xsd:int ;
@@ -1408,9 +1408,9 @@ niiri:871bd0030276be32c9682273d65be8a4
     nidm_qValueFDR: "0.0429338149261202"^^xsd:float ;
     nidm_clusterLabelId: "42"^^xsd:int .
 
-niiri:871bd0030276be32c9682273d65be8a4 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:a9dd639eb89226977a3ede42cafc093c prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:fd8207df6ecd8a6e5899191a7d1b9cec
+niiri:01b4ff55ed7965f77f28199c98d35002
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0043" ;
     nidm_clusterSizeInVoxels: "77"^^xsd:int ;
@@ -1420,9 +1420,9 @@ niiri:fd8207df6ecd8a6e5899191a7d1b9cec
     nidm_qValueFDR: "0.00106255083867027"^^xsd:float ;
     nidm_clusterLabelId: "43"^^xsd:int .
 
-niiri:fd8207df6ecd8a6e5899191a7d1b9cec prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:01b4ff55ed7965f77f28199c98d35002 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:a16c4a98c7239f14c74af90c58802252
+niiri:f606725494013a6004aeb7f3234c5659
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0044" ;
     nidm_clusterSizeInVoxels: "20"^^xsd:int ;
@@ -1432,9 +1432,9 @@ niiri:a16c4a98c7239f14c74af90c58802252
     nidm_qValueFDR: "0.090003354949991"^^xsd:float ;
     nidm_clusterLabelId: "44"^^xsd:int .
 
-niiri:a16c4a98c7239f14c74af90c58802252 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:f606725494013a6004aeb7f3234c5659 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:beba83b8e0b597cc72900977cf176cf6
+niiri:d70674f2ab25c84bf1ccbf050e157cb6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0045" ;
     nidm_clusterSizeInVoxels: "10"^^xsd:int ;
@@ -1444,9 +1444,9 @@ niiri:beba83b8e0b597cc72900977cf176cf6
     nidm_qValueFDR: "0.232854217411059"^^xsd:float ;
     nidm_clusterLabelId: "45"^^xsd:int .
 
-niiri:beba83b8e0b597cc72900977cf176cf6 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:d70674f2ab25c84bf1ccbf050e157cb6 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:2ea9c77f7d859bb390de800ff7c12bdd
+niiri:d3a715b103390651d1c521ee09f466c0
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0046" ;
     nidm_clusterSizeInVoxels: "17"^^xsd:int ;
@@ -1456,9 +1456,9 @@ niiri:2ea9c77f7d859bb390de800ff7c12bdd
     nidm_qValueFDR: "0.120432329815194"^^xsd:float ;
     nidm_clusterLabelId: "46"^^xsd:int .
 
-niiri:2ea9c77f7d859bb390de800ff7c12bdd prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:d3a715b103390651d1c521ee09f466c0 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:667ab285deac3f27ecbbdbc71424991f
+niiri:3577f89d6cde1468b3bf7bab875643fa
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0047" ;
     nidm_clusterSizeInVoxels: "35"^^xsd:int ;
@@ -1468,9 +1468,9 @@ niiri:667ab285deac3f27ecbbdbc71424991f
     nidm_qValueFDR: "0.0215852760173866"^^xsd:float ;
     nidm_clusterLabelId: "47"^^xsd:int .
 
-niiri:667ab285deac3f27ecbbdbc71424991f prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:3577f89d6cde1468b3bf7bab875643fa prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:92c97d83326e6179be7fa554d9ed568a
+niiri:6b28309025a8c950f906f3a74a6104c4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0048" ;
     nidm_clusterSizeInVoxels: "19"^^xsd:int ;
@@ -1480,9 +1480,9 @@ niiri:92c97d83326e6179be7fa554d9ed568a
     nidm_qValueFDR: "0.0987682309376339"^^xsd:float ;
     nidm_clusterLabelId: "48"^^xsd:int .
 
-niiri:92c97d83326e6179be7fa554d9ed568a prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:6b28309025a8c950f906f3a74a6104c4 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:e0f12d9993b033a238dd61773dca28e9
+niiri:40f12e78ef285dbb693762e0e24f5a51
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0049" ;
     nidm_clusterSizeInVoxels: "27"^^xsd:int ;
@@ -1492,9 +1492,9 @@ niiri:e0f12d9993b033a238dd61773dca28e9
     nidm_qValueFDR: "0.0458285125869847"^^xsd:float ;
     nidm_clusterLabelId: "49"^^xsd:int .
 
-niiri:e0f12d9993b033a238dd61773dca28e9 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:40f12e78ef285dbb693762e0e24f5a51 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:3aa56bca1824bde9b5cb4c7830b65b84
+niiri:708e2b5584c9334ba1cde9334d8aee40
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0050" ;
     nidm_clusterSizeInVoxels: "15"^^xsd:int ;
@@ -1504,9 +1504,9 @@ niiri:3aa56bca1824bde9b5cb4c7830b65b84
     nidm_qValueFDR: "0.141785094491174"^^xsd:float ;
     nidm_clusterLabelId: "50"^^xsd:int .
 
-niiri:3aa56bca1824bde9b5cb4c7830b65b84 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:708e2b5584c9334ba1cde9334d8aee40 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:e6016935099bef709428b50f891e4418
+niiri:2ed437f95a18d4610e20aee5f5ca8ca1
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0051" ;
     nidm_clusterSizeInVoxels: "33"^^xsd:int ;
@@ -1516,9 +1516,9 @@ niiri:e6016935099bef709428b50f891e4418
     nidm_qValueFDR: "0.0261907318697071"^^xsd:float ;
     nidm_clusterLabelId: "51"^^xsd:int .
 
-niiri:e6016935099bef709428b50f891e4418 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:2ed437f95a18d4610e20aee5f5ca8ca1 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:75040581b4eec5ea4766cc6aef47a8db
+niiri:c4315919bc864f2492337dd699116ee4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0052" ;
     nidm_clusterSizeInVoxels: "75"^^xsd:int ;
@@ -1528,9 +1528,9 @@ niiri:75040581b4eec5ea4766cc6aef47a8db
     nidm_qValueFDR: "0.00106801490892152"^^xsd:float ;
     nidm_clusterLabelId: "52"^^xsd:int .
 
-niiri:75040581b4eec5ea4766cc6aef47a8db prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:c4315919bc864f2492337dd699116ee4 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:1b5b284497e39b90fa934f2eaa2c5bbd
+niiri:5ad7bfc734bce8d2e03526bbce4c1642
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0053" ;
     nidm_clusterSizeInVoxels: "75"^^xsd:int ;
@@ -1540,9 +1540,9 @@ niiri:1b5b284497e39b90fa934f2eaa2c5bbd
     nidm_qValueFDR: "0.00106801490892152"^^xsd:float ;
     nidm_clusterLabelId: "53"^^xsd:int .
 
-niiri:1b5b284497e39b90fa934f2eaa2c5bbd prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:5ad7bfc734bce8d2e03526bbce4c1642 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:9f190d80d4f3c866def066aba31dc20c
+niiri:f28a45db3e8e726134be22dd55ada8fc
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0054" ;
     nidm_clusterSizeInVoxels: "16"^^xsd:int ;
@@ -1552,9 +1552,9 @@ niiri:9f190d80d4f3c866def066aba31dc20c
     nidm_qValueFDR: "0.13140033434745"^^xsd:float ;
     nidm_clusterLabelId: "54"^^xsd:int .
 
-niiri:9f190d80d4f3c866def066aba31dc20c prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:f28a45db3e8e726134be22dd55ada8fc prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:bad61a3ace8cf7e7c8c50e40ccf98bd4
+niiri:7dbd526d156c17d030cb03d4502bec48
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0055" ;
     nidm_clusterSizeInVoxels: "66"^^xsd:int ;
@@ -1564,9 +1564,9 @@ niiri:bad61a3ace8cf7e7c8c50e40ccf98bd4
     nidm_qValueFDR: "0.00204910367576558"^^xsd:float ;
     nidm_clusterLabelId: "55"^^xsd:int .
 
-niiri:bad61a3ace8cf7e7c8c50e40ccf98bd4 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:7dbd526d156c17d030cb03d4502bec48 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:189c6d65cca27efc776c3691b2470738
+niiri:db64bef791d519bd840c407a07274b39
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0056" ;
     nidm_clusterSizeInVoxels: "14"^^xsd:int ;
@@ -1576,9 +1576,9 @@ niiri:189c6d65cca27efc776c3691b2470738
     nidm_qValueFDR: "0.15179404238237"^^xsd:float ;
     nidm_clusterLabelId: "56"^^xsd:int .
 
-niiri:189c6d65cca27efc776c3691b2470738 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:db64bef791d519bd840c407a07274b39 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:f29da53849f4d24538d6a069a467c443
+niiri:261d424ff1d40e2e1212f8b47057e08d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0057" ;
     nidm_clusterSizeInVoxels: "9"^^xsd:int ;
@@ -1588,9 +1588,9 @@ niiri:f29da53849f4d24538d6a069a467c443
     nidm_qValueFDR: "0.257089854765214"^^xsd:float ;
     nidm_clusterLabelId: "57"^^xsd:int .
 
-niiri:f29da53849f4d24538d6a069a467c443 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:261d424ff1d40e2e1212f8b47057e08d prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:735d11dd0407b58704c0622c1bf21ceb
+niiri:f0b1b468bf91334fdba7c8b7612cca41
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0058" ;
     nidm_clusterSizeInVoxels: "16"^^xsd:int ;
@@ -1600,9 +1600,9 @@ niiri:735d11dd0407b58704c0622c1bf21ceb
     nidm_qValueFDR: "0.13140033434745"^^xsd:float ;
     nidm_clusterLabelId: "58"^^xsd:int .
 
-niiri:735d11dd0407b58704c0622c1bf21ceb prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:f0b1b468bf91334fdba7c8b7612cca41 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:1cab13530af314ae698e165a85ca2de5
+niiri:6faaad2ce4a4160eadbbce94632ec2bf
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0059" ;
     nidm_clusterSizeInVoxels: "41"^^xsd:int ;
@@ -1612,9 +1612,9 @@ niiri:1cab13530af314ae698e165a85ca2de5
     nidm_qValueFDR: "0.0129236214214505"^^xsd:float ;
     nidm_clusterLabelId: "59"^^xsd:int .
 
-niiri:1cab13530af314ae698e165a85ca2de5 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:6faaad2ce4a4160eadbbce94632ec2bf prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:e0728affe728b03b571bb0da5a24b81e
+niiri:8451b5d05d4d0f88becbc68925bab4c9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0060" ;
     nidm_clusterSizeInVoxels: "15"^^xsd:int ;
@@ -1624,9 +1624,9 @@ niiri:e0728affe728b03b571bb0da5a24b81e
     nidm_qValueFDR: "0.141785094491174"^^xsd:float ;
     nidm_clusterLabelId: "60"^^xsd:int .
 
-niiri:e0728affe728b03b571bb0da5a24b81e prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:8451b5d05d4d0f88becbc68925bab4c9 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:2ac5440f1a62a883d86fc94f89789599
+niiri:e8d74786a114ffeb6114fffeeb2583da
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0061" ;
     nidm_clusterSizeInVoxels: "19"^^xsd:int ;
@@ -1636,9 +1636,9 @@ niiri:2ac5440f1a62a883d86fc94f89789599
     nidm_qValueFDR: "0.0987682309376339"^^xsd:float ;
     nidm_clusterLabelId: "61"^^xsd:int .
 
-niiri:2ac5440f1a62a883d86fc94f89789599 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:e8d74786a114ffeb6114fffeeb2583da prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:04a64b18655d556b397f88a52d983f34
+niiri:af4cb856d066cec808680cb766e205ae
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0062" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -1648,9 +1648,9 @@ niiri:04a64b18655d556b397f88a52d983f34
     nidm_qValueFDR: "0.317998323277913"^^xsd:float ;
     nidm_clusterLabelId: "62"^^xsd:int .
 
-niiri:04a64b18655d556b397f88a52d983f34 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:af4cb856d066cec808680cb766e205ae prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:e07163703600f62c37c81aed00f51b7a
+niiri:64c74f4674adc0005dffc886ffba3300
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0063" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -1660,9 +1660,9 @@ niiri:e07163703600f62c37c81aed00f51b7a
     nidm_qValueFDR: "0.296922311851664"^^xsd:float ;
     nidm_clusterLabelId: "63"^^xsd:int .
 
-niiri:e07163703600f62c37c81aed00f51b7a prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:64c74f4674adc0005dffc886ffba3300 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:f4159609553afd6154652d5027b6e84a
+niiri:878873f431f64df4853365a578c78440
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0064" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -1672,9 +1672,9 @@ niiri:f4159609553afd6154652d5027b6e84a
     nidm_qValueFDR: "0.361120489405488"^^xsd:float ;
     nidm_clusterLabelId: "64"^^xsd:int .
 
-niiri:f4159609553afd6154652d5027b6e84a prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:878873f431f64df4853365a578c78440 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:f4231c3f6d55163a61e855e3bf8e3cc5
+niiri:62873793384331403012ec1c900656e0
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0065" ;
     nidm_clusterSizeInVoxels: "29"^^xsd:int ;
@@ -1684,9 +1684,9 @@ niiri:f4231c3f6d55163a61e855e3bf8e3cc5
     nidm_qValueFDR: "0.0404114761521598"^^xsd:float ;
     nidm_clusterLabelId: "65"^^xsd:int .
 
-niiri:f4231c3f6d55163a61e855e3bf8e3cc5 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:62873793384331403012ec1c900656e0 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:f3fc51b4027adc2167b7ea4fb36f64e9
+niiri:cf86c38738ff15923d1bfe58d642e526
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0066" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1696,9 +1696,9 @@ niiri:f3fc51b4027adc2167b7ea4fb36f64e9
     nidm_qValueFDR: "0.477356849101447"^^xsd:float ;
     nidm_clusterLabelId: "66"^^xsd:int .
 
-niiri:f3fc51b4027adc2167b7ea4fb36f64e9 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:cf86c38738ff15923d1bfe58d642e526 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:89485ab1dfdfe29164103a5f95597953
+niiri:6eb2f26421b4abdd2aff61056be6347c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0067" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1708,9 +1708,9 @@ niiri:89485ab1dfdfe29164103a5f95597953
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "67"^^xsd:int .
 
-niiri:89485ab1dfdfe29164103a5f95597953 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:6eb2f26421b4abdd2aff61056be6347c prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:38d55629def18240731e2415b3581423
+niiri:464e6cc9ad8cde4967c4e8430942863e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0068" ;
     nidm_clusterSizeInVoxels: "12"^^xsd:int ;
@@ -1720,9 +1720,9 @@ niiri:38d55629def18240731e2415b3581423
     nidm_qValueFDR: "0.181500977727632"^^xsd:float ;
     nidm_clusterLabelId: "68"^^xsd:int .
 
-niiri:38d55629def18240731e2415b3581423 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:464e6cc9ad8cde4967c4e8430942863e prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:911e248e1a4789966b6c9e185a7126b1
+niiri:0f59b224fb308f5b33db0b615cec440e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0069" ;
     nidm_clusterSizeInVoxels: "9"^^xsd:int ;
@@ -1732,9 +1732,9 @@ niiri:911e248e1a4789966b6c9e185a7126b1
     nidm_qValueFDR: "0.257089854765214"^^xsd:float ;
     nidm_clusterLabelId: "69"^^xsd:int .
 
-niiri:911e248e1a4789966b6c9e185a7126b1 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:0f59b224fb308f5b33db0b615cec440e prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:6110880bd543820677cd9c2981bb03f1
+niiri:61f0e2e951d39892ec38816ca4ff7b91
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0070" ;
     nidm_clusterSizeInVoxels: "13"^^xsd:int ;
@@ -1744,9 +1744,9 @@ niiri:6110880bd543820677cd9c2981bb03f1
     nidm_qValueFDR: "0.164098394910714"^^xsd:float ;
     nidm_clusterLabelId: "70"^^xsd:int .
 
-niiri:6110880bd543820677cd9c2981bb03f1 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:61f0e2e951d39892ec38816ca4ff7b91 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:17de67442fe88be7d5065d079743540f
+niiri:9764501f1b27ea039a6888cad5412dc6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0071" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -1756,9 +1756,9 @@ niiri:17de67442fe88be7d5065d079743540f
     nidm_qValueFDR: "0.317998323277913"^^xsd:float ;
     nidm_clusterLabelId: "71"^^xsd:int .
 
-niiri:17de67442fe88be7d5065d079743540f prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:9764501f1b27ea039a6888cad5412dc6 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:8cbc3782d81e0868d376f120a4236af9
+niiri:c4798ee5bb6817f0ac7d3d1f7cbb895d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0072" ;
     nidm_clusterSizeInVoxels: "14"^^xsd:int ;
@@ -1768,9 +1768,9 @@ niiri:8cbc3782d81e0868d376f120a4236af9
     nidm_qValueFDR: "0.15179404238237"^^xsd:float ;
     nidm_clusterLabelId: "72"^^xsd:int .
 
-niiri:8cbc3782d81e0868d376f120a4236af9 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:c4798ee5bb6817f0ac7d3d1f7cbb895d prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:2f3eeaca715cc267ad827fccd2f2f34b
+niiri:5499ba7833a3a03073324dac7488ac06
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0073" ;
     nidm_clusterSizeInVoxels: "20"^^xsd:int ;
@@ -1780,9 +1780,9 @@ niiri:2f3eeaca715cc267ad827fccd2f2f34b
     nidm_qValueFDR: "0.090003354949991"^^xsd:float ;
     nidm_clusterLabelId: "73"^^xsd:int .
 
-niiri:2f3eeaca715cc267ad827fccd2f2f34b prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:5499ba7833a3a03073324dac7488ac06 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:de6850a6407354dfd567970141571681
+niiri:50c6ebb589d5bdb3e362aaf8f837978b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0074" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -1792,9 +1792,9 @@ niiri:de6850a6407354dfd567970141571681
     nidm_qValueFDR: "0.317998323277913"^^xsd:float ;
     nidm_clusterLabelId: "74"^^xsd:int .
 
-niiri:de6850a6407354dfd567970141571681 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:50c6ebb589d5bdb3e362aaf8f837978b prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:fd0c869c2731be1d9fa597f20662d444
+niiri:a489f5516c417d51a01d581c1281955e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0075" ;
     nidm_clusterSizeInVoxels: "11"^^xsd:int ;
@@ -1804,9 +1804,9 @@ niiri:fd0c869c2731be1d9fa597f20662d444
     nidm_qValueFDR: "0.204909289340264"^^xsd:float ;
     nidm_clusterLabelId: "75"^^xsd:int .
 
-niiri:fd0c869c2731be1d9fa597f20662d444 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:a489f5516c417d51a01d581c1281955e prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:9558c05bc184bbae76bf2776b13f3613
+niiri:e4ff54dd97ad1e3f10b9d1c7027c4645
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0076" ;
     nidm_clusterSizeInVoxels: "24"^^xsd:int ;
@@ -1816,9 +1816,9 @@ niiri:9558c05bc184bbae76bf2776b13f3613
     nidm_qValueFDR: "0.0647162596618474"^^xsd:float ;
     nidm_clusterLabelId: "76"^^xsd:int .
 
-niiri:9558c05bc184bbae76bf2776b13f3613 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:e4ff54dd97ad1e3f10b9d1c7027c4645 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:a46d73eae3d12dd1da0f67fbeb4a1a72
+niiri:8de83fae7bd6e9f8380ec49cdc4829ae
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0077" ;
     nidm_clusterSizeInVoxels: "13"^^xsd:int ;
@@ -1828,9 +1828,9 @@ niiri:a46d73eae3d12dd1da0f67fbeb4a1a72
     nidm_qValueFDR: "0.164098394910714"^^xsd:float ;
     nidm_clusterLabelId: "77"^^xsd:int .
 
-niiri:a46d73eae3d12dd1da0f67fbeb4a1a72 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:8de83fae7bd6e9f8380ec49cdc4829ae prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:7635d7da2581ae0e3d9df35c569ea093
+niiri:85491f67ab81ddeb946caf2849c4b9f4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0078" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -1840,9 +1840,9 @@ niiri:7635d7da2581ae0e3d9df35c569ea093
     nidm_qValueFDR: "0.361120489405488"^^xsd:float ;
     nidm_clusterLabelId: "78"^^xsd:int .
 
-niiri:7635d7da2581ae0e3d9df35c569ea093 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:85491f67ab81ddeb946caf2849c4b9f4 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:19a7c772a61f72e1d78af974571971cd
+niiri:3e9eba22eff518f24b14c038fe2913df
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0079" ;
     nidm_clusterSizeInVoxels: "13"^^xsd:int ;
@@ -1852,9 +1852,9 @@ niiri:19a7c772a61f72e1d78af974571971cd
     nidm_qValueFDR: "0.164098394910714"^^xsd:float ;
     nidm_clusterLabelId: "79"^^xsd:int .
 
-niiri:19a7c772a61f72e1d78af974571971cd prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:3e9eba22eff518f24b14c038fe2913df prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:843d6a80a917e6d0bba5298ced57aba0
+niiri:2b503ca3533d10a4f1f80dad7060444a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0080" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -1864,9 +1864,9 @@ niiri:843d6a80a917e6d0bba5298ced57aba0
     nidm_qValueFDR: "0.296922311851664"^^xsd:float ;
     nidm_clusterLabelId: "80"^^xsd:int .
 
-niiri:843d6a80a917e6d0bba5298ced57aba0 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:2b503ca3533d10a4f1f80dad7060444a prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:81a5a2e83d586c873f45bcbeacbd725e
+niiri:cf6de656d89419d4ac154fd946ec6388
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0081" ;
     nidm_clusterSizeInVoxels: "14"^^xsd:int ;
@@ -1876,9 +1876,9 @@ niiri:81a5a2e83d586c873f45bcbeacbd725e
     nidm_qValueFDR: "0.15179404238237"^^xsd:float ;
     nidm_clusterLabelId: "81"^^xsd:int .
 
-niiri:81a5a2e83d586c873f45bcbeacbd725e prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:cf6de656d89419d4ac154fd946ec6388 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:0dba3e406159d31dec269bb22b1b416a
+niiri:9c0f05c7637bc2f31d907b17584b6aa0
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0082" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1888,9 +1888,9 @@ niiri:0dba3e406159d31dec269bb22b1b416a
     nidm_qValueFDR: "0.529659882057015"^^xsd:float ;
     nidm_clusterLabelId: "82"^^xsd:int .
 
-niiri:0dba3e406159d31dec269bb22b1b416a prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:9c0f05c7637bc2f31d907b17584b6aa0 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:3d62634be01e822042b85fbe2f4b57a5
+niiri:62e799c85533fe86208bf5e33c6a326d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0083" ;
     nidm_clusterSizeInVoxels: "18"^^xsd:int ;
@@ -1900,9 +1900,9 @@ niiri:3d62634be01e822042b85fbe2f4b57a5
     nidm_qValueFDR: "0.111057119624032"^^xsd:float ;
     nidm_clusterLabelId: "83"^^xsd:int .
 
-niiri:3d62634be01e822042b85fbe2f4b57a5 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:62e799c85533fe86208bf5e33c6a326d prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:4d27ad0557a85357aebf8d3cb8a18d20
+niiri:7b8b805f3c10072513741773f37173a9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0084" ;
     nidm_clusterSizeInVoxels: "9"^^xsd:int ;
@@ -1912,9 +1912,9 @@ niiri:4d27ad0557a85357aebf8d3cb8a18d20
     nidm_qValueFDR: "0.257089854765214"^^xsd:float ;
     nidm_clusterLabelId: "84"^^xsd:int .
 
-niiri:4d27ad0557a85357aebf8d3cb8a18d20 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:7b8b805f3c10072513741773f37173a9 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:259f577b521fb0d31342d69e79678fd8
+niiri:c8967930ef6b4850b98397e5a02cf2f7
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0085" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1924,9 +1924,9 @@ niiri:259f577b521fb0d31342d69e79678fd8
     nidm_qValueFDR: "0.477356849101447"^^xsd:float ;
     nidm_clusterLabelId: "85"^^xsd:int .
 
-niiri:259f577b521fb0d31342d69e79678fd8 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:c8967930ef6b4850b98397e5a02cf2f7 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:73ea65987d6ff092b8032a7897f236dc
+niiri:162bab89b0c20f6474f1241e5c7169b3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0086" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1936,9 +1936,9 @@ niiri:73ea65987d6ff092b8032a7897f236dc
     nidm_qValueFDR: "0.477356849101447"^^xsd:float ;
     nidm_clusterLabelId: "86"^^xsd:int .
 
-niiri:73ea65987d6ff092b8032a7897f236dc prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:162bab89b0c20f6474f1241e5c7169b3 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:ba34aadcbdfb22bb96b240c5d8d71cb7
+niiri:91dc841836bbf5d1c0b426905fb75e01
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0087" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -1948,9 +1948,9 @@ niiri:ba34aadcbdfb22bb96b240c5d8d71cb7
     nidm_qValueFDR: "0.317998323277913"^^xsd:float ;
     nidm_clusterLabelId: "87"^^xsd:int .
 
-niiri:ba34aadcbdfb22bb96b240c5d8d71cb7 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:91dc841836bbf5d1c0b426905fb75e01 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:3a163a0cb084881b83df7fb4539004cf
+niiri:3f463a005d2c5f82895c19639d89d232
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0088" ;
     nidm_clusterSizeInVoxels: "17"^^xsd:int ;
@@ -1960,9 +1960,9 @@ niiri:3a163a0cb084881b83df7fb4539004cf
     nidm_qValueFDR: "0.120432329815194"^^xsd:float ;
     nidm_clusterLabelId: "88"^^xsd:int .
 
-niiri:3a163a0cb084881b83df7fb4539004cf prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:3f463a005d2c5f82895c19639d89d232 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:43f0fb5e7c19214fdedd18472535c15a
+niiri:a088e0c82151087e1bf9897ac5ca3823
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0089" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -1972,9 +1972,9 @@ niiri:43f0fb5e7c19214fdedd18472535c15a
     nidm_qValueFDR: "0.317998323277913"^^xsd:float ;
     nidm_clusterLabelId: "89"^^xsd:int .
 
-niiri:43f0fb5e7c19214fdedd18472535c15a prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:a088e0c82151087e1bf9897ac5ca3823 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:2eda6a0e1bdd1c9e5ed07632d4ecdc2f
+niiri:321fa4b64bb46facf5ed354080dc1587
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0090" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -1984,9 +1984,9 @@ niiri:2eda6a0e1bdd1c9e5ed07632d4ecdc2f
     nidm_qValueFDR: "0.361120489405488"^^xsd:float ;
     nidm_clusterLabelId: "90"^^xsd:int .
 
-niiri:2eda6a0e1bdd1c9e5ed07632d4ecdc2f prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:321fa4b64bb46facf5ed354080dc1587 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:69803a9c56c9a9477742ef1bd9b5db35
+niiri:1bb068ae0340b41c3c1e0585e61ab7a2
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0091" ;
     nidm_clusterSizeInVoxels: "23"^^xsd:int ;
@@ -1996,9 +1996,9 @@ niiri:69803a9c56c9a9477742ef1bd9b5db35
     nidm_qValueFDR: "0.0716185181300816"^^xsd:float ;
     nidm_clusterLabelId: "91"^^xsd:int .
 
-niiri:69803a9c56c9a9477742ef1bd9b5db35 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:1bb068ae0340b41c3c1e0585e61ab7a2 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:01e79de738160252561a3797aff0be46
+niiri:0b5c4b3fea9afd08f274ad657436f2dd
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0092" ;
     nidm_clusterSizeInVoxels: "10"^^xsd:int ;
@@ -2008,9 +2008,9 @@ niiri:01e79de738160252561a3797aff0be46
     nidm_qValueFDR: "0.232854217411059"^^xsd:float ;
     nidm_clusterLabelId: "92"^^xsd:int .
 
-niiri:01e79de738160252561a3797aff0be46 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:0b5c4b3fea9afd08f274ad657436f2dd prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:f41790cbed14abdecac7977440cc0bb6
+niiri:7b0e7637357771b4e3c95b60da0daba2
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0093" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -2020,9 +2020,9 @@ niiri:f41790cbed14abdecac7977440cc0bb6
     nidm_qValueFDR: "0.427898326781582"^^xsd:float ;
     nidm_clusterLabelId: "93"^^xsd:int .
 
-niiri:f41790cbed14abdecac7977440cc0bb6 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:7b0e7637357771b4e3c95b60da0daba2 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:9cce28d22165f03a477a1d52851070af
+niiri:b8afe5b11ecf6b25c3098ac5c67b90a0
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0094" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2032,9 +2032,9 @@ niiri:9cce28d22165f03a477a1d52851070af
     nidm_qValueFDR: "0.552437898286094"^^xsd:float ;
     nidm_clusterLabelId: "94"^^xsd:int .
 
-niiri:9cce28d22165f03a477a1d52851070af prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:b8afe5b11ecf6b25c3098ac5c67b90a0 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:cc59f8e2a9544b3ce2e7c770bd643f84
+niiri:a2a8b82493043f5593bcde950e35d4f5
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0095" ;
     nidm_clusterSizeInVoxels: "12"^^xsd:int ;
@@ -2044,9 +2044,9 @@ niiri:cc59f8e2a9544b3ce2e7c770bd643f84
     nidm_qValueFDR: "0.181500977727632"^^xsd:float ;
     nidm_clusterLabelId: "95"^^xsd:int .
 
-niiri:cc59f8e2a9544b3ce2e7c770bd643f84 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:a2a8b82493043f5593bcde950e35d4f5 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:1057dce00f5bb5fa3cfe47e76eb89cbb
+niiri:13a870b0869420f093e2bf23ab79a37e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0096" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2056,9 +2056,9 @@ niiri:1057dce00f5bb5fa3cfe47e76eb89cbb
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "96"^^xsd:int .
 
-niiri:1057dce00f5bb5fa3cfe47e76eb89cbb prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:13a870b0869420f093e2bf23ab79a37e prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:60ab79a3ea3afc698ecd6cf745ac195d
+niiri:9e62040415b20939b8c829b35ac0b428
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0097" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2068,9 +2068,9 @@ niiri:60ab79a3ea3afc698ecd6cf745ac195d
     nidm_qValueFDR: "0.552437898286094"^^xsd:float ;
     nidm_clusterLabelId: "97"^^xsd:int .
 
-niiri:60ab79a3ea3afc698ecd6cf745ac195d prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:9e62040415b20939b8c829b35ac0b428 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:5f6f6b54a9f90d5bb626fde29fa6b1fd
+niiri:ef74f8693d6b0cc1f8f7291479877d46
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0098" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -2080,9 +2080,9 @@ niiri:5f6f6b54a9f90d5bb626fde29fa6b1fd
     nidm_qValueFDR: "0.529659882057015"^^xsd:float ;
     nidm_clusterLabelId: "98"^^xsd:int .
 
-niiri:5f6f6b54a9f90d5bb626fde29fa6b1fd prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:ef74f8693d6b0cc1f8f7291479877d46 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:d2932453ed5d06805f9a2af83c52d15a
+niiri:b4f4a8e2b968691b39abdbd7cd10251b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0099" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2092,9 +2092,9 @@ niiri:d2932453ed5d06805f9a2af83c52d15a
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "99"^^xsd:int .
 
-niiri:d2932453ed5d06805f9a2af83c52d15a prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:b4f4a8e2b968691b39abdbd7cd10251b prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:3fa7a66071d2b8d3530bef533d52b63d
+niiri:b479ffd217729f45ba8e8b497543b71d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0100" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -2104,9 +2104,9 @@ niiri:3fa7a66071d2b8d3530bef533d52b63d
     nidm_qValueFDR: "0.529659882057015"^^xsd:float ;
     nidm_clusterLabelId: "100"^^xsd:int .
 
-niiri:3fa7a66071d2b8d3530bef533d52b63d prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:b479ffd217729f45ba8e8b497543b71d prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:b3bc50a19f719b2fefee16f3b146e23d
+niiri:64b1c86050912153a776e757204d9bd6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0101" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2116,9 +2116,9 @@ niiri:b3bc50a19f719b2fefee16f3b146e23d
     nidm_qValueFDR: "0.552437898286094"^^xsd:float ;
     nidm_clusterLabelId: "101"^^xsd:int .
 
-niiri:b3bc50a19f719b2fefee16f3b146e23d prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:64b1c86050912153a776e757204d9bd6 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:ae4a511d54b76b35f1462db6d3370c9c
+niiri:2262ce46c8d9d3e44fca9d2b9991842a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0102" ;
     nidm_clusterSizeInVoxels: "9"^^xsd:int ;
@@ -2128,9 +2128,9 @@ niiri:ae4a511d54b76b35f1462db6d3370c9c
     nidm_qValueFDR: "0.257089854765214"^^xsd:float ;
     nidm_clusterLabelId: "102"^^xsd:int .
 
-niiri:ae4a511d54b76b35f1462db6d3370c9c prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:2262ce46c8d9d3e44fca9d2b9991842a prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:d9f9aff87a34b9c5479d4873772dd0ed
+niiri:03e5589e0cbf8390adc9f572f09c2111
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0103" ;
     nidm_clusterSizeInVoxels: "11"^^xsd:int ;
@@ -2140,9 +2140,9 @@ niiri:d9f9aff87a34b9c5479d4873772dd0ed
     nidm_qValueFDR: "0.204909289340264"^^xsd:float ;
     nidm_clusterLabelId: "103"^^xsd:int .
 
-niiri:d9f9aff87a34b9c5479d4873772dd0ed prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:03e5589e0cbf8390adc9f572f09c2111 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:8bfeeb8b866911a137111a38c272b615
+niiri:183d033f8dc6f63dd2d370f917d30bf5
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0104" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2152,9 +2152,9 @@ niiri:8bfeeb8b866911a137111a38c272b615
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "104"^^xsd:int .
 
-niiri:8bfeeb8b866911a137111a38c272b615 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:183d033f8dc6f63dd2d370f917d30bf5 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:ac52eb589b96f34cb8f8a5bc4d179c34
+niiri:82ed6a608808b53426982c1cc66a2ec6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0105" ;
     nidm_clusterSizeInVoxels: "11"^^xsd:int ;
@@ -2164,9 +2164,9 @@ niiri:ac52eb589b96f34cb8f8a5bc4d179c34
     nidm_qValueFDR: "0.204909289340264"^^xsd:float ;
     nidm_clusterLabelId: "105"^^xsd:int .
 
-niiri:ac52eb589b96f34cb8f8a5bc4d179c34 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:82ed6a608808b53426982c1cc66a2ec6 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:3355d697f188c4ca897d5bfbad88c46c
+niiri:c38a12c7c56a4a6bcef1a3f1defaede6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0106" ;
     nidm_clusterSizeInVoxels: "14"^^xsd:int ;
@@ -2176,9 +2176,9 @@ niiri:3355d697f188c4ca897d5bfbad88c46c
     nidm_qValueFDR: "0.15179404238237"^^xsd:float ;
     nidm_clusterLabelId: "106"^^xsd:int .
 
-niiri:3355d697f188c4ca897d5bfbad88c46c prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:c38a12c7c56a4a6bcef1a3f1defaede6 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:868f4263fbce64aac9db6a0fc1959caf
+niiri:b903a819026d14c010b6e3c047f2d1f1
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0107" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -2188,9 +2188,9 @@ niiri:868f4263fbce64aac9db6a0fc1959caf
     nidm_qValueFDR: "0.317998323277913"^^xsd:float ;
     nidm_clusterLabelId: "107"^^xsd:int .
 
-niiri:868f4263fbce64aac9db6a0fc1959caf prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:b903a819026d14c010b6e3c047f2d1f1 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:f20ed18d19c8f3654c783f3c512348b3
+niiri:932955007c6604e912ca88f69e4b71b2
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0108" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -2200,9 +2200,9 @@ niiri:f20ed18d19c8f3654c783f3c512348b3
     nidm_qValueFDR: "0.477356849101447"^^xsd:float ;
     nidm_clusterLabelId: "108"^^xsd:int .
 
-niiri:f20ed18d19c8f3654c783f3c512348b3 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:932955007c6604e912ca88f69e4b71b2 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:05512cf6085c8d2b74ae7737861092c8
+niiri:19bb8ba20387a263ccc2a4033c4a6959
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0109" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -2212,9 +2212,9 @@ niiri:05512cf6085c8d2b74ae7737861092c8
     nidm_qValueFDR: "0.477356849101447"^^xsd:float ;
     nidm_clusterLabelId: "109"^^xsd:int .
 
-niiri:05512cf6085c8d2b74ae7737861092c8 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:19bb8ba20387a263ccc2a4033c4a6959 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:f695aae9ae02bed79ba9e19f8af0adb8
+niiri:4c267352cce4185f6d8f19642a2432ea
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0110" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2224,9 +2224,9 @@ niiri:f695aae9ae02bed79ba9e19f8af0adb8
     nidm_qValueFDR: "0.552437898286094"^^xsd:float ;
     nidm_clusterLabelId: "110"^^xsd:int .
 
-niiri:f695aae9ae02bed79ba9e19f8af0adb8 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:4c267352cce4185f6d8f19642a2432ea prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:d1fc4fee78d95536f89feb63f14c968c
+niiri:b779ca098f1180fe09ebe0414895c731
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0111" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -2236,9 +2236,9 @@ niiri:d1fc4fee78d95536f89feb63f14c968c
     nidm_qValueFDR: "0.361120489405488"^^xsd:float ;
     nidm_clusterLabelId: "111"^^xsd:int .
 
-niiri:d1fc4fee78d95536f89feb63f14c968c prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:b779ca098f1180fe09ebe0414895c731 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:e1f20b806abf584189fd37df83ae5f02
+niiri:b7385089cc22c8804fc256dff15181f6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0112" ;
     nidm_clusterSizeInVoxels: "12"^^xsd:int ;
@@ -2248,9 +2248,9 @@ niiri:e1f20b806abf584189fd37df83ae5f02
     nidm_qValueFDR: "0.181500977727632"^^xsd:float ;
     nidm_clusterLabelId: "112"^^xsd:int .
 
-niiri:e1f20b806abf584189fd37df83ae5f02 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:b7385089cc22c8804fc256dff15181f6 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:f4343a9252d96448237743dc7620b82d
+niiri:a34044dfcf23dfe53b2945318b0397f1
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0113" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2260,9 +2260,9 @@ niiri:f4343a9252d96448237743dc7620b82d
     nidm_qValueFDR: "0.552437898286094"^^xsd:float ;
     nidm_clusterLabelId: "113"^^xsd:int .
 
-niiri:f4343a9252d96448237743dc7620b82d prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:a34044dfcf23dfe53b2945318b0397f1 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:f74cf4fd744cb5d2223e69c6b86d72ca
+niiri:e3223bf7299c1367c69b65daadf7dab4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0114" ;
     nidm_clusterSizeInVoxels: "9"^^xsd:int ;
@@ -2272,9 +2272,9 @@ niiri:f74cf4fd744cb5d2223e69c6b86d72ca
     nidm_qValueFDR: "0.257089854765214"^^xsd:float ;
     nidm_clusterLabelId: "114"^^xsd:int .
 
-niiri:f74cf4fd744cb5d2223e69c6b86d72ca prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:e3223bf7299c1367c69b65daadf7dab4 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:2c8ba22e270c2ab78bc2767742ff87f1
+niiri:315a3351fd67e6810a0558156faed379
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0115" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -2284,9 +2284,9 @@ niiri:2c8ba22e270c2ab78bc2767742ff87f1
     nidm_qValueFDR: "0.427898326781582"^^xsd:float ;
     nidm_clusterLabelId: "115"^^xsd:int .
 
-niiri:2c8ba22e270c2ab78bc2767742ff87f1 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:315a3351fd67e6810a0558156faed379 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:ffa25ea15473af14a67c3205bbe9f983
+niiri:956afe330511d5dec77faf29c8e66c5b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0116" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -2296,9 +2296,9 @@ niiri:ffa25ea15473af14a67c3205bbe9f983
     nidm_qValueFDR: "0.477356849101447"^^xsd:float ;
     nidm_clusterLabelId: "116"^^xsd:int .
 
-niiri:ffa25ea15473af14a67c3205bbe9f983 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:956afe330511d5dec77faf29c8e66c5b prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:bc830c332ebaee861ca402fa60321dce
+niiri:4740016eb1ce8e7ec8341eb44cf9ffa5
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0117" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -2308,9 +2308,9 @@ niiri:bc830c332ebaee861ca402fa60321dce
     nidm_qValueFDR: "0.296922311851664"^^xsd:float ;
     nidm_clusterLabelId: "117"^^xsd:int .
 
-niiri:bc830c332ebaee861ca402fa60321dce prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:4740016eb1ce8e7ec8341eb44cf9ffa5 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:47f7311fc1a64f3bf47cf50b4561aabc
+niiri:f956c3347b26a7454fde4d7c1ee3dfac
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0118" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -2320,9 +2320,9 @@ niiri:47f7311fc1a64f3bf47cf50b4561aabc
     nidm_qValueFDR: "0.361120489405488"^^xsd:float ;
     nidm_clusterLabelId: "118"^^xsd:int .
 
-niiri:47f7311fc1a64f3bf47cf50b4561aabc prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:f956c3347b26a7454fde4d7c1ee3dfac prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:b8ae2b4592f8a2f04be965b5829712bf
+niiri:0306caf1c070bce484bea6d4d02ee4b9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0119" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -2332,9 +2332,9 @@ niiri:b8ae2b4592f8a2f04be965b5829712bf
     nidm_qValueFDR: "0.361120489405488"^^xsd:float ;
     nidm_clusterLabelId: "119"^^xsd:int .
 
-niiri:b8ae2b4592f8a2f04be965b5829712bf prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:0306caf1c070bce484bea6d4d02ee4b9 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:a0e10a7c0fca0a0252e91da150ff7c73
+niiri:0718df40c87e4adde0a6b31fdd007bb4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0120" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2344,9 +2344,9 @@ niiri:a0e10a7c0fca0a0252e91da150ff7c73
     nidm_qValueFDR: "0.552437898286094"^^xsd:float ;
     nidm_clusterLabelId: "120"^^xsd:int .
 
-niiri:a0e10a7c0fca0a0252e91da150ff7c73 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:0718df40c87e4adde0a6b31fdd007bb4 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:7ce8d10a760980abe8a87f7a79f378c2
+niiri:c3345fe728c02a6d54b764235fc35217
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0121" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -2356,9 +2356,9 @@ niiri:7ce8d10a760980abe8a87f7a79f378c2
     nidm_qValueFDR: "0.529659882057015"^^xsd:float ;
     nidm_clusterLabelId: "121"^^xsd:int .
 
-niiri:7ce8d10a760980abe8a87f7a79f378c2 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:c3345fe728c02a6d54b764235fc35217 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:4dd100dcaaa90bf1aaa604fdff0ba9ff
+niiri:db4e8782b5b474daeb575623d11d8f36
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0122" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -2368,9 +2368,9 @@ niiri:4dd100dcaaa90bf1aaa604fdff0ba9ff
     nidm_qValueFDR: "0.529659882057015"^^xsd:float ;
     nidm_clusterLabelId: "122"^^xsd:int .
 
-niiri:4dd100dcaaa90bf1aaa604fdff0ba9ff prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:db4e8782b5b474daeb575623d11d8f36 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:ac00e8055c4355ec5762be8458693242
+niiri:3a7bd3c73757ad2c63a505ac44ee7de9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0123" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -2380,9 +2380,9 @@ niiri:ac00e8055c4355ec5762be8458693242
     nidm_qValueFDR: "0.477356849101447"^^xsd:float ;
     nidm_clusterLabelId: "123"^^xsd:int .
 
-niiri:ac00e8055c4355ec5762be8458693242 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:3a7bd3c73757ad2c63a505ac44ee7de9 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:0c01d3025f9ac35ecf95f50b6ad70473
+niiri:ca632dc1f3d6a97bb76e5a785e5f4b39
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0124" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -2392,9 +2392,9 @@ niiri:0c01d3025f9ac35ecf95f50b6ad70473
     nidm_qValueFDR: "0.529659882057015"^^xsd:float ;
     nidm_clusterLabelId: "124"^^xsd:int .
 
-niiri:0c01d3025f9ac35ecf95f50b6ad70473 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:ca632dc1f3d6a97bb76e5a785e5f4b39 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:6f3664cedc79fb9f59b11be01c396b26
+niiri:4d501ade9f45e68e86c0aef60754a9aa
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0125" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -2404,9 +2404,9 @@ niiri:6f3664cedc79fb9f59b11be01c396b26
     nidm_qValueFDR: "0.529659882057015"^^xsd:float ;
     nidm_clusterLabelId: "125"^^xsd:int .
 
-niiri:6f3664cedc79fb9f59b11be01c396b26 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:4d501ade9f45e68e86c0aef60754a9aa prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:c89efa8381d6b8fd6a264562898c049a
+niiri:4353f4b513f6d03c8ce9a7ee07ac3524
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0126" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2416,9 +2416,9 @@ niiri:c89efa8381d6b8fd6a264562898c049a
     nidm_qValueFDR: "0.552437898286094"^^xsd:float ;
     nidm_clusterLabelId: "126"^^xsd:int .
 
-niiri:c89efa8381d6b8fd6a264562898c049a prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:4353f4b513f6d03c8ce9a7ee07ac3524 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:601f2b2d65ca5573b797e7fb5ea7c122
+niiri:d24c03f6c5960ef050e1d0a675496464
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0127" ;
     nidm_clusterSizeInVoxels: "10"^^xsd:int ;
@@ -2428,9 +2428,9 @@ niiri:601f2b2d65ca5573b797e7fb5ea7c122
     nidm_qValueFDR: "0.232854217411059"^^xsd:float ;
     nidm_clusterLabelId: "127"^^xsd:int .
 
-niiri:601f2b2d65ca5573b797e7fb5ea7c122 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:d24c03f6c5960ef050e1d0a675496464 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:41706195949bd303e398c4c6246c9da1
+niiri:0630bc3a96bd8ec1bd4f2dbb98bd8a68
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0128" ;
     nidm_clusterSizeInVoxels: "9"^^xsd:int ;
@@ -2440,9 +2440,9 @@ niiri:41706195949bd303e398c4c6246c9da1
     nidm_qValueFDR: "0.257089854765214"^^xsd:float ;
     nidm_clusterLabelId: "128"^^xsd:int .
 
-niiri:41706195949bd303e398c4c6246c9da1 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:0630bc3a96bd8ec1bd4f2dbb98bd8a68 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:3f5bc238b154db411923ec0d520212a5
+niiri:7a6a9d89a41bce106a6e3f6b9bf39fc2
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0129" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -2452,9 +2452,9 @@ niiri:3f5bc238b154db411923ec0d520212a5
     nidm_qValueFDR: "0.529659882057015"^^xsd:float ;
     nidm_clusterLabelId: "129"^^xsd:int .
 
-niiri:3f5bc238b154db411923ec0d520212a5 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:7a6a9d89a41bce106a6e3f6b9bf39fc2 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:d61c2e3334e7afb034ac8b3a50d8eefd
+niiri:6cd9c8b1f2dc650429e50bd72f6da32d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0130" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2464,9 +2464,9 @@ niiri:d61c2e3334e7afb034ac8b3a50d8eefd
     nidm_qValueFDR: "0.552437898286094"^^xsd:float ;
     nidm_clusterLabelId: "130"^^xsd:int .
 
-niiri:d61c2e3334e7afb034ac8b3a50d8eefd prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:6cd9c8b1f2dc650429e50bd72f6da32d prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:c7f0899e68a33117259a0776f3fbd712
+niiri:f0caefb73eec8df07661fca6c2cc2a56
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0131" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2476,9 +2476,9 @@ niiri:c7f0899e68a33117259a0776f3fbd712
     nidm_qValueFDR: "0.552437898286094"^^xsd:float ;
     nidm_clusterLabelId: "131"^^xsd:int .
 
-niiri:c7f0899e68a33117259a0776f3fbd712 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:f0caefb73eec8df07661fca6c2cc2a56 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:acf0099ad05f52f7740833ae0513f2c4
+niiri:10dda0f512d376c45616527318012baa
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0132" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -2488,9 +2488,9 @@ niiri:acf0099ad05f52f7740833ae0513f2c4
     nidm_qValueFDR: "0.529659882057015"^^xsd:float ;
     nidm_clusterLabelId: "132"^^xsd:int .
 
-niiri:acf0099ad05f52f7740833ae0513f2c4 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:10dda0f512d376c45616527318012baa prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:d639d06c89e7a7987cc7beee7f6eebde
+niiri:3aeaeffb7762bacf9f1b2dc630012fe3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0133" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -2500,9 +2500,9 @@ niiri:d639d06c89e7a7987cc7beee7f6eebde
     nidm_qValueFDR: "0.529659882057015"^^xsd:float ;
     nidm_clusterLabelId: "133"^^xsd:int .
 
-niiri:d639d06c89e7a7987cc7beee7f6eebde prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:3aeaeffb7762bacf9f1b2dc630012fe3 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:019db96efd3f0d5a9f077d436d990e65
+niiri:88ee03bc281326c9948572b0834fecf3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0134" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -2512,9 +2512,9 @@ niiri:019db96efd3f0d5a9f077d436d990e65
     nidm_qValueFDR: "0.477356849101447"^^xsd:float ;
     nidm_clusterLabelId: "134"^^xsd:int .
 
-niiri:019db96efd3f0d5a9f077d436d990e65 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:88ee03bc281326c9948572b0834fecf3 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:3589dce5a9f2dacdad11e4fc0348fe0f
+niiri:30868fad9324d3113736d83bd681718a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0135" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -2524,9 +2524,9 @@ niiri:3589dce5a9f2dacdad11e4fc0348fe0f
     nidm_qValueFDR: "0.361120489405488"^^xsd:float ;
     nidm_clusterLabelId: "135"^^xsd:int .
 
-niiri:3589dce5a9f2dacdad11e4fc0348fe0f prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:30868fad9324d3113736d83bd681718a prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:6c2ff806101a3ff739a426037285f4f7
+niiri:4b462b6d837ce2e27bce61ed0c368fd6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0136" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -2536,9 +2536,9 @@ niiri:6c2ff806101a3ff739a426037285f4f7
     nidm_qValueFDR: "0.477356849101447"^^xsd:float ;
     nidm_clusterLabelId: "136"^^xsd:int .
 
-niiri:6c2ff806101a3ff739a426037285f4f7 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:4b462b6d837ce2e27bce61ed0c368fd6 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:700ddae2d53d6ba003ce7aef4c34cf8c
+niiri:1bf97c65bec07a1317ef69c944689cf8
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0137" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2548,9 +2548,9 @@ niiri:700ddae2d53d6ba003ce7aef4c34cf8c
     nidm_qValueFDR: "0.552437898286094"^^xsd:float ;
     nidm_clusterLabelId: "137"^^xsd:int .
 
-niiri:700ddae2d53d6ba003ce7aef4c34cf8c prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:1bf97c65bec07a1317ef69c944689cf8 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:c226e28f1c7d1bb6df56af26165cf368
+niiri:cd27fa26bbd5aa4fa8cfbebf1bb95ad9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0138" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2560,9 +2560,9 @@ niiri:c226e28f1c7d1bb6df56af26165cf368
     nidm_qValueFDR: "0.552437898286094"^^xsd:float ;
     nidm_clusterLabelId: "138"^^xsd:int .
 
-niiri:c226e28f1c7d1bb6df56af26165cf368 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:cd27fa26bbd5aa4fa8cfbebf1bb95ad9 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:d349e89efbf6c30897c6f74aaef9e81f
+niiri:31a80df97955e986f4be4839a052a5db
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0139" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -2572,9 +2572,9 @@ niiri:d349e89efbf6c30897c6f74aaef9e81f
     nidm_qValueFDR: "0.317998323277913"^^xsd:float ;
     nidm_clusterLabelId: "139"^^xsd:int .
 
-niiri:d349e89efbf6c30897c6f74aaef9e81f prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:31a80df97955e986f4be4839a052a5db prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:cd868dac3ef78cde76ebbceb4543715e
+niiri:39fc04da006cbf70670a7f80045d0d49
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0140" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2584,9 +2584,9 @@ niiri:cd868dac3ef78cde76ebbceb4543715e
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "140"^^xsd:int .
 
-niiri:cd868dac3ef78cde76ebbceb4543715e prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:39fc04da006cbf70670a7f80045d0d49 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:2b8a556886785a97e170fa36a82a529d
+niiri:a2df6515d44ea1c2de2e20cd83b43f91
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0141" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -2596,9 +2596,9 @@ niiri:2b8a556886785a97e170fa36a82a529d
     nidm_qValueFDR: "0.477356849101447"^^xsd:float ;
     nidm_clusterLabelId: "141"^^xsd:int .
 
-niiri:2b8a556886785a97e170fa36a82a529d prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:a2df6515d44ea1c2de2e20cd83b43f91 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:cbd1c61d5f72e84539faeac10377a620
+niiri:9b33ff671ff0c042af89e5b1be1377da
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0142" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2608,9 +2608,9 @@ niiri:cbd1c61d5f72e84539faeac10377a620
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "142"^^xsd:int .
 
-niiri:cbd1c61d5f72e84539faeac10377a620 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:9b33ff671ff0c042af89e5b1be1377da prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:08bad01c6e1b7035d226d8f83114d9d4
+niiri:25e2f4ca28679423b49be4329eea0bc3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0143" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -2620,9 +2620,9 @@ niiri:08bad01c6e1b7035d226d8f83114d9d4
     nidm_qValueFDR: "0.529659882057015"^^xsd:float ;
     nidm_clusterLabelId: "143"^^xsd:int .
 
-niiri:08bad01c6e1b7035d226d8f83114d9d4 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:25e2f4ca28679423b49be4329eea0bc3 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:dbd29bbddcbce1e02e18bedcb8b3c4b3
+niiri:0a729befa841fff84fcf2612fb2ce4a5
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0144" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -2632,9 +2632,9 @@ niiri:dbd29bbddcbce1e02e18bedcb8b3c4b3
     nidm_qValueFDR: "0.317998323277913"^^xsd:float ;
     nidm_clusterLabelId: "144"^^xsd:int .
 
-niiri:dbd29bbddcbce1e02e18bedcb8b3c4b3 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:0a729befa841fff84fcf2612fb2ce4a5 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:1d73a20f9c8bfb47867f2c59ae3c13b5
+niiri:501da0873de972e1023817d65202130e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0145" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -2644,9 +2644,9 @@ niiri:1d73a20f9c8bfb47867f2c59ae3c13b5
     nidm_qValueFDR: "0.427898326781582"^^xsd:float ;
     nidm_clusterLabelId: "145"^^xsd:int .
 
-niiri:1d73a20f9c8bfb47867f2c59ae3c13b5 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:501da0873de972e1023817d65202130e prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:b25e28979a447c1cd5093c9afae92781
+niiri:0336a0114f6c74e1df58148ee9b074f4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0146" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2656,9 +2656,9 @@ niiri:b25e28979a447c1cd5093c9afae92781
     nidm_qValueFDR: "0.552437898286094"^^xsd:float ;
     nidm_clusterLabelId: "146"^^xsd:int .
 
-niiri:b25e28979a447c1cd5093c9afae92781 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:0336a0114f6c74e1df58148ee9b074f4 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:e52574eea0816040ab22d41230ea518c
+niiri:06324b32c616d4e45a79cb65a439ac48
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0147" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2668,9 +2668,9 @@ niiri:e52574eea0816040ab22d41230ea518c
     nidm_qValueFDR: "0.552437898286094"^^xsd:float ;
     nidm_clusterLabelId: "147"^^xsd:int .
 
-niiri:e52574eea0816040ab22d41230ea518c prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:06324b32c616d4e45a79cb65a439ac48 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:cac2f6c0cd35c2d53ed1689d1f149a53
+niiri:ac9a19a2b1c9949a888ebae7d65a2399
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0148" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2680,9 +2680,9 @@ niiri:cac2f6c0cd35c2d53ed1689d1f149a53
     nidm_qValueFDR: "0.552437898286094"^^xsd:float ;
     nidm_clusterLabelId: "148"^^xsd:int .
 
-niiri:cac2f6c0cd35c2d53ed1689d1f149a53 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:ac9a19a2b1c9949a888ebae7d65a2399 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:78cef26d38b3c686cc371fc53f23b0b0
+niiri:061dca60ff6ace182bd1ebe945535ace
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0149" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2692,9 +2692,9 @@ niiri:78cef26d38b3c686cc371fc53f23b0b0
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "149"^^xsd:int .
 
-niiri:78cef26d38b3c686cc371fc53f23b0b0 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:061dca60ff6ace182bd1ebe945535ace prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:ee1be7d7191fe1d0a268751891c07368
+niiri:6242500a1c0ecfe873a2799eca21133b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0150" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2704,9 +2704,9 @@ niiri:ee1be7d7191fe1d0a268751891c07368
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "150"^^xsd:int .
 
-niiri:ee1be7d7191fe1d0a268751891c07368 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:6242500a1c0ecfe873a2799eca21133b prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:460199221aa05d5f8655df003b9ba5e5
+niiri:62f0dcd6742c42c5c8a69829ea982b14
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0151" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2716,9 +2716,9 @@ niiri:460199221aa05d5f8655df003b9ba5e5
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "151"^^xsd:int .
 
-niiri:460199221aa05d5f8655df003b9ba5e5 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:62f0dcd6742c42c5c8a69829ea982b14 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:13c65c64199df9d15af3dcaef046e358
+niiri:ed86b8af25a7303faba66f96f7427038
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0152" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2728,9 +2728,9 @@ niiri:13c65c64199df9d15af3dcaef046e358
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "152"^^xsd:int .
 
-niiri:13c65c64199df9d15af3dcaef046e358 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:ed86b8af25a7303faba66f96f7427038 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:7a0a564d5df4aedd6daf83ea5ff89179
+niiri:81c63725e4640647cd75f101cc0fc8a7
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0153" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -2740,9 +2740,9 @@ niiri:7a0a564d5df4aedd6daf83ea5ff89179
     nidm_qValueFDR: "0.529659882057015"^^xsd:float ;
     nidm_clusterLabelId: "153"^^xsd:int .
 
-niiri:7a0a564d5df4aedd6daf83ea5ff89179 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:81c63725e4640647cd75f101cc0fc8a7 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:64296118b766a08ff9a1b3331ff3a8be
+niiri:4b2e0a2531b0291df0fe5df5bc205ec9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0154" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2752,9 +2752,9 @@ niiri:64296118b766a08ff9a1b3331ff3a8be
     nidm_qValueFDR: "0.552437898286094"^^xsd:float ;
     nidm_clusterLabelId: "154"^^xsd:int .
 
-niiri:64296118b766a08ff9a1b3331ff3a8be prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:4b2e0a2531b0291df0fe5df5bc205ec9 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:2d05298a2bfc1bad012eb9c5a6636ad4
+niiri:7f91f8087c7d8ec7eda6204b5b39482d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0155" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2764,9 +2764,9 @@ niiri:2d05298a2bfc1bad012eb9c5a6636ad4
     nidm_qValueFDR: "0.552437898286094"^^xsd:float ;
     nidm_clusterLabelId: "155"^^xsd:int .
 
-niiri:2d05298a2bfc1bad012eb9c5a6636ad4 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:7f91f8087c7d8ec7eda6204b5b39482d prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:5675ac9e2a66ba888afe627ebfc89ba2
+niiri:2c7f0285c24b2b8b65a032418b15cd16
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0156" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -2776,9 +2776,9 @@ niiri:5675ac9e2a66ba888afe627ebfc89ba2
     nidm_qValueFDR: "0.317998323277913"^^xsd:float ;
     nidm_clusterLabelId: "156"^^xsd:int .
 
-niiri:5675ac9e2a66ba888afe627ebfc89ba2 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:2c7f0285c24b2b8b65a032418b15cd16 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:ec3de522ea3b2037df66f6245f038d27
+niiri:7ed3fe10280b67503b5448524a04f269
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0157" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -2788,9 +2788,9 @@ niiri:ec3de522ea3b2037df66f6245f038d27
     nidm_qValueFDR: "0.317998323277913"^^xsd:float ;
     nidm_clusterLabelId: "157"^^xsd:int .
 
-niiri:ec3de522ea3b2037df66f6245f038d27 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:7ed3fe10280b67503b5448524a04f269 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:d912332211df7778d8d01732fe94c592
+niiri:99c58e7d96cf7da6763a2e1cbba873ae
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0158" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2800,9 +2800,9 @@ niiri:d912332211df7778d8d01732fe94c592
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "158"^^xsd:int .
 
-niiri:d912332211df7778d8d01732fe94c592 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:99c58e7d96cf7da6763a2e1cbba873ae prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:7b7bea73949631fa11f1e655bc82c0ca
+niiri:d5206500679003f5f39472159c4ad0de
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0159" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -2812,9 +2812,9 @@ niiri:7b7bea73949631fa11f1e655bc82c0ca
     nidm_qValueFDR: "0.529659882057015"^^xsd:float ;
     nidm_clusterLabelId: "159"^^xsd:int .
 
-niiri:7b7bea73949631fa11f1e655bc82c0ca prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:d5206500679003f5f39472159c4ad0de prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:522c28dd4e63e1c775b1ebd75bb4c8b3
+niiri:0803006e1feea37abdc724f07464d7a9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0160" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2824,9 +2824,9 @@ niiri:522c28dd4e63e1c775b1ebd75bb4c8b3
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "160"^^xsd:int .
 
-niiri:522c28dd4e63e1c775b1ebd75bb4c8b3 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:0803006e1feea37abdc724f07464d7a9 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:18abb51402bd1a96024eebcb51fe2cea
+niiri:abae6765a0aa40936d109b9a2fd5acbf
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0161" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2836,9 +2836,9 @@ niiri:18abb51402bd1a96024eebcb51fe2cea
     nidm_qValueFDR: "0.552437898286094"^^xsd:float ;
     nidm_clusterLabelId: "161"^^xsd:int .
 
-niiri:18abb51402bd1a96024eebcb51fe2cea prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:abae6765a0aa40936d109b9a2fd5acbf prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:f22d5a21f3420379ca338b596714d6c3
+niiri:4b0a463a8d9ceb66a11c49348ae1f5fc
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0162" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2848,9 +2848,9 @@ niiri:f22d5a21f3420379ca338b596714d6c3
     nidm_qValueFDR: "0.552437898286094"^^xsd:float ;
     nidm_clusterLabelId: "162"^^xsd:int .
 
-niiri:f22d5a21f3420379ca338b596714d6c3 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:4b0a463a8d9ceb66a11c49348ae1f5fc prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:3ee311b3e36564f263d2f8b333315cbe
+niiri:ca33d7428ff48eafbc3f213db2286c92
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0163" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2860,9 +2860,9 @@ niiri:3ee311b3e36564f263d2f8b333315cbe
     nidm_qValueFDR: "0.552437898286094"^^xsd:float ;
     nidm_clusterLabelId: "163"^^xsd:int .
 
-niiri:3ee311b3e36564f263d2f8b333315cbe prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:ca33d7428ff48eafbc3f213db2286c92 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:1f3adbf2a65a904404950a1b8c6598ab
+niiri:a2d559eeea3fd425019a74c32cb07b03
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0164" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -2872,9 +2872,9 @@ niiri:1f3adbf2a65a904404950a1b8c6598ab
     nidm_qValueFDR: "0.477356849101447"^^xsd:float ;
     nidm_clusterLabelId: "164"^^xsd:int .
 
-niiri:1f3adbf2a65a904404950a1b8c6598ab prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:a2d559eeea3fd425019a74c32cb07b03 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:acdbdf918b46bc8c7e5f5f71c88555a8
+niiri:1cffc79d71ec5b44f8be32f71d15b738
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0165" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -2884,9 +2884,9 @@ niiri:acdbdf918b46bc8c7e5f5f71c88555a8
     nidm_qValueFDR: "0.529659882057015"^^xsd:float ;
     nidm_clusterLabelId: "165"^^xsd:int .
 
-niiri:acdbdf918b46bc8c7e5f5f71c88555a8 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:1cffc79d71ec5b44f8be32f71d15b738 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:57bb8e63228982c179f16eb42319da97
+niiri:08835c169510829e8effda3071bba336
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0166" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2896,9 +2896,9 @@ niiri:57bb8e63228982c179f16eb42319da97
     nidm_qValueFDR: "0.552437898286094"^^xsd:float ;
     nidm_clusterLabelId: "166"^^xsd:int .
 
-niiri:57bb8e63228982c179f16eb42319da97 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:08835c169510829e8effda3071bba336 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:47b4c3e270c9cefea83aa0b99207cb4e
+niiri:d5a3f5e4133bc22e2c189ceeb5b93544
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0167" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2908,9 +2908,9 @@ niiri:47b4c3e270c9cefea83aa0b99207cb4e
     nidm_qValueFDR: "0.552437898286094"^^xsd:float ;
     nidm_clusterLabelId: "167"^^xsd:int .
 
-niiri:47b4c3e270c9cefea83aa0b99207cb4e prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:d5a3f5e4133bc22e2c189ceeb5b93544 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:1e1daff291581e1187737e0f917dcaf2
+niiri:9b44436d58818f06cd48133f714e8a99
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0168" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2920,9 +2920,9 @@ niiri:1e1daff291581e1187737e0f917dcaf2
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "168"^^xsd:int .
 
-niiri:1e1daff291581e1187737e0f917dcaf2 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:9b44436d58818f06cd48133f714e8a99 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:6847174e062f3a379b5888fc4135c73f
+niiri:051457613c34bfa68d60b137e8c7ae17
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0169" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -2932,9 +2932,9 @@ niiri:6847174e062f3a379b5888fc4135c73f
     nidm_qValueFDR: "0.529659882057015"^^xsd:float ;
     nidm_clusterLabelId: "169"^^xsd:int .
 
-niiri:6847174e062f3a379b5888fc4135c73f prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:051457613c34bfa68d60b137e8c7ae17 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:a9473168659cdf2b1a2073210ee27791
+niiri:ea9fe9402f815e54e3cef6704ebcb2e4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0170" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2944,9 +2944,9 @@ niiri:a9473168659cdf2b1a2073210ee27791
     nidm_qValueFDR: "0.552437898286094"^^xsd:float ;
     nidm_clusterLabelId: "170"^^xsd:int .
 
-niiri:a9473168659cdf2b1a2073210ee27791 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:ea9fe9402f815e54e3cef6704ebcb2e4 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:907753cf0dfe053ffac4e74053c771f4
+niiri:1dce01b8df60884c582e29243c828080
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0171" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2956,9 +2956,9 @@ niiri:907753cf0dfe053ffac4e74053c771f4
     nidm_qValueFDR: "0.552437898286094"^^xsd:float ;
     nidm_clusterLabelId: "171"^^xsd:int .
 
-niiri:907753cf0dfe053ffac4e74053c771f4 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:1dce01b8df60884c582e29243c828080 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:7a7fab37bd67ec2dae91a58e4367079a
+niiri:eb8a2332e6ccc41b6d1a8cca84b280fe
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0172" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2968,9 +2968,9 @@ niiri:7a7fab37bd67ec2dae91a58e4367079a
     nidm_qValueFDR: "0.552437898286094"^^xsd:float ;
     nidm_clusterLabelId: "172"^^xsd:int .
 
-niiri:7a7fab37bd67ec2dae91a58e4367079a prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:eb8a2332e6ccc41b6d1a8cca84b280fe prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:6b0e32c53f8491486992e204b6c885ee
+niiri:3ab29b7a5414afa7ee3dad94fe418d2f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0173" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2980,9 +2980,9 @@ niiri:6b0e32c53f8491486992e204b6c885ee
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "173"^^xsd:int .
 
-niiri:6b0e32c53f8491486992e204b6c885ee prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:3ab29b7a5414afa7ee3dad94fe418d2f prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:437362f1f721e7635eb6c8e7a49eacc8
+niiri:de99f369510067d001dcfc78a4b7ee95
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0174" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -2992,9 +2992,9 @@ niiri:437362f1f721e7635eb6c8e7a49eacc8
     nidm_qValueFDR: "0.529659882057015"^^xsd:float ;
     nidm_clusterLabelId: "174"^^xsd:int .
 
-niiri:437362f1f721e7635eb6c8e7a49eacc8 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:de99f369510067d001dcfc78a4b7ee95 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:f3e52b5df75745e99bcb5f824b5d95a7
+niiri:03516b1ded0c354154f06310cfeb09c0
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0175" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -3004,9 +3004,9 @@ niiri:f3e52b5df75745e99bcb5f824b5d95a7
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "175"^^xsd:int .
 
-niiri:f3e52b5df75745e99bcb5f824b5d95a7 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:03516b1ded0c354154f06310cfeb09c0 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:e240445d6ab5dec28910648113069e56
+niiri:56da6908cbe82b7569f6ca2737e51eb6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0176" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -3016,9 +3016,9 @@ niiri:e240445d6ab5dec28910648113069e56
     nidm_qValueFDR: "0.427898326781582"^^xsd:float ;
     nidm_clusterLabelId: "176"^^xsd:int .
 
-niiri:e240445d6ab5dec28910648113069e56 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:56da6908cbe82b7569f6ca2737e51eb6 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:e075542d829a72554ead327c95c2e9d8
+niiri:087ce96dd01c83b4336943a7df6de172
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0177" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -3028,9 +3028,9 @@ niiri:e075542d829a72554ead327c95c2e9d8
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "177"^^xsd:int .
 
-niiri:e075542d829a72554ead327c95c2e9d8 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:087ce96dd01c83b4336943a7df6de172 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:d9aa2f1b33b774438046f98fe3595e09
+niiri:1a5540bf2e828d5e14c6001adb4f30d5
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0178" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -3040,9 +3040,9 @@ niiri:d9aa2f1b33b774438046f98fe3595e09
     nidm_qValueFDR: "0.552437898286094"^^xsd:float ;
     nidm_clusterLabelId: "178"^^xsd:int .
 
-niiri:d9aa2f1b33b774438046f98fe3595e09 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:1a5540bf2e828d5e14c6001adb4f30d5 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:13bffc90c8fd1625b76f45711dc4d490
+niiri:b54974658dcfd8d91a65540d01e3250b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0179" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -3052,9 +3052,9 @@ niiri:13bffc90c8fd1625b76f45711dc4d490
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "179"^^xsd:int .
 
-niiri:13bffc90c8fd1625b76f45711dc4d490 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:b54974658dcfd8d91a65540d01e3250b prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:226cf1d14e58a618a7ed1bfe9c594e24
+niiri:b1012bc624cd6b3f47ff149073d0a78b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0180" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -3064,9 +3064,9 @@ niiri:226cf1d14e58a618a7ed1bfe9c594e24
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "180"^^xsd:int .
 
-niiri:226cf1d14e58a618a7ed1bfe9c594e24 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:b1012bc624cd6b3f47ff149073d0a78b prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:54f50d5bf9097a354105a3150da68b70
+niiri:d45da63c733d96ddba5cf2fb05dc0b58
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0181" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -3076,9 +3076,9 @@ niiri:54f50d5bf9097a354105a3150da68b70
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "181"^^xsd:int .
 
-niiri:54f50d5bf9097a354105a3150da68b70 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:d45da63c733d96ddba5cf2fb05dc0b58 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:6f1dfc43277961fa3ac9af2851b18b10
+niiri:14e793643765a6fe10fb66237bee63db
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0182" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -3088,9 +3088,9 @@ niiri:6f1dfc43277961fa3ac9af2851b18b10
     nidm_qValueFDR: "0.529659882057015"^^xsd:float ;
     nidm_clusterLabelId: "182"^^xsd:int .
 
-niiri:6f1dfc43277961fa3ac9af2851b18b10 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:14e793643765a6fe10fb66237bee63db prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:eac8fe1980d2f8fa464fc76d2251099d
+niiri:a3b1937d74b3d7366255ed05df95e8dc
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0183" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -3100,9 +3100,9 @@ niiri:eac8fe1980d2f8fa464fc76d2251099d
     nidm_qValueFDR: "0.477356849101447"^^xsd:float ;
     nidm_clusterLabelId: "183"^^xsd:int .
 
-niiri:eac8fe1980d2f8fa464fc76d2251099d prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:a3b1937d74b3d7366255ed05df95e8dc prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:79433ea0eb0eb190e621fa615f0bf51e
+niiri:4f0d78d14b791c15d9759ece4ec7e6ed
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0184" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -3112,9 +3112,9 @@ niiri:79433ea0eb0eb190e621fa615f0bf51e
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "184"^^xsd:int .
 
-niiri:79433ea0eb0eb190e621fa615f0bf51e prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:4f0d78d14b791c15d9759ece4ec7e6ed prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:7d479ec4ba5d64002174656bfdc52de9
+niiri:f569ae7a0c44f14440097fc2492d13ab
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0185" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -3124,9 +3124,9 @@ niiri:7d479ec4ba5d64002174656bfdc52de9
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "185"^^xsd:int .
 
-niiri:7d479ec4ba5d64002174656bfdc52de9 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:f569ae7a0c44f14440097fc2492d13ab prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:f6e5caa15217c51ffb3a70b27c4655de
+niiri:2fd27f14078fbb1aa402a271e101e35f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0186" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -3136,9 +3136,9 @@ niiri:f6e5caa15217c51ffb3a70b27c4655de
     nidm_qValueFDR: "0.552437898286094"^^xsd:float ;
     nidm_clusterLabelId: "186"^^xsd:int .
 
-niiri:f6e5caa15217c51ffb3a70b27c4655de prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:2fd27f14078fbb1aa402a271e101e35f prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:a1d3eda99ed34e2358f8113bd4e39dbf
+niiri:5476fcd5093f7c864637efaafd42b996
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0187" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -3148,9 +3148,9 @@ niiri:a1d3eda99ed34e2358f8113bd4e39dbf
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "187"^^xsd:int .
 
-niiri:a1d3eda99ed34e2358f8113bd4e39dbf prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:5476fcd5093f7c864637efaafd42b996 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:51e730ef4a2f4f6093b5ca4c2b56ea0f
+niiri:10bac4ccf6049482f632adb3952c3c8c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0188" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -3160,9 +3160,9 @@ niiri:51e730ef4a2f4f6093b5ca4c2b56ea0f
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "188"^^xsd:int .
 
-niiri:51e730ef4a2f4f6093b5ca4c2b56ea0f prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:10bac4ccf6049482f632adb3952c3c8c prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:3352f1f91f74dc735e788278eb1bed90
+niiri:cda273936fc980c18403b41fb8533954
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0189" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -3172,9 +3172,9 @@ niiri:3352f1f91f74dc735e788278eb1bed90
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "189"^^xsd:int .
 
-niiri:3352f1f91f74dc735e788278eb1bed90 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:cda273936fc980c18403b41fb8533954 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:46cfb09d58d7bccc0bf22049c6888ca9
+niiri:89501dfa67d1d32810bbe20fd9b1fe8c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0190" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -3184,9 +3184,9 @@ niiri:46cfb09d58d7bccc0bf22049c6888ca9
     nidm_qValueFDR: "0.552437898286094"^^xsd:float ;
     nidm_clusterLabelId: "190"^^xsd:int .
 
-niiri:46cfb09d58d7bccc0bf22049c6888ca9 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:89501dfa67d1d32810bbe20fd9b1fe8c prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:0abf2e69a6c22d3820c2671d957d5cb6
+niiri:02f6f6429a8304a7731a404570cb4b94
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0191" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -3196,9 +3196,9 @@ niiri:0abf2e69a6c22d3820c2671d957d5cb6
     nidm_qValueFDR: "0.477356849101447"^^xsd:float ;
     nidm_clusterLabelId: "191"^^xsd:int .
 
-niiri:0abf2e69a6c22d3820c2671d957d5cb6 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:02f6f6429a8304a7731a404570cb4b94 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:a4c707ed5e61e6afca1d519a13e265d1
+niiri:8747a3ddd24cbd71e40672d541cefee5
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0192" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -3208,9 +3208,9 @@ niiri:a4c707ed5e61e6afca1d519a13e265d1
     nidm_qValueFDR: "0.552437898286094"^^xsd:float ;
     nidm_clusterLabelId: "192"^^xsd:int .
 
-niiri:a4c707ed5e61e6afca1d519a13e265d1 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:8747a3ddd24cbd71e40672d541cefee5 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:b664590e2a12ae3f5b1c7bfc738917c9
+niiri:c885eb98b2506b007c2d8feb2e37f08e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0193" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -3220,9 +3220,9 @@ niiri:b664590e2a12ae3f5b1c7bfc738917c9
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "193"^^xsd:int .
 
-niiri:b664590e2a12ae3f5b1c7bfc738917c9 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:c885eb98b2506b007c2d8feb2e37f08e prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:6abd89dfa06bba6341117a3456f77a35
+niiri:bd96226234de4e21627b04208c7e537f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0194" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -3232,9 +3232,9 @@ niiri:6abd89dfa06bba6341117a3456f77a35
     nidm_qValueFDR: "0.552437898286094"^^xsd:float ;
     nidm_clusterLabelId: "194"^^xsd:int .
 
-niiri:6abd89dfa06bba6341117a3456f77a35 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:bd96226234de4e21627b04208c7e537f prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:fe9517cb56f6cb1662031dc08caaf182
+niiri:8b7eb042176ff4b34dbab2133217acff
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0195" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -3244,9 +3244,9 @@ niiri:fe9517cb56f6cb1662031dc08caaf182
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "195"^^xsd:int .
 
-niiri:fe9517cb56f6cb1662031dc08caaf182 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:8b7eb042176ff4b34dbab2133217acff prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:50be4fbb838d8e155b244eced8a52d48
+niiri:74aa1acb0840e11af474625bf18a205b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0196" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -3256,9 +3256,9 @@ niiri:50be4fbb838d8e155b244eced8a52d48
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "196"^^xsd:int .
 
-niiri:50be4fbb838d8e155b244eced8a52d48 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:74aa1acb0840e11af474625bf18a205b prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:7625dcfd9f93b74584752753153c19ec
+niiri:1f8d909cef3803a0e6a8e31c86e2cb37
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0197" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -3268,9 +3268,9 @@ niiri:7625dcfd9f93b74584752753153c19ec
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "197"^^xsd:int .
 
-niiri:7625dcfd9f93b74584752753153c19ec prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:1f8d909cef3803a0e6a8e31c86e2cb37 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:1ac5aaf4d3242e8406a5e8348658d29b
+niiri:d1b86bb927184d1863bf16406cbb38ef
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0198" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -3280,9 +3280,9 @@ niiri:1ac5aaf4d3242e8406a5e8348658d29b
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "198"^^xsd:int .
 
-niiri:1ac5aaf4d3242e8406a5e8348658d29b prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:d1b86bb927184d1863bf16406cbb38ef prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:453feff4ca6cc36089bf9e9576cad723
+niiri:8681fd0b6a40a88059175d0b5804a743
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0199" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -3292,9 +3292,9 @@ niiri:453feff4ca6cc36089bf9e9576cad723
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "199"^^xsd:int .
 
-niiri:453feff4ca6cc36089bf9e9576cad723 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:8681fd0b6a40a88059175d0b5804a743 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:a36937f0bb3343166a85a624c7a5008c
+niiri:53d7d39a6b6a7a44a92c2cdc58facf3a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0200" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -3304,9 +3304,9 @@ niiri:a36937f0bb3343166a85a624c7a5008c
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "200"^^xsd:int .
 
-niiri:a36937f0bb3343166a85a624c7a5008c prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:53d7d39a6b6a7a44a92c2cdc58facf3a prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:9539fad3df2122c0c1d221ba62c93b1e
+niiri:b8f303a3f6e3ffbd2a86dd99d6d873fb
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0201" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -3316,9 +3316,9 @@ niiri:9539fad3df2122c0c1d221ba62c93b1e
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "201"^^xsd:int .
 
-niiri:9539fad3df2122c0c1d221ba62c93b1e prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:b8f303a3f6e3ffbd2a86dd99d6d873fb prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:0703f60bbede2cd4ff08171910c78742
+niiri:555db4d96064ec58a79e6099a79dd060
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0202" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -3328,9 +3328,9 @@ niiri:0703f60bbede2cd4ff08171910c78742
     nidm_qValueFDR: "0.552437898286094"^^xsd:float ;
     nidm_clusterLabelId: "202"^^xsd:int .
 
-niiri:0703f60bbede2cd4ff08171910c78742 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:555db4d96064ec58a79e6099a79dd060 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:2192d0176864a609d1f99aeb7606bb20
+niiri:df9fe6cd3c5bf212b4c85e3bd119959c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0203" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -3340,9 +3340,9 @@ niiri:2192d0176864a609d1f99aeb7606bb20
     nidm_qValueFDR: "0.529659882057015"^^xsd:float ;
     nidm_clusterLabelId: "203"^^xsd:int .
 
-niiri:2192d0176864a609d1f99aeb7606bb20 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:df9fe6cd3c5bf212b4c85e3bd119959c prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:c7815fda00367a584b0eaef5d2a3a8d3
+niiri:17f6f685daf3b085f3dac6c057c020c1
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0204" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -3352,9 +3352,9 @@ niiri:c7815fda00367a584b0eaef5d2a3a8d3
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "204"^^xsd:int .
 
-niiri:c7815fda00367a584b0eaef5d2a3a8d3 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:17f6f685daf3b085f3dac6c057c020c1 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:0298b7fe38f8161533f229d225028815
+niiri:c5cf9af3cc2424e4b8e65eb6049706ed
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0205" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -3364,9 +3364,9 @@ niiri:0298b7fe38f8161533f229d225028815
     nidm_qValueFDR: "0.552437898286094"^^xsd:float ;
     nidm_clusterLabelId: "205"^^xsd:int .
 
-niiri:0298b7fe38f8161533f229d225028815 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:c5cf9af3cc2424e4b8e65eb6049706ed prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:0c1cd6f0700636298b473906a5e51975
+niiri:24b677d8caebb84711be327c29be20b9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0206" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -3376,9 +3376,9 @@ niiri:0c1cd6f0700636298b473906a5e51975
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "206"^^xsd:int .
 
-niiri:0c1cd6f0700636298b473906a5e51975 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:24b677d8caebb84711be327c29be20b9 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:a6a6f1a505d5a404d9c028c325bee223
+niiri:c9997d6b8885703c61c50e9494f01f5b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0207" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -3388,9 +3388,9 @@ niiri:a6a6f1a505d5a404d9c028c325bee223
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "207"^^xsd:int .
 
-niiri:a6a6f1a505d5a404d9c028c325bee223 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:c9997d6b8885703c61c50e9494f01f5b prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:f5f7ac01c1435f2b1a5663ae0f9a4c7f
+niiri:18c389e9f560a707e21a88082c18399f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0208" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -3400,9 +3400,9 @@ niiri:f5f7ac01c1435f2b1a5663ae0f9a4c7f
     nidm_qValueFDR: "0.552437898286094"^^xsd:float ;
     nidm_clusterLabelId: "208"^^xsd:int .
 
-niiri:f5f7ac01c1435f2b1a5663ae0f9a4c7f prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:18c389e9f560a707e21a88082c18399f prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:ef1841157cd24be39b9b725e1c39ab72
+niiri:4f2617299971ce7d3a16c3c37b0badbd
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0209" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -3412,9 +3412,9 @@ niiri:ef1841157cd24be39b9b725e1c39ab72
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "209"^^xsd:int .
 
-niiri:ef1841157cd24be39b9b725e1c39ab72 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:4f2617299971ce7d3a16c3c37b0badbd prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:e4109f0f0f898a32d7f3ac2462582221
+niiri:7ab88d893988ef5840b83076dc34632a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0210" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -3424,9 +3424,9 @@ niiri:e4109f0f0f898a32d7f3ac2462582221
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "210"^^xsd:int .
 
-niiri:e4109f0f0f898a32d7f3ac2462582221 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:7ab88d893988ef5840b83076dc34632a prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:4525ab0c75413bf2c98a4586a5abcc36
+niiri:ad4b61cba6b4e1ac8b424d69a662357a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0211" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -3436,9 +3436,9 @@ niiri:4525ab0c75413bf2c98a4586a5abcc36
     nidm_qValueFDR: "0.552437898286094"^^xsd:float ;
     nidm_clusterLabelId: "211"^^xsd:int .
 
-niiri:4525ab0c75413bf2c98a4586a5abcc36 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:ad4b61cba6b4e1ac8b424d69a662357a prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:4eaf48754995dc5302632344b8135db1
+niiri:18172de66764cc046e57e3f71900f308
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0212" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -3448,9 +3448,9 @@ niiri:4eaf48754995dc5302632344b8135db1
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "212"^^xsd:int .
 
-niiri:4eaf48754995dc5302632344b8135db1 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:18172de66764cc046e57e3f71900f308 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:4424249ed6c1cf6688e8d9a01e38e149
+niiri:5b864821dad832cdea33cc2c71107b5d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0213" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -3460,9 +3460,9 @@ niiri:4424249ed6c1cf6688e8d9a01e38e149
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "213"^^xsd:int .
 
-niiri:4424249ed6c1cf6688e8d9a01e38e149 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:5b864821dad832cdea33cc2c71107b5d prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:a39115f19cda212439112978c2f429df
+niiri:54af2492a558bd6b541a83efffeacbc6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0214" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -3472,9 +3472,9 @@ niiri:a39115f19cda212439112978c2f429df
     nidm_qValueFDR: "0.552437898286094"^^xsd:float ;
     nidm_clusterLabelId: "214"^^xsd:int .
 
-niiri:a39115f19cda212439112978c2f429df prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:54af2492a558bd6b541a83efffeacbc6 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:d5f28f9ef79dc06baf5860f0239ca3e7
+niiri:4c87d31930bd2a3884bfbd054121e8ea
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0215" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -3484,9 +3484,9 @@ niiri:d5f28f9ef79dc06baf5860f0239ca3e7
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "215"^^xsd:int .
 
-niiri:d5f28f9ef79dc06baf5860f0239ca3e7 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:4c87d31930bd2a3884bfbd054121e8ea prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:5079e994cd9f24fc30fe92efa7493c57
+niiri:0c1ba90c913890f99f03e9c6732b7833
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0216" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -3496,9 +3496,9 @@ niiri:5079e994cd9f24fc30fe92efa7493c57
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "216"^^xsd:int .
 
-niiri:5079e994cd9f24fc30fe92efa7493c57 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:0c1ba90c913890f99f03e9c6732b7833 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:686ed6dbd2ea21d312152f2e4e96f435
+niiri:7e48fd00328505ec2f7c55286029038c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0217" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -3508,9 +3508,9 @@ niiri:686ed6dbd2ea21d312152f2e4e96f435
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "217"^^xsd:int .
 
-niiri:686ed6dbd2ea21d312152f2e4e96f435 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:7e48fd00328505ec2f7c55286029038c prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:91f65776f22ca4ee422c8dcd4c4c4459
+niiri:fe7b7aeb5b19bcdfb6ba3b9e7bbc0530
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0218" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -3520,9 +3520,9 @@ niiri:91f65776f22ca4ee422c8dcd4c4c4459
     nidm_qValueFDR: "0.552437898286094"^^xsd:float ;
     nidm_clusterLabelId: "218"^^xsd:int .
 
-niiri:91f65776f22ca4ee422c8dcd4c4c4459 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:fe7b7aeb5b19bcdfb6ba3b9e7bbc0530 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:4e1ee3ae277085cca25ed575c4d6c732
+niiri:2598e0a8af6b254c19ea1eae1c055e59
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0219" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -3532,9 +3532,9 @@ niiri:4e1ee3ae277085cca25ed575c4d6c732
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "219"^^xsd:int .
 
-niiri:4e1ee3ae277085cca25ed575c4d6c732 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:2598e0a8af6b254c19ea1eae1c055e59 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:21ba06ef00e16e74fa2aac38752b9ad5
+niiri:ef260aa5a1800f7a5b96c1d3f96edac0
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0220" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -3544,9 +3544,9 @@ niiri:21ba06ef00e16e74fa2aac38752b9ad5
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "220"^^xsd:int .
 
-niiri:21ba06ef00e16e74fa2aac38752b9ad5 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:ef260aa5a1800f7a5b96c1d3f96edac0 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:cb15ce5ea75dc27ee8c68d6f25317137
+niiri:9edfdd818d3f428259751e3a1f4426fa
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0221" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -3556,9 +3556,9 @@ niiri:cb15ce5ea75dc27ee8c68d6f25317137
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "221"^^xsd:int .
 
-niiri:cb15ce5ea75dc27ee8c68d6f25317137 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:9edfdd818d3f428259751e3a1f4426fa prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:9c56529ebb0bf4259a9c564b06624446
+niiri:1667cff121b7be39391cc74c4150a6e4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0222" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -3568,9 +3568,9 @@ niiri:9c56529ebb0bf4259a9c564b06624446
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "222"^^xsd:int .
 
-niiri:9c56529ebb0bf4259a9c564b06624446 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:1667cff121b7be39391cc74c4150a6e4 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:58cc34c1cf71d6fb92343373483bc627
+niiri:8a9dbe909430bab19de8984a30f0827c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0223" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -3580,9 +3580,9 @@ niiri:58cc34c1cf71d6fb92343373483bc627
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "223"^^xsd:int .
 
-niiri:58cc34c1cf71d6fb92343373483bc627 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:8a9dbe909430bab19de8984a30f0827c prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:ef7aa42532c9d5d3093cbb6f46af6456
+niiri:73e5d22f5e99f7222d046e5c8b8f17e5
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0224" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -3592,9 +3592,9 @@ niiri:ef7aa42532c9d5d3093cbb6f46af6456
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "224"^^xsd:int .
 
-niiri:ef7aa42532c9d5d3093cbb6f46af6456 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:73e5d22f5e99f7222d046e5c8b8f17e5 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:4948e1f6d55a77b68ff8403a3b1cc6a9
+niiri:8015064bc0743ed13468353e18ca0971
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0225" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -3604,9 +3604,9 @@ niiri:4948e1f6d55a77b68ff8403a3b1cc6a9
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "225"^^xsd:int .
 
-niiri:4948e1f6d55a77b68ff8403a3b1cc6a9 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:8015064bc0743ed13468353e18ca0971 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:d51ac19a940490ccb81c778042e6d07f
+niiri:eb612c2c1cebda064d6320c535f9294f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0226" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -3616,9 +3616,9 @@ niiri:d51ac19a940490ccb81c778042e6d07f
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "226"^^xsd:int .
 
-niiri:d51ac19a940490ccb81c778042e6d07f prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:eb612c2c1cebda064d6320c535f9294f prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:dd6abaee8e1238ee75ff4cc3940af16c
+niiri:6369784f4c4b56deb50440d6515b981e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0227" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -3628,9 +3628,9 @@ niiri:dd6abaee8e1238ee75ff4cc3940af16c
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "227"^^xsd:int .
 
-niiri:dd6abaee8e1238ee75ff4cc3940af16c prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:6369784f4c4b56deb50440d6515b981e prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:dec8b0ace647b4ba45c324b0822a7d07
+niiri:2147d82387f71f29a3d3dfb09b7b8d64
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0228" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -3640,9 +3640,9 @@ niiri:dec8b0ace647b4ba45c324b0822a7d07
     nidm_qValueFDR: "0.552437898286094"^^xsd:float ;
     nidm_clusterLabelId: "228"^^xsd:int .
 
-niiri:dec8b0ace647b4ba45c324b0822a7d07 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:2147d82387f71f29a3d3dfb09b7b8d64 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:e77710d04eb08640d5c1d3f18d42d3fa
+niiri:790465006aaf87ef2289ea019fdb0b83
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0229" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -3652,9 +3652,9 @@ niiri:e77710d04eb08640d5c1d3f18d42d3fa
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "229"^^xsd:int .
 
-niiri:e77710d04eb08640d5c1d3f18d42d3fa prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:790465006aaf87ef2289ea019fdb0b83 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:cce35d82d42e6ed7353ce989b716eb03
+niiri:730c6026b96772dd69384df78d1b3195
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0230" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -3664,9 +3664,9 @@ niiri:cce35d82d42e6ed7353ce989b716eb03
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "230"^^xsd:int .
 
-niiri:cce35d82d42e6ed7353ce989b716eb03 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:730c6026b96772dd69384df78d1b3195 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:34d4adf23d9292a19ec442ef839b2cff
+niiri:26bef1517140b96419bd96743968bf5a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0231" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -3676,9 +3676,9 @@ niiri:34d4adf23d9292a19ec442ef839b2cff
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "231"^^xsd:int .
 
-niiri:34d4adf23d9292a19ec442ef839b2cff prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:26bef1517140b96419bd96743968bf5a prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:bbd6c18fcbc3934b6a6db033becc5ed1
+niiri:c80e777eb02827978765763f51129026
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0232" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -3688,9 +3688,9 @@ niiri:bbd6c18fcbc3934b6a6db033becc5ed1
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "232"^^xsd:int .
 
-niiri:bbd6c18fcbc3934b6a6db033becc5ed1 prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:c80e777eb02827978765763f51129026 prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:88f0354a46364a076e3c319e275ba3dd
+niiri:6eb9789a31f1c0da3f5dc3fb64518f9e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0233" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -3700,4697 +3700,4697 @@ niiri:88f0354a46364a076e3c319e275ba3dd
     nidm_qValueFDR: "0.578685227694606"^^xsd:float ;
     nidm_clusterLabelId: "233"^^xsd:int .
 
-niiri:88f0354a46364a076e3c319e275ba3dd prov:wasDerivedFrom niiri:fec8545d1e39630ce18d7eddddd0aaa4 .
+niiri:6eb9789a31f1c0da3f5dc3fb64518f9e prov:wasDerivedFrom niiri:8c8ad5dc532e1fc2320f4c3356bdd145 .
 
-niiri:5c0c5cf6ffa6776f5d5c6bfcb665dd1e
+niiri:6375cbd08f405cfa4aa923cd73003620
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0001" ;
-    prov:atLocation niiri:cb3d5a3b64d7d0b319db57a508c6999d ;
+    prov:atLocation niiri:ce4a406feff03df1c1bc96f3bb8b1a6a ;
     prov:value "12.195366859436"^^xsd:float ;
     nidm_equivalentZStatistic: "6.97053078023572"^^xsd:float ;
     nidm_pValueUncorrected: "1.57873714101697e-12"^^xsd:float ;
     nidm_pValueFWER: "3.52098841860382e-07"^^xsd:float ;
     nidm_qValueFDR: "1.32821571221074e-05"^^xsd:float .
 
-niiri:cb3d5a3b64d7d0b319db57a508c6999d
+niiri:ce4a406feff03df1c1bc96f3bb8b1a6a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0001" ;
     nidm_coordinateVector: "[-12,-20,80]"^^xsd:string .
 
-niiri:5c0c5cf6ffa6776f5d5c6bfcb665dd1e prov:wasDerivedFrom niiri:ba835f71b6ca8a486d7c5f7379bd662f .
+niiri:6375cbd08f405cfa4aa923cd73003620 prov:wasDerivedFrom niiri:85fec2a2169d10c191c4e617a17cdba0 .
 
-niiri:63f85dd41ea53558df62bbac4b19011a
+niiri:f9affa16a68b7d08052caab897982f1e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0002" ;
-    prov:atLocation niiri:91a30c7c26a8209cc335eee3b9c316a1 ;
+    prov:atLocation niiri:948e4a7ef33c3baa7c4f2617243129ae ;
     prov:value "12.0285215377808"^^xsd:float ;
     nidm_equivalentZStatistic: "6.92667949448921"^^xsd:float ;
     nidm_pValueUncorrected: "2.15416573468019e-12"^^xsd:float ;
     nidm_pValueFWER: "4.80452217677119e-07"^^xsd:float ;
     nidm_qValueFDR: "1.32821571221074e-05"^^xsd:float .
 
-niiri:91a30c7c26a8209cc335eee3b9c316a1
+niiri:948e4a7ef33c3baa7c4f2617243129ae
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0002" ;
     nidm_coordinateVector: "[-2,48,28]"^^xsd:string .
 
-niiri:63f85dd41ea53558df62bbac4b19011a prov:wasDerivedFrom niiri:ba835f71b6ca8a486d7c5f7379bd662f .
+niiri:f9affa16a68b7d08052caab897982f1e prov:wasDerivedFrom niiri:85fec2a2169d10c191c4e617a17cdba0 .
 
-niiri:043b3733fcb562e9d588c9fd302ed9d0
+niiri:760b5861535d1b8d351a8ea1c8e8055e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0003" ;
-    prov:atLocation niiri:bd2cd838267a5f71e2ace6da2ab746f5 ;
+    prov:atLocation niiri:2981f98fafc6bbd2a22c1698fffaeee3 ;
     prov:value "11.1319952011108"^^xsd:float ;
     nidm_equivalentZStatistic: "6.68038320254177"^^xsd:float ;
     nidm_pValueUncorrected: "1.19159127009993e-11"^^xsd:float ;
     nidm_pValueFWER: "2.65787821074337e-06"^^xsd:float ;
     nidm_qValueFDR: "2.57057234849773e-05"^^xsd:float .
 
-niiri:bd2cd838267a5f71e2ace6da2ab746f5
+niiri:2981f98fafc6bbd2a22c1698fffaeee3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0003" ;
     nidm_coordinateVector: "[28,-82,-34]"^^xsd:string .
 
-niiri:043b3733fcb562e9d588c9fd302ed9d0 prov:wasDerivedFrom niiri:ba835f71b6ca8a486d7c5f7379bd662f .
+niiri:760b5861535d1b8d351a8ea1c8e8055e prov:wasDerivedFrom niiri:85fec2a2169d10c191c4e617a17cdba0 .
 
-niiri:a7cb6c5aa7c44e8e1412e7e097d894b0
+niiri:01d92dcf2decdbf979916bc117777a31
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0004" ;
-    prov:atLocation niiri:f85513c7e4de5695128e247715538d6e ;
+    prov:atLocation niiri:991de64484a40e2c43025eb986c3aeb0 ;
     prov:value "11.1767311096191"^^xsd:float ;
     nidm_equivalentZStatistic: "6.69312218368378"^^xsd:float ;
     nidm_pValueUncorrected: "1.09229292277746e-11"^^xsd:float ;
     nidm_pValueFWER: "2.43638629615628e-06"^^xsd:float ;
     nidm_qValueFDR: "2.57057234849773e-05"^^xsd:float .
 
-niiri:f85513c7e4de5695128e247715538d6e
+niiri:991de64484a40e2c43025eb986c3aeb0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0004" ;
     nidm_coordinateVector: "[16,-18,24]"^^xsd:string .
 
-niiri:a7cb6c5aa7c44e8e1412e7e097d894b0 prov:wasDerivedFrom niiri:887840e0df0dde27ca60bb3a5eed1fdb .
+niiri:01d92dcf2decdbf979916bc117777a31 prov:wasDerivedFrom niiri:1aa2c5542022d8edfbe6faaf12d4ebb7 .
 
-niiri:335d8ea52be5d20d7d7c4db4a1e9f490
+niiri:85893fd2a80f9cb9a50aeeaf16aa5be0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0005" ;
-    prov:atLocation niiri:0b3a3ff41571307909ae084a77734d61 ;
+    prov:atLocation niiri:50a673aee12d5977c697358610b82f93 ;
     prov:value "8.21963119506836"^^xsd:float ;
     nidm_equivalentZStatistic: "5.72404476343991"^^xsd:float ;
     nidm_pValueUncorrected: "5.20086618216453e-09"^^xsd:float ;
     nidm_pValueFWER: "0.00116008955846647"^^xsd:float ;
     nidm_qValueFDR: "0.000453192860238723"^^xsd:float .
 
-niiri:0b3a3ff41571307909ae084a77734d61
+niiri:50a673aee12d5977c697358610b82f93
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0005" ;
     nidm_coordinateVector: "[10,0,22]"^^xsd:string .
 
-niiri:335d8ea52be5d20d7d7c4db4a1e9f490 prov:wasDerivedFrom niiri:887840e0df0dde27ca60bb3a5eed1fdb .
+niiri:85893fd2a80f9cb9a50aeeaf16aa5be0 prov:wasDerivedFrom niiri:1aa2c5542022d8edfbe6faaf12d4ebb7 .
 
-niiri:31ea480a04178c3333f50a26da706158
+niiri:eb798644a33419afda56222bf6a4057c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0006" ;
-    prov:atLocation niiri:5b1ee14770955263f940e2b7de273b8d ;
+    prov:atLocation niiri:79715caa4b342489144deaf29cf8907b ;
     prov:value "7.89727067947388"^^xsd:float ;
     nidm_equivalentZStatistic: "5.59926411112285"^^xsd:float ;
     nidm_pValueUncorrected: "1.0763181346185e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00240080291677169"^^xsd:float ;
     nidm_qValueFDR: "0.000683233949888892"^^xsd:float .
 
-niiri:5b1ee14770955263f940e2b7de273b8d
+niiri:79715caa4b342489144deaf29cf8907b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0006" ;
     nidm_coordinateVector: "[18,-32,20]"^^xsd:string .
 
-niiri:31ea480a04178c3333f50a26da706158 prov:wasDerivedFrom niiri:887840e0df0dde27ca60bb3a5eed1fdb .
+niiri:eb798644a33419afda56222bf6a4057c prov:wasDerivedFrom niiri:1aa2c5542022d8edfbe6faaf12d4ebb7 .
 
-niiri:56e7922f255bf5d2132f359b9c588696
+niiri:8b04f6c0610c61ade2031f4e0e7fd687
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0007" ;
-    prov:atLocation niiri:e03f6d67aaf69387b86b6ab3759b5050 ;
+    prov:atLocation niiri:df7b218fff7e31a0a6a4a8706cdb282e ;
     prov:value "9.78486633300781"^^xsd:float ;
     nidm_equivalentZStatistic: "6.27176668468128"^^xsd:float ;
     nidm_pValueUncorrected: "1.7848711397761e-10"^^xsd:float ;
     nidm_pValueFWER: "3.98127506539003e-05"^^xsd:float ;
     nidm_qValueFDR: "6.33393663622056e-05"^^xsd:float .
 
-niiri:e03f6d67aaf69387b86b6ab3759b5050
+niiri:df7b218fff7e31a0a6a4a8706cdb282e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0007" ;
     nidm_coordinateVector: "[-36,46,-14]"^^xsd:string .
 
-niiri:56e7922f255bf5d2132f359b9c588696 prov:wasDerivedFrom niiri:14b137956e5e00ffd0fdc43f5c22f5c4 .
+niiri:8b04f6c0610c61ade2031f4e0e7fd687 prov:wasDerivedFrom niiri:f9d722fcce853c033260a3ae532235c1 .
 
-niiri:0c9f929cb0bda7f416c985174ac20abe
+niiri:8d815390449dd61ecf2635b2c7a5611c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0008" ;
-    prov:atLocation niiri:d1f7a38b1a290c6904abb4788697c9fb ;
+    prov:atLocation niiri:31d492f86d25c7bb3c9b9d2dae269db3 ;
     prov:value "8.99272632598877"^^xsd:float ;
     nidm_equivalentZStatistic: "6.00574234084408"^^xsd:float ;
     nidm_pValueUncorrected: "9.52292245059994e-10"^^xsd:float ;
     nidm_pValueFWER: "0.000212415401777744"^^xsd:float ;
     nidm_qValueFDR: "0.000159959987970191"^^xsd:float .
 
-niiri:d1f7a38b1a290c6904abb4788697c9fb
+niiri:31d492f86d25c7bb3c9b9d2dae269db3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0008" ;
     nidm_coordinateVector: "[-36,52,8]"^^xsd:string .
 
-niiri:0c9f929cb0bda7f416c985174ac20abe prov:wasDerivedFrom niiri:14b137956e5e00ffd0fdc43f5c22f5c4 .
+niiri:8d815390449dd61ecf2635b2c7a5611c prov:wasDerivedFrom niiri:f9d722fcce853c033260a3ae532235c1 .
 
-niiri:b95534360919178485fc50f77c7bd4da
+niiri:b2ac34a9e9c7de3ca84c442f813d01ef
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0009" ;
-    prov:atLocation niiri:2df5663e63cac7f2cb548fc9206a9dae ;
+    prov:atLocation niiri:a9d3837fe2e1545ff57eec0afa450f12 ;
     prov:value "8.32958316802979"^^xsd:float ;
     nidm_equivalentZStatistic: "5.76557366261307"^^xsd:float ;
     nidm_pValueUncorrected: "4.06902733729453e-09"^^xsd:float ;
     nidm_pValueFWER: "0.000907624981246302"^^xsd:float ;
     nidm_qValueFDR: "0.000384701368615494"^^xsd:float .
 
-niiri:2df5663e63cac7f2cb548fc9206a9dae
+niiri:a9d3837fe2e1545ff57eec0afa450f12
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0009" ;
     nidm_coordinateVector: "[-30,26,0]"^^xsd:string .
 
-niiri:b95534360919178485fc50f77c7bd4da prov:wasDerivedFrom niiri:14b137956e5e00ffd0fdc43f5c22f5c4 .
+niiri:b2ac34a9e9c7de3ca84c442f813d01ef prov:wasDerivedFrom niiri:f9d722fcce853c033260a3ae532235c1 .
 
-niiri:66811a129b32873beb2504cce8ad8717
+niiri:007c46c3626dce09d1207554312d2e9a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0010" ;
-    prov:atLocation niiri:92d2b37c2416217857129de0b058e63a ;
+    prov:atLocation niiri:8d8e9e0f9f2b81a67a6a5db0d0d20327 ;
     prov:value "7.92342185974121"^^xsd:float ;
     nidm_equivalentZStatistic: "5.60956000685145"^^xsd:float ;
     nidm_pValueUncorrected: "1.01420828402254e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00226226252256356"^^xsd:float ;
     nidm_qValueFDR: "0.000660665293349347"^^xsd:float .
 
-niiri:92d2b37c2416217857129de0b058e63a
+niiri:8d8e9e0f9f2b81a67a6a5db0d0d20327
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0010" ;
     nidm_coordinateVector: "[34,24,58]"^^xsd:string .
 
-niiri:66811a129b32873beb2504cce8ad8717 prov:wasDerivedFrom niiri:0549497fa62a1d5511dea65e5ef2cf1b .
+niiri:007c46c3626dce09d1207554312d2e9a prov:wasDerivedFrom niiri:73ec267aa6e4362aa22b8bf333d9a6f3 .
 
-niiri:df12430f8ed7eaeca494b008dc535752
+niiri:0f083958a49b6859e479679cb5c0b402
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0011" ;
-    prov:atLocation niiri:8e5b024ac3052224dc9ffa33ae7fade3 ;
+    prov:atLocation niiri:6d5d48b7c274665475b2ca71cbe88e23 ;
     prov:value "5.66889333724976"^^xsd:float ;
     nidm_equivalentZStatistic: "4.58322220042275"^^xsd:float ;
     nidm_pValueUncorrected: "2.28932521062486e-06"^^xsd:float ;
     nidm_pValueFWER: "0.405319777142171"^^xsd:float ;
     nidm_qValueFDR: "0.0228998003891751"^^xsd:float .
 
-niiri:8e5b024ac3052224dc9ffa33ae7fade3
+niiri:6d5d48b7c274665475b2ca71cbe88e23
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0011" ;
     nidm_coordinateVector: "[42,22,52]"^^xsd:string .
 
-niiri:df12430f8ed7eaeca494b008dc535752 prov:wasDerivedFrom niiri:0549497fa62a1d5511dea65e5ef2cf1b .
+niiri:0f083958a49b6859e479679cb5c0b402 prov:wasDerivedFrom niiri:73ec267aa6e4362aa22b8bf333d9a6f3 .
 
-niiri:f5c619ed9e6dd0204defbd4b15bc8109
+niiri:495925dd7a5c597e0b631259e27402bc
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0012" ;
-    prov:atLocation niiri:d188fd57db2ddba3a2a392b9f0d0cb74 ;
+    prov:atLocation niiri:95d95856a6aad86946eb9d81f7bf0673 ;
     prov:value "4.58756303787231"^^xsd:float ;
     nidm_equivalentZStatistic: "3.95550547589705"^^xsd:float ;
     nidm_pValueUncorrected: "3.81864993630465e-05"^^xsd:float ;
     nidm_pValueFWER: "0.996114645664071"^^xsd:float ;
     nidm_qValueFDR: "0.142799623959245"^^xsd:float .
 
-niiri:d188fd57db2ddba3a2a392b9f0d0cb74
+niiri:95d95856a6aad86946eb9d81f7bf0673
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0012" ;
     nidm_coordinateVector: "[30,18,48]"^^xsd:string .
 
-niiri:f5c619ed9e6dd0204defbd4b15bc8109 prov:wasDerivedFrom niiri:0549497fa62a1d5511dea65e5ef2cf1b .
+niiri:495925dd7a5c597e0b631259e27402bc prov:wasDerivedFrom niiri:73ec267aa6e4362aa22b8bf333d9a6f3 .
 
-niiri:fb6772cae4af8b4a38943fef6eee4a4f
+niiri:78d8a083c90c99f5fc07322a26f5cde9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0013" ;
-    prov:atLocation niiri:26e38f0ca58479e2d682d41398175b05 ;
+    prov:atLocation niiri:34d2ae37ad9642bcc041fa8361a900ea ;
     prov:value "7.39782667160034"^^xsd:float ;
     nidm_equivalentZStatistic: "5.39638585124024"^^xsd:float ;
     nidm_pValueUncorrected: "3.3998318493822e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00758356300256935"^^xsd:float ;
     nidm_qValueFDR: "0.00138047262763128"^^xsd:float .
 
-niiri:26e38f0ca58479e2d682d41398175b05
+niiri:34d2ae37ad9642bcc041fa8361a900ea
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0013" ;
     nidm_coordinateVector: "[-30,52,-44]"^^xsd:string .
 
-niiri:fb6772cae4af8b4a38943fef6eee4a4f prov:wasDerivedFrom niiri:3fbaffdfe735b9ae40c349431f693073 .
+niiri:78d8a083c90c99f5fc07322a26f5cde9 prov:wasDerivedFrom niiri:a78547a90624868c0aef3cebdd83d669 .
 
-niiri:c7940f154ecbf906db93616a70093838
+niiri:c53b99e7694641c31b95648ff991e8a5
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0014" ;
-    prov:atLocation niiri:8a7fa5f1b493388fdbb4584ea50c85e9 ;
+    prov:atLocation niiri:c234452f63bb3ac27195fdeb47ad40bf ;
     prov:value "7.36954021453857"^^xsd:float ;
     nidm_equivalentZStatistic: "5.38452514941599"^^xsd:float ;
     nidm_pValueUncorrected: "3.6318073992625e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00810100072963016"^^xsd:float ;
     nidm_qValueFDR: "0.00145261378503197"^^xsd:float .
 
-niiri:8a7fa5f1b493388fdbb4584ea50c85e9
+niiri:c234452f63bb3ac27195fdeb47ad40bf
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0014" ;
     nidm_coordinateVector: "[20,62,4]"^^xsd:string .
 
-niiri:c7940f154ecbf906db93616a70093838 prov:wasDerivedFrom niiri:6380e74b916ddbf1a024a72c065d623f .
+niiri:c53b99e7694641c31b95648ff991e8a5 prov:wasDerivedFrom niiri:940cf2d7b7d0eb179a5d87089cdef025 .
 
-niiri:e6113f1f4ded222b9b9bef4484db8a83
+niiri:b3b4ea8ddeb67b7b4031f94f6efe9a70
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0015" ;
-    prov:atLocation niiri:9caff916aa89e9fa97320bec7a7c2d3d ;
+    prov:atLocation niiri:7a54b5ab9f0eb5be2d355ab612b3e8dc ;
     prov:value "7.21618938446045"^^xsd:float ;
     nidm_equivalentZStatistic: "5.31949501913396"^^xsd:float ;
     nidm_pValueUncorrected: "5.20278310434108e-08"^^xsd:float ;
     nidm_pValueFWER: "0.0116051721566931"^^xsd:float ;
     nidm_qValueFDR: "0.00179005739670645"^^xsd:float .
 
-niiri:9caff916aa89e9fa97320bec7a7c2d3d
+niiri:7a54b5ab9f0eb5be2d355ab612b3e8dc
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0015" ;
     nidm_coordinateVector: "[52,-72,2]"^^xsd:string .
 
-niiri:e6113f1f4ded222b9b9bef4484db8a83 prov:wasDerivedFrom niiri:4cab3569c0af76ee151f4e707fdd3538 .
+niiri:b3b4ea8ddeb67b7b4031f94f6efe9a70 prov:wasDerivedFrom niiri:22f7499c81f2b4cfb5d9464b77334f85 .
 
-niiri:0c75a687b07e3c7153b0b87d7c9a4327
+niiri:61b0171a6b5389bc91ab6b1f988304af
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0016" ;
-    prov:atLocation niiri:f71c1df1bb3b72c456181bee0b8f6a08 ;
+    prov:atLocation niiri:210a02ccb07cf88b19c88732436048e4 ;
     prov:value "3.82430219650269"^^xsd:float ;
     nidm_equivalentZStatistic: "3.43170583345079"^^xsd:float ;
     nidm_pValueUncorrected: "0.000299898886572558"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999682"^^xsd:float ;
     nidm_qValueFDR: "0.500860780805665"^^xsd:float .
 
-niiri:f71c1df1bb3b72c456181bee0b8f6a08
+niiri:210a02ccb07cf88b19c88732436048e4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0016" ;
     nidm_coordinateVector: "[40,-72,0]"^^xsd:string .
 
-niiri:0c75a687b07e3c7153b0b87d7c9a4327 prov:wasDerivedFrom niiri:4cab3569c0af76ee151f4e707fdd3538 .
+niiri:61b0171a6b5389bc91ab6b1f988304af prov:wasDerivedFrom niiri:22f7499c81f2b4cfb5d9464b77334f85 .
 
-niiri:321e136dac6f6ac382096bc280a03820
+niiri:395843f5ca50db682d73ad4b552a0079
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0017" ;
-    prov:atLocation niiri:3dd0e206f22f076ea2fd011ec3a7a774 ;
+    prov:atLocation niiri:8cde37036aee8f9ea450e67d6b4737cf ;
     prov:value "7.19049739837646"^^xsd:float ;
     nidm_equivalentZStatistic: "5.30847761867744"^^xsd:float ;
     nidm_pValueUncorrected: "5.52723281588285e-08"^^xsd:float ;
     nidm_pValueFWER: "0.0123288799992954"^^xsd:float ;
     nidm_qValueFDR: "0.00187574777550428"^^xsd:float .
 
-niiri:3dd0e206f22f076ea2fd011ec3a7a774
+niiri:8cde37036aee8f9ea450e67d6b4737cf
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0017" ;
     nidm_coordinateVector: "[-40,-72,26]"^^xsd:string .
 
-niiri:321e136dac6f6ac382096bc280a03820 prov:wasDerivedFrom niiri:9a4cbf3c4b4b3511dfc9fd1435a8a28b .
+niiri:395843f5ca50db682d73ad4b552a0079 prov:wasDerivedFrom niiri:313e60cc130ee5f7b46b9a70c28c95a0 .
 
-niiri:f86e12cb13946301e2b16671980e7500
+niiri:c9497860d4fc106d2a8129f3a41c5e21
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0018" ;
-    prov:atLocation niiri:42057404ebcba19e98071b95ffa176ea ;
+    prov:atLocation niiri:3ed159a6a6e2cc0ca8d0aa8e7ada491e ;
     prov:value "6.70591068267822"^^xsd:float ;
     nidm_equivalentZStatistic: "5.09372181887081"^^xsd:float ;
     nidm_pValueUncorrected: "1.75550912029365e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0391578631772435"^^xsd:float ;
     nidm_qValueFDR: "0.00399264077980742"^^xsd:float .
 
-niiri:42057404ebcba19e98071b95ffa176ea
+niiri:3ed159a6a6e2cc0ca8d0aa8e7ada491e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0018" ;
     nidm_coordinateVector: "[-40,-86,14]"^^xsd:string .
 
-niiri:f86e12cb13946301e2b16671980e7500 prov:wasDerivedFrom niiri:9a4cbf3c4b4b3511dfc9fd1435a8a28b .
+niiri:c9497860d4fc106d2a8129f3a41c5e21 prov:wasDerivedFrom niiri:313e60cc130ee5f7b46b9a70c28c95a0 .
 
-niiri:287402136891386317b6f87e0a44e89d
+niiri:5ecb0bf5c97b7f24045a8880831fa426
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0019" ;
-    prov:atLocation niiri:0cf98f3330e4f9dd301c2b0197f4d9c0 ;
+    prov:atLocation niiri:81b9cf871bc6bec3e655da3ee187b454 ;
     prov:value "6.08404064178467"^^xsd:float ;
     nidm_equivalentZStatistic: "4.79678082629552"^^xsd:float ;
     nidm_pValueUncorrected: "8.06179272005991e-07"^^xsd:float ;
     nidm_pValueFWER: "0.179824002311423"^^xsd:float ;
     nidm_qValueFDR: "0.0113500948707688"^^xsd:float .
 
-niiri:0cf98f3330e4f9dd301c2b0197f4d9c0
+niiri:81b9cf871bc6bec3e655da3ee187b454
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0019" ;
     nidm_coordinateVector: "[-48,-60,30]"^^xsd:string .
 
-niiri:287402136891386317b6f87e0a44e89d prov:wasDerivedFrom niiri:9a4cbf3c4b4b3511dfc9fd1435a8a28b .
+niiri:5ecb0bf5c97b7f24045a8880831fa426 prov:wasDerivedFrom niiri:313e60cc130ee5f7b46b9a70c28c95a0 .
 
-niiri:aaf51ee731a9babf836bcdfda837d8d0
+niiri:d36f5f82de4a3b0715a81212cca9c290
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0020" ;
-    prov:atLocation niiri:80673cb23b518aa4ccec855e14143052 ;
+    prov:atLocation niiri:c6a5ddbf6aa7d460ec508fd316db2784 ;
     prov:value "6.76158666610718"^^xsd:float ;
     nidm_equivalentZStatistic: "5.1190933210259"^^xsd:float ;
     nidm_pValueUncorrected: "1.53504013944428e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0342401474138896"^^xsd:float ;
     nidm_qValueFDR: "0.0036643210853873"^^xsd:float .
 
-niiri:80673cb23b518aa4ccec855e14143052
+niiri:c6a5ddbf6aa7d460ec508fd316db2784
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0020" ;
     nidm_coordinateVector: "[-28,60,8]"^^xsd:string .
 
-niiri:aaf51ee731a9babf836bcdfda837d8d0 prov:wasDerivedFrom niiri:c8ec1ca234b9bf8d2809bf619534b056 .
+niiri:d36f5f82de4a3b0715a81212cca9c290 prov:wasDerivedFrom niiri:5755c7b6f3b8bb9a495a80e69a7ab94e .
 
-niiri:d5585e5d68779ecc1ab83b84159e3fec
+niiri:e00bf7ebffe936d438f170dfbba1c2bf
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0021" ;
-    prov:atLocation niiri:5afc2361eccb1b40a736066c043f264b ;
+    prov:atLocation niiri:837aa2fe6f0b45ab2a10036c63a7f241 ;
     prov:value "4.00573968887329"^^xsd:float ;
     nidm_equivalentZStatistic: "3.56362489977281"^^xsd:float ;
     nidm_pValueUncorrected: "0.000182884266391126"^^xsd:float ;
     nidm_pValueFWER: "0.999999996836787"^^xsd:float ;
     nidm_qValueFDR: "0.371800092457092"^^xsd:float .
 
-niiri:5afc2361eccb1b40a736066c043f264b
+niiri:837aa2fe6f0b45ab2a10036c63a7f241
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0021" ;
     nidm_coordinateVector: "[-22,54,4]"^^xsd:string .
 
-niiri:d5585e5d68779ecc1ab83b84159e3fec prov:wasDerivedFrom niiri:c8ec1ca234b9bf8d2809bf619534b056 .
+niiri:e00bf7ebffe936d438f170dfbba1c2bf prov:wasDerivedFrom niiri:5755c7b6f3b8bb9a495a80e69a7ab94e .
 
-niiri:c713fd7a7f587cba755142fa7241d988
+niiri:44b0e53d8cb7cd288c880c38c3120379
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0022" ;
-    prov:atLocation niiri:a3909652f4fd7511ddc3e9a198e184d8 ;
+    prov:atLocation niiri:3cec1451f5427e2546489737253c024b ;
     prov:value "6.5752739906311"^^xsd:float ;
     nidm_equivalentZStatistic: "5.03344180146668"^^xsd:float ;
     nidm_pValueUncorrected: "2.40875558610298e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0537289858908915"^^xsd:float ;
     nidm_qValueFDR: "0.00495708453245008"^^xsd:float .
 
-niiri:a3909652f4fd7511ddc3e9a198e184d8
+niiri:3cec1451f5427e2546489737253c024b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0022" ;
     nidm_coordinateVector: "[60,-54,18]"^^xsd:string .
 
-niiri:c713fd7a7f587cba755142fa7241d988 prov:wasDerivedFrom niiri:1b47349b306df45c874f7c947b149652 .
+niiri:44b0e53d8cb7cd288c880c38c3120379 prov:wasDerivedFrom niiri:23f5c60185b27f2be0dd455c41c3fde3 .
 
-niiri:239a985d1cb8543140006f195c647529
+niiri:ac8f339519721b314dfbcb54584abed9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0023" ;
-    prov:atLocation niiri:1916113714afbab2779bc8a84e11182b ;
+    prov:atLocation niiri:78a873ea8d79ec4f3f6fe4d0cab6817d ;
     prov:value "6.51905012130737"^^xsd:float ;
     nidm_equivalentZStatistic: "5.00716804962526"^^xsd:float ;
     nidm_pValueUncorrected: "2.76183492853299e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0616046698347695"^^xsd:float ;
     nidm_qValueFDR: "0.00529817216776537"^^xsd:float .
 
-niiri:1916113714afbab2779bc8a84e11182b
+niiri:78a873ea8d79ec4f3f6fe4d0cab6817d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0023" ;
     nidm_coordinateVector: "[0,-22,-20]"^^xsd:string .
 
-niiri:239a985d1cb8543140006f195c647529 prov:wasDerivedFrom niiri:c4b71b38ef4c3be049827afa9e8143bc .
+niiri:ac8f339519721b314dfbcb54584abed9 prov:wasDerivedFrom niiri:33cca310ebec4700e45b0560235f03cd .
 
-niiri:b39a8730b974d3d418866558a505f890
+niiri:6614974273127e7f54c4cba899f3eab6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0024" ;
-    prov:atLocation niiri:dc3c1d39354b031307bce5f1134c7020 ;
+    prov:atLocation niiri:333c34b3d2f8aaf1993c6b604235f256 ;
     prov:value "6.48744344711304"^^xsd:float ;
     nidm_equivalentZStatistic: "4.99230910659331"^^xsd:float ;
     nidm_pValueUncorrected: "2.98308350576981e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0665397756356061"^^xsd:float ;
     nidm_qValueFDR: "0.00561544623172705"^^xsd:float .
 
-niiri:dc3c1d39354b031307bce5f1134c7020
+niiri:333c34b3d2f8aaf1993c6b604235f256
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0024" ;
     nidm_coordinateVector: "[10,-30,-36]"^^xsd:string .
 
-niiri:b39a8730b974d3d418866558a505f890 prov:wasDerivedFrom niiri:c4b71b38ef4c3be049827afa9e8143bc .
+niiri:6614974273127e7f54c4cba899f3eab6 prov:wasDerivedFrom niiri:33cca310ebec4700e45b0560235f03cd .
 
-niiri:bfab7cd9c76924ed918dc2594d430185
+niiri:c742243cf82a89d57a67528234343c14
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0025" ;
-    prov:atLocation niiri:8197277fb6c32f0ca5bb1556d1e0b520 ;
+    prov:atLocation niiri:97130dd3e85c7fe87b1fd88f3a5aca5b ;
     prov:value "5.05579805374146"^^xsd:float ;
     nidm_equivalentZStatistic: "4.24143816665454"^^xsd:float ;
     nidm_pValueUncorrected: "1.11046039252827e-05"^^xsd:float ;
     nidm_pValueFWER: "0.863212474362956"^^xsd:float ;
     nidm_qValueFDR: "0.06785188529979"^^xsd:float .
 
-niiri:8197277fb6c32f0ca5bb1556d1e0b520
+niiri:97130dd3e85c7fe87b1fd88f3a5aca5b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0025" ;
     nidm_coordinateVector: "[-10,-24,-18]"^^xsd:string .
 
-niiri:bfab7cd9c76924ed918dc2594d430185 prov:wasDerivedFrom niiri:c4b71b38ef4c3be049827afa9e8143bc .
+niiri:c742243cf82a89d57a67528234343c14 prov:wasDerivedFrom niiri:33cca310ebec4700e45b0560235f03cd .
 
-niiri:53f49ba357cbeee85f0a61174bddd487
+niiri:ef6c96561d3475ee3682ddd186166797
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0026" ;
-    prov:atLocation niiri:f423394a04ebdebfb2028e8f9b17d928 ;
+    prov:atLocation niiri:d05de1a91aa11cafd11ee52e4c03f599 ;
     prov:value "6.43919801712036"^^xsd:float ;
     nidm_equivalentZStatistic: "4.96950298960416"^^xsd:float ;
     nidm_pValueUncorrected: "3.35623679514896e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0748632235875265"^^xsd:float ;
     nidm_qValueFDR: "0.00602839301790402"^^xsd:float .
 
-niiri:f423394a04ebdebfb2028e8f9b17d928
+niiri:d05de1a91aa11cafd11ee52e4c03f599
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0026" ;
     nidm_coordinateVector: "[32,38,50]"^^xsd:string .
 
-niiri:53f49ba357cbeee85f0a61174bddd487 prov:wasDerivedFrom niiri:3e28cae2b2981677b6365484975e315d .
+niiri:ef6c96561d3475ee3682ddd186166797 prov:wasDerivedFrom niiri:68605e1a07366f1a9aaae9f04eb3bbcf .
 
-niiri:7ba2af05d5e9e578cccafc1483313e5d
+niiri:9f24a0581a298125f2f285b756d18966
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0027" ;
-    prov:atLocation niiri:34bd4a587ba081babf303862fb8f698b ;
+    prov:atLocation niiri:e0fd94a7bd3607684a684406ed869b37 ;
     prov:value "4.89343357086182"^^xsd:float ;
     nidm_equivalentZStatistic: "4.14494916695648"^^xsd:float ;
     nidm_pValueUncorrected: "1.69944550607593e-05"^^xsd:float ;
     nidm_pValueFWER: "0.941605195071017"^^xsd:float ;
     nidm_qValueFDR: "0.0877947883186739"^^xsd:float .
 
-niiri:34bd4a587ba081babf303862fb8f698b
+niiri:e0fd94a7bd3607684a684406ed869b37
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0027" ;
     nidm_coordinateVector: "[38,36,44]"^^xsd:string .
 
-niiri:7ba2af05d5e9e578cccafc1483313e5d prov:wasDerivedFrom niiri:3e28cae2b2981677b6365484975e315d .
+niiri:9f24a0581a298125f2f285b756d18966 prov:wasDerivedFrom niiri:68605e1a07366f1a9aaae9f04eb3bbcf .
 
-niiri:5452eb6143fd236e41565163ab9cab9b
+niiri:9c2ce6348aeb7ede7a631d7c312619e2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0028" ;
-    prov:atLocation niiri:2c879e07b9a014e64f418264d4cd2b4b ;
+    prov:atLocation niiri:ad04211aace9e5e98ebb27cbef6f70cf ;
     prov:value "3.84852504730225"^^xsd:float ;
     nidm_equivalentZStatistic: "3.44961290393203"^^xsd:float ;
     nidm_pValueUncorrected: "0.000280695459907387"^^xsd:float ;
     nidm_pValueFWER: "0.999999999998663"^^xsd:float ;
     nidm_qValueFDR: "0.483436985514074"^^xsd:float .
 
-niiri:2c879e07b9a014e64f418264d4cd2b4b
+niiri:ad04211aace9e5e98ebb27cbef6f70cf
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0028" ;
     nidm_coordinateVector: "[28,48,42]"^^xsd:string .
 
-niiri:5452eb6143fd236e41565163ab9cab9b prov:wasDerivedFrom niiri:3e28cae2b2981677b6365484975e315d .
+niiri:9c2ce6348aeb7ede7a631d7c312619e2 prov:wasDerivedFrom niiri:68605e1a07366f1a9aaae9f04eb3bbcf .
 
-niiri:7b039d9637d091dc6000d12a8a71393d
+niiri:f71d38ee9ef7cc1c310f15620e0322f1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0029" ;
-    prov:atLocation niiri:d8e96f4e78306b64f2369e65ebafa356 ;
+    prov:atLocation niiri:bd832f486ff152b465d631cc0a7e77e4 ;
     prov:value "6.41994762420654"^^xsd:float ;
     nidm_equivalentZStatistic: "4.96036060921301"^^xsd:float ;
     nidm_pValueUncorrected: "3.51812182386446e-07"^^xsd:float ;
     nidm_pValueFWER: "0.078474183710761"^^xsd:float ;
     nidm_qValueFDR: "0.00622569915917693"^^xsd:float .
 
-niiri:d8e96f4e78306b64f2369e65ebafa356
+niiri:bd832f486ff152b465d631cc0a7e77e4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0029" ;
     nidm_coordinateVector: "[-50,26,32]"^^xsd:string .
 
-niiri:7b039d9637d091dc6000d12a8a71393d prov:wasDerivedFrom niiri:f362fb2acc0fecc902d53e2682b7f919 .
+niiri:f71d38ee9ef7cc1c310f15620e0322f1 prov:wasDerivedFrom niiri:ab91ba995acbb604c8550a19c6d56878 .
 
-niiri:e1eec2c9ab22a771157b63f96f4e3648
+niiri:bcb9b4ab7230df4bb758bc460b37e486
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0030" ;
-    prov:atLocation niiri:1a34585964e4aaa6e9b5c0537b167afa ;
+    prov:atLocation niiri:ef55d50c8d316e7518f786ea262cdb42 ;
     prov:value "4.49974060058594"^^xsd:float ;
     nidm_equivalentZStatistic: "3.89913272010445"^^xsd:float ;
     nidm_pValueUncorrected: "4.82689255971724e-05"^^xsd:float ;
     nidm_pValueFWER: "0.998798077640618"^^xsd:float ;
     nidm_qValueFDR: "0.163634540984241"^^xsd:float .
 
-niiri:1a34585964e4aaa6e9b5c0537b167afa
+niiri:ef55d50c8d316e7518f786ea262cdb42
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0030" ;
     nidm_coordinateVector: "[-40,22,36]"^^xsd:string .
 
-niiri:e1eec2c9ab22a771157b63f96f4e3648 prov:wasDerivedFrom niiri:f362fb2acc0fecc902d53e2682b7f919 .
+niiri:bcb9b4ab7230df4bb758bc460b37e486 prov:wasDerivedFrom niiri:ab91ba995acbb604c8550a19c6d56878 .
 
-niiri:e747655ed61c067dcc187b824030be00
+niiri:0524275a9408ea6e1dc8e1d6c4ce5393
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0031" ;
-    prov:atLocation niiri:ac00c2bb2f5a70ea6b4a186793a8bf03 ;
+    prov:atLocation niiri:cd88feb0442eabffbada9c5ef879e111 ;
     prov:value "4.05374956130981"^^xsd:float ;
     nidm_equivalentZStatistic: "3.59770236066326"^^xsd:float ;
     nidm_pValueUncorrected: "0.000160520349498539"^^xsd:float ;
     nidm_pValueFWER: "0.999999978604915"^^xsd:float ;
     nidm_qValueFDR: "0.342543683213877"^^xsd:float .
 
-niiri:ac00c2bb2f5a70ea6b4a186793a8bf03
+niiri:cd88feb0442eabffbada9c5ef879e111
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0031" ;
     nidm_coordinateVector: "[-42,32,42]"^^xsd:string .
 
-niiri:e747655ed61c067dcc187b824030be00 prov:wasDerivedFrom niiri:f362fb2acc0fecc902d53e2682b7f919 .
+niiri:0524275a9408ea6e1dc8e1d6c4ce5393 prov:wasDerivedFrom niiri:ab91ba995acbb604c8550a19c6d56878 .
 
-niiri:f9a205dcd7cddda455c20d193be8f9a1
+niiri:1c7d7853345eae89866ead4836881a90
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0032" ;
-    prov:atLocation niiri:ed84b842109dd31c89ba5074de99ffda ;
+    prov:atLocation niiri:c4b770507a4d7626f6271474d76c97b2 ;
     prov:value "6.25023365020752"^^xsd:float ;
     nidm_equivalentZStatistic: "4.87868788208187"^^xsd:float ;
     nidm_pValueUncorrected: "5.339695245965e-07"^^xsd:float ;
     nidm_pValueFWER: "0.119105671995756"^^xsd:float ;
     nidm_qValueFDR: "0.00839771733178921"^^xsd:float .
 
-niiri:ed84b842109dd31c89ba5074de99ffda
+niiri:c4b770507a4d7626f6271474d76c97b2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0032" ;
     nidm_coordinateVector: "[52,-6,-34]"^^xsd:string .
 
-niiri:f9a205dcd7cddda455c20d193be8f9a1 prov:wasDerivedFrom niiri:f20977e52a75b5fa007a387cc6824614 .
+niiri:1c7d7853345eae89866ead4836881a90 prov:wasDerivedFrom niiri:8ddb469ed3d8d13f9f3b41143b2bc54e .
 
-niiri:618cb5bac8ece1d66da8a6ea46d30c75
+niiri:1ed918e3e6e487b700b47936095209c4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0033" ;
-    prov:atLocation niiri:24a8a59b616d44392b530e6b1da0fce3 ;
+    prov:atLocation niiri:ae31349ed28884159eb4d5d66d33e3e3 ;
     prov:value "6.18567895889282"^^xsd:float ;
     nidm_equivalentZStatistic: "4.84710419253793"^^xsd:float ;
     nidm_pValueUncorrected: "6.26383204971326e-07"^^xsd:float ;
     nidm_pValueFWER: "0.139719202260282"^^xsd:float ;
     nidm_qValueFDR: "0.00953069985592431"^^xsd:float .
 
-niiri:24a8a59b616d44392b530e6b1da0fce3
+niiri:ae31349ed28884159eb4d5d66d33e3e3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0033" ;
     nidm_coordinateVector: "[-4,-46,-52]"^^xsd:string .
 
-niiri:618cb5bac8ece1d66da8a6ea46d30c75 prov:wasDerivedFrom niiri:27140d3dcc60dbdda794838cc4910ac1 .
+niiri:1ed918e3e6e487b700b47936095209c4 prov:wasDerivedFrom niiri:fe3d995dc2bfdeb5f29182f0558560a6 .
 
-niiri:1810e8b3f7e7bb68b4fd9164eee54e41
+niiri:837348f6ba9eea5a44579dfe608168d9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0034" ;
-    prov:atLocation niiri:5208b01a8c2a9ecc7648b9ea277e99fc ;
+    prov:atLocation niiri:ef98480f2fd69f2c61f22a53502771c8 ;
     prov:value "3.76085114479065"^^xsd:float ;
     nidm_equivalentZStatistic: "3.38435212152789"^^xsd:float ;
     nidm_pValueUncorrected: "0.00035673219891208"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999995"^^xsd:float ;
     nidm_qValueFDR: "0.549736132547086"^^xsd:float .
 
-niiri:5208b01a8c2a9ecc7648b9ea277e99fc
+niiri:ef98480f2fd69f2c61f22a53502771c8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0034" ;
     nidm_coordinateVector: "[2,-40,-56]"^^xsd:string .
 
-niiri:1810e8b3f7e7bb68b4fd9164eee54e41 prov:wasDerivedFrom niiri:27140d3dcc60dbdda794838cc4910ac1 .
+niiri:837348f6ba9eea5a44579dfe608168d9 prov:wasDerivedFrom niiri:fe3d995dc2bfdeb5f29182f0558560a6 .
 
-niiri:88759cfcfb7edbbfa0e528b9a0d1ccf9
+niiri:fe8cde79b36b2168ffe3f9627203cbad
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0035" ;
-    prov:atLocation niiri:bb8e7291db54bb637d362bda5237f841 ;
+    prov:atLocation niiri:aa376e8ac8714d8b18eae18d6a4283b5 ;
     prov:value "6.11011409759521"^^xsd:float ;
     nidm_equivalentZStatistic: "4.80976084297033"^^xsd:float ;
     nidm_pValueUncorrected: "7.55554926290536e-07"^^xsd:float ;
     nidm_pValueFWER: "0.168531878813079"^^xsd:float ;
     nidm_qValueFDR: "0.0108578016540005"^^xsd:float .
 
-niiri:bb8e7291db54bb637d362bda5237f841
+niiri:aa376e8ac8714d8b18eae18d6a4283b5
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0035" ;
     nidm_coordinateVector: "[-16,-22,24]"^^xsd:string .
 
-niiri:88759cfcfb7edbbfa0e528b9a0d1ccf9 prov:wasDerivedFrom niiri:292c1d14e546541ab02c17303b03d0d1 .
+niiri:fe8cde79b36b2168ffe3f9627203cbad prov:wasDerivedFrom niiri:cfbb41a715a689539e32d23fa5ecf0ad .
 
-niiri:434621bd13567d9a2c5fd1d79530ac72
+niiri:d013871b13a39a72c56c973d8d7c69ea
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0036" ;
-    prov:atLocation niiri:55ed9d66b9acb7e80a3a7daeb1566934 ;
+    prov:atLocation niiri:a0b4f6af10f809dffb754718d563928f ;
     prov:value "4.73779535293579"^^xsd:float ;
     nidm_equivalentZStatistic: "4.04985330158103"^^xsd:float ;
     nidm_pValueUncorrected: "2.56248750450938e-05"^^xsd:float ;
     nidm_pValueFWER: "0.981601010330499"^^xsd:float ;
     nidm_qValueFDR: "0.113611991025762"^^xsd:float .
 
-niiri:55ed9d66b9acb7e80a3a7daeb1566934
+niiri:a0b4f6af10f809dffb754718d563928f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0036" ;
     nidm_coordinateVector: "[-16,-12,22]"^^xsd:string .
 
-niiri:434621bd13567d9a2c5fd1d79530ac72 prov:wasDerivedFrom niiri:292c1d14e546541ab02c17303b03d0d1 .
+niiri:d013871b13a39a72c56c973d8d7c69ea prov:wasDerivedFrom niiri:cfbb41a715a689539e32d23fa5ecf0ad .
 
-niiri:f8d8c714270ee525d22b4519d40c655c
+niiri:4edccd0555b06c37550a7a304066b78e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0037" ;
-    prov:atLocation niiri:b1f69678ec21b54e036ca349f7c9fef8 ;
+    prov:atLocation niiri:0199c0fccb5983aad9bd979030e607bb ;
     prov:value "3.99648928642273"^^xsd:float ;
     nidm_equivalentZStatistic: "3.55702003485366"^^xsd:float ;
     nidm_pValueUncorrected: "0.000187542779954697"^^xsd:float ;
     nidm_pValueFWER: "0.999999997859921"^^xsd:float ;
     nidm_qValueFDR: "0.376379972172505"^^xsd:float .
 
-niiri:b1f69678ec21b54e036ca349f7c9fef8
+niiri:0199c0fccb5983aad9bd979030e607bb
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0037" ;
     nidm_coordinateVector: "[-12,0,12]"^^xsd:string .
 
-niiri:f8d8c714270ee525d22b4519d40c655c prov:wasDerivedFrom niiri:292c1d14e546541ab02c17303b03d0d1 .
+niiri:4edccd0555b06c37550a7a304066b78e prov:wasDerivedFrom niiri:cfbb41a715a689539e32d23fa5ecf0ad .
 
-niiri:b3925f274a8e224e7e058e06bbbb5536
+niiri:937b4c105cb8dab064d0662d01153915
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0038" ;
-    prov:atLocation niiri:287f19134cc5d5770e57e4075b079a00 ;
+    prov:atLocation niiri:ec598d9792349b28137d53c0e27bdcc9 ;
     prov:value "6.04269409179688"^^xsd:float ;
     nidm_equivalentZStatistic: "4.77609641444734"^^xsd:float ;
     nidm_pValueUncorrected: "8.9365362176963e-07"^^xsd:float ;
     nidm_pValueFWER: "0.199335784938733"^^xsd:float ;
     nidm_qValueFDR: "0.0122656272857256"^^xsd:float .
 
-niiri:287f19134cc5d5770e57e4075b079a00
+niiri:ec598d9792349b28137d53c0e27bdcc9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0038" ;
     nidm_coordinateVector: "[60,-26,-26]"^^xsd:string .
 
-niiri:b3925f274a8e224e7e058e06bbbb5536 prov:wasDerivedFrom niiri:3d59b7c113f7b19df2458e17b2f822e9 .
+niiri:937b4c105cb8dab064d0662d01153915 prov:wasDerivedFrom niiri:1ea775914efd19bdf7935c45c2fc61d7 .
 
-niiri:ff174d7c6db7e32869e0a99f614e8289
+niiri:5ef928ba0042c21ed23333a93026c5a5
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0039" ;
-    prov:atLocation niiri:5d0da4517d62b229280cd6b0d4d6e34e ;
+    prov:atLocation niiri:8d5aa4270374437a601d634b8fcd9627 ;
     prov:value "5.89026117324829"^^xsd:float ;
     nidm_equivalentZStatistic: "4.69874511544533"^^xsd:float ;
     nidm_pValueUncorrected: "1.3088244658066e-06"^^xsd:float ;
     nidm_pValueFWER: "0.274583699216449"^^xsd:float ;
     nidm_qValueFDR: "0.0161783507049903"^^xsd:float .
 
-niiri:5d0da4517d62b229280cd6b0d4d6e34e
+niiri:8d5aa4270374437a601d634b8fcd9627
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0039" ;
     nidm_coordinateVector: "[-28,-58,-58]"^^xsd:string .
 
-niiri:ff174d7c6db7e32869e0a99f614e8289 prov:wasDerivedFrom niiri:444ae882759bc4fc11d5ae4c9e6cb1e1 .
+niiri:5ef928ba0042c21ed23333a93026c5a5 prov:wasDerivedFrom niiri:c9c2075e31233972320b91bbe319e15d .
 
-niiri:95f6abe9a06f549319a6f783851d4741
+niiri:3b48cac23fce59fddaa73fd59df07df2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0040" ;
-    prov:atLocation niiri:b992b62e7d34f8d6d167804ed9010892 ;
+    prov:atLocation niiri:e622a01f345c7734af0c378f60d34ee8 ;
     prov:value "5.82566070556641"^^xsd:float ;
     nidm_equivalentZStatistic: "4.6654316334069"^^xsd:float ;
     nidm_pValueUncorrected: "1.5398494003227e-06"^^xsd:float ;
     nidm_pValueFWER: "0.308848975990721"^^xsd:float ;
     nidm_qValueFDR: "0.0177557080539423"^^xsd:float .
 
-niiri:b992b62e7d34f8d6d167804ed9010892
+niiri:e622a01f345c7734af0c378f60d34ee8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0040" ;
     nidm_coordinateVector: "[-48,8,-34]"^^xsd:string .
 
-niiri:95f6abe9a06f549319a6f783851d4741 prov:wasDerivedFrom niiri:59566dcbed59d8991aa0141444f7d8ea .
+niiri:3b48cac23fce59fddaa73fd59df07df2 prov:wasDerivedFrom niiri:184504b2959cc0300f56dbed9be3df0a .
 
-niiri:1cd030f56932f43287bc263768741843
+niiri:91271dfe97a1459e04ef73790c14a894
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0041" ;
-    prov:atLocation niiri:e0590c1970f672da2d3ed4d649408a02 ;
+    prov:atLocation niiri:666e30cb3b16d69e841f24335d524041 ;
     prov:value "5.81330108642578"^^xsd:float ;
     nidm_equivalentZStatistic: "4.65902103562978"^^xsd:float ;
     nidm_pValueUncorrected: "1.58858368881631e-06"^^xsd:float ;
     nidm_pValueFWER: "0.315770599808423"^^xsd:float ;
     nidm_qValueFDR: "0.0181106043668944"^^xsd:float .
 
-niiri:e0590c1970f672da2d3ed4d649408a02
+niiri:666e30cb3b16d69e841f24335d524041
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0041" ;
     nidm_coordinateVector: "[42,-62,30]"^^xsd:string .
 
-niiri:1cd030f56932f43287bc263768741843 prov:wasDerivedFrom niiri:2b54a24f6a0f9527c8816d93199577eb .
+niiri:91271dfe97a1459e04ef73790c14a894 prov:wasDerivedFrom niiri:e56b27d2108b9aebc19f9ff56ac97dce .
 
-niiri:2316dc76081bf4b6ff88390be287a132
+niiri:bd1b4d2f824f4a7a06cbe3b08d77df91
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0042" ;
-    prov:atLocation niiri:7f4f6eb0725a3a678b5a07c736d94088 ;
+    prov:atLocation niiri:305ee930a25a4859579df48853fbc995 ;
     prov:value "5.74564361572266"^^xsd:float ;
     nidm_equivalentZStatistic: "4.62371573654215"^^xsd:float ;
     nidm_pValueUncorrected: "1.8846316389709e-06"^^xsd:float ;
     nidm_pValueFWER: "0.355751628578317"^^xsd:float ;
     nidm_qValueFDR: "0.0201990755486958"^^xsd:float .
 
-niiri:7f4f6eb0725a3a678b5a07c736d94088
+niiri:305ee930a25a4859579df48853fbc995
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0042" ;
     nidm_coordinateVector: "[-66,-34,6]"^^xsd:string .
 
-niiri:2316dc76081bf4b6ff88390be287a132 prov:wasDerivedFrom niiri:678898fc201808d0072b6bbbea15acd2 .
+niiri:bd1b4d2f824f4a7a06cbe3b08d77df91 prov:wasDerivedFrom niiri:e78e0827b0a80cf9fb06ff0a74ee9600 .
 
-niiri:ecd8db6806e25d3beb542ce98d7ffd31
+niiri:d1e90a72a70964a43504b62fa88ceb97
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0043" ;
-    prov:atLocation niiri:67e74bebb3aef324bdfbb1927c4102ab ;
+    prov:atLocation niiri:7a6d9d5ba64d3a00dfc724e8fda92efd ;
     prov:value "5.72459840774536"^^xsd:float ;
     nidm_equivalentZStatistic: "4.61265957667344"^^xsd:float ;
     nidm_pValueUncorrected: "1.98774558690662e-06"^^xsd:float ;
     nidm_pValueFWER: "0.368904498827799"^^xsd:float ;
     nidm_qValueFDR: "0.0207237790143809"^^xsd:float .
 
-niiri:67e74bebb3aef324bdfbb1927c4102ab
+niiri:7a6d9d5ba64d3a00dfc724e8fda92efd
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0043" ;
     nidm_coordinateVector: "[36,-10,-30]"^^xsd:string .
 
-niiri:ecd8db6806e25d3beb542ce98d7ffd31 prov:wasDerivedFrom niiri:5a11d9bb922c3f53cb59978d26e7d5b0 .
+niiri:d1e90a72a70964a43504b62fa88ceb97 prov:wasDerivedFrom niiri:461b922ff7bd3d15d33f54bcbd492da3 .
 
-niiri:c1eb9061ff68199e554a258e7d2b3eba
+niiri:e777d8426ec1922a9300b8c510619da9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0044" ;
-    prov:atLocation niiri:76ece82011b84afeaa2a5a7ab1a920e2 ;
+    prov:atLocation niiri:23b0f724f37361cf3634731181e5dc78 ;
     prov:value "5.54388046264648"^^xsd:float ;
     nidm_equivalentZStatistic: "4.51622836043788"^^xsd:float ;
     nidm_pValueUncorrected: "3.14753889907315e-06"^^xsd:float ;
     nidm_pValueFWER: "0.494815113923139"^^xsd:float ;
     nidm_qValueFDR: "0.0284655212355184"^^xsd:float .
 
-niiri:76ece82011b84afeaa2a5a7ab1a920e2
+niiri:23b0f724f37361cf3634731181e5dc78
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0044" ;
     nidm_coordinateVector: "[30,-8,-36]"^^xsd:string .
 
-niiri:c1eb9061ff68199e554a258e7d2b3eba prov:wasDerivedFrom niiri:5a11d9bb922c3f53cb59978d26e7d5b0 .
+niiri:e777d8426ec1922a9300b8c510619da9 prov:wasDerivedFrom niiri:461b922ff7bd3d15d33f54bcbd492da3 .
 
-niiri:c631dd7b156f3726c21b6d299ced2524
+niiri:87ad6041e36ec3077cd5b4ed5e1e763f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0045" ;
-    prov:atLocation niiri:b4729d5f2dbaa1349314ed4fd23e3d51 ;
+    prov:atLocation niiri:3e3954b4c6a217ea807c8782412311d6 ;
     prov:value "5.70221662521362"^^xsd:float ;
     nidm_equivalentZStatistic: "4.60086214528593"^^xsd:float ;
     nidm_pValueUncorrected: "2.10372912945456e-06"^^xsd:float ;
     nidm_pValueFWER: "0.38325974300236"^^xsd:float ;
     nidm_qValueFDR: "0.0216156089926179"^^xsd:float .
 
-niiri:b4729d5f2dbaa1349314ed4fd23e3d51
+niiri:3e3954b4c6a217ea807c8782412311d6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0045" ;
     nidm_coordinateVector: "[20,-12,-32]"^^xsd:string .
 
-niiri:c631dd7b156f3726c21b6d299ced2524 prov:wasDerivedFrom niiri:64a43fe12cd19a1e197d1e7627a3bda5 .
+niiri:87ad6041e36ec3077cd5b4ed5e1e763f prov:wasDerivedFrom niiri:1cfc9f0a458d8852ad0759c9e8be8a6a .
 
-niiri:3aad84992ebacde3d10bfadda38ecb1b
+niiri:40a241f7cfcef8552dfd5aadd9a4fbf1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0046" ;
-    prov:atLocation niiri:22be3a17e239ca461f954ab69657d740 ;
+    prov:atLocation niiri:02ae91295919dd56e833cd7a1878872d ;
     prov:value "5.64641094207764"^^xsd:float ;
     nidm_equivalentZStatistic: "4.57126970388676"^^xsd:float ;
     nidm_pValueUncorrected: "2.42388931537274e-06"^^xsd:float ;
     nidm_pValueFWER: "0.420654930029894"^^xsd:float ;
     nidm_qValueFDR: "0.0237830877156679"^^xsd:float .
 
-niiri:22be3a17e239ca461f954ab69657d740
+niiri:02ae91295919dd56e833cd7a1878872d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0046" ;
     nidm_coordinateVector: "[-18,40,-18]"^^xsd:string .
 
-niiri:3aad84992ebacde3d10bfadda38ecb1b prov:wasDerivedFrom niiri:df9def02f0fbb31e7bb7de54da832bdb .
+niiri:40a241f7cfcef8552dfd5aadd9a4fbf1 prov:wasDerivedFrom niiri:5bbe3c6a1630a3c2cc55aa12dfd9e286 .
 
-niiri:23f0c7d741cd7bdec521d4d47f46057c
+niiri:8454ccb4e839a31841899dbcc90d3705
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0047" ;
-    prov:atLocation niiri:b72f4dabd901390b9eb5c1e2d7942d1e ;
+    prov:atLocation niiri:c1b0358ca9a48ab3254cdf0336ad4a33 ;
     prov:value "5.51601076126099"^^xsd:float ;
     nidm_equivalentZStatistic: "4.50111380137384"^^xsd:float ;
     nidm_pValueUncorrected: "3.37991495569234e-06"^^xsd:float ;
     nidm_pValueFWER: "0.516023728324697"^^xsd:float ;
     nidm_qValueFDR: "0.0299758857250781"^^xsd:float .
 
-niiri:b72f4dabd901390b9eb5c1e2d7942d1e
+niiri:c1b0358ca9a48ab3254cdf0336ad4a33
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0047" ;
     nidm_coordinateVector: "[-64,-22,18]"^^xsd:string .
 
-niiri:23f0c7d741cd7bdec521d4d47f46057c prov:wasDerivedFrom niiri:49955533f78bc4787cee05a051461dcf .
+niiri:8454ccb4e839a31841899dbcc90d3705 prov:wasDerivedFrom niiri:1e1925d1a7237f41c7f4bbc7a938991e .
 
-niiri:e19773c350b50b7d8a3b47d9447196f0
+niiri:25112a96f0a534131b06def72c92db36
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0048" ;
-    prov:atLocation niiri:57c89bd677e305f56190bb3e4f5f0746 ;
+    prov:atLocation niiri:a8ffc84bd049668e67aacf1f8dd72e50 ;
     prov:value "3.82918906211853"^^xsd:float ;
     nidm_equivalentZStatistic: "3.43532602661172"^^xsd:float ;
     nidm_pValueUncorrected: "0.000295920667697569"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999572"^^xsd:float ;
     nidm_qValueFDR: "0.497645692606821"^^xsd:float .
 
-niiri:57c89bd677e305f56190bb3e4f5f0746
+niiri:a8ffc84bd049668e67aacf1f8dd72e50
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0048" ;
     nidm_coordinateVector: "[-66,-14,12]"^^xsd:string .
 
-niiri:e19773c350b50b7d8a3b47d9447196f0 prov:wasDerivedFrom niiri:49955533f78bc4787cee05a051461dcf .
+niiri:25112a96f0a534131b06def72c92db36 prov:wasDerivedFrom niiri:1e1925d1a7237f41c7f4bbc7a938991e .
 
-niiri:640f907d4e61a8f0b64c49cee18c2868
+niiri:ebbe77abb440c0b57b92a0f3181bf3ef
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0049" ;
-    prov:atLocation niiri:ab8587778455781253a54329b5806379 ;
+    prov:atLocation niiri:3157cc359f1512741beefb7f95680def ;
     prov:value "5.50570774078369"^^xsd:float ;
     nidm_equivalentZStatistic: "4.49550933866504"^^xsd:float ;
     nidm_pValueUncorrected: "3.47018059765336e-06"^^xsd:float ;
     nidm_pValueFWER: "0.523959489710639"^^xsd:float ;
     nidm_qValueFDR: "0.0302612822408903"^^xsd:float .
 
-niiri:ab8587778455781253a54329b5806379
+niiri:3157cc359f1512741beefb7f95680def
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0049" ;
     nidm_coordinateVector: "[-66,-48,6]"^^xsd:string .
 
-niiri:640f907d4e61a8f0b64c49cee18c2868 prov:wasDerivedFrom niiri:49c6aebff31b5e29c05f3709fd4ca0c7 .
+niiri:ebbe77abb440c0b57b92a0f3181bf3ef prov:wasDerivedFrom niiri:45311fe546d4fc676e17072f500c1575 .
 
-niiri:457d426bed2f68f96d1cc2ade09a557d
+niiri:622888501323beabd65ee1c12fd5258f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0050" ;
-    prov:atLocation niiri:65ad2c6de94a4d6574aad746874fefe6 ;
+    prov:atLocation niiri:fb270858fb08b357c3467e4870a4a457 ;
     prov:value "3.62412595748901"^^xsd:float ;
     nidm_equivalentZStatistic: "3.28004199841764"^^xsd:float ;
     nidm_pValueUncorrected: "0.00051895817294012"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.680244967613049"^^xsd:float .
 
-niiri:65ad2c6de94a4d6574aad746874fefe6
+niiri:fb270858fb08b357c3467e4870a4a457
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0050" ;
     nidm_coordinateVector: "[-62,-54,12]"^^xsd:string .
 
-niiri:457d426bed2f68f96d1cc2ade09a557d prov:wasDerivedFrom niiri:49c6aebff31b5e29c05f3709fd4ca0c7 .
+niiri:622888501323beabd65ee1c12fd5258f prov:wasDerivedFrom niiri:45311fe546d4fc676e17072f500c1575 .
 
-niiri:2485eb0ee3130f59d77b5ba61c12caa6
+niiri:2cc303fb0baeaaf69f5c83c6ace6046d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0051" ;
-    prov:atLocation niiri:49d9626964e1b0feb5d3db997a02912c ;
+    prov:atLocation niiri:607064945943841f97401329f5ca9097 ;
     prov:value "5.30499839782715"^^xsd:float ;
     nidm_equivalentZStatistic: "4.38447219630665"^^xsd:float ;
     nidm_pValueUncorrected: "5.81336653915354e-06"^^xsd:float ;
     nidm_pValueFWER: "0.683924483063057"^^xsd:float ;
     nidm_qValueFDR: "0.0434545575886298"^^xsd:float .
 
-niiri:49d9626964e1b0feb5d3db997a02912c
+niiri:607064945943841f97401329f5ca9097
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0051" ;
     nidm_coordinateVector: "[60,-24,12]"^^xsd:string .
 
-niiri:2485eb0ee3130f59d77b5ba61c12caa6 prov:wasDerivedFrom niiri:9315b753bce8ecc349364143d90f1ad9 .
+niiri:2cc303fb0baeaaf69f5c83c6ace6046d prov:wasDerivedFrom niiri:12134d971afb042d040aea6cecc0ebec .
 
-niiri:599c58cb1c715550934270309e5d92c4
+niiri:939c3046fadf99b92e995efdba77b780
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0052" ;
-    prov:atLocation niiri:a0c806bb16f366f2daaa00a3103409fd ;
+    prov:atLocation niiri:614cae25fc7f61eac2167c4d17908165 ;
     prov:value "4.79114770889282"^^xsd:float ;
     nidm_equivalentZStatistic: "4.08274799068102"^^xsd:float ;
     nidm_pValueUncorrected: "2.22531390113856e-05"^^xsd:float ;
     nidm_pValueFWER: "0.971408745964108"^^xsd:float ;
     nidm_qValueFDR: "0.103697297505344"^^xsd:float .
 
-niiri:a0c806bb16f366f2daaa00a3103409fd
+niiri:614cae25fc7f61eac2167c4d17908165
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0052" ;
     nidm_coordinateVector: "[52,-26,14]"^^xsd:string .
 
-niiri:599c58cb1c715550934270309e5d92c4 prov:wasDerivedFrom niiri:9315b753bce8ecc349364143d90f1ad9 .
+niiri:939c3046fadf99b92e995efdba77b780 prov:wasDerivedFrom niiri:12134d971afb042d040aea6cecc0ebec .
 
-niiri:487f02ddfb3f9e916ad2e5e486ad070e
+niiri:59954b6fbe4f7e0ee8297e3dfb447725
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0053" ;
-    prov:atLocation niiri:b51b562218e70b9f595fed09e9dfe68d ;
+    prov:atLocation niiri:e83fc68807e48503e867fd7c663330c0 ;
     prov:value "5.23910284042358"^^xsd:float ;
     nidm_equivalentZStatistic: "4.34722318758447"^^xsd:float ;
     nidm_pValueUncorrected: "6.89359534200573e-06"^^xsd:float ;
     nidm_pValueFWER: "0.735719811343891"^^xsd:float ;
     nidm_qValueFDR: "0.0492439815526957"^^xsd:float .
 
-niiri:b51b562218e70b9f595fed09e9dfe68d
+niiri:e83fc68807e48503e867fd7c663330c0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0053" ;
     nidm_coordinateVector: "[-6,-76,-44]"^^xsd:string .
 
-niiri:487f02ddfb3f9e916ad2e5e486ad070e prov:wasDerivedFrom niiri:c92570bdb9c49bf92cb00c5c23880685 .
+niiri:59954b6fbe4f7e0ee8297e3dfb447725 prov:wasDerivedFrom niiri:7dfc1da184d477320648da6e59dc2a7c .
 
-niiri:a789d5825fdbfdf588b010bc726bf710
+niiri:0d75e98dbb1ee49d43d97017b2bc924f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0054" ;
-    prov:atLocation niiri:77a56c3036c4e2f799d7939c9fdb2eb0 ;
+    prov:atLocation niiri:26be6593f3f57b0aed0ef977c3e0e360 ;
     prov:value "5.23777103424072"^^xsd:float ;
     nidm_equivalentZStatistic: "4.34646618864733"^^xsd:float ;
     nidm_pValueUncorrected: "6.91741829794701e-06"^^xsd:float ;
     nidm_pValueFWER: "0.736746205981572"^^xsd:float ;
     nidm_qValueFDR: "0.0492530384603998"^^xsd:float .
 
-niiri:77a56c3036c4e2f799d7939c9fdb2eb0
+niiri:26be6593f3f57b0aed0ef977c3e0e360
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0054" ;
     nidm_coordinateVector: "[-46,16,42]"^^xsd:string .
 
-niiri:a789d5825fdbfdf588b010bc726bf710 prov:wasDerivedFrom niiri:e491d13c4d524178ac2c358bfec8b0ab .
+niiri:0d75e98dbb1ee49d43d97017b2bc924f prov:wasDerivedFrom niiri:ff37e6b9b5486e16e27ae0fca1db545d .
 
-niiri:7574da76f3b81c35aa42c65a792b9e10
+niiri:60e306c02d06deb6b75ca415cf7afa84
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0055" ;
-    prov:atLocation niiri:1c0aecab207d856680c4d50f3ed33f2b ;
+    prov:atLocation niiri:a44a17f66a85b8599debb783042f342d ;
     prov:value "5.16541767120361"^^xsd:float ;
     nidm_equivalentZStatistic: "4.30508875032236"^^xsd:float ;
     nidm_pValueUncorrected: "8.34594019494261e-06"^^xsd:float ;
     nidm_pValueFWER: "0.79072771323468"^^xsd:float ;
     nidm_qValueFDR: "0.0554020873789584"^^xsd:float .
 
-niiri:1c0aecab207d856680c4d50f3ed33f2b
+niiri:a44a17f66a85b8599debb783042f342d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0055" ;
     nidm_coordinateVector: "[48,-16,14]"^^xsd:string .
 
-niiri:7574da76f3b81c35aa42c65a792b9e10 prov:wasDerivedFrom niiri:605ecba3a006393b32ebef7f5177a299 .
+niiri:60e306c02d06deb6b75ca415cf7afa84 prov:wasDerivedFrom niiri:bfb3c58b6c12062e86b12426bbf496d9 .
 
-niiri:032951392e18253dfc74a1d2b1c12f10
+niiri:70c48b68597d17a57d7df6777d571a0d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0056" ;
-    prov:atLocation niiri:e898e2d82d24df225f1127a92e31f65c ;
+    prov:atLocation niiri:63c92f8e694fff1184419aacd9378eaa ;
     prov:value "5.04228210449219"^^xsd:float ;
     nidm_equivalentZStatistic: "4.23350816985445"^^xsd:float ;
     nidm_pValueUncorrected: "1.1503691013437e-05"^^xsd:float ;
     nidm_pValueFWER: "0.871162148697437"^^xsd:float ;
     nidm_qValueFDR: "0.0694084780297125"^^xsd:float .
 
-niiri:e898e2d82d24df225f1127a92e31f65c
+niiri:63c92f8e694fff1184419aacd9378eaa
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0056" ;
     nidm_coordinateVector: "[56,-14,10]"^^xsd:string .
 
-niiri:032951392e18253dfc74a1d2b1c12f10 prov:wasDerivedFrom niiri:605ecba3a006393b32ebef7f5177a299 .
+niiri:70c48b68597d17a57d7df6777d571a0d prov:wasDerivedFrom niiri:bfb3c58b6c12062e86b12426bbf496d9 .
 
-niiri:520bcf676a06a4ca52471b03575e7a6b
+niiri:4febc9242872f447f9f0fb6d8187edd9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0057" ;
-    prov:atLocation niiri:4bda8b7619e4fc3b50623978723a468a ;
+    prov:atLocation niiri:9cc744b2ef0b321a73a7c3ffc643b63c ;
     prov:value "4.93621253967285"^^xsd:float ;
     nidm_equivalentZStatistic: "4.17063459410943"^^xsd:float ;
     nidm_pValueUncorrected: "1.51876293638109e-05"^^xsd:float ;
     nidm_pValueFWER: "0.924687668878693"^^xsd:float ;
     nidm_qValueFDR: "0.0829690614620754"^^xsd:float .
 
-niiri:4bda8b7619e4fc3b50623978723a468a
+niiri:9cc744b2ef0b321a73a7c3ffc643b63c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0057" ;
     nidm_coordinateVector: "[40,-12,14]"^^xsd:string .
 
-niiri:520bcf676a06a4ca52471b03575e7a6b prov:wasDerivedFrom niiri:605ecba3a006393b32ebef7f5177a299 .
+niiri:4febc9242872f447f9f0fb6d8187edd9 prov:wasDerivedFrom niiri:bfb3c58b6c12062e86b12426bbf496d9 .
 
-niiri:5825afe4f8d264d3a86abf8a8143bb86
+niiri:6309cc2f72b3ba21a56aceea534b259c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0058" ;
-    prov:atLocation niiri:2de1e40f79c81991b212d1351dd8c9ed ;
+    prov:atLocation niiri:16fe50f2d483d0250919ca566d224a60 ;
     prov:value "5.16341876983643"^^xsd:float ;
     nidm_equivalentZStatistic: "4.30393854152611"^^xsd:float ;
     nidm_pValueUncorrected: "8.38941134995164e-06"^^xsd:float ;
     nidm_pValueFWER: "0.792161008528185"^^xsd:float ;
     nidm_qValueFDR: "0.0554020873789584"^^xsd:float .
 
-niiri:2de1e40f79c81991b212d1351dd8c9ed
+niiri:16fe50f2d483d0250919ca566d224a60
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0058" ;
     nidm_coordinateVector: "[-28,6,62]"^^xsd:string .
 
-niiri:5825afe4f8d264d3a86abf8a8143bb86 prov:wasDerivedFrom niiri:792e740d5505df540f825e8630189126 .
+niiri:6309cc2f72b3ba21a56aceea534b259c prov:wasDerivedFrom niiri:b1059120ca68f8c294f13d22a334afc5 .
 
-niiri:8e9b9a00f7fe8891b1220f3ba0ae6380
+niiri:3af656624dd76ed9af5b633959de57aa
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0059" ;
-    prov:atLocation niiri:69e0772e7dad7498a8a5df57e5d5d24b ;
+    prov:atLocation niiri:2207a1786e7e1335381eca0ad553a27d ;
     prov:value "5.15367984771729"^^xsd:float ;
     nidm_equivalentZStatistic: "4.29832907222195"^^xsd:float ;
     nidm_pValueUncorrected: "8.60452684559032e-06"^^xsd:float ;
     nidm_pValueFWER: "0.799092501739318"^^xsd:float ;
     nidm_qValueFDR: "0.0561583848310698"^^xsd:float .
 
-niiri:69e0772e7dad7498a8a5df57e5d5d24b
+niiri:2207a1786e7e1335381eca0ad553a27d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0059" ;
     nidm_coordinateVector: "[-60,8,0]"^^xsd:string .
 
-niiri:8e9b9a00f7fe8891b1220f3ba0ae6380 prov:wasDerivedFrom niiri:5b18eef1ef74501ea55e4ac7f04163eb .
+niiri:3af656624dd76ed9af5b633959de57aa prov:wasDerivedFrom niiri:dd43f04c7775bf5d225a62b05a1f8275 .
 
-niiri:a669ed7f0ef590d607b0c01700cce297
+niiri:6a4d1d270484e6aaf38f13bdd3037234
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0060" ;
-    prov:atLocation niiri:0bb9b8c6033b015bb085e1cc50c5394d ;
+    prov:atLocation niiri:f9bd5a66fb8e6af654b99e17a2115983 ;
     prov:value "4.63001489639282"^^xsd:float ;
     nidm_equivalentZStatistic: "3.98242834282796"^^xsd:float ;
     nidm_pValueUncorrected: "3.41073475436104e-05"^^xsd:float ;
     nidm_pValueFWER: "0.993645272304345"^^xsd:float ;
     nidm_qValueFDR: "0.133707794797061"^^xsd:float .
 
-niiri:0bb9b8c6033b015bb085e1cc50c5394d
+niiri:f9bd5a66fb8e6af654b99e17a2115983
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0060" ;
     nidm_coordinateVector: "[-58,0,2]"^^xsd:string .
 
-niiri:a669ed7f0ef590d607b0c01700cce297 prov:wasDerivedFrom niiri:5b18eef1ef74501ea55e4ac7f04163eb .
+niiri:6a4d1d270484e6aaf38f13bdd3037234 prov:wasDerivedFrom niiri:dd43f04c7775bf5d225a62b05a1f8275 .
 
-niiri:a7eeea51c2bb4172feef3e0ba9a0d435
+niiri:c6fcc1f2ec131691f25f7ea0f2e12eb7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0061" ;
-    prov:atLocation niiri:f0e35547f105243131eff4949ac7ede8 ;
+    prov:atLocation niiri:d28f87df7e33ffced1cd1c65433f6dd9 ;
     prov:value "5.13582944869995"^^xsd:float ;
     nidm_equivalentZStatistic: "4.28802377033811"^^xsd:float ;
     nidm_pValueUncorrected: "9.01349028958887e-06"^^xsd:float ;
     nidm_pValueFWER: "0.811564040895531"^^xsd:float ;
     nidm_qValueFDR: "0.0582499630192324"^^xsd:float .
 
-niiri:f0e35547f105243131eff4949ac7ede8
+niiri:d28f87df7e33ffced1cd1c65433f6dd9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0061" ;
     nidm_coordinateVector: "[62,-4,-18]"^^xsd:string .
 
-niiri:a7eeea51c2bb4172feef3e0ba9a0d435 prov:wasDerivedFrom niiri:2a0d5cd5e741995710fe2bdd14adb005 .
+niiri:c6fcc1f2ec131691f25f7ea0f2e12eb7 prov:wasDerivedFrom niiri:c723d93708cb4dee84578d4dad2314df .
 
-niiri:7e4c23daaec9d9eb36d437eb5c9342e6
+niiri:b749f6df0e9c14d8711813f709744b7f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0062" ;
-    prov:atLocation niiri:83c77d8d93a7158eef0cf81da673f1a3 ;
+    prov:atLocation niiri:ffb706fd0bf0d0619cb3999481194ffb ;
     prov:value "5.06757831573486"^^xsd:float ;
     nidm_equivalentZStatistic: "4.24833497375142"^^xsd:float ;
     nidm_pValueUncorrected: "1.07682603029957e-05"^^xsd:float ;
     nidm_pValueFWER: "0.856090469899599"^^xsd:float ;
     nidm_qValueFDR: "0.0664563384555011"^^xsd:float .
 
-niiri:83c77d8d93a7158eef0cf81da673f1a3
+niiri:ffb706fd0bf0d0619cb3999481194ffb
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0062" ;
     nidm_coordinateVector: "[30,54,-44]"^^xsd:string .
 
-niiri:7e4c23daaec9d9eb36d437eb5c9342e6 prov:wasDerivedFrom niiri:adca675d0dc4660fb2170e6ead12a50a .
+niiri:b749f6df0e9c14d8711813f709744b7f prov:wasDerivedFrom niiri:d30171bbdc271c074a6050acb8a4d34e .
 
-niiri:a3660ec9bcd34f5cb6da9ae0b4066109
+niiri:31f45e8d9b10c8383ebb56334d2cd5f6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0063" ;
-    prov:atLocation niiri:9c631d906d5287aff564998ecc4f8cce ;
+    prov:atLocation niiri:eea3a5acdf27e2de2dab85015bbaea23 ;
     prov:value "5.02421474456787"^^xsd:float ;
     nidm_equivalentZStatistic: "4.2228792447941"^^xsd:float ;
     nidm_pValueUncorrected: "1.20600532134141e-05"^^xsd:float ;
     nidm_pValueFWER: "0.881407445915171"^^xsd:float ;
     nidm_qValueFDR: "0.071813553261658"^^xsd:float .
 
-niiri:9c631d906d5287aff564998ecc4f8cce
+niiri:eea3a5acdf27e2de2dab85015bbaea23
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0063" ;
     nidm_coordinateVector: "[-30,-16,-20]"^^xsd:string .
 
-niiri:a3660ec9bcd34f5cb6da9ae0b4066109 prov:wasDerivedFrom niiri:5e628c0b7abb6a720a8a91ae5f6c769c .
+niiri:31f45e8d9b10c8383ebb56334d2cd5f6 prov:wasDerivedFrom niiri:ea2ed9cc4d84a345a4920b11801993b3 .
 
-niiri:8a18e9844ab6e1afcb094f9b9fe9ade8
+niiri:daf29f6ab3520aed8f7ff3bc5e75f2ab
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0064" ;
-    prov:atLocation niiri:c7fdf91a09e1f605b6f0a86b17fb7ba2 ;
+    prov:atLocation niiri:7f8295ad4df78742c62a26488eb8fad3 ;
     prov:value "4.74015760421753"^^xsd:float ;
     nidm_equivalentZStatistic: "4.05131641531498"^^xsd:float ;
     nidm_pValueUncorrected: "2.54651392115335e-05"^^xsd:float ;
     nidm_pValueFWER: "0.981217661454756"^^xsd:float ;
     nidm_qValueFDR: "0.113611991025762"^^xsd:float .
 
-niiri:c7fdf91a09e1f605b6f0a86b17fb7ba2
+niiri:7f8295ad4df78742c62a26488eb8fad3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0064" ;
     nidm_coordinateVector: "[-22,-18,-20]"^^xsd:string .
 
-niiri:8a18e9844ab6e1afcb094f9b9fe9ade8 prov:wasDerivedFrom niiri:5e628c0b7abb6a720a8a91ae5f6c769c .
+niiri:daf29f6ab3520aed8f7ff3bc5e75f2ab prov:wasDerivedFrom niiri:ea2ed9cc4d84a345a4920b11801993b3 .
 
-niiri:d6c89785a0b95f8bffbed2ff4cb64851
+niiri:ad918640c79c32e0c9a09cfe39505035
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0065" ;
-    prov:atLocation niiri:97cf8d3c545623e4d9dd1de2c4904514 ;
+    prov:atLocation niiri:9b2d2ac968f225bd22ee939592ac64c4 ;
     prov:value "4.96017456054688"^^xsd:float ;
     nidm_equivalentZStatistic: "4.18493879672852"^^xsd:float ;
     nidm_pValueUncorrected: "1.42621472154492e-05"^^xsd:float ;
     nidm_pValueFWER: "0.914023389189348"^^xsd:float ;
     nidm_qValueFDR: "0.0802451723107542"^^xsd:float .
 
-niiri:97cf8d3c545623e4d9dd1de2c4904514
+niiri:9b2d2ac968f225bd22ee939592ac64c4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0065" ;
     nidm_coordinateVector: "[10,-24,16]"^^xsd:string .
 
-niiri:d6c89785a0b95f8bffbed2ff4cb64851 prov:wasDerivedFrom niiri:e8494b3e58d9094d2cc21652c223abe4 .
+niiri:ad918640c79c32e0c9a09cfe39505035 prov:wasDerivedFrom niiri:cf3d3e192bab8fb0febbddda2b472570 .
 
-niiri:39aea2637649c51f04ef88233664ec2c
+niiri:f84262ea494283ee11627a522f8067fc
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0066" ;
-    prov:atLocation niiri:25c72afe587c80bdc78a40751fe14148 ;
+    prov:atLocation niiri:a7010eb90cdca5180078541caabd7ee2 ;
     prov:value "4.94747877120972"^^xsd:float ;
     nidm_equivalentZStatistic: "4.17736739359608"^^xsd:float ;
     nidm_pValueUncorrected: "1.47451242935581e-05"^^xsd:float ;
     nidm_pValueFWER: "0.919779784602502"^^xsd:float ;
     nidm_qValueFDR: "0.0821139058098193"^^xsd:float .
 
-niiri:25c72afe587c80bdc78a40751fe14148
+niiri:a7010eb90cdca5180078541caabd7ee2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0066" ;
     nidm_coordinateVector: "[48,-72,-16]"^^xsd:string .
 
-niiri:39aea2637649c51f04ef88233664ec2c prov:wasDerivedFrom niiri:2a3839763db274e8b4cae9d895b6483d .
+niiri:f84262ea494283ee11627a522f8067fc prov:wasDerivedFrom niiri:a6ee0e116834a7cbcea03e95f20dae54 .
 
-niiri:d4f9b70d314c8c6f922cf7bd9fb1fe30
+niiri:65f0d327b04aadb8425ee54a012bfd51
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0067" ;
-    prov:atLocation niiri:ecb155ab41b55d6238b7afc06b2e2b26 ;
+    prov:atLocation niiri:86c99915fb4938033cef1f1c79f20f26 ;
     prov:value "4.93897771835327"^^xsd:float ;
     nidm_equivalentZStatistic: "4.17228830640617"^^xsd:float ;
     nidm_pValueUncorrected: "1.50777864580398e-05"^^xsd:float ;
     nidm_pValueFWER: "0.923500556854135"^^xsd:float ;
     nidm_qValueFDR: "0.0829347355349478"^^xsd:float .
 
-niiri:ecb155ab41b55d6238b7afc06b2e2b26
+niiri:86c99915fb4938033cef1f1c79f20f26
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0067" ;
     nidm_coordinateVector: "[-26,4,16]"^^xsd:string .
 
-niiri:d4f9b70d314c8c6f922cf7bd9fb1fe30 prov:wasDerivedFrom niiri:d2c4ecdb2f17a5fa414bc38579edb8f3 .
+niiri:65f0d327b04aadb8425ee54a012bfd51 prov:wasDerivedFrom niiri:e9b27c64b1591506ec57168d7dbf134f .
 
-niiri:b4d2481c57ef30b25fbeea3702d7b949
+niiri:135656545b11da25b3b9e5296a4c1583
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0068" ;
-    prov:atLocation niiri:e6a4cafa8e5684c22383551c2dbe5bdd ;
+    prov:atLocation niiri:124fd785f1011c77e93bf0bc0cda783f ;
     prov:value "4.91353464126587"^^xsd:float ;
     nidm_equivalentZStatistic: "4.15704210840336"^^xsd:float ;
     nidm_pValueUncorrected: "1.61197292659621e-05"^^xsd:float ;
     nidm_pValueFWER: "0.933994187279112"^^xsd:float ;
     nidm_qValueFDR: "0.0855746630008624"^^xsd:float .
 
-niiri:e6a4cafa8e5684c22383551c2dbe5bdd
+niiri:124fd785f1011c77e93bf0bc0cda783f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0068" ;
     nidm_coordinateVector: "[26,18,64]"^^xsd:string .
 
-niiri:b4d2481c57ef30b25fbeea3702d7b949 prov:wasDerivedFrom niiri:770d3b226608026413a9c2a34b0a1793 .
+niiri:135656545b11da25b3b9e5296a4c1583 prov:wasDerivedFrom niiri:35e614f307abb1c7215e649c0bbf0aa0 .
 
-niiri:0c29f95be682b4f5566f488c8cdf0854
+niiri:16a0de533a153793ccdac522009f77c2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0069" ;
-    prov:atLocation niiri:47021cde688fadb5d9941d8b66a02b77 ;
+    prov:atLocation niiri:a5edccaa1ee1e1a3cf37954dc584b2c1 ;
     prov:value "4.90734338760376"^^xsd:float ;
     nidm_equivalentZStatistic: "4.15332192293598"^^xsd:float ;
     nidm_pValueUncorrected: "1.63841617967231e-05"^^xsd:float ;
     nidm_pValueFWER: "0.936402129572896"^^xsd:float ;
     nidm_qValueFDR: "0.0863919526492905"^^xsd:float .
 
-niiri:47021cde688fadb5d9941d8b66a02b77
+niiri:a5edccaa1ee1e1a3cf37954dc584b2c1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0069" ;
     nidm_coordinateVector: "[0,-22,-54]"^^xsd:string .
 
-niiri:0c29f95be682b4f5566f488c8cdf0854 prov:wasDerivedFrom niiri:16b9e50b259cea22c334cdb43404b9b4 .
+niiri:16a0de533a153793ccdac522009f77c2 prov:wasDerivedFrom niiri:84661ae12e172546f496d4b26feacce8 .
 
-niiri:6538d60d100cfda9910f74b7a0eb57aa
+niiri:26852796b5d7ba6eb653315a8accd667
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0070" ;
-    prov:atLocation niiri:5e8c23f6e73edc168f9d581e8cd4eb29 ;
+    prov:atLocation niiri:27f8457a9b46baae1a37773f8f85876a ;
     prov:value "4.90487241744995"^^xsd:float ;
     nidm_equivalentZStatistic: "4.15183605169709"^^xsd:float ;
     nidm_pValueUncorrected: "1.64909255723211e-05"^^xsd:float ;
     nidm_pValueFWER: "0.937347294524692"^^xsd:float ;
     nidm_qValueFDR: "0.0866104581112591"^^xsd:float .
 
-niiri:5e8c23f6e73edc168f9d581e8cd4eb29
+niiri:27f8457a9b46baae1a37773f8f85876a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0070" ;
     nidm_coordinateVector: "[10,30,-6]"^^xsd:string .
 
-niiri:6538d60d100cfda9910f74b7a0eb57aa prov:wasDerivedFrom niiri:8d690e036ac0c4f773f14d063bc26982 .
+niiri:26852796b5d7ba6eb653315a8accd667 prov:wasDerivedFrom niiri:b3ab45e7aaebdd6d5415f3e8fb8365d3 .
 
-niiri:e3a4a5c00a5b127c22c7a90646c37e59
+niiri:645365b733aee62b96ed5d9eb97c872a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0071" ;
-    prov:atLocation niiri:552fdebe80de450291edea3e1259b2d9 ;
+    prov:atLocation niiri:61461b4cb693c67119ecef5cce38f06c ;
     prov:value "4.90001773834229"^^xsd:float ;
     nidm_equivalentZStatistic: "4.14891491710542"^^xsd:float ;
     nidm_pValueUncorrected: "1.67027465689529e-05"^^xsd:float ;
     nidm_pValueFWER: "0.939177943711304"^^xsd:float ;
     nidm_qValueFDR: "0.0873354556109577"^^xsd:float .
 
-niiri:552fdebe80de450291edea3e1259b2d9
+niiri:61461b4cb693c67119ecef5cce38f06c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0071" ;
     nidm_coordinateVector: "[28,-14,10]"^^xsd:string .
 
-niiri:e3a4a5c00a5b127c22c7a90646c37e59 prov:wasDerivedFrom niiri:871bd0030276be32c9682273d65be8a4 .
+niiri:645365b733aee62b96ed5d9eb97c872a prov:wasDerivedFrom niiri:a9dd639eb89226977a3ede42cafc093c .
 
-niiri:66599b6396ec5d3d776eea1f305bf4bf
+niiri:9a917736e3d5642e34dc1a8c05d59370
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0072" ;
-    prov:atLocation niiri:7bc7da5422c076be933244c4657cfdcb ;
+    prov:atLocation niiri:7024715a649a60cb4dc55a269c6a23a0 ;
     prov:value "4.8938684463501"^^xsd:float ;
     nidm_equivalentZStatistic: "4.14521124011164"^^xsd:float ;
     nidm_pValueUncorrected: "1.69750293880222e-05"^^xsd:float ;
     nidm_pValueFWER: "0.941446847291943"^^xsd:float ;
     nidm_qValueFDR: "0.0877947883186739"^^xsd:float .
 
-niiri:7bc7da5422c076be933244c4657cfdcb
+niiri:7024715a649a60cb4dc55a269c6a23a0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0072" ;
     nidm_coordinateVector: "[-50,-34,2]"^^xsd:string .
 
-niiri:66599b6396ec5d3d776eea1f305bf4bf prov:wasDerivedFrom niiri:fd8207df6ecd8a6e5899191a7d1b9cec .
+niiri:9a917736e3d5642e34dc1a8c05d59370 prov:wasDerivedFrom niiri:01b4ff55ed7965f77f28199c98d35002 .
 
-niiri:1b91ec1d915124abfb7102f075ee114f
+niiri:8e8f82ce9a9f916915f7207c051727bd
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0073" ;
-    prov:atLocation niiri:af0eca1f60ac2e58cb6fec62f9982c26 ;
+    prov:atLocation niiri:17584b61b2e1ba24747384b5df72b417 ;
     prov:value "4.71507501602173"^^xsd:float ;
     nidm_equivalentZStatistic: "4.03574917489321"^^xsd:float ;
     nidm_pValueUncorrected: "2.72141698914874e-05"^^xsd:float ;
     nidm_pValueFWER: "0.984994076694401"^^xsd:float ;
     nidm_qValueFDR: "0.117674394049896"^^xsd:float .
 
-niiri:af0eca1f60ac2e58cb6fec62f9982c26
+niiri:17584b61b2e1ba24747384b5df72b417
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0073" ;
     nidm_coordinateVector: "[-50,-44,-2]"^^xsd:string .
 
-niiri:1b91ec1d915124abfb7102f075ee114f prov:wasDerivedFrom niiri:fd8207df6ecd8a6e5899191a7d1b9cec .
+niiri:8e8f82ce9a9f916915f7207c051727bd prov:wasDerivedFrom niiri:01b4ff55ed7965f77f28199c98d35002 .
 
-niiri:8aa3b01ee444af495e69be10cbf53286
+niiri:a67831c35816df52629ee7a7fc26dde0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0074" ;
-    prov:atLocation niiri:60a7e5e2fff4cfad3b1011063fd34696 ;
+    prov:atLocation niiri:fa7748f42b4ea105392364e1f036194b ;
     prov:value "4.19112873077393"^^xsd:float ;
     nidm_equivalentZStatistic: "3.69339227166818"^^xsd:float ;
     nidm_pValueUncorrected: "0.000110641138199918"^^xsd:float ;
     nidm_pValueFWER: "0.999998036789566"^^xsd:float ;
     nidm_qValueFDR: "0.27646623644364"^^xsd:float .
 
-niiri:60a7e5e2fff4cfad3b1011063fd34696
+niiri:fa7748f42b4ea105392364e1f036194b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0074" ;
     nidm_coordinateVector: "[-44,-40,2]"^^xsd:string .
 
-niiri:8aa3b01ee444af495e69be10cbf53286 prov:wasDerivedFrom niiri:fd8207df6ecd8a6e5899191a7d1b9cec .
+niiri:a67831c35816df52629ee7a7fc26dde0 prov:wasDerivedFrom niiri:01b4ff55ed7965f77f28199c98d35002 .
 
-niiri:865e5d11fa910596d62e40eef5609628
+niiri:ec5b68946bd31e836ab65ff6af1c4a12
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0075" ;
-    prov:atLocation niiri:c5d99e9f2b535ec03ddcfcba79492a57 ;
+    prov:atLocation niiri:a8ceaa5e8f88a768a13627b2df8779f0 ;
     prov:value "4.8740234375"^^xsd:float ;
     nidm_equivalentZStatistic: "4.13323153375862"^^xsd:float ;
     nidm_pValueUncorrected: "1.78849030254558e-05"^^xsd:float ;
     nidm_pValueFWER: "0.948390984974567"^^xsd:float ;
     nidm_qValueFDR: "0.0906467281751595"^^xsd:float .
 
-niiri:c5d99e9f2b535ec03ddcfcba79492a57
+niiri:a8ceaa5e8f88a768a13627b2df8779f0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0075" ;
     nidm_coordinateVector: "[40,-58,-4]"^^xsd:string .
 
-niiri:865e5d11fa910596d62e40eef5609628 prov:wasDerivedFrom niiri:a16c4a98c7239f14c74af90c58802252 .
+niiri:ec5b68946bd31e836ab65ff6af1c4a12 prov:wasDerivedFrom niiri:f606725494013a6004aeb7f3234c5659 .
 
-niiri:bcad430042f16dff1ed83ae431c070f8
+niiri:75631318c3d0bd234d33224648039cef
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0076" ;
-    prov:atLocation niiri:cb75f4ff2f63215ca951256bcc00b832 ;
+    prov:atLocation niiri:f976f8e9ff5e60139441a829e8309f5c ;
     prov:value "4.85820341110229"^^xsd:float ;
     nidm_equivalentZStatistic: "4.12365167586169"^^xsd:float ;
     nidm_pValueUncorrected: "1.86456349975384e-05"^^xsd:float ;
     nidm_pValueFWER: "0.953518161280421"^^xsd:float ;
     nidm_qValueFDR: "0.0931417862836213"^^xsd:float .
 
-niiri:cb75f4ff2f63215ca951256bcc00b832
+niiri:f976f8e9ff5e60139441a829e8309f5c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0076" ;
     nidm_coordinateVector: "[-36,-10,10]"^^xsd:string .
 
-niiri:bcad430042f16dff1ed83ae431c070f8 prov:wasDerivedFrom niiri:beba83b8e0b597cc72900977cf176cf6 .
+niiri:75631318c3d0bd234d33224648039cef prov:wasDerivedFrom niiri:d70674f2ab25c84bf1ccbf050e157cb6 .
 
-niiri:fc8dc33bc5b91c4e94e461f6322f0c13
+niiri:5bdba307d61986d6149f72dba439105d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0077" ;
-    prov:atLocation niiri:9d9806f8b9a398fd82beb787328c55a5 ;
+    prov:atLocation niiri:e29c2a8f4f6a6f0797b978de28eba557 ;
     prov:value "4.84939575195312"^^xsd:float ;
     nidm_equivalentZStatistic: "4.11830662564564"^^xsd:float ;
     nidm_pValueUncorrected: "1.90833322246675e-05"^^xsd:float ;
     nidm_pValueFWER: "0.956218144422422"^^xsd:float ;
     nidm_qValueFDR: "0.094298931343831"^^xsd:float .
 
-niiri:9d9806f8b9a398fd82beb787328c55a5
+niiri:e29c2a8f4f6a6f0797b978de28eba557
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0077" ;
     nidm_coordinateVector: "[28,-94,12]"^^xsd:string .
 
-niiri:fc8dc33bc5b91c4e94e461f6322f0c13 prov:wasDerivedFrom niiri:2ea9c77f7d859bb390de800ff7c12bdd .
+niiri:5bdba307d61986d6149f72dba439105d prov:wasDerivedFrom niiri:d3a715b103390651d1c521ee09f466c0 .
 
-niiri:fc582bcab54e2cf79907d707a9f51f8b
+niiri:2024155e74ac1cefebed8ca6401c4774
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0078" ;
-    prov:atLocation niiri:5a86e856ce68104f53c7247952f527fe ;
+    prov:atLocation niiri:8ada6393b1a9a3f95ad2291994faec90 ;
     prov:value "4.84849166870117"^^xsd:float ;
     nidm_equivalentZStatistic: "4.11775750127654"^^xsd:float ;
     nidm_pValueUncorrected: "1.91288474941098e-05"^^xsd:float ;
     nidm_pValueFWER: "0.956489104833424"^^xsd:float ;
     nidm_qValueFDR: "0.094298931343831"^^xsd:float .
 
-niiri:5a86e856ce68104f53c7247952f527fe
+niiri:8ada6393b1a9a3f95ad2291994faec90
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0078" ;
     nidm_coordinateVector: "[-54,20,2]"^^xsd:string .
 
-niiri:fc582bcab54e2cf79907d707a9f51f8b prov:wasDerivedFrom niiri:667ab285deac3f27ecbbdbc71424991f .
+niiri:2024155e74ac1cefebed8ca6401c4774 prov:wasDerivedFrom niiri:3577f89d6cde1468b3bf7bab875643fa .
 
-niiri:8322def335da2dc4240f9ca8f3c7a08f
+niiri:d0fc86df54e53e74dd24a6a5984cb2c6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0079" ;
-    prov:atLocation niiri:171f4c43a47bbc3a756c4a635afbc53d ;
+    prov:atLocation niiri:9d85c6c90938d870289914c51cf481cb ;
     prov:value "4.84107542037964"^^xsd:float ;
     nidm_equivalentZStatistic: "4.11324969968147"^^xsd:float ;
     nidm_pValueUncorrected: "1.95064001932144e-05"^^xsd:float ;
     nidm_pValueFWER: "0.9586686962403"^^xsd:float ;
     nidm_qValueFDR: "0.0952087356620267"^^xsd:float .
 
-niiri:171f4c43a47bbc3a756c4a635afbc53d
+niiri:9d85c6c90938d870289914c51cf481cb
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0079" ;
     nidm_coordinateVector: "[-14,-102,16]"^^xsd:string .
 
-niiri:8322def335da2dc4240f9ca8f3c7a08f prov:wasDerivedFrom niiri:92c97d83326e6179be7fa554d9ed568a .
+niiri:d0fc86df54e53e74dd24a6a5984cb2c6 prov:wasDerivedFrom niiri:6b28309025a8c950f906f3a74a6104c4 .
 
-niiri:d34f512e7dd790b3abd0cc3ba064804d
+niiri:25187e17b37ef5575be4d5ced78392b0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0080" ;
-    prov:atLocation niiri:b3238f9ed6739c9e50ac5b7649903780 ;
+    prov:atLocation niiri:525dc2ad246a75dacc4a235e063563e7 ;
     prov:value "4.82058572769165"^^xsd:float ;
     nidm_equivalentZStatistic: "4.10076479505859"^^xsd:float ;
     nidm_pValueUncorrected: "2.05893469639173e-05"^^xsd:float ;
     nidm_pValueFWER: "0.964297185993396"^^xsd:float ;
     nidm_qValueFDR: "0.0988254126520163"^^xsd:float .
 
-niiri:b3238f9ed6739c9e50ac5b7649903780
+niiri:525dc2ad246a75dacc4a235e063563e7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0080" ;
     nidm_coordinateVector: "[-40,0,36]"^^xsd:string .
 
-niiri:d34f512e7dd790b3abd0cc3ba064804d prov:wasDerivedFrom niiri:e0f12d9993b033a238dd61773dca28e9 .
+niiri:25187e17b37ef5575be4d5ced78392b0 prov:wasDerivedFrom niiri:40f12e78ef285dbb693762e0e24f5a51 .
 
-niiri:eae613ff67937874de777c199fc0e712
+niiri:6b28b7892bbd80bbf1d73a494bd4d5f5
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0081" ;
-    prov:atLocation niiri:96fa4565771d09092e8365fbd19c3a42 ;
+    prov:atLocation niiri:7c073ea600f14fd4ea899167ad505fa8 ;
     prov:value "3.8377993106842"^^xsd:float ;
     nidm_equivalentZStatistic: "3.44169525159104"^^xsd:float ;
     nidm_pValueUncorrected: "0.0002890405543442"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999286"^^xsd:float ;
     nidm_qValueFDR: "0.489947318972906"^^xsd:float .
 
-niiri:96fa4565771d09092e8365fbd19c3a42
+niiri:7c073ea600f14fd4ea899167ad505fa8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0081" ;
     nidm_coordinateVector: "[-46,6,32]"^^xsd:string .
 
-niiri:eae613ff67937874de777c199fc0e712 prov:wasDerivedFrom niiri:e0f12d9993b033a238dd61773dca28e9 .
+niiri:6b28b7892bbd80bbf1d73a494bd4d5f5 prov:wasDerivedFrom niiri:40f12e78ef285dbb693762e0e24f5a51 .
 
-niiri:0c2d986077e4a5c4aa9243c25fe32a93
+niiri:deca705eeaa663fdf055aa9f356776a9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0082" ;
-    prov:atLocation niiri:a71770e9738ba7be97b5499c771ee18f ;
+    prov:atLocation niiri:6fb430ff22243bc9598fb0ac4aaf9c27 ;
     prov:value "4.80269765853882"^^xsd:float ;
     nidm_equivalentZStatistic: "4.08982806807398"^^xsd:float ;
     nidm_pValueUncorrected: "2.15846535014386e-05"^^xsd:float ;
     nidm_pValueFWER: "0.968751908822455"^^xsd:float ;
     nidm_qValueFDR: "0.101323968025976"^^xsd:float .
 
-niiri:a71770e9738ba7be97b5499c771ee18f
+niiri:6fb430ff22243bc9598fb0ac4aaf9c27
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0082" ;
     nidm_coordinateVector: "[-8,-2,-26]"^^xsd:string .
 
-niiri:0c2d986077e4a5c4aa9243c25fe32a93 prov:wasDerivedFrom niiri:3aa56bca1824bde9b5cb4c7830b65b84 .
+niiri:deca705eeaa663fdf055aa9f356776a9 prov:wasDerivedFrom niiri:708e2b5584c9334ba1cde9334d8aee40 .
 
-niiri:17f6b9ca0ecafb202e10381cdfc8d5c7
+niiri:d21f3565a424b86ffb29d622322bc1d3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0083" ;
-    prov:atLocation niiri:716a2e8bbf82fdbc3ed38760e208b812 ;
+    prov:atLocation niiri:8dccf601dcdbcf162697530c6196953f ;
     prov:value "4.7697925567627"^^xsd:float ;
     nidm_equivalentZStatistic: "4.06961897184955"^^xsd:float ;
     nidm_pValueUncorrected: "2.35450441299356e-05"^^xsd:float ;
     nidm_pValueFWER: "0.975886012613188"^^xsd:float ;
     nidm_qValueFDR: "0.107275411916197"^^xsd:float .
 
-niiri:716a2e8bbf82fdbc3ed38760e208b812
+niiri:8dccf601dcdbcf162697530c6196953f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0083" ;
     nidm_coordinateVector: "[-54,-14,44]"^^xsd:string .
 
-niiri:17f6b9ca0ecafb202e10381cdfc8d5c7 prov:wasDerivedFrom niiri:e6016935099bef709428b50f891e4418 .
+niiri:d21f3565a424b86ffb29d622322bc1d3 prov:wasDerivedFrom niiri:2ed437f95a18d4610e20aee5f5ca8ca1 .
 
-niiri:e6f78a3bf29d25e68f593050b5f02d21
+niiri:e161951a5e1072e332cd915c3b62c0f7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0084" ;
-    prov:atLocation niiri:5d633af9dca77359bea07159f4ee2500 ;
+    prov:atLocation niiri:5b9b9731572d08126d7aa3c59cec9305 ;
     prov:value "3.66720128059387"^^xsd:float ;
     nidm_equivalentZStatistic: "3.31324766391278"^^xsd:float ;
     nidm_pValueUncorrected: "0.000461096398393313"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.635496970778773"^^xsd:float .
 
-niiri:5d633af9dca77359bea07159f4ee2500
+niiri:5b9b9731572d08126d7aa3c59cec9305
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0084" ;
     nidm_coordinateVector: "[-46,-16,42]"^^xsd:string .
 
-niiri:e6f78a3bf29d25e68f593050b5f02d21 prov:wasDerivedFrom niiri:e6016935099bef709428b50f891e4418 .
+niiri:e161951a5e1072e332cd915c3b62c0f7 prov:wasDerivedFrom niiri:2ed437f95a18d4610e20aee5f5ca8ca1 .
 
-niiri:4fd872970ed44df708416742f907dd60
+niiri:2146b6f3997a0283631b40f42fa43d64
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0085" ;
-    prov:atLocation niiri:ac6e1aa6b3c9b2ffafefc7993bbdb3d5 ;
+    prov:atLocation niiri:82214ebe8ef9b550cf4e1aa7a663349d ;
     prov:value "4.76250028610229"^^xsd:float ;
     nidm_equivalentZStatistic: "4.0651242608467"^^xsd:float ;
     nidm_pValueUncorrected: "2.40034388049315e-05"^^xsd:float ;
     nidm_pValueFWER: "0.977290243152968"^^xsd:float ;
     nidm_qValueFDR: "0.108771358683944"^^xsd:float .
 
-niiri:ac6e1aa6b3c9b2ffafefc7993bbdb3d5
+niiri:82214ebe8ef9b550cf4e1aa7a663349d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0085" ;
     nidm_coordinateVector: "[2,-48,-30]"^^xsd:string .
 
-niiri:4fd872970ed44df708416742f907dd60 prov:wasDerivedFrom niiri:75040581b4eec5ea4766cc6aef47a8db .
+niiri:2146b6f3997a0283631b40f42fa43d64 prov:wasDerivedFrom niiri:c4315919bc864f2492337dd699116ee4 .
 
-niiri:2ca5a6be3c35afb1d8b31cda31292b35
+niiri:0e6bf474e07d5b7b08647f8b148f1967
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0086" ;
-    prov:atLocation niiri:77f0590f945a9f0fa5288494ddd17b52 ;
+    prov:atLocation niiri:ba7fb6c8d83c030743f5d0f254764ced ;
     prov:value "4.6519603729248"^^xsd:float ;
     nidm_equivalentZStatistic: "3.99626416831875"^^xsd:float ;
     nidm_pValueUncorrected: "3.21749621180478e-05"^^xsd:float ;
     nidm_pValueFWER: "0.991944888183868"^^xsd:float ;
     nidm_qValueFDR: "0.128446006759384"^^xsd:float .
 
-niiri:77f0590f945a9f0fa5288494ddd17b52
+niiri:ba7fb6c8d83c030743f5d0f254764ced
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0086" ;
     nidm_coordinateVector: "[8,-50,-40]"^^xsd:string .
 
-niiri:2ca5a6be3c35afb1d8b31cda31292b35 prov:wasDerivedFrom niiri:75040581b4eec5ea4766cc6aef47a8db .
+niiri:0e6bf474e07d5b7b08647f8b148f1967 prov:wasDerivedFrom niiri:c4315919bc864f2492337dd699116ee4 .
 
-niiri:a38570bac87c06908a31a54a84c167b1
+niiri:d72c48f6d8afc2c9c15435f9d82418cf
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0087" ;
-    prov:atLocation niiri:2996faba5ee172677f1c883f4f96df84 ;
+    prov:atLocation niiri:0176ea45bff6510ce2f14431bf105e73 ;
     prov:value "4.10066413879395"^^xsd:float ;
     nidm_equivalentZStatistic: "3.63067985034096"^^xsd:float ;
     nidm_pValueUncorrected: "0.000141337823446053"^^xsd:float ;
     nidm_pValueFWER: "0.999999883838746"^^xsd:float ;
     nidm_qValueFDR: "0.31440196024118"^^xsd:float .
 
-niiri:2996faba5ee172677f1c883f4f96df84
+niiri:0176ea45bff6510ce2f14431bf105e73
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0087" ;
     nidm_coordinateVector: "[-6,-54,-34]"^^xsd:string .
 
-niiri:a38570bac87c06908a31a54a84c167b1 prov:wasDerivedFrom niiri:75040581b4eec5ea4766cc6aef47a8db .
+niiri:d72c48f6d8afc2c9c15435f9d82418cf prov:wasDerivedFrom niiri:c4315919bc864f2492337dd699116ee4 .
 
-niiri:0fd4ff744da0e82ccc15307e98485e12
+niiri:36093115c68af5d4a10804e4c18ac4b8
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0088" ;
-    prov:atLocation niiri:27ad17410385cf16531ede1f0e7f92fb ;
+    prov:atLocation niiri:8f6c6846bbd931f8db1b84eb92b10f53 ;
     prov:value "4.71864032745361"^^xsd:float ;
     nidm_equivalentZStatistic: "4.03796623427238"^^xsd:float ;
     nidm_pValueUncorrected: "2.69583056984324e-05"^^xsd:float ;
     nidm_pValueFWER: "0.984495898499825"^^xsd:float ;
     nidm_qValueFDR: "0.117001939306263"^^xsd:float .
 
-niiri:27ad17410385cf16531ede1f0e7f92fb
+niiri:8f6c6846bbd931f8db1b84eb92b10f53
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0088" ;
     nidm_coordinateVector: "[30,26,-26]"^^xsd:string .
 
-niiri:0fd4ff744da0e82ccc15307e98485e12 prov:wasDerivedFrom niiri:1b5b284497e39b90fa934f2eaa2c5bbd .
+niiri:36093115c68af5d4a10804e4c18ac4b8 prov:wasDerivedFrom niiri:5ad7bfc734bce8d2e03526bbce4c1642 .
 
-niiri:306c809d5c32a2c41d8f9887cf2c9b9b
+niiri:f6438ecb7f50fccc2df09ada0b2c3936
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0089" ;
-    prov:atLocation niiri:a2b2f239e523f6379f3634d3ebaf876a ;
+    prov:atLocation niiri:6f8a1c21df8a5fd72256d5fc0cfd2f29 ;
     prov:value "4.44299697875977"^^xsd:float ;
     nidm_equivalentZStatistic: "3.86221318181419"^^xsd:float ;
     nidm_pValueUncorrected: "5.61822240265908e-05"^^xsd:float ;
     nidm_pValueFWER: "0.999504108645955"^^xsd:float ;
     nidm_qValueFDR: "0.179991208659564"^^xsd:float .
 
-niiri:a2b2f239e523f6379f3634d3ebaf876a
+niiri:6f8a1c21df8a5fd72256d5fc0cfd2f29
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0089" ;
     nidm_coordinateVector: "[24,14,-26]"^^xsd:string .
 
-niiri:306c809d5c32a2c41d8f9887cf2c9b9b prov:wasDerivedFrom niiri:1b5b284497e39b90fa934f2eaa2c5bbd .
+niiri:f6438ecb7f50fccc2df09ada0b2c3936 prov:wasDerivedFrom niiri:5ad7bfc734bce8d2e03526bbce4c1642 .
 
-niiri:f8547bd151dbdbbc5ba877786e167f7e
+niiri:e92804e0ae7f8fae7ff71ce6170d001c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0090" ;
-    prov:atLocation niiri:f29b9f4b46a5244c6a5198760cd3bf04 ;
+    prov:atLocation niiri:12aca80540254ba38eaf72b666080df0 ;
     prov:value "3.96920132637024"^^xsd:float ;
     nidm_equivalentZStatistic: "3.53746207311998"^^xsd:float ;
     nidm_pValueUncorrected: "0.000201996101466206"^^xsd:float ;
     nidm_pValueFWER: "0.999999999353667"^^xsd:float ;
     nidm_qValueFDR: "0.394063237507806"^^xsd:float .
 
-niiri:f29b9f4b46a5244c6a5198760cd3bf04
+niiri:12aca80540254ba38eaf72b666080df0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0090" ;
     nidm_coordinateVector: "[26,14,-18]"^^xsd:string .
 
-niiri:f8547bd151dbdbbc5ba877786e167f7e prov:wasDerivedFrom niiri:1b5b284497e39b90fa934f2eaa2c5bbd .
+niiri:e92804e0ae7f8fae7ff71ce6170d001c prov:wasDerivedFrom niiri:5ad7bfc734bce8d2e03526bbce4c1642 .
 
-niiri:42a50c3eb244dfe091f5c23c2704835b
+niiri:ad38b1977ea2816b6d5129b7de2be1cc
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0091" ;
-    prov:atLocation niiri:26c0c7e4309cea859082f50525cd45ba ;
+    prov:atLocation niiri:2df1390cc5fce031de8c0874577cadce ;
     prov:value "4.70100975036621"^^xsd:float ;
     nidm_equivalentZStatistic: "4.02698888340493"^^xsd:float ;
     nidm_pValueUncorrected: "2.82478512551032e-05"^^xsd:float ;
     nidm_pValueFWER: "0.986841070396366"^^xsd:float ;
     nidm_qValueFDR: "0.12010902462004"^^xsd:float .
 
-niiri:26c0c7e4309cea859082f50525cd45ba
+niiri:2df1390cc5fce031de8c0874577cadce
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0091" ;
     nidm_coordinateVector: "[-28,-16,6]"^^xsd:string .
 
-niiri:42a50c3eb244dfe091f5c23c2704835b prov:wasDerivedFrom niiri:9f190d80d4f3c866def066aba31dc20c .
+niiri:ad38b1977ea2816b6d5129b7de2be1cc prov:wasDerivedFrom niiri:f28a45db3e8e726134be22dd55ada8fc .
 
-niiri:5f6ab64bc5653e5c1c69b4d7e59e56c0
+niiri:381454c1e2fbda01612a05c0a4339f74
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0092" ;
-    prov:atLocation niiri:0437c6eb17d20933f6823a9b6151ab98 ;
+    prov:atLocation niiri:d3ea04f828be657e6bab2138bbf28662 ;
     prov:value "4.67801570892334"^^xsd:float ;
     nidm_equivalentZStatistic: "4.01261939052354"^^xsd:float ;
     nidm_pValueUncorrected: "3.00243455383375e-05"^^xsd:float ;
     nidm_pValueFWER: "0.989477369969029"^^xsd:float ;
     nidm_qValueFDR: "0.124772480459746"^^xsd:float .
 
-niiri:0437c6eb17d20933f6823a9b6151ab98
+niiri:d3ea04f828be657e6bab2138bbf28662
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0092" ;
     nidm_coordinateVector: "[44,0,10]"^^xsd:string .
 
-niiri:5f6ab64bc5653e5c1c69b4d7e59e56c0 prov:wasDerivedFrom niiri:bad61a3ace8cf7e7c8c50e40ccf98bd4 .
+niiri:381454c1e2fbda01612a05c0a4339f74 prov:wasDerivedFrom niiri:7dbd526d156c17d030cb03d4502bec48 .
 
-niiri:85d77ed1bf9f8388298bfe7a77494333
+niiri:b762ee5ba6db8bfb0128b4bb42245b28
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0093" ;
-    prov:atLocation niiri:1cf182c70d175685bf729d5057b31022 ;
+    prov:atLocation niiri:aebbd1158b0ede5b331c1c3f1d17b188 ;
     prov:value "4.22728967666626"^^xsd:float ;
     nidm_equivalentZStatistic: "3.71814419332447"^^xsd:float ;
     nidm_pValueUncorrected: "0.000100345855709283"^^xsd:float ;
     nidm_pValueFWER: "0.999994729417339"^^xsd:float ;
     nidm_qValueFDR: "0.257292468216432"^^xsd:float .
 
-niiri:1cf182c70d175685bf729d5057b31022
+niiri:aebbd1158b0ede5b331c1c3f1d17b188
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0093" ;
     nidm_coordinateVector: "[54,0,16]"^^xsd:string .
 
-niiri:85d77ed1bf9f8388298bfe7a77494333 prov:wasDerivedFrom niiri:bad61a3ace8cf7e7c8c50e40ccf98bd4 .
+niiri:b762ee5ba6db8bfb0128b4bb42245b28 prov:wasDerivedFrom niiri:7dbd526d156c17d030cb03d4502bec48 .
 
-niiri:c30a7b8bf86a990343f6528dc86c8da6
+niiri:85563c1d691e946655502a1d62515133
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0094" ;
-    prov:atLocation niiri:d54e01ce6cebb1fe89926a726c90eab7 ;
+    prov:atLocation niiri:bbf81c743efe445a1c97b21a8fab3e28 ;
     prov:value "4.66959953308105"^^xsd:float ;
     nidm_equivalentZStatistic: "4.00734493617698"^^xsd:float ;
     nidm_pValueUncorrected: "3.07025754018309e-05"^^xsd:float ;
     nidm_pValueFWER: "0.990331612042013"^^xsd:float ;
     nidm_qValueFDR: "0.125816071886827"^^xsd:float .
 
-niiri:d54e01ce6cebb1fe89926a726c90eab7
+niiri:bbf81c743efe445a1c97b21a8fab3e28
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0094" ;
     nidm_coordinateVector: "[-54,-22,12]"^^xsd:string .
 
-niiri:c30a7b8bf86a990343f6528dc86c8da6 prov:wasDerivedFrom niiri:189c6d65cca27efc776c3691b2470738 .
+niiri:85563c1d691e946655502a1d62515133 prov:wasDerivedFrom niiri:db64bef791d519bd840c407a07274b39 .
 
-niiri:1088eceb72998c0658f10b30358f8dee
+niiri:41ddd3c253a63198d170247b8ccef29c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0095" ;
-    prov:atLocation niiri:3cc9446da6d6c70a4656d02b32801137 ;
+    prov:atLocation niiri:921adc178a0217524216f743d14205b3 ;
     prov:value "4.65595293045044"^^xsd:float ;
     nidm_equivalentZStatistic: "3.99877537618825"^^xsd:float ;
     nidm_pValueUncorrected: "3.18355355407585e-05"^^xsd:float ;
     nidm_pValueFWER: "0.991599911633511"^^xsd:float ;
     nidm_qValueFDR: "0.127861903463077"^^xsd:float .
 
-niiri:3cc9446da6d6c70a4656d02b32801137
+niiri:921adc178a0217524216f743d14205b3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0095" ;
     nidm_coordinateVector: "[50,50,-8]"^^xsd:string .
 
-niiri:1088eceb72998c0658f10b30358f8dee prov:wasDerivedFrom niiri:f29da53849f4d24538d6a069a467c443 .
+niiri:41ddd3c253a63198d170247b8ccef29c prov:wasDerivedFrom niiri:261d424ff1d40e2e1212f8b47057e08d .
 
-niiri:671ae43880d238d19d2d2be2b6209076
+niiri:78ffb1d7f41f1c0b6ea5119ca8935556
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0096" ;
-    prov:atLocation niiri:660d6fc3b3ea3e4b958c93bafb20a666 ;
+    prov:atLocation niiri:973e73a26378971ef19237f48098ed3a ;
     prov:value "4.65494585037231"^^xsd:float ;
     nidm_equivalentZStatistic: "3.99814212312407"^^xsd:float ;
     nidm_pValueUncorrected: "3.19208079492261e-05"^^xsd:float ;
     nidm_pValueFWER: "0.991688012376402"^^xsd:float ;
     nidm_qValueFDR: "0.127861903463077"^^xsd:float .
 
-niiri:660d6fc3b3ea3e4b958c93bafb20a666
+niiri:973e73a26378971ef19237f48098ed3a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0096" ;
     nidm_coordinateVector: "[-28,-94,14]"^^xsd:string .
 
-niiri:671ae43880d238d19d2d2be2b6209076 prov:wasDerivedFrom niiri:735d11dd0407b58704c0622c1bf21ceb .
+niiri:78ffb1d7f41f1c0b6ea5119ca8935556 prov:wasDerivedFrom niiri:f0b1b468bf91334fdba7c8b7612cca41 .
 
-niiri:b597b068893e960609d27315716990e2
+niiri:d614eab5b59c47eed1084c951be2e2ac
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0097" ;
-    prov:atLocation niiri:50f893947a270f5af66c2cbd6585e809 ;
+    prov:atLocation niiri:a580eafb1c15748fd65f50cb3130fabb ;
     prov:value "4.59036016464233"^^xsd:float ;
     nidm_equivalentZStatistic: "3.95728588718167"^^xsd:float ;
     nidm_pValueUncorrected: "3.79030920980572e-05"^^xsd:float ;
     nidm_pValueFWER: "0.99598096157132"^^xsd:float ;
     nidm_qValueFDR: "0.142567282550543"^^xsd:float .
 
-niiri:50f893947a270f5af66c2cbd6585e809
+niiri:a580eafb1c15748fd65f50cb3130fabb
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0097" ;
     nidm_coordinateVector: "[40,-8,-4]"^^xsd:string .
 
-niiri:b597b068893e960609d27315716990e2 prov:wasDerivedFrom niiri:1cab13530af314ae698e165a85ca2de5 .
+niiri:d614eab5b59c47eed1084c951be2e2ac prov:wasDerivedFrom niiri:6faaad2ce4a4160eadbbce94632ec2bf .
 
-niiri:d0425a54d68a26b09e3b868f56d2f0f0
+niiri:b50f8c0634d1f6225cc186049de68413
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0098" ;
-    prov:atLocation niiri:f433850395b5c2c86bd5e11b3805dc73 ;
+    prov:atLocation niiri:e96da7fbc7121c5fcada2bd43aff06a1 ;
     prov:value "4.11932277679443"^^xsd:float ;
     nidm_equivalentZStatistic: "3.64370826236287"^^xsd:float ;
     nidm_pValueUncorrected: "0.000134369006709489"^^xsd:float ;
     nidm_pValueFWER: "0.99999978233167"^^xsd:float ;
     nidm_qValueFDR: "0.306052577208852"^^xsd:float .
 
-niiri:f433850395b5c2c86bd5e11b3805dc73
+niiri:e96da7fbc7121c5fcada2bd43aff06a1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0098" ;
     nidm_coordinateVector: "[42,-14,-12]"^^xsd:string .
 
-niiri:d0425a54d68a26b09e3b868f56d2f0f0 prov:wasDerivedFrom niiri:1cab13530af314ae698e165a85ca2de5 .
+niiri:b50f8c0634d1f6225cc186049de68413 prov:wasDerivedFrom niiri:6faaad2ce4a4160eadbbce94632ec2bf .
 
-niiri:4366c702fcc58810550566b4e4d23534
+niiri:37f724585a89abe98ff9f20ca03e9884
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0099" ;
-    prov:atLocation niiri:895f20dcc2031d58bc886785a482f1b5 ;
+    prov:atLocation niiri:e1a4edce029a77b4f6d92ac5806a54ec ;
     prov:value "3.9436137676239"^^xsd:float ;
     nidm_equivalentZStatistic: "3.51902135936471"^^xsd:float ;
     nidm_pValueUncorrected: "0.000216570916963699"^^xsd:float ;
     nidm_pValueFWER: "0.999999999802529"^^xsd:float ;
     nidm_qValueFDR: "0.411752007254358"^^xsd:float .
 
-niiri:895f20dcc2031d58bc886785a482f1b5
+niiri:e1a4edce029a77b4f6d92ac5806a54ec
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0099" ;
     nidm_coordinateVector: "[36,-8,-12]"^^xsd:string .
 
-niiri:4366c702fcc58810550566b4e4d23534 prov:wasDerivedFrom niiri:1cab13530af314ae698e165a85ca2de5 .
+niiri:37f724585a89abe98ff9f20ca03e9884 prov:wasDerivedFrom niiri:6faaad2ce4a4160eadbbce94632ec2bf .
 
-niiri:87643e96d74b14a2c024309920c3827b
+niiri:e12a986e485026e4d146b52ea34da3ea
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0100" ;
-    prov:atLocation niiri:49337bb4cea94fc97b5fb6f4ef8286e1 ;
+    prov:atLocation niiri:c2abbc2ce0ad122a6bc9709ad15207e7 ;
     prov:value "4.55580520629883"^^xsd:float ;
     nidm_equivalentZStatistic: "3.9352264591963"^^xsd:float ;
     nidm_pValueUncorrected: "4.15591423175155e-05"^^xsd:float ;
     nidm_pValueFWER: "0.997392444225686"^^xsd:float ;
     nidm_qValueFDR: "0.150878854905596"^^xsd:float .
 
-niiri:49337bb4cea94fc97b5fb6f4ef8286e1
+niiri:c2abbc2ce0ad122a6bc9709ad15207e7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0100" ;
     nidm_coordinateVector: "[-16,-36,22]"^^xsd:string .
 
-niiri:87643e96d74b14a2c024309920c3827b prov:wasDerivedFrom niiri:e0728affe728b03b571bb0da5a24b81e .
+niiri:e12a986e485026e4d146b52ea34da3ea prov:wasDerivedFrom niiri:8451b5d05d4d0f88becbc68925bab4c9 .
 
-niiri:aba73c7bf694c726dd1a62029c95a89d
+niiri:b9372af04e7acfd4ce56135b4d0536af
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0101" ;
-    prov:atLocation niiri:74374695e7cee91acee321fbeb220133 ;
+    prov:atLocation niiri:4f6cf46b76ce3e5bb2f7e9293eb4e52f ;
     prov:value "4.55545139312744"^^xsd:float ;
     nidm_equivalentZStatistic: "3.93499985843019"^^xsd:float ;
     nidm_pValueUncorrected: "4.15983725905456e-05"^^xsd:float ;
     nidm_pValueFWER: "0.997404409483695"^^xsd:float ;
     nidm_qValueFDR: "0.150878854905596"^^xsd:float .
 
-niiri:74374695e7cee91acee321fbeb220133
+niiri:4f6cf46b76ce3e5bb2f7e9293eb4e52f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0101" ;
     nidm_coordinateVector: "[32,4,46]"^^xsd:string .
 
-niiri:aba73c7bf694c726dd1a62029c95a89d prov:wasDerivedFrom niiri:2ac5440f1a62a883d86fc94f89789599 .
+niiri:b9372af04e7acfd4ce56135b4d0536af prov:wasDerivedFrom niiri:e8d74786a114ffeb6114fffeeb2583da .
 
-niiri:1ced12f966574e6914952926c04a3a91
+niiri:48b80f9b9e00d0859755f74a197e7295
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0102" ;
-    prov:atLocation niiri:e42ccaa79df168a0e41d6ed1ca039dcf ;
+    prov:atLocation niiri:245f24faf67b8c0bed06e039441f3242 ;
     prov:value "4.55117416381836"^^xsd:float ;
     nidm_equivalentZStatistic: "3.93225931513679"^^xsd:float ;
     nidm_pValueUncorrected: "4.20756089468677e-05"^^xsd:float ;
     nidm_pValueFWER: "0.997545471779058"^^xsd:float ;
     nidm_qValueFDR: "0.151725570321213"^^xsd:float .
 
-niiri:e42ccaa79df168a0e41d6ed1ca039dcf
+niiri:245f24faf67b8c0bed06e039441f3242
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0102" ;
     nidm_coordinateVector: "[-66,-38,20]"^^xsd:string .
 
-niiri:1ced12f966574e6914952926c04a3a91 prov:wasDerivedFrom niiri:04a64b18655d556b397f88a52d983f34 .
+niiri:48b80f9b9e00d0859755f74a197e7295 prov:wasDerivedFrom niiri:af4cb856d066cec808680cb766e205ae .
 
-niiri:260f9b244d05e2c1dc6d321bb88eb14e
+niiri:911d519f5928583e1f82ac51bab14528
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0103" ;
-    prov:atLocation niiri:3ee349d2ae3fd31b84b1b3a515f9770a ;
+    prov:atLocation niiri:5edd83cba07a9fb55a7f38bf2a36fdfe ;
     prov:value "4.53549385070801"^^xsd:float ;
     nidm_equivalentZStatistic: "3.92219382792662"^^xsd:float ;
     nidm_pValueUncorrected: "4.38731790728397e-05"^^xsd:float ;
     nidm_pValueFWER: "0.998009069005951"^^xsd:float ;
     nidm_qValueFDR: "0.155845230235465"^^xsd:float .
 
-niiri:3ee349d2ae3fd31b84b1b3a515f9770a
+niiri:5edd83cba07a9fb55a7f38bf2a36fdfe
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0103" ;
     nidm_coordinateVector: "[40,-40,14]"^^xsd:string .
 
-niiri:260f9b244d05e2c1dc6d321bb88eb14e prov:wasDerivedFrom niiri:e07163703600f62c37c81aed00f51b7a .
+niiri:911d519f5928583e1f82ac51bab14528 prov:wasDerivedFrom niiri:64c74f4674adc0005dffc886ffba3300 .
 
-niiri:4bf2c17eaf5e2b6a6bc490e00bf4f4d0
+niiri:b35cc4339b958823a6b0d89e47050e64
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0104" ;
-    prov:atLocation niiri:cec3e23ba7dfca18d4fd168450ff18ff ;
+    prov:atLocation niiri:6326326bf38f1f521effe41a32bcff8c ;
     prov:value "4.53285837173462"^^xsd:float ;
     nidm_equivalentZStatistic: "3.92049917786993"^^xsd:float ;
     nidm_pValueUncorrected: "4.41828687672841e-05"^^xsd:float ;
     nidm_pValueFWER: "0.998079247810657"^^xsd:float ;
     nidm_qValueFDR: "0.156454214178493"^^xsd:float .
 
-niiri:cec3e23ba7dfca18d4fd168450ff18ff
+niiri:6326326bf38f1f521effe41a32bcff8c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0104" ;
     nidm_coordinateVector: "[6,-40,18]"^^xsd:string .
 
-niiri:4bf2c17eaf5e2b6a6bc490e00bf4f4d0 prov:wasDerivedFrom niiri:f4159609553afd6154652d5027b6e84a .
+niiri:b35cc4339b958823a6b0d89e47050e64 prov:wasDerivedFrom niiri:878873f431f64df4853365a578c78440 .
 
-niiri:96efd99f3a78d60684b5b316a0c19cc2
+niiri:98380d632dcdfa9a6e36fc6b78b2273c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0105" ;
-    prov:atLocation niiri:4a2715da0d82ada4545208a80cab2511 ;
+    prov:atLocation niiri:ec5c657b1f38d62cf4afaa29e7f266c0 ;
     prov:value "4.52961778640747"^^xsd:float ;
     nidm_equivalentZStatistic: "3.91841429412832"^^xsd:float ;
     nidm_pValueUncorrected: "4.45667054541632e-05"^^xsd:float ;
     nidm_pValueFWER: "0.998162674504785"^^xsd:float ;
     nidm_qValueFDR: "0.156835312141954"^^xsd:float .
 
-niiri:4a2715da0d82ada4545208a80cab2511
+niiri:ec5c657b1f38d62cf4afaa29e7f266c0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0105" ;
     nidm_coordinateVector: "[52,-68,16]"^^xsd:string .
 
-niiri:96efd99f3a78d60684b5b316a0c19cc2 prov:wasDerivedFrom niiri:f4231c3f6d55163a61e855e3bf8e3cc5 .
+niiri:98380d632dcdfa9a6e36fc6b78b2273c prov:wasDerivedFrom niiri:62873793384331403012ec1c900656e0 .
 
-niiri:0c3cc5af988e7da86a56270c9c96f8c7
+niiri:720ed23eb6c46a721179918c28f55ffc
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0106" ;
-    prov:atLocation niiri:460d184d093c1173982c3b1976da2688 ;
+    prov:atLocation niiri:f824150295332ede014a54eca9b3e037 ;
     prov:value "4.52500677108765"^^xsd:float ;
     nidm_equivalentZStatistic: "3.91544554806561"^^xsd:float ;
     nidm_pValueUncorrected: "4.51187048494672e-05"^^xsd:float ;
     nidm_pValueFWER: "0.998276102661289"^^xsd:float ;
     nidm_qValueFDR: "0.156835312141954"^^xsd:float .
 
-niiri:460d184d093c1173982c3b1976da2688
+niiri:f824150295332ede014a54eca9b3e037
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0106" ;
     nidm_coordinateVector: "[-48,-22,-10]"^^xsd:string .
 
-niiri:0c3cc5af988e7da86a56270c9c96f8c7 prov:wasDerivedFrom niiri:f3fc51b4027adc2167b7ea4fb36f64e9 .
+niiri:720ed23eb6c46a721179918c28f55ffc prov:wasDerivedFrom niiri:cf86c38738ff15923d1bfe58d642e526 .
 
-niiri:7fbb194cd2d6fb1d9d1d16abadf4d2be
+niiri:06f3fa5f5a7dd43a7c83878b6daecccd
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0107" ;
-    prov:atLocation niiri:f38864f25cb61f37ffed64c3e17672dc ;
+    prov:atLocation niiri:2e1377b54d2ffed14f657fdcc448a72b ;
     prov:value "4.48953676223755"^^xsd:float ;
     nidm_equivalentZStatistic: "3.89252279227539"^^xsd:float ;
     nidm_pValueUncorrected: "4.96035879459233e-05"^^xsd:float ;
     nidm_pValueFWER: "0.99896686399793"^^xsd:float ;
     nidm_qValueFDR: "0.165823318703379"^^xsd:float .
 
-niiri:f38864f25cb61f37ffed64c3e17672dc
+niiri:2e1377b54d2ffed14f657fdcc448a72b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0107" ;
     nidm_coordinateVector: "[30,52,-4]"^^xsd:string .
 
-niiri:7fbb194cd2d6fb1d9d1d16abadf4d2be prov:wasDerivedFrom niiri:89485ab1dfdfe29164103a5f95597953 .
+niiri:06f3fa5f5a7dd43a7c83878b6daecccd prov:wasDerivedFrom niiri:6eb2f26421b4abdd2aff61056be6347c .
 
-niiri:2c3112f14d52846a4e846057968ffc37
+niiri:aeae6d15ef755bd8bf17831ae1de5a8b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0108" ;
-    prov:atLocation niiri:0f84a5df8e7af60bd0dd46befca71596 ;
+    prov:atLocation niiri:45a89c69b7ea6fbf25176dea9a058957 ;
     prov:value "4.45128202438354"^^xsd:float ;
     nidm_equivalentZStatistic: "3.8676284436992"^^xsd:float ;
     nidm_pValueUncorrected: "5.49494726368449e-05"^^xsd:float ;
     nidm_pValueFWER: "0.999431806314623"^^xsd:float ;
     nidm_qValueFDR: "0.177705345844304"^^xsd:float .
 
-niiri:0f84a5df8e7af60bd0dd46befca71596
+niiri:45a89c69b7ea6fbf25176dea9a058957
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0108" ;
     nidm_coordinateVector: "[30,-78,12]"^^xsd:string .
 
-niiri:2c3112f14d52846a4e846057968ffc37 prov:wasDerivedFrom niiri:38d55629def18240731e2415b3581423 .
+niiri:aeae6d15ef755bd8bf17831ae1de5a8b prov:wasDerivedFrom niiri:464e6cc9ad8cde4967c4e8430942863e .
 
-niiri:f0ccedd5fce18281ce4d2341d24ffe8e
+niiri:f1c37bc22f16214c1df5f88314a215a4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0109" ;
-    prov:atLocation niiri:8c6052a4b3fd6e34fcd86c593825af20 ;
+    prov:atLocation niiri:e379fe3bb7b26ed85e05da7ee6813086 ;
     prov:value "4.43969058990479"^^xsd:float ;
     nidm_equivalentZStatistic: "3.86004968799798"^^xsd:float ;
     nidm_pValueUncorrected: "5.66819856246958e-05"^^xsd:float ;
     nidm_pValueFWER: "0.999530645129751"^^xsd:float ;
     nidm_qValueFDR: "0.180631808606791"^^xsd:float .
 
-niiri:8c6052a4b3fd6e34fcd86c593825af20
+niiri:e379fe3bb7b26ed85e05da7ee6813086
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0109" ;
     nidm_coordinateVector: "[56,34,-6]"^^xsd:string .
 
-niiri:f0ccedd5fce18281ce4d2341d24ffe8e prov:wasDerivedFrom niiri:911e248e1a4789966b6c9e185a7126b1 .
+niiri:f1c37bc22f16214c1df5f88314a215a4 prov:wasDerivedFrom niiri:0f59b224fb308f5b33db0b615cec440e .
 
-niiri:72d1c291678d22f2bd98eedf3b4f80e1
+niiri:bef3273cb030511d57da83b609f7288b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0110" ;
-    prov:atLocation niiri:e050ac6a4efbe8f0a7222ba8c092f08d ;
+    prov:atLocation niiri:03ef48e74c3406c59a104d33ec1ced06 ;
     prov:value "4.43896007537842"^^xsd:float ;
     nidm_equivalentZStatistic: "3.8595715019443"^^xsd:float ;
     nidm_pValueUncorrected: "5.67930097867819e-05"^^xsd:float ;
     nidm_pValueFWER: "0.999536338351379"^^xsd:float ;
     nidm_qValueFDR: "0.180631808606791"^^xsd:float .
 
-niiri:e050ac6a4efbe8f0a7222ba8c092f08d
+niiri:03ef48e74c3406c59a104d33ec1ced06
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0110" ;
     nidm_coordinateVector: "[-26,-94,2]"^^xsd:string .
 
-niiri:72d1c291678d22f2bd98eedf3b4f80e1 prov:wasDerivedFrom niiri:6110880bd543820677cd9c2981bb03f1 .
+niiri:bef3273cb030511d57da83b609f7288b prov:wasDerivedFrom niiri:61f0e2e951d39892ec38816ca4ff7b91 .
 
-niiri:3305c63dcf3abdaff650b7191ec8d6b0
+niiri:95ad202473a2bf127c7926f3746acacc
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0111" ;
-    prov:atLocation niiri:c6d08c08c9f530820ca2c9f56a4d6448 ;
+    prov:atLocation niiri:36d1028c68af6184089ce9aee42f9174 ;
     prov:value "4.43468761444092"^^xsd:float ;
     nidm_equivalentZStatistic: "3.85677347172615"^^xsd:float ;
     nidm_pValueUncorrected: "5.74467726958128e-05"^^xsd:float ;
     nidm_pValueFWER: "0.999568445566068"^^xsd:float ;
     nidm_qValueFDR: "0.182003342977838"^^xsd:float .
 
-niiri:c6d08c08c9f530820ca2c9f56a4d6448
+niiri:36d1028c68af6184089ce9aee42f9174
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0111" ;
     nidm_coordinateVector: "[-4,2,42]"^^xsd:string .
 
-niiri:3305c63dcf3abdaff650b7191ec8d6b0 prov:wasDerivedFrom niiri:17de67442fe88be7d5065d079743540f .
+niiri:95ad202473a2bf127c7926f3746acacc prov:wasDerivedFrom niiri:9764501f1b27ea039a6888cad5412dc6 .
 
-niiri:77ba8da0f7e4f5aab68f081161fa1bea
+niiri:0fb6745b7885bc7a34cefdeb57f43c2f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0112" ;
-    prov:atLocation niiri:83d5b3ee5bd86eb620c993b83ea0caa6 ;
+    prov:atLocation niiri:92cf7da97869a4b83347f08dbaa11faf ;
     prov:value "4.41122913360596"^^xsd:float ;
     nidm_equivalentZStatistic: "3.84136995866889"^^xsd:float ;
     nidm_pValueUncorrected: "6.1174774538153e-05"^^xsd:float ;
     nidm_pValueFWER: "0.999712443776799"^^xsd:float ;
     nidm_qValueFDR: "0.188911373544714"^^xsd:float .
 
-niiri:83d5b3ee5bd86eb620c993b83ea0caa6
+niiri:92cf7da97869a4b83347f08dbaa11faf
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0112" ;
     nidm_coordinateVector: "[10,-46,-10]"^^xsd:string .
 
-niiri:77ba8da0f7e4f5aab68f081161fa1bea prov:wasDerivedFrom niiri:8cbc3782d81e0868d376f120a4236af9 .
+niiri:0fb6745b7885bc7a34cefdeb57f43c2f prov:wasDerivedFrom niiri:c4798ee5bb6817f0ac7d3d1f7cbb895d .
 
-niiri:ff0dbdfc84bb05fe5679f7b179ee11f0
+niiri:458c984a04e6737387c5f9f56e3c0c8a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0113" ;
-    prov:atLocation niiri:cc552590c3f29a42d9a6610fe218b7e6 ;
+    prov:atLocation niiri:d4a64a06c03e91cda9054bed710dca42 ;
     prov:value "4.40113353729248"^^xsd:float ;
     nidm_equivalentZStatistic: "3.83471966710863"^^xsd:float ;
     nidm_pValueUncorrected: "6.28537919565852e-05"^^xsd:float ;
     nidm_pValueFWER: "0.999760079336093"^^xsd:float ;
     nidm_qValueFDR: "0.192447078003389"^^xsd:float .
 
-niiri:cc552590c3f29a42d9a6610fe218b7e6
+niiri:d4a64a06c03e91cda9054bed710dca42
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0113" ;
     nidm_coordinateVector: "[-56,-28,32]"^^xsd:string .
 
-niiri:ff0dbdfc84bb05fe5679f7b179ee11f0 prov:wasDerivedFrom niiri:2f3eeaca715cc267ad827fccd2f2f34b .
+niiri:458c984a04e6737387c5f9f56e3c0c8a prov:wasDerivedFrom niiri:5499ba7833a3a03073324dac7488ac06 .
 
-niiri:527d0d830812700e62c40d9a6100d315
+niiri:baeb0c03f7acf106a1287e421c2742f3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0114" ;
-    prov:atLocation niiri:9ddaaf7b2ea49bfd8c516120cdaf8904 ;
+    prov:atLocation niiri:856a6c1dbdd8ced84613dc690fc7e35e ;
     prov:value "3.8069314956665"^^xsd:float ;
     nidm_equivalentZStatistic: "3.41880668619853"^^xsd:float ;
     nidm_pValueUncorrected: "0.000314481969186486"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999891"^^xsd:float ;
     nidm_qValueFDR: "0.512736471214834"^^xsd:float .
 
-niiri:9ddaaf7b2ea49bfd8c516120cdaf8904
+niiri:856a6c1dbdd8ced84613dc690fc7e35e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0114" ;
     nidm_coordinateVector: "[-48,-26,38]"^^xsd:string .
 
-niiri:527d0d830812700e62c40d9a6100d315 prov:wasDerivedFrom niiri:2f3eeaca715cc267ad827fccd2f2f34b .
+niiri:baeb0c03f7acf106a1287e421c2742f3 prov:wasDerivedFrom niiri:5499ba7833a3a03073324dac7488ac06 .
 
-niiri:c3a082504bc195d9e4d777deea4e6d17
+niiri:ca0839c16a1a2c559d6575777eda49c0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0115" ;
-    prov:atLocation niiri:94196d9f29b0dd9b11a8162f03bc6f80 ;
+    prov:atLocation niiri:d5aa0acf36e1fe500e1939ac94f4df6f ;
     prov:value "4.3867974281311"^^xsd:float ;
     nidm_equivalentZStatistic: "3.82525392537983"^^xsd:float ;
     nidm_pValueUncorrected: "6.53186827229701e-05"^^xsd:float ;
     nidm_pValueFWER: "0.999815750636743"^^xsd:float ;
     nidm_qValueFDR: "0.197194516669469"^^xsd:float .
 
-niiri:94196d9f29b0dd9b11a8162f03bc6f80
+niiri:d5aa0acf36e1fe500e1939ac94f4df6f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0115" ;
     nidm_coordinateVector: "[-4,-10,-12]"^^xsd:string .
 
-niiri:c3a082504bc195d9e4d777deea4e6d17 prov:wasDerivedFrom niiri:de6850a6407354dfd567970141571681 .
+niiri:ca0839c16a1a2c559d6575777eda49c0 prov:wasDerivedFrom niiri:50c6ebb589d5bdb3e362aaf8f837978b .
 
-niiri:cc6a58fe2921e4ac22cebe6c90dd0ba6
+niiri:8369fa28a67eb70b3c8346f78b861cd7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0116" ;
-    prov:atLocation niiri:8830be0395520c67acf02a3152e0f4d4 ;
+    prov:atLocation niiri:6ed010c8390266e2a02334f0871efbc1 ;
     prov:value "4.38070726394653"^^xsd:float ;
     nidm_equivalentZStatistic: "3.82122488004205"^^xsd:float ;
     nidm_pValueUncorrected: "6.6395247973916e-05"^^xsd:float ;
     nidm_pValueFWER: "0.999835706899974"^^xsd:float ;
     nidm_qValueFDR: "0.199147137761087"^^xsd:float .
 
-niiri:8830be0395520c67acf02a3152e0f4d4
+niiri:6ed010c8390266e2a02334f0871efbc1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0116" ;
     nidm_coordinateVector: "[-12,-84,-42]"^^xsd:string .
 
-niiri:cc6a58fe2921e4ac22cebe6c90dd0ba6 prov:wasDerivedFrom niiri:fd0c869c2731be1d9fa597f20662d444 .
+niiri:8369fa28a67eb70b3c8346f78b861cd7 prov:wasDerivedFrom niiri:a489f5516c417d51a01d581c1281955e .
 
-niiri:c1032fc39d6b775cc9b9991bf5fd94f9
+niiri:c9919f1aac8740808b218ad44f9721a0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0117" ;
-    prov:atLocation niiri:5dba11cc47d82ed9a5828d75f4d25abd ;
+    prov:atLocation niiri:0bc5e8e1b5feb1cc5e112bc5d1f0486c ;
     prov:value "4.37547636032104"^^xsd:float ;
     nidm_equivalentZStatistic: "3.81776053049529"^^xsd:float ;
     nidm_pValueUncorrected: "6.73342723619408e-05"^^xsd:float ;
     nidm_pValueFWER: "0.999851291705404"^^xsd:float ;
     nidm_qValueFDR: "0.200454348633431"^^xsd:float .
 
-niiri:5dba11cc47d82ed9a5828d75f4d25abd
+niiri:0bc5e8e1b5feb1cc5e112bc5d1f0486c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0117" ;
     nidm_coordinateVector: "[-40,0,0]"^^xsd:string .
 
-niiri:c1032fc39d6b775cc9b9991bf5fd94f9 prov:wasDerivedFrom niiri:9558c05bc184bbae76bf2776b13f3613 .
+niiri:c9919f1aac8740808b218ad44f9721a0 prov:wasDerivedFrom niiri:e4ff54dd97ad1e3f10b9d1c7027c4645 .
 
-niiri:1649a7f3e9a2410af3d8e4ef6fd303e2
+niiri:8e304887e697a26945a0a355426f4603
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0118" ;
-    prov:atLocation niiri:165dd2fac7105a73a7b80e22b60705b4 ;
+    prov:atLocation niiri:4035e3a3b521c5cf812810100219fc74 ;
     prov:value "4.36677885055542"^^xsd:float ;
     nidm_equivalentZStatistic: "3.8119925842216"^^xsd:float ;
     nidm_pValueUncorrected: "6.8925506726436e-05"^^xsd:float ;
     nidm_pValueFWER: "0.999874314988424"^^xsd:float ;
     nidm_qValueFDR: "0.203206123512965"^^xsd:float .
 
-niiri:165dd2fac7105a73a7b80e22b60705b4
+niiri:4035e3a3b521c5cf812810100219fc74
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0118" ;
     nidm_coordinateVector: "[-28,0,2]"^^xsd:string .
 
-niiri:1649a7f3e9a2410af3d8e4ef6fd303e2 prov:wasDerivedFrom niiri:a46d73eae3d12dd1da0f67fbeb4a1a72 .
+niiri:8e304887e697a26945a0a355426f4603 prov:wasDerivedFrom niiri:8de83fae7bd6e9f8380ec49cdc4829ae .
 
-niiri:7f5d7505bc741dd7d5b391adf234196c
+niiri:c94747cdbcb83041515a601d983f3b27
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0119" ;
-    prov:atLocation niiri:e59f57cd9f06987b6f61377b25632cc9 ;
+    prov:atLocation niiri:0aaacb97d9578ab5bbd5b285599748af ;
     prov:value "4.35107517242432"^^xsd:float ;
     nidm_equivalentZStatistic: "3.80155384474342"^^xsd:float ;
     nidm_pValueUncorrected: "7.18957405629883e-05"^^xsd:float ;
     nidm_pValueFWER: "0.999907978180442"^^xsd:float ;
     nidm_qValueFDR: "0.208513005623714"^^xsd:float .
 
-niiri:e59f57cd9f06987b6f61377b25632cc9
+niiri:0aaacb97d9578ab5bbd5b285599748af
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0119" ;
     nidm_coordinateVector: "[-50,2,38]"^^xsd:string .
 
-niiri:7f5d7505bc741dd7d5b391adf234196c prov:wasDerivedFrom niiri:7635d7da2581ae0e3d9df35c569ea093 .
+niiri:c94747cdbcb83041515a601d983f3b27 prov:wasDerivedFrom niiri:85491f67ab81ddeb946caf2849c4b9f4 .
 
-niiri:2dc919c851ba7755dbe18a26809b75a0
+niiri:e42d96aae6a120678fb678c94074a5db
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0120" ;
-    prov:atLocation niiri:c15ccc6718f3a15d89f19043f5addb5b ;
+    prov:atLocation niiri:ddc582eb09610fb7b7fc6c9c6c19e864 ;
     prov:value "4.33398485183716"^^xsd:float ;
     nidm_equivalentZStatistic: "3.79015733594979"^^xsd:float ;
     nidm_pValueUncorrected: "7.52759461690733e-05"^^xsd:float ;
     nidm_pValueFWER: "0.999935243728569"^^xsd:float ;
     nidm_qValueFDR: "0.215680526572575"^^xsd:float .
 
-niiri:c15ccc6718f3a15d89f19043f5addb5b
+niiri:ddc582eb09610fb7b7fc6c9c6c19e864
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0120" ;
     nidm_coordinateVector: "[-18,20,-10]"^^xsd:string .
 
-niiri:2dc919c851ba7755dbe18a26809b75a0 prov:wasDerivedFrom niiri:19a7c772a61f72e1d78af974571971cd .
+niiri:e42d96aae6a120678fb678c94074a5db prov:wasDerivedFrom niiri:3e9eba22eff518f24b14c038fe2913df .
 
-niiri:65ae58a9c810213d5e645d1a5efc43b5
+niiri:d358ade24a46e28d596c4d0af691488b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0121" ;
-    prov:atLocation niiri:041c46e2b4d312223fdbb6ad7f6756e2 ;
+    prov:atLocation niiri:725ad5ba6d7cd65f30acf71da2d71a0b ;
     prov:value "4.32422828674316"^^xsd:float ;
     nidm_equivalentZStatistic: "3.78363433945477"^^xsd:float ;
     nidm_pValueUncorrected: "7.72774207707938e-05"^^xsd:float ;
     nidm_pValueFWER: "0.999947322155091"^^xsd:float ;
     nidm_qValueFDR: "0.21884755438417"^^xsd:float .
 
-niiri:041c46e2b4d312223fdbb6ad7f6756e2
+niiri:725ad5ba6d7cd65f30acf71da2d71a0b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0121" ;
     nidm_coordinateVector: "[-54,-44,58]"^^xsd:string .
 
-niiri:65ae58a9c810213d5e645d1a5efc43b5 prov:wasDerivedFrom niiri:843d6a80a917e6d0bba5298ced57aba0 .
+niiri:d358ade24a46e28d596c4d0af691488b prov:wasDerivedFrom niiri:2b503ca3533d10a4f1f80dad7060444a .
 
-niiri:011104b1119694f29047c0d121fc1cda
+niiri:8756d972087f4144374fcbc8ae52666e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0122" ;
-    prov:atLocation niiri:87e8f34b8f412c36edb736b17b6dcecf ;
+    prov:atLocation niiri:b5933bbb6136fc305b2604a8d7deab9e ;
     prov:value "4.26067924499512"^^xsd:float ;
     nidm_equivalentZStatistic: "3.74084237095966"^^xsd:float ;
     nidm_pValueUncorrected: "9.1702262191129e-05"^^xsd:float ;
     nidm_pValueFWER: "0.999987705149813"^^xsd:float ;
     nidm_qValueFDR: "0.242015591352726"^^xsd:float .
 
-niiri:87e8f34b8f412c36edb736b17b6dcecf
+niiri:b5933bbb6136fc305b2604a8d7deab9e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0122" ;
     nidm_coordinateVector: "[-20,44,-4]"^^xsd:string .
 
-niiri:011104b1119694f29047c0d121fc1cda prov:wasDerivedFrom niiri:81a5a2e83d586c873f45bcbeacbd725e .
+niiri:8756d972087f4144374fcbc8ae52666e prov:wasDerivedFrom niiri:cf6de656d89419d4ac154fd946ec6388 .
 
-niiri:2d1ce2b3b7314391e10ed799a9f28906
+niiri:a89e2e80fe4388ce0ae8d072fcec1ac6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0123" ;
-    prov:atLocation niiri:d0729914d5e3c4bac1a31c4f58bc59e7 ;
+    prov:atLocation niiri:1a5dc642a881d6f4e4d3829a697631ac ;
     prov:value "4.18645191192627"^^xsd:float ;
     nidm_equivalentZStatistic: "3.69017800075158"^^xsd:float ;
     nidm_pValueUncorrected: "0.000112048594444025"^^xsd:float ;
     nidm_pValueFWER: "0.999998281846379"^^xsd:float ;
     nidm_qValueFDR: "0.278031328015723"^^xsd:float .
 
-niiri:d0729914d5e3c4bac1a31c4f58bc59e7
+niiri:1a5dc642a881d6f4e4d3829a697631ac
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0123" ;
     nidm_coordinateVector: "[-14,-32,-64]"^^xsd:string .
 
-niiri:2d1ce2b3b7314391e10ed799a9f28906 prov:wasDerivedFrom niiri:0dba3e406159d31dec269bb22b1b416a .
+niiri:a89e2e80fe4388ce0ae8d072fcec1ac6 prov:wasDerivedFrom niiri:9c0f05c7637bc2f31d907b17584b6aa0 .
 
-niiri:a5a2448865b51f8e6018dd6e5c69e2cc
+niiri:ab27403976625180dff5b30fab548263
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0124" ;
-    prov:atLocation niiri:1785b6d6129a2cc148fe835d0e08dd0b ;
+    prov:atLocation niiri:397f7e230bc5b14a56fc501c4f38a3df ;
     prov:value "4.18069553375244"^^xsd:float ;
     nidm_equivalentZStatistic: "3.6862176534993"^^xsd:float ;
     nidm_pValueUncorrected: "0.00011380585323062"^^xsd:float ;
     nidm_pValueFWER: "0.99999854453826"^^xsd:float ;
     nidm_qValueFDR: "0.28014402363808"^^xsd:float .
 
-niiri:1785b6d6129a2cc148fe835d0e08dd0b
+niiri:397f7e230bc5b14a56fc501c4f38a3df
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0124" ;
     nidm_coordinateVector: "[46,-54,14]"^^xsd:string .
 
-niiri:a5a2448865b51f8e6018dd6e5c69e2cc prov:wasDerivedFrom niiri:3d62634be01e822042b85fbe2f4b57a5 .
+niiri:ab27403976625180dff5b30fab548263 prov:wasDerivedFrom niiri:62e799c85533fe86208bf5e33c6a326d .
 
-niiri:8d1da7a81194cb3115ff73028d763837
+niiri:46ddcc1817cf540464c279f74a62d9e4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0125" ;
-    prov:atLocation niiri:8c9a1cdbde509d06bc9249e524560204 ;
+    prov:atLocation niiri:b89df9a7d5311e01dec9a19aebb58fad ;
     prov:value "4.16153001785278"^^xsd:float ;
     nidm_equivalentZStatistic: "3.67299901881211"^^xsd:float ;
     nidm_pValueUncorrected: "0.000119860202107414"^^xsd:float ;
     nidm_pValueFWER: "0.999999174595323"^^xsd:float ;
     nidm_qValueFDR: "0.287520254070199"^^xsd:float .
 
-niiri:8c9a1cdbde509d06bc9249e524560204
+niiri:b89df9a7d5311e01dec9a19aebb58fad
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0125" ;
     nidm_coordinateVector: "[-36,-14,-24]"^^xsd:string .
 
-niiri:8d1da7a81194cb3115ff73028d763837 prov:wasDerivedFrom niiri:4d27ad0557a85357aebf8d3cb8a18d20 .
+niiri:46ddcc1817cf540464c279f74a62d9e4 prov:wasDerivedFrom niiri:7b8b805f3c10072513741773f37173a9 .
 
-niiri:e74db54412c4a302b69fece9334e85e0
+niiri:bf6a4e636ece08a9573e7b57d980d23f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0126" ;
-    prov:atLocation niiri:97f8b327ff6eca1c45f4c9b893a6f549 ;
+    prov:atLocation niiri:c78fc1593491a390909bb0e0d1c8f4c9 ;
     prov:value "4.16062259674072"^^xsd:float ;
     nidm_equivalentZStatistic: "3.67237190318196"^^xsd:float ;
     nidm_pValueUncorrected: "0.00012015480804084"^^xsd:float ;
     nidm_pValueFWER: "0.999999196926834"^^xsd:float ;
     nidm_qValueFDR: "0.287520254070199"^^xsd:float .
 
-niiri:97f8b327ff6eca1c45f4c9b893a6f549
+niiri:c78fc1593491a390909bb0e0d1c8f4c9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0126" ;
     nidm_coordinateVector: "[16,-28,-4]"^^xsd:string .
 
-niiri:e74db54412c4a302b69fece9334e85e0 prov:wasDerivedFrom niiri:259f577b521fb0d31342d69e79678fd8 .
+niiri:bf6a4e636ece08a9573e7b57d980d23f prov:wasDerivedFrom niiri:c8967930ef6b4850b98397e5a02cf2f7 .
 
-niiri:baf9880dde22b6bd57633d511c3fbdee
+niiri:2eae7c427a5a98b75646c2db0e42ffd3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0127" ;
-    prov:atLocation niiri:10f6661f422c4d5e128c60d8bbf34483 ;
+    prov:atLocation niiri:ebe690e4d7b4a7281caa9b69d4aa561e ;
     prov:value "4.14985752105713"^^xsd:float ;
     nidm_equivalentZStatistic: "3.66492347570236"^^xsd:float ;
     nidm_pValueUncorrected: "0.000123706274285817"^^xsd:float ;
     nidm_pValueFWER: "0.999999422317975"^^xsd:float ;
     nidm_qValueFDR: "0.29175084353581"^^xsd:float .
 
-niiri:10f6661f422c4d5e128c60d8bbf34483
+niiri:ebe690e4d7b4a7281caa9b69d4aa561e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0127" ;
     nidm_coordinateVector: "[-28,14,-32]"^^xsd:string .
 
-niiri:baf9880dde22b6bd57633d511c3fbdee prov:wasDerivedFrom niiri:73ea65987d6ff092b8032a7897f236dc .
+niiri:2eae7c427a5a98b75646c2db0e42ffd3 prov:wasDerivedFrom niiri:162bab89b0c20f6474f1241e5c7169b3 .
 
-niiri:ff7cbfb80e98a99ece15374712d7bbf3
+niiri:f175b4660b0c3a112517dde55ce65ffd
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0128" ;
-    prov:atLocation niiri:48c56e1cff6258befee2079ac974cdfe ;
+    prov:atLocation niiri:e80844385b765c376df5c5195c77c748 ;
     prov:value "4.14875411987305"^^xsd:float ;
     nidm_equivalentZStatistic: "3.66415911467327"^^xsd:float ;
     nidm_pValueUncorrected: "0.000124076245730076"^^xsd:float ;
     nidm_pValueFWER: "0.999999441734682"^^xsd:float ;
     nidm_qValueFDR: "0.292006151507083"^^xsd:float .
 
-niiri:48c56e1cff6258befee2079ac974cdfe
+niiri:e80844385b765c376df5c5195c77c748
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0128" ;
     nidm_coordinateVector: "[-34,-66,-12]"^^xsd:string .
 
-niiri:ff7cbfb80e98a99ece15374712d7bbf3 prov:wasDerivedFrom niiri:ba34aadcbdfb22bb96b240c5d8d71cb7 .
+niiri:f175b4660b0c3a112517dde55ce65ffd prov:wasDerivedFrom niiri:91dc841836bbf5d1c0b426905fb75e01 .
 
-niiri:e5ae6607ef1f74d17740d67cbd30f3cc
+niiri:c82901e5c8a2f2e07c026cc63680c42d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0129" ;
-    prov:atLocation niiri:8fe3962f98ed6ef4a016041bccb3decd ;
+    prov:atLocation niiri:a4d26902e57a81a17208a81e72853eac ;
     prov:value "4.14285278320312"^^xsd:float ;
     nidm_equivalentZStatistic: "3.66006819074182"^^xsd:float ;
     nidm_pValueUncorrected: "0.000126074068639181"^^xsd:float ;
     nidm_pValueFWER: "0.999999535656409"^^xsd:float ;
     nidm_qValueFDR: "0.294856542429919"^^xsd:float .
 
-niiri:8fe3962f98ed6ef4a016041bccb3decd
+niiri:a4d26902e57a81a17208a81e72853eac
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0129" ;
     nidm_coordinateVector: "[-36,-36,18]"^^xsd:string .
 
-niiri:e5ae6607ef1f74d17740d67cbd30f3cc prov:wasDerivedFrom niiri:3a163a0cb084881b83df7fb4539004cf .
+niiri:c82901e5c8a2f2e07c026cc63680c42d prov:wasDerivedFrom niiri:3f463a005d2c5f82895c19639d89d232 .
 
-niiri:f27f6c548b20f347c59293da9f535803
+niiri:5e05a6be8ed22422ff22c365a4608304
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0130" ;
-    prov:atLocation niiri:74dd8128a505045e9137cbd31e31f66c ;
+    prov:atLocation niiri:211422795d75783e69bfebe075bb12ba ;
     prov:value "4.13366317749023"^^xsd:float ;
     nidm_equivalentZStatistic: "3.65368808789982"^^xsd:float ;
     nidm_pValueUncorrected: "0.000129250133878323"^^xsd:float ;
     nidm_pValueFWER: "0.999999653050959"^^xsd:float ;
     nidm_qValueFDR: "0.299778606912797"^^xsd:float .
 
-niiri:74dd8128a505045e9137cbd31e31f66c
+niiri:211422795d75783e69bfebe075bb12ba
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0130" ;
     nidm_coordinateVector: "[48,6,-26]"^^xsd:string .
 
-niiri:f27f6c548b20f347c59293da9f535803 prov:wasDerivedFrom niiri:43f0fb5e7c19214fdedd18472535c15a .
+niiri:5e05a6be8ed22422ff22c365a4608304 prov:wasDerivedFrom niiri:a088e0c82151087e1bf9897ac5ca3823 .
 
-niiri:f756b6f61da1646cc690af7d01487191
+niiri:e7bdd69e98dd52520a3f71978bb4d63d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0131" ;
-    prov:atLocation niiri:80aeef67e3ae8218a0930deda8754a8e ;
+    prov:atLocation niiri:0ad970416204095c686c9e26a90dd497 ;
     prov:value "4.13216829299927"^^xsd:float ;
     nidm_equivalentZStatistic: "3.65264911070072"^^xsd:float ;
     nidm_pValueUncorrected: "0.000129774394504789"^^xsd:float ;
     nidm_pValueFWER: "0.999999669292985"^^xsd:float ;
     nidm_qValueFDR: "0.299778606912797"^^xsd:float .
 
-niiri:80aeef67e3ae8218a0930deda8754a8e
+niiri:0ad970416204095c686c9e26a90dd497
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0131" ;
     nidm_coordinateVector: "[0,-36,68]"^^xsd:string .
 
-niiri:f756b6f61da1646cc690af7d01487191 prov:wasDerivedFrom niiri:2eda6a0e1bdd1c9e5ed07632d4ecdc2f .
+niiri:e7bdd69e98dd52520a3f71978bb4d63d prov:wasDerivedFrom niiri:321fa4b64bb46facf5ed354080dc1587 .
 
-niiri:4bd4142b1e187a6f1547307275a6b64a
+niiri:cb0d453b25f613101c49b7755e158915
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0132" ;
-    prov:atLocation niiri:214c5b9a5b733e0a2b01aa0370c70317 ;
+    prov:atLocation niiri:bb9c71a13ba7d3c7720ba36a40323b94 ;
     prov:value "4.12954187393188"^^xsd:float ;
     nidm_equivalentZStatistic: "3.65082293334618"^^xsd:float ;
     nidm_pValueUncorrected: "0.000130700706083675"^^xsd:float ;
     nidm_pValueFWER: "0.99999969612074"^^xsd:float ;
     nidm_qValueFDR: "0.300282900918552"^^xsd:float .
 
-niiri:214c5b9a5b733e0a2b01aa0370c70317
+niiri:bb9c71a13ba7d3c7720ba36a40323b94
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0132" ;
     nidm_coordinateVector: "[0,-66,-32]"^^xsd:string .
 
-niiri:4bd4142b1e187a6f1547307275a6b64a prov:wasDerivedFrom niiri:69803a9c56c9a9477742ef1bd9b5db35 .
+niiri:cb0d453b25f613101c49b7755e158915 prov:wasDerivedFrom niiri:1bb068ae0340b41c3c1e0585e61ab7a2 .
 
-niiri:82e7078422f0b3937478956ca2843ed9
+niiri:5e99034ea754760cb72226c0515da7cb
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0133" ;
-    prov:atLocation niiri:7f935a6b2fe8e680c5275698f3711d68 ;
+    prov:atLocation niiri:c9fab48eb480bedcc91578a2698fde0a ;
     prov:value "3.75143074989319"^^xsd:float ;
     nidm_equivalentZStatistic: "3.3772657457694"^^xsd:float ;
     nidm_pValueUncorrected: "0.000366051410943258"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999997"^^xsd:float ;
     nidm_qValueFDR: "0.557036851440628"^^xsd:float .
 
-niiri:7f935a6b2fe8e680c5275698f3711d68
+niiri:c9fab48eb480bedcc91578a2698fde0a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0133" ;
     nidm_coordinateVector: "[-2,-72,-40]"^^xsd:string .
 
-niiri:82e7078422f0b3937478956ca2843ed9 prov:wasDerivedFrom niiri:69803a9c56c9a9477742ef1bd9b5db35 .
+niiri:5e99034ea754760cb72226c0515da7cb prov:wasDerivedFrom niiri:1bb068ae0340b41c3c1e0585e61ab7a2 .
 
-niiri:9041224ff70fb80d80372bf6cee64f1c
+niiri:129852f860cbdc380fde0cefe3342420
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0134" ;
-    prov:atLocation niiri:818d6163412bc763dcff14dee617a7e4 ;
+    prov:atLocation niiri:205eb48ed5250d88acfbba837645bb72 ;
     prov:value "4.10398292541504"^^xsd:float ;
     nidm_equivalentZStatistic: "3.63300080119002"^^xsd:float ;
     nidm_pValueUncorrected: "0.00014007207404787"^^xsd:float ;
     nidm_pValueFWER: "0.999999869876426"^^xsd:float ;
     nidm_qValueFDR: "0.313079908458167"^^xsd:float .
 
-niiri:818d6163412bc763dcff14dee617a7e4
+niiri:205eb48ed5250d88acfbba837645bb72
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0134" ;
     nidm_coordinateVector: "[-30,-80,-44]"^^xsd:string .
 
-niiri:9041224ff70fb80d80372bf6cee64f1c prov:wasDerivedFrom niiri:01e79de738160252561a3797aff0be46 .
+niiri:129852f860cbdc380fde0cefe3342420 prov:wasDerivedFrom niiri:0b5c4b3fea9afd08f274ad657436f2dd .
 
-niiri:382c7b65c86868f2d1114949721c8c8b
+niiri:b0ded885245f537f83463a08809ba2e2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0135" ;
-    prov:atLocation niiri:a69cfd9529da5843d6391826ca8aa710 ;
+    prov:atLocation niiri:6f21e9e630f7c14252e29da5be8927f7 ;
     prov:value "4.09423494338989"^^xsd:float ;
     nidm_equivalentZStatistic: "3.62617922203425"^^xsd:float ;
     nidm_pValueUncorrected: "0.000143822875420141"^^xsd:float ;
     nidm_pValueFWER: "0.999999906977983"^^xsd:float ;
     nidm_qValueFDR: "0.318311758000453"^^xsd:float .
 
-niiri:a69cfd9529da5843d6391826ca8aa710
+niiri:6f21e9e630f7c14252e29da5be8927f7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0135" ;
     nidm_coordinateVector: "[-18,-58,20]"^^xsd:string .
 
-niiri:382c7b65c86868f2d1114949721c8c8b prov:wasDerivedFrom niiri:f41790cbed14abdecac7977440cc0bb6 .
+niiri:b0ded885245f537f83463a08809ba2e2 prov:wasDerivedFrom niiri:7b0e7637357771b4e3c95b60da0daba2 .
 
-niiri:0ff9790b1632fd8dc7c026079b7e404b
+niiri:22c1d4544f394d556ce159121dad1090
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0136" ;
-    prov:atLocation niiri:b391b16f30fa5bb91a81e95ad82f83a8 ;
+    prov:atLocation niiri:3e383b88dff3fd247a1d4f46b429f125 ;
     prov:value "4.08876514434814"^^xsd:float ;
     nidm_equivalentZStatistic: "3.62234556566246"^^xsd:float ;
     nidm_pValueUncorrected: "0.000145971878909523"^^xsd:float ;
     nidm_pValueFWER: "0.999999923179458"^^xsd:float ;
     nidm_qValueFDR: "0.320746339887158"^^xsd:float .
 
-niiri:b391b16f30fa5bb91a81e95ad82f83a8
+niiri:3e383b88dff3fd247a1d4f46b429f125
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0136" ;
     nidm_coordinateVector: "[-16,58,-4]"^^xsd:string .
 
-niiri:0ff9790b1632fd8dc7c026079b7e404b prov:wasDerivedFrom niiri:9cce28d22165f03a477a1d52851070af .
+niiri:22c1d4544f394d556ce159121dad1090 prov:wasDerivedFrom niiri:b8afe5b11ecf6b25c3098ac5c67b90a0 .
 
-niiri:46679ca6343d1a573a12b3267334ccae
+niiri:547427e4ab366b57aeae32169e9fa826
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0137" ;
-    prov:atLocation niiri:4fc24b19e3f4073fc98c2cf157a77815 ;
+    prov:atLocation niiri:2baf888e6359dbc3d2163775f4559d85 ;
     prov:value "4.06298494338989"^^xsd:float ;
     nidm_equivalentZStatistic: "3.60421915672313"^^xsd:float ;
     nidm_pValueUncorrected: "0.0001565463954466"^^xsd:float ;
     nidm_pValueFWER: "0.999999969751391"^^xsd:float ;
     nidm_qValueFDR: "0.337066691036746"^^xsd:float .
 
-niiri:4fc24b19e3f4073fc98c2cf157a77815
+niiri:2baf888e6359dbc3d2163775f4559d85
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0137" ;
     nidm_coordinateVector: "[-58,-64,12]"^^xsd:string .
 
-niiri:46679ca6343d1a573a12b3267334ccae prov:wasDerivedFrom niiri:cc59f8e2a9544b3ce2e7c770bd643f84 .
+niiri:547427e4ab366b57aeae32169e9fa826 prov:wasDerivedFrom niiri:a2a8b82493043f5593bcde950e35d4f5 .
 
-niiri:e505d9f08efe295d66ff7d2729598e62
+niiri:b237ed83cace8461fcea11375ea64058
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0138" ;
-    prov:atLocation niiri:f6cac4d82fa45980bce788671b68c796 ;
+    prov:atLocation niiri:ff3ac071d67ebff33f35d13e2679dac7 ;
     prov:value "4.02409505844116"^^xsd:float ;
     nidm_equivalentZStatistic: "3.57669340248228"^^xsd:float ;
     nidm_pValueUncorrected: "0.000173983947479694"^^xsd:float ;
     nidm_pValueFWER: "0.999999993280169"^^xsd:float ;
     nidm_qValueFDR: "0.362069612357364"^^xsd:float .
 
-niiri:f6cac4d82fa45980bce788671b68c796
+niiri:ff3ac071d67ebff33f35d13e2679dac7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0138" ;
     nidm_coordinateVector: "[-52,-72,0]"^^xsd:string .
 
-niiri:e505d9f08efe295d66ff7d2729598e62 prov:wasDerivedFrom niiri:1057dce00f5bb5fa3cfe47e76eb89cbb .
+niiri:b237ed83cace8461fcea11375ea64058 prov:wasDerivedFrom niiri:13a870b0869420f093e2bf23ab79a37e .
 
-niiri:0befb71a96e196f1aecb2eefd51a6d97
+niiri:eb9870892ec73e0a42bedc835e702e1e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0139" ;
-    prov:atLocation niiri:55f1bc9fb2977b7990ae8bce10083d5e ;
+    prov:atLocation niiri:4cb8ea570ae8e3ce83375c59900097d2 ;
     prov:value "4.02128601074219"^^xsd:float ;
     nidm_equivalentZStatistic: "3.5746966510118"^^xsd:float ;
     nidm_pValueUncorrected: "0.000175317095178373"^^xsd:float ;
     nidm_pValueFWER: "0.999999994000907"^^xsd:float ;
     nidm_qValueFDR: "0.363217717063605"^^xsd:float .
 
-niiri:55f1bc9fb2977b7990ae8bce10083d5e
+niiri:4cb8ea570ae8e3ce83375c59900097d2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0139" ;
     nidm_coordinateVector: "[-12,-28,-36]"^^xsd:string .
 
-niiri:0befb71a96e196f1aecb2eefd51a6d97 prov:wasDerivedFrom niiri:60ab79a3ea3afc698ecd6cf745ac195d .
+niiri:eb9870892ec73e0a42bedc835e702e1e prov:wasDerivedFrom niiri:9e62040415b20939b8c829b35ac0b428 .
 
-niiri:98c13d4a8425e483950ba8ece5bf4a9f
+niiri:fcfba481a3f9e7e9b20a26684a18708e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0140" ;
-    prov:atLocation niiri:48b17d888a4a392b84acb2d5b67ccb59 ;
+    prov:atLocation niiri:63bfafc8fb101ba5e644b447c56092c7 ;
     prov:value "4.01868104934692"^^xsd:float ;
     nidm_equivalentZStatistic: "3.57284393485473"^^xsd:float ;
     nidm_pValueUncorrected: "0.000176562616446385"^^xsd:float ;
     nidm_pValueFWER: "0.999999994603219"^^xsd:float ;
     nidm_qValueFDR: "0.36472959583602"^^xsd:float .
 
-niiri:48b17d888a4a392b84acb2d5b67ccb59
+niiri:63bfafc8fb101ba5e644b447c56092c7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0140" ;
     nidm_coordinateVector: "[16,66,8]"^^xsd:string .
 
-niiri:98c13d4a8425e483950ba8ece5bf4a9f prov:wasDerivedFrom niiri:5f6f6b54a9f90d5bb626fde29fa6b1fd .
+niiri:fcfba481a3f9e7e9b20a26684a18708e prov:wasDerivedFrom niiri:ef74f8693d6b0cc1f8f7291479877d46 .
 
-niiri:6ad0d5c98c6831dc1f952295b4caf89e
+niiri:4a44af96f5a5a857488581ee74a760c5
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0141" ;
-    prov:atLocation niiri:021f6bacb46f04b2ef69b6934db45bcb ;
+    prov:atLocation niiri:8f1c6e77c3ba88353c96f0c53e4a0f3a ;
     prov:value "4.01162719726562"^^xsd:float ;
     nidm_equivalentZStatistic: "3.5678220431388"^^xsd:float ;
     nidm_pValueUncorrected: "0.000179980416080805"^^xsd:float ;
     nidm_pValueFWER: "0.999999995959358"^^xsd:float ;
     nidm_qValueFDR: "0.368705093303964"^^xsd:float .
 
-niiri:021f6bacb46f04b2ef69b6934db45bcb
+niiri:8f1c6e77c3ba88353c96f0c53e4a0f3a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0141" ;
     nidm_coordinateVector: "[38,-18,-22]"^^xsd:string .
 
-niiri:6ad0d5c98c6831dc1f952295b4caf89e prov:wasDerivedFrom niiri:d2932453ed5d06805f9a2af83c52d15a .
+niiri:4a44af96f5a5a857488581ee74a760c5 prov:wasDerivedFrom niiri:b4f4a8e2b968691b39abdbd7cd10251b .
 
-niiri:c0f6e7b4644cfb60af16d459f0abf3d9
+niiri:365c37bfef2c5372b568baf1a0e25c19
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0142" ;
-    prov:atLocation niiri:3e5fa4a1c3a10b594eed4892e0711540 ;
+    prov:atLocation niiri:c269becdf88d5e85bf338212a81d3460 ;
     prov:value "4.00135660171509"^^xsd:float ;
     nidm_equivalentZStatistic: "3.56049691778852"^^xsd:float ;
     nidm_pValueUncorrected: "0.000185076828154274"^^xsd:float ;
     nidm_pValueFWER: "0.999999997368965"^^xsd:float ;
     nidm_qValueFDR: "0.373725297443398"^^xsd:float .
 
-niiri:3e5fa4a1c3a10b594eed4892e0711540
+niiri:c269becdf88d5e85bf338212a81d3460
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0142" ;
     nidm_coordinateVector: "[-48,-80,4]"^^xsd:string .
 
-niiri:c0f6e7b4644cfb60af16d459f0abf3d9 prov:wasDerivedFrom niiri:3fa7a66071d2b8d3530bef533d52b63d .
+niiri:365c37bfef2c5372b568baf1a0e25c19 prov:wasDerivedFrom niiri:b479ffd217729f45ba8e8b497543b71d .
 
-niiri:af4a6524016fc118e255dc42f2f9c362
+niiri:9bdf6e301bc7d332bfc69fca7860e71a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0143" ;
-    prov:atLocation niiri:1486cf66d9de1dbe26612b03f0e6a4c9 ;
+    prov:atLocation niiri:2b1b92ad42efe2e13047dd7960aa5a24 ;
     prov:value "4.00135326385498"^^xsd:float ;
     nidm_equivalentZStatistic: "3.56049453464796"^^xsd:float ;
     nidm_pValueUncorrected: "0.000185078507948022"^^xsd:float ;
     nidm_pValueFWER: "0.999999997369336"^^xsd:float ;
     nidm_qValueFDR: "0.373725297443398"^^xsd:float .
 
-niiri:1486cf66d9de1dbe26612b03f0e6a4c9
+niiri:2b1b92ad42efe2e13047dd7960aa5a24
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0143" ;
     nidm_coordinateVector: "[-58,12,-8]"^^xsd:string .
 
-niiri:af4a6524016fc118e255dc42f2f9c362 prov:wasDerivedFrom niiri:b3bc50a19f719b2fefee16f3b146e23d .
+niiri:9bdf6e301bc7d332bfc69fca7860e71a prov:wasDerivedFrom niiri:64b1c86050912153a776e757204d9bd6 .
 
-niiri:bf2797ace2e53c69a0cfe47803eb943e
+niiri:f154380a3618d99fcc1963b7595b12cf
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0144" ;
-    prov:atLocation niiri:74fd89207afdcbd8909359b1cd2137af ;
+    prov:atLocation niiri:5c37f393fae5b3f0c9757bc853b9b56e ;
     prov:value "3.99607825279236"^^xsd:float ;
     nidm_equivalentZStatistic: "3.55672625925588"^^xsd:float ;
     nidm_pValueUncorrected: "0.000187752539048236"^^xsd:float ;
     nidm_pValueFWER: "0.999999997897124"^^xsd:float ;
     nidm_qValueFDR: "0.376379972172505"^^xsd:float .
 
-niiri:74fd89207afdcbd8909359b1cd2137af
+niiri:5c37f393fae5b3f0c9757bc853b9b56e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0144" ;
     nidm_coordinateVector: "[-48,-76,38]"^^xsd:string .
 
-niiri:bf2797ace2e53c69a0cfe47803eb943e prov:wasDerivedFrom niiri:ae4a511d54b76b35f1462db6d3370c9c .
+niiri:f154380a3618d99fcc1963b7595b12cf prov:wasDerivedFrom niiri:2262ce46c8d9d3e44fca9d2b9991842a .
 
-niiri:68eb2bb6428cb7fb60f9cc6b4b70731c
+niiri:04b3a6d25c6f054367f9c4694052a759
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0145" ;
-    prov:atLocation niiri:9b177c1403c3d72642752ce1fd26ffc0 ;
+    prov:atLocation niiri:4c62a1b7a4a99ebc81422f9ad84145a8 ;
     prov:value "3.98602223396301"^^xsd:float ;
     nidm_equivalentZStatistic: "3.54953116356185"^^xsd:float ;
     nidm_pValueUncorrected: "0.000192958892207273"^^xsd:float ;
     nidm_pValueFWER: "0.999999998637159"^^xsd:float ;
     nidm_qValueFDR: "0.383480923686124"^^xsd:float .
 
-niiri:9b177c1403c3d72642752ce1fd26ffc0
+niiri:4c62a1b7a4a99ebc81422f9ad84145a8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0145" ;
     nidm_coordinateVector: "[36,-82,-12]"^^xsd:string .
 
-niiri:68eb2bb6428cb7fb60f9cc6b4b70731c prov:wasDerivedFrom niiri:d9f9aff87a34b9c5479d4873772dd0ed .
+niiri:04b3a6d25c6f054367f9c4694052a759 prov:wasDerivedFrom niiri:03e5589e0cbf8390adc9f572f09c2111 .
 
-niiri:89aca1530216702056d8baaf5e96f3b9
+niiri:21a5865dd670800228185cc04d8fc8fb
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0146" ;
-    prov:atLocation niiri:4210b934a7686b52ab673b65b6237b92 ;
+    prov:atLocation niiri:bc24ed4471eb7ddcb8c465323191fbb1 ;
     prov:value "3.98011517524719"^^xsd:float ;
     nidm_equivalentZStatistic: "3.54529763503038"^^xsd:float ;
     nidm_pValueUncorrected: "0.000196084993860035"^^xsd:float ;
     nidm_pValueFWER: "0.999999998948156"^^xsd:float ;
     nidm_qValueFDR: "0.387269615473322"^^xsd:float .
 
-niiri:4210b934a7686b52ab673b65b6237b92
+niiri:bc24ed4471eb7ddcb8c465323191fbb1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0146" ;
     nidm_coordinateVector: "[20,54,-8]"^^xsd:string .
 
-niiri:89aca1530216702056d8baaf5e96f3b9 prov:wasDerivedFrom niiri:8bfeeb8b866911a137111a38c272b615 .
+niiri:21a5865dd670800228185cc04d8fc8fb prov:wasDerivedFrom niiri:183d033f8dc6f63dd2d370f917d30bf5 .
 
-niiri:ae28de6778d667095f89372fc3a550d2
+niiri:c74a4087e267c6fd39be3a397e46725a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0147" ;
-    prov:atLocation niiri:f435575022c6f9a3cd038c9698277abc ;
+    prov:atLocation niiri:a66466e9c70651b2e5c633b33d19f5cf ;
     prov:value "3.96872425079346"^^xsd:float ;
     nidm_equivalentZStatistic: "3.5371191512089"^^xsd:float ;
     nidm_pValueUncorrected: "0.000202258563679281"^^xsd:float ;
     nidm_pValueFWER: "0.99999999936744"^^xsd:float ;
     nidm_qValueFDR: "0.394063237507806"^^xsd:float .
 
-niiri:f435575022c6f9a3cd038c9698277abc
+niiri:a66466e9c70651b2e5c633b33d19f5cf
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0147" ;
     nidm_coordinateVector: "[-14,-94,-10]"^^xsd:string .
 
-niiri:ae28de6778d667095f89372fc3a550d2 prov:wasDerivedFrom niiri:ac52eb589b96f34cb8f8a5bc4d179c34 .
+niiri:c74a4087e267c6fd39be3a397e46725a prov:wasDerivedFrom niiri:82ed6a608808b53426982c1cc66a2ec6 .
 
-niiri:19444cfcec8df5e62fbbfd91a32d5ed2
+niiri:b7c5013ad25e77cc226834b99a8ce972
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0148" ;
-    prov:atLocation niiri:675e1f4fa7e363a599b247e3927ecc92 ;
+    prov:atLocation niiri:74c064010533901b8404367331895a48 ;
     prov:value "3.95317459106445"^^xsd:float ;
     nidm_equivalentZStatistic: "3.5259233176632"^^xsd:float ;
     nidm_pValueUncorrected: "0.0002110045706335"^^xsd:float ;
     nidm_pValueFWER: "0.999999999690183"^^xsd:float ;
     nidm_qValueFDR: "0.405666580848087"^^xsd:float .
 
-niiri:675e1f4fa7e363a599b247e3927ecc92
+niiri:74c064010533901b8404367331895a48
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0148" ;
     nidm_coordinateVector: "[24,42,24]"^^xsd:string .
 
-niiri:19444cfcec8df5e62fbbfd91a32d5ed2 prov:wasDerivedFrom niiri:3355d697f188c4ca897d5bfbad88c46c .
+niiri:b7c5013ad25e77cc226834b99a8ce972 prov:wasDerivedFrom niiri:c38a12c7c56a4a6bcef1a3f1defaede6 .
 
-niiri:7053ec26e42de608655ed244474068db
+niiri:6991f89fa4a569360c7960b2846f6a34
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0149" ;
-    prov:atLocation niiri:0e60e10eda1b6196de171edf4835a00b ;
+    prov:atLocation niiri:4d01562ba8e7aaef06d135d4e94692d7 ;
     prov:value "3.95155644416809"^^xsd:float ;
     nidm_equivalentZStatistic: "3.52475614968874"^^xsd:float ;
     nidm_pValueUncorrected: "0.000211936393588741"^^xsd:float ;
     nidm_pValueFWER: "0.999999999712743"^^xsd:float ;
     nidm_qValueFDR: "0.405953632826713"^^xsd:float .
 
-niiri:0e60e10eda1b6196de171edf4835a00b
+niiri:4d01562ba8e7aaef06d135d4e94692d7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0149" ;
     nidm_coordinateVector: "[12,-40,54]"^^xsd:string .
 
-niiri:7053ec26e42de608655ed244474068db prov:wasDerivedFrom niiri:868f4263fbce64aac9db6a0fc1959caf .
+niiri:6991f89fa4a569360c7960b2846f6a34 prov:wasDerivedFrom niiri:b903a819026d14c010b6e3c047f2d1f1 .
 
-niiri:5d90a7e798fc989106dcd7e3f700063d
+niiri:491aedeeb6989cc87f18a592ce6034b8
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0150" ;
-    prov:atLocation niiri:03b46eda33433662aeba61fcc011b88a ;
+    prov:atLocation niiri:10d3c6a7e17f15b5c99b849bce1f4e00 ;
     prov:value "3.9356153011322"^^xsd:float ;
     nidm_equivalentZStatistic: "3.5132366181111"^^xsd:float ;
     nidm_pValueUncorrected: "0.000221341529396013"^^xsd:float ;
     nidm_pValueFWER: "0.999999999865451"^^xsd:float ;
     nidm_qValueFDR: "0.417114555671981"^^xsd:float .
 
-niiri:03b46eda33433662aeba61fcc011b88a
+niiri:10d3c6a7e17f15b5c99b849bce1f4e00
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0150" ;
     nidm_coordinateVector: "[-38,-42,40]"^^xsd:string .
 
-niiri:5d90a7e798fc989106dcd7e3f700063d prov:wasDerivedFrom niiri:f20ed18d19c8f3654c783f3c512348b3 .
+niiri:491aedeeb6989cc87f18a592ce6034b8 prov:wasDerivedFrom niiri:932955007c6604e912ca88f69e4b71b2 .
 
-niiri:8b40dfda892474fa41abb58fde74a407
+niiri:a0e32572643e1e64ce6a2b660df410a5
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0151" ;
-    prov:atLocation niiri:a347bbd053fb913e14b1f7c3a3bd8e7a ;
+    prov:atLocation niiri:9aa3ceab97fdd6296ca2d454a99e0236 ;
     prov:value "3.9238920211792"^^xsd:float ;
     nidm_equivalentZStatistic: "3.50474037295824"^^xsd:float ;
     nidm_pValueUncorrected: "0.000228526381680583"^^xsd:float ;
     nidm_pValueFWER: "0.999999999924203"^^xsd:float ;
     nidm_qValueFDR: "0.426487116823797"^^xsd:float .
 
-niiri:a347bbd053fb913e14b1f7c3a3bd8e7a
+niiri:9aa3ceab97fdd6296ca2d454a99e0236
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0151" ;
     nidm_coordinateVector: "[26,14,-42]"^^xsd:string .
 
-niiri:8b40dfda892474fa41abb58fde74a407 prov:wasDerivedFrom niiri:05512cf6085c8d2b74ae7737861092c8 .
+niiri:a0e32572643e1e64ce6a2b660df410a5 prov:wasDerivedFrom niiri:19bb8ba20387a263ccc2a4033c4a6959 .
 
-niiri:f980d09473ea1db06a5ae15757b63531
+niiri:eff4c7c132b2d22a84606557001ce26e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0152" ;
-    prov:atLocation niiri:ac45277c6c3e4f5e91852754529d4adf ;
+    prov:atLocation niiri:69acdcdb685d789931e1f31b3781c116 ;
     prov:value "3.92273545265198"^^xsd:float ;
     nidm_equivalentZStatistic: "3.50390103236879"^^xsd:float ;
     nidm_pValueUncorrected: "0.000229247859657944"^^xsd:float ;
     nidm_pValueFWER: "0.999999999928429"^^xsd:float ;
     nidm_qValueFDR: "0.426958547295112"^^xsd:float .
 
-niiri:ac45277c6c3e4f5e91852754529d4adf
+niiri:69acdcdb685d789931e1f31b3781c116
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0152" ;
     nidm_coordinateVector: "[70,-14,-16]"^^xsd:string .
 
-niiri:f980d09473ea1db06a5ae15757b63531 prov:wasDerivedFrom niiri:f695aae9ae02bed79ba9e19f8af0adb8 .
+niiri:eff4c7c132b2d22a84606557001ce26e prov:wasDerivedFrom niiri:4c267352cce4185f6d8f19642a2432ea .
 
-niiri:689291c6ba42ba2ac5cad972a5fef404
+niiri:bbf3d38beafaa3b95e5b56928a96bf1c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0153" ;
-    prov:atLocation niiri:b78b7f1eb50166ff54fb5604ca6337ed ;
+    prov:atLocation niiri:8d526269d332e0c02c7b75355485d2f8 ;
     prov:value "3.92078685760498"^^xsd:float ;
     nidm_equivalentZStatistic: "3.50248644225283"^^xsd:float ;
     nidm_pValueUncorrected: "0.000230468620522117"^^xsd:float ;
     nidm_pValueFWER: "0.999999999935043"^^xsd:float ;
     nidm_qValueFDR: "0.428151423127615"^^xsd:float .
 
-niiri:b78b7f1eb50166ff54fb5604ca6337ed
+niiri:8d526269d332e0c02c7b75355485d2f8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0153" ;
     nidm_coordinateVector: "[34,-76,-48]"^^xsd:string .
 
-niiri:689291c6ba42ba2ac5cad972a5fef404 prov:wasDerivedFrom niiri:d1fc4fee78d95536f89feb63f14c968c .
+niiri:bbf3d38beafaa3b95e5b56928a96bf1c prov:wasDerivedFrom niiri:b779ca098f1180fe09ebe0414895c731 .
 
-niiri:17883bb686073f5e839d5a2c56455e56
+niiri:fde7e62b6e5574c052bb9f546102d87e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0154" ;
-    prov:atLocation niiri:c664cfa73dad97e74074295ac43ea93e ;
+    prov:atLocation niiri:44da668a7172bf8e300266f277be8526 ;
     prov:value "3.91062116622925"^^xsd:float ;
     nidm_equivalentZStatistic: "3.49509717797378"^^xsd:float ;
     nidm_pValueUncorrected: "0.000236944590689236"^^xsd:float ;
     nidm_pValueFWER: "0.99999999996108"^^xsd:float ;
     nidm_qValueFDR: "0.436321106791799"^^xsd:float .
 
-niiri:c664cfa73dad97e74074295ac43ea93e
+niiri:44da668a7172bf8e300266f277be8526
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0154" ;
     nidm_coordinateVector: "[-6,-28,-38]"^^xsd:string .
 
-niiri:17883bb686073f5e839d5a2c56455e56 prov:wasDerivedFrom niiri:e1f20b806abf584189fd37df83ae5f02 .
+niiri:fde7e62b6e5574c052bb9f546102d87e prov:wasDerivedFrom niiri:b7385089cc22c8804fc256dff15181f6 .
 
-niiri:a8eb2fd9a2816c1854b916c6d05cc3de
+niiri:fd29863328da8f073c80249fc257f355
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0155" ;
-    prov:atLocation niiri:605067a9ffda41ab1a46d83048f971b3 ;
+    prov:atLocation niiri:986f6d2591d738e2cadb54b471af94af ;
     prov:value "3.58703351020813"^^xsd:float ;
     nidm_equivalentZStatistic: "3.25118905074874"^^xsd:float ;
     nidm_pValueUncorrected: "0.000574617057569893"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.726302359446116"^^xsd:float .
 
-niiri:605067a9ffda41ab1a46d83048f971b3
+niiri:986f6d2591d738e2cadb54b471af94af
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0155" ;
     nidm_coordinateVector: "[0,-34,-38]"^^xsd:string .
 
-niiri:a8eb2fd9a2816c1854b916c6d05cc3de prov:wasDerivedFrom niiri:e1f20b806abf584189fd37df83ae5f02 .
+niiri:fd29863328da8f073c80249fc257f355 prov:wasDerivedFrom niiri:b7385089cc22c8804fc256dff15181f6 .
 
-niiri:9e2bf19e1e6e723e7ef6ef9189c04fe4
+niiri:bbfd8b6cf217d559db130a9610ba08e1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0156" ;
-    prov:atLocation niiri:835c4fe7a0877e34b674425316a351e8 ;
+    prov:atLocation niiri:924ee8942f43f143db4d35b4c58fba9b ;
     prov:value "3.90419101715088"^^xsd:float ;
     nidm_equivalentZStatistic: "3.49041501158993"^^xsd:float ;
     nidm_pValueUncorrected: "0.000241135489868927"^^xsd:float ;
     nidm_pValueFWER: "0.999999999972007"^^xsd:float ;
     nidm_qValueFDR: "0.441724604413149"^^xsd:float .
 
-niiri:835c4fe7a0877e34b674425316a351e8
+niiri:924ee8942f43f143db4d35b4c58fba9b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0156" ;
     nidm_coordinateVector: "[-38,-32,-20]"^^xsd:string .
 
-niiri:9e2bf19e1e6e723e7ef6ef9189c04fe4 prov:wasDerivedFrom niiri:f4343a9252d96448237743dc7620b82d .
+niiri:bbfd8b6cf217d559db130a9610ba08e1 prov:wasDerivedFrom niiri:a34044dfcf23dfe53b2945318b0397f1 .
 
-niiri:9226f674cf9b761e0a9ecfd66d3a398f
+niiri:7b9ad2de6142a99edfdc041b3923c4a7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0157" ;
-    prov:atLocation niiri:8986fe3ec63b2150128b1ebc207fe996 ;
+    prov:atLocation niiri:436e822866e4609faf1e3f52f35d390a ;
     prov:value "3.89783668518066"^^xsd:float ;
     nidm_equivalentZStatistic: "3.48578178709346"^^xsd:float ;
     nidm_pValueUncorrected: "0.00024535055301822"^^xsd:float ;
     nidm_pValueFWER: "0.999999999979874"^^xsd:float ;
     nidm_qValueFDR: "0.446520868052966"^^xsd:float .
 
-niiri:8986fe3ec63b2150128b1ebc207fe996
+niiri:436e822866e4609faf1e3f52f35d390a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0157" ;
     nidm_coordinateVector: "[-16,-60,-40]"^^xsd:string .
 
-niiri:9226f674cf9b761e0a9ecfd66d3a398f prov:wasDerivedFrom niiri:f74cf4fd744cb5d2223e69c6b86d72ca .
+niiri:7b9ad2de6142a99edfdc041b3923c4a7 prov:wasDerivedFrom niiri:e3223bf7299c1367c69b65daadf7dab4 .
 
-niiri:35761cafae22ec77ae8236d4705d8cf2
+niiri:22f96a3b44837b69cbbf8a2c6235393c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0158" ;
-    prov:atLocation niiri:85a13da6c36c15780f819fee23c0e3db ;
+    prov:atLocation niiri:f0873eb65c77e400ce4652d1321fd7dc ;
     prov:value "3.89488410949707"^^xsd:float ;
     nidm_equivalentZStatistic: "3.48362680959561"^^xsd:float ;
     nidm_pValueUncorrected: "0.000247334358895901"^^xsd:float ;
     nidm_pValueFWER: "0.99999999998276"^^xsd:float ;
     nidm_qValueFDR: "0.448724783299707"^^xsd:float .
 
-niiri:85a13da6c36c15780f819fee23c0e3db
+niiri:f0873eb65c77e400ce4652d1321fd7dc
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0158" ;
     nidm_coordinateVector: "[22,-6,36]"^^xsd:string .
 
-niiri:35761cafae22ec77ae8236d4705d8cf2 prov:wasDerivedFrom niiri:2c8ba22e270c2ab78bc2767742ff87f1 .
+niiri:22f96a3b44837b69cbbf8a2c6235393c prov:wasDerivedFrom niiri:315a3351fd67e6810a0558156faed379 .
 
-niiri:ff502a8d909d3c3fb263e7bba8857ee2
+niiri:4acde4458913098e4ee4d1c2c2fdf3e4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0159" ;
-    prov:atLocation niiri:99e931bccfddb88b417478c52ad364a1 ;
+    prov:atLocation niiri:ef2dcb6bf4f5fa6a95e35be037823273 ;
     prov:value "3.88967633247375"^^xsd:float ;
     nidm_equivalentZStatistic: "3.47982255115638"^^xsd:float ;
     nidm_pValueUncorrected: "0.000250872994247642"^^xsd:float ;
     nidm_pValueFWER: "0.999999999986909"^^xsd:float ;
     nidm_qValueFDR: "0.452045143743209"^^xsd:float .
 
-niiri:99e931bccfddb88b417478c52ad364a1
+niiri:ef2dcb6bf4f5fa6a95e35be037823273
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0159" ;
     nidm_coordinateVector: "[70,-18,22]"^^xsd:string .
 
-niiri:ff502a8d909d3c3fb263e7bba8857ee2 prov:wasDerivedFrom niiri:ffa25ea15473af14a67c3205bbe9f983 .
+niiri:4acde4458913098e4ee4d1c2c2fdf3e4 prov:wasDerivedFrom niiri:956afe330511d5dec77faf29c8e66c5b .
 
-niiri:78f7bb979686e7d99e73f8e3bcdeb29f
+niiri:d0a5abfdb9ce4fbd61ff9387b7bb7058
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0160" ;
-    prov:atLocation niiri:262ada1ef00daebfcc5a3f15081faf81 ;
+    prov:atLocation niiri:ede966d1838252b4a610f64fcfdc2cde ;
     prov:value "3.88418507575989"^^xsd:float ;
     nidm_equivalentZStatistic: "3.47580665261676"^^xsd:float ;
     nidm_pValueUncorrected: "0.000254659668458612"^^xsd:float ;
     nidm_pValueFWER: "0.999999999990239"^^xsd:float ;
     nidm_qValueFDR: "0.454152699790317"^^xsd:float .
 
-niiri:262ada1ef00daebfcc5a3f15081faf81
+niiri:ede966d1838252b4a610f64fcfdc2cde
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0160" ;
     nidm_coordinateVector: "[30,2,6]"^^xsd:string .
 
-niiri:78f7bb979686e7d99e73f8e3bcdeb29f prov:wasDerivedFrom niiri:bc830c332ebaee861ca402fa60321dce .
+niiri:d0a5abfdb9ce4fbd61ff9387b7bb7058 prov:wasDerivedFrom niiri:4740016eb1ce8e7ec8341eb44cf9ffa5 .
 
-niiri:d7d1e168a257cc2a8098d5c4990334fc
+niiri:8eb9d8849b7d8b35f84629d662d9ddce
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0161" ;
-    prov:atLocation niiri:6113b83ffc7f18d4a0cd5ff52a9e1dfc ;
+    prov:atLocation niiri:7074e885282a279bde925ee7cac8966c ;
     prov:value "3.86606097221375"^^xsd:float ;
     nidm_equivalentZStatistic: "3.4625186718634"^^xsd:float ;
     nidm_pValueUncorrected: "0.000267572390954318"^^xsd:float ;
     nidm_pValueFWER: "0.999999999996381"^^xsd:float ;
     nidm_qValueFDR: "0.470059115371888"^^xsd:float .
 
-niiri:6113b83ffc7f18d4a0cd5ff52a9e1dfc
+niiri:7074e885282a279bde925ee7cac8966c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0161" ;
     nidm_coordinateVector: "[44,-70,10]"^^xsd:string .
 
-niiri:d7d1e168a257cc2a8098d5c4990334fc prov:wasDerivedFrom niiri:47f7311fc1a64f3bf47cf50b4561aabc .
+niiri:8eb9d8849b7d8b35f84629d662d9ddce prov:wasDerivedFrom niiri:f956c3347b26a7454fde4d7c1ee3dfac .
 
-niiri:ebb9c3a475d66ccb16fb19d9f0d3ce14
+niiri:b9ada525c8e48deb5d4ab2d7359c8cad
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0162" ;
-    prov:atLocation niiri:46f7f2bdccb029792eb1f98b5b5baef1 ;
+    prov:atLocation niiri:3c562f99bbe0809e80e32866c3fb4ddc ;
     prov:value "3.86296033859253"^^xsd:float ;
     nidm_equivalentZStatistic: "3.46024024384584"^^xsd:float ;
     nidm_pValueUncorrected: "0.00026984682439557"^^xsd:float ;
     nidm_pValueFWER: "0.999999999996958"^^xsd:float ;
     nidm_qValueFDR: "0.472530207119252"^^xsd:float .
 
-niiri:46f7f2bdccb029792eb1f98b5b5baef1
+niiri:3c562f99bbe0809e80e32866c3fb4ddc
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0162" ;
     nidm_coordinateVector: "[62,14,2]"^^xsd:string .
 
-niiri:ebb9c3a475d66ccb16fb19d9f0d3ce14 prov:wasDerivedFrom niiri:b8ae2b4592f8a2f04be965b5829712bf .
+niiri:b9ada525c8e48deb5d4ab2d7359c8cad prov:wasDerivedFrom niiri:0306caf1c070bce484bea6d4d02ee4b9 .
 
-niiri:234f15c91bb1376fd18666ea14553917
+niiri:3858cf13f28f0ad56deb178e3014e96c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0163" ;
-    prov:atLocation niiri:81fa678cb829b598f9461c5b13e08eeb ;
+    prov:atLocation niiri:be16a855a7da7e7571099f7d7fadf88b ;
     prov:value "3.8599865436554"^^xsd:float ;
     nidm_equivalentZStatistic: "3.45805360223286"^^xsd:float ;
     nidm_pValueUncorrected: "0.000272046559771755"^^xsd:float ;
     nidm_pValueFWER: "0.999999999997427"^^xsd:float ;
     nidm_qValueFDR: "0.474088026751007"^^xsd:float .
 
-niiri:81fa678cb829b598f9461c5b13e08eeb
+niiri:be16a855a7da7e7571099f7d7fadf88b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0163" ;
     nidm_coordinateVector: "[-4,-36,-2]"^^xsd:string .
 
-niiri:234f15c91bb1376fd18666ea14553917 prov:wasDerivedFrom niiri:a0e10a7c0fca0a0252e91da150ff7c73 .
+niiri:3858cf13f28f0ad56deb178e3014e96c prov:wasDerivedFrom niiri:0718df40c87e4adde0a6b31fdd007bb4 .
 
-niiri:7850b2964ab00633dad17748772a65f3
+niiri:1112b9b2a26ffc98a6ff69fd57530f89
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0164" ;
-    prov:atLocation niiri:1111921aa18c82a39e80343596bc0094 ;
+    prov:atLocation niiri:46892ae833db38c9bed091f4cc572d1f ;
     prov:value "3.84141182899475"^^xsd:float ;
     nidm_equivalentZStatistic: "3.4443640186187"^^xsd:float ;
     nidm_pValueUncorrected: "0.000286202240919464"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999116"^^xsd:float ;
     nidm_qValueFDR: "0.488513754339778"^^xsd:float .
 
-niiri:1111921aa18c82a39e80343596bc0094
+niiri:46892ae833db38c9bed091f4cc572d1f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0164" ;
     nidm_coordinateVector: "[36,-86,0]"^^xsd:string .
 
-niiri:7850b2964ab00633dad17748772a65f3 prov:wasDerivedFrom niiri:7ce8d10a760980abe8a87f7a79f378c2 .
+niiri:1112b9b2a26ffc98a6ff69fd57530f89 prov:wasDerivedFrom niiri:c3345fe728c02a6d54b764235fc35217 .
 
-niiri:7b821f21d097cc8be558a6d09355f235
+niiri:774e14320ea8f360c6b0c85dfac5a6f6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0165" ;
-    prov:atLocation niiri:4fce38511ab679beeca0106d265285e3 ;
+    prov:atLocation niiri:6cda172da941b8967efdbea8200c7c74 ;
     prov:value "3.83968877792358"^^xsd:float ;
     nidm_equivalentZStatistic: "3.44309136368839"^^xsd:float ;
     nidm_pValueUncorrected: "0.000287552494602217"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999202"^^xsd:float ;
     nidm_qValueFDR: "0.488629379902393"^^xsd:float .
 
-niiri:4fce38511ab679beeca0106d265285e3
+niiri:6cda172da941b8967efdbea8200c7c74
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0165" ;
     nidm_coordinateVector: "[-22,-20,-8]"^^xsd:string .
 
-niiri:7b821f21d097cc8be558a6d09355f235 prov:wasDerivedFrom niiri:4dd100dcaaa90bf1aaa604fdff0ba9ff .
+niiri:774e14320ea8f360c6b0c85dfac5a6f6 prov:wasDerivedFrom niiri:db4e8782b5b474daeb575623d11d8f36 .
 
-niiri:0ed5fd3b050787ec334d9240417cc86b
+niiri:47ddc4f29769c51faebf4ea324bcbea6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0166" ;
-    prov:atLocation niiri:7e187bd41f06a2ac9b65071b34db4f4d ;
+    prov:atLocation niiri:710d166e9d667b62c67e8a53f8271d18 ;
     prov:value "3.82990407943726"^^xsd:float ;
     nidm_equivalentZStatistic: "3.43585539262748"^^xsd:float ;
     nidm_pValueUncorrected: "0.000295343082936661"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999554"^^xsd:float ;
     nidm_qValueFDR: "0.497538796190216"^^xsd:float .
 
-niiri:7e187bd41f06a2ac9b65071b34db4f4d
+niiri:710d166e9d667b62c67e8a53f8271d18
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0166" ;
     nidm_coordinateVector: "[28,10,-48]"^^xsd:string .
 
-niiri:0ed5fd3b050787ec334d9240417cc86b prov:wasDerivedFrom niiri:ac00e8055c4355ec5762be8458693242 .
+niiri:47ddc4f29769c51faebf4ea324bcbea6 prov:wasDerivedFrom niiri:3a7bd3c73757ad2c63a505ac44ee7de9 .
 
-niiri:917c3a971b74e494332c12b9d38f5f02
+niiri:294213488c1599f884797c81cb836c26
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0167" ;
-    prov:atLocation niiri:1e214330c1ac605ba9e2a36127308d66 ;
+    prov:atLocation niiri:6367c8833a918270dfd9c8b1b40ca341 ;
     prov:value "3.82795763015747"^^xsd:float ;
     nidm_equivalentZStatistic: "3.43441413993503"^^xsd:float ;
     nidm_pValueUncorrected: "0.000296918082366093"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999603"^^xsd:float ;
     nidm_qValueFDR: "0.498296237103169"^^xsd:float .
 
-niiri:1e214330c1ac605ba9e2a36127308d66
+niiri:6367c8833a918270dfd9c8b1b40ca341
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0167" ;
     nidm_coordinateVector: "[66,-50,8]"^^xsd:string .
 
-niiri:917c3a971b74e494332c12b9d38f5f02 prov:wasDerivedFrom niiri:0c01d3025f9ac35ecf95f50b6ad70473 .
+niiri:294213488c1599f884797c81cb836c26 prov:wasDerivedFrom niiri:ca632dc1f3d6a97bb76e5a785e5f4b39 .
 
-niiri:ed7bf2f4d7ab358d6ef3f9319bccd007
+niiri:5ef57e2d25150bc6ea7a27effd3f103a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0168" ;
-    prov:atLocation niiri:c1024294630358228bcebd260db7bf8f ;
+    prov:atLocation niiri:57e37097f19962e578c75dbc7bf9fd63 ;
     prov:value "3.8172779083252"^^xsd:float ;
     nidm_equivalentZStatistic: "3.42649555500792"^^xsd:float ;
     nidm_pValueUncorrected: "0.000305711884475035"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999793"^^xsd:float ;
     nidm_qValueFDR: "0.506379555477876"^^xsd:float .
 
-niiri:c1024294630358228bcebd260db7bf8f
+niiri:57e37097f19962e578c75dbc7bf9fd63
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0168" ;
     nidm_coordinateVector: "[4,10,-12]"^^xsd:string .
 
-niiri:ed7bf2f4d7ab358d6ef3f9319bccd007 prov:wasDerivedFrom niiri:6f3664cedc79fb9f59b11be01c396b26 .
+niiri:5ef57e2d25150bc6ea7a27effd3f103a prov:wasDerivedFrom niiri:4d501ade9f45e68e86c0aef60754a9aa .
 
-niiri:b24c5cd9b910fa054ebf0fa0aa6bed8d
+niiri:0d6879c706d432096efe8532fec772d4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0169" ;
-    prov:atLocation niiri:fa58bdddec43dbb6066752da57561818 ;
+    prov:atLocation niiri:9edfb7145b03634fe426e3cb3a1f8f31 ;
     prov:value "3.81648898124695"^^xsd:float ;
     nidm_equivalentZStatistic: "3.42590987377981"^^xsd:float ;
     nidm_pValueUncorrected: "0.000306371831813368"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999803"^^xsd:float ;
     nidm_qValueFDR: "0.506469617613673"^^xsd:float .
 
-niiri:fa58bdddec43dbb6066752da57561818
+niiri:9edfb7145b03634fe426e3cb3a1f8f31
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0169" ;
     nidm_coordinateVector: "[-30,-76,14]"^^xsd:string .
 
-niiri:b24c5cd9b910fa054ebf0fa0aa6bed8d prov:wasDerivedFrom niiri:c89efa8381d6b8fd6a264562898c049a .
+niiri:0d6879c706d432096efe8532fec772d4 prov:wasDerivedFrom niiri:4353f4b513f6d03c8ce9a7ee07ac3524 .
 
-niiri:76656100d047e2ed713b22fc387c3ac1
+niiri:ab5b8f7ed76dff5e4855a5dd6e0a6743
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0170" ;
-    prov:atLocation niiri:b5f3dd3509c4c369cab07cfc6b263d4c ;
+    prov:atLocation niiri:4b10b660ac7ce0aa32872c923c9c69e9 ;
     prov:value "3.81299877166748"^^xsd:float ;
     nidm_equivalentZStatistic: "3.42331762603938"^^xsd:float ;
     nidm_pValueUncorrected: "0.000309308734253833"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999841"^^xsd:float ;
     nidm_qValueFDR: "0.507710079712136"^^xsd:float .
 
-niiri:b5f3dd3509c4c369cab07cfc6b263d4c
+niiri:4b10b660ac7ce0aa32872c923c9c69e9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0170" ;
     nidm_coordinateVector: "[-56,-18,36]"^^xsd:string .
 
-niiri:76656100d047e2ed713b22fc387c3ac1 prov:wasDerivedFrom niiri:601f2b2d65ca5573b797e7fb5ea7c122 .
+niiri:ab5b8f7ed76dff5e4855a5dd6e0a6743 prov:wasDerivedFrom niiri:d24c03f6c5960ef050e1d0a675496464 .
 
-niiri:3583b9c4fc0171a190e35241951dba8c
+niiri:764e3cd68a4e95df65e0a1e502bbd0d3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0171" ;
-    prov:atLocation niiri:ad35dabfe3f4302f7aa5d78104dc9595 ;
+    prov:atLocation niiri:7079336242f83a28182be4daca622d5b ;
     prov:value "3.8037748336792"^^xsd:float ;
     nidm_equivalentZStatistic: "3.41645740843357"^^xsd:float ;
     nidm_pValueUncorrected: "0.000317207934866337"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999911"^^xsd:float ;
     nidm_qValueFDR: "0.514664695786681"^^xsd:float .
 
-niiri:ad35dabfe3f4302f7aa5d78104dc9595
+niiri:7079336242f83a28182be4daca622d5b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0171" ;
     nidm_coordinateVector: "[-34,30,44]"^^xsd:string .
 
-niiri:3583b9c4fc0171a190e35241951dba8c prov:wasDerivedFrom niiri:41706195949bd303e398c4c6246c9da1 .
+niiri:764e3cd68a4e95df65e0a1e502bbd0d3 prov:wasDerivedFrom niiri:0630bc3a96bd8ec1bd4f2dbb98bd8a68 .
 
-niiri:439481b3a0012f61306105bf2a9e776e
+niiri:75596cb1506d72be9c60a786cdfeb9e9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0172" ;
-    prov:atLocation niiri:d64db3448b2d0408bc9c2ba27b8954bc ;
+    prov:atLocation niiri:dcdaa5f8f83360bc6ccfa19fcc3afbe8 ;
     prov:value "3.80352520942688"^^xsd:float ;
     nidm_equivalentZStatistic: "3.41627156249268"^^xsd:float ;
     nidm_pValueUncorrected: "0.00031742451522887"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999912"^^xsd:float ;
     nidm_qValueFDR: "0.514664695786681"^^xsd:float .
 
-niiri:d64db3448b2d0408bc9c2ba27b8954bc
+niiri:dcdaa5f8f83360bc6ccfa19fcc3afbe8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0172" ;
     nidm_coordinateVector: "[18,-78,16]"^^xsd:string .
 
-niiri:439481b3a0012f61306105bf2a9e776e prov:wasDerivedFrom niiri:3f5bc238b154db411923ec0d520212a5 .
+niiri:75596cb1506d72be9c60a786cdfeb9e9 prov:wasDerivedFrom niiri:7a6a9d89a41bce106a6e3f6b9bf39fc2 .
 
-niiri:1556c414fb66f9ab6cc43df03318b6c0
+niiri:cc61bb9a0e1e912d0243c40937af6d28
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0173" ;
-    prov:atLocation niiri:4ee0e9d25b9437d0ab31e8dd4484d4a0 ;
+    prov:atLocation niiri:43baf4b4f25319c4535a3067412de7c0 ;
     prov:value "3.79121017456055"^^xsd:float ;
     nidm_equivalentZStatistic: "3.40709049802208"^^xsd:float ;
     nidm_pValueUncorrected: "0.000328296763804747"^^xsd:float ;
     nidm_pValueFWER: "0.99999999999996"^^xsd:float ;
     nidm_qValueFDR: "0.524856123968262"^^xsd:float .
 
-niiri:4ee0e9d25b9437d0ab31e8dd4484d4a0
+niiri:43baf4b4f25319c4535a3067412de7c0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0173" ;
     nidm_coordinateVector: "[52,-8,52]"^^xsd:string .
 
-niiri:1556c414fb66f9ab6cc43df03318b6c0 prov:wasDerivedFrom niiri:d61c2e3334e7afb034ac8b3a50d8eefd .
+niiri:cc61bb9a0e1e912d0243c40937af6d28 prov:wasDerivedFrom niiri:6cd9c8b1f2dc650429e50bd72f6da32d .
 
-niiri:01f5f6d1e678860e3ba5ed96a8b9c5d9
+niiri:32de098d3053799d0fc2c5c953ee1d3c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0174" ;
-    prov:atLocation niiri:1f2be2e88f5e869401b6058392d3f8d3 ;
+    prov:atLocation niiri:f56888b381f2199a57eb6f32e1b76c94 ;
     prov:value "3.79016637802124"^^xsd:float ;
     nidm_equivalentZStatistic: "3.40631120271348"^^xsd:float ;
     nidm_pValueUncorrected: "0.000329235375377435"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999963"^^xsd:float ;
     nidm_qValueFDR: "0.525348401881072"^^xsd:float .
 
-niiri:1f2be2e88f5e869401b6058392d3f8d3
+niiri:f56888b381f2199a57eb6f32e1b76c94
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0174" ;
     nidm_coordinateVector: "[-38,-20,-18]"^^xsd:string .
 
-niiri:01f5f6d1e678860e3ba5ed96a8b9c5d9 prov:wasDerivedFrom niiri:c7f0899e68a33117259a0776f3fbd712 .
+niiri:32de098d3053799d0fc2c5c953ee1d3c prov:wasDerivedFrom niiri:f0caefb73eec8df07661fca6c2cc2a56 .
 
-niiri:0ec9533ffbb4d7f4726270a2944b2dbb
+niiri:459d474e17bd85aec6efe07624d6ae57
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0175" ;
-    prov:atLocation niiri:c23f591fda8160c477941d2116809c5e ;
+    prov:atLocation niiri:8482429c259a3f7b13d44a7131b80d39 ;
     prov:value "3.78082299232483"^^xsd:float ;
     nidm_equivalentZStatistic: "3.39932758559063"^^xsd:float ;
     nidm_pValueUncorrected: "0.000337758775393771"^^xsd:float ;
     nidm_pValueFWER: "0.99999999999998"^^xsd:float ;
     nidm_qValueFDR: "0.533091122666778"^^xsd:float .
 
-niiri:c23f591fda8160c477941d2116809c5e
+niiri:8482429c259a3f7b13d44a7131b80d39
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0175" ;
     nidm_coordinateVector: "[-64,-16,34]"^^xsd:string .
 
-niiri:0ec9533ffbb4d7f4726270a2944b2dbb prov:wasDerivedFrom niiri:acf0099ad05f52f7740833ae0513f2c4 .
+niiri:459d474e17bd85aec6efe07624d6ae57 prov:wasDerivedFrom niiri:10dda0f512d376c45616527318012baa .
 
-niiri:e64bebd118b0a946836ec84aa101efaf
+niiri:3510b1f1d6805ff05bb7b6b5d36253fa
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0176" ;
-    prov:atLocation niiri:3168c610fa4db5fbc7d85dd821868324 ;
+    prov:atLocation niiri:f5066157a094cacabacac8bdb14ecf29 ;
     prov:value "3.775071144104"^^xsd:float ;
     nidm_equivalentZStatistic: "3.39502136510282"^^xsd:float ;
     nidm_pValueUncorrected: "0.000343116226298679"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999986"^^xsd:float ;
     nidm_qValueFDR: "0.538899956377297"^^xsd:float .
 
-niiri:3168c610fa4db5fbc7d85dd821868324
+niiri:f5066157a094cacabacac8bdb14ecf29
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0176" ;
     nidm_coordinateVector: "[-6,64,24]"^^xsd:string .
 
-niiri:e64bebd118b0a946836ec84aa101efaf prov:wasDerivedFrom niiri:d639d06c89e7a7987cc7beee7f6eebde .
+niiri:3510b1f1d6805ff05bb7b6b5d36253fa prov:wasDerivedFrom niiri:3aeaeffb7762bacf9f1b2dc630012fe3 .
 
-niiri:b79bfb24284bb783de7becea3d6c7594
+niiri:5bf7e5d9bb601821a72345c87cedd51c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0177" ;
-    prov:atLocation niiri:9cb273c27cdca162dbac06aef6a6ce6f ;
+    prov:atLocation niiri:ff6a8ac356b1fcdc3ba1e0677b07ef35 ;
     prov:value "3.77039766311646"^^xsd:float ;
     nidm_equivalentZStatistic: "3.39151850905751"^^xsd:float ;
     nidm_pValueUncorrected: "0.000347532341239631"^^xsd:float ;
     nidm_pValueFWER: "0.99999999999999"^^xsd:float ;
     nidm_qValueFDR: "0.541509095101857"^^xsd:float .
 
-niiri:9cb273c27cdca162dbac06aef6a6ce6f
+niiri:ff6a8ac356b1fcdc3ba1e0677b07ef35
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0177" ;
     nidm_coordinateVector: "[12,-86,2]"^^xsd:string .
 
-niiri:b79bfb24284bb783de7becea3d6c7594 prov:wasDerivedFrom niiri:019db96efd3f0d5a9f077d436d990e65 .
+niiri:5bf7e5d9bb601821a72345c87cedd51c prov:wasDerivedFrom niiri:88ee03bc281326c9948572b0834fecf3 .
 
-niiri:e79401d06adc37ee4b78d19978f78585
+niiri:b691067d61784029be138ffa1686adb8
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0178" ;
-    prov:atLocation niiri:4400c98a34340b7d55bd1142aa8e430c ;
+    prov:atLocation niiri:ccbf47d9d1d8eec7a8d44dfb17daf242 ;
     prov:value "3.76804852485657"^^xsd:float ;
     nidm_equivalentZStatistic: "3.38975644066078"^^xsd:float ;
     nidm_pValueUncorrected: "0.000349773728989367"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999991"^^xsd:float ;
     nidm_qValueFDR: "0.542836741004494"^^xsd:float .
 
-niiri:4400c98a34340b7d55bd1142aa8e430c
+niiri:ccbf47d9d1d8eec7a8d44dfb17daf242
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0178" ;
     nidm_coordinateVector: "[56,-56,4]"^^xsd:string .
 
-niiri:e79401d06adc37ee4b78d19978f78585 prov:wasDerivedFrom niiri:3589dce5a9f2dacdad11e4fc0348fe0f .
+niiri:b691067d61784029be138ffa1686adb8 prov:wasDerivedFrom niiri:30868fad9324d3113736d83bd681718a .
 
-niiri:ff37da2a4f0c0a6297a5db8ab30945c5
+niiri:b2e8f0a888997bba7bfdd9f220a34d7c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0179" ;
-    prov:atLocation niiri:e51b409400bc4492b1ae033d7bd19085 ;
+    prov:atLocation niiri:82e8ec11f93f733e88d5f02ce475eb3a ;
     prov:value "3.76583623886108"^^xsd:float ;
     nidm_equivalentZStatistic: "3.38809619826667"^^xsd:float ;
     nidm_pValueUncorrected: "0.000351897876951224"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999993"^^xsd:float ;
     nidm_qValueFDR: "0.544688226103431"^^xsd:float .
 
-niiri:e51b409400bc4492b1ae033d7bd19085
+niiri:82e8ec11f93f733e88d5f02ce475eb3a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0179" ;
     nidm_coordinateVector: "[30,-10,-22]"^^xsd:string .
 
-niiri:ff37da2a4f0c0a6297a5db8ab30945c5 prov:wasDerivedFrom niiri:6c2ff806101a3ff739a426037285f4f7 .
+niiri:b2e8f0a888997bba7bfdd9f220a34d7c prov:wasDerivedFrom niiri:4b462b6d837ce2e27bce61ed0c368fd6 .
 
-niiri:dd610c86903a2b65db4e265608c060f9
+niiri:db0d54b000c98e5dee79f930e669b285
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0180" ;
-    prov:atLocation niiri:c1fe9a6ef838b0b4038c116cc3740cd9 ;
+    prov:atLocation niiri:68a3e5e2e053a83eaa1d9e2d1081aee6 ;
     prov:value "3.75574827194214"^^xsd:float ;
     nidm_equivalentZStatistic: "3.380515360821"^^xsd:float ;
     nidm_pValueUncorrected: "0.000361750154451945"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999996"^^xsd:float ;
     nidm_qValueFDR: "0.55496612223741"^^xsd:float .
 
-niiri:c1fe9a6ef838b0b4038c116cc3740cd9
+niiri:68a3e5e2e053a83eaa1d9e2d1081aee6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0180" ;
     nidm_coordinateVector: "[-26,22,60]"^^xsd:string .
 
-niiri:dd610c86903a2b65db4e265608c060f9 prov:wasDerivedFrom niiri:700ddae2d53d6ba003ce7aef4c34cf8c .
+niiri:db0d54b000c98e5dee79f930e669b285 prov:wasDerivedFrom niiri:1bf97c65bec07a1317ef69c944689cf8 .
 
-niiri:57dd52ee4f0d1d9c03506ff39479c584
+niiri:79e2013c8aa62a779d24f56c4f7d2b61
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0181" ;
-    prov:atLocation niiri:93ba4fa3b7b3768e6fdc0a9f6444fd2c ;
+    prov:atLocation niiri:6ce596eae40f92939ac779652c7de352 ;
     prov:value "3.75386500358582"^^xsd:float ;
     nidm_equivalentZStatistic: "3.37909828240956"^^xsd:float ;
     nidm_pValueUncorrected: "0.000363620022447164"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999997"^^xsd:float ;
     nidm_qValueFDR: "0.55578840663352"^^xsd:float .
 
-niiri:93ba4fa3b7b3768e6fdc0a9f6444fd2c
+niiri:6ce596eae40f92939ac779652c7de352
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0181" ;
     nidm_coordinateVector: "[8,-92,26]"^^xsd:string .
 
-niiri:57dd52ee4f0d1d9c03506ff39479c584 prov:wasDerivedFrom niiri:c226e28f1c7d1bb6df56af26165cf368 .
+niiri:79e2013c8aa62a779d24f56c4f7d2b61 prov:wasDerivedFrom niiri:cd27fa26bbd5aa4fa8cfbebf1bb95ad9 .
 
-niiri:e2871ebca726df5053d77d25385e3099
+niiri:36d4e5984e645e3739eafcddd636c2a0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0182" ;
-    prov:atLocation niiri:ae350c0ae9ee4d2393cec54aac49bf5b ;
+    prov:atLocation niiri:6a73634a41988180ea6cdf81a21e10fd ;
     prov:value "3.74783110618591"^^xsd:float ;
     nidm_equivalentZStatistic: "3.37455409826951"^^xsd:float ;
     nidm_pValueUncorrected: "0.000369676911683547"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999998"^^xsd:float ;
     nidm_qValueFDR: "0.559414929313896"^^xsd:float .
 
-niiri:ae350c0ae9ee4d2393cec54aac49bf5b
+niiri:6a73634a41988180ea6cdf81a21e10fd
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0182" ;
     nidm_coordinateVector: "[-44,-10,-38]"^^xsd:string .
 
-niiri:e2871ebca726df5053d77d25385e3099 prov:wasDerivedFrom niiri:d349e89efbf6c30897c6f74aaef9e81f .
+niiri:36d4e5984e645e3739eafcddd636c2a0 prov:wasDerivedFrom niiri:31a80df97955e986f4be4839a052a5db .
 
-niiri:12aa07f0139d12698164fc38fa4f2cbf
+niiri:ee94413a615c0ae8d638fa74a0954f38
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0183" ;
-    prov:atLocation niiri:a429b7a35674e2fa4bd9eddbcf7eac1e ;
+    prov:atLocation niiri:6d6ca80aef4904d97475b3a1a85fb36f ;
     prov:value "3.73827314376831"^^xsd:float ;
     nidm_equivalentZStatistic: "3.36734359778017"^^xsd:float ;
     nidm_pValueUncorrected: "0.000379480313921432"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999999"^^xsd:float ;
     nidm_qValueFDR: "0.568714691324852"^^xsd:float .
 
-niiri:a429b7a35674e2fa4bd9eddbcf7eac1e
+niiri:6d6ca80aef4904d97475b3a1a85fb36f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0183" ;
     nidm_coordinateVector: "[32,4,8]"^^xsd:string .
 
-niiri:12aa07f0139d12698164fc38fa4f2cbf prov:wasDerivedFrom niiri:cd868dac3ef78cde76ebbceb4543715e .
+niiri:ee94413a615c0ae8d638fa74a0954f38 prov:wasDerivedFrom niiri:39fc04da006cbf70670a7f80045d0d49 .
 
-niiri:6d82ef6c5b79ee21f49f61c4144c77b2
+niiri:c4ca487861e26bb6edf9d460b8c438f5
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0184" ;
-    prov:atLocation niiri:aff3accbbd76f14d658937fd03eba12c ;
+    prov:atLocation niiri:a984ff9c1bc463c5305396b634b896d7 ;
     prov:value "3.73499631881714"^^xsd:float ;
     nidm_equivalentZStatistic: "3.36486808622606"^^xsd:float ;
     nidm_pValueUncorrected: "0.000382901311427597"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999999"^^xsd:float ;
     nidm_qValueFDR: "0.57046827086113"^^xsd:float .
 
-niiri:aff3accbbd76f14d658937fd03eba12c
+niiri:a984ff9c1bc463c5305396b634b896d7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0184" ;
     nidm_coordinateVector: "[-12,-60,-28]"^^xsd:string .
 
-niiri:6d82ef6c5b79ee21f49f61c4144c77b2 prov:wasDerivedFrom niiri:2b8a556886785a97e170fa36a82a529d .
+niiri:c4ca487861e26bb6edf9d460b8c438f5 prov:wasDerivedFrom niiri:a2df6515d44ea1c2de2e20cd83b43f91 .
 
-niiri:09a0686f4010b14f74f873bb9e5859b4
+niiri:74d29ddfa219f7865899d3e1aa985fad
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0185" ;
-    prov:atLocation niiri:d2df05b7efca297f96a55dfd94e9b231 ;
+    prov:atLocation niiri:862ab06c53bf7580c82758f3c5e05d0c ;
     prov:value "3.71396541595459"^^xsd:float ;
     nidm_equivalentZStatistic: "3.34893751145887"^^xsd:float ;
     nidm_pValueUncorrected: "0.000405610447892446"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.593900566305716"^^xsd:float .
 
-niiri:d2df05b7efca297f96a55dfd94e9b231
+niiri:862ab06c53bf7580c82758f3c5e05d0c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0185" ;
     nidm_coordinateVector: "[26,-8,12]"^^xsd:string .
 
-niiri:09a0686f4010b14f74f873bb9e5859b4 prov:wasDerivedFrom niiri:cbd1c61d5f72e84539faeac10377a620 .
+niiri:74d29ddfa219f7865899d3e1aa985fad prov:wasDerivedFrom niiri:9b33ff671ff0c042af89e5b1be1377da .
 
-niiri:81e790cfa9ebe0580ac21e4679031d54
+niiri:02ee73aa72ad228b43c68c9f025c92c9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0186" ;
-    prov:atLocation niiri:6d8f75af4a6e97ca5cde4a4c2d77f2d1 ;
+    prov:atLocation niiri:8454dc655bb35ba99f3dba0346e7316c ;
     prov:value "3.71342253684998"^^xsd:float ;
     nidm_equivalentZStatistic: "3.34852531049968"^^xsd:float ;
     nidm_pValueUncorrected: "0.000406214298471763"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.593900566305716"^^xsd:float .
 
-niiri:6d8f75af4a6e97ca5cde4a4c2d77f2d1
+niiri:8454dc655bb35ba99f3dba0346e7316c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0186" ;
     nidm_coordinateVector: "[20,-26,14]"^^xsd:string .
 
-niiri:81e790cfa9ebe0580ac21e4679031d54 prov:wasDerivedFrom niiri:08bad01c6e1b7035d226d8f83114d9d4 .
+niiri:02ee73aa72ad228b43c68c9f025c92c9 prov:wasDerivedFrom niiri:25e2f4ca28679423b49be4329eea0bc3 .
 
-niiri:756c3bd1589a6a1a93f8e9b0426d30da
+niiri:5148a355763840d52c51745baf6d8bf1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0187" ;
-    prov:atLocation niiri:eafbe6430229fd9295b4ed3d5265d179 ;
+    prov:atLocation niiri:022b93a52530966eb78075d6eac6ecea ;
     prov:value "3.71231603622437"^^xsd:float ;
     nidm_equivalentZStatistic: "3.34768500611999"^^xsd:float ;
     nidm_pValueUncorrected: "0.000407447880153899"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.594555117771048"^^xsd:float .
 
-niiri:eafbe6430229fd9295b4ed3d5265d179
+niiri:022b93a52530966eb78075d6eac6ecea
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0187" ;
     nidm_coordinateVector: "[8,8,44]"^^xsd:string .
 
-niiri:756c3bd1589a6a1a93f8e9b0426d30da prov:wasDerivedFrom niiri:dbd29bbddcbce1e02e18bedcb8b3c4b3 .
+niiri:5148a355763840d52c51745baf6d8bf1 prov:wasDerivedFrom niiri:0a729befa841fff84fcf2612fb2ce4a5 .
 
-niiri:e6c2bfa55531294a2a6810f1e2499f7e
+niiri:0799198166c4e4ec859a6d6486f90093
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0188" ;
-    prov:atLocation niiri:ba8be61c20624edab79b352cbc6c0c3f ;
+    prov:atLocation niiri:566b1ae67509d41808fda40621ca7b61 ;
     prov:value "3.71084380149841"^^xsd:float ;
     nidm_equivalentZStatistic: "3.34656663561433"^^xsd:float ;
     nidm_pValueUncorrected: "0.00040909505954867"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.595665947803054"^^xsd:float .
 
-niiri:ba8be61c20624edab79b352cbc6c0c3f
+niiri:566b1ae67509d41808fda40621ca7b61
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0188" ;
     nidm_coordinateVector: "[-28,4,-42]"^^xsd:string .
 
-niiri:e6c2bfa55531294a2a6810f1e2499f7e prov:wasDerivedFrom niiri:1d73a20f9c8bfb47867f2c59ae3c13b5 .
+niiri:0799198166c4e4ec859a6d6486f90093 prov:wasDerivedFrom niiri:501da0873de972e1023817d65202130e .
 
-niiri:588e6085420a80bcd1e10a6dde764a47
+niiri:0aa10d875c9c1e35c96e247e10de57ee
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0189" ;
-    prov:atLocation niiri:8bfdd226c46a87c2b9fb259bd51e8cd3 ;
+    prov:atLocation niiri:f4b96ff42be70bb2b09861757cb97da1 ;
     prov:value "3.69969868659973"^^xsd:float ;
     nidm_equivalentZStatistic: "3.3380885246229"^^xsd:float ;
     nidm_pValueUncorrected: "0.00042178434593132"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.607485135007791"^^xsd:float .
 
-niiri:8bfdd226c46a87c2b9fb259bd51e8cd3
+niiri:f4b96ff42be70bb2b09861757cb97da1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0189" ;
     nidm_coordinateVector: "[22,-6,-34]"^^xsd:string .
 
-niiri:588e6085420a80bcd1e10a6dde764a47 prov:wasDerivedFrom niiri:b25e28979a447c1cd5093c9afae92781 .
+niiri:0aa10d875c9c1e35c96e247e10de57ee prov:wasDerivedFrom niiri:0336a0114f6c74e1df58148ee9b074f4 .
 
-niiri:b28414ca025b0ceb35fc0a166285b480
+niiri:df286e546b49998eef6184d9ae67818c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0190" ;
-    prov:atLocation niiri:86ef3b9c9e4f7a9b0c7ff381015d0d5c ;
+    prov:atLocation niiri:40abce439058cc82f5d725ab26b39a04 ;
     prov:value "3.69548296928406"^^xsd:float ;
     nidm_equivalentZStatistic: "3.33487616330673"^^xsd:float ;
     nidm_pValueUncorrected: "0.00042668696793946"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.610645919300431"^^xsd:float .
 
-niiri:86ef3b9c9e4f7a9b0c7ff381015d0d5c
+niiri:40abce439058cc82f5d725ab26b39a04
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0190" ;
     nidm_coordinateVector: "[26,46,4]"^^xsd:string .
 
-niiri:b28414ca025b0ceb35fc0a166285b480 prov:wasDerivedFrom niiri:e52574eea0816040ab22d41230ea518c .
+niiri:df286e546b49998eef6184d9ae67818c prov:wasDerivedFrom niiri:06324b32c616d4e45a79cb65a439ac48 .
 
-niiri:17632dec077de6a4b5e6f11b977be3f4
+niiri:b5c652713f89d13b86856e3329e60e97
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0191" ;
-    prov:atLocation niiri:88f83b15542c493d543d7dba15131255 ;
+    prov:atLocation niiri:12a1b45b727c26d17ba943ca60c4c0bd ;
     prov:value "3.68579792976379"^^xsd:float ;
     nidm_equivalentZStatistic: "3.32748481106661"^^xsd:float ;
     nidm_pValueUncorrected: "0.000438168831523034"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.620072204467785"^^xsd:float .
 
-niiri:88f83b15542c493d543d7dba15131255
+niiri:12a1b45b727c26d17ba943ca60c4c0bd
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0191" ;
     nidm_coordinateVector: "[-18,-16,48]"^^xsd:string .
 
-niiri:17632dec077de6a4b5e6f11b977be3f4 prov:wasDerivedFrom niiri:cac2f6c0cd35c2d53ed1689d1f149a53 .
+niiri:b5c652713f89d13b86856e3329e60e97 prov:wasDerivedFrom niiri:ac9a19a2b1c9949a888ebae7d65a2399 .
 
-niiri:d32bfab4ca3777f99408b23496062f21
+niiri:89124d4a55465ecc6580a87278eb8730
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0192" ;
-    prov:atLocation niiri:7222e0c3ef89b9c8becc19dbb85e4b22 ;
+    prov:atLocation niiri:51cc533c8467f20d1155ffc22498abf5 ;
     prov:value "3.68518376350403"^^xsd:float ;
     nidm_equivalentZStatistic: "3.32701556031273"^^xsd:float ;
     nidm_pValueUncorrected: "0.000438907358197516"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.620072204467785"^^xsd:float .
 
-niiri:7222e0c3ef89b9c8becc19dbb85e4b22
+niiri:51cc533c8467f20d1155ffc22498abf5
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0192" ;
     nidm_coordinateVector: "[-12,38,58]"^^xsd:string .
 
-niiri:d32bfab4ca3777f99408b23496062f21 prov:wasDerivedFrom niiri:78cef26d38b3c686cc371fc53f23b0b0 .
+niiri:89124d4a55465ecc6580a87278eb8730 prov:wasDerivedFrom niiri:061dca60ff6ace182bd1ebe945535ace .
 
-niiri:c72de2624c07eaf74d6e92bb473ec21c
+niiri:7c0c361d425385fbaf81e45ac15b1add
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0193" ;
-    prov:atLocation niiri:72fcaf12715d23476f7fc2f3eeea64a0 ;
+    prov:atLocation niiri:8196fd95c6f6da2498153caebca81a9e ;
     prov:value "3.68469381332397"^^xsd:float ;
     nidm_equivalentZStatistic: "3.32664117032322"^^xsd:float ;
     nidm_pValueUncorrected: "0.000439497416485524"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.620072204467785"^^xsd:float .
 
-niiri:72fcaf12715d23476f7fc2f3eeea64a0
+niiri:8196fd95c6f6da2498153caebca81a9e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0193" ;
     nidm_coordinateVector: "[-20,-2,56]"^^xsd:string .
 
-niiri:c72de2624c07eaf74d6e92bb473ec21c prov:wasDerivedFrom niiri:ee1be7d7191fe1d0a268751891c07368 .
+niiri:7c0c361d425385fbaf81e45ac15b1add prov:wasDerivedFrom niiri:6242500a1c0ecfe873a2799eca21133b .
 
-niiri:e722df44ac69d464af27624984f0bb4c
+niiri:a27efb8e81003403a3b728b02a0305de
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0194" ;
-    prov:atLocation niiri:66ab321f4a5e82659cb5370912d91ed9 ;
+    prov:atLocation niiri:56df4db7d539ca39549ce15b7ea50f31 ;
     prov:value "3.68345642089844"^^xsd:float ;
     nidm_equivalentZStatistic: "3.32569544910563"^^xsd:float ;
     nidm_pValueUncorrected: "0.000440991199531338"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.620678594375276"^^xsd:float .
 
-niiri:66ab321f4a5e82659cb5370912d91ed9
+niiri:56df4db7d539ca39549ce15b7ea50f31
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0194" ;
     nidm_coordinateVector: "[-52,28,12]"^^xsd:string .
 
-niiri:e722df44ac69d464af27624984f0bb4c prov:wasDerivedFrom niiri:460199221aa05d5f8655df003b9ba5e5 .
+niiri:a27efb8e81003403a3b728b02a0305de prov:wasDerivedFrom niiri:62f0dcd6742c42c5c8a69829ea982b14 .
 
-niiri:8a4fa46722b6ec4fe67c5c55b72df858
+niiri:f6c9002f2a33bbdcf918614062da93d1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0195" ;
-    prov:atLocation niiri:1cc0115a9ae6b0efd554881e1b94c5ac ;
+    prov:atLocation niiri:51195bf8976356008123f14dcc2b8de5 ;
     prov:value "3.67815756797791"^^xsd:float ;
     nidm_equivalentZStatistic: "3.32164266737708"^^xsd:float ;
     nidm_pValueUncorrected: "0.000447446096799475"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.624850402893793"^^xsd:float .
 
-niiri:1cc0115a9ae6b0efd554881e1b94c5ac
+niiri:51195bf8976356008123f14dcc2b8de5
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0195" ;
     nidm_coordinateVector: "[22,20,-18]"^^xsd:string .
 
-niiri:8a4fa46722b6ec4fe67c5c55b72df858 prov:wasDerivedFrom niiri:13c65c64199df9d15af3dcaef046e358 .
+niiri:f6c9002f2a33bbdcf918614062da93d1 prov:wasDerivedFrom niiri:ed86b8af25a7303faba66f96f7427038 .
 
-niiri:1c981200507bd3ef3c96df12ef94ef8b
+niiri:273a08beef0cdedfcbf83ba358d17b4a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0196" ;
-    prov:atLocation niiri:18a1ba4f4b46f198e48a8fab512606d1 ;
+    prov:atLocation niiri:bee076b1ef81a577daaacaa7c437434e ;
     prov:value "3.67246556282043"^^xsd:float ;
     nidm_equivalentZStatistic: "3.31728385777887"^^xsd:float ;
     nidm_pValueUncorrected: "0.00045448607795473"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.630238922827796"^^xsd:float .
 
-niiri:18a1ba4f4b46f198e48a8fab512606d1
+niiri:bee076b1ef81a577daaacaa7c437434e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0196" ;
     nidm_coordinateVector: "[-16,56,-10]"^^xsd:string .
 
-niiri:1c981200507bd3ef3c96df12ef94ef8b prov:wasDerivedFrom niiri:7a0a564d5df4aedd6daf83ea5ff89179 .
+niiri:273a08beef0cdedfcbf83ba358d17b4a prov:wasDerivedFrom niiri:81c63725e4640647cd75f101cc0fc8a7 .
 
-niiri:d41c01e2a940202811c21be7e2a39cf8
+niiri:b8d737b346f350b24c46e795748e22fb
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0197" ;
-    prov:atLocation niiri:279d26e2f8d06421d06ac330815fd880 ;
+    prov:atLocation niiri:f381a9b3ecc4a18b9ce6ca29376c4ff2 ;
     prov:value "3.67176198959351"^^xsd:float ;
     nidm_equivalentZStatistic: "3.31674469325952"^^xsd:float ;
     nidm_pValueUncorrected: "0.00045536398943602"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.630238922827796"^^xsd:float .
 
-niiri:279d26e2f8d06421d06ac330815fd880
+niiri:f381a9b3ecc4a18b9ce6ca29376c4ff2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0197" ;
     nidm_coordinateVector: "[-54,-22,60]"^^xsd:string .
 
-niiri:d41c01e2a940202811c21be7e2a39cf8 prov:wasDerivedFrom niiri:64296118b766a08ff9a1b3331ff3a8be .
+niiri:b8d737b346f350b24c46e795748e22fb prov:wasDerivedFrom niiri:4b2e0a2531b0291df0fe5df5bc205ec9 .
 
-niiri:cb5e4a08e9400a334eb9b747b16de07b
+niiri:b628b10379f38e68ed5b66c336b27ce3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0198" ;
-    prov:atLocation niiri:e0cb2ac4803ebf6432fbaf9d8664003a ;
+    prov:atLocation niiri:4a3e07338e224062c86a093f897dd586 ;
     prov:value "3.6656653881073"^^xsd:float ;
     nidm_equivalentZStatistic: "3.31206918161529"^^xsd:float ;
     nidm_pValueUncorrected: "0.000463043207802327"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.636780442381221"^^xsd:float .
 
-niiri:e0cb2ac4803ebf6432fbaf9d8664003a
+niiri:4a3e07338e224062c86a093f897dd586
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0198" ;
     nidm_coordinateVector: "[12,-26,32]"^^xsd:string .
 
-niiri:cb5e4a08e9400a334eb9b747b16de07b prov:wasDerivedFrom niiri:2d05298a2bfc1bad012eb9c5a6636ad4 .
+niiri:b628b10379f38e68ed5b66c336b27ce3 prov:wasDerivedFrom niiri:7f91f8087c7d8ec7eda6204b5b39482d .
 
-niiri:4bde4d943d26283fb187a7fbdf7f3b4d
+niiri:73de5af689e2e854fa7db73a7b08e0fe
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0199" ;
-    prov:atLocation niiri:74cb0e81cf74220bc3cb9f57860c8561 ;
+    prov:atLocation niiri:ebdbc5b2e4abb9eaa379c70ec8dcde1e ;
     prov:value "3.66424226760864"^^xsd:float ;
     nidm_equivalentZStatistic: "3.3109768679857"^^xsd:float ;
     nidm_pValueUncorrected: "0.000464854468121723"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.637917502965391"^^xsd:float .
 
-niiri:74cb0e81cf74220bc3cb9f57860c8561
+niiri:ebdbc5b2e4abb9eaa379c70ec8dcde1e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0199" ;
     nidm_coordinateVector: "[-54,-26,20]"^^xsd:string .
 
-niiri:4bde4d943d26283fb187a7fbdf7f3b4d prov:wasDerivedFrom niiri:5675ac9e2a66ba888afe627ebfc89ba2 .
+niiri:73de5af689e2e854fa7db73a7b08e0fe prov:wasDerivedFrom niiri:2c7f0285c24b2b8b65a032418b15cd16 .
 
-niiri:c266692d1c80522485c97cc3ea18c3ac
+niiri:b0085be54d5b554caf5c0c60d9943ca3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0200" ;
-    prov:atLocation niiri:4bfce0fa1e9dd94ba7fafbc441dbac24 ;
+    prov:atLocation niiri:18a86448a493c980c8799ef2fa49927e ;
     prov:value "3.65446782112122"^^xsd:float ;
     nidm_equivalentZStatistic: "3.30346511601015"^^xsd:float ;
     nidm_pValueUncorrected: "0.000477489250152452"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.649479872404913"^^xsd:float .
 
-niiri:4bfce0fa1e9dd94ba7fafbc441dbac24
+niiri:18a86448a493c980c8799ef2fa49927e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0200" ;
     nidm_coordinateVector: "[28,-26,54]"^^xsd:string .
 
-niiri:c266692d1c80522485c97cc3ea18c3ac prov:wasDerivedFrom niiri:ec3de522ea3b2037df66f6245f038d27 .
+niiri:b0085be54d5b554caf5c0c60d9943ca3 prov:wasDerivedFrom niiri:7ed3fe10280b67503b5448524a04f269 .
 
-niiri:6f7481789f1fc90fd34d16d386705c4c
+niiri:f9e69d234f36d1d73224b4a30b59f7dc
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0201" ;
-    prov:atLocation niiri:220598619807b214635f463c83541c39 ;
+    prov:atLocation niiri:83afb4d3fe181c770288664feec0e8eb ;
     prov:value "3.65308904647827"^^xsd:float ;
     nidm_equivalentZStatistic: "3.30240419282363"^^xsd:float ;
     nidm_pValueUncorrected: "0.000479299143653966"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.650580107543262"^^xsd:float .
 
-niiri:220598619807b214635f463c83541c39
+niiri:83afb4d3fe181c770288664feec0e8eb
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0201" ;
     nidm_coordinateVector: "[56,-12,-34]"^^xsd:string .
 
-niiri:6f7481789f1fc90fd34d16d386705c4c prov:wasDerivedFrom niiri:d912332211df7778d8d01732fe94c592 .
+niiri:f9e69d234f36d1d73224b4a30b59f7dc prov:wasDerivedFrom niiri:99c58e7d96cf7da6763a2e1cbba873ae .
 
-niiri:ef8c6bdb39c721b0f2cdfe89bdda3461
+niiri:fdaaf45a96ab001df01c3f32cad6f0d5
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0202" ;
-    prov:atLocation niiri:3a559a209510f1661bacc06353f06b68 ;
+    prov:atLocation niiri:1ab0b084d0c745086441303217bfb06a ;
     prov:value "3.65141272544861"^^xsd:float ;
     nidm_equivalentZStatistic: "3.30111387597635"^^xsd:float ;
     nidm_pValueUncorrected: "0.000481508936725383"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.652085475027948"^^xsd:float .
 
-niiri:3a559a209510f1661bacc06353f06b68
+niiri:1ab0b084d0c745086441303217bfb06a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0202" ;
     nidm_coordinateVector: "[-32,-26,26]"^^xsd:string .
 
-niiri:ef8c6bdb39c721b0f2cdfe89bdda3461 prov:wasDerivedFrom niiri:7b7bea73949631fa11f1e655bc82c0ca .
+niiri:fdaaf45a96ab001df01c3f32cad6f0d5 prov:wasDerivedFrom niiri:d5206500679003f5f39472159c4ad0de .
 
-niiri:3559a82551b51293a26321ba3f63be57
+niiri:802d2977df694ebb8aa91513a51f9d09
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0203" ;
-    prov:atLocation niiri:47fb39b4708b604798b7097271b8722b ;
+    prov:atLocation niiri:efc63a148d5261c31e0939091f77ceaa ;
     prov:value "3.64412999153137"^^xsd:float ;
     nidm_equivalentZStatistic: "3.2955024977544"^^xsd:float ;
     nidm_pValueUncorrected: "0.000491229150587746"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.660471475830505"^^xsd:float .
 
-niiri:47fb39b4708b604798b7097271b8722b
+niiri:efc63a148d5261c31e0939091f77ceaa
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0203" ;
     nidm_coordinateVector: "[62,-42,32]"^^xsd:string .
 
-niiri:3559a82551b51293a26321ba3f63be57 prov:wasDerivedFrom niiri:522c28dd4e63e1c775b1ebd75bb4c8b3 .
+niiri:802d2977df694ebb8aa91513a51f9d09 prov:wasDerivedFrom niiri:0803006e1feea37abdc724f07464d7a9 .
 
-niiri:292337cfe50250e8c1b9e0526394644c
+niiri:cd20eea678913bcc90beb6f06a1cd190
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0204" ;
-    prov:atLocation niiri:8d49632298c713cfe3e4f7c0b8b81748 ;
+    prov:atLocation niiri:c2889d3d5127c29f90b0ada1c993e777 ;
     prov:value "3.64054799079895"^^xsd:float ;
     nidm_equivalentZStatistic: "3.29273918630896"^^xsd:float ;
     nidm_pValueUncorrected: "0.000496082327765768"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.664365976163986"^^xsd:float .
 
-niiri:8d49632298c713cfe3e4f7c0b8b81748
+niiri:c2889d3d5127c29f90b0ada1c993e777
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0204" ;
     nidm_coordinateVector: "[-50,-34,18]"^^xsd:string .
 
-niiri:292337cfe50250e8c1b9e0526394644c prov:wasDerivedFrom niiri:18abb51402bd1a96024eebcb51fe2cea .
+niiri:cd20eea678913bcc90beb6f06a1cd190 prov:wasDerivedFrom niiri:abae6765a0aa40936d109b9a2fd5acbf .
 
-niiri:faff79bf09b47b4ddc5d0086a7dca9ee
+niiri:edf7c2638a60e524d92e073751527602
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0205" ;
-    prov:atLocation niiri:4cc001e6714eaf0b08158ebe69c8a6dd ;
+    prov:atLocation niiri:16fc3bf39c860621c7aea2f02a4dac4d ;
     prov:value "3.64017224311829"^^xsd:float ;
     nidm_equivalentZStatistic: "3.29244918940118"^^xsd:float ;
     nidm_pValueUncorrected: "0.000496594212155088"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.664365976163986"^^xsd:float .
 
-niiri:4cc001e6714eaf0b08158ebe69c8a6dd
+niiri:16fc3bf39c860621c7aea2f02a4dac4d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0205" ;
     nidm_coordinateVector: "[-42,-28,2]"^^xsd:string .
 
-niiri:faff79bf09b47b4ddc5d0086a7dca9ee prov:wasDerivedFrom niiri:f22d5a21f3420379ca338b596714d6c3 .
+niiri:edf7c2638a60e524d92e073751527602 prov:wasDerivedFrom niiri:4b0a463a8d9ceb66a11c49348ae1f5fc .
 
-niiri:7cc3828aff43a6e5dbc4d120d5f6bdc8
+niiri:b1acd578e7fa991204c8a410a3717560
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0206" ;
-    prov:atLocation niiri:9ca80a13007830e4af8ec0c80ce72261 ;
+    prov:atLocation niiri:b25042964be10a1a50bf593da017ad14 ;
     prov:value "3.63664436340332"^^xsd:float ;
     nidm_equivalentZStatistic: "3.28972522633498"^^xsd:float ;
     nidm_pValueUncorrected: "0.00050142630710126"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.668465061469917"^^xsd:float .
 
-niiri:9ca80a13007830e4af8ec0c80ce72261
+niiri:b25042964be10a1a50bf593da017ad14
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0206" ;
     nidm_coordinateVector: "[-12,-8,-20]"^^xsd:string .
 
-niiri:7cc3828aff43a6e5dbc4d120d5f6bdc8 prov:wasDerivedFrom niiri:3ee311b3e36564f263d2f8b333315cbe .
+niiri:b1acd578e7fa991204c8a410a3717560 prov:wasDerivedFrom niiri:ca33d7428ff48eafbc3f213db2286c92 .
 
-niiri:019054c49f79d7f10b47b2f5163689a6
+niiri:494d32a46900ee1bd2a49c4de9617108
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0207" ;
-    prov:atLocation niiri:a78b382b048dce4b6bc0c858dbdcf1dd ;
+    prov:atLocation niiri:2aa7ecf6ebf03a10e3d10e470e617211 ;
     prov:value "3.63564610481262"^^xsd:float ;
     nidm_equivalentZStatistic: "3.28895405423442"^^xsd:float ;
     nidm_pValueUncorrected: "0.00050280219001142"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.669072337143437"^^xsd:float .
 
-niiri:a78b382b048dce4b6bc0c858dbdcf1dd
+niiri:2aa7ecf6ebf03a10e3d10e470e617211
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0207" ;
     nidm_coordinateVector: "[-30,50,-6]"^^xsd:string .
 
-niiri:019054c49f79d7f10b47b2f5163689a6 prov:wasDerivedFrom niiri:1f3adbf2a65a904404950a1b8c6598ab .
+niiri:494d32a46900ee1bd2a49c4de9617108 prov:wasDerivedFrom niiri:a2d559eeea3fd425019a74c32cb07b03 .
 
-niiri:b155904b83343b83a14963ed3f06f9f6
+niiri:16a6a4016277da6cf913ef3b2c7113db
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0208" ;
-    prov:atLocation niiri:d23dad6368353e03c133e7a880da352b ;
+    prov:atLocation niiri:416a43460ad683e7fc9bd2dc7f3d33fa ;
     prov:value "3.63432455062866"^^xsd:float ;
     nidm_equivalentZStatistic: "3.28793286446379"^^xsd:float ;
     nidm_pValueUncorrected: "0.000504629519068156"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.670129672801443"^^xsd:float .
 
-niiri:d23dad6368353e03c133e7a880da352b
+niiri:416a43460ad683e7fc9bd2dc7f3d33fa
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0208" ;
     nidm_coordinateVector: "[62,6,20]"^^xsd:string .
 
-niiri:b155904b83343b83a14963ed3f06f9f6 prov:wasDerivedFrom niiri:acdbdf918b46bc8c7e5f5f71c88555a8 .
+niiri:16a6a4016277da6cf913ef3b2c7113db prov:wasDerivedFrom niiri:1cffc79d71ec5b44f8be32f71d15b738 .
 
-niiri:b43cb35e3ab74cca689fe5d3597cafd2
+niiri:5d0442cdaea493ca10a242a8af6b8b02
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0209" ;
-    prov:atLocation niiri:62b3808db084d9d452adf57c4d857090 ;
+    prov:atLocation niiri:57429efabfe0638de627a0c651d9d52b ;
     prov:value "3.63211607933044"^^xsd:float ;
     nidm_equivalentZStatistic: "3.2862256597491"^^xsd:float ;
     nidm_pValueUncorrected: "0.000507698146165469"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.672158308361536"^^xsd:float .
 
-niiri:62b3808db084d9d452adf57c4d857090
+niiri:57429efabfe0638de627a0c651d9d52b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0209" ;
     nidm_coordinateVector: "[-24,4,26]"^^xsd:string .
 
-niiri:b43cb35e3ab74cca689fe5d3597cafd2 prov:wasDerivedFrom niiri:57bb8e63228982c179f16eb42319da97 .
+niiri:5d0442cdaea493ca10a242a8af6b8b02 prov:wasDerivedFrom niiri:08835c169510829e8effda3071bba336 .
 
-niiri:ba85cdf66b0935d9c26a3d8fb4ec076e
+niiri:d32c29e6c832599417bd8574e70ffe47
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0210" ;
-    prov:atLocation niiri:ddec368c647bb9a5d779d908f8c0039d ;
+    prov:atLocation niiri:f736a09b34c0dc25a9d0e7be843d9c96 ;
     prov:value "3.63174819946289"^^xsd:float ;
     nidm_equivalentZStatistic: "3.28594119681201"^^xsd:float ;
     nidm_pValueUncorrected: "0.000508211131676539"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.672158308361536"^^xsd:float .
 
-niiri:ddec368c647bb9a5d779d908f8c0039d
+niiri:f736a09b34c0dc25a9d0e7be843d9c96
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0210" ;
     nidm_coordinateVector: "[-8,-90,-30]"^^xsd:string .
 
-niiri:ba85cdf66b0935d9c26a3d8fb4ec076e prov:wasDerivedFrom niiri:47b4c3e270c9cefea83aa0b99207cb4e .
+niiri:d32c29e6c832599417bd8574e70ffe47 prov:wasDerivedFrom niiri:d5a3f5e4133bc22e2c189ceeb5b93544 .
 
-niiri:6b06034302166fca25722f73014f1fa5
+niiri:1da4e83fb9b216cfbd49324f411b7060
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0211" ;
-    prov:atLocation niiri:017514c19df3110d9738f725acf3a6e7 ;
+    prov:atLocation niiri:9dfaa6f7572bbd0cf40dbfceb5ffab83 ;
     prov:value "3.62799787521362"^^xsd:float ;
     nidm_equivalentZStatistic: "3.28303991621965"^^xsd:float ;
     nidm_pValueUncorrected: "0.00051347061762641"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.676617003024309"^^xsd:float .
 
-niiri:017514c19df3110d9738f725acf3a6e7
+niiri:9dfaa6f7572bbd0cf40dbfceb5ffab83
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0211" ;
     nidm_coordinateVector: "[-60,-38,48]"^^xsd:string .
 
-niiri:6b06034302166fca25722f73014f1fa5 prov:wasDerivedFrom niiri:1e1daff291581e1187737e0f917dcaf2 .
+niiri:1da4e83fb9b216cfbd49324f411b7060 prov:wasDerivedFrom niiri:9b44436d58818f06cd48133f714e8a99 .
 
-niiri:5dce25241470c9335c4e8e5e763a7dac
+niiri:d4fa6966b630445b57a0f19116a3daed
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0212" ;
-    prov:atLocation niiri:b6979185cf28e4a8bc80b8086532974e ;
+    prov:atLocation niiri:dfc9b625f7263d322b56af38f35b9481 ;
     prov:value "3.6240873336792"^^xsd:float ;
     nidm_equivalentZStatistic: "3.28001207990403"^^xsd:float ;
     nidm_pValueUncorrected: "0.000519013209931529"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.680244967613049"^^xsd:float .
 
-niiri:b6979185cf28e4a8bc80b8086532974e
+niiri:dfc9b625f7263d322b56af38f35b9481
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0212" ;
     nidm_coordinateVector: "[22,34,-4]"^^xsd:string .
 
-niiri:5dce25241470c9335c4e8e5e763a7dac prov:wasDerivedFrom niiri:6847174e062f3a379b5888fc4135c73f .
+niiri:d4fa6966b630445b57a0f19116a3daed prov:wasDerivedFrom niiri:051457613c34bfa68d60b137e8c7ae17 .
 
-niiri:d105282f9defe267a465f045b1dd0e7d
+niiri:ad65b31051a0c3ef755cdd2741ae415f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0213" ;
-    prov:atLocation niiri:b08f821c14963d93c313967a3a447f63 ;
+    prov:atLocation niiri:82ffc6dfc401537ce52185c43cfcf147 ;
     prov:value "3.62374401092529"^^xsd:float ;
     nidm_equivalentZStatistic: "3.2797461261145"^^xsd:float ;
     nidm_pValueUncorrected: "0.000519502686150974"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.680244967613049"^^xsd:float .
 
-niiri:b08f821c14963d93c313967a3a447f63
+niiri:82ffc6dfc401537ce52185c43cfcf147
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0213" ;
     nidm_coordinateVector: "[46,-58,-18]"^^xsd:string .
 
-niiri:d105282f9defe267a465f045b1dd0e7d prov:wasDerivedFrom niiri:a9473168659cdf2b1a2073210ee27791 .
+niiri:ad65b31051a0c3ef755cdd2741ae415f prov:wasDerivedFrom niiri:ea9fe9402f815e54e3cef6704ebcb2e4 .
 
-niiri:a8289ab936d15b8fb58bbc9bf05aeaf5
+niiri:5c492afc637552d22a37d356b892476b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0214" ;
-    prov:atLocation niiri:7091211174c94f71cb8e6c4ee1b395fd ;
+    prov:atLocation niiri:ab90c63f449b003e4d791be7e3d0e800 ;
     prov:value "3.62238955497742"^^xsd:float ;
     nidm_equivalentZStatistic: "3.27869670069254"^^xsd:float ;
     nidm_pValueUncorrected: "0.000521438278593522"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.681370246579141"^^xsd:float .
 
-niiri:7091211174c94f71cb8e6c4ee1b395fd
+niiri:ab90c63f449b003e4d791be7e3d0e800
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0214" ;
     nidm_coordinateVector: "[-18,62,26]"^^xsd:string .
 
-niiri:a8289ab936d15b8fb58bbc9bf05aeaf5 prov:wasDerivedFrom niiri:907753cf0dfe053ffac4e74053c771f4 .
+niiri:5c492afc637552d22a37d356b892476b prov:wasDerivedFrom niiri:1dce01b8df60884c582e29243c828080 .
 
-niiri:8acb818b9bd4064fdb974a1bdda6017f
+niiri:f6cd2c4025ec944fe9fad4a68eeb76c3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0215" ;
-    prov:atLocation niiri:de20fca34aead465553cd2a0d7c00538 ;
+    prov:atLocation niiri:edf4f82f106c671bdef81e84a01b9486 ;
     prov:value "3.6151659488678"^^xsd:float ;
     nidm_equivalentZStatistic: "3.27309447054155"^^xsd:float ;
     nidm_pValueUncorrected: "0.000531884583176545"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.690041088084649"^^xsd:float .
 
-niiri:de20fca34aead465553cd2a0d7c00538
+niiri:edf4f82f106c671bdef81e84a01b9486
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0215" ;
     nidm_coordinateVector: "[66,-30,8]"^^xsd:string .
 
-niiri:8acb818b9bd4064fdb974a1bdda6017f prov:wasDerivedFrom niiri:7a7fab37bd67ec2dae91a58e4367079a .
+niiri:f6cd2c4025ec944fe9fad4a68eeb76c3 prov:wasDerivedFrom niiri:eb8a2332e6ccc41b6d1a8cca84b280fe .
 
-niiri:01a05158b8b9d9a48af9806cf6f174e6
+niiri:b076644097262f402af618f0521f3c6f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0216" ;
-    prov:atLocation niiri:5a939851cab3866cd5a4cdc829e6d175 ;
+    prov:atLocation niiri:d46c39edd8f989ed016fc63e4e532951 ;
     prov:value "3.60937356948853"^^xsd:float ;
     nidm_equivalentZStatistic: "3.2685956145544"^^xsd:float ;
     nidm_pValueUncorrected: "0.000540413261609474"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.697552180185497"^^xsd:float .
 
-niiri:5a939851cab3866cd5a4cdc829e6d175
+niiri:d46c39edd8f989ed016fc63e4e532951
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0216" ;
     nidm_coordinateVector: "[-10,-18,-42]"^^xsd:string .
 
-niiri:01a05158b8b9d9a48af9806cf6f174e6 prov:wasDerivedFrom niiri:6b0e32c53f8491486992e204b6c885ee .
+niiri:b076644097262f402af618f0521f3c6f prov:wasDerivedFrom niiri:3ab29b7a5414afa7ee3dad94fe418d2f .
 
-niiri:480ccf452d0de5c8338c4bd8561fc873
+niiri:cf314ff0f3be99903935c1888a63ccdc
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0217" ;
-    prov:atLocation niiri:455bc90906fca2efee367054943bcd10 ;
+    prov:atLocation niiri:b27a4f7ac8e1c0c6c2cef33e18a16762 ;
     prov:value "3.60362911224365"^^xsd:float ;
     nidm_equivalentZStatistic: "3.26412815526814"^^xsd:float ;
     nidm_pValueUncorrected: "0.000549007436707605"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.704264807188576"^^xsd:float .
 
-niiri:455bc90906fca2efee367054943bcd10
+niiri:b27a4f7ac8e1c0c6c2cef33e18a16762
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0217" ;
     nidm_coordinateVector: "[32,-36,-6]"^^xsd:string .
 
-niiri:480ccf452d0de5c8338c4bd8561fc873 prov:wasDerivedFrom niiri:437362f1f721e7635eb6c8e7a49eacc8 .
+niiri:cf314ff0f3be99903935c1888a63ccdc prov:wasDerivedFrom niiri:de99f369510067d001dcfc78a4b7ee95 .
 
-niiri:fd777c497dbb657fd82823b623d2dd3a
+niiri:653a08ed610a534c1cf43ad67b874319
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0218" ;
-    prov:atLocation niiri:37981ea26664efc9fd6743ab0a7b732d ;
+    prov:atLocation niiri:fef07c2b8aea1136621b0fce4d8e22f4 ;
     prov:value "3.5972752571106"^^xsd:float ;
     nidm_equivalentZStatistic: "3.25917999430208"^^xsd:float ;
     nidm_pValueUncorrected: "0.000558673768633722"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.712747532197775"^^xsd:float .
 
-niiri:37981ea26664efc9fd6743ab0a7b732d
+niiri:fef07c2b8aea1136621b0fce4d8e22f4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0218" ;
     nidm_coordinateVector: "[52,-2,40]"^^xsd:string .
 
-niiri:fd777c497dbb657fd82823b623d2dd3a prov:wasDerivedFrom niiri:f3e52b5df75745e99bcb5f824b5d95a7 .
+niiri:653a08ed610a534c1cf43ad67b874319 prov:wasDerivedFrom niiri:03516b1ded0c354154f06310cfeb09c0 .
 
-niiri:28a10bfe7a2c092a96599336d5aca46e
+niiri:7132d322b3cc936428996208440f96f6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0219" ;
-    prov:atLocation niiri:b080ece0eb3b899aebcecbbc322ff3a5 ;
+    prov:atLocation niiri:92f24ae50520920d9d40e416007b7466 ;
     prov:value "3.58600521087646"^^xsd:float ;
     nidm_equivalentZStatistic: "3.25038571079181"^^xsd:float ;
     nidm_pValueUncorrected: "0.000576242907006641"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.727015038116334"^^xsd:float .
 
-niiri:b080ece0eb3b899aebcecbbc322ff3a5
+niiri:92f24ae50520920d9d40e416007b7466
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0219" ;
     nidm_coordinateVector: "[14,6,62]"^^xsd:string .
 
-niiri:28a10bfe7a2c092a96599336d5aca46e prov:wasDerivedFrom niiri:e240445d6ab5dec28910648113069e56 .
+niiri:7132d322b3cc936428996208440f96f6 prov:wasDerivedFrom niiri:56da6908cbe82b7569f6ca2737e51eb6 .
 
-niiri:e0fcd11eb8654c7e340d7090beac46a8
+niiri:0640d1c27d97d1f42ae25c516d60eb0c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0220" ;
-    prov:atLocation niiri:03c0e1db52d4c6987426275b18a9744c ;
+    prov:atLocation niiri:94f679f4fb0174f6de4275cf2933e45d ;
     prov:value "3.58496069908142"^^xsd:float ;
     nidm_equivalentZStatistic: "3.24956951283845"^^xsd:float ;
     nidm_pValueUncorrected: "0.00057789913282269"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.727753479695118"^^xsd:float .
 
-niiri:03c0e1db52d4c6987426275b18a9744c
+niiri:94f679f4fb0174f6de4275cf2933e45d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0220" ;
     nidm_coordinateVector: "[48,-68,-22]"^^xsd:string .
 
-niiri:e0fcd11eb8654c7e340d7090beac46a8 prov:wasDerivedFrom niiri:e075542d829a72554ead327c95c2e9d8 .
+niiri:0640d1c27d97d1f42ae25c516d60eb0c prov:wasDerivedFrom niiri:087ce96dd01c83b4336943a7df6de172 .
 
-niiri:527afb8ff80e9a0230db0cf6e8759c40
+niiri:443881374484db2a28a772aefb17c81f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0221" ;
-    prov:atLocation niiri:49382e7805f43abd72df482d6bc18041 ;
+    prov:atLocation niiri:abfaa93e10cd4e067aec5cce0e6988af ;
     prov:value "3.57942819595337"^^xsd:float ;
     nidm_equivalentZStatistic: "3.24524309204834"^^xsd:float ;
     nidm_pValueUncorrected: "0.00058675199606395"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.732763098510088"^^xsd:float .
 
-niiri:49382e7805f43abd72df482d6bc18041
+niiri:abfaa93e10cd4e067aec5cce0e6988af
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0221" ;
     nidm_coordinateVector: "[44,6,54]"^^xsd:string .
 
-niiri:527afb8ff80e9a0230db0cf6e8759c40 prov:wasDerivedFrom niiri:d9aa2f1b33b774438046f98fe3595e09 .
+niiri:443881374484db2a28a772aefb17c81f prov:wasDerivedFrom niiri:1a5540bf2e828d5e14c6001adb4f30d5 .
 
-niiri:29dcb764295a638c24e4c54f67953660
+niiri:cdca9d1394769421f403ff2c2b85319d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0222" ;
-    prov:atLocation niiri:d2550b01b7638d57eafdd91089b16e0c ;
+    prov:atLocation niiri:af2e01b40163257b4d36aca790b9bdea ;
     prov:value "3.57787442207336"^^xsd:float ;
     nidm_equivalentZStatistic: "3.24402705959498"^^xsd:float ;
     nidm_pValueUncorrected: "0.00058926274833293"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.733379048702781"^^xsd:float .
 
-niiri:d2550b01b7638d57eafdd91089b16e0c
+niiri:af2e01b40163257b4d36aca790b9bdea
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0222" ;
     nidm_coordinateVector: "[-52,-36,32]"^^xsd:string .
 
-niiri:29dcb764295a638c24e4c54f67953660 prov:wasDerivedFrom niiri:13bffc90c8fd1625b76f45711dc4d490 .
+niiri:cdca9d1394769421f403ff2c2b85319d prov:wasDerivedFrom niiri:b54974658dcfd8d91a65540d01e3250b .
 
-niiri:9507d455b653afa82e174377053b32fd
+niiri:2f89f4ddc37f465398449ec427aef8f4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0223" ;
-    prov:atLocation niiri:da226d86fa055a7f70f8595d6b0e32fc ;
+    prov:atLocation niiri:6ca8f9ce9b937a2e0b96c22dfdcf588f ;
     prov:value "3.57743859291077"^^xsd:float ;
     nidm_equivalentZStatistic: "3.24368588864821"^^xsd:float ;
     nidm_pValueUncorrected: "0.000589968948020769"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.733379048702781"^^xsd:float .
 
-niiri:da226d86fa055a7f70f8595d6b0e32fc
+niiri:6ca8f9ce9b937a2e0b96c22dfdcf588f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0223" ;
     nidm_coordinateVector: "[-40,-14,-10]"^^xsd:string .
 
-niiri:9507d455b653afa82e174377053b32fd prov:wasDerivedFrom niiri:226cf1d14e58a618a7ed1bfe9c594e24 .
+niiri:2f89f4ddc37f465398449ec427aef8f4 prov:wasDerivedFrom niiri:b1012bc624cd6b3f47ff149073d0a78b .
 
-niiri:338ef1aad0eba02b52b18a5ccccf64b9
+niiri:cce527c4d5173264fd0ba76367f83931
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0224" ;
-    prov:atLocation niiri:1880442a1afa1ae0be72cb6517fdad6b ;
+    prov:atLocation niiri:5f4ae25fe5269d66ca447679a1db8171 ;
     prov:value "3.57096195220947"^^xsd:float ;
     nidm_equivalentZStatistic: "3.23861192072534"^^xsd:float ;
     nidm_pValueUncorrected: "0.000600564422457928"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.742283339420037"^^xsd:float .
 
-niiri:1880442a1afa1ae0be72cb6517fdad6b
+niiri:5f4ae25fe5269d66ca447679a1db8171
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0224" ;
     nidm_coordinateVector: "[24,38,40]"^^xsd:string .
 
-niiri:338ef1aad0eba02b52b18a5ccccf64b9 prov:wasDerivedFrom niiri:54f50d5bf9097a354105a3150da68b70 .
+niiri:cce527c4d5173264fd0ba76367f83931 prov:wasDerivedFrom niiri:d45da63c733d96ddba5cf2fb05dc0b58 .
 
-niiri:0069a554e0ca9a3376528d1782229337
+niiri:f59eaee6cc14a37ee302a26deccb5ba8
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0225" ;
-    prov:atLocation niiri:f142855532e38b46b9133355a9e881a5 ;
+    prov:atLocation niiri:df0c9b42ffecb2d8ebc2d1d89f566469 ;
     prov:value "3.57036733627319"^^xsd:float ;
     nidm_equivalentZStatistic: "3.23814570748812"^^xsd:float ;
     nidm_pValueUncorrected: "0.000601546736720304"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.742311455927918"^^xsd:float .
 
-niiri:f142855532e38b46b9133355a9e881a5
+niiri:df0c9b42ffecb2d8ebc2d1d89f566469
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0225" ;
     nidm_coordinateVector: "[-56,8,-26]"^^xsd:string .
 
-niiri:0069a554e0ca9a3376528d1782229337 prov:wasDerivedFrom niiri:6f1dfc43277961fa3ac9af2851b18b10 .
+niiri:f59eaee6cc14a37ee302a26deccb5ba8 prov:wasDerivedFrom niiri:14e793643765a6fe10fb66237bee63db .
 
-niiri:d818c67e5dec2eb6ae6952cb1d8e6490
+niiri:cbdb1c804f7d0ec340e49acbe0f59365
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0226" ;
-    prov:atLocation niiri:b3c58dbeeecd1d714e31c6df16eca605 ;
+    prov:atLocation niiri:b501cb0bebb39347ca92fbcfc86d2801 ;
     prov:value "3.56984972953796"^^xsd:float ;
     nidm_equivalentZStatistic: "3.23773982240894"^^xsd:float ;
     nidm_pValueUncorrected: "0.000602403147547781"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.742311455927918"^^xsd:float .
 
-niiri:b3c58dbeeecd1d714e31c6df16eca605
+niiri:b501cb0bebb39347ca92fbcfc86d2801
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0226" ;
     nidm_coordinateVector: "[-46,-76,-8]"^^xsd:string .
 
-niiri:d818c67e5dec2eb6ae6952cb1d8e6490 prov:wasDerivedFrom niiri:eac8fe1980d2f8fa464fc76d2251099d .
+niiri:cbdb1c804f7d0ec340e49acbe0f59365 prov:wasDerivedFrom niiri:a3b1937d74b3d7366255ed05df95e8dc .
 
-niiri:944b10d72b78402dcab8a595815ad03c
+niiri:e99c458abc0e31d64f6dc46f9eb3ba86
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0227" ;
-    prov:atLocation niiri:ec89e9bf6e3a6ec013492213a7f95ead ;
+    prov:atLocation niiri:e87776fe0defb58e096d6889e9628b08 ;
     prov:value "3.56818604469299"^^xsd:float ;
     nidm_equivalentZStatistic: "3.23643490706068"^^xsd:float ;
     nidm_pValueUncorrected: "0.000605164134718339"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.744019467604621"^^xsd:float .
 
-niiri:ec89e9bf6e3a6ec013492213a7f95ead
+niiri:e87776fe0defb58e096d6889e9628b08
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0227" ;
     nidm_coordinateVector: "[16,40,20]"^^xsd:string .
 
-niiri:944b10d72b78402dcab8a595815ad03c prov:wasDerivedFrom niiri:79433ea0eb0eb190e621fa615f0bf51e .
+niiri:e99c458abc0e31d64f6dc46f9eb3ba86 prov:wasDerivedFrom niiri:4f0d78d14b791c15d9759ece4ec7e6ed .
 
-niiri:a5224cc9e0429dfa9daa5f454afbd587
+niiri:ed39a62270a751bff5d29b2e4c49e7f8
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0228" ;
-    prov:atLocation niiri:ca94df6b6797b235fbc04993cc66f9b0 ;
+    prov:atLocation niiri:013cdc8bc7bd75dd13e53be4e70de1e7 ;
     prov:value "3.56333160400391"^^xsd:float ;
     nidm_equivalentZStatistic: "3.23262447936818"^^xsd:float ;
     nidm_pValueUncorrected: "0.000613293417818239"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.748959368128923"^^xsd:float .
 
-niiri:ca94df6b6797b235fbc04993cc66f9b0
+niiri:013cdc8bc7bd75dd13e53be4e70de1e7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0228" ;
     nidm_coordinateVector: "[48,-28,22]"^^xsd:string .
 
-niiri:a5224cc9e0429dfa9daa5f454afbd587 prov:wasDerivedFrom niiri:7d479ec4ba5d64002174656bfdc52de9 .
+niiri:ed39a62270a751bff5d29b2e4c49e7f8 prov:wasDerivedFrom niiri:f569ae7a0c44f14440097fc2492d13ab .
 
-niiri:c76cc26051f5bea1921fc20516474612
+niiri:b97a5c6fcb6a02f68a6fadc9cf02ba98
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0229" ;
-    prov:atLocation niiri:2952751017cef1359932bf3336bfd01e ;
+    prov:atLocation niiri:42ba35106dcd2141347921bd860ffc4f ;
     prov:value "3.56151604652405"^^xsd:float ;
     nidm_equivalentZStatistic: "3.23119829562355"^^xsd:float ;
     nidm_pValueUncorrected: "0.000616361933964638"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.750918681283957"^^xsd:float .
 
-niiri:2952751017cef1359932bf3336bfd01e
+niiri:42ba35106dcd2141347921bd860ffc4f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0229" ;
     nidm_coordinateVector: "[6,10,34]"^^xsd:string .
 
-niiri:c76cc26051f5bea1921fc20516474612 prov:wasDerivedFrom niiri:f6e5caa15217c51ffb3a70b27c4655de .
+niiri:b97a5c6fcb6a02f68a6fadc9cf02ba98 prov:wasDerivedFrom niiri:2fd27f14078fbb1aa402a271e101e35f .
 
-niiri:93e7f5eeb92cbfe69494e25162c848aa
+niiri:3fc6abca83add3e6e871c4ba13db90d8
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0230" ;
-    prov:atLocation niiri:2a4ecae66ef702055e93059d47a60ff3 ;
+    prov:atLocation niiri:8f5014db8d06c5cb5b713b4c5644456b ;
     prov:value "3.55326652526855"^^xsd:float ;
     nidm_equivalentZStatistic: "3.22471054262134"^^xsd:float ;
     nidm_pValueUncorrected: "0.000630500477415308"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.758661956634776"^^xsd:float .
 
-niiri:2a4ecae66ef702055e93059d47a60ff3
+niiri:8f5014db8d06c5cb5b713b4c5644456b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0230" ;
     nidm_coordinateVector: "[54,-46,46]"^^xsd:string .
 
-niiri:93e7f5eeb92cbfe69494e25162c848aa prov:wasDerivedFrom niiri:a1d3eda99ed34e2358f8113bd4e39dbf .
+niiri:3fc6abca83add3e6e871c4ba13db90d8 prov:wasDerivedFrom niiri:5476fcd5093f7c864637efaafd42b996 .
 
-niiri:b04bd6e704bb70e3bce09b8a874d7043
+niiri:73ff07955917113509745f126dd5bd76
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0231" ;
-    prov:atLocation niiri:c4517b6615dcf1a6b867a80de4baba62 ;
+    prov:atLocation niiri:b4367bc8834e232852e1f229303575de ;
     prov:value "3.53535223007202"^^xsd:float ;
     nidm_equivalentZStatistic: "3.21057969685079"^^xsd:float ;
     nidm_pValueUncorrected: "0.000662337649990907"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.782699957189858"^^xsd:float .
 
-niiri:c4517b6615dcf1a6b867a80de4baba62
+niiri:b4367bc8834e232852e1f229303575de
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0231" ;
     nidm_coordinateVector: "[-60,-30,22]"^^xsd:string .
 
-niiri:b04bd6e704bb70e3bce09b8a874d7043 prov:wasDerivedFrom niiri:51e730ef4a2f4f6093b5ca4c2b56ea0f .
+niiri:73ff07955917113509745f126dd5bd76 prov:wasDerivedFrom niiri:10bac4ccf6049482f632adb3952c3c8c .
 
-niiri:bba858fce100c5682da038ec3346309c
+niiri:3a2f1d64a861856a52cc3fa9969bc2b0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0232" ;
-    prov:atLocation niiri:d38e96f5e40921d4793395a28aa6619f ;
+    prov:atLocation niiri:35d050255e7913d2871e399b6466dd0b ;
     prov:value "3.53448247909546"^^xsd:float ;
     nidm_equivalentZStatistic: "3.20989215326664"^^xsd:float ;
     nidm_pValueUncorrected: "0.000663923910754316"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.783230703782876"^^xsd:float .
 
-niiri:d38e96f5e40921d4793395a28aa6619f
+niiri:35d050255e7913d2871e399b6466dd0b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0232" ;
     nidm_coordinateVector: "[-46,24,-36]"^^xsd:string .
 
-niiri:bba858fce100c5682da038ec3346309c prov:wasDerivedFrom niiri:3352f1f91f74dc735e788278eb1bed90 .
+niiri:3a2f1d64a861856a52cc3fa9969bc2b0 prov:wasDerivedFrom niiri:cda273936fc980c18403b41fb8533954 .
 
-niiri:373a5f68e73fe5d0fd97dda23ea05d83
+niiri:aef2a2aecfbeec0007f227032d3cef74
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0233" ;
-    prov:atLocation niiri:199516b49cfb38533e880834a47a3d66 ;
+    prov:atLocation niiri:7db42b1f6fa6ef9bdf3710cab7dd6378 ;
     prov:value "3.52919697761536"^^xsd:float ;
     nidm_equivalentZStatistic: "3.20571096990557"^^xsd:float ;
     nidm_pValueUncorrected: "0.000673646212453916"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.790008451230221"^^xsd:float .
 
-niiri:199516b49cfb38533e880834a47a3d66
+niiri:7db42b1f6fa6ef9bdf3710cab7dd6378
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0233" ;
     nidm_coordinateVector: "[18,-84,-44]"^^xsd:string .
 
-niiri:373a5f68e73fe5d0fd97dda23ea05d83 prov:wasDerivedFrom niiri:46cfb09d58d7bccc0bf22049c6888ca9 .
+niiri:aef2a2aecfbeec0007f227032d3cef74 prov:wasDerivedFrom niiri:89501dfa67d1d32810bbe20fd9b1fe8c .
 
-niiri:3986f2091cccc89f019b6bd69b8aa1d9
+niiri:98a88c543aab0179b9f3e245882a9203
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0234" ;
-    prov:atLocation niiri:8670ccf5666cbe8c30249913aec0bd81 ;
+    prov:atLocation niiri:640fa10a58203760c34949fdbdd4513a ;
     prov:value "3.52617359161377"^^xsd:float ;
     nidm_equivalentZStatistic: "3.2033169804895"^^xsd:float ;
     nidm_pValueUncorrected: "0.000679271799107761"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.794036522733694"^^xsd:float .
 
-niiri:8670ccf5666cbe8c30249913aec0bd81
+niiri:640fa10a58203760c34949fdbdd4513a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0234" ;
     nidm_coordinateVector: "[20,-38,-52]"^^xsd:string .
 
-niiri:3986f2091cccc89f019b6bd69b8aa1d9 prov:wasDerivedFrom niiri:0abf2e69a6c22d3820c2671d957d5cb6 .
+niiri:98a88c543aab0179b9f3e245882a9203 prov:wasDerivedFrom niiri:02f6f6429a8304a7731a404570cb4b94 .
 
-niiri:3829d4f4c6c77ddc79a1e18c412aea42
+niiri:3cec9a1c9417800f3a247e3023d0f1cb
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0235" ;
-    prov:atLocation niiri:a716b80861e7d3cbc66f5a3d9dc5fe81 ;
+    prov:atLocation niiri:6343fb8cffbbeab720d14fffd9e903dd ;
     prov:value "3.52416038513184"^^xsd:float ;
     nidm_equivalentZStatistic: "3.20172194962906"^^xsd:float ;
     nidm_pValueUncorrected: "0.000683043949932127"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.796437366060161"^^xsd:float .
 
-niiri:a716b80861e7d3cbc66f5a3d9dc5fe81
+niiri:6343fb8cffbbeab720d14fffd9e903dd
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0235" ;
     nidm_coordinateVector: "[58,12,24]"^^xsd:string .
 
-niiri:3829d4f4c6c77ddc79a1e18c412aea42 prov:wasDerivedFrom niiri:a4c707ed5e61e6afca1d519a13e265d1 .
+niiri:3cec9a1c9417800f3a247e3023d0f1cb prov:wasDerivedFrom niiri:8747a3ddd24cbd71e40672d541cefee5 .
 
-niiri:b1ed886d825af536568af317a4173477
+niiri:a7e2dfc487d0a70d1149fdf1efb30d4c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0236" ;
-    prov:atLocation niiri:276690ec03e527307d636c6fb0b3aa43 ;
+    prov:atLocation niiri:6a152f1146f43c017dc68ab8324ec605 ;
     prov:value "3.51774144172668"^^xsd:float ;
     nidm_equivalentZStatistic: "3.19663137427302"^^xsd:float ;
     nidm_pValueUncorrected: "0.000695212465446571"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.806071113207381"^^xsd:float .
 
-niiri:276690ec03e527307d636c6fb0b3aa43
+niiri:6a152f1146f43c017dc68ab8324ec605
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0236" ;
     nidm_coordinateVector: "[54,-52,26]"^^xsd:string .
 
-niiri:b1ed886d825af536568af317a4173477 prov:wasDerivedFrom niiri:b664590e2a12ae3f5b1c7bfc738917c9 .
+niiri:a7e2dfc487d0a70d1149fdf1efb30d4c prov:wasDerivedFrom niiri:c885eb98b2506b007c2d8feb2e37f08e .
 
-niiri:67f347e7a204c93a10d706891c560791
+niiri:0528a1b646839dcdd2fb0bb16a07223d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0237" ;
-    prov:atLocation niiri:574feb78f5d86bfde1e62fe3cca0590f ;
+    prov:atLocation niiri:4d047343b5b28834cf69c72f874e638d ;
     prov:value "3.51371550559998"^^xsd:float ;
     nidm_equivalentZStatistic: "3.1934347318076"^^xsd:float ;
     nidm_pValueUncorrected: "0.000702955576802444"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.811837038292354"^^xsd:float .
 
-niiri:574feb78f5d86bfde1e62fe3cca0590f
+niiri:4d047343b5b28834cf69c72f874e638d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0237" ;
     nidm_coordinateVector: "[34,12,30]"^^xsd:string .
 
-niiri:67f347e7a204c93a10d706891c560791 prov:wasDerivedFrom niiri:6abd89dfa06bba6341117a3456f77a35 .
+niiri:0528a1b646839dcdd2fb0bb16a07223d prov:wasDerivedFrom niiri:bd96226234de4e21627b04208c7e537f .
 
-niiri:4f96fec959af5ccb3aa99ac5756d95c7
+niiri:9143f6e13fe4ee9fe42fac2f81f2e676
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0238" ;
-    prov:atLocation niiri:08b492b6468d9a2e69ce8d6e8919afb4 ;
+    prov:atLocation niiri:9077c71eee98aae8008376a8ed7b9b4a ;
     prov:value "3.50933194160461"^^xsd:float ;
     nidm_equivalentZStatistic: "3.18995074240404"^^xsd:float ;
     nidm_pValueUncorrected: "0.000711485225238007"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.818238642626287"^^xsd:float .
 
-niiri:08b492b6468d9a2e69ce8d6e8919afb4
+niiri:9077c71eee98aae8008376a8ed7b9b4a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0238" ;
     nidm_coordinateVector: "[62,-40,48]"^^xsd:string .
 
-niiri:4f96fec959af5ccb3aa99ac5756d95c7 prov:wasDerivedFrom niiri:fe9517cb56f6cb1662031dc08caaf182 .
+niiri:9143f6e13fe4ee9fe42fac2f81f2e676 prov:wasDerivedFrom niiri:8b7eb042176ff4b34dbab2133217acff .
 
-niiri:157af58a6279ef51fcf9a28e1c0664a1
+niiri:f5a857ae39046f3db5dec63a77684c88
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0239" ;
-    prov:atLocation niiri:66e93f1739e6835f643b310d93ed007e ;
+    prov:atLocation niiri:6ffc03184a2b6a40feae78bfa7efbfeb ;
     prov:value "3.50692367553711"^^xsd:float ;
     nidm_equivalentZStatistic: "3.18803518455038"^^xsd:float ;
     nidm_pValueUncorrected: "0.000716215526890496"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.821370946387423"^^xsd:float .
 
-niiri:66e93f1739e6835f643b310d93ed007e
+niiri:6ffc03184a2b6a40feae78bfa7efbfeb
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0239" ;
     nidm_coordinateVector: "[22,20,36]"^^xsd:string .
 
-niiri:157af58a6279ef51fcf9a28e1c0664a1 prov:wasDerivedFrom niiri:50be4fbb838d8e155b244eced8a52d48 .
+niiri:f5a857ae39046f3db5dec63a77684c88 prov:wasDerivedFrom niiri:74aa1acb0840e11af474625bf18a205b .
 
-niiri:267a6a1b74c53063e90f02d4c08b6215
+niiri:c3c44bb5597ea19a830120e15048bdfc
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0240" ;
-    prov:atLocation niiri:e755754abc11613c85cdfa1dca5b4593 ;
+    prov:atLocation niiri:2ba4588b7d24368c21cef645f387e746 ;
     prov:value "3.50429320335388"^^xsd:float ;
     nidm_equivalentZStatistic: "3.18594166053569"^^xsd:float ;
     nidm_pValueUncorrected: "0.000721418444738164"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.824888687870713"^^xsd:float .
 
-niiri:e755754abc11613c85cdfa1dca5b4593
+niiri:2ba4588b7d24368c21cef645f387e746
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0240" ;
     nidm_coordinateVector: "[0,-34,28]"^^xsd:string .
 
-niiri:267a6a1b74c53063e90f02d4c08b6215 prov:wasDerivedFrom niiri:7625dcfd9f93b74584752753153c19ec .
+niiri:c3c44bb5597ea19a830120e15048bdfc prov:wasDerivedFrom niiri:1f8d909cef3803a0e6a8e31c86e2cb37 .
 
-niiri:43b6938758516893593f4cdf20f34340
+niiri:a85791f58de3fb579b6358c661ed5fa2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0241" ;
-    prov:atLocation niiri:aa75268c91b8da02bba871a4a3597032 ;
+    prov:atLocation niiri:573674c8cee6088a030e40b5687fd66a ;
     prov:value "3.50173401832581"^^xsd:float ;
     nidm_equivalentZStatistic: "3.18390364686918"^^xsd:float ;
     nidm_pValueUncorrected: "0.00072651685008529"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.828300523267217"^^xsd:float .
 
-niiri:aa75268c91b8da02bba871a4a3597032
+niiri:573674c8cee6088a030e40b5687fd66a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0241" ;
     nidm_coordinateVector: "[8,54,24]"^^xsd:string .
 
-niiri:43b6938758516893593f4cdf20f34340 prov:wasDerivedFrom niiri:1ac5aaf4d3242e8406a5e8348658d29b .
+niiri:a85791f58de3fb579b6358c661ed5fa2 prov:wasDerivedFrom niiri:d1b86bb927184d1863bf16406cbb38ef .
 
-niiri:a410f5da2b153bf301f1cdab68dd0ea6
+niiri:0a7bb31878e22554cbc54493045e8d7d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0242" ;
-    prov:atLocation niiri:b19569c59cdc8ee8931a601d53971753 ;
+    prov:atLocation niiri:cdd8504c583ff46d7c8a7b3108bd3b78 ;
     prov:value "3.50026345252991"^^xsd:float ;
     nidm_equivalentZStatistic: "3.18273201070653"^^xsd:float ;
     nidm_pValueUncorrected: "0.000729462891188581"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.828979444161694"^^xsd:float .
 
-niiri:b19569c59cdc8ee8931a601d53971753
+niiri:cdd8504c583ff46d7c8a7b3108bd3b78
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0242" ;
     nidm_coordinateVector: "[-30,-26,-30]"^^xsd:string .
 
-niiri:a410f5da2b153bf301f1cdab68dd0ea6 prov:wasDerivedFrom niiri:453feff4ca6cc36089bf9e9576cad723 .
+niiri:0a7bb31878e22554cbc54493045e8d7d prov:wasDerivedFrom niiri:8681fd0b6a40a88059175d0b5804a743 .
 
-niiri:3927113e0ec7a1af308fa162e99437f9
+niiri:c5d06f34a6464f6267e87ac23872ca2e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0243" ;
-    prov:atLocation niiri:7227da02604055c63b55c7955bdcac46 ;
+    prov:atLocation niiri:3599d615ec8b933bd560ca5eb76b7f21 ;
     prov:value "3.49797105789185"^^xsd:float ;
     nidm_equivalentZStatistic: "3.18090480576431"^^xsd:float ;
     nidm_pValueUncorrected: "0.000734079319294478"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.831956387035011"^^xsd:float .
 
-niiri:7227da02604055c63b55c7955bdcac46
+niiri:3599d615ec8b933bd560ca5eb76b7f21
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0243" ;
     nidm_coordinateVector: "[-42,14,-32]"^^xsd:string .
 
-niiri:3927113e0ec7a1af308fa162e99437f9 prov:wasDerivedFrom niiri:a36937f0bb3343166a85a624c7a5008c .
+niiri:c5d06f34a6464f6267e87ac23872ca2e prov:wasDerivedFrom niiri:53d7d39a6b6a7a44a92c2cdc58facf3a .
 
-niiri:30674defc26774c78cfb710cf49f9ffc
+niiri:af68b1cc579ac5658c4a2293d9579639
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0244" ;
-    prov:atLocation niiri:70a31d5933b342a728070af7348068dd ;
+    prov:atLocation niiri:19f62681d85fd0553b734d7b621b76c3 ;
     prov:value "3.49039101600647"^^xsd:float ;
     nidm_equivalentZStatistic: "3.17485603225285"^^xsd:float ;
     nidm_pValueUncorrected: "0.000749554293693833"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.843983114081373"^^xsd:float .
 
-niiri:70a31d5933b342a728070af7348068dd
+niiri:19f62681d85fd0553b734d7b621b76c3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0244" ;
     nidm_coordinateVector: "[38,20,-44]"^^xsd:string .
 
-niiri:30674defc26774c78cfb710cf49f9ffc prov:wasDerivedFrom niiri:9539fad3df2122c0c1d221ba62c93b1e .
+niiri:af68b1cc579ac5658c4a2293d9579639 prov:wasDerivedFrom niiri:b8f303a3f6e3ffbd2a86dd99d6d873fb .
 
-niiri:02a8e47c9b68ca96830e1c4b0a1bdfb2
+niiri:77af4bcf04d46e852b0206ce06555bc3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0245" ;
-    prov:atLocation niiri:f2a576427c49aaaa3109a5f7bfe93fce ;
+    prov:atLocation niiri:13a5242219aba3ab609f497a0343d2e9 ;
     prov:value "3.48954701423645"^^xsd:float ;
     nidm_equivalentZStatistic: "3.17418187045752"^^xsd:float ;
     nidm_pValueUncorrected: "0.000751297535500295"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.84451741403903"^^xsd:float .
 
-niiri:f2a576427c49aaaa3109a5f7bfe93fce
+niiri:13a5242219aba3ab609f497a0343d2e9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0245" ;
     nidm_coordinateVector: "[-6,-16,-30]"^^xsd:string .
 
-niiri:02a8e47c9b68ca96830e1c4b0a1bdfb2 prov:wasDerivedFrom niiri:0703f60bbede2cd4ff08171910c78742 .
+niiri:77af4bcf04d46e852b0206ce06555bc3 prov:wasDerivedFrom niiri:555db4d96064ec58a79e6099a79dd060 .
 
-niiri:92e850c4ae029b98ce8e37ccf5c2a489
+niiri:ac4cc325bba6dd74902e4bedc227ea4d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0246" ;
-    prov:atLocation niiri:147054d7a3545b678bac792fdbf68064 ;
+    prov:atLocation niiri:0c0cf4fe47307d156cf82ba69ae5886e ;
     prov:value "3.48527431488037"^^xsd:float ;
     nidm_equivalentZStatistic: "3.1707669420392"^^xsd:float ;
     nidm_pValueUncorrected: "0.00076018534619382"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.850048157107863"^^xsd:float .
 
-niiri:147054d7a3545b678bac792fdbf68064
+niiri:0c0cf4fe47307d156cf82ba69ae5886e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0246" ;
     nidm_coordinateVector: "[48,-44,-14]"^^xsd:string .
 
-niiri:92e850c4ae029b98ce8e37ccf5c2a489 prov:wasDerivedFrom niiri:2192d0176864a609d1f99aeb7606bb20 .
+niiri:ac4cc325bba6dd74902e4bedc227ea4d prov:wasDerivedFrom niiri:df9fe6cd3c5bf212b4c85e3bd119959c .
 
-niiri:b391a9b61ff1a3cc97f6a81f1bd22c2f
+niiri:8bd2069b941164ec318034e819fbd415
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0247" ;
-    prov:atLocation niiri:12426e86e0fb00d146ffbe8336f59e85 ;
+    prov:atLocation niiri:d9c9d3dee1810cae464cf215a3f5fe75 ;
     prov:value "3.47563886642456"^^xsd:float ;
     nidm_equivalentZStatistic: "3.16305338543499"^^xsd:float ;
     nidm_pValueUncorrected: "0.000780618494857888"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.865926190191015"^^xsd:float .
 
-niiri:12426e86e0fb00d146ffbe8336f59e85
+niiri:d9c9d3dee1810cae464cf215a3f5fe75
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0247" ;
     nidm_coordinateVector: "[-54,8,-16]"^^xsd:string .
 
-niiri:b391a9b61ff1a3cc97f6a81f1bd22c2f prov:wasDerivedFrom niiri:c7815fda00367a584b0eaef5d2a3a8d3 .
+niiri:8bd2069b941164ec318034e819fbd415 prov:wasDerivedFrom niiri:17f6f685daf3b085f3dac6c057c020c1 .
 
-niiri:101beaa5b254b0a2495d8e9dd1a668e3
+niiri:60851992aa4e11f85611dcd9fc54b154
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0248" ;
-    prov:atLocation niiri:6fa32114266a66be0893771476327949 ;
+    prov:atLocation niiri:088ffb09b5d95f1915e71e6abafa1edd ;
     prov:value "3.47256183624268"^^xsd:float ;
     nidm_equivalentZStatistic: "3.1605864476201"^^xsd:float ;
     nidm_pValueUncorrected: "0.000787259372072469"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.870414106789922"^^xsd:float .
 
-niiri:6fa32114266a66be0893771476327949
+niiri:088ffb09b5d95f1915e71e6abafa1edd
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0248" ;
     nidm_coordinateVector: "[-18,-18,-44]"^^xsd:string .
 
-niiri:101beaa5b254b0a2495d8e9dd1a668e3 prov:wasDerivedFrom niiri:0298b7fe38f8161533f229d225028815 .
+niiri:60851992aa4e11f85611dcd9fc54b154 prov:wasDerivedFrom niiri:c5cf9af3cc2424e4b8e65eb6049706ed .
 
-niiri:694563d3fce7b1050b91f872cd711ac0
+niiri:e1653eb5a2319fdfa378634babb879b4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0249" ;
-    prov:atLocation niiri:ade2cec4e2e3f6c89578a933442f3f44 ;
+    prov:atLocation niiri:54ec63f77daa9a18ff3b8c3a72842a9e ;
     prov:value "3.45146727561951"^^xsd:float ;
     nidm_equivalentZStatistic: "3.14362649041421"^^xsd:float ;
     nidm_pValueUncorrected: "0.000834341399658656"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.904541913018706"^^xsd:float .
 
-niiri:ade2cec4e2e3f6c89578a933442f3f44
+niiri:54ec63f77daa9a18ff3b8c3a72842a9e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0249" ;
     nidm_coordinateVector: "[28,-82,-26]"^^xsd:string .
 
-niiri:694563d3fce7b1050b91f872cd711ac0 prov:wasDerivedFrom niiri:0c1cd6f0700636298b473906a5e51975 .
+niiri:e1653eb5a2319fdfa378634babb879b4 prov:wasDerivedFrom niiri:24b677d8caebb84711be327c29be20b9 .
 
-niiri:1b6d45bbf74835aa70c91401c2c5223a
+niiri:d78c9899bc897947e0449b5b9372058c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0250" ;
-    prov:atLocation niiri:ff861d2d96bb938a5cbcba9162b7eacd ;
+    prov:atLocation niiri:78b19072340e7131009e1d60e6925937 ;
     prov:value "3.4509379863739"^^xsd:float ;
     nidm_equivalentZStatistic: "3.14319986465702"^^xsd:float ;
     nidm_pValueUncorrected: "0.000835558468664344"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.904541913018706"^^xsd:float .
 
-niiri:ff861d2d96bb938a5cbcba9162b7eacd
+niiri:78b19072340e7131009e1d60e6925937
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0250" ;
     nidm_coordinateVector: "[24,52,6]"^^xsd:string .
 
-niiri:1b6d45bbf74835aa70c91401c2c5223a prov:wasDerivedFrom niiri:a6a6f1a505d5a404d9c028c325bee223 .
+niiri:d78c9899bc897947e0449b5b9372058c prov:wasDerivedFrom niiri:c9997d6b8885703c61c50e9494f01f5b .
 
-niiri:f52f8140fe70249f4f25786ac572993f
+niiri:d36696cd084e014fe3b461011d62026c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0251" ;
-    prov:atLocation niiri:1f5a8eeeec0087009c35d2fce6e99d5f ;
+    prov:atLocation niiri:2f3a040be26b69350ee6668f1e953585 ;
     prov:value "3.44921636581421"^^xsd:float ;
     nidm_equivalentZStatistic: "3.14181181124074"^^xsd:float ;
     nidm_pValueUncorrected: "0.000839529589309329"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.905753908911515"^^xsd:float .
 
-niiri:1f5a8eeeec0087009c35d2fce6e99d5f
+niiri:2f3a040be26b69350ee6668f1e953585
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0251" ;
     nidm_coordinateVector: "[-4,-48,-44]"^^xsd:string .
 
-niiri:f52f8140fe70249f4f25786ac572993f prov:wasDerivedFrom niiri:f5f7ac01c1435f2b1a5663ae0f9a4c7f .
+niiri:d36696cd084e014fe3b461011d62026c prov:wasDerivedFrom niiri:18c389e9f560a707e21a88082c18399f .
 
-niiri:36306c6f527c2b06a1045359517fac9c
+niiri:c7e89f2bfb5ebb96c9943bcc727e584b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0252" ;
-    prov:atLocation niiri:2612ada677eed159584b95ffb1f4b1d8 ;
+    prov:atLocation niiri:05d9b2e1c39a81ce187b6175e51fc747 ;
     prov:value "3.4477481842041"^^xsd:float ;
     nidm_equivalentZStatistic: "3.14062764913883"^^xsd:float ;
     nidm_pValueUncorrected: "0.000842931107996825"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.907476465657815"^^xsd:float .
 
-niiri:2612ada677eed159584b95ffb1f4b1d8
+niiri:05d9b2e1c39a81ce187b6175e51fc747
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0252" ;
     nidm_coordinateVector: "[-18,52,-6]"^^xsd:string .
 
-niiri:36306c6f527c2b06a1045359517fac9c prov:wasDerivedFrom niiri:ef1841157cd24be39b9b725e1c39ab72 .
+niiri:c7e89f2bfb5ebb96c9943bcc727e584b prov:wasDerivedFrom niiri:4f2617299971ce7d3a16c3c37b0badbd .
 
-niiri:b9346fe11034c44bddb0b55793b205a4
+niiri:abcb021cf3e7d4a1923c3e650e8f646d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0253" ;
-    prov:atLocation niiri:29f23c71781634f66978e21da8d51baf ;
+    prov:atLocation niiri:c4ad197d4d9f82b6dd8bb207c1a7e8e4 ;
     prov:value "3.44230937957764"^^xsd:float ;
     nidm_equivalentZStatistic: "3.13623741912434"^^xsd:float ;
     nidm_pValueUncorrected: "0.000855653022884484"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.915554421234191"^^xsd:float .
 
-niiri:29f23c71781634f66978e21da8d51baf
+niiri:c4ad197d4d9f82b6dd8bb207c1a7e8e4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0253" ;
     nidm_coordinateVector: "[-22,12,-26]"^^xsd:string .
 
-niiri:b9346fe11034c44bddb0b55793b205a4 prov:wasDerivedFrom niiri:e4109f0f0f898a32d7f3ac2462582221 .
+niiri:abcb021cf3e7d4a1923c3e650e8f646d prov:wasDerivedFrom niiri:7ab88d893988ef5840b83076dc34632a .
 
-niiri:cf29c1a8bb918b6e5d5ad13958131a43
+niiri:798c8ad3bf29b7e6a1599d243c811ef4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0254" ;
-    prov:atLocation niiri:0e2cf2a8e5c5493529071dbf9ca69a3b ;
+    prov:atLocation niiri:dc041c3c37fe0c0edd7ce9841a6c74c1 ;
     prov:value "3.43941974639893"^^xsd:float ;
     nidm_equivalentZStatistic: "3.13390260786598"^^xsd:float ;
     nidm_pValueUncorrected: "0.000862490493106716"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.919935328973706"^^xsd:float .
 
-niiri:0e2cf2a8e5c5493529071dbf9ca69a3b
+niiri:dc041c3c37fe0c0edd7ce9841a6c74c1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0254" ;
     nidm_coordinateVector: "[46,-30,-6]"^^xsd:string .
 
-niiri:cf29c1a8bb918b6e5d5ad13958131a43 prov:wasDerivedFrom niiri:4525ab0c75413bf2c98a4586a5abcc36 .
+niiri:798c8ad3bf29b7e6a1599d243c811ef4 prov:wasDerivedFrom niiri:ad4b61cba6b4e1ac8b424d69a662357a .
 
-niiri:9c8de8c17d4a738e981a9e95cb8bea2a
+niiri:188e8be049871fa65f8fc1d3fd94eeea
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0255" ;
-    prov:atLocation niiri:b6904e54dc6f210f5f59a30a1bcfc54a ;
+    prov:atLocation niiri:241b86464efb064f25917d09147c860f ;
     prov:value "3.43677449226379"^^xsd:float ;
     nidm_equivalentZStatistic: "3.13176386125168"^^xsd:float ;
     nidm_pValueUncorrected: "0.000868797847718428"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.923879718713014"^^xsd:float .
 
-niiri:b6904e54dc6f210f5f59a30a1bcfc54a
+niiri:241b86464efb064f25917d09147c860f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0255" ;
     nidm_coordinateVector: "[-20,28,8]"^^xsd:string .
 
-niiri:9c8de8c17d4a738e981a9e95cb8bea2a prov:wasDerivedFrom niiri:4eaf48754995dc5302632344b8135db1 .
+niiri:188e8be049871fa65f8fc1d3fd94eeea prov:wasDerivedFrom niiri:18172de66764cc046e57e3f71900f308 .
 
-niiri:0b01472586a4b0c4f8825be66c755556
+niiri:bd959eb0d068217ced11fd9423305a37
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0256" ;
-    prov:atLocation niiri:3120560a320757e9467244f3b855e1cf ;
+    prov:atLocation niiri:9f5778ddf03c3b5ff73110a18039e5d3 ;
     prov:value "3.43498468399048"^^xsd:float ;
     nidm_equivalentZStatistic: "3.13031600570198"^^xsd:float ;
     nidm_pValueUncorrected: "0.000873091748155641"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.926238520156328"^^xsd:float .
 
-niiri:3120560a320757e9467244f3b855e1cf
+niiri:9f5778ddf03c3b5ff73110a18039e5d3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0256" ;
     nidm_coordinateVector: "[40,-70,34]"^^xsd:string .
 
-niiri:0b01472586a4b0c4f8825be66c755556 prov:wasDerivedFrom niiri:4424249ed6c1cf6688e8d9a01e38e149 .
+niiri:bd959eb0d068217ced11fd9423305a37 prov:wasDerivedFrom niiri:5b864821dad832cdea33cc2c71107b5d .
 
-niiri:38ceb79f3c1ba8a4e6956ba24de4d11a
+niiri:bb3156da7e40e4feec485af3e6a32ecd
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0257" ;
-    prov:atLocation niiri:5f8a387c461b3148ad13494d71bda1d1 ;
+    prov:atLocation niiri:13eaebbb8058068078e2c653b9875caa ;
     prov:value "3.43085432052612"^^xsd:float ;
     nidm_equivalentZStatistic: "3.12697243929315"^^xsd:float ;
     nidm_pValueUncorrected: "0.000883082416866077"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.933001754616948"^^xsd:float .
 
-niiri:5f8a387c461b3148ad13494d71bda1d1
+niiri:13eaebbb8058068078e2c653b9875caa
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0257" ;
     nidm_coordinateVector: "[44,-38,-6]"^^xsd:string .
 
-niiri:38ceb79f3c1ba8a4e6956ba24de4d11a prov:wasDerivedFrom niiri:a39115f19cda212439112978c2f429df .
+niiri:bb3156da7e40e4feec485af3e6a32ecd prov:wasDerivedFrom niiri:54af2492a558bd6b541a83efffeacbc6 .
 
-niiri:27594401c561929af8d24f6405f4deba
+niiri:f8e25bc4e933ed306f46968cead64492
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0258" ;
-    prov:atLocation niiri:82eaf07b78957dbaab11aef1baa80aa2 ;
+    prov:atLocation niiri:a03239e65a180276f5a134d7c3ec3985 ;
     prov:value "3.42879891395569"^^xsd:float ;
     nidm_equivalentZStatistic: "3.12530735529034"^^xsd:float ;
     nidm_pValueUncorrected: "0.000888096838085106"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.935884446603093"^^xsd:float .
 
-niiri:82eaf07b78957dbaab11aef1baa80aa2
+niiri:a03239e65a180276f5a134d7c3ec3985
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0258" ;
     nidm_coordinateVector: "[52,-6,8]"^^xsd:string .
 
-niiri:27594401c561929af8d24f6405f4deba prov:wasDerivedFrom niiri:d5f28f9ef79dc06baf5860f0239ca3e7 .
+niiri:f8e25bc4e933ed306f46968cead64492 prov:wasDerivedFrom niiri:4c87d31930bd2a3884bfbd054121e8ea .
 
-niiri:58a735d123722a7558bcc09250d992d7
+niiri:b80c331bc3c013d36540ed2209e180ac
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0259" ;
-    prov:atLocation niiri:2f3e93c7676b5a0e2805bebee1f9d179 ;
+    prov:atLocation niiri:71fc6bdf3b69205367a0010060b137b5 ;
     prov:value "3.42553544044495"^^xsd:float ;
     nidm_equivalentZStatistic: "3.12266195704485"^^xsd:float ;
     nidm_pValueUncorrected: "0.000896117338800573"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.939451992103697"^^xsd:float .
 
-niiri:2f3e93c7676b5a0e2805bebee1f9d179
+niiri:71fc6bdf3b69205367a0010060b137b5
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0259" ;
     nidm_coordinateVector: "[54,-72,8]"^^xsd:string .
 
-niiri:58a735d123722a7558bcc09250d992d7 prov:wasDerivedFrom niiri:5079e994cd9f24fc30fe92efa7493c57 .
+niiri:b80c331bc3c013d36540ed2209e180ac prov:wasDerivedFrom niiri:0c1ba90c913890f99f03e9c6732b7833 .
 
-niiri:e8969dceee58b2b20f0b988472c9653e
+niiri:4deb8dc19d6af02360fbd76e432ce8b6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0260" ;
-    prov:atLocation niiri:a04078d9882464053185059f803d1d26 ;
+    prov:atLocation niiri:b5082c06f45ce0a2dd15d81971c68d59 ;
     prov:value "3.42464590072632"^^xsd:float ;
     nidm_equivalentZStatistic: "3.12194053531123"^^xsd:float ;
     nidm_pValueUncorrected: "0.000898316119580023"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.939451992103697"^^xsd:float .
 
-niiri:a04078d9882464053185059f803d1d26
+niiri:b5082c06f45ce0a2dd15d81971c68d59
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0260" ;
     nidm_coordinateVector: "[-34,-86,12]"^^xsd:string .
 
-niiri:e8969dceee58b2b20f0b988472c9653e prov:wasDerivedFrom niiri:686ed6dbd2ea21d312152f2e4e96f435 .
+niiri:4deb8dc19d6af02360fbd76e432ce8b6 prov:wasDerivedFrom niiri:7e48fd00328505ec2f7c55286029038c .
 
-niiri:767a71267bbe9178e3b5840ace1525ad
+niiri:ed4d3b7d5ccc140dfba860cdd388e8ce
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0261" ;
-    prov:atLocation niiri:140badd68f365dee0f7ca11dddf2e2d4 ;
+    prov:atLocation niiri:06c7a2471791b84ae3c6a36937e0e8a0 ;
     prov:value "3.42428636550903"^^xsd:float ;
     nidm_equivalentZStatistic: "3.12164890720699"^^xsd:float ;
     nidm_pValueUncorrected: "0.00089920636307117"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.939451992103697"^^xsd:float .
 
-niiri:140badd68f365dee0f7ca11dddf2e2d4
+niiri:06c7a2471791b84ae3c6a36937e0e8a0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0261" ;
     nidm_coordinateVector: "[-4,10,-10]"^^xsd:string .
 
-niiri:767a71267bbe9178e3b5840ace1525ad prov:wasDerivedFrom niiri:91f65776f22ca4ee422c8dcd4c4c4459 .
+niiri:ed4d3b7d5ccc140dfba860cdd388e8ce prov:wasDerivedFrom niiri:fe7b7aeb5b19bcdfb6ba3b9e7bbc0530 .
 
-niiri:bc6ae74fd4bd5212ee4a36a237f3490e
+niiri:b7f899e5f3760319ce8ccef45e585946
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0262" ;
-    prov:atLocation niiri:4059198b6c549aa31f9f5cf29e45af3c ;
+    prov:atLocation niiri:1a7b22ad02fe7ed75c7738a5f7ac0c62 ;
     prov:value "3.4242856502533"^^xsd:float ;
     nidm_equivalentZStatistic: "3.12164832702029"^^xsd:float ;
     nidm_pValueUncorrected: "0.000899208134995888"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.939451992103697"^^xsd:float .
 
-niiri:4059198b6c549aa31f9f5cf29e45af3c
+niiri:1a7b22ad02fe7ed75c7738a5f7ac0c62
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0262" ;
     nidm_coordinateVector: "[-66,-32,16]"^^xsd:string .
 
-niiri:bc6ae74fd4bd5212ee4a36a237f3490e prov:wasDerivedFrom niiri:4e1ee3ae277085cca25ed575c4d6c732 .
+niiri:b7f899e5f3760319ce8ccef45e585946 prov:wasDerivedFrom niiri:2598e0a8af6b254c19ea1eae1c055e59 .
 
-niiri:fbf29cced919e01bc4d870031c5b9664
+niiri:30b82d808ecbca165129f91f15eeb7d8
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0263" ;
-    prov:atLocation niiri:057ceabe371a11b3e54a00c7b3846412 ;
+    prov:atLocation niiri:08f17e7b0d90c8d55cce1d84356b89c1 ;
     prov:value "3.42256450653076"^^xsd:float ;
     nidm_equivalentZStatistic: "3.12025192043597"^^xsd:float ;
     nidm_pValueUncorrected: "0.000903482154968605"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.94172231450196"^^xsd:float .
 
-niiri:057ceabe371a11b3e54a00c7b3846412
+niiri:08f17e7b0d90c8d55cce1d84356b89c1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0263" ;
     nidm_coordinateVector: "[-6,10,6]"^^xsd:string .
 
-niiri:fbf29cced919e01bc4d870031c5b9664 prov:wasDerivedFrom niiri:21ba06ef00e16e74fa2aac38752b9ad5 .
+niiri:30b82d808ecbca165129f91f15eeb7d8 prov:wasDerivedFrom niiri:ef260aa5a1800f7a5b96c1d3f96edac0 .
 
-niiri:ad6ebc4267abca02b3f648b13a2bc7e8
+niiri:c0b355fc51e7cd26f5f72e9f5c550472
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0264" ;
-    prov:atLocation niiri:9f50af5738d295fb4c112818e8ed812b ;
+    prov:atLocation niiri:4e1ed2f0db8b7a4f4d7af0bb70e715a4 ;
     prov:value "3.420490026474"^^xsd:float ;
     nidm_equivalentZStatistic: "3.11856808830486"^^xsd:float ;
     nidm_pValueUncorrected: "0.000908660733561772"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.943981476602879"^^xsd:float .
 
-niiri:9f50af5738d295fb4c112818e8ed812b
+niiri:4e1ed2f0db8b7a4f4d7af0bb70e715a4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0264" ;
     nidm_coordinateVector: "[60,22,28]"^^xsd:string .
 
-niiri:ad6ebc4267abca02b3f648b13a2bc7e8 prov:wasDerivedFrom niiri:cb15ce5ea75dc27ee8c68d6f25317137 .
+niiri:c0b355fc51e7cd26f5f72e9f5c550472 prov:wasDerivedFrom niiri:9edfdd818d3f428259751e3a1f4426fa .
 
-niiri:76b0a16db9e2cdc644577f7cb27f8e45
+niiri:a2e099d5d8ff7d6205bb133cc5078448
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0265" ;
-    prov:atLocation niiri:cfc6412303e2e50ffef9b795c9b0ed40 ;
+    prov:atLocation niiri:a95381a6790d557cf86a8873e91a0071 ;
     prov:value "3.42032909393311"^^xsd:float ;
     nidm_equivalentZStatistic: "3.11843742665399"^^xsd:float ;
     nidm_pValueUncorrected: "0.000909063718098957"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.943981476602879"^^xsd:float .
 
-niiri:cfc6412303e2e50ffef9b795c9b0ed40
+niiri:a95381a6790d557cf86a8873e91a0071
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0265" ;
     nidm_coordinateVector: "[6,48,-18]"^^xsd:string .
 
-niiri:76b0a16db9e2cdc644577f7cb27f8e45 prov:wasDerivedFrom niiri:9c56529ebb0bf4259a9c564b06624446 .
+niiri:a2e099d5d8ff7d6205bb133cc5078448 prov:wasDerivedFrom niiri:1667cff121b7be39391cc74c4150a6e4 .
 
-niiri:60aade6cd640aed73151491f62f81cc5
+niiri:cc1877ba95e403c226eac44d78215696
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0266" ;
-    prov:atLocation niiri:d567defdeffdbaabcdc8fcccb18582e6 ;
+    prov:atLocation niiri:f2e91580aedfda1661c00346dcfdf4a4 ;
     prov:value "3.41344952583313"^^xsd:float ;
     nidm_equivalentZStatistic: "3.11284722900141"^^xsd:float ;
     nidm_pValueUncorrected: "0.000926459524586143"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.956145916250816"^^xsd:float .
 
-niiri:d567defdeffdbaabcdc8fcccb18582e6
+niiri:f2e91580aedfda1661c00346dcfdf4a4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0266" ;
     nidm_coordinateVector: "[30,-66,-4]"^^xsd:string .
 
-niiri:60aade6cd640aed73151491f62f81cc5 prov:wasDerivedFrom niiri:58cc34c1cf71d6fb92343373483bc627 .
+niiri:cc1877ba95e403c226eac44d78215696 prov:wasDerivedFrom niiri:8a9dbe909430bab19de8984a30f0827c .
 
-niiri:bcdbc0d0bede0ed614966d0971fab082
+niiri:c1b25d75e61e613c55029c674539f77a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0267" ;
-    prov:atLocation niiri:7828d22e6f7c800b3de1d100a72aeaa6 ;
+    prov:atLocation niiri:d1aefdaa8c182ce454467dd1278dd001 ;
     prov:value "3.41180443763733"^^xsd:float ;
     nidm_equivalentZStatistic: "3.11150911429397"^^xsd:float ;
     nidm_pValueUncorrected: "0.00093066864036262"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.958308660309721"^^xsd:float .
 
-niiri:7828d22e6f7c800b3de1d100a72aeaa6
+niiri:d1aefdaa8c182ce454467dd1278dd001
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0267" ;
     nidm_coordinateVector: "[62,18,8]"^^xsd:string .
 
-niiri:bcdbc0d0bede0ed614966d0971fab082 prov:wasDerivedFrom niiri:ef7aa42532c9d5d3093cbb6f46af6456 .
+niiri:c1b25d75e61e613c55029c674539f77a prov:wasDerivedFrom niiri:73e5d22f5e99f7222d046e5c8b8f17e5 .
 
-niiri:53cd36dd64f896620fc190ddbd15ac00
+niiri:dd0f126c27f7ac1f0c10fd12e39bf105
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0268" ;
-    prov:atLocation niiri:0a9b35f95a04802e6be14f473e26dcbc ;
+    prov:atLocation niiri:da274ebc3923f39c33998c996c5f1b48 ;
     prov:value "3.4099760055542"^^xsd:float ;
     nidm_equivalentZStatistic: "3.11002125556328"^^xsd:float ;
     nidm_pValueUncorrected: "0.000935369406583231"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.960830954574892"^^xsd:float .
 
-niiri:0a9b35f95a04802e6be14f473e26dcbc
+niiri:da274ebc3923f39c33998c996c5f1b48
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0268" ;
     nidm_coordinateVector: "[22,40,38]"^^xsd:string .
 
-niiri:53cd36dd64f896620fc190ddbd15ac00 prov:wasDerivedFrom niiri:4948e1f6d55a77b68ff8403a3b1cc6a9 .
+niiri:dd0f126c27f7ac1f0c10fd12e39bf105 prov:wasDerivedFrom niiri:8015064bc0743ed13468353e18ca0971 .
 
-niiri:a14fcf9ccb355d41569e0f3c6507e437
+niiri:c91264646d693326daa65c4e49da790c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0269" ;
-    prov:atLocation niiri:8aa7b35f567fe23cf02e5c132ec2259e ;
+    prov:atLocation niiri:4b8ff43a5a20f4afeed513550c9779d1 ;
     prov:value "3.40772676467896"^^xsd:float ;
     nidm_equivalentZStatistic: "3.10819008533752"^^xsd:float ;
     nidm_pValueUncorrected: "0.000941184775066772"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.964175735240494"^^xsd:float .
 
-niiri:8aa7b35f567fe23cf02e5c132ec2259e
+niiri:4b8ff43a5a20f4afeed513550c9779d1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0269" ;
     nidm_coordinateVector: "[-12,-74,-32]"^^xsd:string .
 
-niiri:a14fcf9ccb355d41569e0f3c6507e437 prov:wasDerivedFrom niiri:d51ac19a940490ccb81c778042e6d07f .
+niiri:c91264646d693326daa65c4e49da790c prov:wasDerivedFrom niiri:eb612c2c1cebda064d6320c535f9294f .
 
-niiri:50aa138335b817fa5d80de192f3e56fe
+niiri:85a9c11ba54c056a1c94ef036e48c7e8
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0270" ;
-    prov:atLocation niiri:b8782b5412b610e9e02c8ae2f51f811e ;
+    prov:atLocation niiri:98db87a6e1ff03f144dc1294bd88361c ;
     prov:value "3.40043520927429"^^xsd:float ;
     nidm_equivalentZStatistic: "3.10224710205524"^^xsd:float ;
     nidm_pValueUncorrected: "0.000960287852612818"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.977387221974707"^^xsd:float .
 
-niiri:b8782b5412b610e9e02c8ae2f51f811e
+niiri:98db87a6e1ff03f144dc1294bd88361c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0270" ;
     nidm_coordinateVector: "[36,12,8]"^^xsd:string .
 
-niiri:50aa138335b817fa5d80de192f3e56fe prov:wasDerivedFrom niiri:dd6abaee8e1238ee75ff4cc3940af16c .
+niiri:85a9c11ba54c056a1c94ef036e48c7e8 prov:wasDerivedFrom niiri:6369784f4c4b56deb50440d6515b981e .
 
-niiri:dce605d65d09289a881eb04b284924f2
+niiri:80417a00361d173f5c5af02c203f269c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0271" ;
-    prov:atLocation niiri:b0621d155d49ef8642896e35363eaa9e ;
+    prov:atLocation niiri:9ae3231161e4fa13633730f1e4660a9a ;
     prov:value "3.39929604530334"^^xsd:float ;
     nidm_equivalentZStatistic: "3.10131769657828"^^xsd:float ;
     nidm_pValueUncorrected: "0.000963307318207596"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.978600787160336"^^xsd:float .
 
-niiri:b0621d155d49ef8642896e35363eaa9e
+niiri:9ae3231161e4fa13633730f1e4660a9a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0271" ;
     nidm_coordinateVector: "[34,-64,-54]"^^xsd:string .
 
-niiri:dce605d65d09289a881eb04b284924f2 prov:wasDerivedFrom niiri:dec8b0ace647b4ba45c324b0822a7d07 .
+niiri:80417a00361d173f5c5af02c203f269c prov:wasDerivedFrom niiri:2147d82387f71f29a3d3dfb09b7b8d64 .
 
-niiri:50c70741ba2247ba187b32228ba5cb8a
+niiri:f44f60b309d98b4839df00ce58c954d3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0272" ;
-    prov:atLocation niiri:659216a0abb9cfa83ba297653940b95a ;
+    prov:atLocation niiri:c0904438f742cbf33d8af23df92769ae ;
     prov:value "3.39674377441406"^^xsd:float ;
     nidm_equivalentZStatistic: "3.09923447115328"^^xsd:float ;
     nidm_pValueUncorrected: "0.000970107026972977"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.982601015041391"^^xsd:float .
 
-niiri:659216a0abb9cfa83ba297653940b95a
+niiri:c0904438f742cbf33d8af23df92769ae
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0272" ;
     nidm_coordinateVector: "[-6,22,14]"^^xsd:string .
 
-niiri:50c70741ba2247ba187b32228ba5cb8a prov:wasDerivedFrom niiri:e77710d04eb08640d5c1d3f18d42d3fa .
+niiri:f44f60b309d98b4839df00ce58c954d3 prov:wasDerivedFrom niiri:790465006aaf87ef2289ea019fdb0b83 .
 
-niiri:0518f540beb04f2487d45a5646104e9f
+niiri:cb93650662489dd0d5315baef5339a8f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0273" ;
-    prov:atLocation niiri:a671673494c6b11b49c6a4b64a206b75 ;
+    prov:atLocation niiri:0af8678dbadc97c6d0964c0f0dea2c02 ;
     prov:value "3.39575552940369"^^xsd:float ;
     nidm_equivalentZStatistic: "3.09842750203846"^^xsd:float ;
     nidm_pValueUncorrected: "0.00097275281871112"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.983523861304105"^^xsd:float .
 
-niiri:a671673494c6b11b49c6a4b64a206b75
+niiri:0af8678dbadc97c6d0964c0f0dea2c02
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0273" ;
     nidm_coordinateVector: "[40,-70,6]"^^xsd:string .
 
-niiri:0518f540beb04f2487d45a5646104e9f prov:wasDerivedFrom niiri:cce35d82d42e6ed7353ce989b716eb03 .
+niiri:cb93650662489dd0d5315baef5339a8f prov:wasDerivedFrom niiri:730c6026b96772dd69384df78d1b3195 .
 
-niiri:f26539aa4d229b93e34c0c42786c0216
+niiri:8f4b30cf80d927285653473f8c169306
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0274" ;
-    prov:atLocation niiri:d93c3861611074088693299ee91310c7 ;
+    prov:atLocation niiri:9d40e288714ed88d103be79dc9b0b58b ;
     prov:value "3.39392924308777"^^xsd:float ;
     nidm_equivalentZStatistic: "3.09693571606088"^^xsd:float ;
     nidm_pValueUncorrected: "0.000977661355603399"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.986105717216079"^^xsd:float .
 
-niiri:d93c3861611074088693299ee91310c7
+niiri:9d40e288714ed88d103be79dc9b0b58b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0274" ;
     nidm_coordinateVector: "[-48,-6,-36]"^^xsd:string .
 
-niiri:f26539aa4d229b93e34c0c42786c0216 prov:wasDerivedFrom niiri:34d4adf23d9292a19ec442ef839b2cff .
+niiri:8f4b30cf80d927285653473f8c169306 prov:wasDerivedFrom niiri:26bef1517140b96419bd96743968bf5a .
 
-niiri:1b79f8647d5740efff59a55996d73b9f
+niiri:4fd5e1e62237032c0a688ab5a411bfd8
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0275" ;
-    prov:atLocation niiri:fa62ad323338a942257e78fcff0bfde7 ;
+    prov:atLocation niiri:cf60c37ac17a2f336fba57b992c85f9a ;
     prov:value "3.39195704460144"^^xsd:float ;
     nidm_equivalentZStatistic: "3.09532401480647"^^xsd:float ;
     nidm_pValueUncorrected: "0.000982990005503837"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.988983887764777"^^xsd:float .
 
-niiri:fa62ad323338a942257e78fcff0bfde7
+niiri:cf60c37ac17a2f336fba57b992c85f9a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0275" ;
     nidm_coordinateVector: "[-10,-60,-38]"^^xsd:string .
 
-niiri:1b79f8647d5740efff59a55996d73b9f prov:wasDerivedFrom niiri:bbd6c18fcbc3934b6a6db033becc5ed1 .
+niiri:4fd5e1e62237032c0a688ab5a411bfd8 prov:wasDerivedFrom niiri:c80e777eb02827978765763f51129026 .
 
-niiri:6a69aee9cf777be919ff8795f24f3290
+niiri:d3c3847d28d2438a321d68783cee6c15
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0276" ;
-    prov:atLocation niiri:c7b4a32e49dcd80ca13733878f9df03d ;
+    prov:atLocation niiri:60692ff98d1d7460d8d0977b8de1a377 ;
     prov:value "3.38738560676575"^^xsd:float ;
     nidm_equivalentZStatistic: "3.09158527627283"^^xsd:float ;
     nidm_pValueUncorrected: "0.000995453939317104"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.997054018314194"^^xsd:float .
 
-niiri:c7b4a32e49dcd80ca13733878f9df03d
+niiri:60692ff98d1d7460d8d0977b8de1a377
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0276" ;
     nidm_coordinateVector: "[34,-62,-16]"^^xsd:string .
 
-niiri:6a69aee9cf777be919ff8795f24f3290 prov:wasDerivedFrom niiri:88f0354a46364a076e3c319e275ba3dd .
+niiri:d3c3847d28d2438a321d68783cee6c15 prov:wasDerivedFrom niiri:6eb9789a31f1c0da3f5dc3fb64518f9e .
 

--- a/spmexport/ex_spm_non_sphericity/nidm.json
+++ b/spmexport/ex_spm_non_sphericity/nidm.json
@@ -1,0 +1,8483 @@
+{
+  "prefix": {
+    "nidm": "http://purl.org/nidash/nidm#",
+    "niiri": "http://iri.nidash.org/",
+    "spm": "http://purl.org/nidash/spm#",
+    "neurolex": "http://neurolex.org/wiki/",
+    "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/",
+    "dct": "http://purl.org/dc/terms/",
+    "nfo": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#",
+    "dc": "http://purl.org/dc/elements/1.1/",
+    "dctype": "http://purl.org/dc/dcmitype/",
+    "obo": "http://purl.obolibrary.org/obo/",
+    "nidm_NIDMResults": "http://purl.org/nidash/nidm#NIDM_0000027",
+    "nidm_version": "http://purl.org/nidash/nidm#NIDM_0000127",
+    "nidm_spm_results_nidm": "http://purl.org/nidash/nidm#NIDM_0000168",
+    "nidm_softwareVersion": "http://purl.org/nidash/nidm#NIDM_0000122",
+    "nidm_NIDMResultsExport": "http://purl.org/nidash/nidm#NIDM_0000166"
+  },
+  "entity": {
+    "niiri:4e3cc7ffa6f685a0f71dbdd16e102f31": {
+      "prov:type": [
+        {
+        "$": "prov:Bundle",
+        "type": "xsd:QName"
+        },
+        {
+        "$": "nidm_NIDMResults:",
+        "type": "xsd:QName"
+        }
+      ],
+      "prov:label": {
+        "$": "NIDM-Results",
+        "type": "xsd:string"
+      },
+      "nidm_version:": {
+        "$": "1.3.0",
+        "type": "xsd:string"
+      }
+    }
+  },
+  "activity": {
+    "niiri:80d7881ec00396b0fee7ca1bafcd9813": {
+      "prov:type": {
+        "$": "nidm_NIDMResultsExport:",
+        "type": "xsd:QName"
+      },
+      "prov:label": {
+        "$": "NIDM-Results export",
+        "type": "xsd:string"
+      }
+    }
+  },
+  "agent": {
+    "niiri:d47620c0a904862a40d4a674f5975211": {
+      "prov:type": [
+        {
+        "$": "nidm_spm_results_nidm:",
+        "type": "xsd:QName"
+        },
+        {
+        "$": "prov:SoftwareAgent",
+        "type": "xsd:QName"
+        }
+      ],
+      "prov:label": {
+        "$": "spm_results_nidm",
+        "type": "xsd:string"
+      },
+      "nidm_softwareVersion:": {
+        "$": "12.7057",
+        "type": "xsd:string"
+      }
+    }
+  },
+  "wasGeneratedBy": {
+    "_:wGB5": {
+      "prov:entity": "niiri:4e3cc7ffa6f685a0f71dbdd16e102f31",
+      "prov:activity": "niiri:80d7881ec00396b0fee7ca1bafcd9813",
+      "prov:time": "2017-04-19T12:18:37"
+    }
+  },
+  "wasAssociatedWith": {
+    "_:wAW4": {
+      "prov:activity": "niiri:80d7881ec00396b0fee7ca1bafcd9813",
+      "prov:agent": "niiri:d47620c0a904862a40d4a674f5975211"
+    }
+  },
+  "bundle": {
+    "niiri:4e3cc7ffa6f685a0f71dbdd16e102f31": {
+    "prefix": {
+        "nidm_softwareVersion": "http://purl.org/nidash/nidm#NIDM_0000122",
+        "nidm_CoordinateSpace": "http://purl.org/nidash/nidm#NIDM_0000016",
+        "nidm_voxelToWorldMapping": "http://purl.org/nidash/nidm#NIDM_0000132",
+        "nidm_voxelUnits": "http://purl.org/nidash/nidm#NIDM_0000133",
+        "nidm_voxelSize": "http://purl.org/nidash/nidm#NIDM_0000131",
+        "nidm_inWorldCoordinateSystem": "http://purl.org/nidash/nidm#NIDM_0000105",
+        "nidm_numberOfDimensions": "http://purl.org/nidash/nidm#NIDM_0000112",
+        "nidm_dimensionsInVoxels": "http://purl.org/nidash/nidm#NIDM_0000090",
+        "nlx_Imaginginstrument": "http://uri.neuinfo.org/nif/nifstd/birnlex_2094",
+        "nlx_Magneticresonanceimagingscanner": "http://uri.neuinfo.org/nif/nifstd/birnlex_2100",
+        "nidm_grandMeanScaling": "http://purl.org/nidash/nidm#NIDM_0000096",
+        "nidm_hasMRIProtocol": "http://purl.org/nidash/nidm#NIDM_0000172",
+        "nlx_FunctionalMRIprotocol": "http://uri.neuinfo.org/nif/nifstd/birnlex_2250",
+        "nidm_Data": "http://purl.org/nidash/nidm#NIDM_0000169",
+        "nidm_DesignMatrix": "http://purl.org/nidash/nidm#NIDM_0000019",
+        "nidm_regressorNames": "http://purl.org/nidash/nidm#NIDM_0000021",
+        "nidm_hasErrorDependence": "http://purl.org/nidash/nidm#NIDM_0000100",
+        "obo_unstructuredcovariancestructure": "http://purl.obolibrary.org/obo/STATO_0000405",
+        "nidm_dependenceMapWiseDependence": "http://purl.org/nidash/nidm#NIDM_0000089",
+        "nidm_ConstantParameter": "http://purl.org/nidash/nidm#NIDM_0000072",
+        "nidm_errorVarianceHomogeneous": "http://purl.org/nidash/nidm#NIDM_0000094",
+        "nidm_varianceMapWiseDependence": "http://purl.org/nidash/nidm#NIDM_0000126",
+        "nidm_IndependentParameter": "http://purl.org/nidash/nidm#NIDM_0000073",
+        "nidm_withEstimationMethod": "http://purl.org/nidash/nidm#NIDM_0000134",
+        "obo_generalizedleastsquaresestimation": "http://purl.obolibrary.org/obo/STATO_0000372",
+        "nidm_ErrorModel": "http://purl.org/nidash/nidm#NIDM_0000023",
+        "nidm_hasErrorDistribution": "http://purl.org/nidash/nidm#NIDM_0000101",
+        "obo_normaldistribution": "http://purl.obolibrary.org/obo/STATO_0000227",
+        "nidm_ModelParametersEstimation": "http://purl.org/nidash/nidm#NIDM_0000056",
+        "nidm_MaskMap": "http://purl.org/nidash/nidm#NIDM_0000054",
+        "nidm_isUserDefined": "http://purl.org/nidash/nidm#NIDM_0000106",
+        "nidm_inCoordinateSpace": "http://purl.org/nidash/nidm#NIDM_0000104",
+        "nidm_GrandMeanMap": "http://purl.org/nidash/nidm#NIDM_0000033",
+        "nidm_maskedMedian": "http://purl.org/nidash/nidm#NIDM_0000107",
+        "nidm_ParameterEstimateMap": "http://purl.org/nidash/nidm#NIDM_0000061",
+        "nidm_ResidualMeanSquaresMap": "http://purl.org/nidash/nidm#NIDM_0000066",
+        "nidm_ReselsPerVoxelMap": "http://purl.org/nidash/nidm#NIDM_0000144",
+        "obo_contrastweightmatrix": "http://purl.obolibrary.org/obo/STATO_0000323",
+        "nidm_statisticType": "http://purl.org/nidash/nidm#NIDM_0000123",
+        "obo_Fstatistic": "http://purl.obolibrary.org/obo/STATO_0000282",
+        "nidm_contrastName": "http://purl.org/nidash/nidm#NIDM_0000085",
+        "nidm_ContrastEstimation": "http://purl.org/nidash/nidm#NIDM_0000001",
+        "nidm_StatisticMap": "http://purl.org/nidash/nidm#NIDM_0000076",
+        "nidm_errorDegreesOfFreedom": "http://purl.org/nidash/nidm#NIDM_0000093",
+        "nidm_effectDegreesOfFreedom": "http://purl.org/nidash/nidm#NIDM_0000091",
+        "nidm_ContrastExplainedMeanSquareMap": "http://purl.org/nidash/nidm#NIDM_0000163",
+        "obo_statistic": "http://purl.obolibrary.org/obo/STATO_0000039",
+        "nidm_PValueUncorrected": "http://purl.org/nidash/nidm#NIDM_0000160",
+        "obo_FWERadjustedpvalue": "http://purl.obolibrary.org/obo/OBI_0001265",
+        "nidm_HeightThreshold": "http://purl.org/nidash/nidm#NIDM_0000034",
+        "nidm_equivalentThreshold": "http://purl.org/nidash/nidm#NIDM_0000161",
+        "nidm_ExtentThreshold": "http://purl.org/nidash/nidm#NIDM_0000026",
+        "nidm_clusterSizeInVoxels": "http://purl.org/nidash/nidm#NIDM_0000084",
+        "nidm_clusterSizeInResels": "http://purl.org/nidash/nidm#NIDM_0000156",
+        "nidm_PeakDefinitionCriteria": "http://purl.org/nidash/nidm#NIDM_0000063",
+        "nidm_maxNumberOfPeaksPerCluster": "http://purl.org/nidash/nidm#NIDM_0000108",
+        "nidm_minDistanceBetweenPeaks": "http://purl.org/nidash/nidm#NIDM_0000109",
+        "nidm_ClusterDefinitionCriteria": "http://purl.org/nidash/nidm#NIDM_0000007",
+        "nidm_hasConnectivityCriterion": "http://purl.org/nidash/nidm#NIDM_0000099",
+        "nidm_voxel18connected": "http://purl.org/nidash/nidm#NIDM_0000128",
+        "nidm_Inference": "http://purl.org/nidash/nidm#NIDM_0000049",
+        "nidm_hasAlternativeHypothesis": "http://purl.org/nidash/nidm#NIDM_0000097",
+        "nidm_OneTailedTest": "http://purl.org/nidash/nidm#NIDM_0000060",
+        "nidm_SearchSpaceMaskMap": "http://purl.org/nidash/nidm#NIDM_0000068",
+        "nidm_searchVolumeInVoxels": "http://purl.org/nidash/nidm#NIDM_0000121",
+        "nidm_searchVolumeInUnits": "http://purl.org/nidash/nidm#NIDM_0000136",
+        "nidm_reselSizeInVoxels": "http://purl.org/nidash/nidm#NIDM_0000148",
+        "nidm_searchVolumeInResels": "http://purl.org/nidash/nidm#NIDM_0000149",
+        "spm_searchVolumeReselsGeometry": "http://purl.org/nidash/spm#SPM_0000010",
+        "nidm_noiseFWHMInVoxels": "http://purl.org/nidash/nidm#NIDM_0000159",
+        "nidm_noiseFWHMInUnits": "http://purl.org/nidash/nidm#NIDM_0000157",
+        "nidm_randomFieldStationarity": "http://purl.org/nidash/nidm#NIDM_0000120",
+        "nidm_expectedNumberOfVoxelsPerCluster": "http://purl.org/nidash/nidm#NIDM_0000143",
+        "nidm_expectedNumberOfClusters": "http://purl.org/nidash/nidm#NIDM_0000141",
+        "nidm_heightCriticalThresholdFWE05": "http://purl.org/nidash/nidm#NIDM_0000147",
+        "nidm_heightCriticalThresholdFDR05": "http://purl.org/nidash/nidm#NIDM_0000146",
+        "spm_smallestSignificantClusterSizeInVoxelsFWE05": "http://purl.org/nidash/spm#SPM_0000014",
+        "spm_smallestSignificantClusterSizeInVoxelsFDR05": "http://purl.org/nidash/spm#SPM_0000013",
+        "nidm_ExcursionSetMap": "http://purl.org/nidash/nidm#NIDM_0000025",
+        "nidm_numberOfSupraThresholdClusters": "http://purl.org/nidash/nidm#NIDM_0000111",
+        "nidm_pValue": "http://purl.org/nidash/nidm#NIDM_0000114",
+        "nidm_hasClusterLabelsMap": "http://purl.org/nidash/nidm#NIDM_0000098",
+        "nidm_hasMaximumIntensityProjection": "http://purl.org/nidash/nidm#NIDM_0000138",
+        "nidm_ClusterLabelsMap": "http://purl.org/nidash/nidm#NIDM_0000008",
+        "nidm_SupraThresholdCluster": "http://purl.org/nidash/nidm#NIDM_0000070",
+        "nidm_pValueUncorrected": "http://purl.org/nidash/nidm#NIDM_0000116",
+        "nidm_pValueFWER": "http://purl.org/nidash/nidm#NIDM_0000115",
+        "nidm_qValueFDR": "http://purl.org/nidash/nidm#NIDM_0000119",
+        "nidm_clusterLabelId": "http://purl.org/nidash/nidm#NIDM_0000082",
+        "nidm_Peak": "http://purl.org/nidash/nidm#NIDM_0000062",
+        "nidm_equivalentZStatistic": "http://purl.org/nidash/nidm#NIDM_0000092",
+        "nidm_Coordinate": "http://purl.org/nidash/nidm#NIDM_0000015",
+        "nidm_coordinateVector": "http://purl.org/nidash/nidm#NIDM_0000086"
+    },
+    "entity": {
+        "niiri:334a58b04dd8169b2161a2e8b2629a0d": {
+            "prov:type": {
+                "$": "nidm_CoordinateSpace:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Coordinate space 1",
+                "type": "xsd:string"
+            },
+            "nidm_voxelToWorldMapping:": {
+                "$": "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]",
+                "type": "xsd:string"
+            },
+            "nidm_voxelUnits:": {
+                "$": "[\"mm\", \"mm\", \"mm\"]",
+                "type": "xsd:string"
+            },
+            "nidm_voxelSize:": {
+                "$": "[2, 2, 2]",
+                "type": "xsd:string"
+            },
+            "nidm_inWorldCoordinateSystem:": {
+                "$": "nidm_Ixi549CoordinateSystem:",
+                "type": "xsd:string"
+            },
+            "nidm_numberOfDimensions:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_dimensionsInVoxels:": {
+                "$": "[79,95,79]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:825930cb9cecdc2d026a61f46ae3ee93": {
+            "prov:type": [
+                {
+                "$": "prov:Collection",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Data:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Data",
+                "type": "xsd:string"
+            },
+            "nidm_grandMeanScaling:": {
+                "$": "false",
+                "type": "xsd:boolean"
+            },
+            "nidm_hasMRIProtocol:": {
+                "$": "nlx_FunctionalMRIprotocol:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8832b574f38c1ef5b19a5698eedfd522": {
+            "prov:type": {
+                "$": "nidm_DesignMatrix:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "DesignMatrix.csv",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "DesignMatrix.csv",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "text/csv",
+                "type": "xsd:string"
+            },
+            "dc:description": {
+                "$": "niiri:4b5ac7e34167b063095b0c27f615214a",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Design Matrix",
+                "type": "xsd:string"
+            },
+            "nidm_regressorNames:": {
+                "$": "[\"Basis_{1}\", \"Basis_{2}\", \"Basis_{3}\"]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4b5ac7e34167b063095b0c27f615214a": {
+            "prov:type": {
+                "$": "dctype:Image",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "DesignMatrix.png",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "DesignMatrix.png",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/png",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8a6c1f8a466f432d23696a22842630eb": {
+            "prov:type": {
+                "$": "nidm_ErrorModel:",
+                "type": "xsd:QName"
+            },
+            "nidm_hasErrorDistribution:": {
+                "$": "obo_normaldistribution:",
+                "type": "xsd:string"
+            },
+            "nidm_hasErrorDependence:": {
+                "$": "obo_unstructuredcovariancestructure:",
+                "type": "xsd:string"
+            },
+            "nidm_dependenceMapWiseDependence:": {
+                "$": "nidm_ConstantParameter:",
+                "type": "xsd:string"
+            },
+            "nidm_errorVarianceHomogeneous:": {
+                "$": "false",
+                "type": "xsd:boolean"
+            },
+            "nidm_varianceMapWiseDependence:": {
+                "$": "nidm_IndependentParameter:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:fc108568cd5e536825df64c6f1040101": {
+            "prov:type": {
+                "$": "nidm_MaskMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "Mask.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nidm_isUserDefined:": {
+                "$": "false",
+                "type": "xsd:boolean"
+            },
+            "nfo:fileName": {
+                "$": "Mask.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Mask",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:334a58b04dd8169b2161a2e8b2629a0d",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "09d331386156006058738700e3d2402ca557e5ba6f5742af2974eb4c03f0514a5529859c620fe5167c0cfed26e846d21ffd2611e5f479b2d167beec168e978bd",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e09fd9499ed59ea115caabdbd4ec218b": {
+            "prov:type": {
+                "$": "nidm_MaskMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "mask.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "609620056d81292b36b9f1dbbe3d02023728da7cab8f4ca3bf953dd1e5256f1799c5eb65663aa4e8b7c5cdf3cbb521708aaad4eb4cc8182c1e5280a51387678e",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8b44eef148a4672df3b868888c1c1c71": {
+            "prov:type": {
+                "$": "nidm_GrandMeanMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "GrandMean.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "GrandMean.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Grand Mean Map",
+                "type": "xsd:string"
+            },
+            "nidm_maskedMedian:": {
+                "$": "0.0511472336947918",
+                "type": "xsd:float"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:334a58b04dd8169b2161a2e8b2629a0d",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "c111e018cb1cdd0d1318256c5dcb2e0eaaa627bc540216148527056b2969939119310599fb527dfb187ae9ee422dba8e543bf5c190b9f935d828a3a4dab2ebbc",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:69099a5655e274a35cf8497561c281d6": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0001.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0001.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 1",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:334a58b04dd8169b2161a2e8b2629a0d",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "b89a0120673d47d4a2e8ca19a9a69c37d4e514e795580ec064d6c246a23e9a7d5737c49cceefe6de12b67d3d722b18dc74ff194812fe4c6c3fd9145bd76a9a2f",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:08dd8d7791f4ea3b42d7928f3978b481": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0001.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "b89a0120673d47d4a2e8ca19a9a69c37d4e514e795580ec064d6c246a23e9a7d5737c49cceefe6de12b67d3d722b18dc74ff194812fe4c6c3fd9145bd76a9a2f",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:994815a1deaaea1d8a916499a4369008": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0002.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0002.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 2",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:334a58b04dd8169b2161a2e8b2629a0d",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "5ce29a8c6d060417d3246febff5596241f2e6783c1d9761306cf762057696493f53d59a40dcd6821ac1ecf6144669d80b6560bb234e4c5455d651fc4c0024978",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:adc38d535f009898b8597918fea3e74b": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0002.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "5ce29a8c6d060417d3246febff5596241f2e6783c1d9761306cf762057696493f53d59a40dcd6821ac1ecf6144669d80b6560bb234e4c5455d651fc4c0024978",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:438a1a1f15d3ed6c053ad0a47535b905": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0003.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0003.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 3",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:334a58b04dd8169b2161a2e8b2629a0d",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "d8c80bfb0cd41ceae8da00cc1b5f7a39d0c186f8a1308852e0c4d4ecf2143a46153b6d3998bcdc4a41a36a51e52eb5154a5c871a0d326d43cf02834aa7a2802a",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:fc2fc60ae3a1a2a377ce868dcfe7682c": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0003.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "d8c80bfb0cd41ceae8da00cc1b5f7a39d0c186f8a1308852e0c4d4ecf2143a46153b6d3998bcdc4a41a36a51e52eb5154a5c871a0d326d43cf02834aa7a2802a",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:94876fb7a2c046b431df17692c760d6e": {
+            "prov:type": {
+                "$": "nidm_ResidualMeanSquaresMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ResidualMeanSquares.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ResidualMeanSquares.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Residual Mean Squares Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:334a58b04dd8169b2161a2e8b2629a0d",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "8dd13096358e8e9e95b0a11c6c59092dbb5cfc3d586ce9a9606ecaaa7c3f48b5fceee1ff6cf6c356b754b3990b344b66b37058402579c4c37c488fd942540d48",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b88f5c084cf11202884b4336bb357ace": {
+            "prov:type": {
+                "$": "nidm_ResidualMeanSquaresMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "ResMS.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "b3ead22cbbb0b4e40e397cd74f954be9e4de46bbf7aa994f35344329aad57c551fd72827fe1aae6287c0bf37ca1afbaea22993e79b87166e1a921b9e977c2868",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:96116055802375625dcf702ee01581fe": {
+            "prov:type": {
+                "$": "nidm_ReselsPerVoxelMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ReselsPerVoxel.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ReselsPerVoxel.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Resels per Voxel Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:334a58b04dd8169b2161a2e8b2629a0d",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "9e6bd1546a438b4313b95dfeb307638416e999e4c3596b6c3aa8f282fda2df6dae8e1db498dca3dc6717d70138f68a00101ff95a2f5e32e7a1c8074a69f17381",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1328ce3e8c83d35913bbecbd452290df": {
+            "prov:type": {
+                "$": "nidm_ReselsPerVoxelMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "RPV.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "f8c6e2cbdd2c099fe1cdfa7f20c2d735366627a183b06e229d82b06ea4fa189ca42d6fdbbd69ca6504f1865b00f211b940f19f1c2c8df3b424f4eedea9775bb8",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:adbd624b50ba693b3e14fd648e13ebef": {
+            "prov:type": {
+                "$": "obo_contrastweightmatrix:",
+                "type": "xsd:QName"
+            },
+            "nidm_statisticType:": {
+                "$": "obo_Fstatistic:",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "Average effect of condition",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast: Average effect of condition",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "[1, 1, 1]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9ca097a864a89e695f5a0ade9c7a2592": {
+            "prov:type": {
+                "$": "nidm_StatisticMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "FStatistic.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "FStatistic.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "F-Statistic Map: Average effect of condition",
+                "type": "xsd:string"
+            },
+            "nidm_statisticType:": {
+                "$": "obo_Fstatistic:",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "Average effect of condition",
+                "type": "xsd:string"
+            },
+            "nidm_errorDegreesOfFreedom:": {
+                "$": "39",
+                "type": "xsd:float"
+            },
+            "nidm_effectDegreesOfFreedom:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:334a58b04dd8169b2161a2e8b2629a0d",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "531843c41e0edb06002746841a3cdcaf0aa3c319781bcbedc84f6a427e154303731eaf31b1f9a403d6ecdb86716186b69dd471787f683aa7dec5f29f26bc6960",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1300030726b15941203796dca8bcf83c": {
+            "prov:type": {
+                "$": "nidm_StatisticMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "spmF_0001.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "274c247097322961825fc7761087f9352df4af7540ca42c3cfd4a35adf1249b0b72e793d97bdc1051daadce0d855a067ab6d091ed79d9b99a92180586cd65762",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a72a81446159f6a67c6f27a5da80101a": {
+            "prov:type": {
+                "$": "nidm_ContrastExplainedMeanSquareMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ContrastExplainedMeanSquare.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ContrastExplainedMeanSquare.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast Explained Mean Square Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:334a58b04dd8169b2161a2e8b2629a0d",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "367a36ade072cb98530f28763f9b42a7b408eb21636c86c87161b4e3c6def23180be03e7c730f0591f675bcf6d9f9f9e290b2fa98a788e5b44df1683ce024d7a",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6e1bb9294b0707edbbe5ae21cfbadf07": {
+            "prov:type": [
+                {
+                "$": "nidm_HeightThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_PValueUncorrected:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Height Threshold: p<0.001 (unc.)",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "0.000999500201896764",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentThreshold:": [
+                {
+                "$": "niiri:20fda3ccb70028555e7275aefc3215b7",
+                "type": "xsd:string"
+                },
+                {
+                "$": "niiri:ad55acc7ff668917e187d5b8b71ef0fe",
+                "type": "xsd:string"
+                }
+            ]
+        },
+        "niiri:20fda3ccb70028555e7275aefc3215b7": {
+            "prov:type": [
+                {
+                "$": "nidm_HeightThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_statistic:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Height Threshold: F=12.660218)",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "12.6602184255263",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ad55acc7ff668917e187d5b8b71ef0fe": {
+            "prov:type": [
+                {
+                "$": "nidm_HeightThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_FWERadjustedpvalue:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Height Threshold: p<1.000000 (FWE)",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "0.999999999999997",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:636d204ec94986da6b6ce98445053011": {
+            "prov:type": [
+                {
+                "$": "nidm_ExtentThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_statistic:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Extent Threshold: k>=0",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "0",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentThreshold:": [
+                {
+                "$": "niiri:a54887ecc715604dd6455a6477b0a70e",
+                "type": "xsd:string"
+                },
+                {
+                "$": "niiri:6488aa4615162148eb510043add8322a",
+                "type": "xsd:string"
+                }
+            ]
+        },
+        "niiri:a54887ecc715604dd6455a6477b0a70e": {
+            "prov:type": [
+                {
+                "$": "nidm_ExtentThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_FWERadjustedpvalue:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Extent Threshold",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6488aa4615162148eb510043add8322a": {
+            "prov:type": [
+                {
+                "$": "nidm_ExtentThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_PValueUncorrected:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Extent Threshold",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3dd5d16b52227865dddd8a70d5265d53": {
+            "prov:type": {
+                "$": "nidm_PeakDefinitionCriteria:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak Definition Criteria",
+                "type": "xsd:string"
+            },
+            "nidm_maxNumberOfPeaksPerCluster:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_minDistanceBetweenPeaks:": {
+                "$": "8",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:029c2dcb7254e8c7af93bf485d809706": {
+            "prov:type": {
+                "$": "nidm_ClusterDefinitionCriteria:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Cluster Connectivity Criterion: 18",
+                "type": "xsd:string"
+            },
+            "nidm_hasConnectivityCriterion:": {
+                "$": "nidm_voxel18connected:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:db110fb8702367464d0832795a39cbbb": {
+            "prov:type": {
+                "$": "nidm_SearchSpaceMaskMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "SearchSpaceMask.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "SearchSpaceMask.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Search Space Mask Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:334a58b04dd8169b2161a2e8b2629a0d",
+                "type": "xsd:string"
+            },
+            "nidm_searchVolumeInVoxels:": {
+                "$": "167222",
+                "type": "xsd:int"
+            },
+            "nidm_searchVolumeInUnits:": {
+                "$": "1337776",
+                "type": "xsd:float"
+            },
+            "nidm_reselSizeInVoxels:": {
+                "$": "68.5679161280351",
+                "type": "xsd:float"
+            },
+            "nidm_searchVolumeInResels:": {
+                "$": "2244.24204044145",
+                "type": "xsd:float"
+            },
+            "spm_searchVolumeReselsGeometry:": {
+                "$": "[5, 56.1858858382816, 782.552337179563, 2244.24204044145]",
+                "type": "xsd:string"
+            },
+            "nidm_noiseFWHMInVoxels:": {
+                "$": "[4.09364449471869, 4.06742111213816, 4.11805068781302]",
+                "type": "xsd:string"
+            },
+            "nidm_noiseFWHMInUnits:": {
+                "$": "[8.18728898943738, 8.13484222427633, 8.23610137562605]",
+                "type": "xsd:string"
+            },
+            "nidm_randomFieldStationarity:": {
+                "$": "true",
+                "type": "xsd:boolean"
+            },
+            "nidm_expectedNumberOfVoxelsPerCluster:": {
+                "$": "5.40031514302336",
+                "type": "xsd:float"
+            },
+            "nidm_expectedNumberOfClusters:": {
+                "$": "33.3078455926716",
+                "type": "xsd:float"
+            },
+            "nidm_heightCriticalThresholdFWE05:": {
+                "$": "37.9092455175785",
+                "type": "xsd:float"
+            },
+            "nidm_heightCriticalThresholdFDR05:": {
+                "$": "Inf",
+                "type": "xsd:float"
+            },
+            "crypto:sha512": {
+                "$": "09d331386156006058738700e3d2402ca557e5ba6f5742af2974eb4c03f0514a5529859c620fe5167c0cfed26e846d21ffd2611e5f479b2d167beec168e978bd",
+                "type": "xsd:string"
+            },
+            "spm_smallestSignificantClusterSizeInVoxelsFWE05:": {
+                "$": "99",
+                "type": "xsd:int"
+            },
+            "spm_smallestSignificantClusterSizeInVoxelsFDR05:": {
+                "$": "57",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb": {
+            "prov:type": {
+                "$": "nidm_ExcursionSetMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ExcursionSet.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ExcursionSet.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Excursion Set Map",
+                "type": "xsd:string"
+            },
+            "nidm_numberOfSupraThresholdClusters:": {
+                "$": "71",
+                "type": "xsd:int"
+            },
+            "nidm_pValue:": {
+                "$": "9.36073596413678e-09",
+                "type": "xsd:float"
+            },
+            "nidm_hasClusterLabelsMap:": {
+                "$": "niiri:7be8ea19c7603988ed0c6856e309f76b",
+                "type": "xsd:string"
+            },
+            "nidm_hasMaximumIntensityProjection:": {
+                "$": "niiri:a5f4d5f5d9604b6647154be60baf72d4",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:334a58b04dd8169b2161a2e8b2629a0d",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "3cb7cb94a15ceea4d3b829f354f40eaeb85863016ba6e236003b548b7cf18ceaa22541bd90454f190ee0e374f2958f6130c7eb1bf4c55e75bdad693646d71006",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7be8ea19c7603988ed0c6856e309f76b": {
+            "prov:type": {
+                "$": "nidm_ClusterLabelsMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ClusterLabels.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ClusterLabels.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Cluster Labels Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:334a58b04dd8169b2161a2e8b2629a0d",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "403459cc812b3927db0db6d5a3f64b79acf6774fc116e11ed6ecf56ec229afd8812650c060fdf10c2ecdab534ffadb67f4650178e12b65ccea6220e0ed951cb2",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a5f4d5f5d9604b6647154be60baf72d4": {
+            "prov:type": {
+                "$": "dctype:Image",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "MaximumIntensityProjection.png",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "MaximumIntensityProjection.png",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/png",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0502f21f886d74eb5a46cc0e98d99ebd": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0001",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "64",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.933381144039647",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00186515164019167",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.060233823286733",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0331064416134022",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "1",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:0599785d82edc2bd01edfc956f648d55": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0002",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "139",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "2.02718717221111",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.6469154891926e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.000881242002104266",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00187930999732674",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "2",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:503c99586f814910b6b80009bf62943c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0003",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "99",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.44382395718633",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000223613862913789",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00742042768591067",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00529219475562633",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "3",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:018a24899160bba0361882009e28cdf7": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0004",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "100",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.45840803756195",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00021132818538256",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00701417162859297",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00529219475562633",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "4",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:33d37aeafd7dbe4545a7c3723ffec290": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0005",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "41",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.597947295400399",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00937054756605333",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.26810099909693",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0831636096487233",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "5",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c67e26c71245447102997061bd7b4400": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0006",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "42",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.612531375776019",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00868796710659031",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.251270468559567",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0831636096487233",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "6",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:21c6b4d93e2f7d826c174fe1b99df534": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0007",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "27",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.393770170141726",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.02915927403888",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.621383930767395",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.159254496673883",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "7",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:6da0c60471d915bb0e46bffadee4d55a": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0008",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "57",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.831292581410311",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00297536918873803",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0943507032156397",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.04225024248008",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "8",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:a35a0c7d262276e543a1e97fbbe3cdc8": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0009",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "33",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.481274652395443",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0175801280664628",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.443203909376631",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.112910609996037",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "9",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:cfb99edebaae9df65e32c2dc18fd6186": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0010",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "6",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0875044822537169",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.273373266352505",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999888943840686",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.539152830861885",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "10",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:2607cc56c513b9a7b262e9ec22fe2b63": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0011",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "10",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.145840803756195",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.161523634652226",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.995392197803255",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.409577787868145",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "11",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:1daa422fda95bd1a9676984906e1a548": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0012",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "26",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.379186089766107",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0318362117547758",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.653681229272869",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.16145507389922",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "12",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:a6888f03a619f2ef07714763993a3be7": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0013",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "11",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.160424884131814",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.143315972308448",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.991549640351899",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.407017361355993",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "13",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:ff0222b1c30a382e52f5903988ee7a67": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0014",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "16",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.233345286009912",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0825813905071932",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.936111008142629",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.325737707000596",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "14",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:189a48f192c71c34afbefb1b24c895a1": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0015",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "14",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.204177125258673",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.10212573718427",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.966679694237215",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.36254636700416",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "15",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:153d0f62058a9c03f71f38806c01672c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0016",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "35",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.510442813146682",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0149558617235747",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.392344720913691",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.112910609996037",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "16",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:2b8333b9ae75e6a69c6703c1017776ef": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0017",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "32",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.466690572019824",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0190834833796118",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.470398116431399",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.112910609996037",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "17",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:be0ede967cfc83179dfb392adca98376": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0018",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "46",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.670867697278497",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00645728092420274",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.193521561130372",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0764111576030657",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "18",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:23f2b3702fb27a3d52f0874c93630544": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0019",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "15",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.218761205634292",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0917266976854565",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.952887583051913",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.342768186087759",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "19",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:654afa8f2fea6cb2d23c37e50edee008": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0020",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "20",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.29168160751239",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0553545237190288",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.841775430461368",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.231186540238297",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "20",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:dba06f209302f6639800d0af3c93affd": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0021",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "11",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.160424884131814",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.143315972308448",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.991549640351899",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.407017361355993",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "21",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:57c14f931d36e820d2322a1bdd36da40": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0022",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "32",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.466690572019824",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0190834833796118",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.470398116431399",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.112910609996037",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "22",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:2739d32e473645dfabd9a03fc9f4dae7": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0023",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.058336321502478",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.371675909431407",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999995797049595",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.599749762946134",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "23",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:23f5ffb7a02a62400ce3f1cfda032dbe": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0024",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "11",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.160424884131814",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.143315972308448",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.991549640351899",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.407017361355993",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "24",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:3ed09542d8eeb67b7a92a4f1152a9588": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0025",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "5",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0729204018780975",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.317117336021626",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999974131777239",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.549154411159401",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "25",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:ee2c6440d10e17fa3f61858f975e92f6": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0026",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "21",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.306265687888009",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0503036857692116",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.812786836270519",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.223222605600877",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "26",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:25764564ed7b5495d43208d9a742797c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0027",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "25",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.364602009390487",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0347983287867789",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.686218175845877",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.164712089590753",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "27",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:2a5007577d5f397768b0a52d8e1e454a": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0028",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "8",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.116672643004956",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.20781578719113",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999014041359979",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.475965190018395",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "28",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:075d03d6a0a7a8ff06d2fd0a678225e4": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0029",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "12",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.175008964507434",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.127616241080866",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.985744636441848",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.407017361355993",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "29",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f9daf2bb86509394f654f8dfb4a4e15b": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0030",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0145840803756195",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.675180100901307",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999828904",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.675180100901307",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "30",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:447a33078d0ab11fa638dad2f64b7b00": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0031",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "10",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.145840803756195",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.161523634652226",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.995392197803255",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.409577787868145",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "31",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:e979405039e66c5ce2c3d5b5b67f1286": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0032",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.058336321502478",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.371675909431407",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999995797049595",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.599749762946134",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "32",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:02724527e4ee34eff0967177115a83d1": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0033",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "6",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0875044822537169",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.273373266352505",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999888943840686",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.539152830861885",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "33",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c6bf9a9fd500605c73016dfb45e6af98": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0034",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "5",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0729204018780975",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.317117336021626",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999974131777239",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.549154411159401",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "34",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:e3e587be4409f0bc772835a934536590": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0035",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "10",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.145840803756195",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.161523634652226",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.995392197803255",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.409577787868145",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "35",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:6aa3e47b1d56a62cbf353acb1dbf4e63": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0036",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "7",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.102088562629336",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.237571474546961",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99963404273418",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.52711170915107",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "36",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:11267ea4af34c876ad34aa054c834aa1": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0037",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "8",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.116672643004956",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.20781578719113",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999014041359979",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.475965190018395",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "37",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:ed62a9c22b9d6c8f4255706a0676f4da": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0038",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "12",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.175008964507434",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.127616241080866",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.985744636441848",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.407017361355993",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "38",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:7649cec60050f6bbb0a4a68fad360d04": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0039",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "5",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0729204018780975",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.317117336021626",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999974131777239",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.549154411159401",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "39",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:76477879d12f5565edfe6317f1396ae3": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0040",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "5",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0729204018780975",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.317117336021626",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999974131777239",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.549154411159401",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "40",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:b32a94908c3543b6389e71c09e18b028": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0041",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0437522411268585",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.441752016334617",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999592737522",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.653424857494954",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "41",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:505e13c060365ce925c6c78620aace2b": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0042",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "6",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0875044822537169",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.273373266352505",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999888943840686",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.539152830861885",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "42",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:6a2f64f5544ff048d58423df90e157d2": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0043",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "9",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.131256723380575",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.182785449876348",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.997730485940405",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.44750920486968",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "43",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:965bca191e7bce9008d8dd515cf43195": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0044",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0437522411268585",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.441752016334617",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999592737522",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.653424857494954",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "44",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:5c0f8a6949255a54753a5996ab8bf0b5": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0045",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0437522411268585",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.441752016334617",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999592737522",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.653424857494954",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "45",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:e00c0b657ae25f884a41aad34f6d4869": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0046",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0145840803756195",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.675180100901307",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999828904",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.675180100901307",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "46",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:efbb22419db35e6170e4f8c15df564d9": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0047",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.058336321502478",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.371675909431407",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999995797049595",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.599749762946134",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "47",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:792fda8a02886788088cdc21433fe931": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0048",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0437522411268585",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.441752016334617",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999592737522",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.653424857494954",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "48",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:0dd1d301e6eec8815748b738cd4fdb7c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0049",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "5",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0729204018780975",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.317117336021626",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999974131777239",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.549154411159401",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "49",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:0a00a0a76e73ce79a1d09f89ec092795": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0050",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0145840803756195",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.675180100901307",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999828904",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.675180100901307",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "50",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:af99a7152d944fac822b2a894187ecfd": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0051",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0145840803756195",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.675180100901307",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999828904",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.675180100901307",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "51",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:1de9cf5cb4f411c77d648530539b1506": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0052",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0145840803756195",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.675180100901307",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999828904",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.675180100901307",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "52",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:643dd520d22eb83650c21da507f69f60": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0053",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0145840803756195",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.675180100901307",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999828904",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.675180100901307",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "53",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:1a432aa3e7fda423feb9c68ebffde829": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0054",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "6",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0875044822537169",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.273373266352505",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999888943840686",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.539152830861885",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "54",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:1569aa21af436f1447efa2c75903f79c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0055",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0145840803756195",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.675180100901307",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999828904",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.675180100901307",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "55",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:0fb2459e07ec9adca74a9a6a0f036186": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0056",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0145840803756195",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.675180100901307",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999828904",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.675180100901307",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "56",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:e937b5f0f9c2d5b73ead1407d48466e6": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0057",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0145840803756195",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.675180100901307",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999828904",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.675180100901307",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "57",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:321743f529907bc95ee3bc2bb3feb1e2": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0058",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.029168160751239",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.536068820289802",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999982398778",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.675180100901307",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "58",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:7ca293071987c22e76e0b20115b26429": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0059",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0145840803756195",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.675180100901307",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999828904",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.675180100901307",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "59",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:6bb00e27ab3f8d7e1b137fd7b575136a": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0060",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0145840803756195",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.675180100901307",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999828904",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.675180100901307",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "60",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:eea16d34f3c295e17c1d3128d76481f7": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0061",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0145840803756195",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.675180100901307",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999828904",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.675180100901307",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "61",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:2d477a3822ede90c19394a724a2c602f": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0062",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0145840803756195",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.675180100901307",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999828904",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.675180100901307",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "62",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:67886822c4a91ee4d1b7cd6bc45567f5": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0063",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.029168160751239",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.536068820289802",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999982398778",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.675180100901307",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "63",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:5ebab1be1c4c961db315c2ffb23786c0": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0064",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0145840803756195",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.675180100901307",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999828904",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.675180100901307",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "64",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:06a77002692eb72a6823907717b7b96b": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0065",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0145840803756195",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.675180100901307",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999828904",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.675180100901307",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "65",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:70cb31c3da80e76bbcc31227d5a63dd3": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0066",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0145840803756195",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.675180100901307",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999828904",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.675180100901307",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "66",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:1bab28ca73fb58bf072903c327aa6ee2": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0067",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0145840803756195",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.675180100901307",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999828904",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.675180100901307",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "67",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:0d05a2eb7c30f085c9585bd5437f2cf6": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0068",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0145840803756195",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.675180100901307",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999828904",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.675180100901307",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "68",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:cec1367031abea759cc3b3843951c4e9": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0069",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0145840803756195",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.675180100901307",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999828904",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.675180100901307",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "69",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:6ba93f98c147f043bee56b6eaf416136": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0070",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0145840803756195",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.675180100901307",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999828904",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.675180100901307",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "70",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:ac903b7a48abf269c96015efab8d2aa1": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0071",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0145840803756195",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.675180100901307",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999828904",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.675180100901307",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "71",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:de0be50edac74c81f9c1e5814da03b9d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0001",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7f9fdf6f0de7581fd021fc6db0110883",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "39.0658683776855",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.04009751746769",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.3264734660966e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0389037590875805",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.097253800423278",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7f9fdf6f0de7581fd021fc6db0110883": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0001",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-2,-90,28]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3551a670193037285a26d96dd25d4587": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0002",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:23f181033fbbc357802f67e0f5c9c6ac",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "36.2393341064453",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.89725160225159",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.85931842320042e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.071761896035709",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.097253800423278",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:23f181033fbbc357802f67e0f5c9c6ac": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0002",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-42,-64,-8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a397cef7de1b33fff3104633ae867013": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0003",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d0956a4697c01f13d1fd27c41f01ee23",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "17.9251842498779",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.64201416072196",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000135256594276711",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999417997648594",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.642014449876257",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d0956a4697c01f13d1fd27c41f01ee23": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0003",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-40,-52,-10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:795bfdfc1c878985f28b65ddbd93f5e2": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0004",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:3fae1a6119fcbb333560406c0adaf77a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "13.454288482666",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.18324713734782",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000728166268399777",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999996872",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.94954759467573",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3fae1a6119fcbb333560406c0adaf77a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0004",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-38,-70,0]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1bef248663e2601c3f3e8f86ce7bcf8e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0005",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a50093d76450a437f3994a2a331222d2",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "29.4676361083984",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.51162164706026",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.21669348379849e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.305525019896507",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.297255514853906",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a50093d76450a437f3994a2a331222d2": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0005",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[16,-88,24]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:34e046d2eb16a715bed65c1a03b2abc1": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0006",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:03eb88016e6bd2dd5c40edd75ccfd627",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "28.5631580352783",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.45459114773779",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.20266075706888e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.365688847752494",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.297255514853906",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:03eb88016e6bd2dd5c40edd75ccfd627": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0006",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[28,-72,26]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c71c9cb743a850da26dbd07e2a4ab336": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0007",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:81e9ff294c150a3271a867e5bc31370a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "26.9945106506348",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.35204306383375",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.7437380493196e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.489729172437052",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.302930044135827",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:81e9ff294c150a3271a867e5bc31370a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0007",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-32,20,-4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1d00c0696db8e3a3a6f9eeb993c993aa": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0008",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:324e311634f996ef35fec88282031fdd",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "26.8606586456299",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.34306775687574",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.02533878071954e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.501353785238145",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.302930044135827",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:324e311634f996ef35fec88282031fdd": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0008",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-8,50,32]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e105d8c03c8fb50b26c076e73184a484": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0009",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:46442f9a133e99c8e0d2a8f94f5a3dbe",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "25.8067512512207",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.27109313660164",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "9.72585724245967e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.597019202761311",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.317981530335124",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:46442f9a133e99c8e0d2a8f94f5a3dbe": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0009",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-34,8,58]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:98120cf8274f1adde1b9975ee7343d0b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0010",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:8745a1750fbc576ed60637fd96f0bd53",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "25.0769119262695",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.21983658750018",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.22239732009977e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.665677647955296",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.317981530335124",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:8745a1750fbc576ed60637fd96f0bd53": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0010",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[32,-86,0]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:289923b931558b9cf26d6259e84991cc": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0011",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:aadea8cdd84b63fc723d500acfc25900",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "24.5828113555908",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.18444689049798",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.42930633414418e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.711939170732988",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.325084892179266",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:aadea8cdd84b63fc723d500acfc25900": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0011",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[66,-32,30]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:273d6a77c000bfe5f52d296da6ad6478": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0012",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:652a2206db07edc1bd545802c3f663c9",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "14.2693071365356",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.27451594161643",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000529215834762176",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999209483",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.904639459548904",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:652a2206db07edc1bd545802c3f663c9": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0012",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[60,-38,28]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:41059e9d7b27293b0aba3b2a84d455b8": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0013",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a97ce2127d9bef3582961e02700db7f6",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "23.3039436340332",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.09011898331566",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.15575975488491e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.823947459995523",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.412451648636247",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a97ce2127d9bef3582961e02700db7f6": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0013",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[28,30,52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b964c9d32200b841b56fe800b88c0a4b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0014",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4769429683d1135897230ffebc06ac65",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "22.6157932281494",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.03763886298215",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.69959426782984e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.87538446987651",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.43925432096054",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4769429683d1135897230ffebc06ac65": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0014",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-30,-34,6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:cf6cc59258bd447a466c3c1895718676": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0015",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:eb420af4734a6c2a830db882030077df",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "21.8558578491211",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.97819185113407",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.47206660495925e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.921823721412592",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.43925432096054",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:eb420af4734a6c2a830db882030077df": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0015",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-28,0,30]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5175b1641041f873df3e4b8171a20dbd": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0016",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:640b2e1e62f4a54b769f0bb3d8d79b61",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "21.8296661376953",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.97611404363788",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.50252708366527e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.923209894114283",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.43925432096054",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:640b2e1e62f4a54b769f0bb3d8d79b61": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0016",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[8,34,10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:eda52aede28b44456962e7af041dab45": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0017",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:3f60c67308d3c2cc8704c97c6f792d07",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "21.7287845611572",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.96809263472704",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.6225086553876e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.928411428313329",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.43925432096054",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3f60c67308d3c2cc8704c97c6f792d07": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0017",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[46,-56,10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:73097f0b0425dce88560554ead9adec5": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0018",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:db9cfc1e895056414a0d976a338eff75",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "14.2801656723022",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.27570591680179",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000526991241768693",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999156251",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.904639459548904",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:db9cfc1e895056414a0d976a338eff75": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0018",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[48,-48,16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:dee978e74443f1a4c46189f244ae1e75": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0019",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f7b1c619d30c23139ad1157664d70e8f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "21.4629364013672",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.9468129149843",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.95991966499754e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.941069307565192",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.43925432096054",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f7b1c619d30c23139ad1157664d70e8f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0019",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[46,-62,-10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7229cb1ae5d253d150d16f583a790984": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0020",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a95490cb8d27272ebf40ab9641760b2a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "21.4269542694092",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.94391683979485",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.00807329147268e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.942665676683549",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.43925432096054",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a95490cb8d27272ebf40ab9641760b2a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0020",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-8,-32,36]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:31378a601c2becf436d41b267a4b16d5": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0021",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:268e773c306d3890ab5d905af99e9d1f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "20.0413494110107",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.82938429557992",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.42321325474704e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.984364018223445",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.603397549204652",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:268e773c306d3890ab5d905af99e9d1f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0021",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-34,-84,-4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:83bc6d3f85253d9d97da7f55882bc0e2": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0022",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:11db5f1191f39a9f0f88a2e612164508",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "19.5813789367676",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.79000141974546",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.53232118573255e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.991038394814884",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.620995764715313",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:11db5f1191f39a9f0f88a2e612164508": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0022",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-50,2,40]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b9f98ffb929e3828f9472a4a465a4f0d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0023",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4ca72dd3f8082269bb21714642111f36",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "16.7666301727295",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.53217184854778",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00020608070787731",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99996648470095",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.655203493056632",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4ca72dd3f8082269bb21714642111f36": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0023",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-52,-6,46]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3fc414435450d7991a1adccdb53f2ea3": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0024",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ebc812dddae356c4835e80cff836a117",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "19.3040504455566",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.76590943131268",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.2971971291701e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.993825462793153",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.620995764715313",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ebc812dddae356c4835e80cff836a117": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0024",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[24,-46,32]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c636ea0bddcfb80ff2d7e531404b34f1": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0025",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:27909070b90094da7c248e424652127e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "19.1409015655518",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.75161143600874",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.7850813353163e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.995110302012489",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.620995764715313",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:27909070b90094da7c248e424652127e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0025",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[6,16,50]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:17e69e7f43739c2172a5e069dcce782a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0026",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:5e6d74ec4614c24eabbeefa458ae9b94",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "19.098669052124",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.74789498829157",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.91624398706714e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.995405100064856",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.620995764715313",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:5e6d74ec4614c24eabbeefa458ae9b94": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0026",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-4,-24,6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:310041e942b16c12433a1a316b01a18b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0027",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b5ed65cc20e2af254f0c0773a378955e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "19.0145893096924",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.7404771295496",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "9.1835629583259e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.995949293325196",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.620995764715313",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b5ed65cc20e2af254f0c0773a378955e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0027",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-4,0,54]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:830254d5fee868a84ad02a38a3e7bb23": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0028",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c5ab846fb07f8ec905e64d8b25852e7f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "18.8265838623047",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.72379883766124",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "9.81236582245915e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.996978299202392",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.620995764715313",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c5ab846fb07f8ec905e64d8b25852e7f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0028",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[42,-28,30]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d7ae1c6177cf91420976fa8b1b418173": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0029",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6462195dc355a327af5cd5d73524f76f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "18.5199432373047",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.69631988620818",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000109373660980738",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.998191254166604",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.620995764715313",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6462195dc355a327af5cd5d73524f76f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0029",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[52,-12,44]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8f42c8637a3ba73755a9485aaf00eb82": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0030",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6678f079e5924136062e8a6111422c3e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "18.516544342041",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.69601335434539",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000109505728679404",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.998201975106935",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.620995764715313",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6678f079e5924136062e8a6111422c3e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0030",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-40,-28,30]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4e350520ca70ab7fb0dad1e34876ed26": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0031",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e0ae1200c3ffc3c5db37844273e4e303",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "18.4609222412109",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.69099090519778",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000111691062804176",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.998370011058266",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.620995764715313",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e0ae1200c3ffc3c5db37844273e4e303": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0031",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[32,22,-8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:64a12d60baf5c5c9da921d103abfb214": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0032",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e51f9648fbb37b09655d7786ddaac9ff",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "17.9312534332275",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.64257521175179",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00013496203699781",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99941063068466",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.642014449876257",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e51f9648fbb37b09655d7786ddaac9ff": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0032",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[64,-4,10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0e8721be3c984e497213a6eb5d79d336": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0033",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c9b5180b8d4ddcc1a0089df933fe1d66",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "17.8439044952393",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.63448648232359",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000139267429951739",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999509275806277",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.642014449876257",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c9b5180b8d4ddcc1a0089df933fe1d66": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0033",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-22,-72,34]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e8cb5546247d4a3680cfd15b61ec92a8": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0034",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ed43d1458342766e20a370cd82717651",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "17.552827835083",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.60731294050443",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000154692216466135",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999742486133075",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.655203493056632",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ed43d1458342766e20a370cd82717651": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0034",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-6,-44,40]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:feb703455a27d97b3c3dd1a514984c82": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0035",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:9c2467090e8804770ca4c9155328ff6f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "17.2906818389893",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.58254613965863",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000170130746602659",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99986271355264",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.655203493056632",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:9c2467090e8804770ca4c9155328ff6f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0035",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-34,-38,-34]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:28a0f16475271ebd8e455e39cde15030": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0036",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d62fe87691f9afa1a346f5ddd28d979b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "17.1612319946289",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.57021115022413",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000178346794309836",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999901168620001",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.655203493056632",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d62fe87691f9afa1a346f5ddd28d979b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0036",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-46,-16,20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5518c40950022bff274b3d6a606c42f0": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0037",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:46998d4a4e0fcd3525424c2621d0e486",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "17.0075950622559",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.55547987606237",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000188644912021529",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999934173907998",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.655203493056632",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:46998d4a4e0fcd3525424c2621d0e486": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0037",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[24,32,2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f4f7823b1059a0ea57e9561159693d3f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0038",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a7d105498568414d907898529276f8b1",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "16.5308303833008",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.50911812032442",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000224797592033421",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999983487413756",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.655203493056632",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a7d105498568414d907898529276f8b1": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0038",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-26,-90,16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9acefe93a7c31e0167ce0ffe2ceaa937": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0039",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:750a622122e236f5a7a8fe8d719fb55b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "16.5225524902344",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.50830432871627",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0002254864217901",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999983907066973",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.655203493056632",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:750a622122e236f5a7a8fe8d719fb55b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0039",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-28,-4,16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3eeaab0bcdb1598c681f02ebda8bb1e8": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0040",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:102ea580265a6d2daecfec9a22a9b1e4",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "16.1374092102051",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.47009871338807",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00026013355917065",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999995475747835",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.714297554117909",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:102ea580265a6d2daecfec9a22a9b1e4": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0040",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[12,60,20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:762957e2b9b79f111526f35c0c3416cc": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0041",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:1084313fe511021069a095149f1c37de",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "15.9136981964111",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.44759277757755",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000282803055741021",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999997977474125",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.730845085955462",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:1084313fe511021069a095149f1c37de": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0041",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[4,-84,-4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ba7dd3245ca2f03a516b8c2349193add": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0042",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:3e9f38b8aafc94df86bb9516f511f4db",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "15.8536109924316",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.44150764421068",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000289241063091916",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999998385530387",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.730845085955462",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3e9f38b8aafc94df86bb9516f511f4db": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0042",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[62,-18,22]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ce6828c9876402cd1eb1653f92f8b5b1": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0043",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0913fe441dd608e575921c2b4f0500a1",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "15.8288412094116",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.43899416081302",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000291939913913408",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999998530446399",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.730845085955462",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0913fe441dd608e575921c2b4f0500a1": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0043",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[28,-58,44]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:580ea35cc47de5999eda43982afb2748": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0044",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:1eb319b0bd9712d284e197093bcacd55",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "15.7273988723755",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.42866974555038",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000303273553249328",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999007347173",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.736843607649928",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:1eb319b0bd9712d284e197093bcacd55": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0044",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[38,44,0]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:dbf6e6c9df9c1acb5c0e4b176d3529de": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0045",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:67a77f04ccd563945196ea9dd89d135b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "15.4726600646973",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.40252319694713",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000333833435672726",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999648429928",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.766283831090278",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:67a77f04ccd563945196ea9dd89d135b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0045",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[40,-6,-6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:cb04519fde20aaf17e0dc9a593fb3d64": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0046",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c089e08b98fa0c293381772f1ad43eb7",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "15.3332357406616",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.38807697766079",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00035192253822891",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999807374102",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.766283831090278",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c089e08b98fa0c293381772f1ad43eb7": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0046",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[32,14,58]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d2c121ae6272e04656b61fe1f025dc35": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0047",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:cfe785bcd016f63eca725d056a54477f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "15.3172578811646",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.38641524500992",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000354060730342054",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999982049151",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.766283831090278",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:cfe785bcd016f63eca725d056a54477f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0047",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[4,-86,4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:df8d20feb57d27a95ebc95ea167307a2": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0048",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f38a4b2a1e042ce6de00fdcf526dbe7c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "15.3137311935425",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.38604828864924",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000354534526388783",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999823272138",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.766283831090278",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f38a4b2a1e042ce6de00fdcf526dbe7c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0048",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[62,-36,46]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e1adf61d5f82a1f2b659ae4e403de7c6": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0049",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:56d1597c5c0850762b5b4e07acdeb247",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "15.1916456222534",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.37330635701462",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000371356333789152",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999898084819",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.778719805919739",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:56d1597c5c0850762b5b4e07acdeb247": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0049",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-24,18,58]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:bbcbd508c2385f821ae15583d3d00469": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0050",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0b2cb1cecb1b69b139c9f6fc3ef83e39",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "15.0888338088989",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.36251708484568",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000386176732959709",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999936876428",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.787311600282456",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0b2cb1cecb1b69b139c9f6fc3ef83e39": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0050",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[8,-22,-44]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:400a173374e07f6ad6fa8505dd25b493": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0051",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ca25ec1591871d5ddccaa5f5e6f304db",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "14.8200588226318",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.33405240591422",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000427952650791097",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999983180231",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.834595072923498",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ca25ec1591871d5ddccaa5f5e6f304db": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0051",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[38,34,22]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5e8d9c60f45794f6ee76f52290599e75": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0052",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:790cfd7d87f72cac07ad32edea0f5651",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "14.696608543396",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.32085065286489",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000448717729613968",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.9999999911592",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.835113533794074",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:790cfd7d87f72cac07ad32edea0f5651": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0052",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[0,-26,-28]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5352b8108713eb17c53045c149a58a47": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0053",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c191d0465f28572e319e54675be50b51",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "14.2414035797119",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.27145497586776",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00053497811978398",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999933201",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.904639459548904",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c191d0465f28572e319e54675be50b51": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0053",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[40,-50,-22]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4d047c8ee6809f00a9f5c059b315c51b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0054",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:543d1149d7bfdacbb406551cbe82d946",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "14.0012445449829",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.24492687341108",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000587403942481801",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999852106",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.931776511128243",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:543d1149d7bfdacbb406551cbe82d946": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0054",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[8,52,32]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:bbb945c8440c49e2cc1175a521c2126c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0055",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c5ea339216a0e5c8bc8aadff1689b3e7",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "13.9842071533203",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.2430323166614",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000591323980175695",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999867649",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.931776511128243",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c5ea339216a0e5c8bc8aadff1689b3e7": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0055",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-14,-48,-24]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:00c3e6ced7aa1682b713c6694740fe99": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0056",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:9c44f545329074e4000b8310d4b620c7",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "13.9203996658325",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.23592192136056",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000606252725692924",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999913111",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.931776511128243",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:9c44f545329074e4000b8310d4b620c7": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0056",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[20,0,-8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6cae1270b5b27c77bad1a387e664d75b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0057",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c47cfe09b9aab3da8be48f3b5835a42a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "13.8925752639771",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.23281385809669",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000612887021428588",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999927857",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.931776511128243",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c47cfe09b9aab3da8be48f3b5835a42a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0057",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[40,-14,60]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:09a056a78cfbc859552cc5fe35db542b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0058",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:07df63fed0a966bcbd784f826c132acb",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "13.8641185760498",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.22963046726961",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000619751563460058",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999940447",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.931776511128243",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:07df63fed0a966bcbd784f826c132acb": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0058",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-36,10,24]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b43c078a0750c0b86b05a04f00f444dd": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0059",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:82a1a081c2fc5f7c1dd138a92d9cd37d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "13.7912406921387",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.22145599369965",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000637705235827735",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999963824",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.937302971928444",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:82a1a081c2fc5f7c1dd138a92d9cd37d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0059",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[30,-78,14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:733431f958ca44d615fd5672fc566312": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0060",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:18242354f3e85c5abeb04f2a24776aa1",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "13.629490852356",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.20320002112963",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000679547746644249",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999988489",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.94954759467573",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:18242354f3e85c5abeb04f2a24776aa1": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0060",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[18,-78,12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a3a1f315599be97b5ba235320e09d642": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0061",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:3d17907c7b47751bf153c37c651d4aea",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "13.5061225891113",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.18916981007524",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000713410180681495",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999995369",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.94954759467573",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3d17907c7b47751bf153c37c651d4aea": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0061",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[46,8,-16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e97475732149379834546a7b6497a3fb": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0062",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:9ca6aad876741243f44dbfdd251a100a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "13.4754667282104",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.1856690050705",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000722098618250455",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999996325",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.94954759467573",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:9ca6aad876741243f44dbfdd251a100a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0062",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[58,-40,50]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:857dcc58dbe541261ba45dff3d2b361e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0063",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e584e06a075baa5c44d13b1381ce0ec2",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "13.4480972290039",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.18253860543696",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000729950259848011",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999997016",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.94954759467573",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e584e06a075baa5c44d13b1381ce0ec2": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0063",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[46,-66,32]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6e0a324bcd2fe08b3423e3a1291846fd": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0064",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e3a33c2561f68e4588c8a21e486e7f2c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "13.2857608795166",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.16387572537233",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000778416284459293",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999163",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.971579849523251",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e3a33c2561f68e4588c8a21e486e7f2c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0064",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[2,-76,8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7f16505a5183e80a89fdd236a19edcd0": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0065",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:af54c75393d7b35f74b4a955a92b6959",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "13.2286987304688",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.15727638472708",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000796251631906664",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999472",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.971579849523251",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:af54c75393d7b35f74b4a955a92b6959": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0065",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[14,-24,-2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:875b2558dfadf848b15b4bd3a7bedac7": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0066",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d59cf72ab0dd929c2b854e8cf00b3631",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "13.0621271133423",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.13789355719639",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00085083330089919",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999869",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.973821135792583",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d59cf72ab0dd929c2b854e8cf00b3631": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0066",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-36,0,-4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5ebb4f1311ce16efbfe14bbe316a1dd9": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0067",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:1a3a714c8ff947781a0ad2d2c9f1cf30",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "13.0451946258545",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.13591325616981",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000856599341067521",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999886",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.973821135792583",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:1a3a714c8ff947781a0ad2d2c9f1cf30": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0067",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[12,6,62]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c26bf255f07394accb52097e3aa14dcf": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0068",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:fe279a930d64d5a71b800ab242e8f1c3",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "13.0064306259155",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.13137270324883",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000869955985260296",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999919",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.973821135792583",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:fe279a930d64d5a71b800ab242e8f1c3": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0068",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-8,-4,24]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:62972521b018c2b4931966235cb491ff": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0069",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:5e0f8be6d5e367c13936e06a5132c658",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "12.968074798584",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.12687033926247",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00088338914171493",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999942",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.973821135792583",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:5e0f8be6d5e367c13936e06a5132c658": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0069",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[8,-36,40]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:79c914462c21a9da15f185d7c27532c0": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0070",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d98448bb9b3ba696b02a78c75aa3d4a5",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "12.9628992080688",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.12626207199886",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000885218504765861",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999944",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.973821135792583",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d98448bb9b3ba696b02a78c75aa3d4a5": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0070",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[24,38,0]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:474715ccc997937469befbcc9826ba54": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0071",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a4b31efcb7468b12d5ac889153f773bb",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "12.9482192993164",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.12453584528173",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000890429112242686",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999951",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.973821135792583",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a4b31efcb7468b12d5ac889153f773bb": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0071",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[26,-50,46]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:bbd74f64374ff71082a0f30617e201a3": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0072",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:19093ca30f5b7031b50a04dabe2c8580",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "12.9151954650879",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.12064737190897",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000902269894699104",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999964",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.973821135792583",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:19093ca30f5b7031b50a04dabe2c8580": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0072",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-30,-86,8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:95595228f33871513d411cf90c9ac990": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0073",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e16ca3f3b4ac763acebdd770fb53915f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "12.8661985397339",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.11486488202419",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00092014594111034",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999977",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.975928938473905",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e16ca3f3b4ac763acebdd770fb53915f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0073",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[22,-24,38]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a143fe115cb6773e77224c4cf1c48dad": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0074",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0d8c450188c5ca9da526aa9cad61cd4e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "12.8156299591064",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.10888025138563",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000938989080538355",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999985",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.978285341995832",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0d8c450188c5ca9da526aa9cad61cd4e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0074",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[48,50,2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:fddbb1076a0ce325c65aac2f591218cd": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0075",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4da351496d312a5b3b763b22e9887907",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "12.7734069824219",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.10387025917553",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000955035352381506",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999999999",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.978285341995832",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4da351496d312a5b3b763b22e9887907": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0075",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-48,-68,20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1cd54d943a37d511665d0fc8924f35bf": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0076",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f9b1afbacf27286a06aed4990a8d3f17",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "12.7362623214722",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.0994529756118",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000969391758882221",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999993",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.978285341995832",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f9b1afbacf27286a06aed4990a8d3f17": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0076",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[24,-22,36]",
+                "type": "xsd:string"
+            }
+        }
+    },
+    "activity": {
+        "niiri:abe46d73a8429cc97ae789be61c051b7": {
+            "prov:type": {
+                "$": "nidm_ModelParametersEstimation:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Model parameters estimation",
+                "type": "xsd:string"
+            },
+            "nidm_withEstimationMethod:": {
+                "$": "obo_generalizedleastsquaresestimation:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2456cdab46e0eb6c27cca0f6dd52cb86": {
+            "prov:type": {
+                "$": "nidm_ContrastEstimation:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Contrast estimation",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e5a916f24cf27604386c2c32a5bf702b": {
+            "prov:type": {
+                "$": "nidm_Inference:",
+                "type": "xsd:QName"
+            },
+            "nidm_hasAlternativeHypothesis:": {
+                "$": "nidm_OneTailedTest:",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Inference",
+                "type": "xsd:string"
+            }
+        }
+    },
+    "agent": {
+        "niiri:bc2e77c470f6014f2a246955842052c9": {
+            "prov:type": [
+                {
+                "$": "src_SPM:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "prov:SoftwareAgent",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "SPM",
+                "type": "xsd:string"
+            },
+            "nidm_softwareVersion:": {
+                "$": "12.6906",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:693e91ca0bc2876c97cc7ed9b8a8d2da": {
+            "prov:type": [
+                {
+                "$": "nlx_Imaginginstrument:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nlx_Magneticresonanceimagingscanner:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "MRI Scanner",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3db0690d0c427891151946b5624760be": {
+            "prov:type": {
+                "$": "prov:Person",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Person",
+                "type": "xsd:string"
+            }
+        }
+    },
+    "wasGeneratedBy": {
+        "_:wGB19": {
+            "prov:entity": "niiri:fc108568cd5e536825df64c6f1040101",
+            "prov:activity": "niiri:abe46d73a8429cc97ae789be61c051b7"
+        },
+        "_:wGB21": {
+            "prov:entity": "niiri:8b44eef148a4672df3b868888c1c1c71",
+            "prov:activity": "niiri:abe46d73a8429cc97ae789be61c051b7"
+        },
+        "_:wGB25": {
+            "prov:entity": "niiri:69099a5655e274a35cf8497561c281d6",
+            "prov:activity": "niiri:abe46d73a8429cc97ae789be61c051b7"
+        },
+        "_:wGB29": {
+            "prov:entity": "niiri:994815a1deaaea1d8a916499a4369008",
+            "prov:activity": "niiri:abe46d73a8429cc97ae789be61c051b7"
+        },
+        "_:wGB33": {
+            "prov:entity": "niiri:438a1a1f15d3ed6c053ad0a47535b905",
+            "prov:activity": "niiri:abe46d73a8429cc97ae789be61c051b7"
+        },
+        "_:wGB37": {
+            "prov:entity": "niiri:94876fb7a2c046b431df17692c760d6e",
+            "prov:activity": "niiri:abe46d73a8429cc97ae789be61c051b7"
+        },
+        "_:wGB41": {
+            "prov:entity": "niiri:96116055802375625dcf702ee01581fe",
+            "prov:activity": "niiri:abe46d73a8429cc97ae789be61c051b7"
+        },
+        "_:wGB55": {
+            "prov:entity": "niiri:9ca097a864a89e695f5a0ade9c7a2592",
+            "prov:activity": "niiri:2456cdab46e0eb6c27cca0f6dd52cb86"
+        },
+        "_:wGB57": {
+            "prov:entity": "niiri:a72a81446159f6a67c6f27a5da80101a",
+            "prov:activity": "niiri:2456cdab46e0eb6c27cca0f6dd52cb86"
+        },
+        "_:wGB76": {
+            "prov:entity": "niiri:db110fb8702367464d0832795a39cbbb",
+            "prov:activity": "niiri:e5a916f24cf27604386c2c32a5bf702b"
+        },
+        "_:wGB80": {
+            "prov:entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb",
+            "prov:activity": "niiri:e5a916f24cf27604386c2c32a5bf702b"
+        }
+    },
+    "used": {
+        "_:u13": {
+            "prov:activity": "niiri:abe46d73a8429cc97ae789be61c051b7",
+            "prov:entity": "niiri:8832b574f38c1ef5b19a5698eedfd522"
+        },
+        "_:u14": {
+            "prov:activity": "niiri:abe46d73a8429cc97ae789be61c051b7",
+            "prov:entity": "niiri:825930cb9cecdc2d026a61f46ae3ee93"
+        },
+        "_:u15": {
+            "prov:activity": "niiri:abe46d73a8429cc97ae789be61c051b7",
+            "prov:entity": "niiri:8a6c1f8a466f432d23696a22842630eb"
+        },
+        "_:u45": {
+            "prov:activity": "niiri:2456cdab46e0eb6c27cca0f6dd52cb86",
+            "prov:entity": "niiri:fc108568cd5e536825df64c6f1040101"
+        },
+        "_:u46": {
+            "prov:activity": "niiri:2456cdab46e0eb6c27cca0f6dd52cb86",
+            "prov:entity": "niiri:94876fb7a2c046b431df17692c760d6e"
+        },
+        "_:u47": {
+            "prov:activity": "niiri:2456cdab46e0eb6c27cca0f6dd52cb86",
+            "prov:entity": "niiri:8832b574f38c1ef5b19a5698eedfd522"
+        },
+        "_:u48": {
+            "prov:activity": "niiri:2456cdab46e0eb6c27cca0f6dd52cb86",
+            "prov:entity": "niiri:adbd624b50ba693b3e14fd648e13ebef"
+        },
+        "_:u49": {
+            "prov:activity": "niiri:2456cdab46e0eb6c27cca0f6dd52cb86",
+            "prov:entity": "niiri:69099a5655e274a35cf8497561c281d6"
+        },
+        "_:u50": {
+            "prov:activity": "niiri:2456cdab46e0eb6c27cca0f6dd52cb86",
+            "prov:entity": "niiri:994815a1deaaea1d8a916499a4369008"
+        },
+        "_:u51": {
+            "prov:activity": "niiri:2456cdab46e0eb6c27cca0f6dd52cb86",
+            "prov:entity": "niiri:438a1a1f15d3ed6c053ad0a47535b905"
+        },
+        "_:u68": {
+            "prov:activity": "niiri:e5a916f24cf27604386c2c32a5bf702b",
+            "prov:entity": "niiri:6e1bb9294b0707edbbe5ae21cfbadf07"
+        },
+        "_:u69": {
+            "prov:activity": "niiri:e5a916f24cf27604386c2c32a5bf702b",
+            "prov:entity": "niiri:636d204ec94986da6b6ce98445053011"
+        },
+        "_:u70": {
+            "prov:activity": "niiri:e5a916f24cf27604386c2c32a5bf702b",
+            "prov:entity": "niiri:9ca097a864a89e695f5a0ade9c7a2592"
+        },
+        "_:u71": {
+            "prov:activity": "niiri:e5a916f24cf27604386c2c32a5bf702b",
+            "prov:entity": "niiri:96116055802375625dcf702ee01581fe"
+        },
+        "_:u72": {
+            "prov:activity": "niiri:e5a916f24cf27604386c2c32a5bf702b",
+            "prov:entity": "niiri:fc108568cd5e536825df64c6f1040101"
+        },
+        "_:u73": {
+            "prov:activity": "niiri:e5a916f24cf27604386c2c32a5bf702b",
+            "prov:entity": "niiri:3dd5d16b52227865dddd8a70d5265d53"
+        },
+        "_:u74": {
+            "prov:activity": "niiri:e5a916f24cf27604386c2c32a5bf702b",
+            "prov:entity": "niiri:029c2dcb7254e8c7af93bf485d809706"
+        }
+    },
+    "wasDerivedFrom": {
+        "_:wDF18": {
+            "prov:generatedEntity": "niiri:fc108568cd5e536825df64c6f1040101",
+            "prov:usedEntity": "niiri:e09fd9499ed59ea115caabdbd4ec218b"
+        },
+        "_:wDF24": {
+            "prov:generatedEntity": "niiri:69099a5655e274a35cf8497561c281d6",
+            "prov:usedEntity": "niiri:08dd8d7791f4ea3b42d7928f3978b481"
+        },
+        "_:wDF28": {
+            "prov:generatedEntity": "niiri:994815a1deaaea1d8a916499a4369008",
+            "prov:usedEntity": "niiri:adc38d535f009898b8597918fea3e74b"
+        },
+        "_:wDF32": {
+            "prov:generatedEntity": "niiri:438a1a1f15d3ed6c053ad0a47535b905",
+            "prov:usedEntity": "niiri:fc2fc60ae3a1a2a377ce868dcfe7682c"
+        },
+        "_:wDF36": {
+            "prov:generatedEntity": "niiri:94876fb7a2c046b431df17692c760d6e",
+            "prov:usedEntity": "niiri:b88f5c084cf11202884b4336bb357ace"
+        },
+        "_:wDF40": {
+            "prov:generatedEntity": "niiri:96116055802375625dcf702ee01581fe",
+            "prov:usedEntity": "niiri:1328ce3e8c83d35913bbecbd452290df"
+        },
+        "_:wDF54": {
+            "prov:generatedEntity": "niiri:9ca097a864a89e695f5a0ade9c7a2592",
+            "prov:usedEntity": "niiri:1300030726b15941203796dca8bcf83c"
+        },
+        "_:wDF82": {
+            "prov:generatedEntity": "niiri:0502f21f886d74eb5a46cc0e98d99ebd",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF84": {
+            "prov:generatedEntity": "niiri:0599785d82edc2bd01edfc956f648d55",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF86": {
+            "prov:generatedEntity": "niiri:503c99586f814910b6b80009bf62943c",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF88": {
+            "prov:generatedEntity": "niiri:018a24899160bba0361882009e28cdf7",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF90": {
+            "prov:generatedEntity": "niiri:33d37aeafd7dbe4545a7c3723ffec290",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF92": {
+            "prov:generatedEntity": "niiri:c67e26c71245447102997061bd7b4400",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF94": {
+            "prov:generatedEntity": "niiri:21c6b4d93e2f7d826c174fe1b99df534",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF96": {
+            "prov:generatedEntity": "niiri:6da0c60471d915bb0e46bffadee4d55a",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF98": {
+            "prov:generatedEntity": "niiri:a35a0c7d262276e543a1e97fbbe3cdc8",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF100": {
+            "prov:generatedEntity": "niiri:cfb99edebaae9df65e32c2dc18fd6186",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF102": {
+            "prov:generatedEntity": "niiri:2607cc56c513b9a7b262e9ec22fe2b63",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF104": {
+            "prov:generatedEntity": "niiri:1daa422fda95bd1a9676984906e1a548",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF106": {
+            "prov:generatedEntity": "niiri:a6888f03a619f2ef07714763993a3be7",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF108": {
+            "prov:generatedEntity": "niiri:ff0222b1c30a382e52f5903988ee7a67",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF110": {
+            "prov:generatedEntity": "niiri:189a48f192c71c34afbefb1b24c895a1",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF112": {
+            "prov:generatedEntity": "niiri:153d0f62058a9c03f71f38806c01672c",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF114": {
+            "prov:generatedEntity": "niiri:2b8333b9ae75e6a69c6703c1017776ef",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF116": {
+            "prov:generatedEntity": "niiri:be0ede967cfc83179dfb392adca98376",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF118": {
+            "prov:generatedEntity": "niiri:23f2b3702fb27a3d52f0874c93630544",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF120": {
+            "prov:generatedEntity": "niiri:654afa8f2fea6cb2d23c37e50edee008",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF122": {
+            "prov:generatedEntity": "niiri:dba06f209302f6639800d0af3c93affd",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF124": {
+            "prov:generatedEntity": "niiri:57c14f931d36e820d2322a1bdd36da40",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF126": {
+            "prov:generatedEntity": "niiri:2739d32e473645dfabd9a03fc9f4dae7",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF128": {
+            "prov:generatedEntity": "niiri:23f5ffb7a02a62400ce3f1cfda032dbe",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF130": {
+            "prov:generatedEntity": "niiri:3ed09542d8eeb67b7a92a4f1152a9588",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF132": {
+            "prov:generatedEntity": "niiri:ee2c6440d10e17fa3f61858f975e92f6",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF134": {
+            "prov:generatedEntity": "niiri:25764564ed7b5495d43208d9a742797c",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF136": {
+            "prov:generatedEntity": "niiri:2a5007577d5f397768b0a52d8e1e454a",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF138": {
+            "prov:generatedEntity": "niiri:075d03d6a0a7a8ff06d2fd0a678225e4",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF140": {
+            "prov:generatedEntity": "niiri:f9daf2bb86509394f654f8dfb4a4e15b",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF142": {
+            "prov:generatedEntity": "niiri:447a33078d0ab11fa638dad2f64b7b00",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF144": {
+            "prov:generatedEntity": "niiri:e979405039e66c5ce2c3d5b5b67f1286",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF146": {
+            "prov:generatedEntity": "niiri:02724527e4ee34eff0967177115a83d1",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF148": {
+            "prov:generatedEntity": "niiri:c6bf9a9fd500605c73016dfb45e6af98",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF150": {
+            "prov:generatedEntity": "niiri:e3e587be4409f0bc772835a934536590",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF152": {
+            "prov:generatedEntity": "niiri:6aa3e47b1d56a62cbf353acb1dbf4e63",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF154": {
+            "prov:generatedEntity": "niiri:11267ea4af34c876ad34aa054c834aa1",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF156": {
+            "prov:generatedEntity": "niiri:ed62a9c22b9d6c8f4255706a0676f4da",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF158": {
+            "prov:generatedEntity": "niiri:7649cec60050f6bbb0a4a68fad360d04",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF160": {
+            "prov:generatedEntity": "niiri:76477879d12f5565edfe6317f1396ae3",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF162": {
+            "prov:generatedEntity": "niiri:b32a94908c3543b6389e71c09e18b028",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF164": {
+            "prov:generatedEntity": "niiri:505e13c060365ce925c6c78620aace2b",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF166": {
+            "prov:generatedEntity": "niiri:6a2f64f5544ff048d58423df90e157d2",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF168": {
+            "prov:generatedEntity": "niiri:965bca191e7bce9008d8dd515cf43195",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF170": {
+            "prov:generatedEntity": "niiri:5c0f8a6949255a54753a5996ab8bf0b5",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF172": {
+            "prov:generatedEntity": "niiri:e00c0b657ae25f884a41aad34f6d4869",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF174": {
+            "prov:generatedEntity": "niiri:efbb22419db35e6170e4f8c15df564d9",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF176": {
+            "prov:generatedEntity": "niiri:792fda8a02886788088cdc21433fe931",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF178": {
+            "prov:generatedEntity": "niiri:0dd1d301e6eec8815748b738cd4fdb7c",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF180": {
+            "prov:generatedEntity": "niiri:0a00a0a76e73ce79a1d09f89ec092795",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF182": {
+            "prov:generatedEntity": "niiri:af99a7152d944fac822b2a894187ecfd",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF184": {
+            "prov:generatedEntity": "niiri:1de9cf5cb4f411c77d648530539b1506",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF186": {
+            "prov:generatedEntity": "niiri:643dd520d22eb83650c21da507f69f60",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF188": {
+            "prov:generatedEntity": "niiri:1a432aa3e7fda423feb9c68ebffde829",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF190": {
+            "prov:generatedEntity": "niiri:1569aa21af436f1447efa2c75903f79c",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF192": {
+            "prov:generatedEntity": "niiri:0fb2459e07ec9adca74a9a6a0f036186",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF194": {
+            "prov:generatedEntity": "niiri:e937b5f0f9c2d5b73ead1407d48466e6",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF196": {
+            "prov:generatedEntity": "niiri:321743f529907bc95ee3bc2bb3feb1e2",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF198": {
+            "prov:generatedEntity": "niiri:7ca293071987c22e76e0b20115b26429",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF200": {
+            "prov:generatedEntity": "niiri:6bb00e27ab3f8d7e1b137fd7b575136a",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF202": {
+            "prov:generatedEntity": "niiri:eea16d34f3c295e17c1d3128d76481f7",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF204": {
+            "prov:generatedEntity": "niiri:2d477a3822ede90c19394a724a2c602f",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF206": {
+            "prov:generatedEntity": "niiri:67886822c4a91ee4d1b7cd6bc45567f5",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF208": {
+            "prov:generatedEntity": "niiri:5ebab1be1c4c961db315c2ffb23786c0",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF210": {
+            "prov:generatedEntity": "niiri:06a77002692eb72a6823907717b7b96b",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF212": {
+            "prov:generatedEntity": "niiri:70cb31c3da80e76bbcc31227d5a63dd3",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF214": {
+            "prov:generatedEntity": "niiri:1bab28ca73fb58bf072903c327aa6ee2",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF216": {
+            "prov:generatedEntity": "niiri:0d05a2eb7c30f085c9585bd5437f2cf6",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF218": {
+            "prov:generatedEntity": "niiri:cec1367031abea759cc3b3843951c4e9",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF220": {
+            "prov:generatedEntity": "niiri:6ba93f98c147f043bee56b6eaf416136",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF222": {
+            "prov:generatedEntity": "niiri:ac903b7a48abf269c96015efab8d2aa1",
+            "prov:usedEntity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
+        },
+        "_:wDF225": {
+            "prov:generatedEntity": "niiri:de0be50edac74c81f9c1e5814da03b9d",
+            "prov:usedEntity": "niiri:0502f21f886d74eb5a46cc0e98d99ebd"
+        },
+        "_:wDF228": {
+            "prov:generatedEntity": "niiri:3551a670193037285a26d96dd25d4587",
+            "prov:usedEntity": "niiri:0599785d82edc2bd01edfc956f648d55"
+        },
+        "_:wDF231": {
+            "prov:generatedEntity": "niiri:a397cef7de1b33fff3104633ae867013",
+            "prov:usedEntity": "niiri:0599785d82edc2bd01edfc956f648d55"
+        },
+        "_:wDF234": {
+            "prov:generatedEntity": "niiri:795bfdfc1c878985f28b65ddbd93f5e2",
+            "prov:usedEntity": "niiri:0599785d82edc2bd01edfc956f648d55"
+        },
+        "_:wDF237": {
+            "prov:generatedEntity": "niiri:1bef248663e2601c3f3e8f86ce7bcf8e",
+            "prov:usedEntity": "niiri:503c99586f814910b6b80009bf62943c"
+        },
+        "_:wDF240": {
+            "prov:generatedEntity": "niiri:34e046d2eb16a715bed65c1a03b2abc1",
+            "prov:usedEntity": "niiri:018a24899160bba0361882009e28cdf7"
+        },
+        "_:wDF243": {
+            "prov:generatedEntity": "niiri:c71c9cb743a850da26dbd07e2a4ab336",
+            "prov:usedEntity": "niiri:33d37aeafd7dbe4545a7c3723ffec290"
+        },
+        "_:wDF246": {
+            "prov:generatedEntity": "niiri:1d00c0696db8e3a3a6f9eeb993c993aa",
+            "prov:usedEntity": "niiri:c67e26c71245447102997061bd7b4400"
+        },
+        "_:wDF249": {
+            "prov:generatedEntity": "niiri:e105d8c03c8fb50b26c076e73184a484",
+            "prov:usedEntity": "niiri:21c6b4d93e2f7d826c174fe1b99df534"
+        },
+        "_:wDF252": {
+            "prov:generatedEntity": "niiri:98120cf8274f1adde1b9975ee7343d0b",
+            "prov:usedEntity": "niiri:6da0c60471d915bb0e46bffadee4d55a"
+        },
+        "_:wDF255": {
+            "prov:generatedEntity": "niiri:289923b931558b9cf26d6259e84991cc",
+            "prov:usedEntity": "niiri:a35a0c7d262276e543a1e97fbbe3cdc8"
+        },
+        "_:wDF258": {
+            "prov:generatedEntity": "niiri:273d6a77c000bfe5f52d296da6ad6478",
+            "prov:usedEntity": "niiri:a35a0c7d262276e543a1e97fbbe3cdc8"
+        },
+        "_:wDF261": {
+            "prov:generatedEntity": "niiri:41059e9d7b27293b0aba3b2a84d455b8",
+            "prov:usedEntity": "niiri:cfb99edebaae9df65e32c2dc18fd6186"
+        },
+        "_:wDF264": {
+            "prov:generatedEntity": "niiri:b964c9d32200b841b56fe800b88c0a4b",
+            "prov:usedEntity": "niiri:2607cc56c513b9a7b262e9ec22fe2b63"
+        },
+        "_:wDF267": {
+            "prov:generatedEntity": "niiri:cf6cc59258bd447a466c3c1895718676",
+            "prov:usedEntity": "niiri:1daa422fda95bd1a9676984906e1a548"
+        },
+        "_:wDF270": {
+            "prov:generatedEntity": "niiri:5175b1641041f873df3e4b8171a20dbd",
+            "prov:usedEntity": "niiri:a6888f03a619f2ef07714763993a3be7"
+        },
+        "_:wDF273": {
+            "prov:generatedEntity": "niiri:eda52aede28b44456962e7af041dab45",
+            "prov:usedEntity": "niiri:ff0222b1c30a382e52f5903988ee7a67"
+        },
+        "_:wDF276": {
+            "prov:generatedEntity": "niiri:73097f0b0425dce88560554ead9adec5",
+            "prov:usedEntity": "niiri:ff0222b1c30a382e52f5903988ee7a67"
+        },
+        "_:wDF279": {
+            "prov:generatedEntity": "niiri:dee978e74443f1a4c46189f244ae1e75",
+            "prov:usedEntity": "niiri:189a48f192c71c34afbefb1b24c895a1"
+        },
+        "_:wDF282": {
+            "prov:generatedEntity": "niiri:7229cb1ae5d253d150d16f583a790984",
+            "prov:usedEntity": "niiri:153d0f62058a9c03f71f38806c01672c"
+        },
+        "_:wDF285": {
+            "prov:generatedEntity": "niiri:31378a601c2becf436d41b267a4b16d5",
+            "prov:usedEntity": "niiri:2b8333b9ae75e6a69c6703c1017776ef"
+        },
+        "_:wDF288": {
+            "prov:generatedEntity": "niiri:83bc6d3f85253d9d97da7f55882bc0e2",
+            "prov:usedEntity": "niiri:be0ede967cfc83179dfb392adca98376"
+        },
+        "_:wDF291": {
+            "prov:generatedEntity": "niiri:b9f98ffb929e3828f9472a4a465a4f0d",
+            "prov:usedEntity": "niiri:be0ede967cfc83179dfb392adca98376"
+        },
+        "_:wDF294": {
+            "prov:generatedEntity": "niiri:3fc414435450d7991a1adccdb53f2ea3",
+            "prov:usedEntity": "niiri:23f2b3702fb27a3d52f0874c93630544"
+        },
+        "_:wDF297": {
+            "prov:generatedEntity": "niiri:c636ea0bddcfb80ff2d7e531404b34f1",
+            "prov:usedEntity": "niiri:654afa8f2fea6cb2d23c37e50edee008"
+        },
+        "_:wDF300": {
+            "prov:generatedEntity": "niiri:17e69e7f43739c2172a5e069dcce782a",
+            "prov:usedEntity": "niiri:dba06f209302f6639800d0af3c93affd"
+        },
+        "_:wDF303": {
+            "prov:generatedEntity": "niiri:310041e942b16c12433a1a316b01a18b",
+            "prov:usedEntity": "niiri:57c14f931d36e820d2322a1bdd36da40"
+        },
+        "_:wDF306": {
+            "prov:generatedEntity": "niiri:830254d5fee868a84ad02a38a3e7bb23",
+            "prov:usedEntity": "niiri:2739d32e473645dfabd9a03fc9f4dae7"
+        },
+        "_:wDF309": {
+            "prov:generatedEntity": "niiri:d7ae1c6177cf91420976fa8b1b418173",
+            "prov:usedEntity": "niiri:23f5ffb7a02a62400ce3f1cfda032dbe"
+        },
+        "_:wDF312": {
+            "prov:generatedEntity": "niiri:8f42c8637a3ba73755a9485aaf00eb82",
+            "prov:usedEntity": "niiri:3ed09542d8eeb67b7a92a4f1152a9588"
+        },
+        "_:wDF315": {
+            "prov:generatedEntity": "niiri:4e350520ca70ab7fb0dad1e34876ed26",
+            "prov:usedEntity": "niiri:ee2c6440d10e17fa3f61858f975e92f6"
+        },
+        "_:wDF318": {
+            "prov:generatedEntity": "niiri:64a12d60baf5c5c9da921d103abfb214",
+            "prov:usedEntity": "niiri:25764564ed7b5495d43208d9a742797c"
+        },
+        "_:wDF321": {
+            "prov:generatedEntity": "niiri:0e8721be3c984e497213a6eb5d79d336",
+            "prov:usedEntity": "niiri:2a5007577d5f397768b0a52d8e1e454a"
+        },
+        "_:wDF324": {
+            "prov:generatedEntity": "niiri:e8cb5546247d4a3680cfd15b61ec92a8",
+            "prov:usedEntity": "niiri:075d03d6a0a7a8ff06d2fd0a678225e4"
+        },
+        "_:wDF327": {
+            "prov:generatedEntity": "niiri:feb703455a27d97b3c3dd1a514984c82",
+            "prov:usedEntity": "niiri:f9daf2bb86509394f654f8dfb4a4e15b"
+        },
+        "_:wDF330": {
+            "prov:generatedEntity": "niiri:28a0f16475271ebd8e455e39cde15030",
+            "prov:usedEntity": "niiri:447a33078d0ab11fa638dad2f64b7b00"
+        },
+        "_:wDF333": {
+            "prov:generatedEntity": "niiri:5518c40950022bff274b3d6a606c42f0",
+            "prov:usedEntity": "niiri:e979405039e66c5ce2c3d5b5b67f1286"
+        },
+        "_:wDF336": {
+            "prov:generatedEntity": "niiri:f4f7823b1059a0ea57e9561159693d3f",
+            "prov:usedEntity": "niiri:02724527e4ee34eff0967177115a83d1"
+        },
+        "_:wDF339": {
+            "prov:generatedEntity": "niiri:9acefe93a7c31e0167ce0ffe2ceaa937",
+            "prov:usedEntity": "niiri:c6bf9a9fd500605c73016dfb45e6af98"
+        },
+        "_:wDF342": {
+            "prov:generatedEntity": "niiri:3eeaab0bcdb1598c681f02ebda8bb1e8",
+            "prov:usedEntity": "niiri:e3e587be4409f0bc772835a934536590"
+        },
+        "_:wDF345": {
+            "prov:generatedEntity": "niiri:762957e2b9b79f111526f35c0c3416cc",
+            "prov:usedEntity": "niiri:6aa3e47b1d56a62cbf353acb1dbf4e63"
+        },
+        "_:wDF348": {
+            "prov:generatedEntity": "niiri:ba7dd3245ca2f03a516b8c2349193add",
+            "prov:usedEntity": "niiri:11267ea4af34c876ad34aa054c834aa1"
+        },
+        "_:wDF351": {
+            "prov:generatedEntity": "niiri:ce6828c9876402cd1eb1653f92f8b5b1",
+            "prov:usedEntity": "niiri:ed62a9c22b9d6c8f4255706a0676f4da"
+        },
+        "_:wDF354": {
+            "prov:generatedEntity": "niiri:580ea35cc47de5999eda43982afb2748",
+            "prov:usedEntity": "niiri:7649cec60050f6bbb0a4a68fad360d04"
+        },
+        "_:wDF357": {
+            "prov:generatedEntity": "niiri:dbf6e6c9df9c1acb5c0e4b176d3529de",
+            "prov:usedEntity": "niiri:76477879d12f5565edfe6317f1396ae3"
+        },
+        "_:wDF360": {
+            "prov:generatedEntity": "niiri:cb04519fde20aaf17e0dc9a593fb3d64",
+            "prov:usedEntity": "niiri:b32a94908c3543b6389e71c09e18b028"
+        },
+        "_:wDF363": {
+            "prov:generatedEntity": "niiri:d2c121ae6272e04656b61fe1f025dc35",
+            "prov:usedEntity": "niiri:505e13c060365ce925c6c78620aace2b"
+        },
+        "_:wDF366": {
+            "prov:generatedEntity": "niiri:df8d20feb57d27a95ebc95ea167307a2",
+            "prov:usedEntity": "niiri:6a2f64f5544ff048d58423df90e157d2"
+        },
+        "_:wDF369": {
+            "prov:generatedEntity": "niiri:e1adf61d5f82a1f2b659ae4e403de7c6",
+            "prov:usedEntity": "niiri:965bca191e7bce9008d8dd515cf43195"
+        },
+        "_:wDF372": {
+            "prov:generatedEntity": "niiri:bbcbd508c2385f821ae15583d3d00469",
+            "prov:usedEntity": "niiri:5c0f8a6949255a54753a5996ab8bf0b5"
+        },
+        "_:wDF375": {
+            "prov:generatedEntity": "niiri:400a173374e07f6ad6fa8505dd25b493",
+            "prov:usedEntity": "niiri:e00c0b657ae25f884a41aad34f6d4869"
+        },
+        "_:wDF378": {
+            "prov:generatedEntity": "niiri:5e8d9c60f45794f6ee76f52290599e75",
+            "prov:usedEntity": "niiri:efbb22419db35e6170e4f8c15df564d9"
+        },
+        "_:wDF381": {
+            "prov:generatedEntity": "niiri:5352b8108713eb17c53045c149a58a47",
+            "prov:usedEntity": "niiri:792fda8a02886788088cdc21433fe931"
+        },
+        "_:wDF384": {
+            "prov:generatedEntity": "niiri:4d047c8ee6809f00a9f5c059b315c51b",
+            "prov:usedEntity": "niiri:0dd1d301e6eec8815748b738cd4fdb7c"
+        },
+        "_:wDF387": {
+            "prov:generatedEntity": "niiri:bbb945c8440c49e2cc1175a521c2126c",
+            "prov:usedEntity": "niiri:0a00a0a76e73ce79a1d09f89ec092795"
+        },
+        "_:wDF390": {
+            "prov:generatedEntity": "niiri:00c3e6ced7aa1682b713c6694740fe99",
+            "prov:usedEntity": "niiri:af99a7152d944fac822b2a894187ecfd"
+        },
+        "_:wDF393": {
+            "prov:generatedEntity": "niiri:6cae1270b5b27c77bad1a387e664d75b",
+            "prov:usedEntity": "niiri:1de9cf5cb4f411c77d648530539b1506"
+        },
+        "_:wDF396": {
+            "prov:generatedEntity": "niiri:09a056a78cfbc859552cc5fe35db542b",
+            "prov:usedEntity": "niiri:643dd520d22eb83650c21da507f69f60"
+        },
+        "_:wDF399": {
+            "prov:generatedEntity": "niiri:b43c078a0750c0b86b05a04f00f444dd",
+            "prov:usedEntity": "niiri:1a432aa3e7fda423feb9c68ebffde829"
+        },
+        "_:wDF402": {
+            "prov:generatedEntity": "niiri:733431f958ca44d615fd5672fc566312",
+            "prov:usedEntity": "niiri:1569aa21af436f1447efa2c75903f79c"
+        },
+        "_:wDF405": {
+            "prov:generatedEntity": "niiri:a3a1f315599be97b5ba235320e09d642",
+            "prov:usedEntity": "niiri:0fb2459e07ec9adca74a9a6a0f036186"
+        },
+        "_:wDF408": {
+            "prov:generatedEntity": "niiri:e97475732149379834546a7b6497a3fb",
+            "prov:usedEntity": "niiri:e937b5f0f9c2d5b73ead1407d48466e6"
+        },
+        "_:wDF411": {
+            "prov:generatedEntity": "niiri:857dcc58dbe541261ba45dff3d2b361e",
+            "prov:usedEntity": "niiri:321743f529907bc95ee3bc2bb3feb1e2"
+        },
+        "_:wDF414": {
+            "prov:generatedEntity": "niiri:6e0a324bcd2fe08b3423e3a1291846fd",
+            "prov:usedEntity": "niiri:7ca293071987c22e76e0b20115b26429"
+        },
+        "_:wDF417": {
+            "prov:generatedEntity": "niiri:7f16505a5183e80a89fdd236a19edcd0",
+            "prov:usedEntity": "niiri:6bb00e27ab3f8d7e1b137fd7b575136a"
+        },
+        "_:wDF420": {
+            "prov:generatedEntity": "niiri:875b2558dfadf848b15b4bd3a7bedac7",
+            "prov:usedEntity": "niiri:eea16d34f3c295e17c1d3128d76481f7"
+        },
+        "_:wDF423": {
+            "prov:generatedEntity": "niiri:5ebb4f1311ce16efbfe14bbe316a1dd9",
+            "prov:usedEntity": "niiri:2d477a3822ede90c19394a724a2c602f"
+        },
+        "_:wDF426": {
+            "prov:generatedEntity": "niiri:c26bf255f07394accb52097e3aa14dcf",
+            "prov:usedEntity": "niiri:67886822c4a91ee4d1b7cd6bc45567f5"
+        },
+        "_:wDF429": {
+            "prov:generatedEntity": "niiri:62972521b018c2b4931966235cb491ff",
+            "prov:usedEntity": "niiri:5ebab1be1c4c961db315c2ffb23786c0"
+        },
+        "_:wDF432": {
+            "prov:generatedEntity": "niiri:79c914462c21a9da15f185d7c27532c0",
+            "prov:usedEntity": "niiri:06a77002692eb72a6823907717b7b96b"
+        },
+        "_:wDF435": {
+            "prov:generatedEntity": "niiri:474715ccc997937469befbcc9826ba54",
+            "prov:usedEntity": "niiri:70cb31c3da80e76bbcc31227d5a63dd3"
+        },
+        "_:wDF438": {
+            "prov:generatedEntity": "niiri:bbd74f64374ff71082a0f30617e201a3",
+            "prov:usedEntity": "niiri:1bab28ca73fb58bf072903c327aa6ee2"
+        },
+        "_:wDF441": {
+            "prov:generatedEntity": "niiri:95595228f33871513d411cf90c9ac990",
+            "prov:usedEntity": "niiri:0d05a2eb7c30f085c9585bd5437f2cf6"
+        },
+        "_:wDF444": {
+            "prov:generatedEntity": "niiri:a143fe115cb6773e77224c4cf1c48dad",
+            "prov:usedEntity": "niiri:cec1367031abea759cc3b3843951c4e9"
+        },
+        "_:wDF447": {
+            "prov:generatedEntity": "niiri:fddbb1076a0ce325c65aac2f591218cd",
+            "prov:usedEntity": "niiri:6ba93f98c147f043bee56b6eaf416136"
+        },
+        "_:wDF450": {
+            "prov:generatedEntity": "niiri:1cd54d943a37d511665d0fc8924f35bf",
+            "prov:usedEntity": "niiri:ac903b7a48abf269c96015efab8d2aa1"
+        }
+    },
+    "wasAttributedTo": {
+        "_:wAT6": {
+            "prov:entity": "niiri:825930cb9cecdc2d026a61f46ae3ee93",
+            "prov:agent": "niiri:693e91ca0bc2876c97cc7ed9b8a8d2da"
+        },
+        "_:wAT7": {
+            "prov:entity": "niiri:825930cb9cecdc2d026a61f46ae3ee93",
+            "prov:agent": "niiri:3db0690d0c427891151946b5624760be"
+        }
+    },
+    "wasAssociatedWith": {
+        "_:wAW12": {
+            "prov:activity": "niiri:abe46d73a8429cc97ae789be61c051b7",
+            "prov:agent": "niiri:bc2e77c470f6014f2a246955842052c9"
+        },
+        "_:wAW44": {
+            "prov:activity": "niiri:2456cdab46e0eb6c27cca0f6dd52cb86",
+            "prov:agent": "niiri:bc2e77c470f6014f2a246955842052c9"
+        },
+        "_:wAW67": {
+            "prov:activity": "niiri:e5a916f24cf27604386c2c32a5bf702b",
+            "prov:agent": "niiri:bc2e77c470f6014f2a246955842052c9"
+        }
+    }
+    }
+  }
+}

--- a/spmexport/ex_spm_non_sphericity/nidm.jsonld
+++ b/spmexport/ex_spm_non_sphericity/nidm.jsonld
@@ -7,7 +7,7 @@
       "niiri": "http://iri.nidash.org/",
       "spm": "http://purl.org/nidash/spm#",
       "neurolex": "http://neurolex.org/wiki/",
-      "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#",
+      "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/",
       "dct": "http://purl.org/dc/terms/",
       "nfo": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#",
       "dc": "http://purl.org/dc/elements/1.1/",
@@ -22,32 +22,32 @@
   ],
   "@graph": [
     {
-      "@id": "niiri:ae59b3f8b6a7ff8a2ff189b89c331a16",
-      "@type": ["prov:Entity","prov:Bundle","nidm_NIDMResults:"],
+      "@id": "niiri:4e3cc7ffa6f685a0f71dbdd16e102f31",
+      "@type": ["prov:Entity","prov:Bundle","nidm_NIDMResults"],
       "rdfs:label": "NIDM-Results",
-      "nidm_version:": {"@type": "xsd:string", "@value": "1.3.0"}
+      "nidm_version": {"@type": "xsd:string", "@value": "1.3.0"}
     },
     {
-      "@id": "niiri:ccd117e388c60ec9e834266da2abf102",
-      "@type": ["prov:Agent","nidm_spm_results_nidm:","prov:SoftwareAgent"],
+      "@id": "niiri:d47620c0a904862a40d4a674f5975211",
+      "@type": ["prov:Agent","nidm_spm_results_nidm","prov:SoftwareAgent"],
       "rdfs:label": "spm_results_nidm",
-      "nidm_softwareVersion:": {"@type": "xsd:string", "@value": "12.6903"}
+      "nidm_softwareVersion": {"@type": "xsd:string", "@value": "12.7057"}
     },
     {
-      "@id": "niiri:23f1bb1b8637a94e2590757111800672",
-      "@type": ["prov:Activity","nidm_NIDMResultsExport:"],
+      "@id": "niiri:80d7881ec00396b0fee7ca1bafcd9813",
+      "@type": ["prov:Activity","nidm_NIDMResultsExport"],
       "rdfs:label": "NIDM-Results export"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:23f1bb1b8637a94e2590757111800672",
-      "agent": "niiri:ccd117e388c60ec9e834266da2abf102"
+      "activity_associated": "niiri:80d7881ec00396b0fee7ca1bafcd9813",
+      "agent": "niiri:d47620c0a904862a40d4a674f5975211"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:ae59b3f8b6a7ff8a2ff189b89c331a16",
-      "activity": "niiri:23f1bb1b8637a94e2590757111800672",
-      "atTime": "2016-12-07T16:09:07"
+      "entity_generated": "niiri:4e3cc7ffa6f685a0f71dbdd16e102f31",
+      "activity": "niiri:80d7881ec00396b0fee7ca1bafcd9813",
+      "atTime": "2017-04-19T12:18:37"
     }
   ]
 },
@@ -151,535 +151,535 @@
       "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
     }
   ],
-  "@id": "niiri:ae59b3f8b6a7ff8a2ff189b89c331a16",
+  "@id": "niiri:4e3cc7ffa6f685a0f71dbdd16e102f31",
   "@graph": [
     {
-      "@id": "niiri:5190808bd0433895ce27d1d15e3ecde5",
-      "@type": ["prov:Agent","src_SPM:","prov:SoftwareAgent"],
+      "@id": "niiri:bc2e77c470f6014f2a246955842052c9",
+      "@type": ["prov:Agent","src_SPM","prov:SoftwareAgent"],
       "rdfs:label": "SPM",
-      "nidm_softwareVersion:": {"@type": "xsd:string", "@value": "12.12.2"}
+      "nidm_softwareVersion": {"@type": "xsd:string", "@value": "12.6906"}
     },
     {
-      "@id": "niiri:00f2d1f7a8cf8c992c713523daff77a3",
-      "@type": ["prov:Entity","nidm_CoordinateSpace:"],
+      "@id": "niiri:334a58b04dd8169b2161a2e8b2629a0d",
+      "@type": ["prov:Entity","nidm_CoordinateSpace"],
       "rdfs:label": "Coordinate space 1",
-      "nidm_voxelToWorldMapping:": {"@type": "xsd:string", "@value": "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"},
-      "nidm_voxelUnits:": {"@type": "xsd:string", "@value": "[\"mm\", \"mm\", \"mm\"]"},
-      "nidm_voxelSize:": {"@type": "xsd:string", "@value": "[2, 2, 2]"},
-      "nidm_inWorldCoordinateSystem:": {"@id": "nidm_Ixi549CoordinateSystem:"},
-      "nidm_numberOfDimensions:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_dimensionsInVoxels:": {"@type": "xsd:string", "@value": "[79,95,79]"}
+      "nidm_voxelToWorldMapping": {"@type": "xsd:string", "@value": "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"},
+      "nidm_voxelUnits": {"@type": "xsd:string", "@value": "[\"mm\", \"mm\", \"mm\"]"},
+      "nidm_voxelSize": {"@type": "xsd:string", "@value": "[2, 2, 2]"},
+      "nidm_inWorldCoordinateSystem": {"@id": "nidm_Ixi549CoordinateSystem"},
+      "nidm_numberOfDimensions": {"@type": "xsd:int", "@value": "3"},
+      "nidm_dimensionsInVoxels": {"@type": "xsd:string", "@value": "[79,95,79]"}
     },
     {
-      "@id": "niiri:05e5a115fc55ac3b63212ea49766956c",
-      "@type": ["prov:Agent","nlx_Imaginginstrument:","nlx_Magneticresonanceimagingscanner:"],
+      "@id": "niiri:693e91ca0bc2876c97cc7ed9b8a8d2da",
+      "@type": ["prov:Agent","nlx_Imaginginstrument","nlx_Magneticresonanceimagingscanner"],
       "rdfs:label": "MRI Scanner"
     },
     {
-      "@id": "niiri:4da5785dfa10ede96c855801480dfe24",
+      "@id": "niiri:3db0690d0c427891151946b5624760be",
       "@type": ["prov:Agent","prov:Person"],
       "rdfs:label": "Person"
     },
     {
-      "@id": "niiri:a37e19eb8ab9ac7e711912f263377083",
-      "@type": ["prov:Entity","prov:Collection","nidm_Data:"],
+      "@id": "niiri:825930cb9cecdc2d026a61f46ae3ee93",
+      "@type": ["prov:Entity","prov:Collection","nidm_Data"],
       "rdfs:label": "Data",
-      "nidm_grandMeanScaling:": {"@type": "xsd:boolean", "@value": "false"},
-      "nidm_hasMRIProtocol:": {"@id": "nlx_FunctionalMRIprotocol:"}
+      "nidm_grandMeanScaling": {"@type": "xsd:boolean", "@value": "false"},
+      "nidm_hasMRIProtocol": {"@id": "nlx_FunctionalMRIprotocol"}
     },
     {
       "@type": "prov:Attribution",
-      "entity_attributed": "niiri:a37e19eb8ab9ac7e711912f263377083",
-      "agent": "niiri:05e5a115fc55ac3b63212ea49766956c"
+      "entity_attributed": "niiri:825930cb9cecdc2d026a61f46ae3ee93",
+      "agent": "niiri:693e91ca0bc2876c97cc7ed9b8a8d2da"
     },
     {
       "@type": "prov:Attribution",
-      "entity_attributed": "niiri:a37e19eb8ab9ac7e711912f263377083",
-      "agent": "niiri:4da5785dfa10ede96c855801480dfe24"
+      "entity_attributed": "niiri:825930cb9cecdc2d026a61f46ae3ee93",
+      "agent": "niiri:3db0690d0c427891151946b5624760be"
     },
     {
-      "@id": "niiri:a3d0e09632644d2fa25c309763419314",
-      "@type": ["prov:Entity","nidm_DesignMatrix:"],
+      "@id": "niiri:8832b574f38c1ef5b19a5698eedfd522",
+      "@type": ["prov:Entity","nidm_DesignMatrix"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "DesignMatrix.csv"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "DesignMatrix.csv"},
       "dct:format": {"@type": "xsd:string", "@value": "text/csv"},
-      "dc:description": {"@id": "niiri:5864366f6540205d2f87f4479cfc4946"},
+      "dc:description": {"@id": "niiri:4b5ac7e34167b063095b0c27f615214a"},
       "rdfs:label": "Design Matrix",
-      "nidm_regressorNames:": {"@type": "xsd:string", "@value": "[\"Basis_{1}\", \"Basis_{2}\", \"Basis_{3}\"]"}
+      "nidm_regressorNames": {"@type": "xsd:string", "@value": "[\"Basis_{1}\", \"Basis_{2}\", \"Basis_{3}\"]"}
     },
     {
-      "@id": "niiri:5864366f6540205d2f87f4479cfc4946",
+      "@id": "niiri:4b5ac7e34167b063095b0c27f615214a",
       "@type": ["prov:Entity","dctype:Image"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "DesignMatrix.png"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "DesignMatrix.png"},
       "dct:format": {"@type": "xsd:string", "@value": "image/png"}
     },
     {
-      "@id": "niiri:d0f19502a6ee54ef9ed7a784b385d191",
-      "@type": ["prov:Entity","nidm_ErrorModel:"],
-      "nidm_hasErrorDistribution:": {"@id": "obo_normaldistribution:"},
-      "nidm_hasErrorDependence:": {"@id": "obo_unstructuredcovariancestructure:"},
-      "nidm_dependenceMapWiseDependence:": {"@id": "nidm_ConstantParameter:"},
-      "nidm_errorVarianceHomogeneous:": {"@type": "xsd:boolean", "@value": "false"},
-      "nidm_varianceMapWiseDependence:": {"@id": "nidm_IndependentParameter:"}
+      "@id": "niiri:8a6c1f8a466f432d23696a22842630eb",
+      "@type": ["prov:Entity","nidm_ErrorModel"],
+      "nidm_hasErrorDistribution": {"@id": "obo_normaldistribution"},
+      "nidm_hasErrorDependence": {"@id": "obo_unstructuredcovariancestructure"},
+      "nidm_dependenceMapWiseDependence": {"@id": "nidm_ConstantParameter"},
+      "nidm_errorVarianceHomogeneous": {"@type": "xsd:boolean", "@value": "false"},
+      "nidm_varianceMapWiseDependence": {"@id": "nidm_IndependentParameter"}
     },
     {
-      "@id": "niiri:9a49034914ef603f12245b4b2b7d87ce",
-      "@type": ["prov:Activity","nidm_ModelParametersEstimation:"],
+      "@id": "niiri:abe46d73a8429cc97ae789be61c051b7",
+      "@type": ["prov:Activity","nidm_ModelParametersEstimation"],
       "rdfs:label": "Model parameters estimation",
-      "nidm_withEstimationMethod:": {"@id": "obo_generalizedleastsquaresestimation:"}
+      "nidm_withEstimationMethod": {"@id": "obo_generalizedleastsquaresestimation"}
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:9a49034914ef603f12245b4b2b7d87ce",
-      "agent": "niiri:5190808bd0433895ce27d1d15e3ecde5"
+      "activity_associated": "niiri:abe46d73a8429cc97ae789be61c051b7",
+      "agent": "niiri:bc2e77c470f6014f2a246955842052c9"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:9a49034914ef603f12245b4b2b7d87ce",
-      "entity": "niiri:a3d0e09632644d2fa25c309763419314"
+      "activity_using": "niiri:abe46d73a8429cc97ae789be61c051b7",
+      "entity": "niiri:8832b574f38c1ef5b19a5698eedfd522"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:9a49034914ef603f12245b4b2b7d87ce",
-      "entity": "niiri:a37e19eb8ab9ac7e711912f263377083"
+      "activity_using": "niiri:abe46d73a8429cc97ae789be61c051b7",
+      "entity": "niiri:825930cb9cecdc2d026a61f46ae3ee93"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:9a49034914ef603f12245b4b2b7d87ce",
-      "entity": "niiri:d0f19502a6ee54ef9ed7a784b385d191"
+      "activity_using": "niiri:abe46d73a8429cc97ae789be61c051b7",
+      "entity": "niiri:8a6c1f8a466f432d23696a22842630eb"
     },
     {
-      "@id": "niiri:40d21d093fb28877228a457af0198dbe",
-      "@type": ["prov:Entity","nidm_MaskMap:"],
+      "@id": "niiri:fc108568cd5e536825df64c6f1040101",
+      "@type": ["prov:Entity","nidm_MaskMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "Mask.nii.gz"},
-      "nidm_isUserDefined:": {"@type": "xsd:boolean", "@value": "false"},
+      "nidm_isUserDefined": {"@type": "xsd:boolean", "@value": "false"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "Mask.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Mask",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:00f2d1f7a8cf8c992c713523daff77a3"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:334a58b04dd8169b2161a2e8b2629a0d"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "09d331386156006058738700e3d2402ca557e5ba6f5742af2974eb4c03f0514a5529859c620fe5167c0cfed26e846d21ffd2611e5f479b2d167beec168e978bd"}
     },
     {
-      "@id": "niiri:efbd22615b6a3126f4265c4e8db4f65f",
-      "@type": ["prov:Entity","nidm_MaskMap:"],
+      "@id": "niiri:e09fd9499ed59ea115caabdbd4ec218b",
+      "@type": ["prov:Entity","nidm_MaskMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "mask.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "609620056d81292b36b9f1dbbe3d02023728da7cab8f4ca3bf953dd1e5256f1799c5eb65663aa4e8b7c5cdf3cbb521708aaad4eb4cc8182c1e5280a51387678e"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:40d21d093fb28877228a457af0198dbe",
-      "entity": "niiri:efbd22615b6a3126f4265c4e8db4f65f"
+      "entity_derived": "niiri:fc108568cd5e536825df64c6f1040101",
+      "entity": "niiri:e09fd9499ed59ea115caabdbd4ec218b"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:40d21d093fb28877228a457af0198dbe",
-      "activity": "niiri:9a49034914ef603f12245b4b2b7d87ce"
+      "entity_generated": "niiri:fc108568cd5e536825df64c6f1040101",
+      "activity": "niiri:abe46d73a8429cc97ae789be61c051b7"
     },
     {
-      "@id": "niiri:e02454834944d6369e6118b7e6925f76",
-      "@type": ["prov:Entity","nidm_GrandMeanMap:"],
+      "@id": "niiri:8b44eef148a4672df3b868888c1c1c71",
+      "@type": ["prov:Entity","nidm_GrandMeanMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "GrandMean.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "GrandMean.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Grand Mean Map",
-      "nidm_maskedMedian:": {"@type": "xsd:float", "@value": "0.0511472336947918"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:00f2d1f7a8cf8c992c713523daff77a3"},
+      "nidm_maskedMedian": {"@type": "xsd:float", "@value": "0.0511472336947918"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:334a58b04dd8169b2161a2e8b2629a0d"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "c111e018cb1cdd0d1318256c5dcb2e0eaaa627bc540216148527056b2969939119310599fb527dfb187ae9ee422dba8e543bf5c190b9f935d828a3a4dab2ebbc"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:e02454834944d6369e6118b7e6925f76",
-      "activity": "niiri:9a49034914ef603f12245b4b2b7d87ce"
+      "entity_generated": "niiri:8b44eef148a4672df3b868888c1c1c71",
+      "activity": "niiri:abe46d73a8429cc97ae789be61c051b7"
     },
     {
-      "@id": "niiri:c0af1f0d1f8fef01cae72507881d86fb",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:69099a5655e274a35cf8497561c281d6",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0001.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0001.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 1",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:00f2d1f7a8cf8c992c713523daff77a3"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:334a58b04dd8169b2161a2e8b2629a0d"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "b89a0120673d47d4a2e8ca19a9a69c37d4e514e795580ec064d6c246a23e9a7d5737c49cceefe6de12b67d3d722b18dc74ff194812fe4c6c3fd9145bd76a9a2f"}
     },
     {
-      "@id": "niiri:f4f597714134c209bf3d5a0c6c929e28",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:08dd8d7791f4ea3b42d7928f3978b481",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0001.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "b89a0120673d47d4a2e8ca19a9a69c37d4e514e795580ec064d6c246a23e9a7d5737c49cceefe6de12b67d3d722b18dc74ff194812fe4c6c3fd9145bd76a9a2f"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c0af1f0d1f8fef01cae72507881d86fb",
-      "entity": "niiri:f4f597714134c209bf3d5a0c6c929e28"
+      "entity_derived": "niiri:69099a5655e274a35cf8497561c281d6",
+      "entity": "niiri:08dd8d7791f4ea3b42d7928f3978b481"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:c0af1f0d1f8fef01cae72507881d86fb",
-      "activity": "niiri:9a49034914ef603f12245b4b2b7d87ce"
+      "entity_generated": "niiri:69099a5655e274a35cf8497561c281d6",
+      "activity": "niiri:abe46d73a8429cc97ae789be61c051b7"
     },
     {
-      "@id": "niiri:eb153bc18088eeb114d7c02d8398edbd",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:994815a1deaaea1d8a916499a4369008",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0002.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0002.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 2",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:00f2d1f7a8cf8c992c713523daff77a3"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:334a58b04dd8169b2161a2e8b2629a0d"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "5ce29a8c6d060417d3246febff5596241f2e6783c1d9761306cf762057696493f53d59a40dcd6821ac1ecf6144669d80b6560bb234e4c5455d651fc4c0024978"}
     },
     {
-      "@id": "niiri:2b66e604e99057ea8a531c4cdcb8f559",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:adc38d535f009898b8597918fea3e74b",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0002.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "5ce29a8c6d060417d3246febff5596241f2e6783c1d9761306cf762057696493f53d59a40dcd6821ac1ecf6144669d80b6560bb234e4c5455d651fc4c0024978"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:eb153bc18088eeb114d7c02d8398edbd",
-      "entity": "niiri:2b66e604e99057ea8a531c4cdcb8f559"
+      "entity_derived": "niiri:994815a1deaaea1d8a916499a4369008",
+      "entity": "niiri:adc38d535f009898b8597918fea3e74b"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:eb153bc18088eeb114d7c02d8398edbd",
-      "activity": "niiri:9a49034914ef603f12245b4b2b7d87ce"
+      "entity_generated": "niiri:994815a1deaaea1d8a916499a4369008",
+      "activity": "niiri:abe46d73a8429cc97ae789be61c051b7"
     },
     {
-      "@id": "niiri:38398a8ad158ea32ba513829f1560b8e",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:438a1a1f15d3ed6c053ad0a47535b905",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0003.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0003.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 3",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:00f2d1f7a8cf8c992c713523daff77a3"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:334a58b04dd8169b2161a2e8b2629a0d"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "d8c80bfb0cd41ceae8da00cc1b5f7a39d0c186f8a1308852e0c4d4ecf2143a46153b6d3998bcdc4a41a36a51e52eb5154a5c871a0d326d43cf02834aa7a2802a"}
     },
     {
-      "@id": "niiri:6964d146ea43c1d5e55d5afc8fc89ae3",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:fc2fc60ae3a1a2a377ce868dcfe7682c",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0003.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "d8c80bfb0cd41ceae8da00cc1b5f7a39d0c186f8a1308852e0c4d4ecf2143a46153b6d3998bcdc4a41a36a51e52eb5154a5c871a0d326d43cf02834aa7a2802a"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:38398a8ad158ea32ba513829f1560b8e",
-      "entity": "niiri:6964d146ea43c1d5e55d5afc8fc89ae3"
+      "entity_derived": "niiri:438a1a1f15d3ed6c053ad0a47535b905",
+      "entity": "niiri:fc2fc60ae3a1a2a377ce868dcfe7682c"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:38398a8ad158ea32ba513829f1560b8e",
-      "activity": "niiri:9a49034914ef603f12245b4b2b7d87ce"
+      "entity_generated": "niiri:438a1a1f15d3ed6c053ad0a47535b905",
+      "activity": "niiri:abe46d73a8429cc97ae789be61c051b7"
     },
     {
-      "@id": "niiri:a297bf375d9539defdbc8540b2e4d318",
-      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap:"],
+      "@id": "niiri:94876fb7a2c046b431df17692c760d6e",
+      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ResidualMeanSquares.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ResidualMeanSquares.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Residual Mean Squares Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:00f2d1f7a8cf8c992c713523daff77a3"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:334a58b04dd8169b2161a2e8b2629a0d"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "8dd13096358e8e9e95b0a11c6c59092dbb5cfc3d586ce9a9606ecaaa7c3f48b5fceee1ff6cf6c356b754b3990b344b66b37058402579c4c37c488fd942540d48"}
     },
     {
-      "@id": "niiri:484b1a6beac16aa9ee76c98da6c8ed09",
-      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap:"],
+      "@id": "niiri:b88f5c084cf11202884b4336bb357ace",
+      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "ResMS.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "b3ead22cbbb0b4e40e397cd74f954be9e4de46bbf7aa994f35344329aad57c551fd72827fe1aae6287c0bf37ca1afbaea22993e79b87166e1a921b9e977c2868"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a297bf375d9539defdbc8540b2e4d318",
-      "entity": "niiri:484b1a6beac16aa9ee76c98da6c8ed09"
+      "entity_derived": "niiri:94876fb7a2c046b431df17692c760d6e",
+      "entity": "niiri:b88f5c084cf11202884b4336bb357ace"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:a297bf375d9539defdbc8540b2e4d318",
-      "activity": "niiri:9a49034914ef603f12245b4b2b7d87ce"
+      "entity_generated": "niiri:94876fb7a2c046b431df17692c760d6e",
+      "activity": "niiri:abe46d73a8429cc97ae789be61c051b7"
     },
     {
-      "@id": "niiri:de09763e711605a90fbefccccad90faf",
-      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap:"],
+      "@id": "niiri:96116055802375625dcf702ee01581fe",
+      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ReselsPerVoxel.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ReselsPerVoxel.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Resels per Voxel Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:00f2d1f7a8cf8c992c713523daff77a3"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:334a58b04dd8169b2161a2e8b2629a0d"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "9e6bd1546a438b4313b95dfeb307638416e999e4c3596b6c3aa8f282fda2df6dae8e1db498dca3dc6717d70138f68a00101ff95a2f5e32e7a1c8074a69f17381"}
     },
     {
-      "@id": "niiri:505cf442539a5d5327913a5d65e5bc00",
-      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap:"],
+      "@id": "niiri:1328ce3e8c83d35913bbecbd452290df",
+      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "RPV.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "f8c6e2cbdd2c099fe1cdfa7f20c2d735366627a183b06e229d82b06ea4fa189ca42d6fdbbd69ca6504f1865b00f211b940f19f1c2c8df3b424f4eedea9775bb8"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:de09763e711605a90fbefccccad90faf",
-      "entity": "niiri:505cf442539a5d5327913a5d65e5bc00"
+      "entity_derived": "niiri:96116055802375625dcf702ee01581fe",
+      "entity": "niiri:1328ce3e8c83d35913bbecbd452290df"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:de09763e711605a90fbefccccad90faf",
-      "activity": "niiri:9a49034914ef603f12245b4b2b7d87ce"
+      "entity_generated": "niiri:96116055802375625dcf702ee01581fe",
+      "activity": "niiri:abe46d73a8429cc97ae789be61c051b7"
     },
     {
-      "@id": "niiri:f0280f84ac099eac2ffeee96a84304d4",
-      "@type": ["prov:Entity","obo_contrastweightmatrix:"],
-      "nidm_statisticType:": {"@id": "obo_Fstatistic:"},
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "Average effect of condition"},
+      "@id": "niiri:adbd624b50ba693b3e14fd648e13ebef",
+      "@type": ["prov:Entity","obo_contrastweightmatrix"],
+      "nidm_statisticType": {"@id": "obo_Fstatistic"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "Average effect of condition"},
       "rdfs:label": "Contrast: Average effect of condition",
       "prov:value": {"@type": "xsd:string", "@value": "[1, 1, 1]"}
     },
     {
-      "@id": "niiri:8bcee3a21f81e2a43338bf0ee897788a",
-      "@type": ["prov:Activity","nidm_ContrastEstimation:"],
+      "@id": "niiri:2456cdab46e0eb6c27cca0f6dd52cb86",
+      "@type": ["prov:Activity","nidm_ContrastEstimation"],
       "rdfs:label": "Contrast estimation"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:8bcee3a21f81e2a43338bf0ee897788a",
-      "agent": "niiri:5190808bd0433895ce27d1d15e3ecde5"
+      "activity_associated": "niiri:2456cdab46e0eb6c27cca0f6dd52cb86",
+      "agent": "niiri:bc2e77c470f6014f2a246955842052c9"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:8bcee3a21f81e2a43338bf0ee897788a",
-      "entity": "niiri:40d21d093fb28877228a457af0198dbe"
+      "activity_using": "niiri:2456cdab46e0eb6c27cca0f6dd52cb86",
+      "entity": "niiri:fc108568cd5e536825df64c6f1040101"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:8bcee3a21f81e2a43338bf0ee897788a",
-      "entity": "niiri:a297bf375d9539defdbc8540b2e4d318"
+      "activity_using": "niiri:2456cdab46e0eb6c27cca0f6dd52cb86",
+      "entity": "niiri:94876fb7a2c046b431df17692c760d6e"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:8bcee3a21f81e2a43338bf0ee897788a",
-      "entity": "niiri:a3d0e09632644d2fa25c309763419314"
+      "activity_using": "niiri:2456cdab46e0eb6c27cca0f6dd52cb86",
+      "entity": "niiri:8832b574f38c1ef5b19a5698eedfd522"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:8bcee3a21f81e2a43338bf0ee897788a",
-      "entity": "niiri:f0280f84ac099eac2ffeee96a84304d4"
+      "activity_using": "niiri:2456cdab46e0eb6c27cca0f6dd52cb86",
+      "entity": "niiri:adbd624b50ba693b3e14fd648e13ebef"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:8bcee3a21f81e2a43338bf0ee897788a",
-      "entity": "niiri:c0af1f0d1f8fef01cae72507881d86fb"
+      "activity_using": "niiri:2456cdab46e0eb6c27cca0f6dd52cb86",
+      "entity": "niiri:69099a5655e274a35cf8497561c281d6"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:8bcee3a21f81e2a43338bf0ee897788a",
-      "entity": "niiri:eb153bc18088eeb114d7c02d8398edbd"
+      "activity_using": "niiri:2456cdab46e0eb6c27cca0f6dd52cb86",
+      "entity": "niiri:994815a1deaaea1d8a916499a4369008"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:8bcee3a21f81e2a43338bf0ee897788a",
-      "entity": "niiri:38398a8ad158ea32ba513829f1560b8e"
+      "activity_using": "niiri:2456cdab46e0eb6c27cca0f6dd52cb86",
+      "entity": "niiri:438a1a1f15d3ed6c053ad0a47535b905"
     },
     {
-      "@id": "niiri:293542c9d6286efb6ab3045a0df4c7fa",
-      "@type": ["prov:Entity","nidm_StatisticMap:"],
+      "@id": "niiri:9ca097a864a89e695f5a0ade9c7a2592",
+      "@type": ["prov:Entity","nidm_StatisticMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "FStatistic.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "FStatistic.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "F-Statistic Map: Average effect of condition",
-      "nidm_statisticType:": {"@id": "obo_Fstatistic:"},
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "Average effect of condition"},
-      "nidm_errorDegreesOfFreedom:": {"@type": "xsd:float", "@value": "39"},
-      "nidm_effectDegreesOfFreedom:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:00f2d1f7a8cf8c992c713523daff77a3"},
+      "nidm_statisticType": {"@id": "obo_Fstatistic"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "Average effect of condition"},
+      "nidm_errorDegreesOfFreedom": {"@type": "xsd:float", "@value": "39"},
+      "nidm_effectDegreesOfFreedom": {"@type": "xsd:float", "@value": "1"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:334a58b04dd8169b2161a2e8b2629a0d"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "531843c41e0edb06002746841a3cdcaf0aa3c319781bcbedc84f6a427e154303731eaf31b1f9a403d6ecdb86716186b69dd471787f683aa7dec5f29f26bc6960"}
     },
     {
-      "@id": "niiri:72d0db34ef943b13827b9c0881fd280b",
-      "@type": ["prov:Entity","nidm_StatisticMap:"],
+      "@id": "niiri:1300030726b15941203796dca8bcf83c",
+      "@type": ["prov:Entity","nidm_StatisticMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "spmF_0001.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "274c247097322961825fc7761087f9352df4af7540ca42c3cfd4a35adf1249b0b72e793d97bdc1051daadce0d855a067ab6d091ed79d9b99a92180586cd65762"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:293542c9d6286efb6ab3045a0df4c7fa",
-      "entity": "niiri:72d0db34ef943b13827b9c0881fd280b"
+      "entity_derived": "niiri:9ca097a864a89e695f5a0ade9c7a2592",
+      "entity": "niiri:1300030726b15941203796dca8bcf83c"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:293542c9d6286efb6ab3045a0df4c7fa",
-      "activity": "niiri:8bcee3a21f81e2a43338bf0ee897788a"
+      "entity_generated": "niiri:9ca097a864a89e695f5a0ade9c7a2592",
+      "activity": "niiri:2456cdab46e0eb6c27cca0f6dd52cb86"
     },
     {
-      "@id": "niiri:b9b6e9aa5774df7d7f9c348203cf957b",
-      "@type": ["prov:Entity","nidm_ContrastExplainedMeanSquareMap:"],
+      "@id": "niiri:a72a81446159f6a67c6f27a5da80101a",
+      "@type": ["prov:Entity","nidm_ContrastExplainedMeanSquareMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ContrastExplainedMeanSquare.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ContrastExplainedMeanSquare.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Contrast Explained Mean Square Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:00f2d1f7a8cf8c992c713523daff77a3"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:334a58b04dd8169b2161a2e8b2629a0d"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "367a36ade072cb98530f28763f9b42a7b408eb21636c86c87161b4e3c6def23180be03e7c730f0591f675bcf6d9f9f9e290b2fa98a788e5b44df1683ce024d7a"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:b9b6e9aa5774df7d7f9c348203cf957b",
-      "activity": "niiri:8bcee3a21f81e2a43338bf0ee897788a"
+      "entity_generated": "niiri:a72a81446159f6a67c6f27a5da80101a",
+      "activity": "niiri:2456cdab46e0eb6c27cca0f6dd52cb86"
     },
     {
-      "@id": "niiri:69c646be2c3c240aac74d26c00a45790",
-      "@type": ["prov:Entity","nidm_HeightThreshold:","nidm_PValueUncorrected:"],
-      "rdfs:label": "Height Threshold: p<0.001000 (unc.)",
+      "@id": "niiri:6e1bb9294b0707edbbe5ae21cfbadf07",
+      "@type": ["prov:Entity","nidm_HeightThreshold","nidm_PValueUncorrected"],
+      "rdfs:label": "Height Threshold: p<0.001 (unc.)",
       "prov:value": {"@type": "xsd:float", "@value": "0.000999500201896764"},
-      "nidm_equivalentThreshold:": [{"@id": "niiri:d7762f130ac3c03acc3d5f9ce19ad69e"},{"@id": "niiri:1348d4eea57e7b30092ebb92e102a60a"}]
+      "nidm_equivalentThreshold": [{"@id": "niiri:20fda3ccb70028555e7275aefc3215b7"},{"@id": "niiri:ad55acc7ff668917e187d5b8b71ef0fe"}]
     },
     {
-      "@id": "niiri:d7762f130ac3c03acc3d5f9ce19ad69e",
-      "@type": ["prov:Entity","nidm_HeightThreshold:","obo_statistic:"],
-      "rdfs:label": "Height Threshold",
+      "@id": "niiri:20fda3ccb70028555e7275aefc3215b7",
+      "@type": ["prov:Entity","nidm_HeightThreshold","obo_statistic"],
+      "rdfs:label": "Height Threshold: F=12.660218)",
       "prov:value": {"@type": "xsd:float", "@value": "12.6602184255263"}
     },
     {
-      "@id": "niiri:1348d4eea57e7b30092ebb92e102a60a",
-      "@type": ["prov:Entity","nidm_HeightThreshold:","obo_FWERadjustedpvalue:"],
-      "rdfs:label": "Height Threshold",
+      "@id": "niiri:ad55acc7ff668917e187d5b8b71ef0fe",
+      "@type": ["prov:Entity","nidm_HeightThreshold","obo_FWERadjustedpvalue"],
+      "rdfs:label": "Height Threshold: p<1.000000 (FWE)",
       "prov:value": {"@type": "xsd:float", "@value": "0.999999999999997"}
     },
     {
-      "@id": "niiri:b3f0880709cebff161598fc4fff7f8a9",
-      "@type": ["prov:Entity","nidm_ExtentThreshold:","obo_statistic:"],
+      "@id": "niiri:636d204ec94986da6b6ce98445053011",
+      "@type": ["prov:Entity","nidm_ExtentThreshold","obo_statistic"],
       "rdfs:label": "Extent Threshold: k>=0",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "0"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0"},
-      "nidm_equivalentThreshold:": [{"@id": "niiri:c64039e3021e29c8c7d38fb99992c68d"},{"@id": "niiri:e390cc8d251f413995c1456a52dd93c2"}]
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "0"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0"},
+      "nidm_equivalentThreshold": [{"@id": "niiri:a54887ecc715604dd6455a6477b0a70e"},{"@id": "niiri:6488aa4615162148eb510043add8322a"}]
     },
     {
-      "@id": "niiri:c64039e3021e29c8c7d38fb99992c68d",
-      "@type": ["prov:Entity","nidm_ExtentThreshold:","obo_FWERadjustedpvalue:"],
+      "@id": "niiri:a54887ecc715604dd6455a6477b0a70e",
+      "@type": ["prov:Entity","nidm_ExtentThreshold","obo_FWERadjustedpvalue"],
       "rdfs:label": "Extent Threshold",
       "prov:value": {"@type": "xsd:float", "@value": "1"}
     },
     {
-      "@id": "niiri:e390cc8d251f413995c1456a52dd93c2",
-      "@type": ["prov:Entity","nidm_ExtentThreshold:","nidm_PValueUncorrected:"],
+      "@id": "niiri:6488aa4615162148eb510043add8322a",
+      "@type": ["prov:Entity","nidm_ExtentThreshold","nidm_PValueUncorrected"],
       "rdfs:label": "Extent Threshold",
       "prov:value": {"@type": "xsd:float", "@value": "1"}
     },
     {
-      "@id": "niiri:230d82bcf048e9a2c15000cb7d1a3b46",
-      "@type": ["prov:Entity","nidm_PeakDefinitionCriteria:"],
+      "@id": "niiri:3dd5d16b52227865dddd8a70d5265d53",
+      "@type": ["prov:Entity","nidm_PeakDefinitionCriteria"],
       "rdfs:label": "Peak Definition Criteria",
-      "nidm_maxNumberOfPeaksPerCluster:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_minDistanceBetweenPeaks:": {"@type": "xsd:float", "@value": "8"}
+      "nidm_maxNumberOfPeaksPerCluster": {"@type": "xsd:int", "@value": "3"},
+      "nidm_minDistanceBetweenPeaks": {"@type": "xsd:float", "@value": "8"}
     },
     {
-      "@id": "niiri:87caeaa704d6182c6fed9fe2e520169d",
-      "@type": ["prov:Entity","nidm_ClusterDefinitionCriteria:"],
+      "@id": "niiri:029c2dcb7254e8c7af93bf485d809706",
+      "@type": ["prov:Entity","nidm_ClusterDefinitionCriteria"],
       "rdfs:label": "Cluster Connectivity Criterion: 18",
-      "nidm_hasConnectivityCriterion:": {"@id": "nidm_voxel18connected:"}
+      "nidm_hasConnectivityCriterion": {"@id": "nidm_voxel18connected"}
     },
     {
-      "@id": "niiri:bf56eb4a5b14dd758d63d869c739abe4",
-      "@type": ["prov:Activity","nidm_Inference:"],
-      "nidm_hasAlternativeHypothesis:": {"@id": "nidm_OneTailedTest:"},
+      "@id": "niiri:e5a916f24cf27604386c2c32a5bf702b",
+      "@type": ["prov:Activity","nidm_Inference"],
+      "nidm_hasAlternativeHypothesis": {"@id": "nidm_OneTailedTest"},
       "rdfs:label": "Inference"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:bf56eb4a5b14dd758d63d869c739abe4",
-      "agent": "niiri:5190808bd0433895ce27d1d15e3ecde5"
+      "activity_associated": "niiri:e5a916f24cf27604386c2c32a5bf702b",
+      "agent": "niiri:bc2e77c470f6014f2a246955842052c9"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:bf56eb4a5b14dd758d63d869c739abe4",
-      "entity": "niiri:69c646be2c3c240aac74d26c00a45790"
+      "activity_using": "niiri:e5a916f24cf27604386c2c32a5bf702b",
+      "entity": "niiri:6e1bb9294b0707edbbe5ae21cfbadf07"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:bf56eb4a5b14dd758d63d869c739abe4",
-      "entity": "niiri:b3f0880709cebff161598fc4fff7f8a9"
+      "activity_using": "niiri:e5a916f24cf27604386c2c32a5bf702b",
+      "entity": "niiri:636d204ec94986da6b6ce98445053011"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:bf56eb4a5b14dd758d63d869c739abe4",
-      "entity": "niiri:293542c9d6286efb6ab3045a0df4c7fa"
+      "activity_using": "niiri:e5a916f24cf27604386c2c32a5bf702b",
+      "entity": "niiri:9ca097a864a89e695f5a0ade9c7a2592"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:bf56eb4a5b14dd758d63d869c739abe4",
-      "entity": "niiri:de09763e711605a90fbefccccad90faf"
+      "activity_using": "niiri:e5a916f24cf27604386c2c32a5bf702b",
+      "entity": "niiri:96116055802375625dcf702ee01581fe"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:bf56eb4a5b14dd758d63d869c739abe4",
-      "entity": "niiri:40d21d093fb28877228a457af0198dbe"
+      "activity_using": "niiri:e5a916f24cf27604386c2c32a5bf702b",
+      "entity": "niiri:fc108568cd5e536825df64c6f1040101"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:bf56eb4a5b14dd758d63d869c739abe4",
-      "entity": "niiri:230d82bcf048e9a2c15000cb7d1a3b46"
+      "activity_using": "niiri:e5a916f24cf27604386c2c32a5bf702b",
+      "entity": "niiri:3dd5d16b52227865dddd8a70d5265d53"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:bf56eb4a5b14dd758d63d869c739abe4",
-      "entity": "niiri:87caeaa704d6182c6fed9fe2e520169d"
+      "activity_using": "niiri:e5a916f24cf27604386c2c32a5bf702b",
+      "entity": "niiri:029c2dcb7254e8c7af93bf485d809706"
     },
     {
-      "@id": "niiri:357faa323774b23aea02c9b7c4f4f7eb",
-      "@type": ["prov:Entity","nidm_SearchSpaceMaskMap:"],
+      "@id": "niiri:db110fb8702367464d0832795a39cbbb",
+      "@type": ["prov:Entity","nidm_SearchSpaceMaskMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "SearchSpaceMask.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "SearchSpaceMask.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Search Space Mask Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:00f2d1f7a8cf8c992c713523daff77a3"},
-      "nidm_searchVolumeInVoxels:": {"@type": "xsd:int", "@value": "167222"},
-      "nidm_searchVolumeInUnits:": {"@type": "xsd:float", "@value": "1337776"},
-      "nidm_reselSizeInVoxels:": {"@type": "xsd:float", "@value": "68.5679161280351"},
-      "nidm_searchVolumeInResels:": {"@type": "xsd:float", "@value": "2244.24204044145"},
-      "spm_searchVolumeReselsGeometry:": {"@type": "xsd:string", "@value": "[5, 56.1858858382816, 782.552337179563, 2244.24204044145]"},
-      "nidm_noiseFWHMInVoxels:": {"@type": "xsd:string", "@value": "[4.09364449471869, 4.06742111213816, 4.11805068781302]"},
-      "nidm_noiseFWHMInUnits:": {"@type": "xsd:string", "@value": "[8.18728898943738, 8.13484222427633, 8.23610137562605]"},
-      "nidm_randomFieldStationarity:": {"@type": "xsd:boolean", "@value": "true"},
-      "nidm_expectedNumberOfVoxelsPerCluster:": {"@type": "xsd:float", "@value": "5.40031514302336"},
-      "nidm_expectedNumberOfClusters:": {"@type": "xsd:float", "@value": "33.3078455926716"},
-      "nidm_heightCriticalThresholdFWE05:": {"@type": "xsd:float", "@value": "37.9092455175785"},
-      "nidm_heightCriticalThresholdFDR05:": {"@type": "xsd:float", "@value": "Inf"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:334a58b04dd8169b2161a2e8b2629a0d"},
+      "nidm_searchVolumeInVoxels": {"@type": "xsd:int", "@value": "167222"},
+      "nidm_searchVolumeInUnits": {"@type": "xsd:float", "@value": "1337776"},
+      "nidm_reselSizeInVoxels": {"@type": "xsd:float", "@value": "68.5679161280351"},
+      "nidm_searchVolumeInResels": {"@type": "xsd:float", "@value": "2244.24204044145"},
+      "spm_searchVolumeReselsGeometry": {"@type": "xsd:string", "@value": "[5, 56.1858858382816, 782.552337179563, 2244.24204044145]"},
+      "nidm_noiseFWHMInVoxels": {"@type": "xsd:string", "@value": "[4.09364449471869, 4.06742111213816, 4.11805068781302]"},
+      "nidm_noiseFWHMInUnits": {"@type": "xsd:string", "@value": "[8.18728898943738, 8.13484222427633, 8.23610137562605]"},
+      "nidm_randomFieldStationarity": {"@type": "xsd:boolean", "@value": "true"},
+      "nidm_expectedNumberOfVoxelsPerCluster": {"@type": "xsd:float", "@value": "5.40031514302336"},
+      "nidm_expectedNumberOfClusters": {"@type": "xsd:float", "@value": "33.3078455926716"},
+      "nidm_heightCriticalThresholdFWE05": {"@type": "xsd:float", "@value": "37.9092455175785"},
+      "nidm_heightCriticalThresholdFDR05": {"@type": "xsd:float", "@value": "Inf"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "09d331386156006058738700e3d2402ca557e5ba6f5742af2974eb4c03f0514a5529859c620fe5167c0cfed26e846d21ffd2611e5f479b2d167beec168e978bd"},
-      "spm_smallestSignificantClusterSizeInVoxelsFWE05:": {"@type": "xsd:int", "@value": "99"},
-      "spm_smallestSignificantClusterSizeInVoxelsFDR05:": {"@type": "xsd:int", "@value": "57"}
+      "spm_smallestSignificantClusterSizeInVoxelsFWE05": {"@type": "xsd:int", "@value": "99"},
+      "spm_smallestSignificantClusterSizeInVoxelsFDR05": {"@type": "xsd:int", "@value": "57"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:357faa323774b23aea02c9b7c4f4f7eb",
-      "activity": "niiri:bf56eb4a5b14dd758d63d869c739abe4"
+      "entity_generated": "niiri:db110fb8702367464d0832795a39cbbb",
+      "activity": "niiri:e5a916f24cf27604386c2c32a5bf702b"
     },
     {
-      "@id": "niiri:9f1620f32dc4659d77d42ff2a65c79af",
-      "@type": ["prov:Entity","nidm_ExcursionSetMap:"],
+      "@id": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb",
+      "@type": ["prov:Entity","nidm_ExcursionSetMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ExcursionSet.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ExcursionSet.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Excursion Set Map",
-      "nidm_numberOfSupraThresholdClusters:": {"@type": "xsd:int", "@value": "71"},
-      "nidm_pValue:": {"@type": "xsd:float", "@value": "9.36073596413678e-09"},
-      "nidm_hasClusterLabelsMap:": {"@id": "niiri:323afcdadc938b84ca5418963487ffad"},
-      "nidm_hasMaximumIntensityProjection:": {"@id": "niiri:58f2c20c893ac140b40d74e45728d199"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:00f2d1f7a8cf8c992c713523daff77a3"},
+      "nidm_numberOfSupraThresholdClusters": {"@type": "xsd:int", "@value": "71"},
+      "nidm_pValue": {"@type": "xsd:float", "@value": "9.36073596413678e-09"},
+      "nidm_hasClusterLabelsMap": {"@id": "niiri:7be8ea19c7603988ed0c6856e309f76b"},
+      "nidm_hasMaximumIntensityProjection": {"@id": "niiri:a5f4d5f5d9604b6647154be60baf72d4"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:334a58b04dd8169b2161a2e8b2629a0d"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "3cb7cb94a15ceea4d3b829f354f40eaeb85863016ba6e236003b548b7cf18ceaa22541bd90454f190ee0e374f2958f6130c7eb1bf4c55e75bdad693646d71006"}
     },
     {
-      "@id": "niiri:323afcdadc938b84ca5418963487ffad",
-      "@type": ["prov:Entity","nidm_ClusterLabelsMap:"],
+      "@id": "niiri:7be8ea19c7603988ed0c6856e309f76b",
+      "@type": ["prov:Entity","nidm_ClusterLabelsMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ClusterLabels.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ClusterLabels.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Cluster Labels Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:00f2d1f7a8cf8c992c713523daff77a3"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:334a58b04dd8169b2161a2e8b2629a0d"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "403459cc812b3927db0db6d5a3f64b79acf6774fc116e11ed6ecf56ec229afd8812650c060fdf10c2ecdab534ffadb67f4650178e12b65ccea6220e0ed951cb2"}
     },
     {
-      "@id": "niiri:58f2c20c893ac140b40d74e45728d199",
+      "@id": "niiri:a5f4d5f5d9604b6647154be60baf72d4",
       "@type": ["prov:Entity","dctype:Image"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "MaximumIntensityProjection.png"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "MaximumIntensityProjection.png"},
@@ -687,2816 +687,2816 @@
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:9f1620f32dc4659d77d42ff2a65c79af",
-      "activity": "niiri:bf56eb4a5b14dd758d63d869c739abe4"
+      "entity_generated": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb",
+      "activity": "niiri:e5a916f24cf27604386c2c32a5bf702b"
     },
     {
-      "@id": "niiri:2614b44f75a99f07f4673d4500fe47ed",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:0502f21f886d74eb5a46cc0e98d99ebd",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0001",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "64"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.933381144039647"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00186515164019167"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.060233823286733"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0331064416134022"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "1"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "64"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.933381144039647"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00186515164019167"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.060233823286733"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0331064416134022"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "1"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2614b44f75a99f07f4673d4500fe47ed",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:0502f21f886d74eb5a46cc0e98d99ebd",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:26dc30d77d0a0c23d6913e69266e279e",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:0599785d82edc2bd01edfc956f648d55",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0002",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "139"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "2.02718717221111"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.6469154891926e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.000881242002104266"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00187930999732674"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "2"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "139"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "2.02718717221111"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.6469154891926e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.000881242002104266"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00187930999732674"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "2"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:26dc30d77d0a0c23d6913e69266e279e",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:0599785d82edc2bd01edfc956f648d55",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:5819cfbfd916831f2b9b46c44761a13b",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:503c99586f814910b6b80009bf62943c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0003",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "99"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.44382395718633"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000223613862913789"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00742042768591067"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00529219475562633"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "3"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "99"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.44382395718633"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000223613862913789"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00742042768591067"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00529219475562633"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "3"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5819cfbfd916831f2b9b46c44761a13b",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:503c99586f814910b6b80009bf62943c",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:18222312b25450890c50a38e087b5fca",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:018a24899160bba0361882009e28cdf7",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0004",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "100"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.45840803756195"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00021132818538256"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00701417162859297"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00529219475562633"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "4"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "100"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.45840803756195"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00021132818538256"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00701417162859297"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00529219475562633"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "4"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:18222312b25450890c50a38e087b5fca",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:018a24899160bba0361882009e28cdf7",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:fd0ea64d092adb2dc6aef53bb390dd47",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:33d37aeafd7dbe4545a7c3723ffec290",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0005",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "41"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.597947295400399"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00937054756605333"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.26810099909693"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0831636096487233"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "5"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "41"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.597947295400399"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00937054756605333"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.26810099909693"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0831636096487233"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "5"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:fd0ea64d092adb2dc6aef53bb390dd47",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:33d37aeafd7dbe4545a7c3723ffec290",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:086741e220f142a5ba7d24c166640134",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c67e26c71245447102997061bd7b4400",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0006",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "42"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.612531375776019"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00868796710659031"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.251270468559567"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0831636096487233"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "6"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "42"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.612531375776019"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00868796710659031"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.251270468559567"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0831636096487233"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "6"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:086741e220f142a5ba7d24c166640134",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:c67e26c71245447102997061bd7b4400",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:e2190d23e52313b345dec17a936b13ac",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:21c6b4d93e2f7d826c174fe1b99df534",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0007",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "27"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.393770170141726"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.02915927403888"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.621383930767395"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.159254496673883"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "7"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "27"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.393770170141726"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.02915927403888"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.621383930767395"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.159254496673883"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "7"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e2190d23e52313b345dec17a936b13ac",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:21c6b4d93e2f7d826c174fe1b99df534",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:26ab6f532ee67acbd905e1a64f80b9d8",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:6da0c60471d915bb0e46bffadee4d55a",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0008",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "57"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.831292581410311"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00297536918873803"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0943507032156397"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.04225024248008"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "8"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "57"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.831292581410311"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00297536918873803"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0943507032156397"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.04225024248008"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "8"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:26ab6f532ee67acbd905e1a64f80b9d8",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:6da0c60471d915bb0e46bffadee4d55a",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:5107e0fdba262447669255100a242c1c",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:a35a0c7d262276e543a1e97fbbe3cdc8",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0009",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "33"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.481274652395443"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0175801280664628"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.443203909376631"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.112910609996037"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "9"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "33"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.481274652395443"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0175801280664628"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.443203909376631"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.112910609996037"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "9"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5107e0fdba262447669255100a242c1c",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:a35a0c7d262276e543a1e97fbbe3cdc8",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:6d5196dbefc80600da436f72c5fa99e9",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:cfb99edebaae9df65e32c2dc18fd6186",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0010",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "6"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0875044822537169"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.273373266352505"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999888943840686"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.539152830861885"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "10"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "6"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0875044822537169"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.273373266352505"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999888943840686"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.539152830861885"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "10"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6d5196dbefc80600da436f72c5fa99e9",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:cfb99edebaae9df65e32c2dc18fd6186",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:d4c4e9d5661158241502d335eb5a96e4",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:2607cc56c513b9a7b262e9ec22fe2b63",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0011",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "10"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.145840803756195"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.161523634652226"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.995392197803255"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.409577787868145"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "11"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "10"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.145840803756195"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.161523634652226"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.995392197803255"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.409577787868145"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "11"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d4c4e9d5661158241502d335eb5a96e4",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:2607cc56c513b9a7b262e9ec22fe2b63",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:52cc5fe71e36fbe65be2bc6eac0024f0",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:1daa422fda95bd1a9676984906e1a548",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0012",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "26"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.379186089766107"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0318362117547758"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.653681229272869"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.16145507389922"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "12"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "26"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.379186089766107"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0318362117547758"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.653681229272869"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.16145507389922"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "12"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:52cc5fe71e36fbe65be2bc6eac0024f0",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:1daa422fda95bd1a9676984906e1a548",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:c7a355d22d989f24ef00d62137ddfe13",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:a6888f03a619f2ef07714763993a3be7",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0013",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "11"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.160424884131814"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.143315972308448"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.991549640351899"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.407017361355993"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "13"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "11"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.160424884131814"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.143315972308448"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.991549640351899"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.407017361355993"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "13"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c7a355d22d989f24ef00d62137ddfe13",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:a6888f03a619f2ef07714763993a3be7",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:ed934b2b32fd19f3afbe4c6bb5d3f1a3",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:ff0222b1c30a382e52f5903988ee7a67",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0014",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "16"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.233345286009912"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0825813905071932"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.936111008142629"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.325737707000596"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "14"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "16"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.233345286009912"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0825813905071932"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.936111008142629"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.325737707000596"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "14"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ed934b2b32fd19f3afbe4c6bb5d3f1a3",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:ff0222b1c30a382e52f5903988ee7a67",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:f4a1be717fb30bceb6b19d568207e064",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:189a48f192c71c34afbefb1b24c895a1",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0015",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "14"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.204177125258673"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.10212573718427"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.966679694237215"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.36254636700416"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "15"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "14"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.204177125258673"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.10212573718427"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.966679694237215"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.36254636700416"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "15"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f4a1be717fb30bceb6b19d568207e064",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:189a48f192c71c34afbefb1b24c895a1",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:932e333631c50069ac12d36b6efba037",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:153d0f62058a9c03f71f38806c01672c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0016",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "35"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.510442813146682"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0149558617235747"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.392344720913691"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.112910609996037"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "16"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "35"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.510442813146682"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0149558617235747"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.392344720913691"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.112910609996037"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "16"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:932e333631c50069ac12d36b6efba037",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:153d0f62058a9c03f71f38806c01672c",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:d98235d369f4da12b94c1ba7844053d1",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:2b8333b9ae75e6a69c6703c1017776ef",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0017",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "32"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.466690572019824"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0190834833796118"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.470398116431399"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.112910609996037"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "17"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "32"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.466690572019824"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0190834833796118"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.470398116431399"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.112910609996037"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "17"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d98235d369f4da12b94c1ba7844053d1",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:2b8333b9ae75e6a69c6703c1017776ef",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:2b33b3c2fb565f11805c2ab96c217218",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:be0ede967cfc83179dfb392adca98376",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0018",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "46"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.670867697278497"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00645728092420274"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.193521561130372"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0764111576030657"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "18"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "46"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.670867697278497"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00645728092420274"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.193521561130372"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0764111576030657"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "18"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2b33b3c2fb565f11805c2ab96c217218",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:be0ede967cfc83179dfb392adca98376",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:5a17a76cb3f0ca0ddba79372b881b0ac",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:23f2b3702fb27a3d52f0874c93630544",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0019",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "15"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.218761205634292"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0917266976854565"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.952887583051913"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.342768186087759"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "19"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "15"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.218761205634292"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0917266976854565"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.952887583051913"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.342768186087759"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "19"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5a17a76cb3f0ca0ddba79372b881b0ac",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:23f2b3702fb27a3d52f0874c93630544",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:cdbe1592b4a9de39b031d21dc9c2950c",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:654afa8f2fea6cb2d23c37e50edee008",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0020",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "20"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.29168160751239"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0553545237190288"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.841775430461368"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.231186540238297"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "20"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "20"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.29168160751239"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0553545237190288"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.841775430461368"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.231186540238297"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "20"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cdbe1592b4a9de39b031d21dc9c2950c",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:654afa8f2fea6cb2d23c37e50edee008",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:a74c6130611adcee49f9abe720d6e52c",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:dba06f209302f6639800d0af3c93affd",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0021",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "11"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.160424884131814"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.143315972308448"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.991549640351899"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.407017361355993"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "21"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "11"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.160424884131814"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.143315972308448"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.991549640351899"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.407017361355993"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "21"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a74c6130611adcee49f9abe720d6e52c",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:dba06f209302f6639800d0af3c93affd",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:0b42259e10bfb86cff826215fa08b419",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:57c14f931d36e820d2322a1bdd36da40",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0022",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "32"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.466690572019824"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0190834833796118"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.470398116431399"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.112910609996037"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "22"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "32"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.466690572019824"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0190834833796118"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.470398116431399"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.112910609996037"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "22"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0b42259e10bfb86cff826215fa08b419",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:57c14f931d36e820d2322a1bdd36da40",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:59f34e94c3c0a0f91363e1cf44b96bbb",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:2739d32e473645dfabd9a03fc9f4dae7",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0023",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.058336321502478"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.371675909431407"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999995797049595"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.599749762946134"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "23"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.058336321502478"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.371675909431407"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999995797049595"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.599749762946134"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "23"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:59f34e94c3c0a0f91363e1cf44b96bbb",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:2739d32e473645dfabd9a03fc9f4dae7",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:e15a7f7da66912fa92c8140c6338b192",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:23f5ffb7a02a62400ce3f1cfda032dbe",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0024",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "11"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.160424884131814"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.143315972308448"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.991549640351899"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.407017361355993"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "24"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "11"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.160424884131814"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.143315972308448"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.991549640351899"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.407017361355993"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "24"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e15a7f7da66912fa92c8140c6338b192",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:23f5ffb7a02a62400ce3f1cfda032dbe",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:deefe75f432062b10a9b73a0036af48f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:3ed09542d8eeb67b7a92a4f1152a9588",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0025",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "5"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0729204018780975"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.317117336021626"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999974131777239"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.549154411159401"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "25"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "5"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0729204018780975"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.317117336021626"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999974131777239"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.549154411159401"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "25"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:deefe75f432062b10a9b73a0036af48f",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:3ed09542d8eeb67b7a92a4f1152a9588",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:85cc735cf6146dea08ebdfd5febbbbf6",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:ee2c6440d10e17fa3f61858f975e92f6",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0026",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "21"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.306265687888009"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0503036857692116"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.812786836270519"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.223222605600877"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "26"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "21"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.306265687888009"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0503036857692116"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.812786836270519"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.223222605600877"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "26"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:85cc735cf6146dea08ebdfd5febbbbf6",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:ee2c6440d10e17fa3f61858f975e92f6",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:eda691902b8e9f86974b74de47c3be21",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:25764564ed7b5495d43208d9a742797c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0027",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "25"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.364602009390487"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0347983287867789"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.686218175845877"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.164712089590753"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "27"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "25"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.364602009390487"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0347983287867789"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.686218175845877"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.164712089590753"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "27"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:eda691902b8e9f86974b74de47c3be21",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:25764564ed7b5495d43208d9a742797c",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:44c46f8ea3d70ad705fe182f1aaf841e",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:2a5007577d5f397768b0a52d8e1e454a",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0028",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "8"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.116672643004956"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.20781578719113"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999014041359979"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.475965190018395"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "28"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "8"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.116672643004956"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.20781578719113"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999014041359979"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.475965190018395"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "28"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:44c46f8ea3d70ad705fe182f1aaf841e",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:2a5007577d5f397768b0a52d8e1e454a",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:e1e2e1faf57e2ccdad8d1cc2103103f7",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:075d03d6a0a7a8ff06d2fd0a678225e4",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0029",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "12"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.175008964507434"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.127616241080866"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.985744636441848"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.407017361355993"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "29"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "12"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.175008964507434"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.127616241080866"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.985744636441848"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.407017361355993"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "29"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e1e2e1faf57e2ccdad8d1cc2103103f7",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:075d03d6a0a7a8ff06d2fd0a678225e4",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:a63b9651208c3ee898cba42774cbd083",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f9daf2bb86509394f654f8dfb4a4e15b",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0030",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0145840803756195"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.675180100901307"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999828904"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.675180100901307"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "30"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0145840803756195"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.675180100901307"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999828904"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.675180100901307"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "30"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a63b9651208c3ee898cba42774cbd083",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:f9daf2bb86509394f654f8dfb4a4e15b",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:99df9b0bee5015f2e54ddbafb84c5b4b",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:447a33078d0ab11fa638dad2f64b7b00",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0031",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "10"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.145840803756195"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.161523634652226"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.995392197803255"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.409577787868145"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "31"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "10"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.145840803756195"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.161523634652226"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.995392197803255"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.409577787868145"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "31"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:99df9b0bee5015f2e54ddbafb84c5b4b",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:447a33078d0ab11fa638dad2f64b7b00",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:4fb8453b9556b51fec8c4dac94527e32",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:e979405039e66c5ce2c3d5b5b67f1286",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0032",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.058336321502478"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.371675909431407"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999995797049595"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.599749762946134"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "32"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.058336321502478"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.371675909431407"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999995797049595"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.599749762946134"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "32"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4fb8453b9556b51fec8c4dac94527e32",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:e979405039e66c5ce2c3d5b5b67f1286",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:06615834113ebb8c32e91747f3e2ea30",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:02724527e4ee34eff0967177115a83d1",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0033",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "6"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0875044822537169"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.273373266352505"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999888943840686"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.539152830861885"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "33"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "6"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0875044822537169"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.273373266352505"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999888943840686"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.539152830861885"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "33"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:06615834113ebb8c32e91747f3e2ea30",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:02724527e4ee34eff0967177115a83d1",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:ebf5f25253bc1119f25ba867f1a13a26",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c6bf9a9fd500605c73016dfb45e6af98",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0034",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "5"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0729204018780975"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.317117336021626"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999974131777239"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.549154411159401"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "34"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "5"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0729204018780975"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.317117336021626"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999974131777239"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.549154411159401"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "34"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ebf5f25253bc1119f25ba867f1a13a26",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:c6bf9a9fd500605c73016dfb45e6af98",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:e51b44da6f9ef9702d8a79c08d73d19e",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:e3e587be4409f0bc772835a934536590",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0035",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "10"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.145840803756195"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.161523634652226"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.995392197803255"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.409577787868145"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "35"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "10"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.145840803756195"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.161523634652226"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.995392197803255"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.409577787868145"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "35"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e51b44da6f9ef9702d8a79c08d73d19e",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:e3e587be4409f0bc772835a934536590",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:b8483957e8852fa21925543fe06f0492",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:6aa3e47b1d56a62cbf353acb1dbf4e63",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0036",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "7"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.102088562629336"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.237571474546961"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99963404273418"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.52711170915107"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "36"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "7"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.102088562629336"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.237571474546961"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99963404273418"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.52711170915107"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "36"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b8483957e8852fa21925543fe06f0492",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:6aa3e47b1d56a62cbf353acb1dbf4e63",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:1d380370dd353aff7206de21666fb3d4",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:11267ea4af34c876ad34aa054c834aa1",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0037",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "8"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.116672643004956"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.20781578719113"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999014041359979"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.475965190018395"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "37"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "8"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.116672643004956"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.20781578719113"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999014041359979"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.475965190018395"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "37"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1d380370dd353aff7206de21666fb3d4",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:11267ea4af34c876ad34aa054c834aa1",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:68a55477530e699e1f7822c244d7eb8f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:ed62a9c22b9d6c8f4255706a0676f4da",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0038",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "12"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.175008964507434"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.127616241080866"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.985744636441848"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.407017361355993"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "38"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "12"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.175008964507434"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.127616241080866"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.985744636441848"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.407017361355993"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "38"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:68a55477530e699e1f7822c244d7eb8f",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:ed62a9c22b9d6c8f4255706a0676f4da",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:aacb0b550de1bf101b8a9ebfbba31aae",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:7649cec60050f6bbb0a4a68fad360d04",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0039",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "5"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0729204018780975"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.317117336021626"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999974131777239"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.549154411159401"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "39"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "5"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0729204018780975"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.317117336021626"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999974131777239"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.549154411159401"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "39"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:aacb0b550de1bf101b8a9ebfbba31aae",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:7649cec60050f6bbb0a4a68fad360d04",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:18d7d5a2985d2afc116f40bb7d9dd868",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:76477879d12f5565edfe6317f1396ae3",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0040",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "5"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0729204018780975"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.317117336021626"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999974131777239"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.549154411159401"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "40"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "5"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0729204018780975"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.317117336021626"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999974131777239"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.549154411159401"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "40"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:18d7d5a2985d2afc116f40bb7d9dd868",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:76477879d12f5565edfe6317f1396ae3",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:b82b663a41d1d4bc01fd88119e09dfc9",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:b32a94908c3543b6389e71c09e18b028",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0041",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0437522411268585"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.441752016334617"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999592737522"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.653424857494954"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "41"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0437522411268585"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.441752016334617"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999592737522"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.653424857494954"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "41"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b82b663a41d1d4bc01fd88119e09dfc9",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:b32a94908c3543b6389e71c09e18b028",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:74035667fc1f8ff5d347c08183ecb0d2",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:505e13c060365ce925c6c78620aace2b",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0042",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "6"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0875044822537169"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.273373266352505"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999888943840686"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.539152830861885"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "42"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "6"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0875044822537169"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.273373266352505"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999888943840686"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.539152830861885"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "42"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:74035667fc1f8ff5d347c08183ecb0d2",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:505e13c060365ce925c6c78620aace2b",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:a9e9f6c4e1e252f83c00826797f885fd",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:6a2f64f5544ff048d58423df90e157d2",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0043",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "9"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.131256723380575"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.182785449876348"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.997730485940405"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.44750920486968"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "43"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "9"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.131256723380575"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.182785449876348"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.997730485940405"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.44750920486968"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "43"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a9e9f6c4e1e252f83c00826797f885fd",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:6a2f64f5544ff048d58423df90e157d2",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:100b7385b787aa70accf430f06dc1f51",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:965bca191e7bce9008d8dd515cf43195",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0044",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0437522411268585"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.441752016334617"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999592737522"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.653424857494954"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "44"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0437522411268585"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.441752016334617"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999592737522"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.653424857494954"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "44"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:100b7385b787aa70accf430f06dc1f51",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:965bca191e7bce9008d8dd515cf43195",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:677f763bf103868e95ac103a45720d37",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:5c0f8a6949255a54753a5996ab8bf0b5",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0045",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0437522411268585"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.441752016334617"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999592737522"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.653424857494954"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "45"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0437522411268585"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.441752016334617"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999592737522"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.653424857494954"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "45"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:677f763bf103868e95ac103a45720d37",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:5c0f8a6949255a54753a5996ab8bf0b5",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:0c812c731486b17b175ecfc3bf7169f1",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:e00c0b657ae25f884a41aad34f6d4869",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0046",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0145840803756195"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.675180100901307"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999828904"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.675180100901307"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "46"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0145840803756195"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.675180100901307"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999828904"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.675180100901307"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "46"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0c812c731486b17b175ecfc3bf7169f1",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:e00c0b657ae25f884a41aad34f6d4869",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:747d0e971ba4dc1c824eb2073e536769",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:efbb22419db35e6170e4f8c15df564d9",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0047",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.058336321502478"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.371675909431407"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999995797049595"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.599749762946134"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "47"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.058336321502478"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.371675909431407"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999995797049595"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.599749762946134"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "47"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:747d0e971ba4dc1c824eb2073e536769",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:efbb22419db35e6170e4f8c15df564d9",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:db3dd4033ee5e1f792de4dafd8064e08",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:792fda8a02886788088cdc21433fe931",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0048",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0437522411268585"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.441752016334617"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999592737522"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.653424857494954"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "48"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0437522411268585"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.441752016334617"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999592737522"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.653424857494954"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "48"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:db3dd4033ee5e1f792de4dafd8064e08",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:792fda8a02886788088cdc21433fe931",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:5d1b7a0c9ff2df0d604a94edf7efd3ac",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:0dd1d301e6eec8815748b738cd4fdb7c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0049",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "5"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0729204018780975"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.317117336021626"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999974131777239"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.549154411159401"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "49"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "5"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0729204018780975"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.317117336021626"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999974131777239"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.549154411159401"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "49"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5d1b7a0c9ff2df0d604a94edf7efd3ac",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:0dd1d301e6eec8815748b738cd4fdb7c",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:464ed1a86745e5328f28784be3bd4fb3",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:0a00a0a76e73ce79a1d09f89ec092795",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0050",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0145840803756195"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.675180100901307"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999828904"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.675180100901307"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "50"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0145840803756195"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.675180100901307"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999828904"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.675180100901307"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "50"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:464ed1a86745e5328f28784be3bd4fb3",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:0a00a0a76e73ce79a1d09f89ec092795",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:463ba14c93e36d88477f78294036d6ea",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:af99a7152d944fac822b2a894187ecfd",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0051",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0145840803756195"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.675180100901307"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999828904"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.675180100901307"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "51"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0145840803756195"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.675180100901307"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999828904"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.675180100901307"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "51"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:463ba14c93e36d88477f78294036d6ea",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:af99a7152d944fac822b2a894187ecfd",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:95bc5905e6829eb3b10bc4e2e665a6de",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:1de9cf5cb4f411c77d648530539b1506",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0052",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0145840803756195"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.675180100901307"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999828904"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.675180100901307"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "52"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0145840803756195"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.675180100901307"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999828904"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.675180100901307"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "52"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:95bc5905e6829eb3b10bc4e2e665a6de",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:1de9cf5cb4f411c77d648530539b1506",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:79afb4c5267e6717f07bc3ab60650657",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:643dd520d22eb83650c21da507f69f60",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0053",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0145840803756195"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.675180100901307"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999828904"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.675180100901307"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "53"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0145840803756195"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.675180100901307"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999828904"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.675180100901307"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "53"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:79afb4c5267e6717f07bc3ab60650657",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:643dd520d22eb83650c21da507f69f60",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:e1b2a55b7f9b22b0ae0bdfe29112640f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:1a432aa3e7fda423feb9c68ebffde829",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0054",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "6"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0875044822537169"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.273373266352505"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999888943840686"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.539152830861885"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "54"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "6"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0875044822537169"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.273373266352505"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999888943840686"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.539152830861885"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "54"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e1b2a55b7f9b22b0ae0bdfe29112640f",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:1a432aa3e7fda423feb9c68ebffde829",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:b05fa744387c4b5045f0c0b05aacfeb4",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:1569aa21af436f1447efa2c75903f79c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0055",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0145840803756195"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.675180100901307"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999828904"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.675180100901307"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "55"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0145840803756195"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.675180100901307"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999828904"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.675180100901307"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "55"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b05fa744387c4b5045f0c0b05aacfeb4",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:1569aa21af436f1447efa2c75903f79c",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:51f256b7ea3e807cb25c6775473371d8",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:0fb2459e07ec9adca74a9a6a0f036186",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0056",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0145840803756195"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.675180100901307"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999828904"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.675180100901307"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "56"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0145840803756195"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.675180100901307"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999828904"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.675180100901307"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "56"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:51f256b7ea3e807cb25c6775473371d8",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:0fb2459e07ec9adca74a9a6a0f036186",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:dc9c7cf4223aa5e5ce8d564077006cb3",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:e937b5f0f9c2d5b73ead1407d48466e6",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0057",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0145840803756195"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.675180100901307"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999828904"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.675180100901307"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "57"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0145840803756195"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.675180100901307"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999828904"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.675180100901307"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "57"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:dc9c7cf4223aa5e5ce8d564077006cb3",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:e937b5f0f9c2d5b73ead1407d48466e6",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:dd8593a9311adfd7943344f7fcbd8aee",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:321743f529907bc95ee3bc2bb3feb1e2",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0058",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.029168160751239"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.536068820289802"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999982398778"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.675180100901307"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "58"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.029168160751239"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.536068820289802"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999982398778"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.675180100901307"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "58"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:dd8593a9311adfd7943344f7fcbd8aee",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:321743f529907bc95ee3bc2bb3feb1e2",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:f77c3b84351f869eec0ec8a0f4c729f2",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:7ca293071987c22e76e0b20115b26429",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0059",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0145840803756195"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.675180100901307"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999828904"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.675180100901307"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "59"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0145840803756195"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.675180100901307"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999828904"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.675180100901307"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "59"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f77c3b84351f869eec0ec8a0f4c729f2",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:7ca293071987c22e76e0b20115b26429",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:d51318468d3708fb69be47dd8fb73f01",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:6bb00e27ab3f8d7e1b137fd7b575136a",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0060",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0145840803756195"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.675180100901307"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999828904"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.675180100901307"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "60"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0145840803756195"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.675180100901307"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999828904"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.675180100901307"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "60"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d51318468d3708fb69be47dd8fb73f01",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:6bb00e27ab3f8d7e1b137fd7b575136a",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:23ddb476e286b8beace9ac2226fb1e02",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:eea16d34f3c295e17c1d3128d76481f7",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0061",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0145840803756195"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.675180100901307"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999828904"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.675180100901307"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "61"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0145840803756195"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.675180100901307"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999828904"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.675180100901307"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "61"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:23ddb476e286b8beace9ac2226fb1e02",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:eea16d34f3c295e17c1d3128d76481f7",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:9c6347d32a637404df13117cb515bb7a",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:2d477a3822ede90c19394a724a2c602f",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0062",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0145840803756195"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.675180100901307"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999828904"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.675180100901307"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "62"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0145840803756195"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.675180100901307"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999828904"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.675180100901307"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "62"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9c6347d32a637404df13117cb515bb7a",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:2d477a3822ede90c19394a724a2c602f",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:64b9ed90986836033d685bf5b9a5e773",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:67886822c4a91ee4d1b7cd6bc45567f5",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0063",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.029168160751239"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.536068820289802"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999982398778"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.675180100901307"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "63"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.029168160751239"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.536068820289802"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999982398778"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.675180100901307"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "63"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:64b9ed90986836033d685bf5b9a5e773",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:67886822c4a91ee4d1b7cd6bc45567f5",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:f2a361b0d3f278353a770b78f683d8ff",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:5ebab1be1c4c961db315c2ffb23786c0",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0064",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0145840803756195"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.675180100901307"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999828904"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.675180100901307"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "64"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0145840803756195"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.675180100901307"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999828904"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.675180100901307"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "64"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f2a361b0d3f278353a770b78f683d8ff",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:5ebab1be1c4c961db315c2ffb23786c0",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:a2753eb825e8f8fd5a487ef63c2663c8",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:06a77002692eb72a6823907717b7b96b",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0065",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0145840803756195"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.675180100901307"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999828904"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.675180100901307"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "65"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0145840803756195"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.675180100901307"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999828904"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.675180100901307"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "65"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a2753eb825e8f8fd5a487ef63c2663c8",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:06a77002692eb72a6823907717b7b96b",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:85b5285611210be089c4e51b135903dc",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:70cb31c3da80e76bbcc31227d5a63dd3",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0066",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0145840803756195"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.675180100901307"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999828904"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.675180100901307"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "66"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0145840803756195"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.675180100901307"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999828904"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.675180100901307"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "66"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:85b5285611210be089c4e51b135903dc",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:70cb31c3da80e76bbcc31227d5a63dd3",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:1d0913f48b56a9cfb53554e02fef4dd7",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:1bab28ca73fb58bf072903c327aa6ee2",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0067",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0145840803756195"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.675180100901307"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999828904"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.675180100901307"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "67"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0145840803756195"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.675180100901307"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999828904"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.675180100901307"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "67"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1d0913f48b56a9cfb53554e02fef4dd7",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:1bab28ca73fb58bf072903c327aa6ee2",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:ec713ff49cc3d009853754ee51de40a9",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:0d05a2eb7c30f085c9585bd5437f2cf6",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0068",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0145840803756195"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.675180100901307"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999828904"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.675180100901307"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "68"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0145840803756195"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.675180100901307"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999828904"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.675180100901307"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "68"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ec713ff49cc3d009853754ee51de40a9",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:0d05a2eb7c30f085c9585bd5437f2cf6",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:14378386d8b7fa3469c4024d8643a9f6",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:cec1367031abea759cc3b3843951c4e9",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0069",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0145840803756195"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.675180100901307"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999828904"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.675180100901307"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "69"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0145840803756195"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.675180100901307"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999828904"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.675180100901307"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "69"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:14378386d8b7fa3469c4024d8643a9f6",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:cec1367031abea759cc3b3843951c4e9",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:35322e20f0852719cb5f7785e9eafbdf",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:6ba93f98c147f043bee56b6eaf416136",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0070",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0145840803756195"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.675180100901307"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999828904"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.675180100901307"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "70"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0145840803756195"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.675180100901307"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999828904"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.675180100901307"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "70"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:35322e20f0852719cb5f7785e9eafbdf",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:6ba93f98c147f043bee56b6eaf416136",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:c0448343148dd622321d80f7996dd79e",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:ac903b7a48abf269c96015efab8d2aa1",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0071",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0145840803756195"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.675180100901307"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999828904"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.675180100901307"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "71"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0145840803756195"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.675180100901307"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999828904"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.675180100901307"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "71"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c0448343148dd622321d80f7996dd79e",
-      "entity": "niiri:9f1620f32dc4659d77d42ff2a65c79af"
+      "entity_derived": "niiri:ac903b7a48abf269c96015efab8d2aa1",
+      "entity": "niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb"
     },
     {
-      "@id": "niiri:b4be2fe97188738613ff698d95ffd0d3",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:de0be50edac74c81f9c1e5814da03b9d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0001",
-      "prov:atLocation": {"@id": "niiri:1632d5941772ec068ccc444945dee909"},
+      "prov:atLocation": {"@id": "niiri:7f9fdf6f0de7581fd021fc6db0110883"},
       "prov:value": {"@type": "xsd:float", "@value": "39.0658683776855"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.04009751746769"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.3264734660966e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0389037590875805"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.097253800423278"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.04009751746769"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.3264734660966e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0389037590875805"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.097253800423278"}
     },
     {
-      "@id": "niiri:1632d5941772ec068ccc444945dee909",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7f9fdf6f0de7581fd021fc6db0110883",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0001",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-2,-90,28]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-2,-90,28]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b4be2fe97188738613ff698d95ffd0d3",
-      "entity": "niiri:2614b44f75a99f07f4673d4500fe47ed"
+      "entity_derived": "niiri:de0be50edac74c81f9c1e5814da03b9d",
+      "entity": "niiri:0502f21f886d74eb5a46cc0e98d99ebd"
     },
     {
-      "@id": "niiri:5eae8bb9e3cf61596c8706ac43ede1a4",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3551a670193037285a26d96dd25d4587",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0002",
-      "prov:atLocation": {"@id": "niiri:9556e732eb66310b4e70f17e9c505376"},
+      "prov:atLocation": {"@id": "niiri:23f181033fbbc357802f67e0f5c9c6ac"},
       "prov:value": {"@type": "xsd:float", "@value": "36.2393341064453"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.89725160225159"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.85931842320042e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.071761896035709"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.097253800423278"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.89725160225159"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.85931842320042e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.071761896035709"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.097253800423278"}
     },
     {
-      "@id": "niiri:9556e732eb66310b4e70f17e9c505376",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:23f181033fbbc357802f67e0f5c9c6ac",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0002",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-42,-64,-8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-42,-64,-8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5eae8bb9e3cf61596c8706ac43ede1a4",
-      "entity": "niiri:26dc30d77d0a0c23d6913e69266e279e"
+      "entity_derived": "niiri:3551a670193037285a26d96dd25d4587",
+      "entity": "niiri:0599785d82edc2bd01edfc956f648d55"
     },
     {
-      "@id": "niiri:b907bdcd6391fe6a9d5be2e43976eaa4",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a397cef7de1b33fff3104633ae867013",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0003",
-      "prov:atLocation": {"@id": "niiri:0bb9df9b459a66cc22278fa6d5451add"},
+      "prov:atLocation": {"@id": "niiri:d0956a4697c01f13d1fd27c41f01ee23"},
       "prov:value": {"@type": "xsd:float", "@value": "17.9251842498779"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.64201416072196"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000135256594276711"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999417997648594"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.642014449876257"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.64201416072196"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000135256594276711"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999417997648594"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.642014449876257"}
     },
     {
-      "@id": "niiri:0bb9df9b459a66cc22278fa6d5451add",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d0956a4697c01f13d1fd27c41f01ee23",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0003",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-40,-52,-10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-40,-52,-10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b907bdcd6391fe6a9d5be2e43976eaa4",
-      "entity": "niiri:26dc30d77d0a0c23d6913e69266e279e"
+      "entity_derived": "niiri:a397cef7de1b33fff3104633ae867013",
+      "entity": "niiri:0599785d82edc2bd01edfc956f648d55"
     },
     {
-      "@id": "niiri:d6228e5b47bc93a7895c14d907eacdb9",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:795bfdfc1c878985f28b65ddbd93f5e2",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0004",
-      "prov:atLocation": {"@id": "niiri:43e9802e1de5dfb7d43041d791e08855"},
+      "prov:atLocation": {"@id": "niiri:3fae1a6119fcbb333560406c0adaf77a"},
       "prov:value": {"@type": "xsd:float", "@value": "13.454288482666"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.18324713734782"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000728166268399777"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999996872"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.94954759467573"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.18324713734782"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000728166268399777"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999996872"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.94954759467573"}
     },
     {
-      "@id": "niiri:43e9802e1de5dfb7d43041d791e08855",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:3fae1a6119fcbb333560406c0adaf77a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0004",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-38,-70,0]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-38,-70,0]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d6228e5b47bc93a7895c14d907eacdb9",
-      "entity": "niiri:26dc30d77d0a0c23d6913e69266e279e"
+      "entity_derived": "niiri:795bfdfc1c878985f28b65ddbd93f5e2",
+      "entity": "niiri:0599785d82edc2bd01edfc956f648d55"
     },
     {
-      "@id": "niiri:7c544a191a467d8160116c31fe28b615",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:1bef248663e2601c3f3e8f86ce7bcf8e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0005",
-      "prov:atLocation": {"@id": "niiri:f7b88cad1d9f3d365a9aba0b1e6656c7"},
+      "prov:atLocation": {"@id": "niiri:a50093d76450a437f3994a2a331222d2"},
       "prov:value": {"@type": "xsd:float", "@value": "29.4676361083984"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.51162164706026"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.21669348379849e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.305525019896507"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.297255514853906"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.51162164706026"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.21669348379849e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.305525019896507"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.297255514853906"}
     },
     {
-      "@id": "niiri:f7b88cad1d9f3d365a9aba0b1e6656c7",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a50093d76450a437f3994a2a331222d2",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0005",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[16,-88,24]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[16,-88,24]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7c544a191a467d8160116c31fe28b615",
-      "entity": "niiri:5819cfbfd916831f2b9b46c44761a13b"
+      "entity_derived": "niiri:1bef248663e2601c3f3e8f86ce7bcf8e",
+      "entity": "niiri:503c99586f814910b6b80009bf62943c"
     },
     {
-      "@id": "niiri:7296494cc324e9aeba37968107ba9d73",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:34e046d2eb16a715bed65c1a03b2abc1",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0006",
-      "prov:atLocation": {"@id": "niiri:3598d1f8eca639294d0ae8fa05f9d2a6"},
+      "prov:atLocation": {"@id": "niiri:03eb88016e6bd2dd5c40edd75ccfd627"},
       "prov:value": {"@type": "xsd:float", "@value": "28.5631580352783"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.45459114773779"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.20266075706888e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.365688847752494"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.297255514853906"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.45459114773779"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.20266075706888e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.365688847752494"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.297255514853906"}
     },
     {
-      "@id": "niiri:3598d1f8eca639294d0ae8fa05f9d2a6",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:03eb88016e6bd2dd5c40edd75ccfd627",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0006",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[28,-72,26]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[28,-72,26]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7296494cc324e9aeba37968107ba9d73",
-      "entity": "niiri:18222312b25450890c50a38e087b5fca"
+      "entity_derived": "niiri:34e046d2eb16a715bed65c1a03b2abc1",
+      "entity": "niiri:018a24899160bba0361882009e28cdf7"
     },
     {
-      "@id": "niiri:f10fdd104668b16c937b001a6fd48ae7",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c71c9cb743a850da26dbd07e2a4ab336",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0007",
-      "prov:atLocation": {"@id": "niiri:3cd964e18fe79bd491aeaa14bf331bb1"},
+      "prov:atLocation": {"@id": "niiri:81e9ff294c150a3271a867e5bc31370a"},
       "prov:value": {"@type": "xsd:float", "@value": "26.9945106506348"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.35204306383375"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.7437380493196e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.489729172437052"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.302930044135827"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.35204306383375"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.7437380493196e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.489729172437052"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.302930044135827"}
     },
     {
-      "@id": "niiri:3cd964e18fe79bd491aeaa14bf331bb1",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:81e9ff294c150a3271a867e5bc31370a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0007",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-32,20,-4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-32,20,-4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f10fdd104668b16c937b001a6fd48ae7",
-      "entity": "niiri:fd0ea64d092adb2dc6aef53bb390dd47"
+      "entity_derived": "niiri:c71c9cb743a850da26dbd07e2a4ab336",
+      "entity": "niiri:33d37aeafd7dbe4545a7c3723ffec290"
     },
     {
-      "@id": "niiri:11e448feeb5ffb8abe7a056109695d44",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:1d00c0696db8e3a3a6f9eeb993c993aa",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0008",
-      "prov:atLocation": {"@id": "niiri:3a018923a042d3052c1289e3fd69c6f8"},
+      "prov:atLocation": {"@id": "niiri:324e311634f996ef35fec88282031fdd"},
       "prov:value": {"@type": "xsd:float", "@value": "26.8606586456299"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.34306775687574"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.02533878071954e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.501353785238145"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.302930044135827"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.34306775687574"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.02533878071954e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.501353785238145"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.302930044135827"}
     },
     {
-      "@id": "niiri:3a018923a042d3052c1289e3fd69c6f8",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:324e311634f996ef35fec88282031fdd",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0008",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-8,50,32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-8,50,32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:11e448feeb5ffb8abe7a056109695d44",
-      "entity": "niiri:086741e220f142a5ba7d24c166640134"
+      "entity_derived": "niiri:1d00c0696db8e3a3a6f9eeb993c993aa",
+      "entity": "niiri:c67e26c71245447102997061bd7b4400"
     },
     {
-      "@id": "niiri:66a6081521836f12199682cf917bdfd3",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e105d8c03c8fb50b26c076e73184a484",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0009",
-      "prov:atLocation": {"@id": "niiri:e2e98471f8990000bd5f1f2cc71ce750"},
+      "prov:atLocation": {"@id": "niiri:46442f9a133e99c8e0d2a8f94f5a3dbe"},
       "prov:value": {"@type": "xsd:float", "@value": "25.8067512512207"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.27109313660164"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "9.72585724245967e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.597019202761311"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.317981530335124"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.27109313660164"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "9.72585724245967e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.597019202761311"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.317981530335124"}
     },
     {
-      "@id": "niiri:e2e98471f8990000bd5f1f2cc71ce750",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:46442f9a133e99c8e0d2a8f94f5a3dbe",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0009",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-34,8,58]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-34,8,58]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:66a6081521836f12199682cf917bdfd3",
-      "entity": "niiri:e2190d23e52313b345dec17a936b13ac"
+      "entity_derived": "niiri:e105d8c03c8fb50b26c076e73184a484",
+      "entity": "niiri:21c6b4d93e2f7d826c174fe1b99df534"
     },
     {
-      "@id": "niiri:9fc17387bfc87d32609f093c33e59660",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:98120cf8274f1adde1b9975ee7343d0b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0010",
-      "prov:atLocation": {"@id": "niiri:8b08eaf81c36345da1a7568b61ea14d2"},
+      "prov:atLocation": {"@id": "niiri:8745a1750fbc576ed60637fd96f0bd53"},
       "prov:value": {"@type": "xsd:float", "@value": "25.0769119262695"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.21983658750018"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.22239732009977e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.665677647955296"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.317981530335124"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.21983658750018"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.22239732009977e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.665677647955296"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.317981530335124"}
     },
     {
-      "@id": "niiri:8b08eaf81c36345da1a7568b61ea14d2",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:8745a1750fbc576ed60637fd96f0bd53",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0010",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[32,-86,0]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[32,-86,0]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9fc17387bfc87d32609f093c33e59660",
-      "entity": "niiri:26ab6f532ee67acbd905e1a64f80b9d8"
+      "entity_derived": "niiri:98120cf8274f1adde1b9975ee7343d0b",
+      "entity": "niiri:6da0c60471d915bb0e46bffadee4d55a"
     },
     {
-      "@id": "niiri:cb4d051a1e969961f67a1bc3ece80b39",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:289923b931558b9cf26d6259e84991cc",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0011",
-      "prov:atLocation": {"@id": "niiri:c9e5bb380e0350c88780f291f910a20b"},
+      "prov:atLocation": {"@id": "niiri:aadea8cdd84b63fc723d500acfc25900"},
       "prov:value": {"@type": "xsd:float", "@value": "24.5828113555908"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.18444689049798"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.42930633414418e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.711939170732988"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.325084892179266"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.18444689049798"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.42930633414418e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.711939170732988"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.325084892179266"}
     },
     {
-      "@id": "niiri:c9e5bb380e0350c88780f291f910a20b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:aadea8cdd84b63fc723d500acfc25900",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0011",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[66,-32,30]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[66,-32,30]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cb4d051a1e969961f67a1bc3ece80b39",
-      "entity": "niiri:5107e0fdba262447669255100a242c1c"
+      "entity_derived": "niiri:289923b931558b9cf26d6259e84991cc",
+      "entity": "niiri:a35a0c7d262276e543a1e97fbbe3cdc8"
     },
     {
-      "@id": "niiri:8ba50a95bcca89d59a85283f58452ebf",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:273d6a77c000bfe5f52d296da6ad6478",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0012",
-      "prov:atLocation": {"@id": "niiri:49c8600aff97691c964c26199849b79f"},
+      "prov:atLocation": {"@id": "niiri:652a2206db07edc1bd545802c3f663c9"},
       "prov:value": {"@type": "xsd:float", "@value": "14.2693071365356"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.27451594161643"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000529215834762176"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999209483"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.904639459548904"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.27451594161643"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000529215834762176"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999209483"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.904639459548904"}
     },
     {
-      "@id": "niiri:49c8600aff97691c964c26199849b79f",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:652a2206db07edc1bd545802c3f663c9",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0012",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[60,-38,28]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[60,-38,28]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8ba50a95bcca89d59a85283f58452ebf",
-      "entity": "niiri:5107e0fdba262447669255100a242c1c"
+      "entity_derived": "niiri:273d6a77c000bfe5f52d296da6ad6478",
+      "entity": "niiri:a35a0c7d262276e543a1e97fbbe3cdc8"
     },
     {
-      "@id": "niiri:fac0e66136be61d5cb9a227bce4664aa",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:41059e9d7b27293b0aba3b2a84d455b8",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0013",
-      "prov:atLocation": {"@id": "niiri:71bbb509277e9a5a03d8b66d37e30b14"},
+      "prov:atLocation": {"@id": "niiri:a97ce2127d9bef3582961e02700db7f6"},
       "prov:value": {"@type": "xsd:float", "@value": "23.3039436340332"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.09011898331566"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.15575975488491e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.823947459995523"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.412451648636247"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.09011898331566"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.15575975488491e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.823947459995523"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.412451648636247"}
     },
     {
-      "@id": "niiri:71bbb509277e9a5a03d8b66d37e30b14",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a97ce2127d9bef3582961e02700db7f6",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0013",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[28,30,52]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[28,30,52]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:fac0e66136be61d5cb9a227bce4664aa",
-      "entity": "niiri:6d5196dbefc80600da436f72c5fa99e9"
+      "entity_derived": "niiri:41059e9d7b27293b0aba3b2a84d455b8",
+      "entity": "niiri:cfb99edebaae9df65e32c2dc18fd6186"
     },
     {
-      "@id": "niiri:73750c53fdb790c6357c4da82d52bf27",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b964c9d32200b841b56fe800b88c0a4b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0014",
-      "prov:atLocation": {"@id": "niiri:108d1ffc37df484fa90c2c0cb2179d8e"},
+      "prov:atLocation": {"@id": "niiri:4769429683d1135897230ffebc06ac65"},
       "prov:value": {"@type": "xsd:float", "@value": "22.6157932281494"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.03763886298215"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.69959426782984e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.87538446987651"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.43925432096054"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.03763886298215"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.69959426782984e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.87538446987651"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.43925432096054"}
     },
     {
-      "@id": "niiri:108d1ffc37df484fa90c2c0cb2179d8e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4769429683d1135897230ffebc06ac65",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0014",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-30,-34,6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-30,-34,6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:73750c53fdb790c6357c4da82d52bf27",
-      "entity": "niiri:d4c4e9d5661158241502d335eb5a96e4"
+      "entity_derived": "niiri:b964c9d32200b841b56fe800b88c0a4b",
+      "entity": "niiri:2607cc56c513b9a7b262e9ec22fe2b63"
     },
     {
-      "@id": "niiri:ac5d2ec515791af0b5c5bc53bf4d831d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:cf6cc59258bd447a466c3c1895718676",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0015",
-      "prov:atLocation": {"@id": "niiri:20dc2d694289dcfd2c519195b346651d"},
+      "prov:atLocation": {"@id": "niiri:eb420af4734a6c2a830db882030077df"},
       "prov:value": {"@type": "xsd:float", "@value": "21.8558578491211"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.97819185113407"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.47206660495925e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.921823721412592"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.43925432096054"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.97819185113407"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.47206660495925e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.921823721412592"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.43925432096054"}
     },
     {
-      "@id": "niiri:20dc2d694289dcfd2c519195b346651d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:eb420af4734a6c2a830db882030077df",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0015",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-28,0,30]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-28,0,30]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ac5d2ec515791af0b5c5bc53bf4d831d",
-      "entity": "niiri:52cc5fe71e36fbe65be2bc6eac0024f0"
+      "entity_derived": "niiri:cf6cc59258bd447a466c3c1895718676",
+      "entity": "niiri:1daa422fda95bd1a9676984906e1a548"
     },
     {
-      "@id": "niiri:a8dbaf9b6fb366c15ce2430b121036b4",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5175b1641041f873df3e4b8171a20dbd",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0016",
-      "prov:atLocation": {"@id": "niiri:b046a90ecefe5a66e6df2168c0a6515a"},
+      "prov:atLocation": {"@id": "niiri:640b2e1e62f4a54b769f0bb3d8d79b61"},
       "prov:value": {"@type": "xsd:float", "@value": "21.8296661376953"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.97611404363788"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.50252708366527e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.923209894114283"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.43925432096054"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.97611404363788"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.50252708366527e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.923209894114283"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.43925432096054"}
     },
     {
-      "@id": "niiri:b046a90ecefe5a66e6df2168c0a6515a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:640b2e1e62f4a54b769f0bb3d8d79b61",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0016",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[8,34,10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[8,34,10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a8dbaf9b6fb366c15ce2430b121036b4",
-      "entity": "niiri:c7a355d22d989f24ef00d62137ddfe13"
+      "entity_derived": "niiri:5175b1641041f873df3e4b8171a20dbd",
+      "entity": "niiri:a6888f03a619f2ef07714763993a3be7"
     },
     {
-      "@id": "niiri:119133b6405a655126b8ed5645f880f8",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:eda52aede28b44456962e7af041dab45",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0017",
-      "prov:atLocation": {"@id": "niiri:c800c1e03dab542188fcf9894ecf31ee"},
+      "prov:atLocation": {"@id": "niiri:3f60c67308d3c2cc8704c97c6f792d07"},
       "prov:value": {"@type": "xsd:float", "@value": "21.7287845611572"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.96809263472704"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.6225086553876e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.928411428313329"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.43925432096054"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.96809263472704"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.6225086553876e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.928411428313329"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.43925432096054"}
     },
     {
-      "@id": "niiri:c800c1e03dab542188fcf9894ecf31ee",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:3f60c67308d3c2cc8704c97c6f792d07",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0017",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[46,-56,10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[46,-56,10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:119133b6405a655126b8ed5645f880f8",
-      "entity": "niiri:ed934b2b32fd19f3afbe4c6bb5d3f1a3"
+      "entity_derived": "niiri:eda52aede28b44456962e7af041dab45",
+      "entity": "niiri:ff0222b1c30a382e52f5903988ee7a67"
     },
     {
-      "@id": "niiri:14c8cba4f3e9633c20a89ebceee4662c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:73097f0b0425dce88560554ead9adec5",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0018",
-      "prov:atLocation": {"@id": "niiri:5de0c31e65b5cd23874409ac161e2408"},
+      "prov:atLocation": {"@id": "niiri:db9cfc1e895056414a0d976a338eff75"},
       "prov:value": {"@type": "xsd:float", "@value": "14.2801656723022"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.27570591680179"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000526991241768693"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999156251"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.904639459548904"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.27570591680179"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000526991241768693"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999156251"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.904639459548904"}
     },
     {
-      "@id": "niiri:5de0c31e65b5cd23874409ac161e2408",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:db9cfc1e895056414a0d976a338eff75",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0018",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[48,-48,16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[48,-48,16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:14c8cba4f3e9633c20a89ebceee4662c",
-      "entity": "niiri:ed934b2b32fd19f3afbe4c6bb5d3f1a3"
+      "entity_derived": "niiri:73097f0b0425dce88560554ead9adec5",
+      "entity": "niiri:ff0222b1c30a382e52f5903988ee7a67"
     },
     {
-      "@id": "niiri:612280568e6b7910e48dcc0a59228df8",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:dee978e74443f1a4c46189f244ae1e75",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0019",
-      "prov:atLocation": {"@id": "niiri:c6db787a6eeb7e48b987a3fdb908a1df"},
+      "prov:atLocation": {"@id": "niiri:f7b1c619d30c23139ad1157664d70e8f"},
       "prov:value": {"@type": "xsd:float", "@value": "21.4629364013672"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.9468129149843"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.95991966499754e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.941069307565192"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.43925432096054"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.9468129149843"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.95991966499754e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.941069307565192"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.43925432096054"}
     },
     {
-      "@id": "niiri:c6db787a6eeb7e48b987a3fdb908a1df",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f7b1c619d30c23139ad1157664d70e8f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0019",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[46,-62,-10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[46,-62,-10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:612280568e6b7910e48dcc0a59228df8",
-      "entity": "niiri:f4a1be717fb30bceb6b19d568207e064"
+      "entity_derived": "niiri:dee978e74443f1a4c46189f244ae1e75",
+      "entity": "niiri:189a48f192c71c34afbefb1b24c895a1"
     },
     {
-      "@id": "niiri:66efaf9f1823b7df35ef80fe3d5ba73e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:7229cb1ae5d253d150d16f583a790984",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0020",
-      "prov:atLocation": {"@id": "niiri:ec620b6766c6ec678592ded393a36ba9"},
+      "prov:atLocation": {"@id": "niiri:a95490cb8d27272ebf40ab9641760b2a"},
       "prov:value": {"@type": "xsd:float", "@value": "21.4269542694092"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.94391683979485"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.00807329147268e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.942665676683549"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.43925432096054"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.94391683979485"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.00807329147268e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.942665676683549"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.43925432096054"}
     },
     {
-      "@id": "niiri:ec620b6766c6ec678592ded393a36ba9",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a95490cb8d27272ebf40ab9641760b2a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0020",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-8,-32,36]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-8,-32,36]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:66efaf9f1823b7df35ef80fe3d5ba73e",
-      "entity": "niiri:932e333631c50069ac12d36b6efba037"
+      "entity_derived": "niiri:7229cb1ae5d253d150d16f583a790984",
+      "entity": "niiri:153d0f62058a9c03f71f38806c01672c"
     },
     {
-      "@id": "niiri:2210f8a18943d180a900238ceedff24c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:31378a601c2becf436d41b267a4b16d5",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0021",
-      "prov:atLocation": {"@id": "niiri:14e86fb7cd633c0a5ef5c65a00f0e9b4"},
+      "prov:atLocation": {"@id": "niiri:268e773c306d3890ab5d905af99e9d1f"},
       "prov:value": {"@type": "xsd:float", "@value": "20.0413494110107"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.82938429557992"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.42321325474704e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.984364018223445"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.603397549204652"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.82938429557992"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.42321325474704e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.984364018223445"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.603397549204652"}
     },
     {
-      "@id": "niiri:14e86fb7cd633c0a5ef5c65a00f0e9b4",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:268e773c306d3890ab5d905af99e9d1f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0021",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-34,-84,-4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-34,-84,-4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2210f8a18943d180a900238ceedff24c",
-      "entity": "niiri:d98235d369f4da12b94c1ba7844053d1"
+      "entity_derived": "niiri:31378a601c2becf436d41b267a4b16d5",
+      "entity": "niiri:2b8333b9ae75e6a69c6703c1017776ef"
     },
     {
-      "@id": "niiri:3a4c2b67edee58581437ced3e2fa6fdb",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:83bc6d3f85253d9d97da7f55882bc0e2",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0022",
-      "prov:atLocation": {"@id": "niiri:becc56382e6d6bb11aa41e98639fc727"},
+      "prov:atLocation": {"@id": "niiri:11db5f1191f39a9f0f88a2e612164508"},
       "prov:value": {"@type": "xsd:float", "@value": "19.5813789367676"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.79000141974546"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.53232118573255e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.991038394814884"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.620995764715313"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.79000141974546"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.53232118573255e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.991038394814884"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.620995764715313"}
     },
     {
-      "@id": "niiri:becc56382e6d6bb11aa41e98639fc727",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:11db5f1191f39a9f0f88a2e612164508",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0022",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-50,2,40]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-50,2,40]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3a4c2b67edee58581437ced3e2fa6fdb",
-      "entity": "niiri:2b33b3c2fb565f11805c2ab96c217218"
+      "entity_derived": "niiri:83bc6d3f85253d9d97da7f55882bc0e2",
+      "entity": "niiri:be0ede967cfc83179dfb392adca98376"
     },
     {
-      "@id": "niiri:298daf4d8d2eb8870490b32c1ae9975b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b9f98ffb929e3828f9472a4a465a4f0d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0023",
-      "prov:atLocation": {"@id": "niiri:5af651b2bea7dc34805cf2833f2677de"},
+      "prov:atLocation": {"@id": "niiri:4ca72dd3f8082269bb21714642111f36"},
       "prov:value": {"@type": "xsd:float", "@value": "16.7666301727295"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.53217184854778"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00020608070787731"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99996648470095"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.655203493056632"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.53217184854778"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00020608070787731"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99996648470095"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.655203493056632"}
     },
     {
-      "@id": "niiri:5af651b2bea7dc34805cf2833f2677de",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4ca72dd3f8082269bb21714642111f36",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0023",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-52,-6,46]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-52,-6,46]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:298daf4d8d2eb8870490b32c1ae9975b",
-      "entity": "niiri:2b33b3c2fb565f11805c2ab96c217218"
+      "entity_derived": "niiri:b9f98ffb929e3828f9472a4a465a4f0d",
+      "entity": "niiri:be0ede967cfc83179dfb392adca98376"
     },
     {
-      "@id": "niiri:2bb07c496f32733ffaf79205cbde705d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3fc414435450d7991a1adccdb53f2ea3",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0024",
-      "prov:atLocation": {"@id": "niiri:f6451a965ab339d1c415e793ffad62de"},
+      "prov:atLocation": {"@id": "niiri:ebc812dddae356c4835e80cff836a117"},
       "prov:value": {"@type": "xsd:float", "@value": "19.3040504455566"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.76590943131268"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.2971971291701e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.993825462793153"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.620995764715313"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.76590943131268"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.2971971291701e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.993825462793153"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.620995764715313"}
     },
     {
-      "@id": "niiri:f6451a965ab339d1c415e793ffad62de",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ebc812dddae356c4835e80cff836a117",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0024",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[24,-46,32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[24,-46,32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2bb07c496f32733ffaf79205cbde705d",
-      "entity": "niiri:5a17a76cb3f0ca0ddba79372b881b0ac"
+      "entity_derived": "niiri:3fc414435450d7991a1adccdb53f2ea3",
+      "entity": "niiri:23f2b3702fb27a3d52f0874c93630544"
     },
     {
-      "@id": "niiri:438305e8c2f5556b27b914f4d3239071",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c636ea0bddcfb80ff2d7e531404b34f1",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0025",
-      "prov:atLocation": {"@id": "niiri:a9bf98eb09e4b016756eff1156f4286b"},
+      "prov:atLocation": {"@id": "niiri:27909070b90094da7c248e424652127e"},
       "prov:value": {"@type": "xsd:float", "@value": "19.1409015655518"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.75161143600874"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.7850813353163e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.995110302012489"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.620995764715313"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.75161143600874"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.7850813353163e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.995110302012489"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.620995764715313"}
     },
     {
-      "@id": "niiri:a9bf98eb09e4b016756eff1156f4286b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:27909070b90094da7c248e424652127e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0025",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[6,16,50]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[6,16,50]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:438305e8c2f5556b27b914f4d3239071",
-      "entity": "niiri:cdbe1592b4a9de39b031d21dc9c2950c"
+      "entity_derived": "niiri:c636ea0bddcfb80ff2d7e531404b34f1",
+      "entity": "niiri:654afa8f2fea6cb2d23c37e50edee008"
     },
     {
-      "@id": "niiri:ddc9cae8d3158977a73eb0da58b76107",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:17e69e7f43739c2172a5e069dcce782a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0026",
-      "prov:atLocation": {"@id": "niiri:51695623c6ca5bb8c73f0fbd141e34b8"},
+      "prov:atLocation": {"@id": "niiri:5e6d74ec4614c24eabbeefa458ae9b94"},
       "prov:value": {"@type": "xsd:float", "@value": "19.098669052124"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.74789498829157"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.91624398706714e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.995405100064856"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.620995764715313"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.74789498829157"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.91624398706714e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.995405100064856"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.620995764715313"}
     },
     {
-      "@id": "niiri:51695623c6ca5bb8c73f0fbd141e34b8",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:5e6d74ec4614c24eabbeefa458ae9b94",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0026",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-4,-24,6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-4,-24,6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ddc9cae8d3158977a73eb0da58b76107",
-      "entity": "niiri:a74c6130611adcee49f9abe720d6e52c"
+      "entity_derived": "niiri:17e69e7f43739c2172a5e069dcce782a",
+      "entity": "niiri:dba06f209302f6639800d0af3c93affd"
     },
     {
-      "@id": "niiri:8847b40a6f0df9036ec3f2fd39169359",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:310041e942b16c12433a1a316b01a18b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0027",
-      "prov:atLocation": {"@id": "niiri:e273e273caa0ec10a477c3a383d1d039"},
+      "prov:atLocation": {"@id": "niiri:b5ed65cc20e2af254f0c0773a378955e"},
       "prov:value": {"@type": "xsd:float", "@value": "19.0145893096924"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.7404771295496"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "9.1835629583259e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.995949293325196"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.620995764715313"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.7404771295496"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "9.1835629583259e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.995949293325196"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.620995764715313"}
     },
     {
-      "@id": "niiri:e273e273caa0ec10a477c3a383d1d039",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b5ed65cc20e2af254f0c0773a378955e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0027",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-4,0,54]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-4,0,54]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8847b40a6f0df9036ec3f2fd39169359",
-      "entity": "niiri:0b42259e10bfb86cff826215fa08b419"
+      "entity_derived": "niiri:310041e942b16c12433a1a316b01a18b",
+      "entity": "niiri:57c14f931d36e820d2322a1bdd36da40"
     },
     {
-      "@id": "niiri:a7b30b8104925d31a8d85558816954a4",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:830254d5fee868a84ad02a38a3e7bb23",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0028",
-      "prov:atLocation": {"@id": "niiri:91f4273fc35936bf99d99d9ad2fb4cfc"},
+      "prov:atLocation": {"@id": "niiri:c5ab846fb07f8ec905e64d8b25852e7f"},
       "prov:value": {"@type": "xsd:float", "@value": "18.8265838623047"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.72379883766124"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "9.81236582245915e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.996978299202392"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.620995764715313"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.72379883766124"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "9.81236582245915e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.996978299202392"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.620995764715313"}
     },
     {
-      "@id": "niiri:91f4273fc35936bf99d99d9ad2fb4cfc",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c5ab846fb07f8ec905e64d8b25852e7f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0028",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[42,-28,30]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[42,-28,30]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a7b30b8104925d31a8d85558816954a4",
-      "entity": "niiri:59f34e94c3c0a0f91363e1cf44b96bbb"
+      "entity_derived": "niiri:830254d5fee868a84ad02a38a3e7bb23",
+      "entity": "niiri:2739d32e473645dfabd9a03fc9f4dae7"
     },
     {
-      "@id": "niiri:8ed0689ab43fd4b1b7c2ee84f6beba5c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d7ae1c6177cf91420976fa8b1b418173",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0029",
-      "prov:atLocation": {"@id": "niiri:6cb4eee1ad1e08bbcd01a863d6f8b5f8"},
+      "prov:atLocation": {"@id": "niiri:6462195dc355a327af5cd5d73524f76f"},
       "prov:value": {"@type": "xsd:float", "@value": "18.5199432373047"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.69631988620818"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000109373660980738"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.998191254166604"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.620995764715313"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.69631988620818"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000109373660980738"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.998191254166604"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.620995764715313"}
     },
     {
-      "@id": "niiri:6cb4eee1ad1e08bbcd01a863d6f8b5f8",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6462195dc355a327af5cd5d73524f76f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0029",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[52,-12,44]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[52,-12,44]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8ed0689ab43fd4b1b7c2ee84f6beba5c",
-      "entity": "niiri:e15a7f7da66912fa92c8140c6338b192"
+      "entity_derived": "niiri:d7ae1c6177cf91420976fa8b1b418173",
+      "entity": "niiri:23f5ffb7a02a62400ce3f1cfda032dbe"
     },
     {
-      "@id": "niiri:71b0d462c29ff2b8d2aff22b5383b911",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:8f42c8637a3ba73755a9485aaf00eb82",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0030",
-      "prov:atLocation": {"@id": "niiri:ea53f24d5d3a2fad46c71215259a5a7d"},
+      "prov:atLocation": {"@id": "niiri:6678f079e5924136062e8a6111422c3e"},
       "prov:value": {"@type": "xsd:float", "@value": "18.516544342041"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.69601335434539"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000109505728679404"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.998201975106935"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.620995764715313"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.69601335434539"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000109505728679404"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.998201975106935"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.620995764715313"}
     },
     {
-      "@id": "niiri:ea53f24d5d3a2fad46c71215259a5a7d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6678f079e5924136062e8a6111422c3e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0030",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-40,-28,30]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-40,-28,30]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:71b0d462c29ff2b8d2aff22b5383b911",
-      "entity": "niiri:deefe75f432062b10a9b73a0036af48f"
+      "entity_derived": "niiri:8f42c8637a3ba73755a9485aaf00eb82",
+      "entity": "niiri:3ed09542d8eeb67b7a92a4f1152a9588"
     },
     {
-      "@id": "niiri:84f3af431a82fbb9358d6b58ad360b16",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:4e350520ca70ab7fb0dad1e34876ed26",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0031",
-      "prov:atLocation": {"@id": "niiri:f4d3682b9d6a7b0057b4d62e5090ffa9"},
+      "prov:atLocation": {"@id": "niiri:e0ae1200c3ffc3c5db37844273e4e303"},
       "prov:value": {"@type": "xsd:float", "@value": "18.4609222412109"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.69099090519778"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000111691062804176"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.998370011058266"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.620995764715313"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.69099090519778"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000111691062804176"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.998370011058266"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.620995764715313"}
     },
     {
-      "@id": "niiri:f4d3682b9d6a7b0057b4d62e5090ffa9",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e0ae1200c3ffc3c5db37844273e4e303",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0031",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[32,22,-8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[32,22,-8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:84f3af431a82fbb9358d6b58ad360b16",
-      "entity": "niiri:85cc735cf6146dea08ebdfd5febbbbf6"
+      "entity_derived": "niiri:4e350520ca70ab7fb0dad1e34876ed26",
+      "entity": "niiri:ee2c6440d10e17fa3f61858f975e92f6"
     },
     {
-      "@id": "niiri:a5af2910b52203fdd672c66a274d0fbe",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:64a12d60baf5c5c9da921d103abfb214",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0032",
-      "prov:atLocation": {"@id": "niiri:33352188ff1763e86b3df4fa87fbd278"},
+      "prov:atLocation": {"@id": "niiri:e51f9648fbb37b09655d7786ddaac9ff"},
       "prov:value": {"@type": "xsd:float", "@value": "17.9312534332275"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.64257521175179"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00013496203699781"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99941063068466"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.642014449876257"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.64257521175179"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00013496203699781"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99941063068466"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.642014449876257"}
     },
     {
-      "@id": "niiri:33352188ff1763e86b3df4fa87fbd278",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e51f9648fbb37b09655d7786ddaac9ff",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0032",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[64,-4,10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[64,-4,10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a5af2910b52203fdd672c66a274d0fbe",
-      "entity": "niiri:eda691902b8e9f86974b74de47c3be21"
+      "entity_derived": "niiri:64a12d60baf5c5c9da921d103abfb214",
+      "entity": "niiri:25764564ed7b5495d43208d9a742797c"
     },
     {
-      "@id": "niiri:6e3bdb3327ec90d2db2f7ff70f7cb627",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0e8721be3c984e497213a6eb5d79d336",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0033",
-      "prov:atLocation": {"@id": "niiri:22944eab0acc14d93d825f1e7d1cfd34"},
+      "prov:atLocation": {"@id": "niiri:c9b5180b8d4ddcc1a0089df933fe1d66"},
       "prov:value": {"@type": "xsd:float", "@value": "17.8439044952393"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.63448648232359"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000139267429951739"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999509275806277"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.642014449876257"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.63448648232359"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000139267429951739"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999509275806277"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.642014449876257"}
     },
     {
-      "@id": "niiri:22944eab0acc14d93d825f1e7d1cfd34",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c9b5180b8d4ddcc1a0089df933fe1d66",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0033",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-22,-72,34]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-22,-72,34]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6e3bdb3327ec90d2db2f7ff70f7cb627",
-      "entity": "niiri:44c46f8ea3d70ad705fe182f1aaf841e"
+      "entity_derived": "niiri:0e8721be3c984e497213a6eb5d79d336",
+      "entity": "niiri:2a5007577d5f397768b0a52d8e1e454a"
     },
     {
-      "@id": "niiri:a2ba7c350e9e6efdbe0c719e9de18ad8",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e8cb5546247d4a3680cfd15b61ec92a8",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0034",
-      "prov:atLocation": {"@id": "niiri:a7eb863b9f06f839144773c75b850f3a"},
+      "prov:atLocation": {"@id": "niiri:ed43d1458342766e20a370cd82717651"},
       "prov:value": {"@type": "xsd:float", "@value": "17.552827835083"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.60731294050443"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000154692216466135"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999742486133075"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.655203493056632"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.60731294050443"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000154692216466135"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999742486133075"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.655203493056632"}
     },
     {
-      "@id": "niiri:a7eb863b9f06f839144773c75b850f3a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ed43d1458342766e20a370cd82717651",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0034",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-6,-44,40]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-6,-44,40]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a2ba7c350e9e6efdbe0c719e9de18ad8",
-      "entity": "niiri:e1e2e1faf57e2ccdad8d1cc2103103f7"
+      "entity_derived": "niiri:e8cb5546247d4a3680cfd15b61ec92a8",
+      "entity": "niiri:075d03d6a0a7a8ff06d2fd0a678225e4"
     },
     {
-      "@id": "niiri:bfba150f550283418449951c8e862cdc",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:feb703455a27d97b3c3dd1a514984c82",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0035",
-      "prov:atLocation": {"@id": "niiri:0858bf7232b97f8889a993d00c66391c"},
+      "prov:atLocation": {"@id": "niiri:9c2467090e8804770ca4c9155328ff6f"},
       "prov:value": {"@type": "xsd:float", "@value": "17.2906818389893"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.58254613965863"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000170130746602659"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99986271355264"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.655203493056632"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.58254613965863"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000170130746602659"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99986271355264"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.655203493056632"}
     },
     {
-      "@id": "niiri:0858bf7232b97f8889a993d00c66391c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:9c2467090e8804770ca4c9155328ff6f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0035",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-34,-38,-34]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-34,-38,-34]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:bfba150f550283418449951c8e862cdc",
-      "entity": "niiri:a63b9651208c3ee898cba42774cbd083"
+      "entity_derived": "niiri:feb703455a27d97b3c3dd1a514984c82",
+      "entity": "niiri:f9daf2bb86509394f654f8dfb4a4e15b"
     },
     {
-      "@id": "niiri:3d432d24c1b40847e1aad79c018abae4",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:28a0f16475271ebd8e455e39cde15030",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0036",
-      "prov:atLocation": {"@id": "niiri:b117dbcec89fdaa7e022b0c62f784d39"},
+      "prov:atLocation": {"@id": "niiri:d62fe87691f9afa1a346f5ddd28d979b"},
       "prov:value": {"@type": "xsd:float", "@value": "17.1612319946289"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.57021115022413"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000178346794309836"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999901168620001"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.655203493056632"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.57021115022413"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000178346794309836"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999901168620001"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.655203493056632"}
     },
     {
-      "@id": "niiri:b117dbcec89fdaa7e022b0c62f784d39",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d62fe87691f9afa1a346f5ddd28d979b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0036",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-46,-16,20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-46,-16,20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3d432d24c1b40847e1aad79c018abae4",
-      "entity": "niiri:99df9b0bee5015f2e54ddbafb84c5b4b"
+      "entity_derived": "niiri:28a0f16475271ebd8e455e39cde15030",
+      "entity": "niiri:447a33078d0ab11fa638dad2f64b7b00"
     },
     {
-      "@id": "niiri:4124ce0ca684403359fec60d38ec647b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5518c40950022bff274b3d6a606c42f0",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0037",
-      "prov:atLocation": {"@id": "niiri:e186490bd92fb3b7db54fd2ac28f57bf"},
+      "prov:atLocation": {"@id": "niiri:46998d4a4e0fcd3525424c2621d0e486"},
       "prov:value": {"@type": "xsd:float", "@value": "17.0075950622559"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.55547987606237"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000188644912021529"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999934173907998"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.655203493056632"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.55547987606237"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000188644912021529"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999934173907998"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.655203493056632"}
     },
     {
-      "@id": "niiri:e186490bd92fb3b7db54fd2ac28f57bf",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:46998d4a4e0fcd3525424c2621d0e486",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0037",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[24,32,2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[24,32,2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4124ce0ca684403359fec60d38ec647b",
-      "entity": "niiri:4fb8453b9556b51fec8c4dac94527e32"
+      "entity_derived": "niiri:5518c40950022bff274b3d6a606c42f0",
+      "entity": "niiri:e979405039e66c5ce2c3d5b5b67f1286"
     },
     {
-      "@id": "niiri:656111533d822eb5e80c14aaa8ec5277",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f4f7823b1059a0ea57e9561159693d3f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0038",
-      "prov:atLocation": {"@id": "niiri:d8759922b592403e4b271841a2cd7caa"},
+      "prov:atLocation": {"@id": "niiri:a7d105498568414d907898529276f8b1"},
       "prov:value": {"@type": "xsd:float", "@value": "16.5308303833008"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.50911812032442"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000224797592033421"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999983487413756"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.655203493056632"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.50911812032442"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000224797592033421"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999983487413756"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.655203493056632"}
     },
     {
-      "@id": "niiri:d8759922b592403e4b271841a2cd7caa",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a7d105498568414d907898529276f8b1",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0038",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-26,-90,16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-26,-90,16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:656111533d822eb5e80c14aaa8ec5277",
-      "entity": "niiri:06615834113ebb8c32e91747f3e2ea30"
+      "entity_derived": "niiri:f4f7823b1059a0ea57e9561159693d3f",
+      "entity": "niiri:02724527e4ee34eff0967177115a83d1"
     },
     {
-      "@id": "niiri:595ef0d6fdea073f86b47c75b3d155b8",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:9acefe93a7c31e0167ce0ffe2ceaa937",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0039",
-      "prov:atLocation": {"@id": "niiri:f08647b25bf3126df7b3808fcac785b8"},
+      "prov:atLocation": {"@id": "niiri:750a622122e236f5a7a8fe8d719fb55b"},
       "prov:value": {"@type": "xsd:float", "@value": "16.5225524902344"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.50830432871627"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0002254864217901"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999983907066973"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.655203493056632"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.50830432871627"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0002254864217901"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999983907066973"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.655203493056632"}
     },
     {
-      "@id": "niiri:f08647b25bf3126df7b3808fcac785b8",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:750a622122e236f5a7a8fe8d719fb55b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0039",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-28,-4,16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-28,-4,16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:595ef0d6fdea073f86b47c75b3d155b8",
-      "entity": "niiri:ebf5f25253bc1119f25ba867f1a13a26"
+      "entity_derived": "niiri:9acefe93a7c31e0167ce0ffe2ceaa937",
+      "entity": "niiri:c6bf9a9fd500605c73016dfb45e6af98"
     },
     {
-      "@id": "niiri:c298852f98f17ca701a41c53eaf7b107",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3eeaab0bcdb1598c681f02ebda8bb1e8",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0040",
-      "prov:atLocation": {"@id": "niiri:0a0f4003136bb331371d2e48a04a4277"},
+      "prov:atLocation": {"@id": "niiri:102ea580265a6d2daecfec9a22a9b1e4"},
       "prov:value": {"@type": "xsd:float", "@value": "16.1374092102051"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.47009871338807"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00026013355917065"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999995475747835"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.714297554117909"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.47009871338807"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00026013355917065"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999995475747835"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.714297554117909"}
     },
     {
-      "@id": "niiri:0a0f4003136bb331371d2e48a04a4277",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:102ea580265a6d2daecfec9a22a9b1e4",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0040",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[12,60,20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[12,60,20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c298852f98f17ca701a41c53eaf7b107",
-      "entity": "niiri:e51b44da6f9ef9702d8a79c08d73d19e"
+      "entity_derived": "niiri:3eeaab0bcdb1598c681f02ebda8bb1e8",
+      "entity": "niiri:e3e587be4409f0bc772835a934536590"
     },
     {
-      "@id": "niiri:36a652eea4c7ac20af73fbdd72bfd50f",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:762957e2b9b79f111526f35c0c3416cc",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0041",
-      "prov:atLocation": {"@id": "niiri:aec8a1a1e442c5f005622e4f7812287e"},
+      "prov:atLocation": {"@id": "niiri:1084313fe511021069a095149f1c37de"},
       "prov:value": {"@type": "xsd:float", "@value": "15.9136981964111"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.44759277757755"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000282803055741021"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999997977474125"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.730845085955462"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.44759277757755"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000282803055741021"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999997977474125"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.730845085955462"}
     },
     {
-      "@id": "niiri:aec8a1a1e442c5f005622e4f7812287e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:1084313fe511021069a095149f1c37de",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0041",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[4,-84,-4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[4,-84,-4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:36a652eea4c7ac20af73fbdd72bfd50f",
-      "entity": "niiri:b8483957e8852fa21925543fe06f0492"
+      "entity_derived": "niiri:762957e2b9b79f111526f35c0c3416cc",
+      "entity": "niiri:6aa3e47b1d56a62cbf353acb1dbf4e63"
     },
     {
-      "@id": "niiri:1099753739cedf3c7eddb2da41cd1f43",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ba7dd3245ca2f03a516b8c2349193add",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0042",
-      "prov:atLocation": {"@id": "niiri:31ee057da380c3b2ff19a8d5cad92798"},
+      "prov:atLocation": {"@id": "niiri:3e9f38b8aafc94df86bb9516f511f4db"},
       "prov:value": {"@type": "xsd:float", "@value": "15.8536109924316"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.44150764421068"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000289241063091916"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999998385530387"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.730845085955462"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.44150764421068"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000289241063091916"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999998385530387"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.730845085955462"}
     },
     {
-      "@id": "niiri:31ee057da380c3b2ff19a8d5cad92798",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:3e9f38b8aafc94df86bb9516f511f4db",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0042",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[62,-18,22]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[62,-18,22]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1099753739cedf3c7eddb2da41cd1f43",
-      "entity": "niiri:1d380370dd353aff7206de21666fb3d4"
+      "entity_derived": "niiri:ba7dd3245ca2f03a516b8c2349193add",
+      "entity": "niiri:11267ea4af34c876ad34aa054c834aa1"
     },
     {
-      "@id": "niiri:59a93557347fa5539b9b61f828d0435f",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ce6828c9876402cd1eb1653f92f8b5b1",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0043",
-      "prov:atLocation": {"@id": "niiri:6574f0e7bae8fd427e7a5b46ab994492"},
+      "prov:atLocation": {"@id": "niiri:0913fe441dd608e575921c2b4f0500a1"},
       "prov:value": {"@type": "xsd:float", "@value": "15.8288412094116"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.43899416081302"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000291939913913408"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999998530446399"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.730845085955462"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.43899416081302"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000291939913913408"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999998530446399"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.730845085955462"}
     },
     {
-      "@id": "niiri:6574f0e7bae8fd427e7a5b46ab994492",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0913fe441dd608e575921c2b4f0500a1",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0043",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[28,-58,44]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[28,-58,44]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:59a93557347fa5539b9b61f828d0435f",
-      "entity": "niiri:68a55477530e699e1f7822c244d7eb8f"
+      "entity_derived": "niiri:ce6828c9876402cd1eb1653f92f8b5b1",
+      "entity": "niiri:ed62a9c22b9d6c8f4255706a0676f4da"
     },
     {
-      "@id": "niiri:32f10e6869aaf6c0ca25e73f7ebc26e2",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:580ea35cc47de5999eda43982afb2748",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0044",
-      "prov:atLocation": {"@id": "niiri:926fecabbaf195c68687730a66cdaeb2"},
+      "prov:atLocation": {"@id": "niiri:1eb319b0bd9712d284e197093bcacd55"},
       "prov:value": {"@type": "xsd:float", "@value": "15.7273988723755"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.42866974555038"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000303273553249328"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999007347173"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.736843607649928"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.42866974555038"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000303273553249328"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999007347173"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.736843607649928"}
     },
     {
-      "@id": "niiri:926fecabbaf195c68687730a66cdaeb2",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:1eb319b0bd9712d284e197093bcacd55",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0044",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[38,44,0]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[38,44,0]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:32f10e6869aaf6c0ca25e73f7ebc26e2",
-      "entity": "niiri:aacb0b550de1bf101b8a9ebfbba31aae"
+      "entity_derived": "niiri:580ea35cc47de5999eda43982afb2748",
+      "entity": "niiri:7649cec60050f6bbb0a4a68fad360d04"
     },
     {
-      "@id": "niiri:cbf40cf2484c9f75c34529d78f40f15d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:dbf6e6c9df9c1acb5c0e4b176d3529de",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0045",
-      "prov:atLocation": {"@id": "niiri:55f1d43a8bb8799dfd32c66925f7d19d"},
+      "prov:atLocation": {"@id": "niiri:67a77f04ccd563945196ea9dd89d135b"},
       "prov:value": {"@type": "xsd:float", "@value": "15.4726600646973"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.40252319694713"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000333833435672726"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999648429928"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.766283831090278"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.40252319694713"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000333833435672726"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999648429928"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.766283831090278"}
     },
     {
-      "@id": "niiri:55f1d43a8bb8799dfd32c66925f7d19d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:67a77f04ccd563945196ea9dd89d135b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0045",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[40,-6,-6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[40,-6,-6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cbf40cf2484c9f75c34529d78f40f15d",
-      "entity": "niiri:18d7d5a2985d2afc116f40bb7d9dd868"
+      "entity_derived": "niiri:dbf6e6c9df9c1acb5c0e4b176d3529de",
+      "entity": "niiri:76477879d12f5565edfe6317f1396ae3"
     },
     {
-      "@id": "niiri:95a78404fc8bda4d787b98fbc9b48494",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:cb04519fde20aaf17e0dc9a593fb3d64",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0046",
-      "prov:atLocation": {"@id": "niiri:02186d81df3437bfcd3dfedfba544439"},
+      "prov:atLocation": {"@id": "niiri:c089e08b98fa0c293381772f1ad43eb7"},
       "prov:value": {"@type": "xsd:float", "@value": "15.3332357406616"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.38807697766079"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00035192253822891"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999807374102"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.766283831090278"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.38807697766079"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00035192253822891"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999807374102"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.766283831090278"}
     },
     {
-      "@id": "niiri:02186d81df3437bfcd3dfedfba544439",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c089e08b98fa0c293381772f1ad43eb7",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0046",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[32,14,58]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[32,14,58]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:95a78404fc8bda4d787b98fbc9b48494",
-      "entity": "niiri:b82b663a41d1d4bc01fd88119e09dfc9"
+      "entity_derived": "niiri:cb04519fde20aaf17e0dc9a593fb3d64",
+      "entity": "niiri:b32a94908c3543b6389e71c09e18b028"
     },
     {
-      "@id": "niiri:64009818f6d53df0a0772b73e0d6b8ab",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d2c121ae6272e04656b61fe1f025dc35",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0047",
-      "prov:atLocation": {"@id": "niiri:a4770fa7b3785a1cc18136e5f58c75e9"},
+      "prov:atLocation": {"@id": "niiri:cfe785bcd016f63eca725d056a54477f"},
       "prov:value": {"@type": "xsd:float", "@value": "15.3172578811646"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.38641524500992"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000354060730342054"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999982049151"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.766283831090278"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.38641524500992"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000354060730342054"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999982049151"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.766283831090278"}
     },
     {
-      "@id": "niiri:a4770fa7b3785a1cc18136e5f58c75e9",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:cfe785bcd016f63eca725d056a54477f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0047",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[4,-86,4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[4,-86,4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:64009818f6d53df0a0772b73e0d6b8ab",
-      "entity": "niiri:74035667fc1f8ff5d347c08183ecb0d2"
+      "entity_derived": "niiri:d2c121ae6272e04656b61fe1f025dc35",
+      "entity": "niiri:505e13c060365ce925c6c78620aace2b"
     },
     {
-      "@id": "niiri:d856e8b83939b59218ac7a746b463ee3",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:df8d20feb57d27a95ebc95ea167307a2",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0048",
-      "prov:atLocation": {"@id": "niiri:2bb3575890e47e2c795acd56341b710d"},
+      "prov:atLocation": {"@id": "niiri:f38a4b2a1e042ce6de00fdcf526dbe7c"},
       "prov:value": {"@type": "xsd:float", "@value": "15.3137311935425"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.38604828864924"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000354534526388783"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999823272138"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.766283831090278"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.38604828864924"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000354534526388783"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999823272138"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.766283831090278"}
     },
     {
-      "@id": "niiri:2bb3575890e47e2c795acd56341b710d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f38a4b2a1e042ce6de00fdcf526dbe7c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0048",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[62,-36,46]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[62,-36,46]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d856e8b83939b59218ac7a746b463ee3",
-      "entity": "niiri:a9e9f6c4e1e252f83c00826797f885fd"
+      "entity_derived": "niiri:df8d20feb57d27a95ebc95ea167307a2",
+      "entity": "niiri:6a2f64f5544ff048d58423df90e157d2"
     },
     {
-      "@id": "niiri:499615260dd74f9d189314807c6f588d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e1adf61d5f82a1f2b659ae4e403de7c6",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0049",
-      "prov:atLocation": {"@id": "niiri:d2d393550d128ce668f6e44797305dab"},
+      "prov:atLocation": {"@id": "niiri:56d1597c5c0850762b5b4e07acdeb247"},
       "prov:value": {"@type": "xsd:float", "@value": "15.1916456222534"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.37330635701462"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000371356333789152"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999898084819"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.778719805919739"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.37330635701462"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000371356333789152"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999898084819"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.778719805919739"}
     },
     {
-      "@id": "niiri:d2d393550d128ce668f6e44797305dab",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:56d1597c5c0850762b5b4e07acdeb247",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0049",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-24,18,58]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-24,18,58]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:499615260dd74f9d189314807c6f588d",
-      "entity": "niiri:100b7385b787aa70accf430f06dc1f51"
+      "entity_derived": "niiri:e1adf61d5f82a1f2b659ae4e403de7c6",
+      "entity": "niiri:965bca191e7bce9008d8dd515cf43195"
     },
     {
-      "@id": "niiri:4fde7ff637ea89cf29d7c5813cc8e4a9",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:bbcbd508c2385f821ae15583d3d00469",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0050",
-      "prov:atLocation": {"@id": "niiri:67ceb8c7a82ec04487273d003017bc73"},
+      "prov:atLocation": {"@id": "niiri:0b2cb1cecb1b69b139c9f6fc3ef83e39"},
       "prov:value": {"@type": "xsd:float", "@value": "15.0888338088989"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.36251708484568"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000386176732959709"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999936876428"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.787311600282456"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.36251708484568"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000386176732959709"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999936876428"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.787311600282456"}
     },
     {
-      "@id": "niiri:67ceb8c7a82ec04487273d003017bc73",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0b2cb1cecb1b69b139c9f6fc3ef83e39",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0050",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[8,-22,-44]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[8,-22,-44]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4fde7ff637ea89cf29d7c5813cc8e4a9",
-      "entity": "niiri:677f763bf103868e95ac103a45720d37"
+      "entity_derived": "niiri:bbcbd508c2385f821ae15583d3d00469",
+      "entity": "niiri:5c0f8a6949255a54753a5996ab8bf0b5"
     },
     {
-      "@id": "niiri:0e6dfe430b9215e3a35cd3cc66d9cffe",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:400a173374e07f6ad6fa8505dd25b493",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0051",
-      "prov:atLocation": {"@id": "niiri:55b9d9758877f1f69da568a70e591c9e"},
+      "prov:atLocation": {"@id": "niiri:ca25ec1591871d5ddccaa5f5e6f304db"},
       "prov:value": {"@type": "xsd:float", "@value": "14.8200588226318"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.33405240591422"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000427952650791097"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999983180231"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.834595072923498"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.33405240591422"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000427952650791097"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999983180231"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.834595072923498"}
     },
     {
-      "@id": "niiri:55b9d9758877f1f69da568a70e591c9e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ca25ec1591871d5ddccaa5f5e6f304db",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0051",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[38,34,22]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[38,34,22]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0e6dfe430b9215e3a35cd3cc66d9cffe",
-      "entity": "niiri:0c812c731486b17b175ecfc3bf7169f1"
+      "entity_derived": "niiri:400a173374e07f6ad6fa8505dd25b493",
+      "entity": "niiri:e00c0b657ae25f884a41aad34f6d4869"
     },
     {
-      "@id": "niiri:82c3f1e4c0dc909c3ba79639eda9a8af",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5e8d9c60f45794f6ee76f52290599e75",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0052",
-      "prov:atLocation": {"@id": "niiri:d12a3140e4f088df81db3c536483c2c1"},
+      "prov:atLocation": {"@id": "niiri:790cfd7d87f72cac07ad32edea0f5651"},
       "prov:value": {"@type": "xsd:float", "@value": "14.696608543396"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.32085065286489"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000448717729613968"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.9999999911592"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.835113533794074"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.32085065286489"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000448717729613968"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.9999999911592"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.835113533794074"}
     },
     {
-      "@id": "niiri:d12a3140e4f088df81db3c536483c2c1",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:790cfd7d87f72cac07ad32edea0f5651",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0052",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[0,-26,-28]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[0,-26,-28]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:82c3f1e4c0dc909c3ba79639eda9a8af",
-      "entity": "niiri:747d0e971ba4dc1c824eb2073e536769"
+      "entity_derived": "niiri:5e8d9c60f45794f6ee76f52290599e75",
+      "entity": "niiri:efbb22419db35e6170e4f8c15df564d9"
     },
     {
-      "@id": "niiri:94bc6a18ed5db528a3f4237966e8d39e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5352b8108713eb17c53045c149a58a47",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0053",
-      "prov:atLocation": {"@id": "niiri:f54d2a9846066f14b56154dba91fd892"},
+      "prov:atLocation": {"@id": "niiri:c191d0465f28572e319e54675be50b51"},
       "prov:value": {"@type": "xsd:float", "@value": "14.2414035797119"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.27145497586776"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00053497811978398"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999933201"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.904639459548904"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.27145497586776"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00053497811978398"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999933201"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.904639459548904"}
     },
     {
-      "@id": "niiri:f54d2a9846066f14b56154dba91fd892",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c191d0465f28572e319e54675be50b51",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0053",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[40,-50,-22]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[40,-50,-22]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:94bc6a18ed5db528a3f4237966e8d39e",
-      "entity": "niiri:db3dd4033ee5e1f792de4dafd8064e08"
+      "entity_derived": "niiri:5352b8108713eb17c53045c149a58a47",
+      "entity": "niiri:792fda8a02886788088cdc21433fe931"
     },
     {
-      "@id": "niiri:91fe83f3f4e1b6b6297f0a1782fcfc01",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:4d047c8ee6809f00a9f5c059b315c51b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0054",
-      "prov:atLocation": {"@id": "niiri:cca51657add022838ebb58d09ebbc39f"},
+      "prov:atLocation": {"@id": "niiri:543d1149d7bfdacbb406551cbe82d946"},
       "prov:value": {"@type": "xsd:float", "@value": "14.0012445449829"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.24492687341108"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000587403942481801"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999852106"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.931776511128243"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.24492687341108"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000587403942481801"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999852106"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.931776511128243"}
     },
     {
-      "@id": "niiri:cca51657add022838ebb58d09ebbc39f",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:543d1149d7bfdacbb406551cbe82d946",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0054",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[8,52,32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[8,52,32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:91fe83f3f4e1b6b6297f0a1782fcfc01",
-      "entity": "niiri:5d1b7a0c9ff2df0d604a94edf7efd3ac"
+      "entity_derived": "niiri:4d047c8ee6809f00a9f5c059b315c51b",
+      "entity": "niiri:0dd1d301e6eec8815748b738cd4fdb7c"
     },
     {
-      "@id": "niiri:ca5b7c73b9e8e2c0a918d6cb7d3e700a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:bbb945c8440c49e2cc1175a521c2126c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0055",
-      "prov:atLocation": {"@id": "niiri:615c290f65ed81c412ee36643ca93374"},
+      "prov:atLocation": {"@id": "niiri:c5ea339216a0e5c8bc8aadff1689b3e7"},
       "prov:value": {"@type": "xsd:float", "@value": "13.9842071533203"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.2430323166614"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000591323980175695"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999867649"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.931776511128243"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.2430323166614"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000591323980175695"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999867649"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.931776511128243"}
     },
     {
-      "@id": "niiri:615c290f65ed81c412ee36643ca93374",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c5ea339216a0e5c8bc8aadff1689b3e7",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0055",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-14,-48,-24]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-14,-48,-24]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ca5b7c73b9e8e2c0a918d6cb7d3e700a",
-      "entity": "niiri:464ed1a86745e5328f28784be3bd4fb3"
+      "entity_derived": "niiri:bbb945c8440c49e2cc1175a521c2126c",
+      "entity": "niiri:0a00a0a76e73ce79a1d09f89ec092795"
     },
     {
-      "@id": "niiri:af7fb718df18d23512b5191e557f013b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:00c3e6ced7aa1682b713c6694740fe99",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0056",
-      "prov:atLocation": {"@id": "niiri:9197a509e59f57ac84b0239635308061"},
+      "prov:atLocation": {"@id": "niiri:9c44f545329074e4000b8310d4b620c7"},
       "prov:value": {"@type": "xsd:float", "@value": "13.9203996658325"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.23592192136056"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000606252725692924"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999913111"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.931776511128243"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.23592192136056"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000606252725692924"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999913111"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.931776511128243"}
     },
     {
-      "@id": "niiri:9197a509e59f57ac84b0239635308061",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:9c44f545329074e4000b8310d4b620c7",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0056",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[20,0,-8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[20,0,-8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:af7fb718df18d23512b5191e557f013b",
-      "entity": "niiri:463ba14c93e36d88477f78294036d6ea"
+      "entity_derived": "niiri:00c3e6ced7aa1682b713c6694740fe99",
+      "entity": "niiri:af99a7152d944fac822b2a894187ecfd"
     },
     {
-      "@id": "niiri:d2e0ed53e1395f81afcf2c95a72904cb",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:6cae1270b5b27c77bad1a387e664d75b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0057",
-      "prov:atLocation": {"@id": "niiri:c00d337b23bc1146a58e3df8b6100a12"},
+      "prov:atLocation": {"@id": "niiri:c47cfe09b9aab3da8be48f3b5835a42a"},
       "prov:value": {"@type": "xsd:float", "@value": "13.8925752639771"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.23281385809669"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000612887021428588"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999927857"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.931776511128243"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.23281385809669"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000612887021428588"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999927857"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.931776511128243"}
     },
     {
-      "@id": "niiri:c00d337b23bc1146a58e3df8b6100a12",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c47cfe09b9aab3da8be48f3b5835a42a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0057",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[40,-14,60]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[40,-14,60]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d2e0ed53e1395f81afcf2c95a72904cb",
-      "entity": "niiri:95bc5905e6829eb3b10bc4e2e665a6de"
+      "entity_derived": "niiri:6cae1270b5b27c77bad1a387e664d75b",
+      "entity": "niiri:1de9cf5cb4f411c77d648530539b1506"
     },
     {
-      "@id": "niiri:101101311ec53c8ad517daf2f38ebb16",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:09a056a78cfbc859552cc5fe35db542b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0058",
-      "prov:atLocation": {"@id": "niiri:f9398ef8c49f3dd85693821995b9b83d"},
+      "prov:atLocation": {"@id": "niiri:07df63fed0a966bcbd784f826c132acb"},
       "prov:value": {"@type": "xsd:float", "@value": "13.8641185760498"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.22963046726961"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000619751563460058"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999940447"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.931776511128243"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.22963046726961"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000619751563460058"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999940447"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.931776511128243"}
     },
     {
-      "@id": "niiri:f9398ef8c49f3dd85693821995b9b83d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:07df63fed0a966bcbd784f826c132acb",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0058",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-36,10,24]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-36,10,24]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:101101311ec53c8ad517daf2f38ebb16",
-      "entity": "niiri:79afb4c5267e6717f07bc3ab60650657"
+      "entity_derived": "niiri:09a056a78cfbc859552cc5fe35db542b",
+      "entity": "niiri:643dd520d22eb83650c21da507f69f60"
     },
     {
-      "@id": "niiri:52d4ccbdd886a6567e9796c4dc2b100b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b43c078a0750c0b86b05a04f00f444dd",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0059",
-      "prov:atLocation": {"@id": "niiri:b3247b408c10346934d93d3b89c3b08e"},
+      "prov:atLocation": {"@id": "niiri:82a1a081c2fc5f7c1dd138a92d9cd37d"},
       "prov:value": {"@type": "xsd:float", "@value": "13.7912406921387"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.22145599369965"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000637705235827735"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999963824"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.937302971928444"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.22145599369965"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000637705235827735"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999963824"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.937302971928444"}
     },
     {
-      "@id": "niiri:b3247b408c10346934d93d3b89c3b08e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:82a1a081c2fc5f7c1dd138a92d9cd37d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0059",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[30,-78,14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[30,-78,14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:52d4ccbdd886a6567e9796c4dc2b100b",
-      "entity": "niiri:e1b2a55b7f9b22b0ae0bdfe29112640f"
+      "entity_derived": "niiri:b43c078a0750c0b86b05a04f00f444dd",
+      "entity": "niiri:1a432aa3e7fda423feb9c68ebffde829"
     },
     {
-      "@id": "niiri:7686ac01dd44c71076c194c60258e230",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:733431f958ca44d615fd5672fc566312",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0060",
-      "prov:atLocation": {"@id": "niiri:c45e3cb57bd46521af944759f48b6aed"},
+      "prov:atLocation": {"@id": "niiri:18242354f3e85c5abeb04f2a24776aa1"},
       "prov:value": {"@type": "xsd:float", "@value": "13.629490852356"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.20320002112963"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000679547746644249"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999988489"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.94954759467573"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.20320002112963"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000679547746644249"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999988489"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.94954759467573"}
     },
     {
-      "@id": "niiri:c45e3cb57bd46521af944759f48b6aed",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:18242354f3e85c5abeb04f2a24776aa1",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0060",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[18,-78,12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[18,-78,12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7686ac01dd44c71076c194c60258e230",
-      "entity": "niiri:b05fa744387c4b5045f0c0b05aacfeb4"
+      "entity_derived": "niiri:733431f958ca44d615fd5672fc566312",
+      "entity": "niiri:1569aa21af436f1447efa2c75903f79c"
     },
     {
-      "@id": "niiri:2d83af76705abacd39ed564c16f5bd54",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a3a1f315599be97b5ba235320e09d642",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0061",
-      "prov:atLocation": {"@id": "niiri:19317ea03e1a885d53f69a47e6bf8983"},
+      "prov:atLocation": {"@id": "niiri:3d17907c7b47751bf153c37c651d4aea"},
       "prov:value": {"@type": "xsd:float", "@value": "13.5061225891113"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.18916981007524"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000713410180681495"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999995369"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.94954759467573"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.18916981007524"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000713410180681495"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999995369"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.94954759467573"}
     },
     {
-      "@id": "niiri:19317ea03e1a885d53f69a47e6bf8983",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:3d17907c7b47751bf153c37c651d4aea",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0061",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[46,8,-16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[46,8,-16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2d83af76705abacd39ed564c16f5bd54",
-      "entity": "niiri:51f256b7ea3e807cb25c6775473371d8"
+      "entity_derived": "niiri:a3a1f315599be97b5ba235320e09d642",
+      "entity": "niiri:0fb2459e07ec9adca74a9a6a0f036186"
     },
     {
-      "@id": "niiri:50553f55b08c318ae6ca6c8dcbb8872b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e97475732149379834546a7b6497a3fb",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0062",
-      "prov:atLocation": {"@id": "niiri:91921c68ad1794bbce0d4ee2240ffd53"},
+      "prov:atLocation": {"@id": "niiri:9ca6aad876741243f44dbfdd251a100a"},
       "prov:value": {"@type": "xsd:float", "@value": "13.4754667282104"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.1856690050705"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000722098618250455"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999996325"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.94954759467573"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.1856690050705"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000722098618250455"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999996325"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.94954759467573"}
     },
     {
-      "@id": "niiri:91921c68ad1794bbce0d4ee2240ffd53",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:9ca6aad876741243f44dbfdd251a100a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0062",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[58,-40,50]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[58,-40,50]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:50553f55b08c318ae6ca6c8dcbb8872b",
-      "entity": "niiri:dc9c7cf4223aa5e5ce8d564077006cb3"
+      "entity_derived": "niiri:e97475732149379834546a7b6497a3fb",
+      "entity": "niiri:e937b5f0f9c2d5b73ead1407d48466e6"
     },
     {
-      "@id": "niiri:eb9596c3e1486c6990a5fb92461fe7c6",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:857dcc58dbe541261ba45dff3d2b361e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0063",
-      "prov:atLocation": {"@id": "niiri:562c07654934ee9bca299e9fa13ac7cd"},
+      "prov:atLocation": {"@id": "niiri:e584e06a075baa5c44d13b1381ce0ec2"},
       "prov:value": {"@type": "xsd:float", "@value": "13.4480972290039"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.18253860543696"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000729950259848011"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999997016"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.94954759467573"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.18253860543696"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000729950259848011"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999997016"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.94954759467573"}
     },
     {
-      "@id": "niiri:562c07654934ee9bca299e9fa13ac7cd",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e584e06a075baa5c44d13b1381ce0ec2",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0063",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[46,-66,32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[46,-66,32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:eb9596c3e1486c6990a5fb92461fe7c6",
-      "entity": "niiri:dd8593a9311adfd7943344f7fcbd8aee"
+      "entity_derived": "niiri:857dcc58dbe541261ba45dff3d2b361e",
+      "entity": "niiri:321743f529907bc95ee3bc2bb3feb1e2"
     },
     {
-      "@id": "niiri:99bc3c3064f7e63cde024e02a67c7dd9",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:6e0a324bcd2fe08b3423e3a1291846fd",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0064",
-      "prov:atLocation": {"@id": "niiri:edfe2d3ea7bf016746e7bfcc71201bd7"},
+      "prov:atLocation": {"@id": "niiri:e3a33c2561f68e4588c8a21e486e7f2c"},
       "prov:value": {"@type": "xsd:float", "@value": "13.2857608795166"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.16387572537233"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000778416284459293"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999163"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.971579849523251"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.16387572537233"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000778416284459293"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999163"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.971579849523251"}
     },
     {
-      "@id": "niiri:edfe2d3ea7bf016746e7bfcc71201bd7",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e3a33c2561f68e4588c8a21e486e7f2c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0064",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[2,-76,8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[2,-76,8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:99bc3c3064f7e63cde024e02a67c7dd9",
-      "entity": "niiri:f77c3b84351f869eec0ec8a0f4c729f2"
+      "entity_derived": "niiri:6e0a324bcd2fe08b3423e3a1291846fd",
+      "entity": "niiri:7ca293071987c22e76e0b20115b26429"
     },
     {
-      "@id": "niiri:0ad6a4b511f23009870cb9b825de4ffd",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:7f16505a5183e80a89fdd236a19edcd0",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0065",
-      "prov:atLocation": {"@id": "niiri:0c3fbfe97e3803ec8b14fb9f52d44997"},
+      "prov:atLocation": {"@id": "niiri:af54c75393d7b35f74b4a955a92b6959"},
       "prov:value": {"@type": "xsd:float", "@value": "13.2286987304688"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.15727638472708"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000796251631906664"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999472"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.971579849523251"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.15727638472708"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000796251631906664"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999472"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.971579849523251"}
     },
     {
-      "@id": "niiri:0c3fbfe97e3803ec8b14fb9f52d44997",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:af54c75393d7b35f74b4a955a92b6959",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0065",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[14,-24,-2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[14,-24,-2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0ad6a4b511f23009870cb9b825de4ffd",
-      "entity": "niiri:d51318468d3708fb69be47dd8fb73f01"
+      "entity_derived": "niiri:7f16505a5183e80a89fdd236a19edcd0",
+      "entity": "niiri:6bb00e27ab3f8d7e1b137fd7b575136a"
     },
     {
-      "@id": "niiri:8caf8a7a70d4e5fe14391e5c25841da4",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:875b2558dfadf848b15b4bd3a7bedac7",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0066",
-      "prov:atLocation": {"@id": "niiri:5bc4ef05b320e7f65a2358fe409beb02"},
+      "prov:atLocation": {"@id": "niiri:d59cf72ab0dd929c2b854e8cf00b3631"},
       "prov:value": {"@type": "xsd:float", "@value": "13.0621271133423"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.13789355719639"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00085083330089919"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999869"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.973821135792583"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.13789355719639"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00085083330089919"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999869"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.973821135792583"}
     },
     {
-      "@id": "niiri:5bc4ef05b320e7f65a2358fe409beb02",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d59cf72ab0dd929c2b854e8cf00b3631",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0066",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-36,0,-4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-36,0,-4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8caf8a7a70d4e5fe14391e5c25841da4",
-      "entity": "niiri:23ddb476e286b8beace9ac2226fb1e02"
+      "entity_derived": "niiri:875b2558dfadf848b15b4bd3a7bedac7",
+      "entity": "niiri:eea16d34f3c295e17c1d3128d76481f7"
     },
     {
-      "@id": "niiri:30ef3b47f5d27871a175d290f6c7ab08",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5ebb4f1311ce16efbfe14bbe316a1dd9",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0067",
-      "prov:atLocation": {"@id": "niiri:68fd9ce883588a363d129ffb7eb32766"},
+      "prov:atLocation": {"@id": "niiri:1a3a714c8ff947781a0ad2d2c9f1cf30"},
       "prov:value": {"@type": "xsd:float", "@value": "13.0451946258545"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.13591325616981"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000856599341067521"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999886"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.973821135792583"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.13591325616981"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000856599341067521"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999886"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.973821135792583"}
     },
     {
-      "@id": "niiri:68fd9ce883588a363d129ffb7eb32766",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:1a3a714c8ff947781a0ad2d2c9f1cf30",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0067",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[12,6,62]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[12,6,62]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:30ef3b47f5d27871a175d290f6c7ab08",
-      "entity": "niiri:9c6347d32a637404df13117cb515bb7a"
+      "entity_derived": "niiri:5ebb4f1311ce16efbfe14bbe316a1dd9",
+      "entity": "niiri:2d477a3822ede90c19394a724a2c602f"
     },
     {
-      "@id": "niiri:2932ff2d9ff5ee4eb44ab8faa6ae4a63",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c26bf255f07394accb52097e3aa14dcf",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0068",
-      "prov:atLocation": {"@id": "niiri:de40e4efcb3cabdc06e2207288c91bf3"},
+      "prov:atLocation": {"@id": "niiri:fe279a930d64d5a71b800ab242e8f1c3"},
       "prov:value": {"@type": "xsd:float", "@value": "13.0064306259155"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.13137270324883"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000869955985260296"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999919"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.973821135792583"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.13137270324883"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000869955985260296"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999919"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.973821135792583"}
     },
     {
-      "@id": "niiri:de40e4efcb3cabdc06e2207288c91bf3",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:fe279a930d64d5a71b800ab242e8f1c3",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0068",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-8,-4,24]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-8,-4,24]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2932ff2d9ff5ee4eb44ab8faa6ae4a63",
-      "entity": "niiri:64b9ed90986836033d685bf5b9a5e773"
+      "entity_derived": "niiri:c26bf255f07394accb52097e3aa14dcf",
+      "entity": "niiri:67886822c4a91ee4d1b7cd6bc45567f5"
     },
     {
-      "@id": "niiri:c2049a099809392011d02b1523fcd2ca",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:62972521b018c2b4931966235cb491ff",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0069",
-      "prov:atLocation": {"@id": "niiri:727c2045bba80d1ade0c258ba7a0fa62"},
+      "prov:atLocation": {"@id": "niiri:5e0f8be6d5e367c13936e06a5132c658"},
       "prov:value": {"@type": "xsd:float", "@value": "12.968074798584"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.12687033926247"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00088338914171493"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999942"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.973821135792583"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.12687033926247"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00088338914171493"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999942"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.973821135792583"}
     },
     {
-      "@id": "niiri:727c2045bba80d1ade0c258ba7a0fa62",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:5e0f8be6d5e367c13936e06a5132c658",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0069",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[8,-36,40]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[8,-36,40]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c2049a099809392011d02b1523fcd2ca",
-      "entity": "niiri:f2a361b0d3f278353a770b78f683d8ff"
+      "entity_derived": "niiri:62972521b018c2b4931966235cb491ff",
+      "entity": "niiri:5ebab1be1c4c961db315c2ffb23786c0"
     },
     {
-      "@id": "niiri:c145759062c5e5ea4411b780ae9bb58d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:79c914462c21a9da15f185d7c27532c0",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0070",
-      "prov:atLocation": {"@id": "niiri:254d63eddaa0fdf7034a46228cbf2641"},
+      "prov:atLocation": {"@id": "niiri:d98448bb9b3ba696b02a78c75aa3d4a5"},
       "prov:value": {"@type": "xsd:float", "@value": "12.9628992080688"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.12626207199886"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000885218504765861"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999944"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.973821135792583"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.12626207199886"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000885218504765861"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999944"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.973821135792583"}
     },
     {
-      "@id": "niiri:254d63eddaa0fdf7034a46228cbf2641",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d98448bb9b3ba696b02a78c75aa3d4a5",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0070",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[24,38,0]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[24,38,0]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c145759062c5e5ea4411b780ae9bb58d",
-      "entity": "niiri:a2753eb825e8f8fd5a487ef63c2663c8"
+      "entity_derived": "niiri:79c914462c21a9da15f185d7c27532c0",
+      "entity": "niiri:06a77002692eb72a6823907717b7b96b"
     },
     {
-      "@id": "niiri:cac376cb0260ec15d3d40dae08f77da6",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:474715ccc997937469befbcc9826ba54",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0071",
-      "prov:atLocation": {"@id": "niiri:f6e4e8dfcf902a5b780272dc26c1b958"},
+      "prov:atLocation": {"@id": "niiri:a4b31efcb7468b12d5ac889153f773bb"},
       "prov:value": {"@type": "xsd:float", "@value": "12.9482192993164"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.12453584528173"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000890429112242686"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999951"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.973821135792583"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.12453584528173"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000890429112242686"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999951"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.973821135792583"}
     },
     {
-      "@id": "niiri:f6e4e8dfcf902a5b780272dc26c1b958",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a4b31efcb7468b12d5ac889153f773bb",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0071",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[26,-50,46]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[26,-50,46]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cac376cb0260ec15d3d40dae08f77da6",
-      "entity": "niiri:85b5285611210be089c4e51b135903dc"
+      "entity_derived": "niiri:474715ccc997937469befbcc9826ba54",
+      "entity": "niiri:70cb31c3da80e76bbcc31227d5a63dd3"
     },
     {
-      "@id": "niiri:9f4be5bf3e2394450f15c3bd3f04e0b4",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:bbd74f64374ff71082a0f30617e201a3",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0072",
-      "prov:atLocation": {"@id": "niiri:eeb740356934b4e34ad535bbf2868366"},
+      "prov:atLocation": {"@id": "niiri:19093ca30f5b7031b50a04dabe2c8580"},
       "prov:value": {"@type": "xsd:float", "@value": "12.9151954650879"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.12064737190897"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000902269894699104"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999964"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.973821135792583"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.12064737190897"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000902269894699104"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999964"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.973821135792583"}
     },
     {
-      "@id": "niiri:eeb740356934b4e34ad535bbf2868366",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:19093ca30f5b7031b50a04dabe2c8580",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0072",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-30,-86,8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-30,-86,8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9f4be5bf3e2394450f15c3bd3f04e0b4",
-      "entity": "niiri:1d0913f48b56a9cfb53554e02fef4dd7"
+      "entity_derived": "niiri:bbd74f64374ff71082a0f30617e201a3",
+      "entity": "niiri:1bab28ca73fb58bf072903c327aa6ee2"
     },
     {
-      "@id": "niiri:820e843198ddfac162a65814dfe44e4b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:95595228f33871513d411cf90c9ac990",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0073",
-      "prov:atLocation": {"@id": "niiri:c584945b7b1f425e4d105a7be69d98a2"},
+      "prov:atLocation": {"@id": "niiri:e16ca3f3b4ac763acebdd770fb53915f"},
       "prov:value": {"@type": "xsd:float", "@value": "12.8661985397339"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.11486488202419"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00092014594111034"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999977"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.975928938473905"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.11486488202419"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00092014594111034"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999977"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.975928938473905"}
     },
     {
-      "@id": "niiri:c584945b7b1f425e4d105a7be69d98a2",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e16ca3f3b4ac763acebdd770fb53915f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0073",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[22,-24,38]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[22,-24,38]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:820e843198ddfac162a65814dfe44e4b",
-      "entity": "niiri:ec713ff49cc3d009853754ee51de40a9"
+      "entity_derived": "niiri:95595228f33871513d411cf90c9ac990",
+      "entity": "niiri:0d05a2eb7c30f085c9585bd5437f2cf6"
     },
     {
-      "@id": "niiri:d9a9bc29896278cf65fd0c19f8bab212",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a143fe115cb6773e77224c4cf1c48dad",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0074",
-      "prov:atLocation": {"@id": "niiri:f690d8ccf99f04c1cdef2f57bd8121b1"},
+      "prov:atLocation": {"@id": "niiri:0d8c450188c5ca9da526aa9cad61cd4e"},
       "prov:value": {"@type": "xsd:float", "@value": "12.8156299591064"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.10888025138563"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000938989080538355"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999985"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.978285341995832"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.10888025138563"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000938989080538355"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999985"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.978285341995832"}
     },
     {
-      "@id": "niiri:f690d8ccf99f04c1cdef2f57bd8121b1",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0d8c450188c5ca9da526aa9cad61cd4e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0074",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[48,50,2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[48,50,2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d9a9bc29896278cf65fd0c19f8bab212",
-      "entity": "niiri:14378386d8b7fa3469c4024d8643a9f6"
+      "entity_derived": "niiri:a143fe115cb6773e77224c4cf1c48dad",
+      "entity": "niiri:cec1367031abea759cc3b3843951c4e9"
     },
     {
-      "@id": "niiri:99c82d559aae2b5f5396006039103bca",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:fddbb1076a0ce325c65aac2f591218cd",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0075",
-      "prov:atLocation": {"@id": "niiri:a06eabcf0a3a383a6b7272083f79dad0"},
+      "prov:atLocation": {"@id": "niiri:4da351496d312a5b3b763b22e9887907"},
       "prov:value": {"@type": "xsd:float", "@value": "12.7734069824219"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.10387025917553"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000955035352381506"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999999999"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.978285341995832"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.10387025917553"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000955035352381506"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999999999"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.978285341995832"}
     },
     {
-      "@id": "niiri:a06eabcf0a3a383a6b7272083f79dad0",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4da351496d312a5b3b763b22e9887907",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0075",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-48,-68,20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-48,-68,20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:99c82d559aae2b5f5396006039103bca",
-      "entity": "niiri:35322e20f0852719cb5f7785e9eafbdf"
+      "entity_derived": "niiri:fddbb1076a0ce325c65aac2f591218cd",
+      "entity": "niiri:6ba93f98c147f043bee56b6eaf416136"
     },
     {
-      "@id": "niiri:d145dcd6e4a69342e9c71383317b475d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:1cd54d943a37d511665d0fc8924f35bf",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0076",
-      "prov:atLocation": {"@id": "niiri:bad0281bedb6add01c67a6368047075d"},
+      "prov:atLocation": {"@id": "niiri:f9b1afbacf27286a06aed4990a8d3f17"},
       "prov:value": {"@type": "xsd:float", "@value": "12.7362623214722"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.0994529756118"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000969391758882221"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999993"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.978285341995832"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.0994529756118"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000969391758882221"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999993"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.978285341995832"}
     },
     {
-      "@id": "niiri:bad0281bedb6add01c67a6368047075d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f9b1afbacf27286a06aed4990a8d3f17",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0076",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[24,-22,36]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[24,-22,36]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d145dcd6e4a69342e9c71383317b475d",
-      "entity": "niiri:c0448343148dd622321d80f7996dd79e"
+      "entity_derived": "niiri:1cd54d943a37d511665d0fc8924f35bf",
+      "entity": "niiri:ac903b7a48abf269c96015efab8d2aa1"
     }
   ]
 }

--- a/spmexport/ex_spm_non_sphericity/nidm.ttl
+++ b/spmexport/ex_spm_non_sphericity/nidm.ttl
@@ -4,7 +4,7 @@
 @prefix niiri: <http://iri.nidash.org/> .
 @prefix spm: <http://purl.org/nidash/spm#> .
 @prefix neurolex: <http://neurolex.org/wiki/> .
-@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#> .
+@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
@@ -17,27 +17,27 @@
 @prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-niiri:ae59b3f8b6a7ff8a2ff189b89c331a16
+niiri:4e3cc7ffa6f685a0f71dbdd16e102f31
   a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
   rdfs:label "NIDM-Results" ;
   nidm_version: "1.3.0"^^xsd:string .
 
-niiri:ccd117e388c60ec9e834266da2abf102
+niiri:d47620c0a904862a40d4a674f5975211
   a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
   rdfs:label "spm_results_nidm" ;
-  nidm_softwareVersion: "12.6903"^^xsd:string .
+  nidm_softwareVersion: "12.7057"^^xsd:string .
 
-niiri:23f1bb1b8637a94e2590757111800672
+niiri:80d7881ec00396b0fee7ca1bafcd9813
   a prov:Activity, nidm_NIDMResultsExport: ; 
   rdfs:label "NIDM-Results export" .
 
-niiri:23f1bb1b8637a94e2590757111800672 prov:wasAssociatedWith niiri:ccd117e388c60ec9e834266da2abf102 .
+niiri:80d7881ec00396b0fee7ca1bafcd9813 prov:wasAssociatedWith niiri:d47620c0a904862a40d4a674f5975211 .
 
 _:blank5 a prov:Generation .
 
-niiri:ae59b3f8b6a7ff8a2ff189b89c331a16 prov:qualifiedGeneration _:blank5 .
+niiri:4e3cc7ffa6f685a0f71dbdd16e102f31 prov:qualifiedGeneration _:blank5 .
 
-_:blank5 prov:atTime "2016-12-07T16:09:07"^^xsd:dateTime .
+_:blank5 prov:atTime "2017-04-19T12:18:37"^^xsd:dateTime .
 
 @prefix nidm_Ixi549CoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000050> .
 @prefix src_SPM: <http://scicrunch.org/resolver/SCR_007037> .
@@ -135,12 +135,12 @@ _:blank5 prov:atTime "2016-12-07T16:09:07"^^xsd:dateTime .
 @prefix nidm_Coordinate: <http://purl.org/nidash/nidm#NIDM_0000015> .
 @prefix nidm_coordinateVector: <http://purl.org/nidash/nidm#NIDM_0000086> .
 
-niiri:5190808bd0433895ce27d1d15e3ecde5
+niiri:bc2e77c470f6014f2a246955842052c9
     a prov:Agent, src_SPM:, prov:SoftwareAgent ; 
     rdfs:label "SPM" ;
-    nidm_softwareVersion: "12.12.2"^^xsd:string .
+    nidm_softwareVersion: "12.6906"^^xsd:string .
 
-niiri:00f2d1f7a8cf8c992c713523daff77a3
+niiri:334a58b04dd8169b2161a2e8b2629a0d
     a prov:Entity, nidm_CoordinateSpace: ; 
     rdfs:label "Coordinate space 1" ;
     nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
@@ -150,40 +150,40 @@ niiri:00f2d1f7a8cf8c992c713523daff77a3
     nidm_numberOfDimensions: "3"^^xsd:int ;
     nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
 
-niiri:05e5a115fc55ac3b63212ea49766956c
+niiri:693e91ca0bc2876c97cc7ed9b8a8d2da
     a prov:Agent, nlx_Imaginginstrument:, nlx_Magneticresonanceimagingscanner: ; 
     rdfs:label "MRI Scanner" .
 
-niiri:4da5785dfa10ede96c855801480dfe24
+niiri:3db0690d0c427891151946b5624760be
     a prov:Agent, prov:Person ; 
     rdfs:label "Person" .
 
-niiri:a37e19eb8ab9ac7e711912f263377083
+niiri:825930cb9cecdc2d026a61f46ae3ee93
     a prov:Entity, prov:Collection, nidm_Data: ; 
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "false"^^xsd:boolean ;
     nidm_hasMRIProtocol: nlx_FunctionalMRIprotocol: .
 
-niiri:a37e19eb8ab9ac7e711912f263377083 prov:wasAttributedTo niiri:05e5a115fc55ac3b63212ea49766956c .
+niiri:825930cb9cecdc2d026a61f46ae3ee93 prov:wasAttributedTo niiri:693e91ca0bc2876c97cc7ed9b8a8d2da .
 
-niiri:a37e19eb8ab9ac7e711912f263377083 prov:wasAttributedTo niiri:4da5785dfa10ede96c855801480dfe24 .
+niiri:825930cb9cecdc2d026a61f46ae3ee93 prov:wasAttributedTo niiri:3db0690d0c427891151946b5624760be .
 
-niiri:a3d0e09632644d2fa25c309763419314
+niiri:8832b574f38c1ef5b19a5698eedfd522
     a prov:Entity, nidm_DesignMatrix: ; 
     prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.csv"^^xsd:string ;
     dct:format "text/csv"^^xsd:string ;
-    dc:description niiri:5864366f6540205d2f87f4479cfc4946 ;
+    dc:description niiri:4b5ac7e34167b063095b0c27f615214a ;
     rdfs:label "Design Matrix" ;
     nidm_regressorNames: "[\"Basis_{1}\", \"Basis_{2}\", \"Basis_{3}\"]"^^xsd:string .
 
-niiri:5864366f6540205d2f87f4479cfc4946
+niiri:4b5ac7e34167b063095b0c27f615214a
     a prov:Entity, dctype:Image ; 
     prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:d0f19502a6ee54ef9ed7a784b385d191
+niiri:8a6c1f8a466f432d23696a22842630eb
     a prov:Entity, nidm_ErrorModel: ; 
     nidm_hasErrorDistribution: obo_normaldistribution: ;
     nidm_hasErrorDependence: obo_unstructuredcovariancestructure: ;
@@ -191,174 +191,174 @@ niiri:d0f19502a6ee54ef9ed7a784b385d191
     nidm_errorVarianceHomogeneous: "false"^^xsd:boolean ;
     nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
 
-niiri:9a49034914ef603f12245b4b2b7d87ce
+niiri:abe46d73a8429cc97ae789be61c051b7
     a prov:Activity, nidm_ModelParametersEstimation: ; 
     rdfs:label "Model parameters estimation" ;
     nidm_withEstimationMethod: obo_generalizedleastsquaresestimation: .
 
-niiri:9a49034914ef603f12245b4b2b7d87ce prov:wasAssociatedWith niiri:5190808bd0433895ce27d1d15e3ecde5 .
+niiri:abe46d73a8429cc97ae789be61c051b7 prov:wasAssociatedWith niiri:bc2e77c470f6014f2a246955842052c9 .
 
-niiri:9a49034914ef603f12245b4b2b7d87ce prov:used niiri:a3d0e09632644d2fa25c309763419314 .
+niiri:abe46d73a8429cc97ae789be61c051b7 prov:used niiri:8832b574f38c1ef5b19a5698eedfd522 .
 
-niiri:9a49034914ef603f12245b4b2b7d87ce prov:used niiri:a37e19eb8ab9ac7e711912f263377083 .
+niiri:abe46d73a8429cc97ae789be61c051b7 prov:used niiri:825930cb9cecdc2d026a61f46ae3ee93 .
 
-niiri:9a49034914ef603f12245b4b2b7d87ce prov:used niiri:d0f19502a6ee54ef9ed7a784b385d191 .
+niiri:abe46d73a8429cc97ae789be61c051b7 prov:used niiri:8a6c1f8a466f432d23696a22842630eb .
 
-niiri:40d21d093fb28877228a457af0198dbe
+niiri:fc108568cd5e536825df64c6f1040101
     a prov:Entity, nidm_MaskMap: ; 
     prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
     nidm_isUserDefined: "false"^^xsd:boolean ;
     nfo:fileName "Mask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Mask" ;
-    nidm_inCoordinateSpace: niiri:00f2d1f7a8cf8c992c713523daff77a3 ;
+    nidm_inCoordinateSpace: niiri:334a58b04dd8169b2161a2e8b2629a0d ;
     crypto:sha512 "09d331386156006058738700e3d2402ca557e5ba6f5742af2974eb4c03f0514a5529859c620fe5167c0cfed26e846d21ffd2611e5f479b2d167beec168e978bd"^^xsd:string .
 
-niiri:efbd22615b6a3126f4265c4e8db4f65f
+niiri:e09fd9499ed59ea115caabdbd4ec218b
     a prov:Entity, nidm_MaskMap: ; 
     nfo:fileName "mask.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "609620056d81292b36b9f1dbbe3d02023728da7cab8f4ca3bf953dd1e5256f1799c5eb65663aa4e8b7c5cdf3cbb521708aaad4eb4cc8182c1e5280a51387678e"^^xsd:string .
 
-niiri:40d21d093fb28877228a457af0198dbe prov:wasDerivedFrom niiri:efbd22615b6a3126f4265c4e8db4f65f .
+niiri:fc108568cd5e536825df64c6f1040101 prov:wasDerivedFrom niiri:e09fd9499ed59ea115caabdbd4ec218b .
 
-niiri:40d21d093fb28877228a457af0198dbe prov:wasGeneratedBy niiri:9a49034914ef603f12245b4b2b7d87ce .
+niiri:fc108568cd5e536825df64c6f1040101 prov:wasGeneratedBy niiri:abe46d73a8429cc97ae789be61c051b7 .
 
-niiri:e02454834944d6369e6118b7e6925f76
+niiri:8b44eef148a4672df3b868888c1c1c71
     a prov:Entity, nidm_GrandMeanMap: ; 
     prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
     nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Grand Mean Map" ;
     nidm_maskedMedian: "0.0511472336947918"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:00f2d1f7a8cf8c992c713523daff77a3 ;
+    nidm_inCoordinateSpace: niiri:334a58b04dd8169b2161a2e8b2629a0d ;
     crypto:sha512 "c111e018cb1cdd0d1318256c5dcb2e0eaaa627bc540216148527056b2969939119310599fb527dfb187ae9ee422dba8e543bf5c190b9f935d828a3a4dab2ebbc"^^xsd:string .
 
-niiri:e02454834944d6369e6118b7e6925f76 prov:wasGeneratedBy niiri:9a49034914ef603f12245b4b2b7d87ce .
+niiri:8b44eef148a4672df3b868888c1c1c71 prov:wasGeneratedBy niiri:abe46d73a8429cc97ae789be61c051b7 .
 
-niiri:c0af1f0d1f8fef01cae72507881d86fb
+niiri:69099a5655e274a35cf8497561c281d6
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0001.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0001.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 1" ;
-    nidm_inCoordinateSpace: niiri:00f2d1f7a8cf8c992c713523daff77a3 ;
+    nidm_inCoordinateSpace: niiri:334a58b04dd8169b2161a2e8b2629a0d ;
     crypto:sha512 "b89a0120673d47d4a2e8ca19a9a69c37d4e514e795580ec064d6c246a23e9a7d5737c49cceefe6de12b67d3d722b18dc74ff194812fe4c6c3fd9145bd76a9a2f"^^xsd:string .
 
-niiri:f4f597714134c209bf3d5a0c6c929e28
+niiri:08dd8d7791f4ea3b42d7928f3978b481
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "b89a0120673d47d4a2e8ca19a9a69c37d4e514e795580ec064d6c246a23e9a7d5737c49cceefe6de12b67d3d722b18dc74ff194812fe4c6c3fd9145bd76a9a2f"^^xsd:string .
 
-niiri:c0af1f0d1f8fef01cae72507881d86fb prov:wasDerivedFrom niiri:f4f597714134c209bf3d5a0c6c929e28 .
+niiri:69099a5655e274a35cf8497561c281d6 prov:wasDerivedFrom niiri:08dd8d7791f4ea3b42d7928f3978b481 .
 
-niiri:c0af1f0d1f8fef01cae72507881d86fb prov:wasGeneratedBy niiri:9a49034914ef603f12245b4b2b7d87ce .
+niiri:69099a5655e274a35cf8497561c281d6 prov:wasGeneratedBy niiri:abe46d73a8429cc97ae789be61c051b7 .
 
-niiri:eb153bc18088eeb114d7c02d8398edbd
+niiri:994815a1deaaea1d8a916499a4369008
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0002.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0002.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 2" ;
-    nidm_inCoordinateSpace: niiri:00f2d1f7a8cf8c992c713523daff77a3 ;
+    nidm_inCoordinateSpace: niiri:334a58b04dd8169b2161a2e8b2629a0d ;
     crypto:sha512 "5ce29a8c6d060417d3246febff5596241f2e6783c1d9761306cf762057696493f53d59a40dcd6821ac1ecf6144669d80b6560bb234e4c5455d651fc4c0024978"^^xsd:string .
 
-niiri:2b66e604e99057ea8a531c4cdcb8f559
+niiri:adc38d535f009898b8597918fea3e74b
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0002.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "5ce29a8c6d060417d3246febff5596241f2e6783c1d9761306cf762057696493f53d59a40dcd6821ac1ecf6144669d80b6560bb234e4c5455d651fc4c0024978"^^xsd:string .
 
-niiri:eb153bc18088eeb114d7c02d8398edbd prov:wasDerivedFrom niiri:2b66e604e99057ea8a531c4cdcb8f559 .
+niiri:994815a1deaaea1d8a916499a4369008 prov:wasDerivedFrom niiri:adc38d535f009898b8597918fea3e74b .
 
-niiri:eb153bc18088eeb114d7c02d8398edbd prov:wasGeneratedBy niiri:9a49034914ef603f12245b4b2b7d87ce .
+niiri:994815a1deaaea1d8a916499a4369008 prov:wasGeneratedBy niiri:abe46d73a8429cc97ae789be61c051b7 .
 
-niiri:38398a8ad158ea32ba513829f1560b8e
+niiri:438a1a1f15d3ed6c053ad0a47535b905
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0003.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0003.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 3" ;
-    nidm_inCoordinateSpace: niiri:00f2d1f7a8cf8c992c713523daff77a3 ;
+    nidm_inCoordinateSpace: niiri:334a58b04dd8169b2161a2e8b2629a0d ;
     crypto:sha512 "d8c80bfb0cd41ceae8da00cc1b5f7a39d0c186f8a1308852e0c4d4ecf2143a46153b6d3998bcdc4a41a36a51e52eb5154a5c871a0d326d43cf02834aa7a2802a"^^xsd:string .
 
-niiri:6964d146ea43c1d5e55d5afc8fc89ae3
+niiri:fc2fc60ae3a1a2a377ce868dcfe7682c
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0003.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "d8c80bfb0cd41ceae8da00cc1b5f7a39d0c186f8a1308852e0c4d4ecf2143a46153b6d3998bcdc4a41a36a51e52eb5154a5c871a0d326d43cf02834aa7a2802a"^^xsd:string .
 
-niiri:38398a8ad158ea32ba513829f1560b8e prov:wasDerivedFrom niiri:6964d146ea43c1d5e55d5afc8fc89ae3 .
+niiri:438a1a1f15d3ed6c053ad0a47535b905 prov:wasDerivedFrom niiri:fc2fc60ae3a1a2a377ce868dcfe7682c .
 
-niiri:38398a8ad158ea32ba513829f1560b8e prov:wasGeneratedBy niiri:9a49034914ef603f12245b4b2b7d87ce .
+niiri:438a1a1f15d3ed6c053ad0a47535b905 prov:wasGeneratedBy niiri:abe46d73a8429cc97ae789be61c051b7 .
 
-niiri:a297bf375d9539defdbc8540b2e4d318
+niiri:94876fb7a2c046b431df17692c760d6e
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Residual Mean Squares Map" ;
-    nidm_inCoordinateSpace: niiri:00f2d1f7a8cf8c992c713523daff77a3 ;
+    nidm_inCoordinateSpace: niiri:334a58b04dd8169b2161a2e8b2629a0d ;
     crypto:sha512 "8dd13096358e8e9e95b0a11c6c59092dbb5cfc3d586ce9a9606ecaaa7c3f48b5fceee1ff6cf6c356b754b3990b344b66b37058402579c4c37c488fd942540d48"^^xsd:string .
 
-niiri:484b1a6beac16aa9ee76c98da6c8ed09
+niiri:b88f5c084cf11202884b4336bb357ace
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     nfo:fileName "ResMS.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "b3ead22cbbb0b4e40e397cd74f954be9e4de46bbf7aa994f35344329aad57c551fd72827fe1aae6287c0bf37ca1afbaea22993e79b87166e1a921b9e977c2868"^^xsd:string .
 
-niiri:a297bf375d9539defdbc8540b2e4d318 prov:wasDerivedFrom niiri:484b1a6beac16aa9ee76c98da6c8ed09 .
+niiri:94876fb7a2c046b431df17692c760d6e prov:wasDerivedFrom niiri:b88f5c084cf11202884b4336bb357ace .
 
-niiri:a297bf375d9539defdbc8540b2e4d318 prov:wasGeneratedBy niiri:9a49034914ef603f12245b4b2b7d87ce .
+niiri:94876fb7a2c046b431df17692c760d6e prov:wasGeneratedBy niiri:abe46d73a8429cc97ae789be61c051b7 .
 
-niiri:de09763e711605a90fbefccccad90faf
+niiri:96116055802375625dcf702ee01581fe
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Resels per Voxel Map" ;
-    nidm_inCoordinateSpace: niiri:00f2d1f7a8cf8c992c713523daff77a3 ;
+    nidm_inCoordinateSpace: niiri:334a58b04dd8169b2161a2e8b2629a0d ;
     crypto:sha512 "9e6bd1546a438b4313b95dfeb307638416e999e4c3596b6c3aa8f282fda2df6dae8e1db498dca3dc6717d70138f68a00101ff95a2f5e32e7a1c8074a69f17381"^^xsd:string .
 
-niiri:505cf442539a5d5327913a5d65e5bc00
+niiri:1328ce3e8c83d35913bbecbd452290df
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     nfo:fileName "RPV.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "f8c6e2cbdd2c099fe1cdfa7f20c2d735366627a183b06e229d82b06ea4fa189ca42d6fdbbd69ca6504f1865b00f211b940f19f1c2c8df3b424f4eedea9775bb8"^^xsd:string .
 
-niiri:de09763e711605a90fbefccccad90faf prov:wasDerivedFrom niiri:505cf442539a5d5327913a5d65e5bc00 .
+niiri:96116055802375625dcf702ee01581fe prov:wasDerivedFrom niiri:1328ce3e8c83d35913bbecbd452290df .
 
-niiri:de09763e711605a90fbefccccad90faf prov:wasGeneratedBy niiri:9a49034914ef603f12245b4b2b7d87ce .
+niiri:96116055802375625dcf702ee01581fe prov:wasGeneratedBy niiri:abe46d73a8429cc97ae789be61c051b7 .
 
-niiri:f0280f84ac099eac2ffeee96a84304d4
+niiri:adbd624b50ba693b3e14fd648e13ebef
     a prov:Entity, obo_contrastweightmatrix: ; 
     nidm_statisticType: obo_Fstatistic: ;
     nidm_contrastName: "Average effect of condition"^^xsd:string ;
     rdfs:label "Contrast: Average effect of condition" ;
     prov:value "[1, 1, 1]"^^xsd:string .
 
-niiri:8bcee3a21f81e2a43338bf0ee897788a
+niiri:2456cdab46e0eb6c27cca0f6dd52cb86
     a prov:Activity, nidm_ContrastEstimation: ; 
     rdfs:label "Contrast estimation" .
 
-niiri:8bcee3a21f81e2a43338bf0ee897788a prov:wasAssociatedWith niiri:5190808bd0433895ce27d1d15e3ecde5 .
+niiri:2456cdab46e0eb6c27cca0f6dd52cb86 prov:wasAssociatedWith niiri:bc2e77c470f6014f2a246955842052c9 .
 
-niiri:8bcee3a21f81e2a43338bf0ee897788a prov:used niiri:40d21d093fb28877228a457af0198dbe .
+niiri:2456cdab46e0eb6c27cca0f6dd52cb86 prov:used niiri:fc108568cd5e536825df64c6f1040101 .
 
-niiri:8bcee3a21f81e2a43338bf0ee897788a prov:used niiri:a297bf375d9539defdbc8540b2e4d318 .
+niiri:2456cdab46e0eb6c27cca0f6dd52cb86 prov:used niiri:94876fb7a2c046b431df17692c760d6e .
 
-niiri:8bcee3a21f81e2a43338bf0ee897788a prov:used niiri:a3d0e09632644d2fa25c309763419314 .
+niiri:2456cdab46e0eb6c27cca0f6dd52cb86 prov:used niiri:8832b574f38c1ef5b19a5698eedfd522 .
 
-niiri:8bcee3a21f81e2a43338bf0ee897788a prov:used niiri:f0280f84ac099eac2ffeee96a84304d4 .
+niiri:2456cdab46e0eb6c27cca0f6dd52cb86 prov:used niiri:adbd624b50ba693b3e14fd648e13ebef .
 
-niiri:8bcee3a21f81e2a43338bf0ee897788a prov:used niiri:c0af1f0d1f8fef01cae72507881d86fb .
+niiri:2456cdab46e0eb6c27cca0f6dd52cb86 prov:used niiri:69099a5655e274a35cf8497561c281d6 .
 
-niiri:8bcee3a21f81e2a43338bf0ee897788a prov:used niiri:eb153bc18088eeb114d7c02d8398edbd .
+niiri:2456cdab46e0eb6c27cca0f6dd52cb86 prov:used niiri:994815a1deaaea1d8a916499a4369008 .
 
-niiri:8bcee3a21f81e2a43338bf0ee897788a prov:used niiri:38398a8ad158ea32ba513829f1560b8e .
+niiri:2456cdab46e0eb6c27cca0f6dd52cb86 prov:used niiri:438a1a1f15d3ed6c053ad0a47535b905 .
 
-niiri:293542c9d6286efb6ab3045a0df4c7fa
+niiri:9ca097a864a89e695f5a0ade9c7a2592
     a prov:Entity, nidm_StatisticMap: ; 
     prov:atLocation "FStatistic.nii.gz"^^xsd:anyURI ;
     nfo:fileName "FStatistic.nii.gz"^^xsd:string ;
@@ -368,104 +368,104 @@ niiri:293542c9d6286efb6ab3045a0df4c7fa
     nidm_contrastName: "Average effect of condition"^^xsd:string ;
     nidm_errorDegreesOfFreedom: "39"^^xsd:float ;
     nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:00f2d1f7a8cf8c992c713523daff77a3 ;
+    nidm_inCoordinateSpace: niiri:334a58b04dd8169b2161a2e8b2629a0d ;
     crypto:sha512 "531843c41e0edb06002746841a3cdcaf0aa3c319781bcbedc84f6a427e154303731eaf31b1f9a403d6ecdb86716186b69dd471787f683aa7dec5f29f26bc6960"^^xsd:string .
 
-niiri:72d0db34ef943b13827b9c0881fd280b
+niiri:1300030726b15941203796dca8bcf83c
     a prov:Entity, nidm_StatisticMap: ; 
     nfo:fileName "spmF_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "274c247097322961825fc7761087f9352df4af7540ca42c3cfd4a35adf1249b0b72e793d97bdc1051daadce0d855a067ab6d091ed79d9b99a92180586cd65762"^^xsd:string .
 
-niiri:293542c9d6286efb6ab3045a0df4c7fa prov:wasDerivedFrom niiri:72d0db34ef943b13827b9c0881fd280b .
+niiri:9ca097a864a89e695f5a0ade9c7a2592 prov:wasDerivedFrom niiri:1300030726b15941203796dca8bcf83c .
 
-niiri:293542c9d6286efb6ab3045a0df4c7fa prov:wasGeneratedBy niiri:8bcee3a21f81e2a43338bf0ee897788a .
+niiri:9ca097a864a89e695f5a0ade9c7a2592 prov:wasGeneratedBy niiri:2456cdab46e0eb6c27cca0f6dd52cb86 .
 
-niiri:b9b6e9aa5774df7d7f9c348203cf957b
+niiri:a72a81446159f6a67c6f27a5da80101a
     a prov:Entity, nidm_ContrastExplainedMeanSquareMap: ; 
     prov:atLocation "ContrastExplainedMeanSquare.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ContrastExplainedMeanSquare.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Explained Mean Square Map" ;
-    nidm_inCoordinateSpace: niiri:00f2d1f7a8cf8c992c713523daff77a3 ;
+    nidm_inCoordinateSpace: niiri:334a58b04dd8169b2161a2e8b2629a0d ;
     crypto:sha512 "367a36ade072cb98530f28763f9b42a7b408eb21636c86c87161b4e3c6def23180be03e7c730f0591f675bcf6d9f9f9e290b2fa98a788e5b44df1683ce024d7a"^^xsd:string .
 
-niiri:b9b6e9aa5774df7d7f9c348203cf957b prov:wasGeneratedBy niiri:8bcee3a21f81e2a43338bf0ee897788a .
+niiri:a72a81446159f6a67c6f27a5da80101a prov:wasGeneratedBy niiri:2456cdab46e0eb6c27cca0f6dd52cb86 .
 
-niiri:69c646be2c3c240aac74d26c00a45790
+niiri:6e1bb9294b0707edbbe5ae21cfbadf07
     a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
-    rdfs:label "Height Threshold: p<0.001000 (unc.)" ;
+    rdfs:label "Height Threshold: p<0.001 (unc.)" ;
     prov:value "0.000999500201896764"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:d7762f130ac3c03acc3d5f9ce19ad69e ;
-    nidm_equivalentThreshold: niiri:1348d4eea57e7b30092ebb92e102a60a .
+    nidm_equivalentThreshold: niiri:20fda3ccb70028555e7275aefc3215b7 ;
+    nidm_equivalentThreshold: niiri:ad55acc7ff668917e187d5b8b71ef0fe .
 
-niiri:d7762f130ac3c03acc3d5f9ce19ad69e
+niiri:20fda3ccb70028555e7275aefc3215b7
     a prov:Entity, nidm_HeightThreshold:, obo_statistic: ; 
-    rdfs:label "Height Threshold" ;
+    rdfs:label "Height Threshold: F=12.660218)" ;
     prov:value "12.6602184255263"^^xsd:float .
 
-niiri:1348d4eea57e7b30092ebb92e102a60a
+niiri:ad55acc7ff668917e187d5b8b71ef0fe
     a prov:Entity, nidm_HeightThreshold:, obo_FWERadjustedpvalue: ; 
-    rdfs:label "Height Threshold" ;
+    rdfs:label "Height Threshold: p<1.000000 (FWE)" ;
     prov:value "0.999999999999997"^^xsd:float .
 
-niiri:b3f0880709cebff161598fc4fff7f8a9
+niiri:636d204ec94986da6b6ce98445053011
     a prov:Entity, nidm_ExtentThreshold:, obo_statistic: ; 
     rdfs:label "Extent Threshold: k>=0" ;
     nidm_clusterSizeInVoxels: "0"^^xsd:int ;
     nidm_clusterSizeInResels: "0"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:c64039e3021e29c8c7d38fb99992c68d ;
-    nidm_equivalentThreshold: niiri:e390cc8d251f413995c1456a52dd93c2 .
+    nidm_equivalentThreshold: niiri:a54887ecc715604dd6455a6477b0a70e ;
+    nidm_equivalentThreshold: niiri:6488aa4615162148eb510043add8322a .
 
-niiri:c64039e3021e29c8c7d38fb99992c68d
+niiri:a54887ecc715604dd6455a6477b0a70e
     a prov:Entity, nidm_ExtentThreshold:, obo_FWERadjustedpvalue: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:e390cc8d251f413995c1456a52dd93c2
+niiri:6488aa4615162148eb510043add8322a
     a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:230d82bcf048e9a2c15000cb7d1a3b46
+niiri:3dd5d16b52227865dddd8a70d5265d53
     a prov:Entity, nidm_PeakDefinitionCriteria: ; 
     rdfs:label "Peak Definition Criteria" ;
     nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
     nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
 
-niiri:87caeaa704d6182c6fed9fe2e520169d
+niiri:029c2dcb7254e8c7af93bf485d809706
     a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
     rdfs:label "Cluster Connectivity Criterion: 18" ;
     nidm_hasConnectivityCriterion: nidm_voxel18connected: .
 
-niiri:bf56eb4a5b14dd758d63d869c739abe4
+niiri:e5a916f24cf27604386c2c32a5bf702b
     a prov:Activity, nidm_Inference: ; 
     nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
     rdfs:label "Inference" .
 
-niiri:bf56eb4a5b14dd758d63d869c739abe4 prov:wasAssociatedWith niiri:5190808bd0433895ce27d1d15e3ecde5 .
+niiri:e5a916f24cf27604386c2c32a5bf702b prov:wasAssociatedWith niiri:bc2e77c470f6014f2a246955842052c9 .
 
-niiri:bf56eb4a5b14dd758d63d869c739abe4 prov:used niiri:69c646be2c3c240aac74d26c00a45790 .
+niiri:e5a916f24cf27604386c2c32a5bf702b prov:used niiri:6e1bb9294b0707edbbe5ae21cfbadf07 .
 
-niiri:bf56eb4a5b14dd758d63d869c739abe4 prov:used niiri:b3f0880709cebff161598fc4fff7f8a9 .
+niiri:e5a916f24cf27604386c2c32a5bf702b prov:used niiri:636d204ec94986da6b6ce98445053011 .
 
-niiri:bf56eb4a5b14dd758d63d869c739abe4 prov:used niiri:293542c9d6286efb6ab3045a0df4c7fa .
+niiri:e5a916f24cf27604386c2c32a5bf702b prov:used niiri:9ca097a864a89e695f5a0ade9c7a2592 .
 
-niiri:bf56eb4a5b14dd758d63d869c739abe4 prov:used niiri:de09763e711605a90fbefccccad90faf .
+niiri:e5a916f24cf27604386c2c32a5bf702b prov:used niiri:96116055802375625dcf702ee01581fe .
 
-niiri:bf56eb4a5b14dd758d63d869c739abe4 prov:used niiri:40d21d093fb28877228a457af0198dbe .
+niiri:e5a916f24cf27604386c2c32a5bf702b prov:used niiri:fc108568cd5e536825df64c6f1040101 .
 
-niiri:bf56eb4a5b14dd758d63d869c739abe4 prov:used niiri:230d82bcf048e9a2c15000cb7d1a3b46 .
+niiri:e5a916f24cf27604386c2c32a5bf702b prov:used niiri:3dd5d16b52227865dddd8a70d5265d53 .
 
-niiri:bf56eb4a5b14dd758d63d869c739abe4 prov:used niiri:87caeaa704d6182c6fed9fe2e520169d .
+niiri:e5a916f24cf27604386c2c32a5bf702b prov:used niiri:029c2dcb7254e8c7af93bf485d809706 .
 
-niiri:357faa323774b23aea02c9b7c4f4f7eb
+niiri:db110fb8702367464d0832795a39cbbb
     a prov:Entity, nidm_SearchSpaceMaskMap: ; 
     prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
     nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Search Space Mask Map" ;
-    nidm_inCoordinateSpace: niiri:00f2d1f7a8cf8c992c713523daff77a3 ;
+    nidm_inCoordinateSpace: niiri:334a58b04dd8169b2161a2e8b2629a0d ;
     nidm_searchVolumeInVoxels: "167222"^^xsd:int ;
     nidm_searchVolumeInUnits: "1337776"^^xsd:float ;
     nidm_reselSizeInVoxels: "68.5679161280351"^^xsd:float ;
@@ -482,9 +482,9 @@ niiri:357faa323774b23aea02c9b7c4f4f7eb
     spm_smallestSignificantClusterSizeInVoxelsFWE05: "99"^^xsd:int ;
     spm_smallestSignificantClusterSizeInVoxelsFDR05: "57"^^xsd:int .
 
-niiri:357faa323774b23aea02c9b7c4f4f7eb prov:wasGeneratedBy niiri:bf56eb4a5b14dd758d63d869c739abe4 .
+niiri:db110fb8702367464d0832795a39cbbb prov:wasGeneratedBy niiri:e5a916f24cf27604386c2c32a5bf702b .
 
-niiri:9f1620f32dc4659d77d42ff2a65c79af
+niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb
     a prov:Entity, nidm_ExcursionSetMap: ; 
     prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
@@ -492,29 +492,29 @@ niiri:9f1620f32dc4659d77d42ff2a65c79af
     rdfs:label "Excursion Set Map" ;
     nidm_numberOfSupraThresholdClusters: "71"^^xsd:int ;
     nidm_pValue: "9.36073596413678e-09"^^xsd:float ;
-    nidm_hasClusterLabelsMap: niiri:323afcdadc938b84ca5418963487ffad ;
-    nidm_hasMaximumIntensityProjection: niiri:58f2c20c893ac140b40d74e45728d199 ;
-    nidm_inCoordinateSpace: niiri:00f2d1f7a8cf8c992c713523daff77a3 ;
+    nidm_hasClusterLabelsMap: niiri:7be8ea19c7603988ed0c6856e309f76b ;
+    nidm_hasMaximumIntensityProjection: niiri:a5f4d5f5d9604b6647154be60baf72d4 ;
+    nidm_inCoordinateSpace: niiri:334a58b04dd8169b2161a2e8b2629a0d ;
     crypto:sha512 "3cb7cb94a15ceea4d3b829f354f40eaeb85863016ba6e236003b548b7cf18ceaa22541bd90454f190ee0e374f2958f6130c7eb1bf4c55e75bdad693646d71006"^^xsd:string .
 
-niiri:323afcdadc938b84ca5418963487ffad
+niiri:7be8ea19c7603988ed0c6856e309f76b
     a prov:Entity, nidm_ClusterLabelsMap: ; 
     prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Cluster Labels Map" ;
-    nidm_inCoordinateSpace: niiri:00f2d1f7a8cf8c992c713523daff77a3 ;
+    nidm_inCoordinateSpace: niiri:334a58b04dd8169b2161a2e8b2629a0d ;
     crypto:sha512 "403459cc812b3927db0db6d5a3f64b79acf6774fc116e11ed6ecf56ec229afd8812650c060fdf10c2ecdab534ffadb67f4650178e12b65ccea6220e0ed951cb2"^^xsd:string .
 
-niiri:58f2c20c893ac140b40d74e45728d199
+niiri:a5f4d5f5d9604b6647154be60baf72d4
     a prov:Entity, dctype:Image ; 
     prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
     nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:9f1620f32dc4659d77d42ff2a65c79af prov:wasGeneratedBy niiri:bf56eb4a5b14dd758d63d869c739abe4 .
+niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb prov:wasGeneratedBy niiri:e5a916f24cf27604386c2c32a5bf702b .
 
-niiri:2614b44f75a99f07f4673d4500fe47ed
+niiri:0502f21f886d74eb5a46cc0e98d99ebd
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0001" ;
     nidm_clusterSizeInVoxels: "64"^^xsd:int ;
@@ -524,9 +524,9 @@ niiri:2614b44f75a99f07f4673d4500fe47ed
     nidm_qValueFDR: "0.0331064416134022"^^xsd:float ;
     nidm_clusterLabelId: "1"^^xsd:int .
 
-niiri:2614b44f75a99f07f4673d4500fe47ed prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:0502f21f886d74eb5a46cc0e98d99ebd prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:26dc30d77d0a0c23d6913e69266e279e
+niiri:0599785d82edc2bd01edfc956f648d55
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0002" ;
     nidm_clusterSizeInVoxels: "139"^^xsd:int ;
@@ -536,9 +536,9 @@ niiri:26dc30d77d0a0c23d6913e69266e279e
     nidm_qValueFDR: "0.00187930999732674"^^xsd:float ;
     nidm_clusterLabelId: "2"^^xsd:int .
 
-niiri:26dc30d77d0a0c23d6913e69266e279e prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:0599785d82edc2bd01edfc956f648d55 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:5819cfbfd916831f2b9b46c44761a13b
+niiri:503c99586f814910b6b80009bf62943c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0003" ;
     nidm_clusterSizeInVoxels: "99"^^xsd:int ;
@@ -548,9 +548,9 @@ niiri:5819cfbfd916831f2b9b46c44761a13b
     nidm_qValueFDR: "0.00529219475562633"^^xsd:float ;
     nidm_clusterLabelId: "3"^^xsd:int .
 
-niiri:5819cfbfd916831f2b9b46c44761a13b prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:503c99586f814910b6b80009bf62943c prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:18222312b25450890c50a38e087b5fca
+niiri:018a24899160bba0361882009e28cdf7
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0004" ;
     nidm_clusterSizeInVoxels: "100"^^xsd:int ;
@@ -560,9 +560,9 @@ niiri:18222312b25450890c50a38e087b5fca
     nidm_qValueFDR: "0.00529219475562633"^^xsd:float ;
     nidm_clusterLabelId: "4"^^xsd:int .
 
-niiri:18222312b25450890c50a38e087b5fca prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:018a24899160bba0361882009e28cdf7 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:fd0ea64d092adb2dc6aef53bb390dd47
+niiri:33d37aeafd7dbe4545a7c3723ffec290
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0005" ;
     nidm_clusterSizeInVoxels: "41"^^xsd:int ;
@@ -572,9 +572,9 @@ niiri:fd0ea64d092adb2dc6aef53bb390dd47
     nidm_qValueFDR: "0.0831636096487233"^^xsd:float ;
     nidm_clusterLabelId: "5"^^xsd:int .
 
-niiri:fd0ea64d092adb2dc6aef53bb390dd47 prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:33d37aeafd7dbe4545a7c3723ffec290 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:086741e220f142a5ba7d24c166640134
+niiri:c67e26c71245447102997061bd7b4400
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0006" ;
     nidm_clusterSizeInVoxels: "42"^^xsd:int ;
@@ -584,9 +584,9 @@ niiri:086741e220f142a5ba7d24c166640134
     nidm_qValueFDR: "0.0831636096487233"^^xsd:float ;
     nidm_clusterLabelId: "6"^^xsd:int .
 
-niiri:086741e220f142a5ba7d24c166640134 prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:c67e26c71245447102997061bd7b4400 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:e2190d23e52313b345dec17a936b13ac
+niiri:21c6b4d93e2f7d826c174fe1b99df534
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0007" ;
     nidm_clusterSizeInVoxels: "27"^^xsd:int ;
@@ -596,9 +596,9 @@ niiri:e2190d23e52313b345dec17a936b13ac
     nidm_qValueFDR: "0.159254496673883"^^xsd:float ;
     nidm_clusterLabelId: "7"^^xsd:int .
 
-niiri:e2190d23e52313b345dec17a936b13ac prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:21c6b4d93e2f7d826c174fe1b99df534 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:26ab6f532ee67acbd905e1a64f80b9d8
+niiri:6da0c60471d915bb0e46bffadee4d55a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0008" ;
     nidm_clusterSizeInVoxels: "57"^^xsd:int ;
@@ -608,9 +608,9 @@ niiri:26ab6f532ee67acbd905e1a64f80b9d8
     nidm_qValueFDR: "0.04225024248008"^^xsd:float ;
     nidm_clusterLabelId: "8"^^xsd:int .
 
-niiri:26ab6f532ee67acbd905e1a64f80b9d8 prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:6da0c60471d915bb0e46bffadee4d55a prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:5107e0fdba262447669255100a242c1c
+niiri:a35a0c7d262276e543a1e97fbbe3cdc8
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0009" ;
     nidm_clusterSizeInVoxels: "33"^^xsd:int ;
@@ -620,9 +620,9 @@ niiri:5107e0fdba262447669255100a242c1c
     nidm_qValueFDR: "0.112910609996037"^^xsd:float ;
     nidm_clusterLabelId: "9"^^xsd:int .
 
-niiri:5107e0fdba262447669255100a242c1c prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:a35a0c7d262276e543a1e97fbbe3cdc8 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:6d5196dbefc80600da436f72c5fa99e9
+niiri:cfb99edebaae9df65e32c2dc18fd6186
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0010" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -632,9 +632,9 @@ niiri:6d5196dbefc80600da436f72c5fa99e9
     nidm_qValueFDR: "0.539152830861885"^^xsd:float ;
     nidm_clusterLabelId: "10"^^xsd:int .
 
-niiri:6d5196dbefc80600da436f72c5fa99e9 prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:cfb99edebaae9df65e32c2dc18fd6186 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:d4c4e9d5661158241502d335eb5a96e4
+niiri:2607cc56c513b9a7b262e9ec22fe2b63
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0011" ;
     nidm_clusterSizeInVoxels: "10"^^xsd:int ;
@@ -644,9 +644,9 @@ niiri:d4c4e9d5661158241502d335eb5a96e4
     nidm_qValueFDR: "0.409577787868145"^^xsd:float ;
     nidm_clusterLabelId: "11"^^xsd:int .
 
-niiri:d4c4e9d5661158241502d335eb5a96e4 prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:2607cc56c513b9a7b262e9ec22fe2b63 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:52cc5fe71e36fbe65be2bc6eac0024f0
+niiri:1daa422fda95bd1a9676984906e1a548
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0012" ;
     nidm_clusterSizeInVoxels: "26"^^xsd:int ;
@@ -656,9 +656,9 @@ niiri:52cc5fe71e36fbe65be2bc6eac0024f0
     nidm_qValueFDR: "0.16145507389922"^^xsd:float ;
     nidm_clusterLabelId: "12"^^xsd:int .
 
-niiri:52cc5fe71e36fbe65be2bc6eac0024f0 prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:1daa422fda95bd1a9676984906e1a548 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:c7a355d22d989f24ef00d62137ddfe13
+niiri:a6888f03a619f2ef07714763993a3be7
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0013" ;
     nidm_clusterSizeInVoxels: "11"^^xsd:int ;
@@ -668,9 +668,9 @@ niiri:c7a355d22d989f24ef00d62137ddfe13
     nidm_qValueFDR: "0.407017361355993"^^xsd:float ;
     nidm_clusterLabelId: "13"^^xsd:int .
 
-niiri:c7a355d22d989f24ef00d62137ddfe13 prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:a6888f03a619f2ef07714763993a3be7 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:ed934b2b32fd19f3afbe4c6bb5d3f1a3
+niiri:ff0222b1c30a382e52f5903988ee7a67
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0014" ;
     nidm_clusterSizeInVoxels: "16"^^xsd:int ;
@@ -680,9 +680,9 @@ niiri:ed934b2b32fd19f3afbe4c6bb5d3f1a3
     nidm_qValueFDR: "0.325737707000596"^^xsd:float ;
     nidm_clusterLabelId: "14"^^xsd:int .
 
-niiri:ed934b2b32fd19f3afbe4c6bb5d3f1a3 prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:ff0222b1c30a382e52f5903988ee7a67 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:f4a1be717fb30bceb6b19d568207e064
+niiri:189a48f192c71c34afbefb1b24c895a1
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0015" ;
     nidm_clusterSizeInVoxels: "14"^^xsd:int ;
@@ -692,9 +692,9 @@ niiri:f4a1be717fb30bceb6b19d568207e064
     nidm_qValueFDR: "0.36254636700416"^^xsd:float ;
     nidm_clusterLabelId: "15"^^xsd:int .
 
-niiri:f4a1be717fb30bceb6b19d568207e064 prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:189a48f192c71c34afbefb1b24c895a1 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:932e333631c50069ac12d36b6efba037
+niiri:153d0f62058a9c03f71f38806c01672c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0016" ;
     nidm_clusterSizeInVoxels: "35"^^xsd:int ;
@@ -704,9 +704,9 @@ niiri:932e333631c50069ac12d36b6efba037
     nidm_qValueFDR: "0.112910609996037"^^xsd:float ;
     nidm_clusterLabelId: "16"^^xsd:int .
 
-niiri:932e333631c50069ac12d36b6efba037 prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:153d0f62058a9c03f71f38806c01672c prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:d98235d369f4da12b94c1ba7844053d1
+niiri:2b8333b9ae75e6a69c6703c1017776ef
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0017" ;
     nidm_clusterSizeInVoxels: "32"^^xsd:int ;
@@ -716,9 +716,9 @@ niiri:d98235d369f4da12b94c1ba7844053d1
     nidm_qValueFDR: "0.112910609996037"^^xsd:float ;
     nidm_clusterLabelId: "17"^^xsd:int .
 
-niiri:d98235d369f4da12b94c1ba7844053d1 prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:2b8333b9ae75e6a69c6703c1017776ef prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:2b33b3c2fb565f11805c2ab96c217218
+niiri:be0ede967cfc83179dfb392adca98376
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0018" ;
     nidm_clusterSizeInVoxels: "46"^^xsd:int ;
@@ -728,9 +728,9 @@ niiri:2b33b3c2fb565f11805c2ab96c217218
     nidm_qValueFDR: "0.0764111576030657"^^xsd:float ;
     nidm_clusterLabelId: "18"^^xsd:int .
 
-niiri:2b33b3c2fb565f11805c2ab96c217218 prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:be0ede967cfc83179dfb392adca98376 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:5a17a76cb3f0ca0ddba79372b881b0ac
+niiri:23f2b3702fb27a3d52f0874c93630544
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0019" ;
     nidm_clusterSizeInVoxels: "15"^^xsd:int ;
@@ -740,9 +740,9 @@ niiri:5a17a76cb3f0ca0ddba79372b881b0ac
     nidm_qValueFDR: "0.342768186087759"^^xsd:float ;
     nidm_clusterLabelId: "19"^^xsd:int .
 
-niiri:5a17a76cb3f0ca0ddba79372b881b0ac prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:23f2b3702fb27a3d52f0874c93630544 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:cdbe1592b4a9de39b031d21dc9c2950c
+niiri:654afa8f2fea6cb2d23c37e50edee008
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0020" ;
     nidm_clusterSizeInVoxels: "20"^^xsd:int ;
@@ -752,9 +752,9 @@ niiri:cdbe1592b4a9de39b031d21dc9c2950c
     nidm_qValueFDR: "0.231186540238297"^^xsd:float ;
     nidm_clusterLabelId: "20"^^xsd:int .
 
-niiri:cdbe1592b4a9de39b031d21dc9c2950c prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:654afa8f2fea6cb2d23c37e50edee008 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:a74c6130611adcee49f9abe720d6e52c
+niiri:dba06f209302f6639800d0af3c93affd
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0021" ;
     nidm_clusterSizeInVoxels: "11"^^xsd:int ;
@@ -764,9 +764,9 @@ niiri:a74c6130611adcee49f9abe720d6e52c
     nidm_qValueFDR: "0.407017361355993"^^xsd:float ;
     nidm_clusterLabelId: "21"^^xsd:int .
 
-niiri:a74c6130611adcee49f9abe720d6e52c prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:dba06f209302f6639800d0af3c93affd prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:0b42259e10bfb86cff826215fa08b419
+niiri:57c14f931d36e820d2322a1bdd36da40
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0022" ;
     nidm_clusterSizeInVoxels: "32"^^xsd:int ;
@@ -776,9 +776,9 @@ niiri:0b42259e10bfb86cff826215fa08b419
     nidm_qValueFDR: "0.112910609996037"^^xsd:float ;
     nidm_clusterLabelId: "22"^^xsd:int .
 
-niiri:0b42259e10bfb86cff826215fa08b419 prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:57c14f931d36e820d2322a1bdd36da40 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:59f34e94c3c0a0f91363e1cf44b96bbb
+niiri:2739d32e473645dfabd9a03fc9f4dae7
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0023" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -788,9 +788,9 @@ niiri:59f34e94c3c0a0f91363e1cf44b96bbb
     nidm_qValueFDR: "0.599749762946134"^^xsd:float ;
     nidm_clusterLabelId: "23"^^xsd:int .
 
-niiri:59f34e94c3c0a0f91363e1cf44b96bbb prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:2739d32e473645dfabd9a03fc9f4dae7 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:e15a7f7da66912fa92c8140c6338b192
+niiri:23f5ffb7a02a62400ce3f1cfda032dbe
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0024" ;
     nidm_clusterSizeInVoxels: "11"^^xsd:int ;
@@ -800,9 +800,9 @@ niiri:e15a7f7da66912fa92c8140c6338b192
     nidm_qValueFDR: "0.407017361355993"^^xsd:float ;
     nidm_clusterLabelId: "24"^^xsd:int .
 
-niiri:e15a7f7da66912fa92c8140c6338b192 prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:23f5ffb7a02a62400ce3f1cfda032dbe prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:deefe75f432062b10a9b73a0036af48f
+niiri:3ed09542d8eeb67b7a92a4f1152a9588
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0025" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -812,9 +812,9 @@ niiri:deefe75f432062b10a9b73a0036af48f
     nidm_qValueFDR: "0.549154411159401"^^xsd:float ;
     nidm_clusterLabelId: "25"^^xsd:int .
 
-niiri:deefe75f432062b10a9b73a0036af48f prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:3ed09542d8eeb67b7a92a4f1152a9588 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:85cc735cf6146dea08ebdfd5febbbbf6
+niiri:ee2c6440d10e17fa3f61858f975e92f6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0026" ;
     nidm_clusterSizeInVoxels: "21"^^xsd:int ;
@@ -824,9 +824,9 @@ niiri:85cc735cf6146dea08ebdfd5febbbbf6
     nidm_qValueFDR: "0.223222605600877"^^xsd:float ;
     nidm_clusterLabelId: "26"^^xsd:int .
 
-niiri:85cc735cf6146dea08ebdfd5febbbbf6 prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:ee2c6440d10e17fa3f61858f975e92f6 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:eda691902b8e9f86974b74de47c3be21
+niiri:25764564ed7b5495d43208d9a742797c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0027" ;
     nidm_clusterSizeInVoxels: "25"^^xsd:int ;
@@ -836,9 +836,9 @@ niiri:eda691902b8e9f86974b74de47c3be21
     nidm_qValueFDR: "0.164712089590753"^^xsd:float ;
     nidm_clusterLabelId: "27"^^xsd:int .
 
-niiri:eda691902b8e9f86974b74de47c3be21 prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:25764564ed7b5495d43208d9a742797c prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:44c46f8ea3d70ad705fe182f1aaf841e
+niiri:2a5007577d5f397768b0a52d8e1e454a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0028" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -848,9 +848,9 @@ niiri:44c46f8ea3d70ad705fe182f1aaf841e
     nidm_qValueFDR: "0.475965190018395"^^xsd:float ;
     nidm_clusterLabelId: "28"^^xsd:int .
 
-niiri:44c46f8ea3d70ad705fe182f1aaf841e prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:2a5007577d5f397768b0a52d8e1e454a prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:e1e2e1faf57e2ccdad8d1cc2103103f7
+niiri:075d03d6a0a7a8ff06d2fd0a678225e4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0029" ;
     nidm_clusterSizeInVoxels: "12"^^xsd:int ;
@@ -860,9 +860,9 @@ niiri:e1e2e1faf57e2ccdad8d1cc2103103f7
     nidm_qValueFDR: "0.407017361355993"^^xsd:float ;
     nidm_clusterLabelId: "29"^^xsd:int .
 
-niiri:e1e2e1faf57e2ccdad8d1cc2103103f7 prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:075d03d6a0a7a8ff06d2fd0a678225e4 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:a63b9651208c3ee898cba42774cbd083
+niiri:f9daf2bb86509394f654f8dfb4a4e15b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0030" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -872,9 +872,9 @@ niiri:a63b9651208c3ee898cba42774cbd083
     nidm_qValueFDR: "0.675180100901307"^^xsd:float ;
     nidm_clusterLabelId: "30"^^xsd:int .
 
-niiri:a63b9651208c3ee898cba42774cbd083 prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:f9daf2bb86509394f654f8dfb4a4e15b prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:99df9b0bee5015f2e54ddbafb84c5b4b
+niiri:447a33078d0ab11fa638dad2f64b7b00
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0031" ;
     nidm_clusterSizeInVoxels: "10"^^xsd:int ;
@@ -884,9 +884,9 @@ niiri:99df9b0bee5015f2e54ddbafb84c5b4b
     nidm_qValueFDR: "0.409577787868145"^^xsd:float ;
     nidm_clusterLabelId: "31"^^xsd:int .
 
-niiri:99df9b0bee5015f2e54ddbafb84c5b4b prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:447a33078d0ab11fa638dad2f64b7b00 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:4fb8453b9556b51fec8c4dac94527e32
+niiri:e979405039e66c5ce2c3d5b5b67f1286
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0032" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -896,9 +896,9 @@ niiri:4fb8453b9556b51fec8c4dac94527e32
     nidm_qValueFDR: "0.599749762946134"^^xsd:float ;
     nidm_clusterLabelId: "32"^^xsd:int .
 
-niiri:4fb8453b9556b51fec8c4dac94527e32 prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:e979405039e66c5ce2c3d5b5b67f1286 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:06615834113ebb8c32e91747f3e2ea30
+niiri:02724527e4ee34eff0967177115a83d1
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0033" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -908,9 +908,9 @@ niiri:06615834113ebb8c32e91747f3e2ea30
     nidm_qValueFDR: "0.539152830861885"^^xsd:float ;
     nidm_clusterLabelId: "33"^^xsd:int .
 
-niiri:06615834113ebb8c32e91747f3e2ea30 prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:02724527e4ee34eff0967177115a83d1 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:ebf5f25253bc1119f25ba867f1a13a26
+niiri:c6bf9a9fd500605c73016dfb45e6af98
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0034" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -920,9 +920,9 @@ niiri:ebf5f25253bc1119f25ba867f1a13a26
     nidm_qValueFDR: "0.549154411159401"^^xsd:float ;
     nidm_clusterLabelId: "34"^^xsd:int .
 
-niiri:ebf5f25253bc1119f25ba867f1a13a26 prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:c6bf9a9fd500605c73016dfb45e6af98 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:e51b44da6f9ef9702d8a79c08d73d19e
+niiri:e3e587be4409f0bc772835a934536590
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0035" ;
     nidm_clusterSizeInVoxels: "10"^^xsd:int ;
@@ -932,9 +932,9 @@ niiri:e51b44da6f9ef9702d8a79c08d73d19e
     nidm_qValueFDR: "0.409577787868145"^^xsd:float ;
     nidm_clusterLabelId: "35"^^xsd:int .
 
-niiri:e51b44da6f9ef9702d8a79c08d73d19e prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:e3e587be4409f0bc772835a934536590 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:b8483957e8852fa21925543fe06f0492
+niiri:6aa3e47b1d56a62cbf353acb1dbf4e63
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0036" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -944,9 +944,9 @@ niiri:b8483957e8852fa21925543fe06f0492
     nidm_qValueFDR: "0.52711170915107"^^xsd:float ;
     nidm_clusterLabelId: "36"^^xsd:int .
 
-niiri:b8483957e8852fa21925543fe06f0492 prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:6aa3e47b1d56a62cbf353acb1dbf4e63 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:1d380370dd353aff7206de21666fb3d4
+niiri:11267ea4af34c876ad34aa054c834aa1
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0037" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -956,9 +956,9 @@ niiri:1d380370dd353aff7206de21666fb3d4
     nidm_qValueFDR: "0.475965190018395"^^xsd:float ;
     nidm_clusterLabelId: "37"^^xsd:int .
 
-niiri:1d380370dd353aff7206de21666fb3d4 prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:11267ea4af34c876ad34aa054c834aa1 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:68a55477530e699e1f7822c244d7eb8f
+niiri:ed62a9c22b9d6c8f4255706a0676f4da
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0038" ;
     nidm_clusterSizeInVoxels: "12"^^xsd:int ;
@@ -968,9 +968,9 @@ niiri:68a55477530e699e1f7822c244d7eb8f
     nidm_qValueFDR: "0.407017361355993"^^xsd:float ;
     nidm_clusterLabelId: "38"^^xsd:int .
 
-niiri:68a55477530e699e1f7822c244d7eb8f prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:ed62a9c22b9d6c8f4255706a0676f4da prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:aacb0b550de1bf101b8a9ebfbba31aae
+niiri:7649cec60050f6bbb0a4a68fad360d04
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0039" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -980,9 +980,9 @@ niiri:aacb0b550de1bf101b8a9ebfbba31aae
     nidm_qValueFDR: "0.549154411159401"^^xsd:float ;
     nidm_clusterLabelId: "39"^^xsd:int .
 
-niiri:aacb0b550de1bf101b8a9ebfbba31aae prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:7649cec60050f6bbb0a4a68fad360d04 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:18d7d5a2985d2afc116f40bb7d9dd868
+niiri:76477879d12f5565edfe6317f1396ae3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0040" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -992,9 +992,9 @@ niiri:18d7d5a2985d2afc116f40bb7d9dd868
     nidm_qValueFDR: "0.549154411159401"^^xsd:float ;
     nidm_clusterLabelId: "40"^^xsd:int .
 
-niiri:18d7d5a2985d2afc116f40bb7d9dd868 prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:76477879d12f5565edfe6317f1396ae3 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:b82b663a41d1d4bc01fd88119e09dfc9
+niiri:b32a94908c3543b6389e71c09e18b028
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0041" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1004,9 +1004,9 @@ niiri:b82b663a41d1d4bc01fd88119e09dfc9
     nidm_qValueFDR: "0.653424857494954"^^xsd:float ;
     nidm_clusterLabelId: "41"^^xsd:int .
 
-niiri:b82b663a41d1d4bc01fd88119e09dfc9 prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:b32a94908c3543b6389e71c09e18b028 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:74035667fc1f8ff5d347c08183ecb0d2
+niiri:505e13c060365ce925c6c78620aace2b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0042" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -1016,9 +1016,9 @@ niiri:74035667fc1f8ff5d347c08183ecb0d2
     nidm_qValueFDR: "0.539152830861885"^^xsd:float ;
     nidm_clusterLabelId: "42"^^xsd:int .
 
-niiri:74035667fc1f8ff5d347c08183ecb0d2 prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:505e13c060365ce925c6c78620aace2b prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:a9e9f6c4e1e252f83c00826797f885fd
+niiri:6a2f64f5544ff048d58423df90e157d2
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0043" ;
     nidm_clusterSizeInVoxels: "9"^^xsd:int ;
@@ -1028,9 +1028,9 @@ niiri:a9e9f6c4e1e252f83c00826797f885fd
     nidm_qValueFDR: "0.44750920486968"^^xsd:float ;
     nidm_clusterLabelId: "43"^^xsd:int .
 
-niiri:a9e9f6c4e1e252f83c00826797f885fd prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:6a2f64f5544ff048d58423df90e157d2 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:100b7385b787aa70accf430f06dc1f51
+niiri:965bca191e7bce9008d8dd515cf43195
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0044" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1040,9 +1040,9 @@ niiri:100b7385b787aa70accf430f06dc1f51
     nidm_qValueFDR: "0.653424857494954"^^xsd:float ;
     nidm_clusterLabelId: "44"^^xsd:int .
 
-niiri:100b7385b787aa70accf430f06dc1f51 prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:965bca191e7bce9008d8dd515cf43195 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:677f763bf103868e95ac103a45720d37
+niiri:5c0f8a6949255a54753a5996ab8bf0b5
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0045" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1052,9 +1052,9 @@ niiri:677f763bf103868e95ac103a45720d37
     nidm_qValueFDR: "0.653424857494954"^^xsd:float ;
     nidm_clusterLabelId: "45"^^xsd:int .
 
-niiri:677f763bf103868e95ac103a45720d37 prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:5c0f8a6949255a54753a5996ab8bf0b5 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:0c812c731486b17b175ecfc3bf7169f1
+niiri:e00c0b657ae25f884a41aad34f6d4869
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0046" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1064,9 +1064,9 @@ niiri:0c812c731486b17b175ecfc3bf7169f1
     nidm_qValueFDR: "0.675180100901307"^^xsd:float ;
     nidm_clusterLabelId: "46"^^xsd:int .
 
-niiri:0c812c731486b17b175ecfc3bf7169f1 prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:e00c0b657ae25f884a41aad34f6d4869 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:747d0e971ba4dc1c824eb2073e536769
+niiri:efbb22419db35e6170e4f8c15df564d9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0047" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1076,9 +1076,9 @@ niiri:747d0e971ba4dc1c824eb2073e536769
     nidm_qValueFDR: "0.599749762946134"^^xsd:float ;
     nidm_clusterLabelId: "47"^^xsd:int .
 
-niiri:747d0e971ba4dc1c824eb2073e536769 prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:efbb22419db35e6170e4f8c15df564d9 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:db3dd4033ee5e1f792de4dafd8064e08
+niiri:792fda8a02886788088cdc21433fe931
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0048" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1088,9 +1088,9 @@ niiri:db3dd4033ee5e1f792de4dafd8064e08
     nidm_qValueFDR: "0.653424857494954"^^xsd:float ;
     nidm_clusterLabelId: "48"^^xsd:int .
 
-niiri:db3dd4033ee5e1f792de4dafd8064e08 prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:792fda8a02886788088cdc21433fe931 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:5d1b7a0c9ff2df0d604a94edf7efd3ac
+niiri:0dd1d301e6eec8815748b738cd4fdb7c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0049" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -1100,9 +1100,9 @@ niiri:5d1b7a0c9ff2df0d604a94edf7efd3ac
     nidm_qValueFDR: "0.549154411159401"^^xsd:float ;
     nidm_clusterLabelId: "49"^^xsd:int .
 
-niiri:5d1b7a0c9ff2df0d604a94edf7efd3ac prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:0dd1d301e6eec8815748b738cd4fdb7c prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:464ed1a86745e5328f28784be3bd4fb3
+niiri:0a00a0a76e73ce79a1d09f89ec092795
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0050" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1112,9 +1112,9 @@ niiri:464ed1a86745e5328f28784be3bd4fb3
     nidm_qValueFDR: "0.675180100901307"^^xsd:float ;
     nidm_clusterLabelId: "50"^^xsd:int .
 
-niiri:464ed1a86745e5328f28784be3bd4fb3 prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:0a00a0a76e73ce79a1d09f89ec092795 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:463ba14c93e36d88477f78294036d6ea
+niiri:af99a7152d944fac822b2a894187ecfd
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0051" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1124,9 +1124,9 @@ niiri:463ba14c93e36d88477f78294036d6ea
     nidm_qValueFDR: "0.675180100901307"^^xsd:float ;
     nidm_clusterLabelId: "51"^^xsd:int .
 
-niiri:463ba14c93e36d88477f78294036d6ea prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:af99a7152d944fac822b2a894187ecfd prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:95bc5905e6829eb3b10bc4e2e665a6de
+niiri:1de9cf5cb4f411c77d648530539b1506
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0052" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1136,9 +1136,9 @@ niiri:95bc5905e6829eb3b10bc4e2e665a6de
     nidm_qValueFDR: "0.675180100901307"^^xsd:float ;
     nidm_clusterLabelId: "52"^^xsd:int .
 
-niiri:95bc5905e6829eb3b10bc4e2e665a6de prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:1de9cf5cb4f411c77d648530539b1506 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:79afb4c5267e6717f07bc3ab60650657
+niiri:643dd520d22eb83650c21da507f69f60
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0053" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1148,9 +1148,9 @@ niiri:79afb4c5267e6717f07bc3ab60650657
     nidm_qValueFDR: "0.675180100901307"^^xsd:float ;
     nidm_clusterLabelId: "53"^^xsd:int .
 
-niiri:79afb4c5267e6717f07bc3ab60650657 prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:643dd520d22eb83650c21da507f69f60 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:e1b2a55b7f9b22b0ae0bdfe29112640f
+niiri:1a432aa3e7fda423feb9c68ebffde829
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0054" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -1160,9 +1160,9 @@ niiri:e1b2a55b7f9b22b0ae0bdfe29112640f
     nidm_qValueFDR: "0.539152830861885"^^xsd:float ;
     nidm_clusterLabelId: "54"^^xsd:int .
 
-niiri:e1b2a55b7f9b22b0ae0bdfe29112640f prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:1a432aa3e7fda423feb9c68ebffde829 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:b05fa744387c4b5045f0c0b05aacfeb4
+niiri:1569aa21af436f1447efa2c75903f79c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0055" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1172,9 +1172,9 @@ niiri:b05fa744387c4b5045f0c0b05aacfeb4
     nidm_qValueFDR: "0.675180100901307"^^xsd:float ;
     nidm_clusterLabelId: "55"^^xsd:int .
 
-niiri:b05fa744387c4b5045f0c0b05aacfeb4 prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:1569aa21af436f1447efa2c75903f79c prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:51f256b7ea3e807cb25c6775473371d8
+niiri:0fb2459e07ec9adca74a9a6a0f036186
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0056" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1184,9 +1184,9 @@ niiri:51f256b7ea3e807cb25c6775473371d8
     nidm_qValueFDR: "0.675180100901307"^^xsd:float ;
     nidm_clusterLabelId: "56"^^xsd:int .
 
-niiri:51f256b7ea3e807cb25c6775473371d8 prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:0fb2459e07ec9adca74a9a6a0f036186 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:dc9c7cf4223aa5e5ce8d564077006cb3
+niiri:e937b5f0f9c2d5b73ead1407d48466e6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0057" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1196,9 +1196,9 @@ niiri:dc9c7cf4223aa5e5ce8d564077006cb3
     nidm_qValueFDR: "0.675180100901307"^^xsd:float ;
     nidm_clusterLabelId: "57"^^xsd:int .
 
-niiri:dc9c7cf4223aa5e5ce8d564077006cb3 prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:e937b5f0f9c2d5b73ead1407d48466e6 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:dd8593a9311adfd7943344f7fcbd8aee
+niiri:321743f529907bc95ee3bc2bb3feb1e2
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0058" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1208,9 +1208,9 @@ niiri:dd8593a9311adfd7943344f7fcbd8aee
     nidm_qValueFDR: "0.675180100901307"^^xsd:float ;
     nidm_clusterLabelId: "58"^^xsd:int .
 
-niiri:dd8593a9311adfd7943344f7fcbd8aee prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:321743f529907bc95ee3bc2bb3feb1e2 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:f77c3b84351f869eec0ec8a0f4c729f2
+niiri:7ca293071987c22e76e0b20115b26429
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0059" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1220,9 +1220,9 @@ niiri:f77c3b84351f869eec0ec8a0f4c729f2
     nidm_qValueFDR: "0.675180100901307"^^xsd:float ;
     nidm_clusterLabelId: "59"^^xsd:int .
 
-niiri:f77c3b84351f869eec0ec8a0f4c729f2 prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:7ca293071987c22e76e0b20115b26429 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:d51318468d3708fb69be47dd8fb73f01
+niiri:6bb00e27ab3f8d7e1b137fd7b575136a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0060" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1232,9 +1232,9 @@ niiri:d51318468d3708fb69be47dd8fb73f01
     nidm_qValueFDR: "0.675180100901307"^^xsd:float ;
     nidm_clusterLabelId: "60"^^xsd:int .
 
-niiri:d51318468d3708fb69be47dd8fb73f01 prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:6bb00e27ab3f8d7e1b137fd7b575136a prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:23ddb476e286b8beace9ac2226fb1e02
+niiri:eea16d34f3c295e17c1d3128d76481f7
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0061" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1244,9 +1244,9 @@ niiri:23ddb476e286b8beace9ac2226fb1e02
     nidm_qValueFDR: "0.675180100901307"^^xsd:float ;
     nidm_clusterLabelId: "61"^^xsd:int .
 
-niiri:23ddb476e286b8beace9ac2226fb1e02 prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:eea16d34f3c295e17c1d3128d76481f7 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:9c6347d32a637404df13117cb515bb7a
+niiri:2d477a3822ede90c19394a724a2c602f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0062" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1256,9 +1256,9 @@ niiri:9c6347d32a637404df13117cb515bb7a
     nidm_qValueFDR: "0.675180100901307"^^xsd:float ;
     nidm_clusterLabelId: "62"^^xsd:int .
 
-niiri:9c6347d32a637404df13117cb515bb7a prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:2d477a3822ede90c19394a724a2c602f prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:64b9ed90986836033d685bf5b9a5e773
+niiri:67886822c4a91ee4d1b7cd6bc45567f5
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0063" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1268,9 +1268,9 @@ niiri:64b9ed90986836033d685bf5b9a5e773
     nidm_qValueFDR: "0.675180100901307"^^xsd:float ;
     nidm_clusterLabelId: "63"^^xsd:int .
 
-niiri:64b9ed90986836033d685bf5b9a5e773 prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:67886822c4a91ee4d1b7cd6bc45567f5 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:f2a361b0d3f278353a770b78f683d8ff
+niiri:5ebab1be1c4c961db315c2ffb23786c0
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0064" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1280,9 +1280,9 @@ niiri:f2a361b0d3f278353a770b78f683d8ff
     nidm_qValueFDR: "0.675180100901307"^^xsd:float ;
     nidm_clusterLabelId: "64"^^xsd:int .
 
-niiri:f2a361b0d3f278353a770b78f683d8ff prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:5ebab1be1c4c961db315c2ffb23786c0 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:a2753eb825e8f8fd5a487ef63c2663c8
+niiri:06a77002692eb72a6823907717b7b96b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0065" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1292,9 +1292,9 @@ niiri:a2753eb825e8f8fd5a487ef63c2663c8
     nidm_qValueFDR: "0.675180100901307"^^xsd:float ;
     nidm_clusterLabelId: "65"^^xsd:int .
 
-niiri:a2753eb825e8f8fd5a487ef63c2663c8 prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:06a77002692eb72a6823907717b7b96b prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:85b5285611210be089c4e51b135903dc
+niiri:70cb31c3da80e76bbcc31227d5a63dd3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0066" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1304,9 +1304,9 @@ niiri:85b5285611210be089c4e51b135903dc
     nidm_qValueFDR: "0.675180100901307"^^xsd:float ;
     nidm_clusterLabelId: "66"^^xsd:int .
 
-niiri:85b5285611210be089c4e51b135903dc prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:70cb31c3da80e76bbcc31227d5a63dd3 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:1d0913f48b56a9cfb53554e02fef4dd7
+niiri:1bab28ca73fb58bf072903c327aa6ee2
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0067" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1316,9 +1316,9 @@ niiri:1d0913f48b56a9cfb53554e02fef4dd7
     nidm_qValueFDR: "0.675180100901307"^^xsd:float ;
     nidm_clusterLabelId: "67"^^xsd:int .
 
-niiri:1d0913f48b56a9cfb53554e02fef4dd7 prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:1bab28ca73fb58bf072903c327aa6ee2 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:ec713ff49cc3d009853754ee51de40a9
+niiri:0d05a2eb7c30f085c9585bd5437f2cf6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0068" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1328,9 +1328,9 @@ niiri:ec713ff49cc3d009853754ee51de40a9
     nidm_qValueFDR: "0.675180100901307"^^xsd:float ;
     nidm_clusterLabelId: "68"^^xsd:int .
 
-niiri:ec713ff49cc3d009853754ee51de40a9 prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:0d05a2eb7c30f085c9585bd5437f2cf6 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:14378386d8b7fa3469c4024d8643a9f6
+niiri:cec1367031abea759cc3b3843951c4e9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0069" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1340,9 +1340,9 @@ niiri:14378386d8b7fa3469c4024d8643a9f6
     nidm_qValueFDR: "0.675180100901307"^^xsd:float ;
     nidm_clusterLabelId: "69"^^xsd:int .
 
-niiri:14378386d8b7fa3469c4024d8643a9f6 prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:cec1367031abea759cc3b3843951c4e9 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:35322e20f0852719cb5f7785e9eafbdf
+niiri:6ba93f98c147f043bee56b6eaf416136
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0070" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1352,9 +1352,9 @@ niiri:35322e20f0852719cb5f7785e9eafbdf
     nidm_qValueFDR: "0.675180100901307"^^xsd:float ;
     nidm_clusterLabelId: "70"^^xsd:int .
 
-niiri:35322e20f0852719cb5f7785e9eafbdf prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:6ba93f98c147f043bee56b6eaf416136 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:c0448343148dd622321d80f7996dd79e
+niiri:ac903b7a48abf269c96015efab8d2aa1
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0071" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1364,1297 +1364,1297 @@ niiri:c0448343148dd622321d80f7996dd79e
     nidm_qValueFDR: "0.675180100901307"^^xsd:float ;
     nidm_clusterLabelId: "71"^^xsd:int .
 
-niiri:c0448343148dd622321d80f7996dd79e prov:wasDerivedFrom niiri:9f1620f32dc4659d77d42ff2a65c79af .
+niiri:ac903b7a48abf269c96015efab8d2aa1 prov:wasDerivedFrom niiri:f4a3eb8cc20d959e49b7c1ebb8d42adb .
 
-niiri:b4be2fe97188738613ff698d95ffd0d3
+niiri:de0be50edac74c81f9c1e5814da03b9d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0001" ;
-    prov:atLocation niiri:1632d5941772ec068ccc444945dee909 ;
+    prov:atLocation niiri:7f9fdf6f0de7581fd021fc6db0110883 ;
     prov:value "39.0658683776855"^^xsd:float ;
     nidm_equivalentZStatistic: "5.04009751746769"^^xsd:float ;
     nidm_pValueUncorrected: "2.3264734660966e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0389037590875805"^^xsd:float ;
     nidm_qValueFDR: "0.097253800423278"^^xsd:float .
 
-niiri:1632d5941772ec068ccc444945dee909
+niiri:7f9fdf6f0de7581fd021fc6db0110883
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0001" ;
     nidm_coordinateVector: "[-2,-90,28]"^^xsd:string .
 
-niiri:b4be2fe97188738613ff698d95ffd0d3 prov:wasDerivedFrom niiri:2614b44f75a99f07f4673d4500fe47ed .
+niiri:de0be50edac74c81f9c1e5814da03b9d prov:wasDerivedFrom niiri:0502f21f886d74eb5a46cc0e98d99ebd .
 
-niiri:5eae8bb9e3cf61596c8706ac43ede1a4
+niiri:3551a670193037285a26d96dd25d4587
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0002" ;
-    prov:atLocation niiri:9556e732eb66310b4e70f17e9c505376 ;
+    prov:atLocation niiri:23f181033fbbc357802f67e0f5c9c6ac ;
     prov:value "36.2393341064453"^^xsd:float ;
     nidm_equivalentZStatistic: "4.89725160225159"^^xsd:float ;
     nidm_pValueUncorrected: "4.85931842320042e-07"^^xsd:float ;
     nidm_pValueFWER: "0.071761896035709"^^xsd:float ;
     nidm_qValueFDR: "0.097253800423278"^^xsd:float .
 
-niiri:9556e732eb66310b4e70f17e9c505376
+niiri:23f181033fbbc357802f67e0f5c9c6ac
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0002" ;
     nidm_coordinateVector: "[-42,-64,-8]"^^xsd:string .
 
-niiri:5eae8bb9e3cf61596c8706ac43ede1a4 prov:wasDerivedFrom niiri:26dc30d77d0a0c23d6913e69266e279e .
+niiri:3551a670193037285a26d96dd25d4587 prov:wasDerivedFrom niiri:0599785d82edc2bd01edfc956f648d55 .
 
-niiri:b907bdcd6391fe6a9d5be2e43976eaa4
+niiri:a397cef7de1b33fff3104633ae867013
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0003" ;
-    prov:atLocation niiri:0bb9df9b459a66cc22278fa6d5451add ;
+    prov:atLocation niiri:d0956a4697c01f13d1fd27c41f01ee23 ;
     prov:value "17.9251842498779"^^xsd:float ;
     nidm_equivalentZStatistic: "3.64201416072196"^^xsd:float ;
     nidm_pValueUncorrected: "0.000135256594276711"^^xsd:float ;
     nidm_pValueFWER: "0.999417997648594"^^xsd:float ;
     nidm_qValueFDR: "0.642014449876257"^^xsd:float .
 
-niiri:0bb9df9b459a66cc22278fa6d5451add
+niiri:d0956a4697c01f13d1fd27c41f01ee23
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0003" ;
     nidm_coordinateVector: "[-40,-52,-10]"^^xsd:string .
 
-niiri:b907bdcd6391fe6a9d5be2e43976eaa4 prov:wasDerivedFrom niiri:26dc30d77d0a0c23d6913e69266e279e .
+niiri:a397cef7de1b33fff3104633ae867013 prov:wasDerivedFrom niiri:0599785d82edc2bd01edfc956f648d55 .
 
-niiri:d6228e5b47bc93a7895c14d907eacdb9
+niiri:795bfdfc1c878985f28b65ddbd93f5e2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0004" ;
-    prov:atLocation niiri:43e9802e1de5dfb7d43041d791e08855 ;
+    prov:atLocation niiri:3fae1a6119fcbb333560406c0adaf77a ;
     prov:value "13.454288482666"^^xsd:float ;
     nidm_equivalentZStatistic: "3.18324713734782"^^xsd:float ;
     nidm_pValueUncorrected: "0.000728166268399777"^^xsd:float ;
     nidm_pValueFWER: "0.999999999996872"^^xsd:float ;
     nidm_qValueFDR: "0.94954759467573"^^xsd:float .
 
-niiri:43e9802e1de5dfb7d43041d791e08855
+niiri:3fae1a6119fcbb333560406c0adaf77a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0004" ;
     nidm_coordinateVector: "[-38,-70,0]"^^xsd:string .
 
-niiri:d6228e5b47bc93a7895c14d907eacdb9 prov:wasDerivedFrom niiri:26dc30d77d0a0c23d6913e69266e279e .
+niiri:795bfdfc1c878985f28b65ddbd93f5e2 prov:wasDerivedFrom niiri:0599785d82edc2bd01edfc956f648d55 .
 
-niiri:7c544a191a467d8160116c31fe28b615
+niiri:1bef248663e2601c3f3e8f86ce7bcf8e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0005" ;
-    prov:atLocation niiri:f7b88cad1d9f3d365a9aba0b1e6656c7 ;
+    prov:atLocation niiri:a50093d76450a437f3994a2a331222d2 ;
     prov:value "29.4676361083984"^^xsd:float ;
     nidm_equivalentZStatistic: "4.51162164706026"^^xsd:float ;
     nidm_pValueUncorrected: "3.21669348379849e-06"^^xsd:float ;
     nidm_pValueFWER: "0.305525019896507"^^xsd:float ;
     nidm_qValueFDR: "0.297255514853906"^^xsd:float .
 
-niiri:f7b88cad1d9f3d365a9aba0b1e6656c7
+niiri:a50093d76450a437f3994a2a331222d2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0005" ;
     nidm_coordinateVector: "[16,-88,24]"^^xsd:string .
 
-niiri:7c544a191a467d8160116c31fe28b615 prov:wasDerivedFrom niiri:5819cfbfd916831f2b9b46c44761a13b .
+niiri:1bef248663e2601c3f3e8f86ce7bcf8e prov:wasDerivedFrom niiri:503c99586f814910b6b80009bf62943c .
 
-niiri:7296494cc324e9aeba37968107ba9d73
+niiri:34e046d2eb16a715bed65c1a03b2abc1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0006" ;
-    prov:atLocation niiri:3598d1f8eca639294d0ae8fa05f9d2a6 ;
+    prov:atLocation niiri:03eb88016e6bd2dd5c40edd75ccfd627 ;
     prov:value "28.5631580352783"^^xsd:float ;
     nidm_equivalentZStatistic: "4.45459114773779"^^xsd:float ;
     nidm_pValueUncorrected: "4.20266075706888e-06"^^xsd:float ;
     nidm_pValueFWER: "0.365688847752494"^^xsd:float ;
     nidm_qValueFDR: "0.297255514853906"^^xsd:float .
 
-niiri:3598d1f8eca639294d0ae8fa05f9d2a6
+niiri:03eb88016e6bd2dd5c40edd75ccfd627
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0006" ;
     nidm_coordinateVector: "[28,-72,26]"^^xsd:string .
 
-niiri:7296494cc324e9aeba37968107ba9d73 prov:wasDerivedFrom niiri:18222312b25450890c50a38e087b5fca .
+niiri:34e046d2eb16a715bed65c1a03b2abc1 prov:wasDerivedFrom niiri:018a24899160bba0361882009e28cdf7 .
 
-niiri:f10fdd104668b16c937b001a6fd48ae7
+niiri:c71c9cb743a850da26dbd07e2a4ab336
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0007" ;
-    prov:atLocation niiri:3cd964e18fe79bd491aeaa14bf331bb1 ;
+    prov:atLocation niiri:81e9ff294c150a3271a867e5bc31370a ;
     prov:value "26.9945106506348"^^xsd:float ;
     nidm_equivalentZStatistic: "4.35204306383375"^^xsd:float ;
     nidm_pValueUncorrected: "6.7437380493196e-06"^^xsd:float ;
     nidm_pValueFWER: "0.489729172437052"^^xsd:float ;
     nidm_qValueFDR: "0.302930044135827"^^xsd:float .
 
-niiri:3cd964e18fe79bd491aeaa14bf331bb1
+niiri:81e9ff294c150a3271a867e5bc31370a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0007" ;
     nidm_coordinateVector: "[-32,20,-4]"^^xsd:string .
 
-niiri:f10fdd104668b16c937b001a6fd48ae7 prov:wasDerivedFrom niiri:fd0ea64d092adb2dc6aef53bb390dd47 .
+niiri:c71c9cb743a850da26dbd07e2a4ab336 prov:wasDerivedFrom niiri:33d37aeafd7dbe4545a7c3723ffec290 .
 
-niiri:11e448feeb5ffb8abe7a056109695d44
+niiri:1d00c0696db8e3a3a6f9eeb993c993aa
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0008" ;
-    prov:atLocation niiri:3a018923a042d3052c1289e3fd69c6f8 ;
+    prov:atLocation niiri:324e311634f996ef35fec88282031fdd ;
     prov:value "26.8606586456299"^^xsd:float ;
     nidm_equivalentZStatistic: "4.34306775687574"^^xsd:float ;
     nidm_pValueUncorrected: "7.02533878071954e-06"^^xsd:float ;
     nidm_pValueFWER: "0.501353785238145"^^xsd:float ;
     nidm_qValueFDR: "0.302930044135827"^^xsd:float .
 
-niiri:3a018923a042d3052c1289e3fd69c6f8
+niiri:324e311634f996ef35fec88282031fdd
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0008" ;
     nidm_coordinateVector: "[-8,50,32]"^^xsd:string .
 
-niiri:11e448feeb5ffb8abe7a056109695d44 prov:wasDerivedFrom niiri:086741e220f142a5ba7d24c166640134 .
+niiri:1d00c0696db8e3a3a6f9eeb993c993aa prov:wasDerivedFrom niiri:c67e26c71245447102997061bd7b4400 .
 
-niiri:66a6081521836f12199682cf917bdfd3
+niiri:e105d8c03c8fb50b26c076e73184a484
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0009" ;
-    prov:atLocation niiri:e2e98471f8990000bd5f1f2cc71ce750 ;
+    prov:atLocation niiri:46442f9a133e99c8e0d2a8f94f5a3dbe ;
     prov:value "25.8067512512207"^^xsd:float ;
     nidm_equivalentZStatistic: "4.27109313660164"^^xsd:float ;
     nidm_pValueUncorrected: "9.72585724245967e-06"^^xsd:float ;
     nidm_pValueFWER: "0.597019202761311"^^xsd:float ;
     nidm_qValueFDR: "0.317981530335124"^^xsd:float .
 
-niiri:e2e98471f8990000bd5f1f2cc71ce750
+niiri:46442f9a133e99c8e0d2a8f94f5a3dbe
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0009" ;
     nidm_coordinateVector: "[-34,8,58]"^^xsd:string .
 
-niiri:66a6081521836f12199682cf917bdfd3 prov:wasDerivedFrom niiri:e2190d23e52313b345dec17a936b13ac .
+niiri:e105d8c03c8fb50b26c076e73184a484 prov:wasDerivedFrom niiri:21c6b4d93e2f7d826c174fe1b99df534 .
 
-niiri:9fc17387bfc87d32609f093c33e59660
+niiri:98120cf8274f1adde1b9975ee7343d0b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0010" ;
-    prov:atLocation niiri:8b08eaf81c36345da1a7568b61ea14d2 ;
+    prov:atLocation niiri:8745a1750fbc576ed60637fd96f0bd53 ;
     prov:value "25.0769119262695"^^xsd:float ;
     nidm_equivalentZStatistic: "4.21983658750018"^^xsd:float ;
     nidm_pValueUncorrected: "1.22239732009977e-05"^^xsd:float ;
     nidm_pValueFWER: "0.665677647955296"^^xsd:float ;
     nidm_qValueFDR: "0.317981530335124"^^xsd:float .
 
-niiri:8b08eaf81c36345da1a7568b61ea14d2
+niiri:8745a1750fbc576ed60637fd96f0bd53
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0010" ;
     nidm_coordinateVector: "[32,-86,0]"^^xsd:string .
 
-niiri:9fc17387bfc87d32609f093c33e59660 prov:wasDerivedFrom niiri:26ab6f532ee67acbd905e1a64f80b9d8 .
+niiri:98120cf8274f1adde1b9975ee7343d0b prov:wasDerivedFrom niiri:6da0c60471d915bb0e46bffadee4d55a .
 
-niiri:cb4d051a1e969961f67a1bc3ece80b39
+niiri:289923b931558b9cf26d6259e84991cc
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0011" ;
-    prov:atLocation niiri:c9e5bb380e0350c88780f291f910a20b ;
+    prov:atLocation niiri:aadea8cdd84b63fc723d500acfc25900 ;
     prov:value "24.5828113555908"^^xsd:float ;
     nidm_equivalentZStatistic: "4.18444689049798"^^xsd:float ;
     nidm_pValueUncorrected: "1.42930633414418e-05"^^xsd:float ;
     nidm_pValueFWER: "0.711939170732988"^^xsd:float ;
     nidm_qValueFDR: "0.325084892179266"^^xsd:float .
 
-niiri:c9e5bb380e0350c88780f291f910a20b
+niiri:aadea8cdd84b63fc723d500acfc25900
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0011" ;
     nidm_coordinateVector: "[66,-32,30]"^^xsd:string .
 
-niiri:cb4d051a1e969961f67a1bc3ece80b39 prov:wasDerivedFrom niiri:5107e0fdba262447669255100a242c1c .
+niiri:289923b931558b9cf26d6259e84991cc prov:wasDerivedFrom niiri:a35a0c7d262276e543a1e97fbbe3cdc8 .
 
-niiri:8ba50a95bcca89d59a85283f58452ebf
+niiri:273d6a77c000bfe5f52d296da6ad6478
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0012" ;
-    prov:atLocation niiri:49c8600aff97691c964c26199849b79f ;
+    prov:atLocation niiri:652a2206db07edc1bd545802c3f663c9 ;
     prov:value "14.2693071365356"^^xsd:float ;
     nidm_equivalentZStatistic: "3.27451594161643"^^xsd:float ;
     nidm_pValueUncorrected: "0.000529215834762176"^^xsd:float ;
     nidm_pValueFWER: "0.999999999209483"^^xsd:float ;
     nidm_qValueFDR: "0.904639459548904"^^xsd:float .
 
-niiri:49c8600aff97691c964c26199849b79f
+niiri:652a2206db07edc1bd545802c3f663c9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0012" ;
     nidm_coordinateVector: "[60,-38,28]"^^xsd:string .
 
-niiri:8ba50a95bcca89d59a85283f58452ebf prov:wasDerivedFrom niiri:5107e0fdba262447669255100a242c1c .
+niiri:273d6a77c000bfe5f52d296da6ad6478 prov:wasDerivedFrom niiri:a35a0c7d262276e543a1e97fbbe3cdc8 .
 
-niiri:fac0e66136be61d5cb9a227bce4664aa
+niiri:41059e9d7b27293b0aba3b2a84d455b8
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0013" ;
-    prov:atLocation niiri:71bbb509277e9a5a03d8b66d37e30b14 ;
+    prov:atLocation niiri:a97ce2127d9bef3582961e02700db7f6 ;
     prov:value "23.3039436340332"^^xsd:float ;
     nidm_equivalentZStatistic: "4.09011898331566"^^xsd:float ;
     nidm_pValueUncorrected: "2.15575975488491e-05"^^xsd:float ;
     nidm_pValueFWER: "0.823947459995523"^^xsd:float ;
     nidm_qValueFDR: "0.412451648636247"^^xsd:float .
 
-niiri:71bbb509277e9a5a03d8b66d37e30b14
+niiri:a97ce2127d9bef3582961e02700db7f6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0013" ;
     nidm_coordinateVector: "[28,30,52]"^^xsd:string .
 
-niiri:fac0e66136be61d5cb9a227bce4664aa prov:wasDerivedFrom niiri:6d5196dbefc80600da436f72c5fa99e9 .
+niiri:41059e9d7b27293b0aba3b2a84d455b8 prov:wasDerivedFrom niiri:cfb99edebaae9df65e32c2dc18fd6186 .
 
-niiri:73750c53fdb790c6357c4da82d52bf27
+niiri:b964c9d32200b841b56fe800b88c0a4b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0014" ;
-    prov:atLocation niiri:108d1ffc37df484fa90c2c0cb2179d8e ;
+    prov:atLocation niiri:4769429683d1135897230ffebc06ac65 ;
     prov:value "22.6157932281494"^^xsd:float ;
     nidm_equivalentZStatistic: "4.03763886298215"^^xsd:float ;
     nidm_pValueUncorrected: "2.69959426782984e-05"^^xsd:float ;
     nidm_pValueFWER: "0.87538446987651"^^xsd:float ;
     nidm_qValueFDR: "0.43925432096054"^^xsd:float .
 
-niiri:108d1ffc37df484fa90c2c0cb2179d8e
+niiri:4769429683d1135897230ffebc06ac65
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0014" ;
     nidm_coordinateVector: "[-30,-34,6]"^^xsd:string .
 
-niiri:73750c53fdb790c6357c4da82d52bf27 prov:wasDerivedFrom niiri:d4c4e9d5661158241502d335eb5a96e4 .
+niiri:b964c9d32200b841b56fe800b88c0a4b prov:wasDerivedFrom niiri:2607cc56c513b9a7b262e9ec22fe2b63 .
 
-niiri:ac5d2ec515791af0b5c5bc53bf4d831d
+niiri:cf6cc59258bd447a466c3c1895718676
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0015" ;
-    prov:atLocation niiri:20dc2d694289dcfd2c519195b346651d ;
+    prov:atLocation niiri:eb420af4734a6c2a830db882030077df ;
     prov:value "21.8558578491211"^^xsd:float ;
     nidm_equivalentZStatistic: "3.97819185113407"^^xsd:float ;
     nidm_pValueUncorrected: "3.47206660495925e-05"^^xsd:float ;
     nidm_pValueFWER: "0.921823721412592"^^xsd:float ;
     nidm_qValueFDR: "0.43925432096054"^^xsd:float .
 
-niiri:20dc2d694289dcfd2c519195b346651d
+niiri:eb420af4734a6c2a830db882030077df
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0015" ;
     nidm_coordinateVector: "[-28,0,30]"^^xsd:string .
 
-niiri:ac5d2ec515791af0b5c5bc53bf4d831d prov:wasDerivedFrom niiri:52cc5fe71e36fbe65be2bc6eac0024f0 .
+niiri:cf6cc59258bd447a466c3c1895718676 prov:wasDerivedFrom niiri:1daa422fda95bd1a9676984906e1a548 .
 
-niiri:a8dbaf9b6fb366c15ce2430b121036b4
+niiri:5175b1641041f873df3e4b8171a20dbd
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0016" ;
-    prov:atLocation niiri:b046a90ecefe5a66e6df2168c0a6515a ;
+    prov:atLocation niiri:640b2e1e62f4a54b769f0bb3d8d79b61 ;
     prov:value "21.8296661376953"^^xsd:float ;
     nidm_equivalentZStatistic: "3.97611404363788"^^xsd:float ;
     nidm_pValueUncorrected: "3.50252708366527e-05"^^xsd:float ;
     nidm_pValueFWER: "0.923209894114283"^^xsd:float ;
     nidm_qValueFDR: "0.43925432096054"^^xsd:float .
 
-niiri:b046a90ecefe5a66e6df2168c0a6515a
+niiri:640b2e1e62f4a54b769f0bb3d8d79b61
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0016" ;
     nidm_coordinateVector: "[8,34,10]"^^xsd:string .
 
-niiri:a8dbaf9b6fb366c15ce2430b121036b4 prov:wasDerivedFrom niiri:c7a355d22d989f24ef00d62137ddfe13 .
+niiri:5175b1641041f873df3e4b8171a20dbd prov:wasDerivedFrom niiri:a6888f03a619f2ef07714763993a3be7 .
 
-niiri:119133b6405a655126b8ed5645f880f8
+niiri:eda52aede28b44456962e7af041dab45
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0017" ;
-    prov:atLocation niiri:c800c1e03dab542188fcf9894ecf31ee ;
+    prov:atLocation niiri:3f60c67308d3c2cc8704c97c6f792d07 ;
     prov:value "21.7287845611572"^^xsd:float ;
     nidm_equivalentZStatistic: "3.96809263472704"^^xsd:float ;
     nidm_pValueUncorrected: "3.6225086553876e-05"^^xsd:float ;
     nidm_pValueFWER: "0.928411428313329"^^xsd:float ;
     nidm_qValueFDR: "0.43925432096054"^^xsd:float .
 
-niiri:c800c1e03dab542188fcf9894ecf31ee
+niiri:3f60c67308d3c2cc8704c97c6f792d07
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0017" ;
     nidm_coordinateVector: "[46,-56,10]"^^xsd:string .
 
-niiri:119133b6405a655126b8ed5645f880f8 prov:wasDerivedFrom niiri:ed934b2b32fd19f3afbe4c6bb5d3f1a3 .
+niiri:eda52aede28b44456962e7af041dab45 prov:wasDerivedFrom niiri:ff0222b1c30a382e52f5903988ee7a67 .
 
-niiri:14c8cba4f3e9633c20a89ebceee4662c
+niiri:73097f0b0425dce88560554ead9adec5
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0018" ;
-    prov:atLocation niiri:5de0c31e65b5cd23874409ac161e2408 ;
+    prov:atLocation niiri:db9cfc1e895056414a0d976a338eff75 ;
     prov:value "14.2801656723022"^^xsd:float ;
     nidm_equivalentZStatistic: "3.27570591680179"^^xsd:float ;
     nidm_pValueUncorrected: "0.000526991241768693"^^xsd:float ;
     nidm_pValueFWER: "0.999999999156251"^^xsd:float ;
     nidm_qValueFDR: "0.904639459548904"^^xsd:float .
 
-niiri:5de0c31e65b5cd23874409ac161e2408
+niiri:db9cfc1e895056414a0d976a338eff75
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0018" ;
     nidm_coordinateVector: "[48,-48,16]"^^xsd:string .
 
-niiri:14c8cba4f3e9633c20a89ebceee4662c prov:wasDerivedFrom niiri:ed934b2b32fd19f3afbe4c6bb5d3f1a3 .
+niiri:73097f0b0425dce88560554ead9adec5 prov:wasDerivedFrom niiri:ff0222b1c30a382e52f5903988ee7a67 .
 
-niiri:612280568e6b7910e48dcc0a59228df8
+niiri:dee978e74443f1a4c46189f244ae1e75
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0019" ;
-    prov:atLocation niiri:c6db787a6eeb7e48b987a3fdb908a1df ;
+    prov:atLocation niiri:f7b1c619d30c23139ad1157664d70e8f ;
     prov:value "21.4629364013672"^^xsd:float ;
     nidm_equivalentZStatistic: "3.9468129149843"^^xsd:float ;
     nidm_pValueUncorrected: "3.95991966499754e-05"^^xsd:float ;
     nidm_pValueFWER: "0.941069307565192"^^xsd:float ;
     nidm_qValueFDR: "0.43925432096054"^^xsd:float .
 
-niiri:c6db787a6eeb7e48b987a3fdb908a1df
+niiri:f7b1c619d30c23139ad1157664d70e8f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0019" ;
     nidm_coordinateVector: "[46,-62,-10]"^^xsd:string .
 
-niiri:612280568e6b7910e48dcc0a59228df8 prov:wasDerivedFrom niiri:f4a1be717fb30bceb6b19d568207e064 .
+niiri:dee978e74443f1a4c46189f244ae1e75 prov:wasDerivedFrom niiri:189a48f192c71c34afbefb1b24c895a1 .
 
-niiri:66efaf9f1823b7df35ef80fe3d5ba73e
+niiri:7229cb1ae5d253d150d16f583a790984
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0020" ;
-    prov:atLocation niiri:ec620b6766c6ec678592ded393a36ba9 ;
+    prov:atLocation niiri:a95490cb8d27272ebf40ab9641760b2a ;
     prov:value "21.4269542694092"^^xsd:float ;
     nidm_equivalentZStatistic: "3.94391683979485"^^xsd:float ;
     nidm_pValueUncorrected: "4.00807329147268e-05"^^xsd:float ;
     nidm_pValueFWER: "0.942665676683549"^^xsd:float ;
     nidm_qValueFDR: "0.43925432096054"^^xsd:float .
 
-niiri:ec620b6766c6ec678592ded393a36ba9
+niiri:a95490cb8d27272ebf40ab9641760b2a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0020" ;
     nidm_coordinateVector: "[-8,-32,36]"^^xsd:string .
 
-niiri:66efaf9f1823b7df35ef80fe3d5ba73e prov:wasDerivedFrom niiri:932e333631c50069ac12d36b6efba037 .
+niiri:7229cb1ae5d253d150d16f583a790984 prov:wasDerivedFrom niiri:153d0f62058a9c03f71f38806c01672c .
 
-niiri:2210f8a18943d180a900238ceedff24c
+niiri:31378a601c2becf436d41b267a4b16d5
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0021" ;
-    prov:atLocation niiri:14e86fb7cd633c0a5ef5c65a00f0e9b4 ;
+    prov:atLocation niiri:268e773c306d3890ab5d905af99e9d1f ;
     prov:value "20.0413494110107"^^xsd:float ;
     nidm_equivalentZStatistic: "3.82938429557992"^^xsd:float ;
     nidm_pValueUncorrected: "6.42321325474704e-05"^^xsd:float ;
     nidm_pValueFWER: "0.984364018223445"^^xsd:float ;
     nidm_qValueFDR: "0.603397549204652"^^xsd:float .
 
-niiri:14e86fb7cd633c0a5ef5c65a00f0e9b4
+niiri:268e773c306d3890ab5d905af99e9d1f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0021" ;
     nidm_coordinateVector: "[-34,-84,-4]"^^xsd:string .
 
-niiri:2210f8a18943d180a900238ceedff24c prov:wasDerivedFrom niiri:d98235d369f4da12b94c1ba7844053d1 .
+niiri:31378a601c2becf436d41b267a4b16d5 prov:wasDerivedFrom niiri:2b8333b9ae75e6a69c6703c1017776ef .
 
-niiri:3a4c2b67edee58581437ced3e2fa6fdb
+niiri:83bc6d3f85253d9d97da7f55882bc0e2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0022" ;
-    prov:atLocation niiri:becc56382e6d6bb11aa41e98639fc727 ;
+    prov:atLocation niiri:11db5f1191f39a9f0f88a2e612164508 ;
     prov:value "19.5813789367676"^^xsd:float ;
     nidm_equivalentZStatistic: "3.79000141974546"^^xsd:float ;
     nidm_pValueUncorrected: "7.53232118573255e-05"^^xsd:float ;
     nidm_pValueFWER: "0.991038394814884"^^xsd:float ;
     nidm_qValueFDR: "0.620995764715313"^^xsd:float .
 
-niiri:becc56382e6d6bb11aa41e98639fc727
+niiri:11db5f1191f39a9f0f88a2e612164508
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0022" ;
     nidm_coordinateVector: "[-50,2,40]"^^xsd:string .
 
-niiri:3a4c2b67edee58581437ced3e2fa6fdb prov:wasDerivedFrom niiri:2b33b3c2fb565f11805c2ab96c217218 .
+niiri:83bc6d3f85253d9d97da7f55882bc0e2 prov:wasDerivedFrom niiri:be0ede967cfc83179dfb392adca98376 .
 
-niiri:298daf4d8d2eb8870490b32c1ae9975b
+niiri:b9f98ffb929e3828f9472a4a465a4f0d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0023" ;
-    prov:atLocation niiri:5af651b2bea7dc34805cf2833f2677de ;
+    prov:atLocation niiri:4ca72dd3f8082269bb21714642111f36 ;
     prov:value "16.7666301727295"^^xsd:float ;
     nidm_equivalentZStatistic: "3.53217184854778"^^xsd:float ;
     nidm_pValueUncorrected: "0.00020608070787731"^^xsd:float ;
     nidm_pValueFWER: "0.99996648470095"^^xsd:float ;
     nidm_qValueFDR: "0.655203493056632"^^xsd:float .
 
-niiri:5af651b2bea7dc34805cf2833f2677de
+niiri:4ca72dd3f8082269bb21714642111f36
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0023" ;
     nidm_coordinateVector: "[-52,-6,46]"^^xsd:string .
 
-niiri:298daf4d8d2eb8870490b32c1ae9975b prov:wasDerivedFrom niiri:2b33b3c2fb565f11805c2ab96c217218 .
+niiri:b9f98ffb929e3828f9472a4a465a4f0d prov:wasDerivedFrom niiri:be0ede967cfc83179dfb392adca98376 .
 
-niiri:2bb07c496f32733ffaf79205cbde705d
+niiri:3fc414435450d7991a1adccdb53f2ea3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0024" ;
-    prov:atLocation niiri:f6451a965ab339d1c415e793ffad62de ;
+    prov:atLocation niiri:ebc812dddae356c4835e80cff836a117 ;
     prov:value "19.3040504455566"^^xsd:float ;
     nidm_equivalentZStatistic: "3.76590943131268"^^xsd:float ;
     nidm_pValueUncorrected: "8.2971971291701e-05"^^xsd:float ;
     nidm_pValueFWER: "0.993825462793153"^^xsd:float ;
     nidm_qValueFDR: "0.620995764715313"^^xsd:float .
 
-niiri:f6451a965ab339d1c415e793ffad62de
+niiri:ebc812dddae356c4835e80cff836a117
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0024" ;
     nidm_coordinateVector: "[24,-46,32]"^^xsd:string .
 
-niiri:2bb07c496f32733ffaf79205cbde705d prov:wasDerivedFrom niiri:5a17a76cb3f0ca0ddba79372b881b0ac .
+niiri:3fc414435450d7991a1adccdb53f2ea3 prov:wasDerivedFrom niiri:23f2b3702fb27a3d52f0874c93630544 .
 
-niiri:438305e8c2f5556b27b914f4d3239071
+niiri:c636ea0bddcfb80ff2d7e531404b34f1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0025" ;
-    prov:atLocation niiri:a9bf98eb09e4b016756eff1156f4286b ;
+    prov:atLocation niiri:27909070b90094da7c248e424652127e ;
     prov:value "19.1409015655518"^^xsd:float ;
     nidm_equivalentZStatistic: "3.75161143600874"^^xsd:float ;
     nidm_pValueUncorrected: "8.7850813353163e-05"^^xsd:float ;
     nidm_pValueFWER: "0.995110302012489"^^xsd:float ;
     nidm_qValueFDR: "0.620995764715313"^^xsd:float .
 
-niiri:a9bf98eb09e4b016756eff1156f4286b
+niiri:27909070b90094da7c248e424652127e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0025" ;
     nidm_coordinateVector: "[6,16,50]"^^xsd:string .
 
-niiri:438305e8c2f5556b27b914f4d3239071 prov:wasDerivedFrom niiri:cdbe1592b4a9de39b031d21dc9c2950c .
+niiri:c636ea0bddcfb80ff2d7e531404b34f1 prov:wasDerivedFrom niiri:654afa8f2fea6cb2d23c37e50edee008 .
 
-niiri:ddc9cae8d3158977a73eb0da58b76107
+niiri:17e69e7f43739c2172a5e069dcce782a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0026" ;
-    prov:atLocation niiri:51695623c6ca5bb8c73f0fbd141e34b8 ;
+    prov:atLocation niiri:5e6d74ec4614c24eabbeefa458ae9b94 ;
     prov:value "19.098669052124"^^xsd:float ;
     nidm_equivalentZStatistic: "3.74789498829157"^^xsd:float ;
     nidm_pValueUncorrected: "8.91624398706714e-05"^^xsd:float ;
     nidm_pValueFWER: "0.995405100064856"^^xsd:float ;
     nidm_qValueFDR: "0.620995764715313"^^xsd:float .
 
-niiri:51695623c6ca5bb8c73f0fbd141e34b8
+niiri:5e6d74ec4614c24eabbeefa458ae9b94
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0026" ;
     nidm_coordinateVector: "[-4,-24,6]"^^xsd:string .
 
-niiri:ddc9cae8d3158977a73eb0da58b76107 prov:wasDerivedFrom niiri:a74c6130611adcee49f9abe720d6e52c .
+niiri:17e69e7f43739c2172a5e069dcce782a prov:wasDerivedFrom niiri:dba06f209302f6639800d0af3c93affd .
 
-niiri:8847b40a6f0df9036ec3f2fd39169359
+niiri:310041e942b16c12433a1a316b01a18b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0027" ;
-    prov:atLocation niiri:e273e273caa0ec10a477c3a383d1d039 ;
+    prov:atLocation niiri:b5ed65cc20e2af254f0c0773a378955e ;
     prov:value "19.0145893096924"^^xsd:float ;
     nidm_equivalentZStatistic: "3.7404771295496"^^xsd:float ;
     nidm_pValueUncorrected: "9.1835629583259e-05"^^xsd:float ;
     nidm_pValueFWER: "0.995949293325196"^^xsd:float ;
     nidm_qValueFDR: "0.620995764715313"^^xsd:float .
 
-niiri:e273e273caa0ec10a477c3a383d1d039
+niiri:b5ed65cc20e2af254f0c0773a378955e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0027" ;
     nidm_coordinateVector: "[-4,0,54]"^^xsd:string .
 
-niiri:8847b40a6f0df9036ec3f2fd39169359 prov:wasDerivedFrom niiri:0b42259e10bfb86cff826215fa08b419 .
+niiri:310041e942b16c12433a1a316b01a18b prov:wasDerivedFrom niiri:57c14f931d36e820d2322a1bdd36da40 .
 
-niiri:a7b30b8104925d31a8d85558816954a4
+niiri:830254d5fee868a84ad02a38a3e7bb23
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0028" ;
-    prov:atLocation niiri:91f4273fc35936bf99d99d9ad2fb4cfc ;
+    prov:atLocation niiri:c5ab846fb07f8ec905e64d8b25852e7f ;
     prov:value "18.8265838623047"^^xsd:float ;
     nidm_equivalentZStatistic: "3.72379883766124"^^xsd:float ;
     nidm_pValueUncorrected: "9.81236582245915e-05"^^xsd:float ;
     nidm_pValueFWER: "0.996978299202392"^^xsd:float ;
     nidm_qValueFDR: "0.620995764715313"^^xsd:float .
 
-niiri:91f4273fc35936bf99d99d9ad2fb4cfc
+niiri:c5ab846fb07f8ec905e64d8b25852e7f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0028" ;
     nidm_coordinateVector: "[42,-28,30]"^^xsd:string .
 
-niiri:a7b30b8104925d31a8d85558816954a4 prov:wasDerivedFrom niiri:59f34e94c3c0a0f91363e1cf44b96bbb .
+niiri:830254d5fee868a84ad02a38a3e7bb23 prov:wasDerivedFrom niiri:2739d32e473645dfabd9a03fc9f4dae7 .
 
-niiri:8ed0689ab43fd4b1b7c2ee84f6beba5c
+niiri:d7ae1c6177cf91420976fa8b1b418173
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0029" ;
-    prov:atLocation niiri:6cb4eee1ad1e08bbcd01a863d6f8b5f8 ;
+    prov:atLocation niiri:6462195dc355a327af5cd5d73524f76f ;
     prov:value "18.5199432373047"^^xsd:float ;
     nidm_equivalentZStatistic: "3.69631988620818"^^xsd:float ;
     nidm_pValueUncorrected: "0.000109373660980738"^^xsd:float ;
     nidm_pValueFWER: "0.998191254166604"^^xsd:float ;
     nidm_qValueFDR: "0.620995764715313"^^xsd:float .
 
-niiri:6cb4eee1ad1e08bbcd01a863d6f8b5f8
+niiri:6462195dc355a327af5cd5d73524f76f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0029" ;
     nidm_coordinateVector: "[52,-12,44]"^^xsd:string .
 
-niiri:8ed0689ab43fd4b1b7c2ee84f6beba5c prov:wasDerivedFrom niiri:e15a7f7da66912fa92c8140c6338b192 .
+niiri:d7ae1c6177cf91420976fa8b1b418173 prov:wasDerivedFrom niiri:23f5ffb7a02a62400ce3f1cfda032dbe .
 
-niiri:71b0d462c29ff2b8d2aff22b5383b911
+niiri:8f42c8637a3ba73755a9485aaf00eb82
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0030" ;
-    prov:atLocation niiri:ea53f24d5d3a2fad46c71215259a5a7d ;
+    prov:atLocation niiri:6678f079e5924136062e8a6111422c3e ;
     prov:value "18.516544342041"^^xsd:float ;
     nidm_equivalentZStatistic: "3.69601335434539"^^xsd:float ;
     nidm_pValueUncorrected: "0.000109505728679404"^^xsd:float ;
     nidm_pValueFWER: "0.998201975106935"^^xsd:float ;
     nidm_qValueFDR: "0.620995764715313"^^xsd:float .
 
-niiri:ea53f24d5d3a2fad46c71215259a5a7d
+niiri:6678f079e5924136062e8a6111422c3e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0030" ;
     nidm_coordinateVector: "[-40,-28,30]"^^xsd:string .
 
-niiri:71b0d462c29ff2b8d2aff22b5383b911 prov:wasDerivedFrom niiri:deefe75f432062b10a9b73a0036af48f .
+niiri:8f42c8637a3ba73755a9485aaf00eb82 prov:wasDerivedFrom niiri:3ed09542d8eeb67b7a92a4f1152a9588 .
 
-niiri:84f3af431a82fbb9358d6b58ad360b16
+niiri:4e350520ca70ab7fb0dad1e34876ed26
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0031" ;
-    prov:atLocation niiri:f4d3682b9d6a7b0057b4d62e5090ffa9 ;
+    prov:atLocation niiri:e0ae1200c3ffc3c5db37844273e4e303 ;
     prov:value "18.4609222412109"^^xsd:float ;
     nidm_equivalentZStatistic: "3.69099090519778"^^xsd:float ;
     nidm_pValueUncorrected: "0.000111691062804176"^^xsd:float ;
     nidm_pValueFWER: "0.998370011058266"^^xsd:float ;
     nidm_qValueFDR: "0.620995764715313"^^xsd:float .
 
-niiri:f4d3682b9d6a7b0057b4d62e5090ffa9
+niiri:e0ae1200c3ffc3c5db37844273e4e303
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0031" ;
     nidm_coordinateVector: "[32,22,-8]"^^xsd:string .
 
-niiri:84f3af431a82fbb9358d6b58ad360b16 prov:wasDerivedFrom niiri:85cc735cf6146dea08ebdfd5febbbbf6 .
+niiri:4e350520ca70ab7fb0dad1e34876ed26 prov:wasDerivedFrom niiri:ee2c6440d10e17fa3f61858f975e92f6 .
 
-niiri:a5af2910b52203fdd672c66a274d0fbe
+niiri:64a12d60baf5c5c9da921d103abfb214
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0032" ;
-    prov:atLocation niiri:33352188ff1763e86b3df4fa87fbd278 ;
+    prov:atLocation niiri:e51f9648fbb37b09655d7786ddaac9ff ;
     prov:value "17.9312534332275"^^xsd:float ;
     nidm_equivalentZStatistic: "3.64257521175179"^^xsd:float ;
     nidm_pValueUncorrected: "0.00013496203699781"^^xsd:float ;
     nidm_pValueFWER: "0.99941063068466"^^xsd:float ;
     nidm_qValueFDR: "0.642014449876257"^^xsd:float .
 
-niiri:33352188ff1763e86b3df4fa87fbd278
+niiri:e51f9648fbb37b09655d7786ddaac9ff
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0032" ;
     nidm_coordinateVector: "[64,-4,10]"^^xsd:string .
 
-niiri:a5af2910b52203fdd672c66a274d0fbe prov:wasDerivedFrom niiri:eda691902b8e9f86974b74de47c3be21 .
+niiri:64a12d60baf5c5c9da921d103abfb214 prov:wasDerivedFrom niiri:25764564ed7b5495d43208d9a742797c .
 
-niiri:6e3bdb3327ec90d2db2f7ff70f7cb627
+niiri:0e8721be3c984e497213a6eb5d79d336
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0033" ;
-    prov:atLocation niiri:22944eab0acc14d93d825f1e7d1cfd34 ;
+    prov:atLocation niiri:c9b5180b8d4ddcc1a0089df933fe1d66 ;
     prov:value "17.8439044952393"^^xsd:float ;
     nidm_equivalentZStatistic: "3.63448648232359"^^xsd:float ;
     nidm_pValueUncorrected: "0.000139267429951739"^^xsd:float ;
     nidm_pValueFWER: "0.999509275806277"^^xsd:float ;
     nidm_qValueFDR: "0.642014449876257"^^xsd:float .
 
-niiri:22944eab0acc14d93d825f1e7d1cfd34
+niiri:c9b5180b8d4ddcc1a0089df933fe1d66
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0033" ;
     nidm_coordinateVector: "[-22,-72,34]"^^xsd:string .
 
-niiri:6e3bdb3327ec90d2db2f7ff70f7cb627 prov:wasDerivedFrom niiri:44c46f8ea3d70ad705fe182f1aaf841e .
+niiri:0e8721be3c984e497213a6eb5d79d336 prov:wasDerivedFrom niiri:2a5007577d5f397768b0a52d8e1e454a .
 
-niiri:a2ba7c350e9e6efdbe0c719e9de18ad8
+niiri:e8cb5546247d4a3680cfd15b61ec92a8
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0034" ;
-    prov:atLocation niiri:a7eb863b9f06f839144773c75b850f3a ;
+    prov:atLocation niiri:ed43d1458342766e20a370cd82717651 ;
     prov:value "17.552827835083"^^xsd:float ;
     nidm_equivalentZStatistic: "3.60731294050443"^^xsd:float ;
     nidm_pValueUncorrected: "0.000154692216466135"^^xsd:float ;
     nidm_pValueFWER: "0.999742486133075"^^xsd:float ;
     nidm_qValueFDR: "0.655203493056632"^^xsd:float .
 
-niiri:a7eb863b9f06f839144773c75b850f3a
+niiri:ed43d1458342766e20a370cd82717651
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0034" ;
     nidm_coordinateVector: "[-6,-44,40]"^^xsd:string .
 
-niiri:a2ba7c350e9e6efdbe0c719e9de18ad8 prov:wasDerivedFrom niiri:e1e2e1faf57e2ccdad8d1cc2103103f7 .
+niiri:e8cb5546247d4a3680cfd15b61ec92a8 prov:wasDerivedFrom niiri:075d03d6a0a7a8ff06d2fd0a678225e4 .
 
-niiri:bfba150f550283418449951c8e862cdc
+niiri:feb703455a27d97b3c3dd1a514984c82
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0035" ;
-    prov:atLocation niiri:0858bf7232b97f8889a993d00c66391c ;
+    prov:atLocation niiri:9c2467090e8804770ca4c9155328ff6f ;
     prov:value "17.2906818389893"^^xsd:float ;
     nidm_equivalentZStatistic: "3.58254613965863"^^xsd:float ;
     nidm_pValueUncorrected: "0.000170130746602659"^^xsd:float ;
     nidm_pValueFWER: "0.99986271355264"^^xsd:float ;
     nidm_qValueFDR: "0.655203493056632"^^xsd:float .
 
-niiri:0858bf7232b97f8889a993d00c66391c
+niiri:9c2467090e8804770ca4c9155328ff6f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0035" ;
     nidm_coordinateVector: "[-34,-38,-34]"^^xsd:string .
 
-niiri:bfba150f550283418449951c8e862cdc prov:wasDerivedFrom niiri:a63b9651208c3ee898cba42774cbd083 .
+niiri:feb703455a27d97b3c3dd1a514984c82 prov:wasDerivedFrom niiri:f9daf2bb86509394f654f8dfb4a4e15b .
 
-niiri:3d432d24c1b40847e1aad79c018abae4
+niiri:28a0f16475271ebd8e455e39cde15030
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0036" ;
-    prov:atLocation niiri:b117dbcec89fdaa7e022b0c62f784d39 ;
+    prov:atLocation niiri:d62fe87691f9afa1a346f5ddd28d979b ;
     prov:value "17.1612319946289"^^xsd:float ;
     nidm_equivalentZStatistic: "3.57021115022413"^^xsd:float ;
     nidm_pValueUncorrected: "0.000178346794309836"^^xsd:float ;
     nidm_pValueFWER: "0.999901168620001"^^xsd:float ;
     nidm_qValueFDR: "0.655203493056632"^^xsd:float .
 
-niiri:b117dbcec89fdaa7e022b0c62f784d39
+niiri:d62fe87691f9afa1a346f5ddd28d979b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0036" ;
     nidm_coordinateVector: "[-46,-16,20]"^^xsd:string .
 
-niiri:3d432d24c1b40847e1aad79c018abae4 prov:wasDerivedFrom niiri:99df9b0bee5015f2e54ddbafb84c5b4b .
+niiri:28a0f16475271ebd8e455e39cde15030 prov:wasDerivedFrom niiri:447a33078d0ab11fa638dad2f64b7b00 .
 
-niiri:4124ce0ca684403359fec60d38ec647b
+niiri:5518c40950022bff274b3d6a606c42f0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0037" ;
-    prov:atLocation niiri:e186490bd92fb3b7db54fd2ac28f57bf ;
+    prov:atLocation niiri:46998d4a4e0fcd3525424c2621d0e486 ;
     prov:value "17.0075950622559"^^xsd:float ;
     nidm_equivalentZStatistic: "3.55547987606237"^^xsd:float ;
     nidm_pValueUncorrected: "0.000188644912021529"^^xsd:float ;
     nidm_pValueFWER: "0.999934173907998"^^xsd:float ;
     nidm_qValueFDR: "0.655203493056632"^^xsd:float .
 
-niiri:e186490bd92fb3b7db54fd2ac28f57bf
+niiri:46998d4a4e0fcd3525424c2621d0e486
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0037" ;
     nidm_coordinateVector: "[24,32,2]"^^xsd:string .
 
-niiri:4124ce0ca684403359fec60d38ec647b prov:wasDerivedFrom niiri:4fb8453b9556b51fec8c4dac94527e32 .
+niiri:5518c40950022bff274b3d6a606c42f0 prov:wasDerivedFrom niiri:e979405039e66c5ce2c3d5b5b67f1286 .
 
-niiri:656111533d822eb5e80c14aaa8ec5277
+niiri:f4f7823b1059a0ea57e9561159693d3f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0038" ;
-    prov:atLocation niiri:d8759922b592403e4b271841a2cd7caa ;
+    prov:atLocation niiri:a7d105498568414d907898529276f8b1 ;
     prov:value "16.5308303833008"^^xsd:float ;
     nidm_equivalentZStatistic: "3.50911812032442"^^xsd:float ;
     nidm_pValueUncorrected: "0.000224797592033421"^^xsd:float ;
     nidm_pValueFWER: "0.999983487413756"^^xsd:float ;
     nidm_qValueFDR: "0.655203493056632"^^xsd:float .
 
-niiri:d8759922b592403e4b271841a2cd7caa
+niiri:a7d105498568414d907898529276f8b1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0038" ;
     nidm_coordinateVector: "[-26,-90,16]"^^xsd:string .
 
-niiri:656111533d822eb5e80c14aaa8ec5277 prov:wasDerivedFrom niiri:06615834113ebb8c32e91747f3e2ea30 .
+niiri:f4f7823b1059a0ea57e9561159693d3f prov:wasDerivedFrom niiri:02724527e4ee34eff0967177115a83d1 .
 
-niiri:595ef0d6fdea073f86b47c75b3d155b8
+niiri:9acefe93a7c31e0167ce0ffe2ceaa937
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0039" ;
-    prov:atLocation niiri:f08647b25bf3126df7b3808fcac785b8 ;
+    prov:atLocation niiri:750a622122e236f5a7a8fe8d719fb55b ;
     prov:value "16.5225524902344"^^xsd:float ;
     nidm_equivalentZStatistic: "3.50830432871627"^^xsd:float ;
     nidm_pValueUncorrected: "0.0002254864217901"^^xsd:float ;
     nidm_pValueFWER: "0.999983907066973"^^xsd:float ;
     nidm_qValueFDR: "0.655203493056632"^^xsd:float .
 
-niiri:f08647b25bf3126df7b3808fcac785b8
+niiri:750a622122e236f5a7a8fe8d719fb55b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0039" ;
     nidm_coordinateVector: "[-28,-4,16]"^^xsd:string .
 
-niiri:595ef0d6fdea073f86b47c75b3d155b8 prov:wasDerivedFrom niiri:ebf5f25253bc1119f25ba867f1a13a26 .
+niiri:9acefe93a7c31e0167ce0ffe2ceaa937 prov:wasDerivedFrom niiri:c6bf9a9fd500605c73016dfb45e6af98 .
 
-niiri:c298852f98f17ca701a41c53eaf7b107
+niiri:3eeaab0bcdb1598c681f02ebda8bb1e8
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0040" ;
-    prov:atLocation niiri:0a0f4003136bb331371d2e48a04a4277 ;
+    prov:atLocation niiri:102ea580265a6d2daecfec9a22a9b1e4 ;
     prov:value "16.1374092102051"^^xsd:float ;
     nidm_equivalentZStatistic: "3.47009871338807"^^xsd:float ;
     nidm_pValueUncorrected: "0.00026013355917065"^^xsd:float ;
     nidm_pValueFWER: "0.999995475747835"^^xsd:float ;
     nidm_qValueFDR: "0.714297554117909"^^xsd:float .
 
-niiri:0a0f4003136bb331371d2e48a04a4277
+niiri:102ea580265a6d2daecfec9a22a9b1e4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0040" ;
     nidm_coordinateVector: "[12,60,20]"^^xsd:string .
 
-niiri:c298852f98f17ca701a41c53eaf7b107 prov:wasDerivedFrom niiri:e51b44da6f9ef9702d8a79c08d73d19e .
+niiri:3eeaab0bcdb1598c681f02ebda8bb1e8 prov:wasDerivedFrom niiri:e3e587be4409f0bc772835a934536590 .
 
-niiri:36a652eea4c7ac20af73fbdd72bfd50f
+niiri:762957e2b9b79f111526f35c0c3416cc
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0041" ;
-    prov:atLocation niiri:aec8a1a1e442c5f005622e4f7812287e ;
+    prov:atLocation niiri:1084313fe511021069a095149f1c37de ;
     prov:value "15.9136981964111"^^xsd:float ;
     nidm_equivalentZStatistic: "3.44759277757755"^^xsd:float ;
     nidm_pValueUncorrected: "0.000282803055741021"^^xsd:float ;
     nidm_pValueFWER: "0.999997977474125"^^xsd:float ;
     nidm_qValueFDR: "0.730845085955462"^^xsd:float .
 
-niiri:aec8a1a1e442c5f005622e4f7812287e
+niiri:1084313fe511021069a095149f1c37de
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0041" ;
     nidm_coordinateVector: "[4,-84,-4]"^^xsd:string .
 
-niiri:36a652eea4c7ac20af73fbdd72bfd50f prov:wasDerivedFrom niiri:b8483957e8852fa21925543fe06f0492 .
+niiri:762957e2b9b79f111526f35c0c3416cc prov:wasDerivedFrom niiri:6aa3e47b1d56a62cbf353acb1dbf4e63 .
 
-niiri:1099753739cedf3c7eddb2da41cd1f43
+niiri:ba7dd3245ca2f03a516b8c2349193add
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0042" ;
-    prov:atLocation niiri:31ee057da380c3b2ff19a8d5cad92798 ;
+    prov:atLocation niiri:3e9f38b8aafc94df86bb9516f511f4db ;
     prov:value "15.8536109924316"^^xsd:float ;
     nidm_equivalentZStatistic: "3.44150764421068"^^xsd:float ;
     nidm_pValueUncorrected: "0.000289241063091916"^^xsd:float ;
     nidm_pValueFWER: "0.999998385530387"^^xsd:float ;
     nidm_qValueFDR: "0.730845085955462"^^xsd:float .
 
-niiri:31ee057da380c3b2ff19a8d5cad92798
+niiri:3e9f38b8aafc94df86bb9516f511f4db
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0042" ;
     nidm_coordinateVector: "[62,-18,22]"^^xsd:string .
 
-niiri:1099753739cedf3c7eddb2da41cd1f43 prov:wasDerivedFrom niiri:1d380370dd353aff7206de21666fb3d4 .
+niiri:ba7dd3245ca2f03a516b8c2349193add prov:wasDerivedFrom niiri:11267ea4af34c876ad34aa054c834aa1 .
 
-niiri:59a93557347fa5539b9b61f828d0435f
+niiri:ce6828c9876402cd1eb1653f92f8b5b1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0043" ;
-    prov:atLocation niiri:6574f0e7bae8fd427e7a5b46ab994492 ;
+    prov:atLocation niiri:0913fe441dd608e575921c2b4f0500a1 ;
     prov:value "15.8288412094116"^^xsd:float ;
     nidm_equivalentZStatistic: "3.43899416081302"^^xsd:float ;
     nidm_pValueUncorrected: "0.000291939913913408"^^xsd:float ;
     nidm_pValueFWER: "0.999998530446399"^^xsd:float ;
     nidm_qValueFDR: "0.730845085955462"^^xsd:float .
 
-niiri:6574f0e7bae8fd427e7a5b46ab994492
+niiri:0913fe441dd608e575921c2b4f0500a1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0043" ;
     nidm_coordinateVector: "[28,-58,44]"^^xsd:string .
 
-niiri:59a93557347fa5539b9b61f828d0435f prov:wasDerivedFrom niiri:68a55477530e699e1f7822c244d7eb8f .
+niiri:ce6828c9876402cd1eb1653f92f8b5b1 prov:wasDerivedFrom niiri:ed62a9c22b9d6c8f4255706a0676f4da .
 
-niiri:32f10e6869aaf6c0ca25e73f7ebc26e2
+niiri:580ea35cc47de5999eda43982afb2748
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0044" ;
-    prov:atLocation niiri:926fecabbaf195c68687730a66cdaeb2 ;
+    prov:atLocation niiri:1eb319b0bd9712d284e197093bcacd55 ;
     prov:value "15.7273988723755"^^xsd:float ;
     nidm_equivalentZStatistic: "3.42866974555038"^^xsd:float ;
     nidm_pValueUncorrected: "0.000303273553249328"^^xsd:float ;
     nidm_pValueFWER: "0.999999007347173"^^xsd:float ;
     nidm_qValueFDR: "0.736843607649928"^^xsd:float .
 
-niiri:926fecabbaf195c68687730a66cdaeb2
+niiri:1eb319b0bd9712d284e197093bcacd55
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0044" ;
     nidm_coordinateVector: "[38,44,0]"^^xsd:string .
 
-niiri:32f10e6869aaf6c0ca25e73f7ebc26e2 prov:wasDerivedFrom niiri:aacb0b550de1bf101b8a9ebfbba31aae .
+niiri:580ea35cc47de5999eda43982afb2748 prov:wasDerivedFrom niiri:7649cec60050f6bbb0a4a68fad360d04 .
 
-niiri:cbf40cf2484c9f75c34529d78f40f15d
+niiri:dbf6e6c9df9c1acb5c0e4b176d3529de
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0045" ;
-    prov:atLocation niiri:55f1d43a8bb8799dfd32c66925f7d19d ;
+    prov:atLocation niiri:67a77f04ccd563945196ea9dd89d135b ;
     prov:value "15.4726600646973"^^xsd:float ;
     nidm_equivalentZStatistic: "3.40252319694713"^^xsd:float ;
     nidm_pValueUncorrected: "0.000333833435672726"^^xsd:float ;
     nidm_pValueFWER: "0.999999648429928"^^xsd:float ;
     nidm_qValueFDR: "0.766283831090278"^^xsd:float .
 
-niiri:55f1d43a8bb8799dfd32c66925f7d19d
+niiri:67a77f04ccd563945196ea9dd89d135b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0045" ;
     nidm_coordinateVector: "[40,-6,-6]"^^xsd:string .
 
-niiri:cbf40cf2484c9f75c34529d78f40f15d prov:wasDerivedFrom niiri:18d7d5a2985d2afc116f40bb7d9dd868 .
+niiri:dbf6e6c9df9c1acb5c0e4b176d3529de prov:wasDerivedFrom niiri:76477879d12f5565edfe6317f1396ae3 .
 
-niiri:95a78404fc8bda4d787b98fbc9b48494
+niiri:cb04519fde20aaf17e0dc9a593fb3d64
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0046" ;
-    prov:atLocation niiri:02186d81df3437bfcd3dfedfba544439 ;
+    prov:atLocation niiri:c089e08b98fa0c293381772f1ad43eb7 ;
     prov:value "15.3332357406616"^^xsd:float ;
     nidm_equivalentZStatistic: "3.38807697766079"^^xsd:float ;
     nidm_pValueUncorrected: "0.00035192253822891"^^xsd:float ;
     nidm_pValueFWER: "0.999999807374102"^^xsd:float ;
     nidm_qValueFDR: "0.766283831090278"^^xsd:float .
 
-niiri:02186d81df3437bfcd3dfedfba544439
+niiri:c089e08b98fa0c293381772f1ad43eb7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0046" ;
     nidm_coordinateVector: "[32,14,58]"^^xsd:string .
 
-niiri:95a78404fc8bda4d787b98fbc9b48494 prov:wasDerivedFrom niiri:b82b663a41d1d4bc01fd88119e09dfc9 .
+niiri:cb04519fde20aaf17e0dc9a593fb3d64 prov:wasDerivedFrom niiri:b32a94908c3543b6389e71c09e18b028 .
 
-niiri:64009818f6d53df0a0772b73e0d6b8ab
+niiri:d2c121ae6272e04656b61fe1f025dc35
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0047" ;
-    prov:atLocation niiri:a4770fa7b3785a1cc18136e5f58c75e9 ;
+    prov:atLocation niiri:cfe785bcd016f63eca725d056a54477f ;
     prov:value "15.3172578811646"^^xsd:float ;
     nidm_equivalentZStatistic: "3.38641524500992"^^xsd:float ;
     nidm_pValueUncorrected: "0.000354060730342054"^^xsd:float ;
     nidm_pValueFWER: "0.99999982049151"^^xsd:float ;
     nidm_qValueFDR: "0.766283831090278"^^xsd:float .
 
-niiri:a4770fa7b3785a1cc18136e5f58c75e9
+niiri:cfe785bcd016f63eca725d056a54477f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0047" ;
     nidm_coordinateVector: "[4,-86,4]"^^xsd:string .
 
-niiri:64009818f6d53df0a0772b73e0d6b8ab prov:wasDerivedFrom niiri:74035667fc1f8ff5d347c08183ecb0d2 .
+niiri:d2c121ae6272e04656b61fe1f025dc35 prov:wasDerivedFrom niiri:505e13c060365ce925c6c78620aace2b .
 
-niiri:d856e8b83939b59218ac7a746b463ee3
+niiri:df8d20feb57d27a95ebc95ea167307a2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0048" ;
-    prov:atLocation niiri:2bb3575890e47e2c795acd56341b710d ;
+    prov:atLocation niiri:f38a4b2a1e042ce6de00fdcf526dbe7c ;
     prov:value "15.3137311935425"^^xsd:float ;
     nidm_equivalentZStatistic: "3.38604828864924"^^xsd:float ;
     nidm_pValueUncorrected: "0.000354534526388783"^^xsd:float ;
     nidm_pValueFWER: "0.999999823272138"^^xsd:float ;
     nidm_qValueFDR: "0.766283831090278"^^xsd:float .
 
-niiri:2bb3575890e47e2c795acd56341b710d
+niiri:f38a4b2a1e042ce6de00fdcf526dbe7c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0048" ;
     nidm_coordinateVector: "[62,-36,46]"^^xsd:string .
 
-niiri:d856e8b83939b59218ac7a746b463ee3 prov:wasDerivedFrom niiri:a9e9f6c4e1e252f83c00826797f885fd .
+niiri:df8d20feb57d27a95ebc95ea167307a2 prov:wasDerivedFrom niiri:6a2f64f5544ff048d58423df90e157d2 .
 
-niiri:499615260dd74f9d189314807c6f588d
+niiri:e1adf61d5f82a1f2b659ae4e403de7c6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0049" ;
-    prov:atLocation niiri:d2d393550d128ce668f6e44797305dab ;
+    prov:atLocation niiri:56d1597c5c0850762b5b4e07acdeb247 ;
     prov:value "15.1916456222534"^^xsd:float ;
     nidm_equivalentZStatistic: "3.37330635701462"^^xsd:float ;
     nidm_pValueUncorrected: "0.000371356333789152"^^xsd:float ;
     nidm_pValueFWER: "0.999999898084819"^^xsd:float ;
     nidm_qValueFDR: "0.778719805919739"^^xsd:float .
 
-niiri:d2d393550d128ce668f6e44797305dab
+niiri:56d1597c5c0850762b5b4e07acdeb247
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0049" ;
     nidm_coordinateVector: "[-24,18,58]"^^xsd:string .
 
-niiri:499615260dd74f9d189314807c6f588d prov:wasDerivedFrom niiri:100b7385b787aa70accf430f06dc1f51 .
+niiri:e1adf61d5f82a1f2b659ae4e403de7c6 prov:wasDerivedFrom niiri:965bca191e7bce9008d8dd515cf43195 .
 
-niiri:4fde7ff637ea89cf29d7c5813cc8e4a9
+niiri:bbcbd508c2385f821ae15583d3d00469
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0050" ;
-    prov:atLocation niiri:67ceb8c7a82ec04487273d003017bc73 ;
+    prov:atLocation niiri:0b2cb1cecb1b69b139c9f6fc3ef83e39 ;
     prov:value "15.0888338088989"^^xsd:float ;
     nidm_equivalentZStatistic: "3.36251708484568"^^xsd:float ;
     nidm_pValueUncorrected: "0.000386176732959709"^^xsd:float ;
     nidm_pValueFWER: "0.999999936876428"^^xsd:float ;
     nidm_qValueFDR: "0.787311600282456"^^xsd:float .
 
-niiri:67ceb8c7a82ec04487273d003017bc73
+niiri:0b2cb1cecb1b69b139c9f6fc3ef83e39
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0050" ;
     nidm_coordinateVector: "[8,-22,-44]"^^xsd:string .
 
-niiri:4fde7ff637ea89cf29d7c5813cc8e4a9 prov:wasDerivedFrom niiri:677f763bf103868e95ac103a45720d37 .
+niiri:bbcbd508c2385f821ae15583d3d00469 prov:wasDerivedFrom niiri:5c0f8a6949255a54753a5996ab8bf0b5 .
 
-niiri:0e6dfe430b9215e3a35cd3cc66d9cffe
+niiri:400a173374e07f6ad6fa8505dd25b493
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0051" ;
-    prov:atLocation niiri:55b9d9758877f1f69da568a70e591c9e ;
+    prov:atLocation niiri:ca25ec1591871d5ddccaa5f5e6f304db ;
     prov:value "14.8200588226318"^^xsd:float ;
     nidm_equivalentZStatistic: "3.33405240591422"^^xsd:float ;
     nidm_pValueUncorrected: "0.000427952650791097"^^xsd:float ;
     nidm_pValueFWER: "0.999999983180231"^^xsd:float ;
     nidm_qValueFDR: "0.834595072923498"^^xsd:float .
 
-niiri:55b9d9758877f1f69da568a70e591c9e
+niiri:ca25ec1591871d5ddccaa5f5e6f304db
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0051" ;
     nidm_coordinateVector: "[38,34,22]"^^xsd:string .
 
-niiri:0e6dfe430b9215e3a35cd3cc66d9cffe prov:wasDerivedFrom niiri:0c812c731486b17b175ecfc3bf7169f1 .
+niiri:400a173374e07f6ad6fa8505dd25b493 prov:wasDerivedFrom niiri:e00c0b657ae25f884a41aad34f6d4869 .
 
-niiri:82c3f1e4c0dc909c3ba79639eda9a8af
+niiri:5e8d9c60f45794f6ee76f52290599e75
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0052" ;
-    prov:atLocation niiri:d12a3140e4f088df81db3c536483c2c1 ;
+    prov:atLocation niiri:790cfd7d87f72cac07ad32edea0f5651 ;
     prov:value "14.696608543396"^^xsd:float ;
     nidm_equivalentZStatistic: "3.32085065286489"^^xsd:float ;
     nidm_pValueUncorrected: "0.000448717729613968"^^xsd:float ;
     nidm_pValueFWER: "0.9999999911592"^^xsd:float ;
     nidm_qValueFDR: "0.835113533794074"^^xsd:float .
 
-niiri:d12a3140e4f088df81db3c536483c2c1
+niiri:790cfd7d87f72cac07ad32edea0f5651
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0052" ;
     nidm_coordinateVector: "[0,-26,-28]"^^xsd:string .
 
-niiri:82c3f1e4c0dc909c3ba79639eda9a8af prov:wasDerivedFrom niiri:747d0e971ba4dc1c824eb2073e536769 .
+niiri:5e8d9c60f45794f6ee76f52290599e75 prov:wasDerivedFrom niiri:efbb22419db35e6170e4f8c15df564d9 .
 
-niiri:94bc6a18ed5db528a3f4237966e8d39e
+niiri:5352b8108713eb17c53045c149a58a47
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0053" ;
-    prov:atLocation niiri:f54d2a9846066f14b56154dba91fd892 ;
+    prov:atLocation niiri:c191d0465f28572e319e54675be50b51 ;
     prov:value "14.2414035797119"^^xsd:float ;
     nidm_equivalentZStatistic: "3.27145497586776"^^xsd:float ;
     nidm_pValueUncorrected: "0.00053497811978398"^^xsd:float ;
     nidm_pValueFWER: "0.99999999933201"^^xsd:float ;
     nidm_qValueFDR: "0.904639459548904"^^xsd:float .
 
-niiri:f54d2a9846066f14b56154dba91fd892
+niiri:c191d0465f28572e319e54675be50b51
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0053" ;
     nidm_coordinateVector: "[40,-50,-22]"^^xsd:string .
 
-niiri:94bc6a18ed5db528a3f4237966e8d39e prov:wasDerivedFrom niiri:db3dd4033ee5e1f792de4dafd8064e08 .
+niiri:5352b8108713eb17c53045c149a58a47 prov:wasDerivedFrom niiri:792fda8a02886788088cdc21433fe931 .
 
-niiri:91fe83f3f4e1b6b6297f0a1782fcfc01
+niiri:4d047c8ee6809f00a9f5c059b315c51b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0054" ;
-    prov:atLocation niiri:cca51657add022838ebb58d09ebbc39f ;
+    prov:atLocation niiri:543d1149d7bfdacbb406551cbe82d946 ;
     prov:value "14.0012445449829"^^xsd:float ;
     nidm_equivalentZStatistic: "3.24492687341108"^^xsd:float ;
     nidm_pValueUncorrected: "0.000587403942481801"^^xsd:float ;
     nidm_pValueFWER: "0.999999999852106"^^xsd:float ;
     nidm_qValueFDR: "0.931776511128243"^^xsd:float .
 
-niiri:cca51657add022838ebb58d09ebbc39f
+niiri:543d1149d7bfdacbb406551cbe82d946
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0054" ;
     nidm_coordinateVector: "[8,52,32]"^^xsd:string .
 
-niiri:91fe83f3f4e1b6b6297f0a1782fcfc01 prov:wasDerivedFrom niiri:5d1b7a0c9ff2df0d604a94edf7efd3ac .
+niiri:4d047c8ee6809f00a9f5c059b315c51b prov:wasDerivedFrom niiri:0dd1d301e6eec8815748b738cd4fdb7c .
 
-niiri:ca5b7c73b9e8e2c0a918d6cb7d3e700a
+niiri:bbb945c8440c49e2cc1175a521c2126c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0055" ;
-    prov:atLocation niiri:615c290f65ed81c412ee36643ca93374 ;
+    prov:atLocation niiri:c5ea339216a0e5c8bc8aadff1689b3e7 ;
     prov:value "13.9842071533203"^^xsd:float ;
     nidm_equivalentZStatistic: "3.2430323166614"^^xsd:float ;
     nidm_pValueUncorrected: "0.000591323980175695"^^xsd:float ;
     nidm_pValueFWER: "0.999999999867649"^^xsd:float ;
     nidm_qValueFDR: "0.931776511128243"^^xsd:float .
 
-niiri:615c290f65ed81c412ee36643ca93374
+niiri:c5ea339216a0e5c8bc8aadff1689b3e7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0055" ;
     nidm_coordinateVector: "[-14,-48,-24]"^^xsd:string .
 
-niiri:ca5b7c73b9e8e2c0a918d6cb7d3e700a prov:wasDerivedFrom niiri:464ed1a86745e5328f28784be3bd4fb3 .
+niiri:bbb945c8440c49e2cc1175a521c2126c prov:wasDerivedFrom niiri:0a00a0a76e73ce79a1d09f89ec092795 .
 
-niiri:af7fb718df18d23512b5191e557f013b
+niiri:00c3e6ced7aa1682b713c6694740fe99
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0056" ;
-    prov:atLocation niiri:9197a509e59f57ac84b0239635308061 ;
+    prov:atLocation niiri:9c44f545329074e4000b8310d4b620c7 ;
     prov:value "13.9203996658325"^^xsd:float ;
     nidm_equivalentZStatistic: "3.23592192136056"^^xsd:float ;
     nidm_pValueUncorrected: "0.000606252725692924"^^xsd:float ;
     nidm_pValueFWER: "0.999999999913111"^^xsd:float ;
     nidm_qValueFDR: "0.931776511128243"^^xsd:float .
 
-niiri:9197a509e59f57ac84b0239635308061
+niiri:9c44f545329074e4000b8310d4b620c7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0056" ;
     nidm_coordinateVector: "[20,0,-8]"^^xsd:string .
 
-niiri:af7fb718df18d23512b5191e557f013b prov:wasDerivedFrom niiri:463ba14c93e36d88477f78294036d6ea .
+niiri:00c3e6ced7aa1682b713c6694740fe99 prov:wasDerivedFrom niiri:af99a7152d944fac822b2a894187ecfd .
 
-niiri:d2e0ed53e1395f81afcf2c95a72904cb
+niiri:6cae1270b5b27c77bad1a387e664d75b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0057" ;
-    prov:atLocation niiri:c00d337b23bc1146a58e3df8b6100a12 ;
+    prov:atLocation niiri:c47cfe09b9aab3da8be48f3b5835a42a ;
     prov:value "13.8925752639771"^^xsd:float ;
     nidm_equivalentZStatistic: "3.23281385809669"^^xsd:float ;
     nidm_pValueUncorrected: "0.000612887021428588"^^xsd:float ;
     nidm_pValueFWER: "0.999999999927857"^^xsd:float ;
     nidm_qValueFDR: "0.931776511128243"^^xsd:float .
 
-niiri:c00d337b23bc1146a58e3df8b6100a12
+niiri:c47cfe09b9aab3da8be48f3b5835a42a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0057" ;
     nidm_coordinateVector: "[40,-14,60]"^^xsd:string .
 
-niiri:d2e0ed53e1395f81afcf2c95a72904cb prov:wasDerivedFrom niiri:95bc5905e6829eb3b10bc4e2e665a6de .
+niiri:6cae1270b5b27c77bad1a387e664d75b prov:wasDerivedFrom niiri:1de9cf5cb4f411c77d648530539b1506 .
 
-niiri:101101311ec53c8ad517daf2f38ebb16
+niiri:09a056a78cfbc859552cc5fe35db542b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0058" ;
-    prov:atLocation niiri:f9398ef8c49f3dd85693821995b9b83d ;
+    prov:atLocation niiri:07df63fed0a966bcbd784f826c132acb ;
     prov:value "13.8641185760498"^^xsd:float ;
     nidm_equivalentZStatistic: "3.22963046726961"^^xsd:float ;
     nidm_pValueUncorrected: "0.000619751563460058"^^xsd:float ;
     nidm_pValueFWER: "0.999999999940447"^^xsd:float ;
     nidm_qValueFDR: "0.931776511128243"^^xsd:float .
 
-niiri:f9398ef8c49f3dd85693821995b9b83d
+niiri:07df63fed0a966bcbd784f826c132acb
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0058" ;
     nidm_coordinateVector: "[-36,10,24]"^^xsd:string .
 
-niiri:101101311ec53c8ad517daf2f38ebb16 prov:wasDerivedFrom niiri:79afb4c5267e6717f07bc3ab60650657 .
+niiri:09a056a78cfbc859552cc5fe35db542b prov:wasDerivedFrom niiri:643dd520d22eb83650c21da507f69f60 .
 
-niiri:52d4ccbdd886a6567e9796c4dc2b100b
+niiri:b43c078a0750c0b86b05a04f00f444dd
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0059" ;
-    prov:atLocation niiri:b3247b408c10346934d93d3b89c3b08e ;
+    prov:atLocation niiri:82a1a081c2fc5f7c1dd138a92d9cd37d ;
     prov:value "13.7912406921387"^^xsd:float ;
     nidm_equivalentZStatistic: "3.22145599369965"^^xsd:float ;
     nidm_pValueUncorrected: "0.000637705235827735"^^xsd:float ;
     nidm_pValueFWER: "0.999999999963824"^^xsd:float ;
     nidm_qValueFDR: "0.937302971928444"^^xsd:float .
 
-niiri:b3247b408c10346934d93d3b89c3b08e
+niiri:82a1a081c2fc5f7c1dd138a92d9cd37d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0059" ;
     nidm_coordinateVector: "[30,-78,14]"^^xsd:string .
 
-niiri:52d4ccbdd886a6567e9796c4dc2b100b prov:wasDerivedFrom niiri:e1b2a55b7f9b22b0ae0bdfe29112640f .
+niiri:b43c078a0750c0b86b05a04f00f444dd prov:wasDerivedFrom niiri:1a432aa3e7fda423feb9c68ebffde829 .
 
-niiri:7686ac01dd44c71076c194c60258e230
+niiri:733431f958ca44d615fd5672fc566312
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0060" ;
-    prov:atLocation niiri:c45e3cb57bd46521af944759f48b6aed ;
+    prov:atLocation niiri:18242354f3e85c5abeb04f2a24776aa1 ;
     prov:value "13.629490852356"^^xsd:float ;
     nidm_equivalentZStatistic: "3.20320002112963"^^xsd:float ;
     nidm_pValueUncorrected: "0.000679547746644249"^^xsd:float ;
     nidm_pValueFWER: "0.999999999988489"^^xsd:float ;
     nidm_qValueFDR: "0.94954759467573"^^xsd:float .
 
-niiri:c45e3cb57bd46521af944759f48b6aed
+niiri:18242354f3e85c5abeb04f2a24776aa1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0060" ;
     nidm_coordinateVector: "[18,-78,12]"^^xsd:string .
 
-niiri:7686ac01dd44c71076c194c60258e230 prov:wasDerivedFrom niiri:b05fa744387c4b5045f0c0b05aacfeb4 .
+niiri:733431f958ca44d615fd5672fc566312 prov:wasDerivedFrom niiri:1569aa21af436f1447efa2c75903f79c .
 
-niiri:2d83af76705abacd39ed564c16f5bd54
+niiri:a3a1f315599be97b5ba235320e09d642
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0061" ;
-    prov:atLocation niiri:19317ea03e1a885d53f69a47e6bf8983 ;
+    prov:atLocation niiri:3d17907c7b47751bf153c37c651d4aea ;
     prov:value "13.5061225891113"^^xsd:float ;
     nidm_equivalentZStatistic: "3.18916981007524"^^xsd:float ;
     nidm_pValueUncorrected: "0.000713410180681495"^^xsd:float ;
     nidm_pValueFWER: "0.999999999995369"^^xsd:float ;
     nidm_qValueFDR: "0.94954759467573"^^xsd:float .
 
-niiri:19317ea03e1a885d53f69a47e6bf8983
+niiri:3d17907c7b47751bf153c37c651d4aea
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0061" ;
     nidm_coordinateVector: "[46,8,-16]"^^xsd:string .
 
-niiri:2d83af76705abacd39ed564c16f5bd54 prov:wasDerivedFrom niiri:51f256b7ea3e807cb25c6775473371d8 .
+niiri:a3a1f315599be97b5ba235320e09d642 prov:wasDerivedFrom niiri:0fb2459e07ec9adca74a9a6a0f036186 .
 
-niiri:50553f55b08c318ae6ca6c8dcbb8872b
+niiri:e97475732149379834546a7b6497a3fb
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0062" ;
-    prov:atLocation niiri:91921c68ad1794bbce0d4ee2240ffd53 ;
+    prov:atLocation niiri:9ca6aad876741243f44dbfdd251a100a ;
     prov:value "13.4754667282104"^^xsd:float ;
     nidm_equivalentZStatistic: "3.1856690050705"^^xsd:float ;
     nidm_pValueUncorrected: "0.000722098618250455"^^xsd:float ;
     nidm_pValueFWER: "0.999999999996325"^^xsd:float ;
     nidm_qValueFDR: "0.94954759467573"^^xsd:float .
 
-niiri:91921c68ad1794bbce0d4ee2240ffd53
+niiri:9ca6aad876741243f44dbfdd251a100a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0062" ;
     nidm_coordinateVector: "[58,-40,50]"^^xsd:string .
 
-niiri:50553f55b08c318ae6ca6c8dcbb8872b prov:wasDerivedFrom niiri:dc9c7cf4223aa5e5ce8d564077006cb3 .
+niiri:e97475732149379834546a7b6497a3fb prov:wasDerivedFrom niiri:e937b5f0f9c2d5b73ead1407d48466e6 .
 
-niiri:eb9596c3e1486c6990a5fb92461fe7c6
+niiri:857dcc58dbe541261ba45dff3d2b361e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0063" ;
-    prov:atLocation niiri:562c07654934ee9bca299e9fa13ac7cd ;
+    prov:atLocation niiri:e584e06a075baa5c44d13b1381ce0ec2 ;
     prov:value "13.4480972290039"^^xsd:float ;
     nidm_equivalentZStatistic: "3.18253860543696"^^xsd:float ;
     nidm_pValueUncorrected: "0.000729950259848011"^^xsd:float ;
     nidm_pValueFWER: "0.999999999997016"^^xsd:float ;
     nidm_qValueFDR: "0.94954759467573"^^xsd:float .
 
-niiri:562c07654934ee9bca299e9fa13ac7cd
+niiri:e584e06a075baa5c44d13b1381ce0ec2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0063" ;
     nidm_coordinateVector: "[46,-66,32]"^^xsd:string .
 
-niiri:eb9596c3e1486c6990a5fb92461fe7c6 prov:wasDerivedFrom niiri:dd8593a9311adfd7943344f7fcbd8aee .
+niiri:857dcc58dbe541261ba45dff3d2b361e prov:wasDerivedFrom niiri:321743f529907bc95ee3bc2bb3feb1e2 .
 
-niiri:99bc3c3064f7e63cde024e02a67c7dd9
+niiri:6e0a324bcd2fe08b3423e3a1291846fd
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0064" ;
-    prov:atLocation niiri:edfe2d3ea7bf016746e7bfcc71201bd7 ;
+    prov:atLocation niiri:e3a33c2561f68e4588c8a21e486e7f2c ;
     prov:value "13.2857608795166"^^xsd:float ;
     nidm_equivalentZStatistic: "3.16387572537233"^^xsd:float ;
     nidm_pValueUncorrected: "0.000778416284459293"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999163"^^xsd:float ;
     nidm_qValueFDR: "0.971579849523251"^^xsd:float .
 
-niiri:edfe2d3ea7bf016746e7bfcc71201bd7
+niiri:e3a33c2561f68e4588c8a21e486e7f2c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0064" ;
     nidm_coordinateVector: "[2,-76,8]"^^xsd:string .
 
-niiri:99bc3c3064f7e63cde024e02a67c7dd9 prov:wasDerivedFrom niiri:f77c3b84351f869eec0ec8a0f4c729f2 .
+niiri:6e0a324bcd2fe08b3423e3a1291846fd prov:wasDerivedFrom niiri:7ca293071987c22e76e0b20115b26429 .
 
-niiri:0ad6a4b511f23009870cb9b825de4ffd
+niiri:7f16505a5183e80a89fdd236a19edcd0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0065" ;
-    prov:atLocation niiri:0c3fbfe97e3803ec8b14fb9f52d44997 ;
+    prov:atLocation niiri:af54c75393d7b35f74b4a955a92b6959 ;
     prov:value "13.2286987304688"^^xsd:float ;
     nidm_equivalentZStatistic: "3.15727638472708"^^xsd:float ;
     nidm_pValueUncorrected: "0.000796251631906664"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999472"^^xsd:float ;
     nidm_qValueFDR: "0.971579849523251"^^xsd:float .
 
-niiri:0c3fbfe97e3803ec8b14fb9f52d44997
+niiri:af54c75393d7b35f74b4a955a92b6959
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0065" ;
     nidm_coordinateVector: "[14,-24,-2]"^^xsd:string .
 
-niiri:0ad6a4b511f23009870cb9b825de4ffd prov:wasDerivedFrom niiri:d51318468d3708fb69be47dd8fb73f01 .
+niiri:7f16505a5183e80a89fdd236a19edcd0 prov:wasDerivedFrom niiri:6bb00e27ab3f8d7e1b137fd7b575136a .
 
-niiri:8caf8a7a70d4e5fe14391e5c25841da4
+niiri:875b2558dfadf848b15b4bd3a7bedac7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0066" ;
-    prov:atLocation niiri:5bc4ef05b320e7f65a2358fe409beb02 ;
+    prov:atLocation niiri:d59cf72ab0dd929c2b854e8cf00b3631 ;
     prov:value "13.0621271133423"^^xsd:float ;
     nidm_equivalentZStatistic: "3.13789355719639"^^xsd:float ;
     nidm_pValueUncorrected: "0.00085083330089919"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999869"^^xsd:float ;
     nidm_qValueFDR: "0.973821135792583"^^xsd:float .
 
-niiri:5bc4ef05b320e7f65a2358fe409beb02
+niiri:d59cf72ab0dd929c2b854e8cf00b3631
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0066" ;
     nidm_coordinateVector: "[-36,0,-4]"^^xsd:string .
 
-niiri:8caf8a7a70d4e5fe14391e5c25841da4 prov:wasDerivedFrom niiri:23ddb476e286b8beace9ac2226fb1e02 .
+niiri:875b2558dfadf848b15b4bd3a7bedac7 prov:wasDerivedFrom niiri:eea16d34f3c295e17c1d3128d76481f7 .
 
-niiri:30ef3b47f5d27871a175d290f6c7ab08
+niiri:5ebb4f1311ce16efbfe14bbe316a1dd9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0067" ;
-    prov:atLocation niiri:68fd9ce883588a363d129ffb7eb32766 ;
+    prov:atLocation niiri:1a3a714c8ff947781a0ad2d2c9f1cf30 ;
     prov:value "13.0451946258545"^^xsd:float ;
     nidm_equivalentZStatistic: "3.13591325616981"^^xsd:float ;
     nidm_pValueUncorrected: "0.000856599341067521"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999886"^^xsd:float ;
     nidm_qValueFDR: "0.973821135792583"^^xsd:float .
 
-niiri:68fd9ce883588a363d129ffb7eb32766
+niiri:1a3a714c8ff947781a0ad2d2c9f1cf30
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0067" ;
     nidm_coordinateVector: "[12,6,62]"^^xsd:string .
 
-niiri:30ef3b47f5d27871a175d290f6c7ab08 prov:wasDerivedFrom niiri:9c6347d32a637404df13117cb515bb7a .
+niiri:5ebb4f1311ce16efbfe14bbe316a1dd9 prov:wasDerivedFrom niiri:2d477a3822ede90c19394a724a2c602f .
 
-niiri:2932ff2d9ff5ee4eb44ab8faa6ae4a63
+niiri:c26bf255f07394accb52097e3aa14dcf
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0068" ;
-    prov:atLocation niiri:de40e4efcb3cabdc06e2207288c91bf3 ;
+    prov:atLocation niiri:fe279a930d64d5a71b800ab242e8f1c3 ;
     prov:value "13.0064306259155"^^xsd:float ;
     nidm_equivalentZStatistic: "3.13137270324883"^^xsd:float ;
     nidm_pValueUncorrected: "0.000869955985260296"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999919"^^xsd:float ;
     nidm_qValueFDR: "0.973821135792583"^^xsd:float .
 
-niiri:de40e4efcb3cabdc06e2207288c91bf3
+niiri:fe279a930d64d5a71b800ab242e8f1c3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0068" ;
     nidm_coordinateVector: "[-8,-4,24]"^^xsd:string .
 
-niiri:2932ff2d9ff5ee4eb44ab8faa6ae4a63 prov:wasDerivedFrom niiri:64b9ed90986836033d685bf5b9a5e773 .
+niiri:c26bf255f07394accb52097e3aa14dcf prov:wasDerivedFrom niiri:67886822c4a91ee4d1b7cd6bc45567f5 .
 
-niiri:c2049a099809392011d02b1523fcd2ca
+niiri:62972521b018c2b4931966235cb491ff
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0069" ;
-    prov:atLocation niiri:727c2045bba80d1ade0c258ba7a0fa62 ;
+    prov:atLocation niiri:5e0f8be6d5e367c13936e06a5132c658 ;
     prov:value "12.968074798584"^^xsd:float ;
     nidm_equivalentZStatistic: "3.12687033926247"^^xsd:float ;
     nidm_pValueUncorrected: "0.00088338914171493"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999942"^^xsd:float ;
     nidm_qValueFDR: "0.973821135792583"^^xsd:float .
 
-niiri:727c2045bba80d1ade0c258ba7a0fa62
+niiri:5e0f8be6d5e367c13936e06a5132c658
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0069" ;
     nidm_coordinateVector: "[8,-36,40]"^^xsd:string .
 
-niiri:c2049a099809392011d02b1523fcd2ca prov:wasDerivedFrom niiri:f2a361b0d3f278353a770b78f683d8ff .
+niiri:62972521b018c2b4931966235cb491ff prov:wasDerivedFrom niiri:5ebab1be1c4c961db315c2ffb23786c0 .
 
-niiri:c145759062c5e5ea4411b780ae9bb58d
+niiri:79c914462c21a9da15f185d7c27532c0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0070" ;
-    prov:atLocation niiri:254d63eddaa0fdf7034a46228cbf2641 ;
+    prov:atLocation niiri:d98448bb9b3ba696b02a78c75aa3d4a5 ;
     prov:value "12.9628992080688"^^xsd:float ;
     nidm_equivalentZStatistic: "3.12626207199886"^^xsd:float ;
     nidm_pValueUncorrected: "0.000885218504765861"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999944"^^xsd:float ;
     nidm_qValueFDR: "0.973821135792583"^^xsd:float .
 
-niiri:254d63eddaa0fdf7034a46228cbf2641
+niiri:d98448bb9b3ba696b02a78c75aa3d4a5
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0070" ;
     nidm_coordinateVector: "[24,38,0]"^^xsd:string .
 
-niiri:c145759062c5e5ea4411b780ae9bb58d prov:wasDerivedFrom niiri:a2753eb825e8f8fd5a487ef63c2663c8 .
+niiri:79c914462c21a9da15f185d7c27532c0 prov:wasDerivedFrom niiri:06a77002692eb72a6823907717b7b96b .
 
-niiri:cac376cb0260ec15d3d40dae08f77da6
+niiri:474715ccc997937469befbcc9826ba54
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0071" ;
-    prov:atLocation niiri:f6e4e8dfcf902a5b780272dc26c1b958 ;
+    prov:atLocation niiri:a4b31efcb7468b12d5ac889153f773bb ;
     prov:value "12.9482192993164"^^xsd:float ;
     nidm_equivalentZStatistic: "3.12453584528173"^^xsd:float ;
     nidm_pValueUncorrected: "0.000890429112242686"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999951"^^xsd:float ;
     nidm_qValueFDR: "0.973821135792583"^^xsd:float .
 
-niiri:f6e4e8dfcf902a5b780272dc26c1b958
+niiri:a4b31efcb7468b12d5ac889153f773bb
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0071" ;
     nidm_coordinateVector: "[26,-50,46]"^^xsd:string .
 
-niiri:cac376cb0260ec15d3d40dae08f77da6 prov:wasDerivedFrom niiri:85b5285611210be089c4e51b135903dc .
+niiri:474715ccc997937469befbcc9826ba54 prov:wasDerivedFrom niiri:70cb31c3da80e76bbcc31227d5a63dd3 .
 
-niiri:9f4be5bf3e2394450f15c3bd3f04e0b4
+niiri:bbd74f64374ff71082a0f30617e201a3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0072" ;
-    prov:atLocation niiri:eeb740356934b4e34ad535bbf2868366 ;
+    prov:atLocation niiri:19093ca30f5b7031b50a04dabe2c8580 ;
     prov:value "12.9151954650879"^^xsd:float ;
     nidm_equivalentZStatistic: "3.12064737190897"^^xsd:float ;
     nidm_pValueUncorrected: "0.000902269894699104"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999964"^^xsd:float ;
     nidm_qValueFDR: "0.973821135792583"^^xsd:float .
 
-niiri:eeb740356934b4e34ad535bbf2868366
+niiri:19093ca30f5b7031b50a04dabe2c8580
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0072" ;
     nidm_coordinateVector: "[-30,-86,8]"^^xsd:string .
 
-niiri:9f4be5bf3e2394450f15c3bd3f04e0b4 prov:wasDerivedFrom niiri:1d0913f48b56a9cfb53554e02fef4dd7 .
+niiri:bbd74f64374ff71082a0f30617e201a3 prov:wasDerivedFrom niiri:1bab28ca73fb58bf072903c327aa6ee2 .
 
-niiri:820e843198ddfac162a65814dfe44e4b
+niiri:95595228f33871513d411cf90c9ac990
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0073" ;
-    prov:atLocation niiri:c584945b7b1f425e4d105a7be69d98a2 ;
+    prov:atLocation niiri:e16ca3f3b4ac763acebdd770fb53915f ;
     prov:value "12.8661985397339"^^xsd:float ;
     nidm_equivalentZStatistic: "3.11486488202419"^^xsd:float ;
     nidm_pValueUncorrected: "0.00092014594111034"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999977"^^xsd:float ;
     nidm_qValueFDR: "0.975928938473905"^^xsd:float .
 
-niiri:c584945b7b1f425e4d105a7be69d98a2
+niiri:e16ca3f3b4ac763acebdd770fb53915f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0073" ;
     nidm_coordinateVector: "[22,-24,38]"^^xsd:string .
 
-niiri:820e843198ddfac162a65814dfe44e4b prov:wasDerivedFrom niiri:ec713ff49cc3d009853754ee51de40a9 .
+niiri:95595228f33871513d411cf90c9ac990 prov:wasDerivedFrom niiri:0d05a2eb7c30f085c9585bd5437f2cf6 .
 
-niiri:d9a9bc29896278cf65fd0c19f8bab212
+niiri:a143fe115cb6773e77224c4cf1c48dad
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0074" ;
-    prov:atLocation niiri:f690d8ccf99f04c1cdef2f57bd8121b1 ;
+    prov:atLocation niiri:0d8c450188c5ca9da526aa9cad61cd4e ;
     prov:value "12.8156299591064"^^xsd:float ;
     nidm_equivalentZStatistic: "3.10888025138563"^^xsd:float ;
     nidm_pValueUncorrected: "0.000938989080538355"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999985"^^xsd:float ;
     nidm_qValueFDR: "0.978285341995832"^^xsd:float .
 
-niiri:f690d8ccf99f04c1cdef2f57bd8121b1
+niiri:0d8c450188c5ca9da526aa9cad61cd4e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0074" ;
     nidm_coordinateVector: "[48,50,2]"^^xsd:string .
 
-niiri:d9a9bc29896278cf65fd0c19f8bab212 prov:wasDerivedFrom niiri:14378386d8b7fa3469c4024d8643a9f6 .
+niiri:a143fe115cb6773e77224c4cf1c48dad prov:wasDerivedFrom niiri:cec1367031abea759cc3b3843951c4e9 .
 
-niiri:99c82d559aae2b5f5396006039103bca
+niiri:fddbb1076a0ce325c65aac2f591218cd
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0075" ;
-    prov:atLocation niiri:a06eabcf0a3a383a6b7272083f79dad0 ;
+    prov:atLocation niiri:4da351496d312a5b3b763b22e9887907 ;
     prov:value "12.7734069824219"^^xsd:float ;
     nidm_equivalentZStatistic: "3.10387025917553"^^xsd:float ;
     nidm_pValueUncorrected: "0.000955035352381506"^^xsd:float ;
     nidm_pValueFWER: "0.99999999999999"^^xsd:float ;
     nidm_qValueFDR: "0.978285341995832"^^xsd:float .
 
-niiri:a06eabcf0a3a383a6b7272083f79dad0
+niiri:4da351496d312a5b3b763b22e9887907
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0075" ;
     nidm_coordinateVector: "[-48,-68,20]"^^xsd:string .
 
-niiri:99c82d559aae2b5f5396006039103bca prov:wasDerivedFrom niiri:35322e20f0852719cb5f7785e9eafbdf .
+niiri:fddbb1076a0ce325c65aac2f591218cd prov:wasDerivedFrom niiri:6ba93f98c147f043bee56b6eaf416136 .
 
-niiri:d145dcd6e4a69342e9c71383317b475d
+niiri:1cd54d943a37d511665d0fc8924f35bf
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0076" ;
-    prov:atLocation niiri:bad0281bedb6add01c67a6368047075d ;
+    prov:atLocation niiri:f9b1afbacf27286a06aed4990a8d3f17 ;
     prov:value "12.7362623214722"^^xsd:float ;
     nidm_equivalentZStatistic: "3.0994529756118"^^xsd:float ;
     nidm_pValueUncorrected: "0.000969391758882221"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999993"^^xsd:float ;
     nidm_qValueFDR: "0.978285341995832"^^xsd:float .
 
-niiri:bad0281bedb6add01c67a6368047075d
+niiri:f9b1afbacf27286a06aed4990a8d3f17
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0076" ;
     nidm_coordinateVector: "[24,-22,36]"^^xsd:string .
 
-niiri:d145dcd6e4a69342e9c71383317b475d prov:wasDerivedFrom niiri:c0448343148dd622321d80f7996dd79e .
+niiri:1cd54d943a37d511665d0fc8924f35bf prov:wasDerivedFrom niiri:ac903b7a48abf269c96015efab8d2aa1 .
 

--- a/spmexport/ex_spm_partial_conjunction/nidm.json
+++ b/spmexport/ex_spm_partial_conjunction/nidm.json
@@ -1,0 +1,16071 @@
+{
+  "prefix": {
+    "nidm": "http://purl.org/nidash/nidm#",
+    "niiri": "http://iri.nidash.org/",
+    "spm": "http://purl.org/nidash/spm#",
+    "neurolex": "http://neurolex.org/wiki/",
+    "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/",
+    "dct": "http://purl.org/dc/terms/",
+    "nfo": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#",
+    "dc": "http://purl.org/dc/elements/1.1/",
+    "dctype": "http://purl.org/dc/dcmitype/",
+    "obo": "http://purl.obolibrary.org/obo/",
+    "nidm_NIDMResults": "http://purl.org/nidash/nidm#NIDM_0000027",
+    "nidm_version": "http://purl.org/nidash/nidm#NIDM_0000127",
+    "nidm_spm_results_nidm": "http://purl.org/nidash/nidm#NIDM_0000168",
+    "nidm_softwareVersion": "http://purl.org/nidash/nidm#NIDM_0000122",
+    "nidm_NIDMResultsExport": "http://purl.org/nidash/nidm#NIDM_0000166"
+  },
+  "entity": {
+    "niiri:ba1fb3597bc0b59f859a3efc40c4f95b": {
+      "prov:type": [
+        {
+        "$": "prov:Bundle",
+        "type": "xsd:QName"
+        },
+        {
+        "$": "nidm_NIDMResults:",
+        "type": "xsd:QName"
+        }
+      ],
+      "prov:label": {
+        "$": "NIDM-Results",
+        "type": "xsd:string"
+      },
+      "nidm_version:": {
+        "$": "1.3.0",
+        "type": "xsd:string"
+      }
+    }
+  },
+  "activity": {
+    "niiri:d5312e2f7b2e014fe0e8c544933bdd34": {
+      "prov:type": {
+        "$": "nidm_NIDMResultsExport:",
+        "type": "xsd:QName"
+      },
+      "prov:label": {
+        "$": "NIDM-Results export",
+        "type": "xsd:string"
+      }
+    }
+  },
+  "agent": {
+    "niiri:36ef4229b87d0546f0547127a62087a2": {
+      "prov:type": [
+        {
+        "$": "nidm_spm_results_nidm:",
+        "type": "xsd:QName"
+        },
+        {
+        "$": "prov:SoftwareAgent",
+        "type": "xsd:QName"
+        }
+      ],
+      "prov:label": {
+        "$": "spm_results_nidm",
+        "type": "xsd:string"
+      },
+      "nidm_softwareVersion:": {
+        "$": "12.7057",
+        "type": "xsd:string"
+      }
+    }
+  },
+  "wasGeneratedBy": {
+    "_:wGB5": {
+      "prov:entity": "niiri:ba1fb3597bc0b59f859a3efc40c4f95b",
+      "prov:activity": "niiri:d5312e2f7b2e014fe0e8c544933bdd34",
+      "prov:time": "2017-04-19T12:18:44"
+    }
+  },
+  "wasAssociatedWith": {
+    "_:wAW4": {
+      "prov:activity": "niiri:d5312e2f7b2e014fe0e8c544933bdd34",
+      "prov:agent": "niiri:36ef4229b87d0546f0547127a62087a2"
+    }
+  },
+  "bundle": {
+    "niiri:ba1fb3597bc0b59f859a3efc40c4f95b": {
+    "prefix": {
+        "nidm_softwareVersion": "http://purl.org/nidash/nidm#NIDM_0000122",
+        "nidm_CoordinateSpace": "http://purl.org/nidash/nidm#NIDM_0000016",
+        "nidm_voxelToWorldMapping": "http://purl.org/nidash/nidm#NIDM_0000132",
+        "nidm_voxelUnits": "http://purl.org/nidash/nidm#NIDM_0000133",
+        "nidm_voxelSize": "http://purl.org/nidash/nidm#NIDM_0000131",
+        "nidm_inWorldCoordinateSystem": "http://purl.org/nidash/nidm#NIDM_0000105",
+        "nidm_numberOfDimensions": "http://purl.org/nidash/nidm#NIDM_0000112",
+        "nidm_dimensionsInVoxels": "http://purl.org/nidash/nidm#NIDM_0000090",
+        "nlx_Imaginginstrument": "http://uri.neuinfo.org/nif/nifstd/birnlex_2094",
+        "nlx_Magneticresonanceimagingscanner": "http://uri.neuinfo.org/nif/nifstd/birnlex_2100",
+        "nidm_grandMeanScaling": "http://purl.org/nidash/nidm#NIDM_0000096",
+        "nidm_targetIntensity": "http://purl.org/nidash/nidm#NIDM_0000124",
+        "nidm_hasMRIProtocol": "http://purl.org/nidash/nidm#NIDM_0000172",
+        "nlx_FunctionalMRIprotocol": "http://uri.neuinfo.org/nif/nifstd/birnlex_2250",
+        "nidm_Data": "http://purl.org/nidash/nidm#NIDM_0000169",
+        "spm_DCTDriftModel": "http://purl.org/nidash/spm#SPM_0000002",
+        "spm_SPMsDriftCutoffPeriod": "http://purl.org/nidash/spm#SPM_0000001",
+        "nidm_hasDriftModel": "http://purl.org/nidash/nidm#NIDM_0000088",
+        "nidm_hasHRFBasis": "http://purl.org/nidash/nidm#NIDM_0000102",
+        "spm_SPMsCanonicalHRF": "http://purl.org/nidash/spm#SPM_0000004",
+        "nidm_DesignMatrix": "http://purl.org/nidash/nidm#NIDM_0000019",
+        "nidm_regressorNames": "http://purl.org/nidash/nidm#NIDM_0000021",
+        "nidm_hasErrorDependence": "http://purl.org/nidash/nidm#NIDM_0000100",
+        "obo_Toeplitzcovariancestructure": "http://purl.obolibrary.org/obo/STATO_0000357",
+        "nidm_dependenceMapWiseDependence": "http://purl.org/nidash/nidm#NIDM_0000089",
+        "nidm_ConstantParameter": "http://purl.org/nidash/nidm#NIDM_0000072",
+        "nidm_errorVarianceHomogeneous": "http://purl.org/nidash/nidm#NIDM_0000094",
+        "nidm_varianceMapWiseDependence": "http://purl.org/nidash/nidm#NIDM_0000126",
+        "nidm_IndependentParameter": "http://purl.org/nidash/nidm#NIDM_0000073",
+        "nidm_withEstimationMethod": "http://purl.org/nidash/nidm#NIDM_0000134",
+        "obo_generalizedleastsquaresestimation": "http://purl.obolibrary.org/obo/STATO_0000372",
+        "nidm_ErrorModel": "http://purl.org/nidash/nidm#NIDM_0000023",
+        "nidm_hasErrorDistribution": "http://purl.org/nidash/nidm#NIDM_0000101",
+        "obo_normaldistribution": "http://purl.obolibrary.org/obo/STATO_0000227",
+        "nidm_ModelParametersEstimation": "http://purl.org/nidash/nidm#NIDM_0000056",
+        "nidm_MaskMap": "http://purl.org/nidash/nidm#NIDM_0000054",
+        "nidm_isUserDefined": "http://purl.org/nidash/nidm#NIDM_0000106",
+        "nidm_inCoordinateSpace": "http://purl.org/nidash/nidm#NIDM_0000104",
+        "nidm_GrandMeanMap": "http://purl.org/nidash/nidm#NIDM_0000033",
+        "nidm_maskedMedian": "http://purl.org/nidash/nidm#NIDM_0000107",
+        "nidm_ParameterEstimateMap": "http://purl.org/nidash/nidm#NIDM_0000061",
+        "nidm_ResidualMeanSquaresMap": "http://purl.org/nidash/nidm#NIDM_0000066",
+        "nidm_ReselsPerVoxelMap": "http://purl.org/nidash/nidm#NIDM_0000144",
+        "obo_contrastweightmatrix": "http://purl.obolibrary.org/obo/STATO_0000323",
+        "nidm_statisticType": "http://purl.org/nidash/nidm#NIDM_0000123",
+        "obo_tstatistic": "http://purl.obolibrary.org/obo/STATO_0000176",
+        "nidm_contrastName": "http://purl.org/nidash/nidm#NIDM_0000085",
+        "nidm_ContrastEstimation": "http://purl.org/nidash/nidm#NIDM_0000001",
+        "nidm_StatisticMap": "http://purl.org/nidash/nidm#NIDM_0000076",
+        "nidm_errorDegreesOfFreedom": "http://purl.org/nidash/nidm#NIDM_0000093",
+        "nidm_effectDegreesOfFreedom": "http://purl.org/nidash/nidm#NIDM_0000091",
+        "nidm_ContrastMap": "http://purl.org/nidash/nidm#NIDM_0000002",
+        "nidm_ContrastStandardErrorMap": "http://purl.org/nidash/nidm#NIDM_0000013",
+        "obo_statistic": "http://purl.obolibrary.org/obo/STATO_0000039",
+        "nidm_PValueUncorrected": "http://purl.org/nidash/nidm#NIDM_0000160",
+        "obo_FWERadjustedpvalue": "http://purl.obolibrary.org/obo/OBI_0001265",
+        "nidm_HeightThreshold": "http://purl.org/nidash/nidm#NIDM_0000034",
+        "nidm_equivalentThreshold": "http://purl.org/nidash/nidm#NIDM_0000161",
+        "nidm_ExtentThreshold": "http://purl.org/nidash/nidm#NIDM_0000026",
+        "nidm_clusterSizeInVoxels": "http://purl.org/nidash/nidm#NIDM_0000084",
+        "nidm_clusterSizeInResels": "http://purl.org/nidash/nidm#NIDM_0000156",
+        "nidm_PeakDefinitionCriteria": "http://purl.org/nidash/nidm#NIDM_0000063",
+        "nidm_maxNumberOfPeaksPerCluster": "http://purl.org/nidash/nidm#NIDM_0000108",
+        "nidm_minDistanceBetweenPeaks": "http://purl.org/nidash/nidm#NIDM_0000109",
+        "nidm_ClusterDefinitionCriteria": "http://purl.org/nidash/nidm#NIDM_0000007",
+        "nidm_hasConnectivityCriterion": "http://purl.org/nidash/nidm#NIDM_0000099",
+        "nidm_voxel18connected": "http://purl.org/nidash/nidm#NIDM_0000128",
+        "spm_PartialConjunctionInference": "http://purl.org/nidash/spm#SPM_0000005",
+        "nidm_hasAlternativeHypothesis": "http://purl.org/nidash/nidm#NIDM_0000097",
+        "nidm_OneTailedTest": "http://purl.org/nidash/nidm#NIDM_0000060",
+        "spm_partialConjunctionDegree": "http://purl.org/nidash/spm#SPM_0000015",
+        "nidm_SearchSpaceMaskMap": "http://purl.org/nidash/nidm#NIDM_0000068",
+        "nidm_searchVolumeInVoxels": "http://purl.org/nidash/nidm#NIDM_0000121",
+        "nidm_searchVolumeInUnits": "http://purl.org/nidash/nidm#NIDM_0000136",
+        "nidm_reselSizeInVoxels": "http://purl.org/nidash/nidm#NIDM_0000148",
+        "nidm_searchVolumeInResels": "http://purl.org/nidash/nidm#NIDM_0000149",
+        "spm_searchVolumeReselsGeometry": "http://purl.org/nidash/spm#SPM_0000010",
+        "nidm_noiseFWHMInVoxels": "http://purl.org/nidash/nidm#NIDM_0000159",
+        "nidm_noiseFWHMInUnits": "http://purl.org/nidash/nidm#NIDM_0000157",
+        "nidm_randomFieldStationarity": "http://purl.org/nidash/nidm#NIDM_0000120",
+        "nidm_expectedNumberOfVoxelsPerCluster": "http://purl.org/nidash/nidm#NIDM_0000143",
+        "nidm_expectedNumberOfClusters": "http://purl.org/nidash/nidm#NIDM_0000141",
+        "nidm_heightCriticalThresholdFWE05": "http://purl.org/nidash/nidm#NIDM_0000147",
+        "nidm_heightCriticalThresholdFDR05": "http://purl.org/nidash/nidm#NIDM_0000146",
+        "nidm_ExcursionSetMap": "http://purl.org/nidash/nidm#NIDM_0000025",
+        "nidm_numberOfSupraThresholdClusters": "http://purl.org/nidash/nidm#NIDM_0000111",
+        "nidm_pValue": "http://purl.org/nidash/nidm#NIDM_0000114",
+        "nidm_hasClusterLabelsMap": "http://purl.org/nidash/nidm#NIDM_0000098",
+        "nidm_hasMaximumIntensityProjection": "http://purl.org/nidash/nidm#NIDM_0000138",
+        "nidm_ClusterLabelsMap": "http://purl.org/nidash/nidm#NIDM_0000008",
+        "nidm_SupraThresholdCluster": "http://purl.org/nidash/nidm#NIDM_0000070",
+        "nidm_pValueUncorrected": "http://purl.org/nidash/nidm#NIDM_0000116",
+        "nidm_pValueFWER": "http://purl.org/nidash/nidm#NIDM_0000115",
+        "nidm_qValueFDR": "http://purl.org/nidash/nidm#NIDM_0000119",
+        "nidm_clusterLabelId": "http://purl.org/nidash/nidm#NIDM_0000082",
+        "nidm_Peak": "http://purl.org/nidash/nidm#NIDM_0000062",
+        "nidm_equivalentZStatistic": "http://purl.org/nidash/nidm#NIDM_0000092",
+        "nidm_Coordinate": "http://purl.org/nidash/nidm#NIDM_0000015",
+        "nidm_coordinateVector": "http://purl.org/nidash/nidm#NIDM_0000086"
+    },
+    "entity": {
+        "niiri:21f24d2b86fec337fe05741e4da7e8c3": {
+            "prov:type": {
+                "$": "nidm_CoordinateSpace:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Coordinate space 1",
+                "type": "xsd:string"
+            },
+            "nidm_voxelToWorldMapping:": {
+                "$": "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]",
+                "type": "xsd:string"
+            },
+            "nidm_voxelUnits:": {
+                "$": "[\"mm\", \"mm\", \"mm\"]",
+                "type": "xsd:string"
+            },
+            "nidm_voxelSize:": {
+                "$": "[2, 2, 2]",
+                "type": "xsd:string"
+            },
+            "nidm_inWorldCoordinateSystem:": {
+                "$": "nidm_Ixi549CoordinateSystem:",
+                "type": "xsd:string"
+            },
+            "nidm_numberOfDimensions:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_dimensionsInVoxels:": {
+                "$": "[79,95,79]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b0407acb83b2703b82444e30fcac401b": {
+            "prov:type": [
+                {
+                "$": "prov:Collection",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Data:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Data",
+                "type": "xsd:string"
+            },
+            "nidm_grandMeanScaling:": {
+                "$": "true",
+                "type": "xsd:boolean"
+            },
+            "nidm_targetIntensity:": {
+                "$": "100",
+                "type": "xsd:float"
+            },
+            "nidm_hasMRIProtocol:": {
+                "$": "nlx_FunctionalMRIprotocol:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b557e098b34f31a9e2f16762e818990f": {
+            "prov:type": {
+                "$": "spm_DCTDriftModel:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "SPM's DCT Drift Model",
+                "type": "xsd:string"
+            },
+            "spm_SPMsDriftCutoffPeriod:": {
+                "$": "128",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:59859d0ad01111bc8ee8288526aae37d": {
+            "prov:type": {
+                "$": "nidm_DesignMatrix:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "DesignMatrix.csv",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "DesignMatrix.csv",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "text/csv",
+                "type": "xsd:string"
+            },
+            "dc:description": {
+                "$": "niiri:606e0581bbcbad8b686c00155e95f5a0",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Design Matrix",
+                "type": "xsd:string"
+            },
+            "nidm_regressorNames:": {
+                "$": "[\"Sn(1) to*bf(1)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) constant\"]",
+                "type": "xsd:string"
+            },
+            "nidm_hasDriftModel:": {
+                "$": "niiri:b557e098b34f31a9e2f16762e818990f",
+                "type": "xsd:string"
+            },
+            "nidm_hasHRFBasis:": {
+                "$": "spm_SPMsCanonicalHRF:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:606e0581bbcbad8b686c00155e95f5a0": {
+            "prov:type": {
+                "$": "dctype:Image",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "DesignMatrix.png",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "DesignMatrix.png",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/png",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:16eb1e414b6a4247bd1b7cfca669048c": {
+            "prov:type": {
+                "$": "nidm_ErrorModel:",
+                "type": "xsd:QName"
+            },
+            "nidm_hasErrorDistribution:": {
+                "$": "obo_normaldistribution:",
+                "type": "xsd:string"
+            },
+            "nidm_hasErrorDependence:": {
+                "$": "obo_Toeplitzcovariancestructure:",
+                "type": "xsd:string"
+            },
+            "nidm_dependenceMapWiseDependence:": {
+                "$": "nidm_ConstantParameter:",
+                "type": "xsd:string"
+            },
+            "nidm_errorVarianceHomogeneous:": {
+                "$": "true",
+                "type": "xsd:boolean"
+            },
+            "nidm_varianceMapWiseDependence:": {
+                "$": "nidm_IndependentParameter:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:aba08deba6439b8fd82d98d160e5d070": {
+            "prov:type": {
+                "$": "nidm_MaskMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "Mask.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nidm_isUserDefined:": {
+                "$": "false",
+                "type": "xsd:boolean"
+            },
+            "nfo:fileName": {
+                "$": "Mask.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Mask",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:21f24d2b86fec337fe05741e4da7e8c3",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b3f11481d93002948ba4265eb6fc7a17": {
+            "prov:type": {
+                "$": "nidm_MaskMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "mask.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "36929e1f5f4143bd9cc818cd896a25f129961fab208c3a4438555f40444c08347b359142ee8c53ece6e8cca1627f49db0788a1fd3b9e2ecaef61999c6c6c67ac",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4f4a4075f1bc1968a80b2f594b2a5ef9": {
+            "prov:type": {
+                "$": "nidm_GrandMeanMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "GrandMean.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "GrandMean.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Grand Mean Map",
+                "type": "xsd:string"
+            },
+            "nidm_maskedMedian:": {
+                "$": "111.557487487793",
+                "type": "xsd:float"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:21f24d2b86fec337fe05741e4da7e8c3",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "512157cc6bff89d9343a09b4068226eb3edd64a8cbcee861f06231767fae6f8d4819921182adebee083a9bf309afd65529ab04a92f0aa6b0038c8098550f6124",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a5c5180e35f868db315e52abaf2ab6cf": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0001.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0001.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 1",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:21f24d2b86fec337fe05741e4da7e8c3",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5ff4045c3fb225d6d68fbb0c98b08a69": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0001.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:109842e828160f2f74424c94fa31d3ac": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0002.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0002.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 2",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:21f24d2b86fec337fe05741e4da7e8c3",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9237a7292e50834f847b622ac8097d47": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0002.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:670abeebbed6d1e906338a6a7b6e100d": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0003.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0003.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 3",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:21f24d2b86fec337fe05741e4da7e8c3",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e1ead41ef090189a9edc014566d7fa8a": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0003.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9d50bf99d1eb9b3e0c264b87fd74b224": {
+            "prov:type": {
+                "$": "nidm_ResidualMeanSquaresMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ResidualMeanSquares.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ResidualMeanSquares.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Residual Mean Squares Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:21f24d2b86fec337fe05741e4da7e8c3",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "991abf563d795a43b1e2eef8643e57023f2e0b090b2031f05f839321fc0643df6f71d423486a1021519b6dc82f6b0f563e19f3fbd50cb16063bed54a0e192d3e",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0ecf4a4c4ca5a416fa2e7555c094ddb6": {
+            "prov:type": {
+                "$": "nidm_ResidualMeanSquaresMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "ResMS.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "40b28d03fcf9a2f60b11f10d7fb83bf3618b234fb5aedf09df644cb7cbb6aab8c9f468897c1078166d455a3d04a83f4e3bf762cfca0b4ea982d7a4e406849f18",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:bc8b436cc11302e4d61399ed8127ddce": {
+            "prov:type": {
+                "$": "nidm_ReselsPerVoxelMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ReselsPerVoxel.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ReselsPerVoxel.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Resels per Voxel Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:21f24d2b86fec337fe05741e4da7e8c3",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "1a3f9216e145249ccc0b14b2bc337d6b38b81ad45e32768001fb22b35f0c2c0f3e2bce013b40c85f7dc0fc62723ac761ee7f7e1e6aff128a05f0ba7b8b8202a3",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4d7372ca3c6f7a39fc98bc6a82293781": {
+            "prov:type": {
+                "$": "nidm_ReselsPerVoxelMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "RPV.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "4f76663162857f6b38b2a45a63b15a23b2ca8b338c283b69c1e71f2ea2f43797d045a733cd14e845be9c12f8b8f84d3931c599a08e8f6d77e99fab46ad87ab8f",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e12b3b920d0b0e8c6be817754a69ec93": {
+            "prov:type": {
+                "$": "obo_contrastweightmatrix:",
+                "type": "xsd:QName"
+            },
+            "nidm_statisticType:": {
+                "$": "obo_tstatistic:",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast: tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "[1, 0, 0]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ef836beafc2e291065c57b3a7e86dc80": {
+            "prov:type": {
+                "$": "nidm_StatisticMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "TStatistic_0001.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "TStatistic_0001.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "T-Statistic Map: tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "nidm_statisticType:": {
+                "$": "obo_tstatistic:",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "nidm_errorDegreesOfFreedom:": {
+                "$": "97.9999999998522",
+                "type": "xsd:float"
+            },
+            "nidm_effectDegreesOfFreedom:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:21f24d2b86fec337fe05741e4da7e8c3",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "90a7b52d7e93a959aa14734abe286d20002ca269bfa11f4ad798c65573c0912e923220c2dbcd25ac59c7dff26c3685907c0b8083db510ee63663d534206e0f96",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:49749ebbcacba1baa8e79e02c1938189": {
+            "prov:type": {
+                "$": "nidm_StatisticMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "spmT_0001.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "d288b1b0f117f64502555da13c5398dffa5bf5ff0b58951510e43d5388755bc185798802a92e98a07c7e313c6991066d2908f2a44aa5153ba23433da1335970f",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9d77bd5bfcea339e1308f2f57159142a": {
+            "prov:type": {
+                "$": "nidm_ContrastMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "Contrast_0001.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "Contrast_0001.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast Map: tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:21f24d2b86fec337fe05741e4da7e8c3",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "fc5e2ad175243ee496db98f9b2e1b235c4c3bae1a8d7122ce461c897b537e40c49dfee5d6cf20f71c6a2bb9b5f0760fcb4ecd8fe2e9428910ef3d60d8f3c56a9",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:05afb3605ef5b9f0b252b00b89bc58c8": {
+            "prov:type": {
+                "$": "nidm_ContrastMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "con_0001.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "d4aa46b3603ba508578e39751262d528cf6d1ed2e722ec46f1cd8194c50591e46b229deb8cb4f72d1b7e0e2640f3e6604be7a335301c5c8357f453e5d0d4daf2",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2fcd23f1ed3c1835696b5f3f6c067474": {
+            "prov:type": {
+                "$": "nidm_ContrastStandardErrorMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ContrastStandardError_0001.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ContrastStandardError_0001.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast Standard Error Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:21f24d2b86fec337fe05741e4da7e8c3",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "791d48f5d1adb15079a5289271ce0c4b95c56d69bfdb3e5d41b0d24eb538d3075e1cdd15502494b5a5a18c16eaa2153cb4847a996043fa48cdaf26e938a2576d",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ba7f4a78f7bfc8dfe15e84f017dffc6f": {
+            "prov:type": {
+                "$": "obo_contrastweightmatrix:",
+                "type": "xsd:QName"
+            },
+            "nidm_statisticType:": {
+                "$": "obo_tstatistic:",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "tone counting probe vs baseline (orth. w.r.t {1})",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast: tone counting probe vs baseline (orth. w.r.t {1})",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "[-0.919333604280958, 1, 0]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:955daf8b5134c9320aad7d629101cc88": {
+            "prov:type": {
+                "$": "nidm_StatisticMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "TStatistic_0002.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "TStatistic_0002.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "T-Statistic Map: tone counting probe vs baseline (orth. w.r.t {1})",
+                "type": "xsd:string"
+            },
+            "nidm_statisticType:": {
+                "$": "obo_tstatistic:",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "tone counting probe vs baseline (orth. w.r.t {1})",
+                "type": "xsd:string"
+            },
+            "nidm_errorDegreesOfFreedom:": {
+                "$": "97.9999999998522",
+                "type": "xsd:float"
+            },
+            "nidm_effectDegreesOfFreedom:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:21f24d2b86fec337fe05741e4da7e8c3",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "d90b7e100f85bd13206e5074638371c2e4559ff1a748aa67a42ac9d0da802b9f2b04df108d32f3ea375017805784a9814b9b2eb515bbe8930b1fe39eb68e6299",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:de187bcb23967e7a4b132bd43bbb2d3c": {
+            "prov:type": {
+                "$": "nidm_StatisticMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "spmT_0003.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "16529d1636b3f7868ae8acaee472adf6ad23cebc0fdbb7412821197d62029e7d5b1dd078621353bca152fba21256adb888cd718b194876faaa82995ffe653e74",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:66ede7151e2d666315b2d79e13573a47": {
+            "prov:type": {
+                "$": "nidm_ContrastMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "Contrast_0002.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "Contrast_0002.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast Map: tone counting probe vs baseline (orth. w.r.t {1})",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "tone counting probe vs baseline (orth. w.r.t {1})",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:21f24d2b86fec337fe05741e4da7e8c3",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "89f2233bd64ee40c2ceb5f4e9d0bcbb9a681ad9fa298da4fbdec7173edf186ce33efe3dd331eab07bdbeb7283538e62798692680031d672e724fd90e790439fd",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ceab125faff01ef71a425d244d8dd312": {
+            "prov:type": {
+                "$": "nidm_ContrastMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "con_0003.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "2c14d615d64b789ee26a22dea4052e1f42f951e9154448c931c0e2d16c7a8c5acb33dfb228e8e61da37f13a182ec2e50aeba6434e05e6dcc5d9cab2f1f6ff680",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6b4d76daa5ef6289730f139f490051cd": {
+            "prov:type": {
+                "$": "nidm_ContrastStandardErrorMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ContrastStandardError_0002.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ContrastStandardError_0002.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast Standard Error Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:21f24d2b86fec337fe05741e4da7e8c3",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "25ba224b75eef1f03b89e808e7b221a122e53101f981cbbc08c77ce9a7890e2e889e3170ff47c10efaf34f13109689d3b14cb13970e62d2fe341b79fd4c01253",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:40130c07affd508ab9ba7401250e23da": {
+            "prov:type": [
+                {
+                "$": "nidm_HeightThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_PValueUncorrected:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Height Threshold: p<0.001 (unc.)",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "0.000999499935993353",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentThreshold:": [
+                {
+                "$": "niiri:c84125bf0a4147bdec34e8d62a7d8e9b",
+                "type": "xsd:string"
+                },
+                {
+                "$": "niiri:69b20013b8e5b45f8fab306ece980cf8",
+                "type": "xsd:string"
+                }
+            ]
+        },
+        "niiri:c84125bf0a4147bdec34e8d62a7d8e9b": {
+            "prov:type": [
+                {
+                "$": "nidm_HeightThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_statistic:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Height Threshold: T=1.878787)",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1.87878728784405",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:69b20013b8e5b45f8fab306ece980cf8": {
+            "prov:type": [
+                {
+                "$": "nidm_HeightThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_FWERadjustedpvalue:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Height Threshold: p<1.000000 (FWE)",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:559eaf01d0bac3504edd2c4d5066dd7b": {
+            "prov:type": [
+                {
+                "$": "nidm_ExtentThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_statistic:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Extent Threshold: k>=0",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "0",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentThreshold:": [
+                {
+                "$": "niiri:76a9c78f5f4fa409b43bc97e69a2d2f9",
+                "type": "xsd:string"
+                },
+                {
+                "$": "niiri:80a186d719df191589b700394aee0091",
+                "type": "xsd:string"
+                }
+            ]
+        },
+        "niiri:76a9c78f5f4fa409b43bc97e69a2d2f9": {
+            "prov:type": [
+                {
+                "$": "nidm_ExtentThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_FWERadjustedpvalue:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Extent Threshold",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:80a186d719df191589b700394aee0091": {
+            "prov:type": [
+                {
+                "$": "nidm_ExtentThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_PValueUncorrected:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Extent Threshold",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b479dc4f3908a8dd60cf9f33a5c34288": {
+            "prov:type": {
+                "$": "nidm_PeakDefinitionCriteria:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak Definition Criteria",
+                "type": "xsd:string"
+            },
+            "nidm_maxNumberOfPeaksPerCluster:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_minDistanceBetweenPeaks:": {
+                "$": "8",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0e2a9f5b87827358154ae143f1e5c8cb": {
+            "prov:type": {
+                "$": "nidm_ClusterDefinitionCriteria:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Cluster Connectivity Criterion: 18",
+                "type": "xsd:string"
+            },
+            "nidm_hasConnectivityCriterion:": {
+                "$": "nidm_voxel18connected:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a251b2ee9dd7a651ce291377b22b331c": {
+            "prov:type": {
+                "$": "nidm_SearchSpaceMaskMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "SearchSpaceMask.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "SearchSpaceMask.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Search Space Mask Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:21f24d2b86fec337fe05741e4da7e8c3",
+                "type": "xsd:string"
+            },
+            "nidm_searchVolumeInVoxels:": {
+                "$": "223057",
+                "type": "xsd:int"
+            },
+            "nidm_searchVolumeInUnits:": {
+                "$": "1784456",
+                "type": "xsd:float"
+            },
+            "nidm_reselSizeInVoxels:": {
+                "$": "65.5786964036542",
+                "type": "xsd:float"
+            },
+            "nidm_searchVolumeInResels:": {
+                "$": "3155.84193266257",
+                "type": "xsd:float"
+            },
+            "spm_searchVolumeReselsGeometry:": {
+                "$": "[6, 97.8140592306853, 965.938819261507, 3155.84193266257]",
+                "type": "xsd:string"
+            },
+            "nidm_noiseFWHMInVoxels:": {
+                "$": "[4.09118640605185, 4.0346308705955, 3.97291894351243]",
+                "type": "xsd:string"
+            },
+            "nidm_noiseFWHMInUnits:": {
+                "$": "[8.18237281210369, 8.069261741191, 7.94583788702486]",
+                "type": "xsd:string"
+            },
+            "nidm_randomFieldStationarity:": {
+                "$": "true",
+                "type": "xsd:boolean"
+            },
+            "nidm_expectedNumberOfVoxelsPerCluster:": {
+                "$": "4.48720741199687",
+                "type": "xsd:float"
+            },
+            "nidm_expectedNumberOfClusters:": {
+                "$": "53.4877161971437",
+                "type": "xsd:float"
+            },
+            "nidm_heightCriticalThresholdFWE05:": {
+                "$": "3.40927969090373",
+                "type": "xsd:float"
+            },
+            "nidm_heightCriticalThresholdFDR05:": {
+                "$": "3.13529944419861",
+                "type": "xsd:float"
+            },
+            "crypto:sha512": {
+                "$": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8523ea1215430db79b6d67ec562629a2": {
+            "prov:type": {
+                "$": "nidm_ExcursionSetMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ExcursionSet.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ExcursionSet.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Excursion Set Map",
+                "type": "xsd:string"
+            },
+            "nidm_numberOfSupraThresholdClusters:": {
+                "$": "134",
+                "type": "xsd:int"
+            },
+            "nidm_pValue:": {
+                "$": "0",
+                "type": "xsd:float"
+            },
+            "nidm_hasClusterLabelsMap:": {
+                "$": "niiri:af09603d1be9b472972dc427857a08f5",
+                "type": "xsd:string"
+            },
+            "nidm_hasMaximumIntensityProjection:": {
+                "$": "niiri:c51837890dc0834460dea9471719a9de",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:21f24d2b86fec337fe05741e4da7e8c3",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "cf57cbfbb81ca96369b3e2527d0e6705441089b119d0cc15f3355ae7c3de2b6c17c3185f6664cd5c9a9f7bb25112d87c762671c4061a04dacad4674fe7e19086",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:af09603d1be9b472972dc427857a08f5": {
+            "prov:type": {
+                "$": "nidm_ClusterLabelsMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ClusterLabels.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ClusterLabels.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Cluster Labels Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:21f24d2b86fec337fe05741e4da7e8c3",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "33456d0efb388a323fb05180352e48d0ded234d80fb937b966c0a2109eb1117bb43213ec4702cf2796847b35ad2eb181cac47b0d81190b774e1fb76e8f404828",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c51837890dc0834460dea9471719a9de": {
+            "prov:type": {
+                "$": "dctype:Image",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "MaximumIntensityProjection.png",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "MaximumIntensityProjection.png",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/png",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:212a130c85dc60414b3a3ae20326ccc1": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0001",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "569",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "8.67659821259109",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.59059333148921e-14",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "2.9902746945254e-12",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "1",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:b6f31947ea1d789fff0bd7ebbd8d5aa3": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0002",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "72",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.0979175242646",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000456822125239121",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0241382695122647",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "2",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:171c8ac1a84198593464a36bac244ff0": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0003",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4084",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "62.2763217930088",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.88095587224324e-50",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "3",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:7174a23494a5602d1cf5b80e0b3957b3": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0004",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "127",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.93660452196673",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.32942985629811e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.000710828909921357",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "4",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:2cd32bc92eb7dd286253f06b6c4516f9": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0005",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "243",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "3.70547164439303",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.05092156231224e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1.63186693513673e-06",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "5",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:6438830b93a9866c5a8c4cb39850d977": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0006",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "71",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.08266866976093",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000490622471602205",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0259009393395414",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "6",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:58fb2509f9d4dbc78a02bfcd61bb139b": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0007",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "159",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "2.42456786608433",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.16558815218048e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.000115825656174406",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "7",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:2657e564e7bba015b389e0943b63badb": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0008",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "106",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.61637857738955",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.75592881772267e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00254060489524977",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "8",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:a8bb66759e4caade20c1a9e56f9516ec": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0009",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "99",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.50963659586383",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.40805683281378e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00395456046436182",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "9",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:7f817d4ab9fea049a6960806e46dae6f": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0010",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "190",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "2.89728235569826",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.18195857892405e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "2.23680911922708e-05",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "10",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:a088090c906271f3f2487f7339f0082c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0011",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "38",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.579456471139651",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00658479944411763",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.296864657161",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "11",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:5cb5cd73033206c0daaf4927462a1873": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0012",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "59",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.899682415716827",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0011885055655797",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0615919923617647",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "12",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f4def9a581b3c307c2f4fb9e2e226d0e": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0013",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "62",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.945428979227852",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000947699277992949",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0494269540893172",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "13",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:dfdffb6b309c9dbdb7e869a40c441373": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0014",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "10",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.15248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.127107912598347",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.998884789335864",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "14",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:51dff688583f66b2d156042da2e15fbc": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0015",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "32",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.487963344117601",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0113417541818962",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.454822870496334",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "15",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:e56f07808adb058d01196164f0775b64": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0016",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "28",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.426967926102901",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0166100165318646",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.588699772362037",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "16",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:14930f43331616f26135da44caf5ca49": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0017",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "34",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.518461053124951",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00942859389252268",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.396080250089626",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "17",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:d6ab9aad7ae91e9a945d6044d0e1d6cd": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0018",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "38",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.579456471139651",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00658479944411763",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.296864657161",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "18",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:950bb8c15f6d86506fdad52c1ea79861": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0019",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "13",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.198235108547775",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0856930391599127",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.989781188153603",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "19",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f4783b6466e014e6e52055bae529f918": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0020",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "33",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.503212198621276",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0103362007698988",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.424697778316067",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "20",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:e493acb406e5cff7f2b3bdae4a6c7854": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0021",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "8",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.1219908360294",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.169043835402863",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999881638693591",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "21",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:0337643db0192f78f5b32cbf7ed520a4": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0022",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "71",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.08266866976093",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000490622471602205",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0259009393395414",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "22",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:1a04d969a09af1e47b83e8c89999ecc0": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0023",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "46",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.701447307169051",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00332827413277407",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.163075806793513",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "23",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:cad3a1438e0a5950942cd5ed7b22e997": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0024",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "13",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.198235108547775",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0856930391599127",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.989781188153603",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "24",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:aa48c521a0de3bccee7d00f6ba89c3cf": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0025",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0609954180147001",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.32633981091806",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999973738745",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "25",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:666175487bab3267d4af86f55ff4bd3b": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0026",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "10",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.15248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.127107912598347",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.998884789335864",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "26",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:6951754ac73a67bbeeec0a4f76595341": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0027",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "8",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.1219908360294",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.169043835402863",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999881638693591",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "27",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:92c69844c448bad6dc16185f863b358e": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0028",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "25",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.381221362591876",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0223806036413691",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.697927243750861",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "28",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:177bfa600d85757ea0c4626517c44033": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0029",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "41",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.625203034650676",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00507211415165039",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.237609053919574",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "29",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:746b0b97599bb9118ebd954e679a2576": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0030",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "8",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.1219908360294",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.169043835402863",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999881638693591",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "30",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:54c365a30f25bdcc066a52c171908849": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0031",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "8",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.1219908360294",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.169043835402863",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999881638693591",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "31",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:b9e88b2bbae3b722fa155ba8e9501a86": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0032",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "17",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.259230526562475",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0529640912194042",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.941159699711307",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "32",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:6b8826bcc0a021bc10b09d6a6d4302fd": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0033",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "9",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.137239690533075",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.146196434998771",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999598263205668",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "33",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:cc1d6ba65b10195363d6da601013d7a1": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0034",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "15",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.228732817555125",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0670091344004676",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.972240178220986",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "34",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:82933f30610ef29a453f4b374990b32f": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0035",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "5",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0762442725183751",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.272686785534213",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999536932681",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "35",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:14f8555b74f38f3e8db5c662f1a8015c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0036",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "12",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.1829862540441",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0973627773701174",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.994525819003439",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "36",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:8c06ba2c370d4dda4947f0cbe66ca91e": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0037",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "10",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.15248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.127107912598347",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.998884789335864",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "37",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:337d987921a53a135ec5d7ccac93719b": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0038",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "31",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.472714489613926",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0124572388764659",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.486399348250455",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "38",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:8b64f56916b41aba13f0c3626eccb6c6": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0039",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "33",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.503212198621276",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0103362007698988",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.424697778316067",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "39",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:7167233a4e5f287b27d1ea49b05f5e73": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0040",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "29",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.442216780606576",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.015074614560243",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.553495904109026",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "40",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:9bcff3c8230d1d562436a59af916d435": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0041",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "59",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.899682415716827",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0011885055655797",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0615919923617647",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "41",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:1f551e5f86fc52cb27432b3822b69ca7": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0042",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "15",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.228732817555125",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0670091344004676",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.972240178220986",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "42",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:222cf8fd43a488444ee6a32847bc1d9a": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0043",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "12",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.1829862540441",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0973627773701174",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.994525819003439",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "43",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:944e97172e0a25bb481c848ff69da03e": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0044",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "11",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.167737399540425",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.111020787763232",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.997363356013822",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "44",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f16d0ba2c74c51bb5e78d2245c00a45f": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0045",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "5",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0762442725183751",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.272686785534213",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999536932681",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "45",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:209a4a28e55d93fc75c92925f0f7d71b": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0046",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "33",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.503212198621276",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0103362007698988",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.424697778316067",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "46",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:357268aff375a1c533059d48c5f8dcb0": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0047",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "13",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.198235108547775",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0856930391599127",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.989781188153603",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "47",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:0a39de1cb252a793d03ed45aa12d8950": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0048",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "7",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.106741981525725",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.196676917108917",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999973003386476",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "48",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:2ce7fa7ad1d0a7052668df06aeeb62b3": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0049",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "24",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.365972508088201",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0247841432800404",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.734369018761218",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "49",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:837c632e63a40a2ac1469c8d1ba1b864": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0050",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.49389125238231",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999996633",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "50",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:47f25a919baaf59e7867aa98557a23e4": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0051",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "6",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0914931270220502",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.230530023375576",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999995585095987",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "51",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:82870fabf2e7a1a9a595fb88debeb7ef": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0052",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "5",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0762442725183751",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.272686785534213",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999536932681",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "52",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:54fe9c7a58c48364f79822c24b7f0a36": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0053",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "20",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0378410014811752",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.867877895229885",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "53",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:9f649ce7c963c614e6fb0b5f0f441d80": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0054",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "9",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.137239690533075",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.146196434998771",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999598263205668",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "54",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:aa6b7754ff9629fdf69c2b137c4af89e": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0055",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "20",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0378410014811752",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.867877895229885",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "55",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:992eba93ccac4ef864d1e4c888fef260": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0056",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "26",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.396470217095551",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0202374895099589",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.661237868692417",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "56",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:2913f23a1813eb7942fb6b12aea56fda": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0057",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "15",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.228732817555125",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0670091344004676",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.972240178220986",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "57",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:1c4944ab6edec9e1dbd0763deb0ea5f5": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0058",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "17",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.259230526562475",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0529640912194042",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.941159699711307",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "58",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:807decf567867596e9ede288b13f016a": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0059",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "31",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.472714489613926",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0124572388764659",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.486399348250455",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "59",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:106990f64fdbe0a92e78b55484d984e7": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0060",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "5",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0762442725183751",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.272686785534213",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999536932681",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "60",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:9a89982690b205094ce375806ee327d2": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0061",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "7",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.106741981525725",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.196676917108917",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999973003386476",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "61",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:86396384ac8248dc2499f53d12283a2f": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0062",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "23",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.350723653584526",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0274850060586512",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.770099852065948",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "62",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:2ead289cc63835350630bfc68f2d003d": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0063",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "6",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0914931270220502",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.230530023375576",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999995585095987",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "63",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:0ff3515dad74fb4659ac475f78bb2c0d": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0064",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0609954180147001",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.32633981091806",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999973738745",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "64",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:e28eff3b2e060f982dbfeec40075736b": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0065",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0457465635110251",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.396774248526764",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999393034",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "65",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:5621f89640fa5a0a90c32a936e6e0a8d": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0066",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "8",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.1219908360294",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.169043835402863",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999881638693591",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "66",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f6474f5545e9725192cc8b6256e5bfb0": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0067",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "6",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0914931270220502",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.230530023375576",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999995585095987",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "67",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:2f15ad69e6c9c21540fd55e8e1488dca": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0068",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "6",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0914931270220502",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.230530023375576",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999995585095987",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "68",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:42ca52d223a11cd4060ba3459f14c1ab": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0069",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "14",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.21348396305145",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0756664557235371",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.982529227014855",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "69",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:29b8562f8375bc52056233a05357c8ba": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0070",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "7",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.106741981525725",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.196676917108917",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999973003386476",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "70",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:39feea9bf256b35cba29d53ba142d102": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0071",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "7",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.106741981525725",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.196676917108917",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999973003386476",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "71",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:aeed349c1d870c766c3846139baddfcf": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0072",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "5",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0762442725183751",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.272686785534213",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999536932681",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "72",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:fb34b9243fbfd4d52f33195ad11fa75e": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0073",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "7",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.106741981525725",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.196676917108917",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999973003386476",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "73",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:ae4e3431e53d6bb86cb5f49df3e1dd3c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0074",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0457465635110251",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.396774248526764",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999393034",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "74",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:3ae2d61c89fb13f4e75319093956440c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0075",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0609954180147001",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.32633981091806",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999973738745",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "75",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:b9c3425be7ea99b14efce8bce592b25b": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0076",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "5",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0762442725183751",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.272686785534213",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999536932681",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "76",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:53c378a2e0ca3196fa50b2b2030c0fcc": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0077",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "7",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.106741981525725",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.196676917108917",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999973003386476",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "77",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:43e5c93bebd29ba8da99711ae8d9c3e1": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0078",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.49389125238231",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999996633",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "78",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:7fd1e3a607dbe6cfba8a4e086242d6b7": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0079",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0457465635110251",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.396774248526764",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999393034",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "79",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:d2c986d4849a217bf93ccf9e1e40ff7d": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0080",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "8",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.1219908360294",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.169043835402863",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999881638693591",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "80",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:bac839d7d5a8f71351fbf0af9d7d237d": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0081",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0457465635110251",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.396774248526764",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999393034",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "81",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:950ebb223c0553663a2925b4cebca2f2": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0082",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "10",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.15248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.127107912598347",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.998884789335864",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "82",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:9a52ab95dd907c0f7f51fb102fd28f70": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0083",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "10",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.15248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.127107912598347",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.998884789335864",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "83",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f6d437c16c83f9a147b1bb4222d3abc6": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0084",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0457465635110251",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.396774248526764",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999393034",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "84",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:8837f9a734738e041b5341b9172fb036": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0085",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0457465635110251",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.396774248526764",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999393034",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "85",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:8b57160e5bbb28c42ed70eb49e48b412": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0086",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "7",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.106741981525725",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.196676917108917",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999973003386476",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "86",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c45c033aff250585c0df5bd7ebfa55c2": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0087",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "6",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0914931270220502",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.230530023375576",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999995585095987",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "87",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:95162bceebb39a10b64eb05d8de3fd22": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0088",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "11",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.167737399540425",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.111020787763232",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.997363356013822",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "88",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:3ed2c390b2b8ba7d7280d7aaf1f7a0e5": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0089",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0457465635110251",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.396774248526764",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999393034",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "89",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:a7eac8bb5c994b37b60795763e4a8b47": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0090",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.49389125238231",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999996633",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "90",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:df913e2209fc5cbf0b94dbb97361067d": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0091",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "6",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0914931270220502",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.230530023375576",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999995585095987",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "91",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:20e5d869565077dcc873c4847e343626": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0092",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "5",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0762442725183751",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.272686785534213",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999536932681",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "92",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:b53c18c408c426d6208825bc03bda76c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0093",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "8",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.1219908360294",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.169043835402863",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999881638693591",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "93",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:5040d4f96058237b55074ccbae780c73": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0094",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.641209332153058",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999999",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "94",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:dc90ccd75e3ef3f441e343a64ffc8a53": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0095",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "7",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.106741981525725",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.196676917108917",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999973003386476",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "95",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:92eaf289a4d8a69bb8c61dcf57734f87": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0096",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.49389125238231",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999996633",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "96",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c40c3a11ae575e327a69951e39f7cf1e": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0097",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0609954180147001",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.32633981091806",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999973738745",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "97",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:004221f4a994d829f5e16e54483a92e9": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0098",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "21",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.320225944577176",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0339584497531345",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.837383388101696",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "98",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:996665a23456cb618780744372406eba": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0099",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0609954180147001",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.32633981091806",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999973738745",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "99",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:09c11fea29165ff889d59486cc998f06": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0100",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0457465635110251",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.396774248526764",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999393034",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "100",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:10c4f42b041516447c28674dab2cde5b": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0101",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.641209332153058",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999999",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "101",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c39f3e559dae9a5d556ae9b5045842da": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0102",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.641209332153058",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999999",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "102",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:231b63a3acf5fa6923ad638c6827b93e": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0103",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.49389125238231",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999996633",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "103",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:7a2a292e9fd06f3e19425b30b04888ad": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0104",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0457465635110251",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.396774248526764",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999393034",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "104",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f7777aa15969e9f0700b324454e85979": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0105",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.641209332153058",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999999",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "105",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:8005738cdc3c09b780e2ba1a36547702": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0106",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0457465635110251",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.396774248526764",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999393034",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "106",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:bd14daedcd6c35f47c42f6681a25a48e": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0107",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.641209332153058",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999999",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "107",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:30ebc4167834c5d88670b4e8b93ee950": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0108",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0457465635110251",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.396774248526764",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999393034",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "108",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:5d3db32c6d2773404bb204393a96f250": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0109",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.49389125238231",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999996633",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "109",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:6d6e5cd089cb7ce9b9715c42e896cd46": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0110",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.641209332153058",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999999",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "110",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:189cb4ae2ff1cc4b031011345ea5e5b0": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0111",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0457465635110251",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.396774248526764",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999393034",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "111",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:697f2d7f340407941e5a743646226280": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0112",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.49389125238231",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999996633",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "112",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:15af37e0e71211cb9816e08cc4cd0b88": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0113",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.641209332153058",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999999",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "113",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:3fb8aaff3e01f2366b6d14baa9559ec9": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0114",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.641209332153058",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999999",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "114",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:557d4e957f05b5913d7a77c829b15561": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0115",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.641209332153058",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999999",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "115",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:73719d062893a763bcb9efcf192d5c98": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0116",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.641209332153058",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999999",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "116",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:254124ed2b4a8c1c5be4de8f4c74580d": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0117",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.49389125238231",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999996633",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "117",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:a0c4e98f01e68139790391bbf8725466": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0118",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.49389125238231",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999996633",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "118",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:98295b38fd8a93e7e4ee1dfd88c76887": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0119",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.641209332153058",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999999",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "119",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:33a90732b73cfec988bd66955a0c2126": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0120",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.641209332153058",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999999",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "120",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:ec3bd6715d891de0f42ba2dc11f9430c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0121",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.641209332153058",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999999",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "121",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:8aa002c426d46d7b9d4dc5e2c38279d3": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0122",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.641209332153058",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999999",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "122",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:5d895214e17bb9af3199b1f47611a048": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0123",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.641209332153058",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999999",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "123",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:781f6f173dae32b1495eaef04f1b405a": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0124",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.641209332153058",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999999",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "124",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:d98430357b786f52e1aba172bbfea688": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0125",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0457465635110251",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.396774248526764",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999393034",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "125",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:fe57af8773140946a4555792ccdee632": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0126",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.641209332153058",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999999",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "126",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:678cf59b6ed563cbae258da7bd9a2417": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0127",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.641209332153058",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999999",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "127",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:fb40247362abead8bfd05d8c0f86fcc6": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0128",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.641209332153058",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999999",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "128",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f0413bd7869f1537bac196460adb50ad": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0129",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.641209332153058",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999999",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "129",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:fd3eca9e0c356a0d39da224ef34ff7aa": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0130",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.641209332153058",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999999",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "130",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:b2244e3b33c0159757aa93c2de26c3a1": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0131",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.641209332153058",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999999",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "131",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:8b70b13ee54cf4407e3be646e313b866": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0132",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.641209332153058",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999999",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "132",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:cfc211e4c6c91ecd22c4f0f2f0075044": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0133",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.641209332153058",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999999",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "133",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f00195d4acadb18083e5d9b4023ca225": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0134",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.641209332153058",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999999",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "134",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f2c008500acb79baf9b5ce05210f9bb9": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0001",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:83ef927efc7de9ab53de628e0e4eba1b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.61011266708374",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "6.51265120547007",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.69179131709529e-11",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "8.23475922277556e-06",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000129439334006007",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:83ef927efc7de9ab53de628e0e4eba1b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0001",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-46,-66,-8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1fa4a48ba4a927736beae3c9f786d502": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0002",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:36d111a494f38a79183bc43c5d3c8dc6",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.14067697525024",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.94920489177576",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.3472408744164e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.000300511459932193",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0016296513076278",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:36d111a494f38a79183bc43c5d3c8dc6": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0002",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-34,-72,-16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6a83a6584dca6366715d149902302674": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0003",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:553889dbf2e240f257cb6fc52f945311",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.39726591110229",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.03216968185068",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.42479864742684e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0540868376963655",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0144418464851922",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:553889dbf2e240f257cb6fc52f945311": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0003",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-40,-48,-14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:32f1a2c6ca2ddb9829b059ddbe234078": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0004",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6028c33dcc61afb7c773a2c95eb048c1",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.07992362976074",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.87535600284606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.10967798786044e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.000470578397640152",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0016296513076278",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6028c33dcc61afb7c773a2c95eb048c1": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0004",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[34,-86,10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b514d16779b8ecd93200134e45991536": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0005",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:1230bad84e8f2bfea468396bc431e6ec",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.95166039466858",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.47003158157261",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.91040240832474e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.497269375153304",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0815933520961271",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:1230bad84e8f2bfea468396bc431e6ec": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0005",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[42,-86,12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:23faf3bc0650966493e9f36e0ca600b8": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0006",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c7f4a3b9045d9f445d2145b126d0e4fd",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.85145282745361",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.34253727556279",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.04232894899182e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.676230493527593",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.107852519413958",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c7f4a3b9045d9f445d2145b126d0e4fd": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0006",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[38,-84,2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8779cf8885e2bb57f1eb0502089c61a7": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0007",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:96fce76485c81a95e0c5588233442fcc",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.96536254882812",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.73554616923849",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.85993045806765e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00108404146331869",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00195763806925102",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:96fce76485c81a95e0c5588233442fcc": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0007",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[8,6,-4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f617e967f1244bd4a0ee551172e05935": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0008",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:119da361d8cff441d6a0ef67380f70b3",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.76170587539673",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.4852660945335",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.06423748094764e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00460442620206421",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0037086909867648",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:119da361d8cff441d6a0ef67380f70b3": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0008",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[20,16,6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:09a006cc070777c7bc9ff02587a9475f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0009",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:5829801409b541d6efa67494d24ec16a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.67560243606567",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.3788042778508",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.74910847922294e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00836264901674123",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00496133762447783",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:5829801409b541d6efa67494d24ec16a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0009",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-32,24,2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ec49a9f4a91ebfee81f8ba5ab02662d0": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0010",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:613b7228e65741491fdbfb7f9b4fbb1e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.89568662643433",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.65016589891917",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.01465316335737e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00178772445204086",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00218637116402122",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:613b7228e65741491fdbfb7f9b4fbb1e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0010",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[36,-76,-14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d7db9d99f9156bfd0c9e6482f6b282d1": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0011",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6e6dfcb4a088e040e68b43aa9dae945a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.36620903015137",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.99326640019021",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.9683290059257e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0662106660868522",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0150086130881337",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6e6dfcb4a088e040e68b43aa9dae945a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0011",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[26,-78,-12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b1965951f77cadf6336644280d9e0eb2": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0012",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b0bcc363e13905c0cec9abc9a5f926cd",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.82210826873779",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.30513434912561",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.34422125894907e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.727285909061263",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.11336333992572",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b0bcc363e13905c0cec9abc9a5f926cd": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0012",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[44,-70,-14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:95c8fcf40d4086295dd49408d12a5369": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0013",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6858d0c8f88e8fe9c91135874f2b7ea0",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.87710690498352",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.62735471926077",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "9.14970854637431e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00204090649550025",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00218637116402122",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6858d0c8f88e8fe9c91135874f2b7ea0": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0013",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[38,-64,52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6a44a9a24517109ec3074ac91077f376": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0014",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:beea954b53ac5e2e78c8261689528de9",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.83855104446411",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.32609620488621",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.58875776796231e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.698927552906607",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.107852519413958",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:beea954b53ac5e2e78c8261689528de9": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0014",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[46,-58,44]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:75efdb8848f89afcfba1a207d71a6086": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0015",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:9c9662a0587b95df451773773737bc67",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.7466766834259",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.2088532772211",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.28334991591483e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.843938187211889",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.138131675608108",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:9c9662a0587b95df451773773737bc67": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0015",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[36,-56,38]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7f82efbbcbb2b7ca685a4c40df6d517f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0016",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:9991f49a01ab3c078e441bc6d0aafc88",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.65790581703186",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.35687718443792",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.23363166746071e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00944341194070347",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00515918806035713",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:9991f49a01ab3c078e441bc6d0aafc88": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0016",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[52,-46,-12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3957970d9b8be40cdba7d77e9fc1af08": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0017",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4e6a4d59eabe77a5d46c722f954d7dc8",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.61188387870789",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.29978067068531",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.79709378278892e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0129308238104803",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00597334524948961",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4e6a4d59eabe77a5d46c722f954d7dc8": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0017",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-44,4,34]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ebbf36d0c0f06a153cfcf5a4d5d87c41": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0018",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:1b7890a36a01ed5e0fdb9f9a5a6e12e4",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.4259147644043",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.06801755102317",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.0099017394859e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0448322696793468",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.013317352840512",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:1b7890a36a01ed5e0fdb9f9a5a6e12e4": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0018",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-32,-4,56]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:31ec0b3be00fd80d126fc2af1ce352dd": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0019",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f40c694ee792eefb7eec37d13ca8cb2a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.66663575172424",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.10648471595799",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.00863015121788e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.931784139682597",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.179785700482736",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f40c694ee792eefb7eec37d13ca8cb2a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0019",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-32,-4,46]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2c6257c20ce92f4d4b1e41e803eef7b2": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0020",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c005427742dbeae90aefba064639c45c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.37134194374084",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.72719680893962",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "9.68106320935469e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999922876108057",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.368886365441825",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c005427742dbeae90aefba064639c45c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0020",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-30,4,50]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:108d6134cb55a8d7a0a3b38e0911631f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0021",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d7fdf8001a1fc850f4cddb011811e7a0",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.41093230247498",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.04927492203708",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.21745057982226e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0494617928204381",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0139107162783319",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d7fdf8001a1fc850f4cddb011811e7a0": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0021",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[36,-56,-16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f3b0431eda7e1bbfb898867a9c5f20db": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0022",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:9e301d0fec3b6d6b3f6b0358a11f4b0c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.56456685066223",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.97565696467545",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.50926166180487e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.98538798365609",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.231754253732683",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:9e301d0fec3b6d6b3f6b0358a11f4b0c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0022",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[22,-64,-18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6914d04832f348c47b11f7e72bf95b91": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0023",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ab7b2f582e75105be0c5b2aaec2daa19",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.23492169380188",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.82833550427561",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.88394970027595e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.144038846632802",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0248776371912962",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ab7b2f582e75105be0c5b2aaec2daa19": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0023",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[42,12,26]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:bedd2a1fe4cc40fb4348c1e3f84fe4ce": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0024",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:2c68c2c5f82c2c4469180668066cc07d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.61081290245056",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.03497166916066",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.73044431503555e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.9682181756112",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.211273225680016",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:2c68c2c5f82c2c4469180668066cc07d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0024",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[42,16,38]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:489fe008583f9540151b81533b9acb5e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0025",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:87fc4ec7f9fd634eb08dad6106d9ce4c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.52718925476074",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.92767211706964",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.288601775293e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.993030331302132",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.253783543711115",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:87fc4ec7f9fd634eb08dad6106d9ce4c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0025",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[34,8,26]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a5a33f4d819b8eb7632b4b1e5316ae25": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0026",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6c61922e9036d2efdfaea284d524d0c0",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.19025158882141",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.77204817208862",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "9.11809358350446e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.179866253319972",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0295002808813131",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6c61922e9036d2efdfaea284d524d0c0": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0026",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-54,-32,42]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3dbba6caca10b3238c9bd1b6e4ac3ff1": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0027",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7b6a8a30f2afb4cffe0e6d51e5acbab6",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.01900839805603",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.55550961951652",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.61293619352454e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.38653459603819",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0625267026051373",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7b6a8a30f2afb4cffe0e6d51e5acbab6": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0027",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-40,46,26]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6edb5d4ccd344696f8f8a3ed75c82f37": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0028",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:44d61d9d7c7c707923228503bfa247b4",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.89200973510742",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.39418165104258",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.55954066971953e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.603469212296398",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0986382553356101",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:44d61d9d7c7c707923228503bfa247b4": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0028",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-16,-66,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4021174e55dc807e3de6628bf8eb04e4": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0029",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f83aa6697a4e460e152625e9ddb5dc97",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.35510396957397",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.7062743430358",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000105165232115123",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999959028289625",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.368886365441825",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f83aa6697a4e460e152625e9ddb5dc97": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0029",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-28,-56,52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0ae175b8baba9cf71436e5d6fd22e350": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0030",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:3b217402d63aa3747829c99e4b9d2316",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.8795006275177",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.3782590505152",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.98155518916066e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.626033894289313",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.101663811457838",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3b217402d63aa3747829c99e4b9d2316": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0030",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[24,-80,52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5678d8d6c35ed00e4d4e18d18efb6ece": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0031",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e4c5369a0d51a9a3ff7813c71f43d5a7",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.87628078460693",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.37415966779458",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.09505679249889e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.631833416620066",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.101663811457838",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e4c5369a0d51a9a3ff7813c71f43d5a7": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0031",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[54,-26,-6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:42466a1a262537fe1909213e41f7608f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0032",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:2322f7716f2993b1fd0d53ab1bfae19c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.84026718139648",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.32828345765019",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.51379916874573e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.695928446009514",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.107852519413958",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:2322f7716f2993b1fd0d53ab1bfae19c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0032",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[48,-30,42]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f9b9bbd2555a0f9eff6c0d4a46615477": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0033",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:946da552af58194fc6edde9153721a83",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.78784370422363",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.26142274674112",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.01564786331165e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.783507209855174",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.124104049442798",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:946da552af58194fc6edde9153721a83": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0033",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[38,32,50]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5d8297107655c470b20029a7607b59d6": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0034",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:eb06915f3583668239f7287af4563b3a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.75120162963867",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.21463429501137",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.2509162441221e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.837748139540634",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.137791224379057",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:eb06915f3583668239f7287af4563b3a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0034",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[18,-58,32]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8a6ddd866c065982183951ef56d075a5": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0035",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7670ea31408ac573f533b63db34e12c8",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.30655765533447",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.64368706323795",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000134380079716223",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999995072124642",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.411522109968619",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7670ea31408ac573f533b63db34e12c8": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0035",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[20,-68,32]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ebeb5e8cbd97a7c980eb6e8048e3aa7d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0036",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c8066704e7c4e7181a0ae455141068fa",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.7451183795929",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.20686225088754",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.2947043287137e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.846041948741843",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.138131675608108",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c8066704e7c4e7181a0ae455141068fa": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0036",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-14,-96,0]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f0a3195f5086136d59542c82017b3a01": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0037",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a7dea9a67fc3b6b8b46c2229ae066f85",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.71638298034668",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.17013318145876",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.52210841696254e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.88214338657563",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.152011884720848",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a7dea9a67fc3b6b8b46c2229ae066f85": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0037",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-32,-72,58]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e93ed6c3aa25b233cb79929e574105d9": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0038",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:831b8e76702d7b18f1caa06765d78f13",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.08894777297974",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.36255760699966",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000386120057750849",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999998331",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.636831894546098",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:831b8e76702d7b18f1caa06765d78f13": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0038",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-20,-74,58]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e515516c5ff1d233ae675e7803ccd1db": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0039",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:71a18ae0067f3eb6f488e73a8eed631d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.68441557884216",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.12924185142476",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.81980698354955e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.915958567777936",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.169764205739198",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:71a18ae0067f3eb6f488e73a8eed631d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0039",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-48,-42,8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b165c84e39ed0a56c6fcfe2cf6485d45": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0040",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c59aa6c2583c6162213161db59c0cdfa",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.66335368156433",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.10228278327608",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.04546926624305e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.934473772130028",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.180381705425717",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c59aa6c2583c6162213161db59c0cdfa": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0040",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[48,-52,-24]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ff9ae21e91aa2853a4df2c66190d9a69": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0041",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d006be9910c4fdf007dcb927133b1b34",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.27386736869812",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.60151277214208",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000158185438331238",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999040177611",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.418270156640619",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d006be9910c4fdf007dcb927133b1b34": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0041",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[44,-44,-28]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:07dafc52bdbe3bac0a138605d2cfa21e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0042",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:5424fb677782b73cf78964d910cc0921",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.64867973327637",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.08349211971756",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.21819671972767e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.945632017925947",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.1898401047323",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:5424fb677782b73cf78964d910cc0921": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0042",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-50,-58,52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8bbb069d9a8a8deae00856c0bac1dca3": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0043",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:8959c9a0a8c3ec7c7ef746684cae1e87",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.64205074310303",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.07500123020084",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.30070519045e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.950216866218648",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.1898401047323",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:8959c9a0a8c3ec7c7ef746684cae1e87": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0043",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-16,-62,32]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:83820e300b8ac064252e16de139eccae": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0044",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b6d09fc20724d7c85a681cd22742edf4",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.03684568405151",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.29512938083033",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000491881875043121",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999991",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.71408368346076",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b6d09fc20724d7c85a681cd22742edf4": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0044",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-24,-60,36]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:96dad918bf5b91086582f2216b436cf1": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0045",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d9c26099c0e501b5aea3bea542119b22",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.62229943275452",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.0496944261574",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.56422773555753e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.962265585786802",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.205120702581303",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d9c26099c0e501b5aea3bea542119b22": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0045",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-42,-86,16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b36997cc891aca5718ab9e08f9f432be": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0046",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0ef0527a41b5e316ed802defc1b39a56",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.59810495376587",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.01867880935315",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.92626931942541e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.97396448920475",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.21596866367834",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0ef0527a41b5e316ed802defc1b39a56": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0046",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[50,12,-12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:25c1c6fe5473de8cd328924f02807315": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0047",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:36a4bb29de9bb248d7239d223f1f865c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.58033466339111",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.99588757924215",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.22261580589789e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.98064397547503",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.22269791282493",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:36a4bb29de9bb248d7239d223f1f865c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0047",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[10,56,-20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:289a61918b6511cb6b776c8ac53da1fb": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0048",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:5207732da4f07346337949bb54bf30d8",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.57430815696716",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.98815622046766",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.32944052300332e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.982580167470916",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.22642798795628",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:5207732da4f07346337949bb54bf30d8": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0048",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-58,-46,-2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5b892640561d323072506be428e65c2c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0049",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d240e37d1a3ccee80381d4a0ccec305b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.56071877479553",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.97071867739396",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.58280756852514e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.986393731480231",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.23304271385756",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d240e37d1a3ccee80381d4a0ccec305b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0049",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[46,-40,2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:70699d653df50cd6d5e59c21dedb8323": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0050",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:81dca2f2f612f00b789df6e3ebb1af42",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.54513788223267",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.95071921672779",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.89583464949217e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.989920329912446",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.240658196026741",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:81dca2f2f612f00b789df6e3ebb1af42": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0050",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[48,14,52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:201264c80972dcebd2c7ea04534507f6": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0051",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a7b889f37c8fdd43f35c04b78cc226b2",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.51254177093506",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.90885728034341",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.63668626720093e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.994942233722668",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.267046680534214",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a7b889f37c8fdd43f35c04b78cc226b2": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0051",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-52,-44,56]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b44f502f04b58f2cf2d267fb394a2207": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0052",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:87c7b6e56ec1bbda155c55cec46b9a8c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.50266766548157",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.89617059063353",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.88627843049372e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.995967498491102",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.267780274176525",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:87c7b6e56ec1bbda155c55cec46b9a8c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0052",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-12,36,-18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1f6b053553d3aeb85e957aa471ba1b95": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0053",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:57a35110569fb6d0b6a603c14633ce79",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1.89663207530975",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.11350866317858",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000924385411494866",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.962543829897604",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:57a35110569fb6d0b6a603c14633ce79": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0053",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-6,48,-16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6ba4d4daf1fd511897ca0be0927d8a89": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0054",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:944364ab4b3104947bddc393f78f4442",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.47411036491394",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.85946417006895",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.68179580313632e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.998007647418056",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.292256519682192",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:944364ab4b3104947bddc393f78f4442": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0054",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-20,-94,24]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:74e91aadd62ca24aff8ec843f5b9cf73": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0055",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b56f1032a996acfee4bdb230b29e91d6",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.47011852264404",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.85433149398881",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.80231377617091e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.998205767610089",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.293636732712391",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b56f1032a996acfee4bdb230b29e91d6": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0055",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-12,18,42]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:20009017f6e554d7929aee14c3cb2b0a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0056",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4098b8dc55187d1b591a67c566c304d1",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.46635222434998",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.8494884380349",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.91823851514572e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.998376942414084",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.294187599254207",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4098b8dc55187d1b591a67c566c304d1": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0056",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[48,-76,0]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:50726c9e381e8c0cadcb5c25bfce42c4": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0057",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:eac87d7000647e4f1c4c33f0fccd4ba6",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.44098949432373",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.81686512377712",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.75790026252177e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999204444055832",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.321048096330285",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:eac87d7000647e4f1c4c33f0fccd4ba6": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0057",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-52,24,18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f65e0cae04132c7a84d5a8f11123339a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0058",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c7f2ef37f7f022ac15cc88574f9d27c7",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.43735671043396",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.81219103522413",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.88701755224841e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999285679399569",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.321708874973631",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c7f2ef37f7f022ac15cc88574f9d27c7": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0058",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-26,-74,24]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f7a1eeb8810d3507d311591e2f7997ab": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0059",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:841e0f6ceb12de956b666f63bb8438ca",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.43673038482666",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.81138514524412",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.90951304638254e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999298924132454",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.321708874973631",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:841e0f6ceb12de956b666f63bb8438ca": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0059",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[12,50,-10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1f1e980431dd78b887d46d0d999586d6": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0060",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0b3bc38c6284016e53a9355a01069eb7",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.43038630485535",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.8032216915074",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.14132165696713e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999421405677481",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.325210886758063",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0b3bc38c6284016e53a9355a01069eb7": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0060",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-42,-38,44]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:dac1b7a25e803b8443975ee1030a9b0e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0061",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:fdfbbbc1a393300697b91e0c5b685119",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.40943622589111",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.77625633974215",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.96015746719059e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999702913851826",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.343869281784496",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:fdfbbbc1a393300697b91e0c5b685119": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0061",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[0,10,34]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d5b79c346d3f077001fa066fa2d1a90d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0062",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:15a6f00994c97e4acbaee735fb13fdc7",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.40475845336914",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.77023398434736",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.15472821792396e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999745792273193",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.347513578737157",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:15a6f00994c97e4acbaee735fb13fdc7": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0062",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[44,-42,18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:199023e997d45cf3233e578d536f4c5c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0063",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0d56a8634361bb98f6349ca40ded5b4d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.40324783325195",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.76828903590742",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.21851578610699e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999758407620262",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.347513578737157",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0d56a8634361bb98f6349ca40ded5b4d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0063",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[58,-60,20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:cc258c6487aa920075b8a9d74a761b48": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0064",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:3c7c457d319c1fc2fa269d1baabb4067",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.39750051498413",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.76088876011273",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.46553582728449e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999801447697793",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.353141402062803",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3c7c457d319c1fc2fa269d1baabb4067": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0064",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[18,56,30]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:64b4dccdedec0a80f2fe74dd14cc1002": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0065",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:5a441cb24733925f0b14a28f79922340",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.39031767845154",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.75163897818956",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.78411611173746e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999845514728957",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.360940928701093",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:5a441cb24733925f0b14a28f79922340": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0065",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-34,20,-34]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d3b936a394a469d3174e0f8343bd463f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0066",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d2aa8e04105ae05392733434b72a496a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.38168978691101",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.74052666970635",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "9.18175293811441e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999886700884216",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.36651035415338",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d2aa8e04105ae05392733434b72a496a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0066",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[22,0,0]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f51500ecaf58b3d1cd1042a40b408879": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0067",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:936515ba136a6b86b620bbefc5690e0e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.37978529930115",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.73807354189968",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "9.27178550079732e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999894332475117",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.36651035415338",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:936515ba136a6b86b620bbefc5690e0e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0067",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-48,-44,-34]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4ff8360d7fc12f9cfc4bcd4dfe7c00dd": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0068",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e0facfeceef20219293cb21eee4ddb30",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.37950778007507",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.73771606840228",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "9.28497425036756e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999895404897798",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.36651035415338",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e0facfeceef20219293cb21eee4ddb30": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0068",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-62,-22,46]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:73e236d5a6d25c17dd9cded1da30b954": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0069",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:5e77ae62f461f7d159dbf41101989ed2",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.12179732322693",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.40504947037839",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000330760343973724",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999968743",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.587708479280999",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:5e77ae62f461f7d159dbf41101989ed2": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0069",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-62,-32,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e9e3416cc410461e50330f128b2e5ef5": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0070",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:5c701d285e118964f4e84c6e7d6537c1",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.36615061759949",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.72050850696656",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "9.94110221242961e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999936749755425",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.368886365441825",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:5c701d285e118964f4e84c6e7d6537c1": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0070",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[28,18,-20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:680d3d98098fe3304954deff21a29e7b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0071",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:2b83a17bd863606f8500314b2def6d23",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.35984563827515",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.71238457004225",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000102657853048083",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999950532037692",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.368886365441825",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:2b83a17bd863606f8500314b2def6d23": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0071",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[4,-4,-14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:47943ba3e02dcae014366323aa4ab25f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0072",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f09814cccec0ffd89a77db71136e90a2",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.24515843391418",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.56445653816859",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000182305428946816",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999804294694",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.444734823272248",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f09814cccec0ffd89a77db71136e90a2": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0072",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-6,-6,-14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d2e4b7191441a73d13865ac94f555793": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0073",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:9b72a267f0038b95d676e5cc83318080",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.33331298828125",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.67818733586012",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000117448705507006",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999983460313748",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.391344305962907",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:9b72a267f0038b95d676e5cc83318080": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0073",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-20,-88,-10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8cf5f9af5ca1975fc1c28c8c1557d889": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0074",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:537726e1a04c94675e66e07efbc28e13",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.33159112930298",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.67596752451816",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000118474833320836",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999984649789011",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.391580012304676",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:537726e1a04c94675e66e07efbc28e13": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0074",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-10,-84,-10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:45eef5c14e0789f2e938b481f651929c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0075",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:46c9e214eec026cee9cbc592615480de",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.32321286201477",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.66516536058509",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000123589411157754",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999989391962664",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.39972936309914",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:46c9e214eec026cee9cbc592615480de": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0075",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[30,20,-38]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:788812e3c1a5e8e9dc131a6099bb1cc2": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0076",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:332da0b388b9ea6a8859b4b2d788ad6f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.3199303150177",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.66093272184923",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000125649373061587",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999990848449071",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.402380964108359",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:332da0b388b9ea6a8859b4b2d788ad6f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0076",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-32,-74,-34]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3e2507719bb8e8cec2153c1d7c6d11f9": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0077",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ae757bdf540f21b90dc47b8794c934d9",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.31843018531799",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.65899831919211",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00012660150034427",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999991450468149",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.402380964108359",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ae757bdf540f21b90dc47b8794c934d9": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0077",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[64,-48,34]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a5458865e5677ec6fc83283980aaada6": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0078",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0dcf4ce843f00cd9033a7e2afd199a20",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.31528902053833",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.65494765701128",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00012861722720714",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999992594228668",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.404908421693631",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0dcf4ce843f00cd9033a7e2afd199a20": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0078",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-12,-12,2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0bad50db6253e7c03b817887ef216040": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0079",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4389f2b6c2b6084518dcf9c6e3e274ec",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.30988264083862",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.64797539896827",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000132157469679206",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999994237019437",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.41105817784359",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4389f2b6c2b6084518dcf9c6e3e274ec": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0079",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-48,-44,20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a6b4a34fb40ee0a15bffe18d35ac9f31": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0080",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c56830dc76f0cf45f60a678fce7533c9",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.30309462547302",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.63922043208072",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000136732321226352",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999582138664",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.412454685345903",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c56830dc76f0cf45f60a678fce7533c9": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0080",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-52,-52,20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:78892fc1529eb6f3ae71eda0c5cb75dc": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0081",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f399f79c516833e75e018feb17e33afb",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.30742883682251",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.64481067597732",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000133794356756312",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999994864920274",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.411522109968619",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f399f79c516833e75e018feb17e33afb": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0081",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-8,-4,68]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d2d93102aaafa6fbf39c89330edf7d36": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0082",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:54139976336939af57421f288b0e9dab",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.30296897888184",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.63905836767043",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000136818389668947",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999995846467612",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.412454685345903",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:54139976336939af57421f288b0e9dab": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0082",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[24,36,34]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f9d5a38c2897f37b953727849193451c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0083",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:50e5e469d6707c527eb94fd063197ff7",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.30046772956848",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.63583207709644",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000138542396657115",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999631754215",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.413429132458979",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:50e5e469d6707c527eb94fd063197ff7": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0083",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[46,-42,46]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e69b435cb561850d5bb26d896306c312": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0084",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f81bff3e58fea6964d48c247d09b95ed",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.14905881881714",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.44029990384982",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000290534960819211",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999971054",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.554694102883098",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f81bff3e58fea6964d48c247d09b95ed": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0084",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[42,-48,38]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6f25ec29f560c0501f2c9be49ad80287": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0085",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d5f0e8cf4ef0c2d23df21b39a0a7ce72",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.29290223121643",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.62607273627958",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000143882164975628",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999997457251428",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.416670883231346",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d5f0e8cf4ef0c2d23df21b39a0a7ce72": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0085",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[8,-54,72]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1c087be2a968de7ac0a2bea646c020cb": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0086",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e7806e0fcab4c0eb3a7f57e5ee03788b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.28387594223022",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.61442740814864",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000150506069076406",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999998385622597",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.418270156640619",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e7806e0fcab4c0eb3a7f57e5ee03788b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0086",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-50,-40,30]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:fb0dd18eb34c8e74b938fd5ddf517ce5": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0087",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:aa3855fba367b0ad316c27d8b09af4d1",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.27538919448853",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.60347660612369",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000156994509713848",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999998960052528",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.418270156640619",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:aa3855fba367b0ad316c27d8b09af4d1": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0087",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[40,-2,-10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2f736c7d40b35980222068c405413bae": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0088",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:53e1ecfd3011d4d05f60ec3d43f5cdf3",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.27404403686523",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.60174075534084",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000158046749744623",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999031182047",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.418270156640619",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:53e1ecfd3011d4d05f60ec3d43f5cdf3": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0088",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-42,-22,70]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7980b5dd38316b9b2ecbc76101c2a0b5": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0089",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:8b38f2871372df699f2f367c731b12a3",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.27214431762695",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.59928920970321",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000159544081014595",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999123899245",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.418270156640619",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:8b38f2871372df699f2f367c731b12a3": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0089",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-40,-86,28]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b05ecaea88de142b8ca1773ff4972f5e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0090",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f22fe5774a94e8360abdcf02dd02e53d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.27202653884888",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.59913721633081",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000159637349828712",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999129364364",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.418270156640619",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f22fe5774a94e8360abdcf02dd02e53d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0090",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[32,58,22]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:47d4cfe6ec57e882523a5f15411848d2": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0091",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:5495296622af4ad50502b8b2f7e08245",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.27080631256104",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.59756249884937",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000160606663523355",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999184134104",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.418270156640619",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:5495296622af4ad50502b8b2f7e08245": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0091",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[44,-62,-36]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4dc1e5e65b8110f5c3d324caa9587124": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0092",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:08507e5bd6094aa94b8ccf63d7df9415",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.25528573989868",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.57753033271362",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000173427989261232",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999651142222",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.432415839107375",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:08507e5bd6094aa94b8ccf63d7df9415": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0092",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-56,-34,-18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8c3105cb051b8d67f47a2e2e97720b1f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0093",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:5fa31ed28407d8ef344d786db87d0ab2",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.24145913124084",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.55968043051933",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00018565317676611",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999842303019",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.448708397422201",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:5fa31ed28407d8ef344d786db87d0ab2": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0093",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[42,16,6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:cbd485923e06556ee8d61eae7a353bc3": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0094",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:13e7354b0f59c7b5993f11f6d72cdacc",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.2288510799408",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.54340035775212",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000197501273445089",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999925925981",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.461177773590418",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:13e7354b0f59c7b5993f11f6d72cdacc": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0094",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[14,58,10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:18b3136cd14e6ff7733c13a8bdaa6346": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0095",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:39d7636932e3d3377734bf37ba671d26",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.22417545318604",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.53736219289604",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000202072513955764",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999944466357",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.466991649207176",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:39d7636932e3d3377734bf37ba671d26": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0095",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[20,36,56]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f83fcb8aadbc17649f8866d0a02e98f2": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0096",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:823ebff49a536adfb982018013149f69",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.21693515777588",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.5280111500348",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000209347259857662",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999996475463",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.474122401075389",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:823ebff49a536adfb982018013149f69": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0096",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-46,-16,-26]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6ac9a02ed616ed9c5160a35845282afa": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0097",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:dbf3fb337eb7a2ddb7d78423e621f1bd",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.21399617195129",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.52421508195077",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000212369663955547",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999970782305",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.474122401075389",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:dbf3fb337eb7a2ddb7d78423e621f1bd": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0097",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-36,-48,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a3bf33e6499e7a0a31c9702c6d60fc3c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0098",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:5cb10b840a952460027010421de8c620",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.21233320236206",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.5220670758195",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000214097893396659",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999973744615",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.474122401075389",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:5cb10b840a952460027010421de8c620": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0098",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[64,-48,22]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0de985ab54c7b41ae1d397bc56243722": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0099",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:2448323ca81528a1cd5e1421cfb4745c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.19926238059998",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.50518208844769",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000228147544614088",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999988890482",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.490541911210553",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:2448323ca81528a1cd5e1421cfb4745c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0099",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-62,-16,30]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:dafae508abe6b629f3a5b25e99e2b8a6": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0100",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0f59e5f95827337c606de13c426760b3",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.17726922035217",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.47676404129424",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000253752120226602",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999997591668",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.522483308971289",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0f59e5f95827337c606de13c426760b3": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0100",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[60,16,4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9f241776c24bfec38480e757272c95ef": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0101",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:475f99b85d7b3507277fe4cc199d02da",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.17222547531128",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.47024563153578",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000259991300800011",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999998329023",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.528007569567315",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:475f99b85d7b3507277fe4cc199d02da": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0101",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-38,16,16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:64e9f022bd6687a619e8398b70936591": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0102",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ab9a9062532d2e24f71d5f942396e83c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.17077469825745",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.46837060004652",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000261812316486365",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999998497371",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.528007569567315",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ab9a9062532d2e24f71d5f942396e83c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0102",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[30,8,54]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f39083490c271135692376a9b6145545": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0103",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:fc43ea1ac52f1f092d78f8698757e2c9",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.16687154769897",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.46332585702272",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000266770915118508",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999998873444",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.532041442688517",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:fc43ea1ac52f1f092d78f8698757e2c9": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0103",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[4,-74,40]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5fb2a670883af294357a4ab2154ab6b1": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0104",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:063b2c2ce28d037a1a6851fbbcbb9e62",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.16552972793579",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.46159152037966",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000268495752957176",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999998980469",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.532232376423935",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:063b2c2ce28d037a1a6851fbbcbb9e62": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0104",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-18,-94,4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ee341bb063e9247becec364805165eb3": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0105",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:3caf76e9df39a2dd7c3751565762561b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.15602898597717",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.44931067015382",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000281009846776592",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999503037",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.54825725843418",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3caf76e9df39a2dd7c3751565762561b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0105",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[32,46,18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:db4b88ce7955c87529d9cdcac1067e5c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0106",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:32da5de8e2d1066fafe66482f6376ce8",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.1544976234436",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.44733105425233",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000283077187230862",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999558251",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.548832170867961",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:32da5de8e2d1066fafe66482f6376ce8": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0106",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-6,34,-4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6ab66734fa9b63bf93c3eb233efd164e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0107",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:439a96c6b9c8da3c658cd86b4f5faa7c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.14432787895203",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.43418345508983",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000297170899168919",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999800735",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.559218724487036",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:439a96c6b9c8da3c658cd86b4f5faa7c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0107",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[26,12,-28]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7a920cc103779299492bdd1b7abf0d4c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0108",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:62a9547c589c74225214f116b688bb4f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.13841390609741",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.42653698017951",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000305665256597809",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999875989",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.566169265576836",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:62a9547c589c74225214f116b688bb4f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0108",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[62,8,26]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0091960b7df9e3b2ee0b995c7a9fee2e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0109",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:dd731654874737e36a1145e73ec3c503",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.13535809516907",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.42258573937654",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00031014265931506",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999903261",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.56744192975625",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:dd731654874737e36a1145e73ec3c503": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0109",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[46,-14,-28]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:be68a46819185a1181faf0074de880e1": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0110",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4f894d57ccb0687917202eb233a2d0b4",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.10883116722107",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.38827937085858",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000351662935259678",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999989834",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.612415661510894",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4f894d57ccb0687917202eb233a2d0b4": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0110",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[36,-74,-26]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9c1ebb72f8df3bd670dd7093690f96e7": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0111",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f54e09b1927d965f6e9d8e3ab8911024",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.09861969947815",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.3750702611999",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000368984236825298",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999995928",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.628845185882367",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f54e09b1927d965f6e9d8e3ab8911024": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0111",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-46,-62,-30]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:13a5abfae24999f832ff63e132d71526": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0112",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:45414be04daca1ed9416e031c998e67c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.0976128578186",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.37376776772589",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000370734464924194",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999996285",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.628845185882367",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:45414be04daca1ed9416e031c998e67c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0112",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[48,2,46]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0db89c6238aa0a65c9a6789ba0981b57": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0113",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:16e32bd5f320f75cf3ad9cfb6feb184b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.09218430519104",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.36674489388815",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000380305072376852",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999997744",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.636831894546098",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:16e32bd5f320f75cf3ad9cfb6feb184b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0113",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-8,6,56]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3cef58b75474f5f62c6e5f17b7eb47a4": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0114",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:9c0c51b01429787a73fcf756db784b5f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.09025764465332",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.36425228187917",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000383756749400832",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999998114",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.636831894546098",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:9c0c51b01429787a73fcf756db784b5f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0114",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[34,4,38]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7f48dee052c9626e7e52439acf0f2384": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0115",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a1e1bf42329e82bb1986471311192a86",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.08849263191223",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.36196875235771",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000386944402984701",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999998401",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.636831894546098",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a1e1bf42329e82bb1986471311192a86": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0115",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[46,36,38]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4d3efcbf06221edd111b9ececccbf578": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0116",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:5a4dc409a4f82fe2fbd2adb378f0236f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.08788776397705",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.36118617856085",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000388042466764382",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999998489",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.636831894546098",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:5a4dc409a4f82fe2fbd2adb378f0236f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0116",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-54,6,42]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:559d842aee52f555e32eaea8e5f6af4d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0117",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:342a55c31a6fd1e19f7882456cd37086",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.08684039115906",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.35983108220205",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000389950706039088",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999999863",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.636831894546098",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:342a55c31a6fd1e19f7882456cd37086": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0117",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-34,-40,-40]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9bfa3d4282d5fe49d0a5d7837246515a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0118",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:167f928519ef5a6d9da97ba177d7a184",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.08542251586914",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.35799660180066",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000392547891568396",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999998802",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.637367081876291",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:167f928519ef5a6d9da97ba177d7a184": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0118",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-4,8,62]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ed129b762540244ebbab654eba8430b6": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0119",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0b74a6907723aa376792f985e57be958",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.07837462425232",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.34887743272549",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000405698407881738",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999388",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.647755183120289",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0b74a6907723aa376792f985e57be958": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0119",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-66,-48,8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:aa361f26f45828a6bf37d7fa0ef9e035": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0120",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e7a563685357fbfa9c1ec890f67b4177",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.07339262962341",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.34243086058129",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000415240207444101",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999623",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.656030294621312",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e7a563685357fbfa9c1ec890f67b4177": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0120",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[8,8,58]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:50115084698b0f76f38b7c1104d53bc9": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0121",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:36a59a6bca96123bd24e4f7fb86b1265",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.07233357429504",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.34106042406055",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000417295287676644",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999999966",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.656030294621312",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:36a59a6bca96123bd24e4f7fb86b1265": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0121",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[28,2,42]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:371a172468bf76afe6aadb917ee05964": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0122",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:1fdf380fc216afd4e474f786711ae4a3",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.07037234306335",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.33852251317794",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000421126024625074",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999999972",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.656638431383812",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:1fdf380fc216afd4e474f786711ae4a3": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0122",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-26,-62,38]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:dbaab492fac4e6b9eab8dcfc58c98506": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0123",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:bf121c922c17087120c57855bde78999",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.06974482536316",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.33771046876864",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000422358600173256",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999736",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.656638431383812",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:bf121c922c17087120c57855bde78999": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0123",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-26,42,32]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ffed331acd64084a30d48b98739e86bc": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0124",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:922a9bfb72c5e23ead8d55c367f66e58",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.03006720542908",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.28635424154638",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000507466425831105",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999996",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.719385736915496",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:922a9bfb72c5e23ead8d55c367f66e58": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0124",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-24,52,30]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3d0a016a27aa65b6bbbd681333dcc446": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0125",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f67405bdcbba3036ce596ecbe71d55f6",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.06143498420715",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.32695652276829",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000439000355666241",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999885",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.670181351155627",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f67405bdcbba3036ce596ecbe71d55f6": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0125",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[18,38,14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:86b63b6d4bdec0c181ff785f7344f2f7": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0126",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:55bcafcdb10ff4c30819df223c6bb9f9",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.05234718322754",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.31519469431882",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000457896584486805",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999955",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.688415587572674",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:55bcafcdb10ff4c30819df223c6bb9f9": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0126",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[24,22,-26]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e8710216ba3ec832f617a9e1b98c0bf3": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0127",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:503f728df63ec6878c21347bf151b385",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.04952502250671",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.31154189928606",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000463916722561963",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999966",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.689628882399469",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:503f728df63ec6878c21347bf151b385": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0127",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[62,-42,26]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6c4a7be328ce49c5e98564e34076236c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0128",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:2802bfbc4d5696139c24254736b2ec6e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.04026675224304",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.29955792608204",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000484186200885861",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999987",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.708672597818405",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:2802bfbc4d5696139c24254736b2ec6e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0128",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[54,28,-8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b8b143f3a3bab02055f06c8fa221c1c4": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0129",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7074580d5d21e58a02ca62c86ceee8a4",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.03539657592773",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.2932534755313",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000495175737833864",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999992",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.714810085213215",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7074580d5d21e58a02ca62c86ceee8a4": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0129",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[26,18,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:bbb810096180dab5916a19ea19eb4d52": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0130",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:dc3f0897a248b50a8c972c3fe31b0be6",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.03219079971313",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.28910342358113",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000502535420826677",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999995",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.717697062544172",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:dc3f0897a248b50a8c972c3fe31b0be6": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0130",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[56,4,-36]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5ad6239481925bf6bc3a6ffbd30cf7e6": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0131",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0f51826584cb999e63e872c756b90d6c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.0319082736969",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.28873767184649",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000503188874995342",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999995",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.717697062544172",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0f51826584cb999e63e872c756b90d6c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0131",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[14,-92,24]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:29763b527003432a0c2b21c172ec4a81": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0132",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b5b1c2b39a254a42755330020659e9d8",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.02607893943787",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.2811909187824",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000516848742881382",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999997",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.724198294562932",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b5b1c2b39a254a42755330020659e9d8": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0132",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[12,56,0]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b10c8559c8983dbf10bcbbd87ba3a30b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0133",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f883d32b205932078c22794402ab6d7d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.01380300521851",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.26529688051921",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000546747002303394",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999999",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.745134331831463",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f883d32b205932078c22794402ab6d7d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0133",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[62,32,-12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b4e1b1ca0ed3d9d8f28f683410396141": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0134",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:fb5f8c42764e6c71abadc95704e8f2c2",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.00120663642883",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.24898603700399",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000579085815334945",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.768049313732932",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:fb5f8c42764e6c71abadc95704e8f2c2": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0134",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[38,-74,26]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2c97f5daab495771999c9c6ed9658dae": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0135",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:2aa43c399b59790e4dfbf04b8fbd8f94",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1.99859607219696",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.24560542001545",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000586005808283274",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.771799008009002",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:2aa43c399b59790e4dfbf04b8fbd8f94": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0135",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-12,-96,24]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f1ee6434b4e9e350b5883b0db78d72fc": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0136",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:baca96ed8f0f9063a0508601dbbfaec3",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1.99211156368256",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.2372077945609",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000603527423333361",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.784349992009541",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:baca96ed8f0f9063a0508601dbbfaec3": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0136",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-30,-56,-20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:08fdef8ced896bffb0a9f513bb82f661": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0137",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:55b8ab77a10b3e815abd7fdaf9da8c21",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1.97817039489746",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.21915195379217",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00064285166979039",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.812778132844403",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:55b8ab77a10b3e815abd7fdaf9da8c21": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0137",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-32,-6,-6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:33e039efa523781d074f8709e436c6c1": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0138",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:8c6f1b0f1ca84fc63bf1d797146a2970",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1.96776080131531",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.20566861907462",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000673745357239186",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.83480060265404",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:8c6f1b0f1ca84fc63bf1d797146a2970": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0138",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[60,-46,44]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7d85e08ff8a27a219706a4be288209f2": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0139",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:df69c761e2c334ab7f7bc845d48eff42",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1.96240246295929",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.19872762272311",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000690177580666695",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.842166706625736",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:df69c761e2c334ab7f7bc845d48eff42": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0139",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-52,12,-8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1952a27691fae0a16a11d4d1da1b6ab0": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0140",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4a129fd0910d8fcc9ed909a91502fe25",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1.96232461929321",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.19862678466389",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00069041900707012",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.842166706625736",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4a129fd0910d8fcc9ed909a91502fe25": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0140",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-14,2,46]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:28fc29227a7d0e7b676cba34c11619a0": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0141",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:5844e4e8f06aabbaf3dc89083886f1be",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1.96151995658875",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.19758442738721",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000692919185722674",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.842166706625736",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:5844e4e8f06aabbaf3dc89083886f1be": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0141",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[34,-60,-32]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4969976c6b8f566ff774a986d7a36a79": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0142",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:146d39b6994eeae0540ab9b27e8c09be",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1.95875000953674",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.19399619652422",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000701589830133797",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.843663873798835",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:146d39b6994eeae0540ab9b27e8c09be": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0142",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[12,-10,8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9601c3a9c37cd454e282dd247386189b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0143",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:8ba20ce09c34b99a2b6902f97564b1d0",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1.9506379365921",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.1834872473508",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000727562614758925",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.859623644795425",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:8ba20ce09c34b99a2b6902f97564b1d0": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0143",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[44,42,-18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4fe52494e0e2ce9d3cab8ce7ef9c43a2": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0144",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:1ffc820e35aa9baee7e0c3ed0d901ab2",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1.94860780239105",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.18085716601903",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00073420004030933",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.86202414328266",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:1ffc820e35aa9baee7e0c3ed0d901ab2": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0144",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[18,56,2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6a53d2070def16165db38789830277ca": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0145",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:95aae888c2d85975406eda8841e11c3f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1.94670081138611",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.1783865823579",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000740485731772766",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.86202414328266",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:95aae888c2d85975406eda8841e11c3f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0145",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[50,24,40]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:78ecf12590514c80a21b976921614adc": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0146",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:dca356aa3b54948ba75d86da6cafa306",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1.93218469619751",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.1595792273601",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0007899856837843",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.892323800210792",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:dca356aa3b54948ba75d86da6cafa306": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0146",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-26,-90,28]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2cc54cd7893515b53af0b26c486419e8": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0147",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:55ddd3faba6b02c3055057f36f9a40ba",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1.9286732673645",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.15502945825559",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000802409503939616",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.899089242384032",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:55ddd3faba6b02c3055057f36f9a40ba": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0147",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-54,-12,44]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:383e2e40e4478c46a885723e580540e9": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0148",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:cfd86c6efe2ad2bbacea8ddaa77f7b0f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1.9261577129364",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.15176997808161",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000811420301080279",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.903090399433177",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:cfd86c6efe2ad2bbacea8ddaa77f7b0f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0148",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-48,-38,-12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d6f790d81f1079150604aaa16ea4f5c7": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0149",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a57f977529bc658a16c9ca211d898787",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1.92179548740387",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.14611757652157",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00082726738760952",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.909690617648608",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a57f977529bc658a16c9ca211d898787": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0149",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[64,-36,16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:61c1675e82feee3a2ba070ebd84e8f84": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0150",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:01c04a79b15ce0c1fb943eeaf3cba959",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1.92164015769958",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.1459163032625",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000827836893399936",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.909690617648608",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:01c04a79b15ce0c1fb943eeaf3cba959": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0150",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[34,-22,68]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b21afe1ebc2946d76e1feed501da0a13": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0151",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7228805920f29320ea05f2cac92707d8",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1.91999924182892",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.14379002300768",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000833875309880328",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.911263261101385",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7228805920f29320ea05f2cac92707d8": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0151",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-8,-78,38]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2c07a6ac701630dbce313c1c9311af3a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0152",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4960f9500adb74ecfb4ca0a6db8f59ab",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1.91007256507874",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.13092665544988",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000871278372345574",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.936494724004281",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4960f9500adb74ecfb4ca0a6db8f59ab": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0152",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[2,-62,6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:491c487f7a368b1aa7a2a4d48952759c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0153",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6e76cea4d9ee60e95c20e1e738bf0ac3",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1.90749907493591",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.12759169376378",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000881224174023254",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.940790144374657",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6e76cea4d9ee60e95c20e1e738bf0ac3": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0153",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[50,26,-16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:fcca986bd2deab6ef39bb2525ae730c8": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0154",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:109a15fd9ceb50e814d71b953c67ae72",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1.90495073795319",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.12428927452869",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000891175681828393",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.945029582142648",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:109a15fd9ceb50e814d71b953c67ae72": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0154",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-34,-36,38]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:358a334c1617e7ce360e2f5605342b32": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0155",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a6038e05091afb020d82c47e5d7b134c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1.90267658233643",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.1213421258659",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000900143739462567",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.948488792214144",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a6038e05091afb020d82c47e5d7b134c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0155",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[14,-22,54]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0e6bfffafd9d245f4dd49561f6c28e08": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0156",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:37db3664c9849d417bb8a0681cc58067",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1.89570164680481",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.11230283620396",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000928169828270153",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.962543829897604",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:37db3664c9849d417bb8a0681cc58067": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0156",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[16,-8,36]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f45794d952959fc21a4f15a7662b0673": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0157",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:596817d06440ee2934239c14263f4174",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1.88845551013947",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.10291168362407",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000958134082593487",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.98075710938733",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:596817d06440ee2934239c14263f4174": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0157",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[52,24,-14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ec709d3ce148902d8c0bd7af6efd254a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0158",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:20a2d53484d9fe5f16ed0cf8192effdb",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1.88693702220917",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.10094364030331",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000964525016047491",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.982061324215166",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:20a2d53484d9fe5f16ed0cf8192effdb": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0158",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-32,-78,-6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:44179ac71aa6a866710bacec2f633862": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0159",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:9a7ff27b1b6b41cb81e8847242b24fed",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1.88384366035461",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.09693442242366",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000977665622006629",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.988067762617164",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:9a7ff27b1b6b41cb81e8847242b24fed": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0159",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-20,36,46]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:fdea430f757b7b55cda702759b054832": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0160",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:386e33278e20d303c4d3f45997d793bf",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1.88228130340576",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.09490947009333",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000984364888377609",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.989519036052045",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:386e33278e20d303c4d3f45997d793bf": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0160",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[42,24,-40]",
+                "type": "xsd:string"
+            }
+        }
+    },
+    "activity": {
+        "niiri:10b49e4617715cf283ca55ab051c7161": {
+            "prov:type": {
+                "$": "nidm_ModelParametersEstimation:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Model parameters estimation",
+                "type": "xsd:string"
+            },
+            "nidm_withEstimationMethod:": {
+                "$": "obo_generalizedleastsquaresestimation:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:dd06c607e32f76dc0e4ff497c11b759c": {
+            "prov:type": {
+                "$": "nidm_ContrastEstimation:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Contrast estimation 1",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b91cbbf6a4f5303474a88b3cbc77d086": {
+            "prov:type": {
+                "$": "nidm_ContrastEstimation:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Contrast estimation 2",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c134406116e621fbf4bcc19eb85f6dec": {
+            "prov:type": {
+                "$": "spm_PartialConjunctionInference:",
+                "type": "xsd:QName"
+            },
+            "nidm_hasAlternativeHypothesis:": {
+                "$": "nidm_OneTailedTest:",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Partial Conjunction Inference",
+                "type": "xsd:string"
+            },
+            "spm_partialConjunctionDegree:": {
+                "$": "2",
+                "type": "xsd:int"
+            }
+        }
+    },
+    "agent": {
+        "niiri:9d7bdfb1f005a1c77912a13aad1d7cca": {
+            "prov:type": [
+                {
+                "$": "src_SPM:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "prov:SoftwareAgent",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "SPM",
+                "type": "xsd:string"
+            },
+            "nidm_softwareVersion:": {
+                "$": "12.6906",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4dd802783f824c7aacfc4e4e4ee26461": {
+            "prov:type": [
+                {
+                "$": "nlx_Imaginginstrument:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nlx_Magneticresonanceimagingscanner:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "MRI Scanner",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:37dff96025f813fa2cae9c2f2ab20af0": {
+            "prov:type": {
+                "$": "prov:Person",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Person",
+                "type": "xsd:string"
+            }
+        }
+    },
+    "wasGeneratedBy": {
+        "_:wGB20": {
+            "prov:entity": "niiri:aba08deba6439b8fd82d98d160e5d070",
+            "prov:activity": "niiri:10b49e4617715cf283ca55ab051c7161"
+        },
+        "_:wGB22": {
+            "prov:entity": "niiri:4f4a4075f1bc1968a80b2f594b2a5ef9",
+            "prov:activity": "niiri:10b49e4617715cf283ca55ab051c7161"
+        },
+        "_:wGB26": {
+            "prov:entity": "niiri:a5c5180e35f868db315e52abaf2ab6cf",
+            "prov:activity": "niiri:10b49e4617715cf283ca55ab051c7161"
+        },
+        "_:wGB30": {
+            "prov:entity": "niiri:109842e828160f2f74424c94fa31d3ac",
+            "prov:activity": "niiri:10b49e4617715cf283ca55ab051c7161"
+        },
+        "_:wGB34": {
+            "prov:entity": "niiri:670abeebbed6d1e906338a6a7b6e100d",
+            "prov:activity": "niiri:10b49e4617715cf283ca55ab051c7161"
+        },
+        "_:wGB38": {
+            "prov:entity": "niiri:9d50bf99d1eb9b3e0c264b87fd74b224",
+            "prov:activity": "niiri:10b49e4617715cf283ca55ab051c7161"
+        },
+        "_:wGB42": {
+            "prov:entity": "niiri:bc8b436cc11302e4d61399ed8127ddce",
+            "prov:activity": "niiri:10b49e4617715cf283ca55ab051c7161"
+        },
+        "_:wGB56": {
+            "prov:entity": "niiri:ef836beafc2e291065c57b3a7e86dc80",
+            "prov:activity": "niiri:dd06c607e32f76dc0e4ff497c11b759c"
+        },
+        "_:wGB60": {
+            "prov:entity": "niiri:9d77bd5bfcea339e1308f2f57159142a",
+            "prov:activity": "niiri:dd06c607e32f76dc0e4ff497c11b759c"
+        },
+        "_:wGB62": {
+            "prov:entity": "niiri:2fcd23f1ed3c1835696b5f3f6c067474",
+            "prov:activity": "niiri:dd06c607e32f76dc0e4ff497c11b759c"
+        },
+        "_:wGB76": {
+            "prov:entity": "niiri:955daf8b5134c9320aad7d629101cc88",
+            "prov:activity": "niiri:b91cbbf6a4f5303474a88b3cbc77d086"
+        },
+        "_:wGB80": {
+            "prov:entity": "niiri:66ede7151e2d666315b2d79e13573a47",
+            "prov:activity": "niiri:b91cbbf6a4f5303474a88b3cbc77d086"
+        },
+        "_:wGB82": {
+            "prov:entity": "niiri:6b4d76daa5ef6289730f139f490051cd",
+            "prov:activity": "niiri:b91cbbf6a4f5303474a88b3cbc77d086"
+        },
+        "_:wGB102": {
+            "prov:entity": "niiri:a251b2ee9dd7a651ce291377b22b331c",
+            "prov:activity": "niiri:c134406116e621fbf4bcc19eb85f6dec"
+        },
+        "_:wGB106": {
+            "prov:entity": "niiri:8523ea1215430db79b6d67ec562629a2",
+            "prov:activity": "niiri:c134406116e621fbf4bcc19eb85f6dec"
+        }
+    },
+    "used": {
+        "_:u14": {
+            "prov:activity": "niiri:10b49e4617715cf283ca55ab051c7161",
+            "prov:entity": "niiri:59859d0ad01111bc8ee8288526aae37d"
+        },
+        "_:u15": {
+            "prov:activity": "niiri:10b49e4617715cf283ca55ab051c7161",
+            "prov:entity": "niiri:b0407acb83b2703b82444e30fcac401b"
+        },
+        "_:u16": {
+            "prov:activity": "niiri:10b49e4617715cf283ca55ab051c7161",
+            "prov:entity": "niiri:16eb1e414b6a4247bd1b7cfca669048c"
+        },
+        "_:u46": {
+            "prov:activity": "niiri:dd06c607e32f76dc0e4ff497c11b759c",
+            "prov:entity": "niiri:aba08deba6439b8fd82d98d160e5d070"
+        },
+        "_:u47": {
+            "prov:activity": "niiri:dd06c607e32f76dc0e4ff497c11b759c",
+            "prov:entity": "niiri:9d50bf99d1eb9b3e0c264b87fd74b224"
+        },
+        "_:u48": {
+            "prov:activity": "niiri:dd06c607e32f76dc0e4ff497c11b759c",
+            "prov:entity": "niiri:59859d0ad01111bc8ee8288526aae37d"
+        },
+        "_:u49": {
+            "prov:activity": "niiri:dd06c607e32f76dc0e4ff497c11b759c",
+            "prov:entity": "niiri:e12b3b920d0b0e8c6be817754a69ec93"
+        },
+        "_:u50": {
+            "prov:activity": "niiri:dd06c607e32f76dc0e4ff497c11b759c",
+            "prov:entity": "niiri:a5c5180e35f868db315e52abaf2ab6cf"
+        },
+        "_:u51": {
+            "prov:activity": "niiri:dd06c607e32f76dc0e4ff497c11b759c",
+            "prov:entity": "niiri:109842e828160f2f74424c94fa31d3ac"
+        },
+        "_:u52": {
+            "prov:activity": "niiri:dd06c607e32f76dc0e4ff497c11b759c",
+            "prov:entity": "niiri:670abeebbed6d1e906338a6a7b6e100d"
+        },
+        "_:u66": {
+            "prov:activity": "niiri:b91cbbf6a4f5303474a88b3cbc77d086",
+            "prov:entity": "niiri:aba08deba6439b8fd82d98d160e5d070"
+        },
+        "_:u67": {
+            "prov:activity": "niiri:b91cbbf6a4f5303474a88b3cbc77d086",
+            "prov:entity": "niiri:9d50bf99d1eb9b3e0c264b87fd74b224"
+        },
+        "_:u68": {
+            "prov:activity": "niiri:b91cbbf6a4f5303474a88b3cbc77d086",
+            "prov:entity": "niiri:59859d0ad01111bc8ee8288526aae37d"
+        },
+        "_:u69": {
+            "prov:activity": "niiri:b91cbbf6a4f5303474a88b3cbc77d086",
+            "prov:entity": "niiri:ba7f4a78f7bfc8dfe15e84f017dffc6f"
+        },
+        "_:u70": {
+            "prov:activity": "niiri:b91cbbf6a4f5303474a88b3cbc77d086",
+            "prov:entity": "niiri:a5c5180e35f868db315e52abaf2ab6cf"
+        },
+        "_:u71": {
+            "prov:activity": "niiri:b91cbbf6a4f5303474a88b3cbc77d086",
+            "prov:entity": "niiri:109842e828160f2f74424c94fa31d3ac"
+        },
+        "_:u72": {
+            "prov:activity": "niiri:b91cbbf6a4f5303474a88b3cbc77d086",
+            "prov:entity": "niiri:670abeebbed6d1e906338a6a7b6e100d"
+        },
+        "_:u93": {
+            "prov:activity": "niiri:c134406116e621fbf4bcc19eb85f6dec",
+            "prov:entity": "niiri:40130c07affd508ab9ba7401250e23da"
+        },
+        "_:u94": {
+            "prov:activity": "niiri:c134406116e621fbf4bcc19eb85f6dec",
+            "prov:entity": "niiri:559eaf01d0bac3504edd2c4d5066dd7b"
+        },
+        "_:u95": {
+            "prov:activity": "niiri:c134406116e621fbf4bcc19eb85f6dec",
+            "prov:entity": "niiri:ef836beafc2e291065c57b3a7e86dc80"
+        },
+        "_:u96": {
+            "prov:activity": "niiri:c134406116e621fbf4bcc19eb85f6dec",
+            "prov:entity": "niiri:955daf8b5134c9320aad7d629101cc88"
+        },
+        "_:u97": {
+            "prov:activity": "niiri:c134406116e621fbf4bcc19eb85f6dec",
+            "prov:entity": "niiri:bc8b436cc11302e4d61399ed8127ddce"
+        },
+        "_:u98": {
+            "prov:activity": "niiri:c134406116e621fbf4bcc19eb85f6dec",
+            "prov:entity": "niiri:aba08deba6439b8fd82d98d160e5d070"
+        },
+        "_:u99": {
+            "prov:activity": "niiri:c134406116e621fbf4bcc19eb85f6dec",
+            "prov:entity": "niiri:b479dc4f3908a8dd60cf9f33a5c34288"
+        },
+        "_:u100": {
+            "prov:activity": "niiri:c134406116e621fbf4bcc19eb85f6dec",
+            "prov:entity": "niiri:0e2a9f5b87827358154ae143f1e5c8cb"
+        }
+    },
+    "wasDerivedFrom": {
+        "_:wDF19": {
+            "prov:generatedEntity": "niiri:aba08deba6439b8fd82d98d160e5d070",
+            "prov:usedEntity": "niiri:b3f11481d93002948ba4265eb6fc7a17"
+        },
+        "_:wDF25": {
+            "prov:generatedEntity": "niiri:a5c5180e35f868db315e52abaf2ab6cf",
+            "prov:usedEntity": "niiri:5ff4045c3fb225d6d68fbb0c98b08a69"
+        },
+        "_:wDF29": {
+            "prov:generatedEntity": "niiri:109842e828160f2f74424c94fa31d3ac",
+            "prov:usedEntity": "niiri:9237a7292e50834f847b622ac8097d47"
+        },
+        "_:wDF33": {
+            "prov:generatedEntity": "niiri:670abeebbed6d1e906338a6a7b6e100d",
+            "prov:usedEntity": "niiri:e1ead41ef090189a9edc014566d7fa8a"
+        },
+        "_:wDF37": {
+            "prov:generatedEntity": "niiri:9d50bf99d1eb9b3e0c264b87fd74b224",
+            "prov:usedEntity": "niiri:0ecf4a4c4ca5a416fa2e7555c094ddb6"
+        },
+        "_:wDF41": {
+            "prov:generatedEntity": "niiri:bc8b436cc11302e4d61399ed8127ddce",
+            "prov:usedEntity": "niiri:4d7372ca3c6f7a39fc98bc6a82293781"
+        },
+        "_:wDF55": {
+            "prov:generatedEntity": "niiri:ef836beafc2e291065c57b3a7e86dc80",
+            "prov:usedEntity": "niiri:49749ebbcacba1baa8e79e02c1938189"
+        },
+        "_:wDF59": {
+            "prov:generatedEntity": "niiri:9d77bd5bfcea339e1308f2f57159142a",
+            "prov:usedEntity": "niiri:05afb3605ef5b9f0b252b00b89bc58c8"
+        },
+        "_:wDF75": {
+            "prov:generatedEntity": "niiri:955daf8b5134c9320aad7d629101cc88",
+            "prov:usedEntity": "niiri:de187bcb23967e7a4b132bd43bbb2d3c"
+        },
+        "_:wDF79": {
+            "prov:generatedEntity": "niiri:66ede7151e2d666315b2d79e13573a47",
+            "prov:usedEntity": "niiri:ceab125faff01ef71a425d244d8dd312"
+        },
+        "_:wDF108": {
+            "prov:generatedEntity": "niiri:212a130c85dc60414b3a3ae20326ccc1",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF110": {
+            "prov:generatedEntity": "niiri:b6f31947ea1d789fff0bd7ebbd8d5aa3",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF112": {
+            "prov:generatedEntity": "niiri:171c8ac1a84198593464a36bac244ff0",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF114": {
+            "prov:generatedEntity": "niiri:7174a23494a5602d1cf5b80e0b3957b3",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF116": {
+            "prov:generatedEntity": "niiri:2cd32bc92eb7dd286253f06b6c4516f9",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF118": {
+            "prov:generatedEntity": "niiri:6438830b93a9866c5a8c4cb39850d977",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF120": {
+            "prov:generatedEntity": "niiri:58fb2509f9d4dbc78a02bfcd61bb139b",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF122": {
+            "prov:generatedEntity": "niiri:2657e564e7bba015b389e0943b63badb",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF124": {
+            "prov:generatedEntity": "niiri:a8bb66759e4caade20c1a9e56f9516ec",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF126": {
+            "prov:generatedEntity": "niiri:7f817d4ab9fea049a6960806e46dae6f",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF128": {
+            "prov:generatedEntity": "niiri:a088090c906271f3f2487f7339f0082c",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF130": {
+            "prov:generatedEntity": "niiri:5cb5cd73033206c0daaf4927462a1873",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF132": {
+            "prov:generatedEntity": "niiri:f4def9a581b3c307c2f4fb9e2e226d0e",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF134": {
+            "prov:generatedEntity": "niiri:dfdffb6b309c9dbdb7e869a40c441373",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF136": {
+            "prov:generatedEntity": "niiri:51dff688583f66b2d156042da2e15fbc",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF138": {
+            "prov:generatedEntity": "niiri:e56f07808adb058d01196164f0775b64",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF140": {
+            "prov:generatedEntity": "niiri:14930f43331616f26135da44caf5ca49",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF142": {
+            "prov:generatedEntity": "niiri:d6ab9aad7ae91e9a945d6044d0e1d6cd",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF144": {
+            "prov:generatedEntity": "niiri:950bb8c15f6d86506fdad52c1ea79861",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF146": {
+            "prov:generatedEntity": "niiri:f4783b6466e014e6e52055bae529f918",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF148": {
+            "prov:generatedEntity": "niiri:e493acb406e5cff7f2b3bdae4a6c7854",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF150": {
+            "prov:generatedEntity": "niiri:0337643db0192f78f5b32cbf7ed520a4",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF152": {
+            "prov:generatedEntity": "niiri:1a04d969a09af1e47b83e8c89999ecc0",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF154": {
+            "prov:generatedEntity": "niiri:cad3a1438e0a5950942cd5ed7b22e997",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF156": {
+            "prov:generatedEntity": "niiri:aa48c521a0de3bccee7d00f6ba89c3cf",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF158": {
+            "prov:generatedEntity": "niiri:666175487bab3267d4af86f55ff4bd3b",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF160": {
+            "prov:generatedEntity": "niiri:6951754ac73a67bbeeec0a4f76595341",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF162": {
+            "prov:generatedEntity": "niiri:92c69844c448bad6dc16185f863b358e",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF164": {
+            "prov:generatedEntity": "niiri:177bfa600d85757ea0c4626517c44033",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF166": {
+            "prov:generatedEntity": "niiri:746b0b97599bb9118ebd954e679a2576",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF168": {
+            "prov:generatedEntity": "niiri:54c365a30f25bdcc066a52c171908849",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF170": {
+            "prov:generatedEntity": "niiri:b9e88b2bbae3b722fa155ba8e9501a86",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF172": {
+            "prov:generatedEntity": "niiri:6b8826bcc0a021bc10b09d6a6d4302fd",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF174": {
+            "prov:generatedEntity": "niiri:cc1d6ba65b10195363d6da601013d7a1",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF176": {
+            "prov:generatedEntity": "niiri:82933f30610ef29a453f4b374990b32f",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF178": {
+            "prov:generatedEntity": "niiri:14f8555b74f38f3e8db5c662f1a8015c",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF180": {
+            "prov:generatedEntity": "niiri:8c06ba2c370d4dda4947f0cbe66ca91e",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF182": {
+            "prov:generatedEntity": "niiri:337d987921a53a135ec5d7ccac93719b",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF184": {
+            "prov:generatedEntity": "niiri:8b64f56916b41aba13f0c3626eccb6c6",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF186": {
+            "prov:generatedEntity": "niiri:7167233a4e5f287b27d1ea49b05f5e73",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF188": {
+            "prov:generatedEntity": "niiri:9bcff3c8230d1d562436a59af916d435",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF190": {
+            "prov:generatedEntity": "niiri:1f551e5f86fc52cb27432b3822b69ca7",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF192": {
+            "prov:generatedEntity": "niiri:222cf8fd43a488444ee6a32847bc1d9a",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF194": {
+            "prov:generatedEntity": "niiri:944e97172e0a25bb481c848ff69da03e",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF196": {
+            "prov:generatedEntity": "niiri:f16d0ba2c74c51bb5e78d2245c00a45f",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF198": {
+            "prov:generatedEntity": "niiri:209a4a28e55d93fc75c92925f0f7d71b",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF200": {
+            "prov:generatedEntity": "niiri:357268aff375a1c533059d48c5f8dcb0",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF202": {
+            "prov:generatedEntity": "niiri:0a39de1cb252a793d03ed45aa12d8950",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF204": {
+            "prov:generatedEntity": "niiri:2ce7fa7ad1d0a7052668df06aeeb62b3",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF206": {
+            "prov:generatedEntity": "niiri:837c632e63a40a2ac1469c8d1ba1b864",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF208": {
+            "prov:generatedEntity": "niiri:47f25a919baaf59e7867aa98557a23e4",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF210": {
+            "prov:generatedEntity": "niiri:82870fabf2e7a1a9a595fb88debeb7ef",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF212": {
+            "prov:generatedEntity": "niiri:54fe9c7a58c48364f79822c24b7f0a36",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF214": {
+            "prov:generatedEntity": "niiri:9f649ce7c963c614e6fb0b5f0f441d80",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF216": {
+            "prov:generatedEntity": "niiri:aa6b7754ff9629fdf69c2b137c4af89e",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF218": {
+            "prov:generatedEntity": "niiri:992eba93ccac4ef864d1e4c888fef260",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF220": {
+            "prov:generatedEntity": "niiri:2913f23a1813eb7942fb6b12aea56fda",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF222": {
+            "prov:generatedEntity": "niiri:1c4944ab6edec9e1dbd0763deb0ea5f5",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF224": {
+            "prov:generatedEntity": "niiri:807decf567867596e9ede288b13f016a",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF226": {
+            "prov:generatedEntity": "niiri:106990f64fdbe0a92e78b55484d984e7",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF228": {
+            "prov:generatedEntity": "niiri:9a89982690b205094ce375806ee327d2",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF230": {
+            "prov:generatedEntity": "niiri:86396384ac8248dc2499f53d12283a2f",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF232": {
+            "prov:generatedEntity": "niiri:2ead289cc63835350630bfc68f2d003d",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF234": {
+            "prov:generatedEntity": "niiri:0ff3515dad74fb4659ac475f78bb2c0d",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF236": {
+            "prov:generatedEntity": "niiri:e28eff3b2e060f982dbfeec40075736b",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF238": {
+            "prov:generatedEntity": "niiri:5621f89640fa5a0a90c32a936e6e0a8d",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF240": {
+            "prov:generatedEntity": "niiri:f6474f5545e9725192cc8b6256e5bfb0",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF242": {
+            "prov:generatedEntity": "niiri:2f15ad69e6c9c21540fd55e8e1488dca",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF244": {
+            "prov:generatedEntity": "niiri:42ca52d223a11cd4060ba3459f14c1ab",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF246": {
+            "prov:generatedEntity": "niiri:29b8562f8375bc52056233a05357c8ba",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF248": {
+            "prov:generatedEntity": "niiri:39feea9bf256b35cba29d53ba142d102",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF250": {
+            "prov:generatedEntity": "niiri:aeed349c1d870c766c3846139baddfcf",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF252": {
+            "prov:generatedEntity": "niiri:fb34b9243fbfd4d52f33195ad11fa75e",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF254": {
+            "prov:generatedEntity": "niiri:ae4e3431e53d6bb86cb5f49df3e1dd3c",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF256": {
+            "prov:generatedEntity": "niiri:3ae2d61c89fb13f4e75319093956440c",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF258": {
+            "prov:generatedEntity": "niiri:b9c3425be7ea99b14efce8bce592b25b",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF260": {
+            "prov:generatedEntity": "niiri:53c378a2e0ca3196fa50b2b2030c0fcc",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF262": {
+            "prov:generatedEntity": "niiri:43e5c93bebd29ba8da99711ae8d9c3e1",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF264": {
+            "prov:generatedEntity": "niiri:7fd1e3a607dbe6cfba8a4e086242d6b7",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF266": {
+            "prov:generatedEntity": "niiri:d2c986d4849a217bf93ccf9e1e40ff7d",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF268": {
+            "prov:generatedEntity": "niiri:bac839d7d5a8f71351fbf0af9d7d237d",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF270": {
+            "prov:generatedEntity": "niiri:950ebb223c0553663a2925b4cebca2f2",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF272": {
+            "prov:generatedEntity": "niiri:9a52ab95dd907c0f7f51fb102fd28f70",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF274": {
+            "prov:generatedEntity": "niiri:f6d437c16c83f9a147b1bb4222d3abc6",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF276": {
+            "prov:generatedEntity": "niiri:8837f9a734738e041b5341b9172fb036",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF278": {
+            "prov:generatedEntity": "niiri:8b57160e5bbb28c42ed70eb49e48b412",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF280": {
+            "prov:generatedEntity": "niiri:c45c033aff250585c0df5bd7ebfa55c2",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF282": {
+            "prov:generatedEntity": "niiri:95162bceebb39a10b64eb05d8de3fd22",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF284": {
+            "prov:generatedEntity": "niiri:3ed2c390b2b8ba7d7280d7aaf1f7a0e5",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF286": {
+            "prov:generatedEntity": "niiri:a7eac8bb5c994b37b60795763e4a8b47",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF288": {
+            "prov:generatedEntity": "niiri:df913e2209fc5cbf0b94dbb97361067d",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF290": {
+            "prov:generatedEntity": "niiri:20e5d869565077dcc873c4847e343626",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF292": {
+            "prov:generatedEntity": "niiri:b53c18c408c426d6208825bc03bda76c",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF294": {
+            "prov:generatedEntity": "niiri:5040d4f96058237b55074ccbae780c73",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF296": {
+            "prov:generatedEntity": "niiri:dc90ccd75e3ef3f441e343a64ffc8a53",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF298": {
+            "prov:generatedEntity": "niiri:92eaf289a4d8a69bb8c61dcf57734f87",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF300": {
+            "prov:generatedEntity": "niiri:c40c3a11ae575e327a69951e39f7cf1e",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF302": {
+            "prov:generatedEntity": "niiri:004221f4a994d829f5e16e54483a92e9",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF304": {
+            "prov:generatedEntity": "niiri:996665a23456cb618780744372406eba",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF306": {
+            "prov:generatedEntity": "niiri:09c11fea29165ff889d59486cc998f06",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF308": {
+            "prov:generatedEntity": "niiri:10c4f42b041516447c28674dab2cde5b",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF310": {
+            "prov:generatedEntity": "niiri:c39f3e559dae9a5d556ae9b5045842da",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF312": {
+            "prov:generatedEntity": "niiri:231b63a3acf5fa6923ad638c6827b93e",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF314": {
+            "prov:generatedEntity": "niiri:7a2a292e9fd06f3e19425b30b04888ad",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF316": {
+            "prov:generatedEntity": "niiri:f7777aa15969e9f0700b324454e85979",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF318": {
+            "prov:generatedEntity": "niiri:8005738cdc3c09b780e2ba1a36547702",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF320": {
+            "prov:generatedEntity": "niiri:bd14daedcd6c35f47c42f6681a25a48e",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF322": {
+            "prov:generatedEntity": "niiri:30ebc4167834c5d88670b4e8b93ee950",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF324": {
+            "prov:generatedEntity": "niiri:5d3db32c6d2773404bb204393a96f250",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF326": {
+            "prov:generatedEntity": "niiri:6d6e5cd089cb7ce9b9715c42e896cd46",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF328": {
+            "prov:generatedEntity": "niiri:189cb4ae2ff1cc4b031011345ea5e5b0",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF330": {
+            "prov:generatedEntity": "niiri:697f2d7f340407941e5a743646226280",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF332": {
+            "prov:generatedEntity": "niiri:15af37e0e71211cb9816e08cc4cd0b88",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF334": {
+            "prov:generatedEntity": "niiri:3fb8aaff3e01f2366b6d14baa9559ec9",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF336": {
+            "prov:generatedEntity": "niiri:557d4e957f05b5913d7a77c829b15561",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF338": {
+            "prov:generatedEntity": "niiri:73719d062893a763bcb9efcf192d5c98",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF340": {
+            "prov:generatedEntity": "niiri:254124ed2b4a8c1c5be4de8f4c74580d",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF342": {
+            "prov:generatedEntity": "niiri:a0c4e98f01e68139790391bbf8725466",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF344": {
+            "prov:generatedEntity": "niiri:98295b38fd8a93e7e4ee1dfd88c76887",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF346": {
+            "prov:generatedEntity": "niiri:33a90732b73cfec988bd66955a0c2126",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF348": {
+            "prov:generatedEntity": "niiri:ec3bd6715d891de0f42ba2dc11f9430c",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF350": {
+            "prov:generatedEntity": "niiri:8aa002c426d46d7b9d4dc5e2c38279d3",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF352": {
+            "prov:generatedEntity": "niiri:5d895214e17bb9af3199b1f47611a048",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF354": {
+            "prov:generatedEntity": "niiri:781f6f173dae32b1495eaef04f1b405a",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF356": {
+            "prov:generatedEntity": "niiri:d98430357b786f52e1aba172bbfea688",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF358": {
+            "prov:generatedEntity": "niiri:fe57af8773140946a4555792ccdee632",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF360": {
+            "prov:generatedEntity": "niiri:678cf59b6ed563cbae258da7bd9a2417",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF362": {
+            "prov:generatedEntity": "niiri:fb40247362abead8bfd05d8c0f86fcc6",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF364": {
+            "prov:generatedEntity": "niiri:f0413bd7869f1537bac196460adb50ad",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF366": {
+            "prov:generatedEntity": "niiri:fd3eca9e0c356a0d39da224ef34ff7aa",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF368": {
+            "prov:generatedEntity": "niiri:b2244e3b33c0159757aa93c2de26c3a1",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF370": {
+            "prov:generatedEntity": "niiri:8b70b13ee54cf4407e3be646e313b866",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF372": {
+            "prov:generatedEntity": "niiri:cfc211e4c6c91ecd22c4f0f2f0075044",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF374": {
+            "prov:generatedEntity": "niiri:f00195d4acadb18083e5d9b4023ca225",
+            "prov:usedEntity": "niiri:8523ea1215430db79b6d67ec562629a2"
+        },
+        "_:wDF377": {
+            "prov:generatedEntity": "niiri:f2c008500acb79baf9b5ce05210f9bb9",
+            "prov:usedEntity": "niiri:212a130c85dc60414b3a3ae20326ccc1"
+        },
+        "_:wDF380": {
+            "prov:generatedEntity": "niiri:1fa4a48ba4a927736beae3c9f786d502",
+            "prov:usedEntity": "niiri:212a130c85dc60414b3a3ae20326ccc1"
+        },
+        "_:wDF383": {
+            "prov:generatedEntity": "niiri:6a83a6584dca6366715d149902302674",
+            "prov:usedEntity": "niiri:212a130c85dc60414b3a3ae20326ccc1"
+        },
+        "_:wDF386": {
+            "prov:generatedEntity": "niiri:32f1a2c6ca2ddb9829b059ddbe234078",
+            "prov:usedEntity": "niiri:b6f31947ea1d789fff0bd7ebbd8d5aa3"
+        },
+        "_:wDF389": {
+            "prov:generatedEntity": "niiri:b514d16779b8ecd93200134e45991536",
+            "prov:usedEntity": "niiri:b6f31947ea1d789fff0bd7ebbd8d5aa3"
+        },
+        "_:wDF392": {
+            "prov:generatedEntity": "niiri:23faf3bc0650966493e9f36e0ca600b8",
+            "prov:usedEntity": "niiri:b6f31947ea1d789fff0bd7ebbd8d5aa3"
+        },
+        "_:wDF395": {
+            "prov:generatedEntity": "niiri:8779cf8885e2bb57f1eb0502089c61a7",
+            "prov:usedEntity": "niiri:171c8ac1a84198593464a36bac244ff0"
+        },
+        "_:wDF398": {
+            "prov:generatedEntity": "niiri:f617e967f1244bd4a0ee551172e05935",
+            "prov:usedEntity": "niiri:171c8ac1a84198593464a36bac244ff0"
+        },
+        "_:wDF401": {
+            "prov:generatedEntity": "niiri:09a006cc070777c7bc9ff02587a9475f",
+            "prov:usedEntity": "niiri:171c8ac1a84198593464a36bac244ff0"
+        },
+        "_:wDF404": {
+            "prov:generatedEntity": "niiri:ec49a9f4a91ebfee81f8ba5ab02662d0",
+            "prov:usedEntity": "niiri:7174a23494a5602d1cf5b80e0b3957b3"
+        },
+        "_:wDF407": {
+            "prov:generatedEntity": "niiri:d7db9d99f9156bfd0c9e6482f6b282d1",
+            "prov:usedEntity": "niiri:7174a23494a5602d1cf5b80e0b3957b3"
+        },
+        "_:wDF410": {
+            "prov:generatedEntity": "niiri:b1965951f77cadf6336644280d9e0eb2",
+            "prov:usedEntity": "niiri:7174a23494a5602d1cf5b80e0b3957b3"
+        },
+        "_:wDF413": {
+            "prov:generatedEntity": "niiri:95c8fcf40d4086295dd49408d12a5369",
+            "prov:usedEntity": "niiri:2cd32bc92eb7dd286253f06b6c4516f9"
+        },
+        "_:wDF416": {
+            "prov:generatedEntity": "niiri:6a44a9a24517109ec3074ac91077f376",
+            "prov:usedEntity": "niiri:2cd32bc92eb7dd286253f06b6c4516f9"
+        },
+        "_:wDF419": {
+            "prov:generatedEntity": "niiri:75efdb8848f89afcfba1a207d71a6086",
+            "prov:usedEntity": "niiri:2cd32bc92eb7dd286253f06b6c4516f9"
+        },
+        "_:wDF422": {
+            "prov:generatedEntity": "niiri:7f82efbbcbb2b7ca685a4c40df6d517f",
+            "prov:usedEntity": "niiri:6438830b93a9866c5a8c4cb39850d977"
+        },
+        "_:wDF425": {
+            "prov:generatedEntity": "niiri:3957970d9b8be40cdba7d77e9fc1af08",
+            "prov:usedEntity": "niiri:58fb2509f9d4dbc78a02bfcd61bb139b"
+        },
+        "_:wDF428": {
+            "prov:generatedEntity": "niiri:ebbf36d0c0f06a153cfcf5a4d5d87c41",
+            "prov:usedEntity": "niiri:2657e564e7bba015b389e0943b63badb"
+        },
+        "_:wDF431": {
+            "prov:generatedEntity": "niiri:31ec0b3be00fd80d126fc2af1ce352dd",
+            "prov:usedEntity": "niiri:2657e564e7bba015b389e0943b63badb"
+        },
+        "_:wDF434": {
+            "prov:generatedEntity": "niiri:2c6257c20ce92f4d4b1e41e803eef7b2",
+            "prov:usedEntity": "niiri:2657e564e7bba015b389e0943b63badb"
+        },
+        "_:wDF437": {
+            "prov:generatedEntity": "niiri:108d6134cb55a8d7a0a3b38e0911631f",
+            "prov:usedEntity": "niiri:a8bb66759e4caade20c1a9e56f9516ec"
+        },
+        "_:wDF440": {
+            "prov:generatedEntity": "niiri:f3b0431eda7e1bbfb898867a9c5f20db",
+            "prov:usedEntity": "niiri:a8bb66759e4caade20c1a9e56f9516ec"
+        },
+        "_:wDF443": {
+            "prov:generatedEntity": "niiri:6914d04832f348c47b11f7e72bf95b91",
+            "prov:usedEntity": "niiri:7f817d4ab9fea049a6960806e46dae6f"
+        },
+        "_:wDF446": {
+            "prov:generatedEntity": "niiri:bedd2a1fe4cc40fb4348c1e3f84fe4ce",
+            "prov:usedEntity": "niiri:7f817d4ab9fea049a6960806e46dae6f"
+        },
+        "_:wDF449": {
+            "prov:generatedEntity": "niiri:489fe008583f9540151b81533b9acb5e",
+            "prov:usedEntity": "niiri:7f817d4ab9fea049a6960806e46dae6f"
+        },
+        "_:wDF452": {
+            "prov:generatedEntity": "niiri:a5a33f4d819b8eb7632b4b1e5316ae25",
+            "prov:usedEntity": "niiri:a088090c906271f3f2487f7339f0082c"
+        },
+        "_:wDF455": {
+            "prov:generatedEntity": "niiri:3dbba6caca10b3238c9bd1b6e4ac3ff1",
+            "prov:usedEntity": "niiri:5cb5cd73033206c0daaf4927462a1873"
+        },
+        "_:wDF458": {
+            "prov:generatedEntity": "niiri:6edb5d4ccd344696f8f8a3ed75c82f37",
+            "prov:usedEntity": "niiri:f4def9a581b3c307c2f4fb9e2e226d0e"
+        },
+        "_:wDF461": {
+            "prov:generatedEntity": "niiri:4021174e55dc807e3de6628bf8eb04e4",
+            "prov:usedEntity": "niiri:f4def9a581b3c307c2f4fb9e2e226d0e"
+        },
+        "_:wDF464": {
+            "prov:generatedEntity": "niiri:0ae175b8baba9cf71436e5d6fd22e350",
+            "prov:usedEntity": "niiri:dfdffb6b309c9dbdb7e869a40c441373"
+        },
+        "_:wDF467": {
+            "prov:generatedEntity": "niiri:5678d8d6c35ed00e4d4e18d18efb6ece",
+            "prov:usedEntity": "niiri:51dff688583f66b2d156042da2e15fbc"
+        },
+        "_:wDF470": {
+            "prov:generatedEntity": "niiri:42466a1a262537fe1909213e41f7608f",
+            "prov:usedEntity": "niiri:e56f07808adb058d01196164f0775b64"
+        },
+        "_:wDF473": {
+            "prov:generatedEntity": "niiri:f9b9bbd2555a0f9eff6c0d4a46615477",
+            "prov:usedEntity": "niiri:14930f43331616f26135da44caf5ca49"
+        },
+        "_:wDF476": {
+            "prov:generatedEntity": "niiri:5d8297107655c470b20029a7607b59d6",
+            "prov:usedEntity": "niiri:d6ab9aad7ae91e9a945d6044d0e1d6cd"
+        },
+        "_:wDF479": {
+            "prov:generatedEntity": "niiri:8a6ddd866c065982183951ef56d075a5",
+            "prov:usedEntity": "niiri:d6ab9aad7ae91e9a945d6044d0e1d6cd"
+        },
+        "_:wDF482": {
+            "prov:generatedEntity": "niiri:ebeb5e8cbd97a7c980eb6e8048e3aa7d",
+            "prov:usedEntity": "niiri:950bb8c15f6d86506fdad52c1ea79861"
+        },
+        "_:wDF485": {
+            "prov:generatedEntity": "niiri:f0a3195f5086136d59542c82017b3a01",
+            "prov:usedEntity": "niiri:f4783b6466e014e6e52055bae529f918"
+        },
+        "_:wDF488": {
+            "prov:generatedEntity": "niiri:e93ed6c3aa25b233cb79929e574105d9",
+            "prov:usedEntity": "niiri:f4783b6466e014e6e52055bae529f918"
+        },
+        "_:wDF491": {
+            "prov:generatedEntity": "niiri:e515516c5ff1d233ae675e7803ccd1db",
+            "prov:usedEntity": "niiri:e493acb406e5cff7f2b3bdae4a6c7854"
+        },
+        "_:wDF494": {
+            "prov:generatedEntity": "niiri:b165c84e39ed0a56c6fcfe2cf6485d45",
+            "prov:usedEntity": "niiri:0337643db0192f78f5b32cbf7ed520a4"
+        },
+        "_:wDF497": {
+            "prov:generatedEntity": "niiri:ff9ae21e91aa2853a4df2c66190d9a69",
+            "prov:usedEntity": "niiri:0337643db0192f78f5b32cbf7ed520a4"
+        },
+        "_:wDF500": {
+            "prov:generatedEntity": "niiri:07dafc52bdbe3bac0a138605d2cfa21e",
+            "prov:usedEntity": "niiri:1a04d969a09af1e47b83e8c89999ecc0"
+        },
+        "_:wDF503": {
+            "prov:generatedEntity": "niiri:8bbb069d9a8a8deae00856c0bac1dca3",
+            "prov:usedEntity": "niiri:cad3a1438e0a5950942cd5ed7b22e997"
+        },
+        "_:wDF506": {
+            "prov:generatedEntity": "niiri:83820e300b8ac064252e16de139eccae",
+            "prov:usedEntity": "niiri:cad3a1438e0a5950942cd5ed7b22e997"
+        },
+        "_:wDF509": {
+            "prov:generatedEntity": "niiri:96dad918bf5b91086582f2216b436cf1",
+            "prov:usedEntity": "niiri:aa48c521a0de3bccee7d00f6ba89c3cf"
+        },
+        "_:wDF512": {
+            "prov:generatedEntity": "niiri:b36997cc891aca5718ab9e08f9f432be",
+            "prov:usedEntity": "niiri:666175487bab3267d4af86f55ff4bd3b"
+        },
+        "_:wDF515": {
+            "prov:generatedEntity": "niiri:25c1c6fe5473de8cd328924f02807315",
+            "prov:usedEntity": "niiri:6951754ac73a67bbeeec0a4f76595341"
+        },
+        "_:wDF518": {
+            "prov:generatedEntity": "niiri:289a61918b6511cb6b776c8ac53da1fb",
+            "prov:usedEntity": "niiri:92c69844c448bad6dc16185f863b358e"
+        },
+        "_:wDF521": {
+            "prov:generatedEntity": "niiri:5b892640561d323072506be428e65c2c",
+            "prov:usedEntity": "niiri:177bfa600d85757ea0c4626517c44033"
+        },
+        "_:wDF524": {
+            "prov:generatedEntity": "niiri:70699d653df50cd6d5e59c21dedb8323",
+            "prov:usedEntity": "niiri:746b0b97599bb9118ebd954e679a2576"
+        },
+        "_:wDF527": {
+            "prov:generatedEntity": "niiri:201264c80972dcebd2c7ea04534507f6",
+            "prov:usedEntity": "niiri:54c365a30f25bdcc066a52c171908849"
+        },
+        "_:wDF530": {
+            "prov:generatedEntity": "niiri:b44f502f04b58f2cf2d267fb394a2207",
+            "prov:usedEntity": "niiri:b9e88b2bbae3b722fa155ba8e9501a86"
+        },
+        "_:wDF533": {
+            "prov:generatedEntity": "niiri:1f6b053553d3aeb85e957aa471ba1b95",
+            "prov:usedEntity": "niiri:b9e88b2bbae3b722fa155ba8e9501a86"
+        },
+        "_:wDF536": {
+            "prov:generatedEntity": "niiri:6ba4d4daf1fd511897ca0be0927d8a89",
+            "prov:usedEntity": "niiri:6b8826bcc0a021bc10b09d6a6d4302fd"
+        },
+        "_:wDF539": {
+            "prov:generatedEntity": "niiri:74e91aadd62ca24aff8ec843f5b9cf73",
+            "prov:usedEntity": "niiri:cc1d6ba65b10195363d6da601013d7a1"
+        },
+        "_:wDF542": {
+            "prov:generatedEntity": "niiri:20009017f6e554d7929aee14c3cb2b0a",
+            "prov:usedEntity": "niiri:82933f30610ef29a453f4b374990b32f"
+        },
+        "_:wDF545": {
+            "prov:generatedEntity": "niiri:50726c9e381e8c0cadcb5c25bfce42c4",
+            "prov:usedEntity": "niiri:14f8555b74f38f3e8db5c662f1a8015c"
+        },
+        "_:wDF548": {
+            "prov:generatedEntity": "niiri:f65e0cae04132c7a84d5a8f11123339a",
+            "prov:usedEntity": "niiri:8c06ba2c370d4dda4947f0cbe66ca91e"
+        },
+        "_:wDF551": {
+            "prov:generatedEntity": "niiri:f7a1eeb8810d3507d311591e2f7997ab",
+            "prov:usedEntity": "niiri:337d987921a53a135ec5d7ccac93719b"
+        },
+        "_:wDF554": {
+            "prov:generatedEntity": "niiri:1f1e980431dd78b887d46d0d999586d6",
+            "prov:usedEntity": "niiri:8b64f56916b41aba13f0c3626eccb6c6"
+        },
+        "_:wDF557": {
+            "prov:generatedEntity": "niiri:dac1b7a25e803b8443975ee1030a9b0e",
+            "prov:usedEntity": "niiri:7167233a4e5f287b27d1ea49b05f5e73"
+        },
+        "_:wDF560": {
+            "prov:generatedEntity": "niiri:d5b79c346d3f077001fa066fa2d1a90d",
+            "prov:usedEntity": "niiri:9bcff3c8230d1d562436a59af916d435"
+        },
+        "_:wDF563": {
+            "prov:generatedEntity": "niiri:199023e997d45cf3233e578d536f4c5c",
+            "prov:usedEntity": "niiri:1f551e5f86fc52cb27432b3822b69ca7"
+        },
+        "_:wDF566": {
+            "prov:generatedEntity": "niiri:cc258c6487aa920075b8a9d74a761b48",
+            "prov:usedEntity": "niiri:222cf8fd43a488444ee6a32847bc1d9a"
+        },
+        "_:wDF569": {
+            "prov:generatedEntity": "niiri:64b4dccdedec0a80f2fe74dd14cc1002",
+            "prov:usedEntity": "niiri:944e97172e0a25bb481c848ff69da03e"
+        },
+        "_:wDF572": {
+            "prov:generatedEntity": "niiri:d3b936a394a469d3174e0f8343bd463f",
+            "prov:usedEntity": "niiri:f16d0ba2c74c51bb5e78d2245c00a45f"
+        },
+        "_:wDF575": {
+            "prov:generatedEntity": "niiri:f51500ecaf58b3d1cd1042a40b408879",
+            "prov:usedEntity": "niiri:209a4a28e55d93fc75c92925f0f7d71b"
+        },
+        "_:wDF578": {
+            "prov:generatedEntity": "niiri:4ff8360d7fc12f9cfc4bcd4dfe7c00dd",
+            "prov:usedEntity": "niiri:357268aff375a1c533059d48c5f8dcb0"
+        },
+        "_:wDF581": {
+            "prov:generatedEntity": "niiri:73e236d5a6d25c17dd9cded1da30b954",
+            "prov:usedEntity": "niiri:357268aff375a1c533059d48c5f8dcb0"
+        },
+        "_:wDF584": {
+            "prov:generatedEntity": "niiri:e9e3416cc410461e50330f128b2e5ef5",
+            "prov:usedEntity": "niiri:0a39de1cb252a793d03ed45aa12d8950"
+        },
+        "_:wDF587": {
+            "prov:generatedEntity": "niiri:680d3d98098fe3304954deff21a29e7b",
+            "prov:usedEntity": "niiri:2ce7fa7ad1d0a7052668df06aeeb62b3"
+        },
+        "_:wDF590": {
+            "prov:generatedEntity": "niiri:47943ba3e02dcae014366323aa4ab25f",
+            "prov:usedEntity": "niiri:2ce7fa7ad1d0a7052668df06aeeb62b3"
+        },
+        "_:wDF593": {
+            "prov:generatedEntity": "niiri:d2e4b7191441a73d13865ac94f555793",
+            "prov:usedEntity": "niiri:837c632e63a40a2ac1469c8d1ba1b864"
+        },
+        "_:wDF596": {
+            "prov:generatedEntity": "niiri:8cf5f9af5ca1975fc1c28c8c1557d889",
+            "prov:usedEntity": "niiri:47f25a919baaf59e7867aa98557a23e4"
+        },
+        "_:wDF599": {
+            "prov:generatedEntity": "niiri:45eef5c14e0789f2e938b481f651929c",
+            "prov:usedEntity": "niiri:82870fabf2e7a1a9a595fb88debeb7ef"
+        },
+        "_:wDF602": {
+            "prov:generatedEntity": "niiri:788812e3c1a5e8e9dc131a6099bb1cc2",
+            "prov:usedEntity": "niiri:54fe9c7a58c48364f79822c24b7f0a36"
+        },
+        "_:wDF605": {
+            "prov:generatedEntity": "niiri:3e2507719bb8e8cec2153c1d7c6d11f9",
+            "prov:usedEntity": "niiri:9f649ce7c963c614e6fb0b5f0f441d80"
+        },
+        "_:wDF608": {
+            "prov:generatedEntity": "niiri:a5458865e5677ec6fc83283980aaada6",
+            "prov:usedEntity": "niiri:aa6b7754ff9629fdf69c2b137c4af89e"
+        },
+        "_:wDF611": {
+            "prov:generatedEntity": "niiri:0bad50db6253e7c03b817887ef216040",
+            "prov:usedEntity": "niiri:992eba93ccac4ef864d1e4c888fef260"
+        },
+        "_:wDF614": {
+            "prov:generatedEntity": "niiri:a6b4a34fb40ee0a15bffe18d35ac9f31",
+            "prov:usedEntity": "niiri:992eba93ccac4ef864d1e4c888fef260"
+        },
+        "_:wDF617": {
+            "prov:generatedEntity": "niiri:78892fc1529eb6f3ae71eda0c5cb75dc",
+            "prov:usedEntity": "niiri:2913f23a1813eb7942fb6b12aea56fda"
+        },
+        "_:wDF620": {
+            "prov:generatedEntity": "niiri:d2d93102aaafa6fbf39c89330edf7d36",
+            "prov:usedEntity": "niiri:1c4944ab6edec9e1dbd0763deb0ea5f5"
+        },
+        "_:wDF623": {
+            "prov:generatedEntity": "niiri:f9d5a38c2897f37b953727849193451c",
+            "prov:usedEntity": "niiri:807decf567867596e9ede288b13f016a"
+        },
+        "_:wDF626": {
+            "prov:generatedEntity": "niiri:e69b435cb561850d5bb26d896306c312",
+            "prov:usedEntity": "niiri:807decf567867596e9ede288b13f016a"
+        },
+        "_:wDF629": {
+            "prov:generatedEntity": "niiri:6f25ec29f560c0501f2c9be49ad80287",
+            "prov:usedEntity": "niiri:106990f64fdbe0a92e78b55484d984e7"
+        },
+        "_:wDF632": {
+            "prov:generatedEntity": "niiri:1c087be2a968de7ac0a2bea646c020cb",
+            "prov:usedEntity": "niiri:9a89982690b205094ce375806ee327d2"
+        },
+        "_:wDF635": {
+            "prov:generatedEntity": "niiri:fb0dd18eb34c8e74b938fd5ddf517ce5",
+            "prov:usedEntity": "niiri:86396384ac8248dc2499f53d12283a2f"
+        },
+        "_:wDF638": {
+            "prov:generatedEntity": "niiri:2f736c7d40b35980222068c405413bae",
+            "prov:usedEntity": "niiri:2ead289cc63835350630bfc68f2d003d"
+        },
+        "_:wDF641": {
+            "prov:generatedEntity": "niiri:7980b5dd38316b9b2ecbc76101c2a0b5",
+            "prov:usedEntity": "niiri:0ff3515dad74fb4659ac475f78bb2c0d"
+        },
+        "_:wDF644": {
+            "prov:generatedEntity": "niiri:b05ecaea88de142b8ca1773ff4972f5e",
+            "prov:usedEntity": "niiri:e28eff3b2e060f982dbfeec40075736b"
+        },
+        "_:wDF647": {
+            "prov:generatedEntity": "niiri:47d4cfe6ec57e882523a5f15411848d2",
+            "prov:usedEntity": "niiri:5621f89640fa5a0a90c32a936e6e0a8d"
+        },
+        "_:wDF650": {
+            "prov:generatedEntity": "niiri:4dc1e5e65b8110f5c3d324caa9587124",
+            "prov:usedEntity": "niiri:f6474f5545e9725192cc8b6256e5bfb0"
+        },
+        "_:wDF653": {
+            "prov:generatedEntity": "niiri:8c3105cb051b8d67f47a2e2e97720b1f",
+            "prov:usedEntity": "niiri:2f15ad69e6c9c21540fd55e8e1488dca"
+        },
+        "_:wDF656": {
+            "prov:generatedEntity": "niiri:cbd485923e06556ee8d61eae7a353bc3",
+            "prov:usedEntity": "niiri:42ca52d223a11cd4060ba3459f14c1ab"
+        },
+        "_:wDF659": {
+            "prov:generatedEntity": "niiri:18b3136cd14e6ff7733c13a8bdaa6346",
+            "prov:usedEntity": "niiri:29b8562f8375bc52056233a05357c8ba"
+        },
+        "_:wDF662": {
+            "prov:generatedEntity": "niiri:f83fcb8aadbc17649f8866d0a02e98f2",
+            "prov:usedEntity": "niiri:39feea9bf256b35cba29d53ba142d102"
+        },
+        "_:wDF665": {
+            "prov:generatedEntity": "niiri:6ac9a02ed616ed9c5160a35845282afa",
+            "prov:usedEntity": "niiri:aeed349c1d870c766c3846139baddfcf"
+        },
+        "_:wDF668": {
+            "prov:generatedEntity": "niiri:a3bf33e6499e7a0a31c9702c6d60fc3c",
+            "prov:usedEntity": "niiri:fb34b9243fbfd4d52f33195ad11fa75e"
+        },
+        "_:wDF671": {
+            "prov:generatedEntity": "niiri:0de985ab54c7b41ae1d397bc56243722",
+            "prov:usedEntity": "niiri:ae4e3431e53d6bb86cb5f49df3e1dd3c"
+        },
+        "_:wDF674": {
+            "prov:generatedEntity": "niiri:dafae508abe6b629f3a5b25e99e2b8a6",
+            "prov:usedEntity": "niiri:3ae2d61c89fb13f4e75319093956440c"
+        },
+        "_:wDF677": {
+            "prov:generatedEntity": "niiri:9f241776c24bfec38480e757272c95ef",
+            "prov:usedEntity": "niiri:b9c3425be7ea99b14efce8bce592b25b"
+        },
+        "_:wDF680": {
+            "prov:generatedEntity": "niiri:64e9f022bd6687a619e8398b70936591",
+            "prov:usedEntity": "niiri:53c378a2e0ca3196fa50b2b2030c0fcc"
+        },
+        "_:wDF683": {
+            "prov:generatedEntity": "niiri:f39083490c271135692376a9b6145545",
+            "prov:usedEntity": "niiri:43e5c93bebd29ba8da99711ae8d9c3e1"
+        },
+        "_:wDF686": {
+            "prov:generatedEntity": "niiri:5fb2a670883af294357a4ab2154ab6b1",
+            "prov:usedEntity": "niiri:7fd1e3a607dbe6cfba8a4e086242d6b7"
+        },
+        "_:wDF689": {
+            "prov:generatedEntity": "niiri:ee341bb063e9247becec364805165eb3",
+            "prov:usedEntity": "niiri:d2c986d4849a217bf93ccf9e1e40ff7d"
+        },
+        "_:wDF692": {
+            "prov:generatedEntity": "niiri:db4b88ce7955c87529d9cdcac1067e5c",
+            "prov:usedEntity": "niiri:bac839d7d5a8f71351fbf0af9d7d237d"
+        },
+        "_:wDF695": {
+            "prov:generatedEntity": "niiri:6ab66734fa9b63bf93c3eb233efd164e",
+            "prov:usedEntity": "niiri:950ebb223c0553663a2925b4cebca2f2"
+        },
+        "_:wDF698": {
+            "prov:generatedEntity": "niiri:7a920cc103779299492bdd1b7abf0d4c",
+            "prov:usedEntity": "niiri:9a52ab95dd907c0f7f51fb102fd28f70"
+        },
+        "_:wDF701": {
+            "prov:generatedEntity": "niiri:0091960b7df9e3b2ee0b995c7a9fee2e",
+            "prov:usedEntity": "niiri:f6d437c16c83f9a147b1bb4222d3abc6"
+        },
+        "_:wDF704": {
+            "prov:generatedEntity": "niiri:be68a46819185a1181faf0074de880e1",
+            "prov:usedEntity": "niiri:8837f9a734738e041b5341b9172fb036"
+        },
+        "_:wDF707": {
+            "prov:generatedEntity": "niiri:9c1ebb72f8df3bd670dd7093690f96e7",
+            "prov:usedEntity": "niiri:8b57160e5bbb28c42ed70eb49e48b412"
+        },
+        "_:wDF710": {
+            "prov:generatedEntity": "niiri:13a5abfae24999f832ff63e132d71526",
+            "prov:usedEntity": "niiri:c45c033aff250585c0df5bd7ebfa55c2"
+        },
+        "_:wDF713": {
+            "prov:generatedEntity": "niiri:0db89c6238aa0a65c9a6789ba0981b57",
+            "prov:usedEntity": "niiri:95162bceebb39a10b64eb05d8de3fd22"
+        },
+        "_:wDF716": {
+            "prov:generatedEntity": "niiri:3cef58b75474f5f62c6e5f17b7eb47a4",
+            "prov:usedEntity": "niiri:3ed2c390b2b8ba7d7280d7aaf1f7a0e5"
+        },
+        "_:wDF719": {
+            "prov:generatedEntity": "niiri:7f48dee052c9626e7e52439acf0f2384",
+            "prov:usedEntity": "niiri:a7eac8bb5c994b37b60795763e4a8b47"
+        },
+        "_:wDF722": {
+            "prov:generatedEntity": "niiri:4d3efcbf06221edd111b9ececccbf578",
+            "prov:usedEntity": "niiri:df913e2209fc5cbf0b94dbb97361067d"
+        },
+        "_:wDF725": {
+            "prov:generatedEntity": "niiri:559d842aee52f555e32eaea8e5f6af4d",
+            "prov:usedEntity": "niiri:20e5d869565077dcc873c4847e343626"
+        },
+        "_:wDF728": {
+            "prov:generatedEntity": "niiri:9bfa3d4282d5fe49d0a5d7837246515a",
+            "prov:usedEntity": "niiri:b53c18c408c426d6208825bc03bda76c"
+        },
+        "_:wDF731": {
+            "prov:generatedEntity": "niiri:ed129b762540244ebbab654eba8430b6",
+            "prov:usedEntity": "niiri:5040d4f96058237b55074ccbae780c73"
+        },
+        "_:wDF734": {
+            "prov:generatedEntity": "niiri:aa361f26f45828a6bf37d7fa0ef9e035",
+            "prov:usedEntity": "niiri:dc90ccd75e3ef3f441e343a64ffc8a53"
+        },
+        "_:wDF737": {
+            "prov:generatedEntity": "niiri:50115084698b0f76f38b7c1104d53bc9",
+            "prov:usedEntity": "niiri:92eaf289a4d8a69bb8c61dcf57734f87"
+        },
+        "_:wDF740": {
+            "prov:generatedEntity": "niiri:371a172468bf76afe6aadb917ee05964",
+            "prov:usedEntity": "niiri:c40c3a11ae575e327a69951e39f7cf1e"
+        },
+        "_:wDF743": {
+            "prov:generatedEntity": "niiri:dbaab492fac4e6b9eab8dcfc58c98506",
+            "prov:usedEntity": "niiri:004221f4a994d829f5e16e54483a92e9"
+        },
+        "_:wDF746": {
+            "prov:generatedEntity": "niiri:ffed331acd64084a30d48b98739e86bc",
+            "prov:usedEntity": "niiri:004221f4a994d829f5e16e54483a92e9"
+        },
+        "_:wDF749": {
+            "prov:generatedEntity": "niiri:3d0a016a27aa65b6bbbd681333dcc446",
+            "prov:usedEntity": "niiri:996665a23456cb618780744372406eba"
+        },
+        "_:wDF752": {
+            "prov:generatedEntity": "niiri:86b63b6d4bdec0c181ff785f7344f2f7",
+            "prov:usedEntity": "niiri:09c11fea29165ff889d59486cc998f06"
+        },
+        "_:wDF755": {
+            "prov:generatedEntity": "niiri:e8710216ba3ec832f617a9e1b98c0bf3",
+            "prov:usedEntity": "niiri:10c4f42b041516447c28674dab2cde5b"
+        },
+        "_:wDF758": {
+            "prov:generatedEntity": "niiri:6c4a7be328ce49c5e98564e34076236c",
+            "prov:usedEntity": "niiri:c39f3e559dae9a5d556ae9b5045842da"
+        },
+        "_:wDF761": {
+            "prov:generatedEntity": "niiri:b8b143f3a3bab02055f06c8fa221c1c4",
+            "prov:usedEntity": "niiri:231b63a3acf5fa6923ad638c6827b93e"
+        },
+        "_:wDF764": {
+            "prov:generatedEntity": "niiri:bbb810096180dab5916a19ea19eb4d52",
+            "prov:usedEntity": "niiri:7a2a292e9fd06f3e19425b30b04888ad"
+        },
+        "_:wDF767": {
+            "prov:generatedEntity": "niiri:5ad6239481925bf6bc3a6ffbd30cf7e6",
+            "prov:usedEntity": "niiri:f7777aa15969e9f0700b324454e85979"
+        },
+        "_:wDF770": {
+            "prov:generatedEntity": "niiri:29763b527003432a0c2b21c172ec4a81",
+            "prov:usedEntity": "niiri:8005738cdc3c09b780e2ba1a36547702"
+        },
+        "_:wDF773": {
+            "prov:generatedEntity": "niiri:b10c8559c8983dbf10bcbbd87ba3a30b",
+            "prov:usedEntity": "niiri:bd14daedcd6c35f47c42f6681a25a48e"
+        },
+        "_:wDF776": {
+            "prov:generatedEntity": "niiri:b4e1b1ca0ed3d9d8f28f683410396141",
+            "prov:usedEntity": "niiri:30ebc4167834c5d88670b4e8b93ee950"
+        },
+        "_:wDF779": {
+            "prov:generatedEntity": "niiri:2c97f5daab495771999c9c6ed9658dae",
+            "prov:usedEntity": "niiri:5d3db32c6d2773404bb204393a96f250"
+        },
+        "_:wDF782": {
+            "prov:generatedEntity": "niiri:f1ee6434b4e9e350b5883b0db78d72fc",
+            "prov:usedEntity": "niiri:6d6e5cd089cb7ce9b9715c42e896cd46"
+        },
+        "_:wDF785": {
+            "prov:generatedEntity": "niiri:08fdef8ced896bffb0a9f513bb82f661",
+            "prov:usedEntity": "niiri:189cb4ae2ff1cc4b031011345ea5e5b0"
+        },
+        "_:wDF788": {
+            "prov:generatedEntity": "niiri:33e039efa523781d074f8709e436c6c1",
+            "prov:usedEntity": "niiri:697f2d7f340407941e5a743646226280"
+        },
+        "_:wDF791": {
+            "prov:generatedEntity": "niiri:7d85e08ff8a27a219706a4be288209f2",
+            "prov:usedEntity": "niiri:15af37e0e71211cb9816e08cc4cd0b88"
+        },
+        "_:wDF794": {
+            "prov:generatedEntity": "niiri:1952a27691fae0a16a11d4d1da1b6ab0",
+            "prov:usedEntity": "niiri:3fb8aaff3e01f2366b6d14baa9559ec9"
+        },
+        "_:wDF797": {
+            "prov:generatedEntity": "niiri:28fc29227a7d0e7b676cba34c11619a0",
+            "prov:usedEntity": "niiri:557d4e957f05b5913d7a77c829b15561"
+        },
+        "_:wDF800": {
+            "prov:generatedEntity": "niiri:4969976c6b8f566ff774a986d7a36a79",
+            "prov:usedEntity": "niiri:73719d062893a763bcb9efcf192d5c98"
+        },
+        "_:wDF803": {
+            "prov:generatedEntity": "niiri:9601c3a9c37cd454e282dd247386189b",
+            "prov:usedEntity": "niiri:254124ed2b4a8c1c5be4de8f4c74580d"
+        },
+        "_:wDF806": {
+            "prov:generatedEntity": "niiri:4fe52494e0e2ce9d3cab8ce7ef9c43a2",
+            "prov:usedEntity": "niiri:a0c4e98f01e68139790391bbf8725466"
+        },
+        "_:wDF809": {
+            "prov:generatedEntity": "niiri:6a53d2070def16165db38789830277ca",
+            "prov:usedEntity": "niiri:98295b38fd8a93e7e4ee1dfd88c76887"
+        },
+        "_:wDF812": {
+            "prov:generatedEntity": "niiri:78ecf12590514c80a21b976921614adc",
+            "prov:usedEntity": "niiri:33a90732b73cfec988bd66955a0c2126"
+        },
+        "_:wDF815": {
+            "prov:generatedEntity": "niiri:2cc54cd7893515b53af0b26c486419e8",
+            "prov:usedEntity": "niiri:ec3bd6715d891de0f42ba2dc11f9430c"
+        },
+        "_:wDF818": {
+            "prov:generatedEntity": "niiri:383e2e40e4478c46a885723e580540e9",
+            "prov:usedEntity": "niiri:8aa002c426d46d7b9d4dc5e2c38279d3"
+        },
+        "_:wDF821": {
+            "prov:generatedEntity": "niiri:d6f790d81f1079150604aaa16ea4f5c7",
+            "prov:usedEntity": "niiri:5d895214e17bb9af3199b1f47611a048"
+        },
+        "_:wDF824": {
+            "prov:generatedEntity": "niiri:61c1675e82feee3a2ba070ebd84e8f84",
+            "prov:usedEntity": "niiri:781f6f173dae32b1495eaef04f1b405a"
+        },
+        "_:wDF827": {
+            "prov:generatedEntity": "niiri:b21afe1ebc2946d76e1feed501da0a13",
+            "prov:usedEntity": "niiri:d98430357b786f52e1aba172bbfea688"
+        },
+        "_:wDF830": {
+            "prov:generatedEntity": "niiri:2c07a6ac701630dbce313c1c9311af3a",
+            "prov:usedEntity": "niiri:fe57af8773140946a4555792ccdee632"
+        },
+        "_:wDF833": {
+            "prov:generatedEntity": "niiri:491c487f7a368b1aa7a2a4d48952759c",
+            "prov:usedEntity": "niiri:678cf59b6ed563cbae258da7bd9a2417"
+        },
+        "_:wDF836": {
+            "prov:generatedEntity": "niiri:fcca986bd2deab6ef39bb2525ae730c8",
+            "prov:usedEntity": "niiri:fb40247362abead8bfd05d8c0f86fcc6"
+        },
+        "_:wDF839": {
+            "prov:generatedEntity": "niiri:358a334c1617e7ce360e2f5605342b32",
+            "prov:usedEntity": "niiri:f0413bd7869f1537bac196460adb50ad"
+        },
+        "_:wDF842": {
+            "prov:generatedEntity": "niiri:0e6bfffafd9d245f4dd49561f6c28e08",
+            "prov:usedEntity": "niiri:fd3eca9e0c356a0d39da224ef34ff7aa"
+        },
+        "_:wDF845": {
+            "prov:generatedEntity": "niiri:f45794d952959fc21a4f15a7662b0673",
+            "prov:usedEntity": "niiri:b2244e3b33c0159757aa93c2de26c3a1"
+        },
+        "_:wDF848": {
+            "prov:generatedEntity": "niiri:ec709d3ce148902d8c0bd7af6efd254a",
+            "prov:usedEntity": "niiri:8b70b13ee54cf4407e3be646e313b866"
+        },
+        "_:wDF851": {
+            "prov:generatedEntity": "niiri:44179ac71aa6a866710bacec2f633862",
+            "prov:usedEntity": "niiri:cfc211e4c6c91ecd22c4f0f2f0075044"
+        },
+        "_:wDF854": {
+            "prov:generatedEntity": "niiri:fdea430f757b7b55cda702759b054832",
+            "prov:usedEntity": "niiri:f00195d4acadb18083e5d9b4023ca225"
+        }
+    },
+    "wasAttributedTo": {
+        "_:wAT6": {
+            "prov:entity": "niiri:b0407acb83b2703b82444e30fcac401b",
+            "prov:agent": "niiri:4dd802783f824c7aacfc4e4e4ee26461"
+        },
+        "_:wAT7": {
+            "prov:entity": "niiri:b0407acb83b2703b82444e30fcac401b",
+            "prov:agent": "niiri:37dff96025f813fa2cae9c2f2ab20af0"
+        }
+    },
+    "wasAssociatedWith": {
+        "_:wAW13": {
+            "prov:activity": "niiri:10b49e4617715cf283ca55ab051c7161",
+            "prov:agent": "niiri:9d7bdfb1f005a1c77912a13aad1d7cca"
+        },
+        "_:wAW45": {
+            "prov:activity": "niiri:dd06c607e32f76dc0e4ff497c11b759c",
+            "prov:agent": "niiri:9d7bdfb1f005a1c77912a13aad1d7cca"
+        },
+        "_:wAW65": {
+            "prov:activity": "niiri:b91cbbf6a4f5303474a88b3cbc77d086",
+            "prov:agent": "niiri:9d7bdfb1f005a1c77912a13aad1d7cca"
+        },
+        "_:wAW92": {
+            "prov:activity": "niiri:c134406116e621fbf4bcc19eb85f6dec",
+            "prov:agent": "niiri:9d7bdfb1f005a1c77912a13aad1d7cca"
+        }
+    }
+    }
+  }
+}

--- a/spmexport/ex_spm_partial_conjunction/nidm.jsonld
+++ b/spmexport/ex_spm_partial_conjunction/nidm.jsonld
@@ -7,7 +7,7 @@
       "niiri": "http://iri.nidash.org/",
       "spm": "http://purl.org/nidash/spm#",
       "neurolex": "http://neurolex.org/wiki/",
-      "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#",
+      "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/",
       "dct": "http://purl.org/dc/terms/",
       "nfo": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#",
       "dc": "http://purl.org/dc/elements/1.1/",
@@ -22,32 +22,32 @@
   ],
   "@graph": [
     {
-      "@id": "niiri:1e805678e8d91a4581c0bed1666665ec",
-      "@type": ["prov:Entity","prov:Bundle","nidm_NIDMResults:"],
+      "@id": "niiri:ba1fb3597bc0b59f859a3efc40c4f95b",
+      "@type": ["prov:Entity","prov:Bundle","nidm_NIDMResults"],
       "rdfs:label": "NIDM-Results",
-      "nidm_version:": {"@type": "xsd:string", "@value": "1.3.0"}
+      "nidm_version": {"@type": "xsd:string", "@value": "1.3.0"}
     },
     {
-      "@id": "niiri:9c6891309f399ec96286e6577bc877cf",
-      "@type": ["prov:Agent","nidm_spm_results_nidm:","prov:SoftwareAgent"],
+      "@id": "niiri:36ef4229b87d0546f0547127a62087a2",
+      "@type": ["prov:Agent","nidm_spm_results_nidm","prov:SoftwareAgent"],
       "rdfs:label": "spm_results_nidm",
-      "nidm_softwareVersion:": {"@type": "xsd:string", "@value": "12.6903"}
+      "nidm_softwareVersion": {"@type": "xsd:string", "@value": "12.7057"}
     },
     {
-      "@id": "niiri:25cb52028c9f0280dca0e45a2dda8352",
-      "@type": ["prov:Activity","nidm_NIDMResultsExport:"],
+      "@id": "niiri:d5312e2f7b2e014fe0e8c544933bdd34",
+      "@type": ["prov:Activity","nidm_NIDMResultsExport"],
       "rdfs:label": "NIDM-Results export"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:25cb52028c9f0280dca0e45a2dda8352",
-      "agent": "niiri:9c6891309f399ec96286e6577bc877cf"
+      "activity_associated": "niiri:d5312e2f7b2e014fe0e8c544933bdd34",
+      "agent": "niiri:36ef4229b87d0546f0547127a62087a2"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:1e805678e8d91a4581c0bed1666665ec",
-      "activity": "niiri:25cb52028c9f0280dca0e45a2dda8352",
-      "atTime": "2016-12-07T16:09:15"
+      "entity_generated": "niiri:ba1fb3597bc0b59f859a3efc40c4f95b",
+      "activity": "niiri:d5312e2f7b2e014fe0e8c544933bdd34",
+      "atTime": "2017-04-19T12:18:44"
     }
   ]
 },
@@ -157,703 +157,703 @@
       "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
     }
   ],
-  "@id": "niiri:1e805678e8d91a4581c0bed1666665ec",
+  "@id": "niiri:ba1fb3597bc0b59f859a3efc40c4f95b",
   "@graph": [
     {
-      "@id": "niiri:efa026de268c2c7adcb83113c80feffe",
-      "@type": ["prov:Agent","src_SPM:","prov:SoftwareAgent"],
+      "@id": "niiri:9d7bdfb1f005a1c77912a13aad1d7cca",
+      "@type": ["prov:Agent","src_SPM","prov:SoftwareAgent"],
       "rdfs:label": "SPM",
-      "nidm_softwareVersion:": {"@type": "xsd:string", "@value": "12.12.2"}
+      "nidm_softwareVersion": {"@type": "xsd:string", "@value": "12.6906"}
     },
     {
-      "@id": "niiri:2041dec7e8e64e30d54afd5c1e5ed5d5",
-      "@type": ["prov:Entity","nidm_CoordinateSpace:"],
+      "@id": "niiri:21f24d2b86fec337fe05741e4da7e8c3",
+      "@type": ["prov:Entity","nidm_CoordinateSpace"],
       "rdfs:label": "Coordinate space 1",
-      "nidm_voxelToWorldMapping:": {"@type": "xsd:string", "@value": "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"},
-      "nidm_voxelUnits:": {"@type": "xsd:string", "@value": "[\"mm\", \"mm\", \"mm\"]"},
-      "nidm_voxelSize:": {"@type": "xsd:string", "@value": "[2, 2, 2]"},
-      "nidm_inWorldCoordinateSystem:": {"@id": "nidm_Ixi549CoordinateSystem:"},
-      "nidm_numberOfDimensions:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_dimensionsInVoxels:": {"@type": "xsd:string", "@value": "[79,95,79]"}
+      "nidm_voxelToWorldMapping": {"@type": "xsd:string", "@value": "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"},
+      "nidm_voxelUnits": {"@type": "xsd:string", "@value": "[\"mm\", \"mm\", \"mm\"]"},
+      "nidm_voxelSize": {"@type": "xsd:string", "@value": "[2, 2, 2]"},
+      "nidm_inWorldCoordinateSystem": {"@id": "nidm_Ixi549CoordinateSystem"},
+      "nidm_numberOfDimensions": {"@type": "xsd:int", "@value": "3"},
+      "nidm_dimensionsInVoxels": {"@type": "xsd:string", "@value": "[79,95,79]"}
     },
     {
-      "@id": "niiri:e542fdfb0839ca0528cef73de2652f98",
-      "@type": ["prov:Agent","nlx_Imaginginstrument:","nlx_Magneticresonanceimagingscanner:"],
+      "@id": "niiri:4dd802783f824c7aacfc4e4e4ee26461",
+      "@type": ["prov:Agent","nlx_Imaginginstrument","nlx_Magneticresonanceimagingscanner"],
       "rdfs:label": "MRI Scanner"
     },
     {
-      "@id": "niiri:927fa72d7b5ce13647f6c65adbbf6bf7",
+      "@id": "niiri:37dff96025f813fa2cae9c2f2ab20af0",
       "@type": ["prov:Agent","prov:Person"],
       "rdfs:label": "Person"
     },
     {
-      "@id": "niiri:6681bf626b7371145c7895482260b2a1",
-      "@type": ["prov:Entity","prov:Collection","nidm_Data:"],
+      "@id": "niiri:b0407acb83b2703b82444e30fcac401b",
+      "@type": ["prov:Entity","prov:Collection","nidm_Data"],
       "rdfs:label": "Data",
-      "nidm_grandMeanScaling:": {"@type": "xsd:boolean", "@value": "true"},
-      "nidm_targetIntensity:": {"@type": "xsd:float", "@value": "100"},
-      "nidm_hasMRIProtocol:": {"@id": "nlx_FunctionalMRIprotocol:"}
+      "nidm_grandMeanScaling": {"@type": "xsd:boolean", "@value": "true"},
+      "nidm_targetIntensity": {"@type": "xsd:float", "@value": "100"},
+      "nidm_hasMRIProtocol": {"@id": "nlx_FunctionalMRIprotocol"}
     },
     {
       "@type": "prov:Attribution",
-      "entity_attributed": "niiri:6681bf626b7371145c7895482260b2a1",
-      "agent": "niiri:e542fdfb0839ca0528cef73de2652f98"
+      "entity_attributed": "niiri:b0407acb83b2703b82444e30fcac401b",
+      "agent": "niiri:4dd802783f824c7aacfc4e4e4ee26461"
     },
     {
       "@type": "prov:Attribution",
-      "entity_attributed": "niiri:6681bf626b7371145c7895482260b2a1",
-      "agent": "niiri:927fa72d7b5ce13647f6c65adbbf6bf7"
+      "entity_attributed": "niiri:b0407acb83b2703b82444e30fcac401b",
+      "agent": "niiri:37dff96025f813fa2cae9c2f2ab20af0"
     },
     {
-      "@id": "niiri:38e737c30e2fb759db92d8bc4268e81b",
-      "@type": ["prov:Entity","spm_DCTDriftModel:"],
+      "@id": "niiri:b557e098b34f31a9e2f16762e818990f",
+      "@type": ["prov:Entity","spm_DCTDriftModel"],
       "rdfs:label": "SPM's DCT Drift Model",
-      "spm_SPMsDriftCutoffPeriod:": {"@type": "xsd:float", "@value": "128"}
+      "spm_SPMsDriftCutoffPeriod": {"@type": "xsd:float", "@value": "128"}
     },
     {
-      "@id": "niiri:e1a0227db35f62505199c7caf2715949",
-      "@type": ["prov:Entity","nidm_DesignMatrix:"],
+      "@id": "niiri:59859d0ad01111bc8ee8288526aae37d",
+      "@type": ["prov:Entity","nidm_DesignMatrix"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "DesignMatrix.csv"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "DesignMatrix.csv"},
       "dct:format": {"@type": "xsd:string", "@value": "text/csv"},
-      "dc:description": {"@id": "niiri:200cebbb19189fc612ba6efcaba103f0"},
+      "dc:description": {"@id": "niiri:606e0581bbcbad8b686c00155e95f5a0"},
       "rdfs:label": "Design Matrix",
-      "nidm_regressorNames:": {"@type": "xsd:string", "@value": "[\"Sn(1) to*bf(1)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) constant\"]"},
-      "nidm_hasDriftModel:": {"@id": "niiri:38e737c30e2fb759db92d8bc4268e81b"},
-      "nidm_hasHRFBasis:": {"@id": "spm_SPMsCanonicalHRF:"}
+      "nidm_regressorNames": {"@type": "xsd:string", "@value": "[\"Sn(1) to*bf(1)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) constant\"]"},
+      "nidm_hasDriftModel": {"@id": "niiri:b557e098b34f31a9e2f16762e818990f"},
+      "nidm_hasHRFBasis": {"@id": "spm_SPMsCanonicalHRF"}
     },
     {
-      "@id": "niiri:200cebbb19189fc612ba6efcaba103f0",
+      "@id": "niiri:606e0581bbcbad8b686c00155e95f5a0",
       "@type": ["prov:Entity","dctype:Image"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "DesignMatrix.png"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "DesignMatrix.png"},
       "dct:format": {"@type": "xsd:string", "@value": "image/png"}
     },
     {
-      "@id": "niiri:d1b295db79dc87c49bb51479ebdee218",
-      "@type": ["prov:Entity","nidm_ErrorModel:"],
-      "nidm_hasErrorDistribution:": {"@id": "obo_normaldistribution:"},
-      "nidm_hasErrorDependence:": {"@id": "obo_Toeplitzcovariancestructure:"},
-      "nidm_dependenceMapWiseDependence:": {"@id": "nidm_ConstantParameter:"},
-      "nidm_errorVarianceHomogeneous:": {"@type": "xsd:boolean", "@value": "true"},
-      "nidm_varianceMapWiseDependence:": {"@id": "nidm_IndependentParameter:"}
+      "@id": "niiri:16eb1e414b6a4247bd1b7cfca669048c",
+      "@type": ["prov:Entity","nidm_ErrorModel"],
+      "nidm_hasErrorDistribution": {"@id": "obo_normaldistribution"},
+      "nidm_hasErrorDependence": {"@id": "obo_Toeplitzcovariancestructure"},
+      "nidm_dependenceMapWiseDependence": {"@id": "nidm_ConstantParameter"},
+      "nidm_errorVarianceHomogeneous": {"@type": "xsd:boolean", "@value": "true"},
+      "nidm_varianceMapWiseDependence": {"@id": "nidm_IndependentParameter"}
     },
     {
-      "@id": "niiri:7acaa5ee9bfb239b4c336845cc77e1ad",
-      "@type": ["prov:Activity","nidm_ModelParametersEstimation:"],
+      "@id": "niiri:10b49e4617715cf283ca55ab051c7161",
+      "@type": ["prov:Activity","nidm_ModelParametersEstimation"],
       "rdfs:label": "Model parameters estimation",
-      "nidm_withEstimationMethod:": {"@id": "obo_generalizedleastsquaresestimation:"}
+      "nidm_withEstimationMethod": {"@id": "obo_generalizedleastsquaresestimation"}
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:7acaa5ee9bfb239b4c336845cc77e1ad",
-      "agent": "niiri:efa026de268c2c7adcb83113c80feffe"
+      "activity_associated": "niiri:10b49e4617715cf283ca55ab051c7161",
+      "agent": "niiri:9d7bdfb1f005a1c77912a13aad1d7cca"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:7acaa5ee9bfb239b4c336845cc77e1ad",
-      "entity": "niiri:e1a0227db35f62505199c7caf2715949"
+      "activity_using": "niiri:10b49e4617715cf283ca55ab051c7161",
+      "entity": "niiri:59859d0ad01111bc8ee8288526aae37d"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:7acaa5ee9bfb239b4c336845cc77e1ad",
-      "entity": "niiri:6681bf626b7371145c7895482260b2a1"
+      "activity_using": "niiri:10b49e4617715cf283ca55ab051c7161",
+      "entity": "niiri:b0407acb83b2703b82444e30fcac401b"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:7acaa5ee9bfb239b4c336845cc77e1ad",
-      "entity": "niiri:d1b295db79dc87c49bb51479ebdee218"
+      "activity_using": "niiri:10b49e4617715cf283ca55ab051c7161",
+      "entity": "niiri:16eb1e414b6a4247bd1b7cfca669048c"
     },
     {
-      "@id": "niiri:4a1b25825ebfaf1382fe57aac7e6174c",
-      "@type": ["prov:Entity","nidm_MaskMap:"],
+      "@id": "niiri:aba08deba6439b8fd82d98d160e5d070",
+      "@type": ["prov:Entity","nidm_MaskMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "Mask.nii.gz"},
-      "nidm_isUserDefined:": {"@type": "xsd:boolean", "@value": "false"},
+      "nidm_isUserDefined": {"@type": "xsd:boolean", "@value": "false"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "Mask.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Mask",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:2041dec7e8e64e30d54afd5c1e5ed5d5"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:21f24d2b86fec337fe05741e4da7e8c3"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876"}
     },
     {
-      "@id": "niiri:16f899a6f193249b767a93ea52a8290c",
-      "@type": ["prov:Entity","nidm_MaskMap:"],
+      "@id": "niiri:b3f11481d93002948ba4265eb6fc7a17",
+      "@type": ["prov:Entity","nidm_MaskMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "mask.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "36929e1f5f4143bd9cc818cd896a25f129961fab208c3a4438555f40444c08347b359142ee8c53ece6e8cca1627f49db0788a1fd3b9e2ecaef61999c6c6c67ac"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4a1b25825ebfaf1382fe57aac7e6174c",
-      "entity": "niiri:16f899a6f193249b767a93ea52a8290c"
+      "entity_derived": "niiri:aba08deba6439b8fd82d98d160e5d070",
+      "entity": "niiri:b3f11481d93002948ba4265eb6fc7a17"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:4a1b25825ebfaf1382fe57aac7e6174c",
-      "activity": "niiri:7acaa5ee9bfb239b4c336845cc77e1ad"
+      "entity_generated": "niiri:aba08deba6439b8fd82d98d160e5d070",
+      "activity": "niiri:10b49e4617715cf283ca55ab051c7161"
     },
     {
-      "@id": "niiri:dc34026c4b4c9e6d2afb7d3f79aedd00",
-      "@type": ["prov:Entity","nidm_GrandMeanMap:"],
+      "@id": "niiri:4f4a4075f1bc1968a80b2f594b2a5ef9",
+      "@type": ["prov:Entity","nidm_GrandMeanMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "GrandMean.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "GrandMean.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Grand Mean Map",
-      "nidm_maskedMedian:": {"@type": "xsd:float", "@value": "111.557487487793"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:2041dec7e8e64e30d54afd5c1e5ed5d5"},
+      "nidm_maskedMedian": {"@type": "xsd:float", "@value": "111.557487487793"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:21f24d2b86fec337fe05741e4da7e8c3"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "512157cc6bff89d9343a09b4068226eb3edd64a8cbcee861f06231767fae6f8d4819921182adebee083a9bf309afd65529ab04a92f0aa6b0038c8098550f6124"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:dc34026c4b4c9e6d2afb7d3f79aedd00",
-      "activity": "niiri:7acaa5ee9bfb239b4c336845cc77e1ad"
+      "entity_generated": "niiri:4f4a4075f1bc1968a80b2f594b2a5ef9",
+      "activity": "niiri:10b49e4617715cf283ca55ab051c7161"
     },
     {
-      "@id": "niiri:03d5307ba8e51d1aad0db72fb88d6549",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:a5c5180e35f868db315e52abaf2ab6cf",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0001.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0001.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 1",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:2041dec7e8e64e30d54afd5c1e5ed5d5"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:21f24d2b86fec337fe05741e4da7e8c3"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd"}
     },
     {
-      "@id": "niiri:bc25474037aee5bb4f0ce9ca2c6bb584",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:5ff4045c3fb225d6d68fbb0c98b08a69",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0001.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:03d5307ba8e51d1aad0db72fb88d6549",
-      "entity": "niiri:bc25474037aee5bb4f0ce9ca2c6bb584"
+      "entity_derived": "niiri:a5c5180e35f868db315e52abaf2ab6cf",
+      "entity": "niiri:5ff4045c3fb225d6d68fbb0c98b08a69"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:03d5307ba8e51d1aad0db72fb88d6549",
-      "activity": "niiri:7acaa5ee9bfb239b4c336845cc77e1ad"
+      "entity_generated": "niiri:a5c5180e35f868db315e52abaf2ab6cf",
+      "activity": "niiri:10b49e4617715cf283ca55ab051c7161"
     },
     {
-      "@id": "niiri:a8816b2cfe85140efa0620be4aab5614",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:109842e828160f2f74424c94fa31d3ac",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0002.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0002.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 2",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:2041dec7e8e64e30d54afd5c1e5ed5d5"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:21f24d2b86fec337fe05741e4da7e8c3"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c"}
     },
     {
-      "@id": "niiri:245ffc0843b07513d2b4f41431b2ac4e",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:9237a7292e50834f847b622ac8097d47",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0002.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a8816b2cfe85140efa0620be4aab5614",
-      "entity": "niiri:245ffc0843b07513d2b4f41431b2ac4e"
+      "entity_derived": "niiri:109842e828160f2f74424c94fa31d3ac",
+      "entity": "niiri:9237a7292e50834f847b622ac8097d47"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:a8816b2cfe85140efa0620be4aab5614",
-      "activity": "niiri:7acaa5ee9bfb239b4c336845cc77e1ad"
+      "entity_generated": "niiri:109842e828160f2f74424c94fa31d3ac",
+      "activity": "niiri:10b49e4617715cf283ca55ab051c7161"
     },
     {
-      "@id": "niiri:4e97093a58d33a65dc12233b6c898b62",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:670abeebbed6d1e906338a6a7b6e100d",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0003.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0003.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 3",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:2041dec7e8e64e30d54afd5c1e5ed5d5"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:21f24d2b86fec337fe05741e4da7e8c3"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373"}
     },
     {
-      "@id": "niiri:115b809113660156811cf73cdcf32fce",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:e1ead41ef090189a9edc014566d7fa8a",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0003.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4e97093a58d33a65dc12233b6c898b62",
-      "entity": "niiri:115b809113660156811cf73cdcf32fce"
+      "entity_derived": "niiri:670abeebbed6d1e906338a6a7b6e100d",
+      "entity": "niiri:e1ead41ef090189a9edc014566d7fa8a"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:4e97093a58d33a65dc12233b6c898b62",
-      "activity": "niiri:7acaa5ee9bfb239b4c336845cc77e1ad"
+      "entity_generated": "niiri:670abeebbed6d1e906338a6a7b6e100d",
+      "activity": "niiri:10b49e4617715cf283ca55ab051c7161"
     },
     {
-      "@id": "niiri:30f40812f50fccb6b59091ec7c587071",
-      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap:"],
+      "@id": "niiri:9d50bf99d1eb9b3e0c264b87fd74b224",
+      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ResidualMeanSquares.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ResidualMeanSquares.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Residual Mean Squares Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:2041dec7e8e64e30d54afd5c1e5ed5d5"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:21f24d2b86fec337fe05741e4da7e8c3"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "991abf563d795a43b1e2eef8643e57023f2e0b090b2031f05f839321fc0643df6f71d423486a1021519b6dc82f6b0f563e19f3fbd50cb16063bed54a0e192d3e"}
     },
     {
-      "@id": "niiri:a303f4f3614814399a66413d10ad60b1",
-      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap:"],
+      "@id": "niiri:0ecf4a4c4ca5a416fa2e7555c094ddb6",
+      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "ResMS.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "40b28d03fcf9a2f60b11f10d7fb83bf3618b234fb5aedf09df644cb7cbb6aab8c9f468897c1078166d455a3d04a83f4e3bf762cfca0b4ea982d7a4e406849f18"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:30f40812f50fccb6b59091ec7c587071",
-      "entity": "niiri:a303f4f3614814399a66413d10ad60b1"
+      "entity_derived": "niiri:9d50bf99d1eb9b3e0c264b87fd74b224",
+      "entity": "niiri:0ecf4a4c4ca5a416fa2e7555c094ddb6"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:30f40812f50fccb6b59091ec7c587071",
-      "activity": "niiri:7acaa5ee9bfb239b4c336845cc77e1ad"
+      "entity_generated": "niiri:9d50bf99d1eb9b3e0c264b87fd74b224",
+      "activity": "niiri:10b49e4617715cf283ca55ab051c7161"
     },
     {
-      "@id": "niiri:25cb1d7201060f78fd019e0bb4a23ea3",
-      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap:"],
+      "@id": "niiri:bc8b436cc11302e4d61399ed8127ddce",
+      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ReselsPerVoxel.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ReselsPerVoxel.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Resels per Voxel Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:2041dec7e8e64e30d54afd5c1e5ed5d5"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:21f24d2b86fec337fe05741e4da7e8c3"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "1a3f9216e145249ccc0b14b2bc337d6b38b81ad45e32768001fb22b35f0c2c0f3e2bce013b40c85f7dc0fc62723ac761ee7f7e1e6aff128a05f0ba7b8b8202a3"}
     },
     {
-      "@id": "niiri:91241afaf3a7f86610c092094ce1fd43",
-      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap:"],
+      "@id": "niiri:4d7372ca3c6f7a39fc98bc6a82293781",
+      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "RPV.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "4f76663162857f6b38b2a45a63b15a23b2ca8b338c283b69c1e71f2ea2f43797d045a733cd14e845be9c12f8b8f84d3931c599a08e8f6d77e99fab46ad87ab8f"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:25cb1d7201060f78fd019e0bb4a23ea3",
-      "entity": "niiri:91241afaf3a7f86610c092094ce1fd43"
+      "entity_derived": "niiri:bc8b436cc11302e4d61399ed8127ddce",
+      "entity": "niiri:4d7372ca3c6f7a39fc98bc6a82293781"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:25cb1d7201060f78fd019e0bb4a23ea3",
-      "activity": "niiri:7acaa5ee9bfb239b4c336845cc77e1ad"
+      "entity_generated": "niiri:bc8b436cc11302e4d61399ed8127ddce",
+      "activity": "niiri:10b49e4617715cf283ca55ab051c7161"
     },
     {
-      "@id": "niiri:d83fd950805feda98418d40b12d3a3f0",
-      "@type": ["prov:Entity","obo_contrastweightmatrix:"],
-      "nidm_statisticType:": {"@id": "obo_tstatistic:"},
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
+      "@id": "niiri:e12b3b920d0b0e8c6be817754a69ec93",
+      "@type": ["prov:Entity","obo_contrastweightmatrix"],
+      "nidm_statisticType": {"@id": "obo_tstatistic"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
       "rdfs:label": "Contrast: tone counting vs baseline",
       "prov:value": {"@type": "xsd:string", "@value": "[1, 0, 0]"}
     },
     {
-      "@id": "niiri:5abe791cb79edc4cccac6abf5a11e076",
-      "@type": ["prov:Activity","nidm_ContrastEstimation:"],
+      "@id": "niiri:dd06c607e32f76dc0e4ff497c11b759c",
+      "@type": ["prov:Activity","nidm_ContrastEstimation"],
       "rdfs:label": "Contrast estimation 1"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:5abe791cb79edc4cccac6abf5a11e076",
-      "agent": "niiri:efa026de268c2c7adcb83113c80feffe"
+      "activity_associated": "niiri:dd06c607e32f76dc0e4ff497c11b759c",
+      "agent": "niiri:9d7bdfb1f005a1c77912a13aad1d7cca"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:5abe791cb79edc4cccac6abf5a11e076",
-      "entity": "niiri:4a1b25825ebfaf1382fe57aac7e6174c"
+      "activity_using": "niiri:dd06c607e32f76dc0e4ff497c11b759c",
+      "entity": "niiri:aba08deba6439b8fd82d98d160e5d070"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:5abe791cb79edc4cccac6abf5a11e076",
-      "entity": "niiri:30f40812f50fccb6b59091ec7c587071"
+      "activity_using": "niiri:dd06c607e32f76dc0e4ff497c11b759c",
+      "entity": "niiri:9d50bf99d1eb9b3e0c264b87fd74b224"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:5abe791cb79edc4cccac6abf5a11e076",
-      "entity": "niiri:e1a0227db35f62505199c7caf2715949"
+      "activity_using": "niiri:dd06c607e32f76dc0e4ff497c11b759c",
+      "entity": "niiri:59859d0ad01111bc8ee8288526aae37d"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:5abe791cb79edc4cccac6abf5a11e076",
-      "entity": "niiri:d83fd950805feda98418d40b12d3a3f0"
+      "activity_using": "niiri:dd06c607e32f76dc0e4ff497c11b759c",
+      "entity": "niiri:e12b3b920d0b0e8c6be817754a69ec93"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:5abe791cb79edc4cccac6abf5a11e076",
-      "entity": "niiri:03d5307ba8e51d1aad0db72fb88d6549"
+      "activity_using": "niiri:dd06c607e32f76dc0e4ff497c11b759c",
+      "entity": "niiri:a5c5180e35f868db315e52abaf2ab6cf"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:5abe791cb79edc4cccac6abf5a11e076",
-      "entity": "niiri:a8816b2cfe85140efa0620be4aab5614"
+      "activity_using": "niiri:dd06c607e32f76dc0e4ff497c11b759c",
+      "entity": "niiri:109842e828160f2f74424c94fa31d3ac"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:5abe791cb79edc4cccac6abf5a11e076",
-      "entity": "niiri:4e97093a58d33a65dc12233b6c898b62"
+      "activity_using": "niiri:dd06c607e32f76dc0e4ff497c11b759c",
+      "entity": "niiri:670abeebbed6d1e906338a6a7b6e100d"
     },
     {
-      "@id": "niiri:35c5be3ff2b46cabb83d5d20de1bbfe3",
-      "@type": ["prov:Entity","nidm_StatisticMap:"],
+      "@id": "niiri:ef836beafc2e291065c57b3a7e86dc80",
+      "@type": ["prov:Entity","nidm_StatisticMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "TStatistic_0001.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "TStatistic_0001.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "T-Statistic Map: tone counting vs baseline",
-      "nidm_statisticType:": {"@id": "obo_tstatistic:"},
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
-      "nidm_errorDegreesOfFreedom:": {"@type": "xsd:float", "@value": "97.9999999998522"},
-      "nidm_effectDegreesOfFreedom:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:2041dec7e8e64e30d54afd5c1e5ed5d5"},
+      "nidm_statisticType": {"@id": "obo_tstatistic"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
+      "nidm_errorDegreesOfFreedom": {"@type": "xsd:float", "@value": "97.9999999998522"},
+      "nidm_effectDegreesOfFreedom": {"@type": "xsd:float", "@value": "1"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:21f24d2b86fec337fe05741e4da7e8c3"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "90a7b52d7e93a959aa14734abe286d20002ca269bfa11f4ad798c65573c0912e923220c2dbcd25ac59c7dff26c3685907c0b8083db510ee63663d534206e0f96"}
     },
     {
-      "@id": "niiri:fbb31560904631bd3afe3b59b74e14be",
-      "@type": ["prov:Entity","nidm_StatisticMap:"],
+      "@id": "niiri:49749ebbcacba1baa8e79e02c1938189",
+      "@type": ["prov:Entity","nidm_StatisticMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "spmT_0001.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "d288b1b0f117f64502555da13c5398dffa5bf5ff0b58951510e43d5388755bc185798802a92e98a07c7e313c6991066d2908f2a44aa5153ba23433da1335970f"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:35c5be3ff2b46cabb83d5d20de1bbfe3",
-      "entity": "niiri:fbb31560904631bd3afe3b59b74e14be"
+      "entity_derived": "niiri:ef836beafc2e291065c57b3a7e86dc80",
+      "entity": "niiri:49749ebbcacba1baa8e79e02c1938189"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:35c5be3ff2b46cabb83d5d20de1bbfe3",
-      "activity": "niiri:5abe791cb79edc4cccac6abf5a11e076"
+      "entity_generated": "niiri:ef836beafc2e291065c57b3a7e86dc80",
+      "activity": "niiri:dd06c607e32f76dc0e4ff497c11b759c"
     },
     {
-      "@id": "niiri:61ec0f02bd4bb0e15edd816988222775",
-      "@type": ["prov:Entity","nidm_ContrastMap:"],
+      "@id": "niiri:9d77bd5bfcea339e1308f2f57159142a",
+      "@type": ["prov:Entity","nidm_ContrastMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "Contrast_0001.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "Contrast_0001.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Contrast Map: tone counting vs baseline",
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:2041dec7e8e64e30d54afd5c1e5ed5d5"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:21f24d2b86fec337fe05741e4da7e8c3"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "fc5e2ad175243ee496db98f9b2e1b235c4c3bae1a8d7122ce461c897b537e40c49dfee5d6cf20f71c6a2bb9b5f0760fcb4ecd8fe2e9428910ef3d60d8f3c56a9"}
     },
     {
-      "@id": "niiri:ba752875ff6ce17c2871d56a45b924e7",
-      "@type": ["prov:Entity","nidm_ContrastMap:"],
+      "@id": "niiri:05afb3605ef5b9f0b252b00b89bc58c8",
+      "@type": ["prov:Entity","nidm_ContrastMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "con_0001.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "d4aa46b3603ba508578e39751262d528cf6d1ed2e722ec46f1cd8194c50591e46b229deb8cb4f72d1b7e0e2640f3e6604be7a335301c5c8357f453e5d0d4daf2"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:61ec0f02bd4bb0e15edd816988222775",
-      "entity": "niiri:ba752875ff6ce17c2871d56a45b924e7"
+      "entity_derived": "niiri:9d77bd5bfcea339e1308f2f57159142a",
+      "entity": "niiri:05afb3605ef5b9f0b252b00b89bc58c8"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:61ec0f02bd4bb0e15edd816988222775",
-      "activity": "niiri:5abe791cb79edc4cccac6abf5a11e076"
+      "entity_generated": "niiri:9d77bd5bfcea339e1308f2f57159142a",
+      "activity": "niiri:dd06c607e32f76dc0e4ff497c11b759c"
     },
     {
-      "@id": "niiri:2fd2006e149f67aefe1d282c5fd6cf4c",
-      "@type": ["prov:Entity","nidm_ContrastStandardErrorMap:"],
+      "@id": "niiri:2fcd23f1ed3c1835696b5f3f6c067474",
+      "@type": ["prov:Entity","nidm_ContrastStandardErrorMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ContrastStandardError_0001.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ContrastStandardError_0001.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Contrast Standard Error Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:2041dec7e8e64e30d54afd5c1e5ed5d5"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:21f24d2b86fec337fe05741e4da7e8c3"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "791d48f5d1adb15079a5289271ce0c4b95c56d69bfdb3e5d41b0d24eb538d3075e1cdd15502494b5a5a18c16eaa2153cb4847a996043fa48cdaf26e938a2576d"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:2fd2006e149f67aefe1d282c5fd6cf4c",
-      "activity": "niiri:5abe791cb79edc4cccac6abf5a11e076"
+      "entity_generated": "niiri:2fcd23f1ed3c1835696b5f3f6c067474",
+      "activity": "niiri:dd06c607e32f76dc0e4ff497c11b759c"
     },
     {
-      "@id": "niiri:30ce6fd109cd2ceea8faa079a66d9f5c",
-      "@type": ["prov:Entity","obo_contrastweightmatrix:"],
-      "nidm_statisticType:": {"@id": "obo_tstatistic:"},
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "tone counting probe vs baseline (orth. w.r.t {1})"},
+      "@id": "niiri:ba7f4a78f7bfc8dfe15e84f017dffc6f",
+      "@type": ["prov:Entity","obo_contrastweightmatrix"],
+      "nidm_statisticType": {"@id": "obo_tstatistic"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "tone counting probe vs baseline (orth. w.r.t {1})"},
       "rdfs:label": "Contrast: tone counting probe vs baseline (orth. w.r.t {1})",
       "prov:value": {"@type": "xsd:string", "@value": "[-0.919333604280958, 1, 0]"}
     },
     {
-      "@id": "niiri:c6a22989f43b68b871331c4257dd8326",
-      "@type": ["prov:Activity","nidm_ContrastEstimation:"],
+      "@id": "niiri:b91cbbf6a4f5303474a88b3cbc77d086",
+      "@type": ["prov:Activity","nidm_ContrastEstimation"],
       "rdfs:label": "Contrast estimation 2"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:c6a22989f43b68b871331c4257dd8326",
-      "agent": "niiri:efa026de268c2c7adcb83113c80feffe"
+      "activity_associated": "niiri:b91cbbf6a4f5303474a88b3cbc77d086",
+      "agent": "niiri:9d7bdfb1f005a1c77912a13aad1d7cca"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:c6a22989f43b68b871331c4257dd8326",
-      "entity": "niiri:4a1b25825ebfaf1382fe57aac7e6174c"
+      "activity_using": "niiri:b91cbbf6a4f5303474a88b3cbc77d086",
+      "entity": "niiri:aba08deba6439b8fd82d98d160e5d070"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:c6a22989f43b68b871331c4257dd8326",
-      "entity": "niiri:30f40812f50fccb6b59091ec7c587071"
+      "activity_using": "niiri:b91cbbf6a4f5303474a88b3cbc77d086",
+      "entity": "niiri:9d50bf99d1eb9b3e0c264b87fd74b224"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:c6a22989f43b68b871331c4257dd8326",
-      "entity": "niiri:e1a0227db35f62505199c7caf2715949"
+      "activity_using": "niiri:b91cbbf6a4f5303474a88b3cbc77d086",
+      "entity": "niiri:59859d0ad01111bc8ee8288526aae37d"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:c6a22989f43b68b871331c4257dd8326",
-      "entity": "niiri:30ce6fd109cd2ceea8faa079a66d9f5c"
+      "activity_using": "niiri:b91cbbf6a4f5303474a88b3cbc77d086",
+      "entity": "niiri:ba7f4a78f7bfc8dfe15e84f017dffc6f"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:c6a22989f43b68b871331c4257dd8326",
-      "entity": "niiri:03d5307ba8e51d1aad0db72fb88d6549"
+      "activity_using": "niiri:b91cbbf6a4f5303474a88b3cbc77d086",
+      "entity": "niiri:a5c5180e35f868db315e52abaf2ab6cf"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:c6a22989f43b68b871331c4257dd8326",
-      "entity": "niiri:a8816b2cfe85140efa0620be4aab5614"
+      "activity_using": "niiri:b91cbbf6a4f5303474a88b3cbc77d086",
+      "entity": "niiri:109842e828160f2f74424c94fa31d3ac"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:c6a22989f43b68b871331c4257dd8326",
-      "entity": "niiri:4e97093a58d33a65dc12233b6c898b62"
+      "activity_using": "niiri:b91cbbf6a4f5303474a88b3cbc77d086",
+      "entity": "niiri:670abeebbed6d1e906338a6a7b6e100d"
     },
     {
-      "@id": "niiri:01987becac1b40cdffe20150c4b33a59",
-      "@type": ["prov:Entity","nidm_StatisticMap:"],
+      "@id": "niiri:955daf8b5134c9320aad7d629101cc88",
+      "@type": ["prov:Entity","nidm_StatisticMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "TStatistic_0002.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "TStatistic_0002.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "T-Statistic Map: tone counting probe vs baseline (orth. w.r.t {1})",
-      "nidm_statisticType:": {"@id": "obo_tstatistic:"},
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "tone counting probe vs baseline (orth. w.r.t {1})"},
-      "nidm_errorDegreesOfFreedom:": {"@type": "xsd:float", "@value": "97.9999999998522"},
-      "nidm_effectDegreesOfFreedom:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:2041dec7e8e64e30d54afd5c1e5ed5d5"},
+      "nidm_statisticType": {"@id": "obo_tstatistic"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "tone counting probe vs baseline (orth. w.r.t {1})"},
+      "nidm_errorDegreesOfFreedom": {"@type": "xsd:float", "@value": "97.9999999998522"},
+      "nidm_effectDegreesOfFreedom": {"@type": "xsd:float", "@value": "1"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:21f24d2b86fec337fe05741e4da7e8c3"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "d90b7e100f85bd13206e5074638371c2e4559ff1a748aa67a42ac9d0da802b9f2b04df108d32f3ea375017805784a9814b9b2eb515bbe8930b1fe39eb68e6299"}
     },
     {
-      "@id": "niiri:e1bccab747dae000113e66e77ec4821f",
-      "@type": ["prov:Entity","nidm_StatisticMap:"],
+      "@id": "niiri:de187bcb23967e7a4b132bd43bbb2d3c",
+      "@type": ["prov:Entity","nidm_StatisticMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "spmT_0003.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "16529d1636b3f7868ae8acaee472adf6ad23cebc0fdbb7412821197d62029e7d5b1dd078621353bca152fba21256adb888cd718b194876faaa82995ffe653e74"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:01987becac1b40cdffe20150c4b33a59",
-      "entity": "niiri:e1bccab747dae000113e66e77ec4821f"
+      "entity_derived": "niiri:955daf8b5134c9320aad7d629101cc88",
+      "entity": "niiri:de187bcb23967e7a4b132bd43bbb2d3c"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:01987becac1b40cdffe20150c4b33a59",
-      "activity": "niiri:c6a22989f43b68b871331c4257dd8326"
+      "entity_generated": "niiri:955daf8b5134c9320aad7d629101cc88",
+      "activity": "niiri:b91cbbf6a4f5303474a88b3cbc77d086"
     },
     {
-      "@id": "niiri:6ae2e9f62ec52a002b8d8692bd9dadd0",
-      "@type": ["prov:Entity","nidm_ContrastMap:"],
+      "@id": "niiri:66ede7151e2d666315b2d79e13573a47",
+      "@type": ["prov:Entity","nidm_ContrastMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "Contrast_0002.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "Contrast_0002.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Contrast Map: tone counting probe vs baseline (orth. w.r.t {1})",
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "tone counting probe vs baseline (orth. w.r.t {1})"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:2041dec7e8e64e30d54afd5c1e5ed5d5"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "tone counting probe vs baseline (orth. w.r.t {1})"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:21f24d2b86fec337fe05741e4da7e8c3"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "89f2233bd64ee40c2ceb5f4e9d0bcbb9a681ad9fa298da4fbdec7173edf186ce33efe3dd331eab07bdbeb7283538e62798692680031d672e724fd90e790439fd"}
     },
     {
-      "@id": "niiri:3e1a2f6bc81c7612a4b172dffb80a2c0",
-      "@type": ["prov:Entity","nidm_ContrastMap:"],
+      "@id": "niiri:ceab125faff01ef71a425d244d8dd312",
+      "@type": ["prov:Entity","nidm_ContrastMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "con_0003.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "2c14d615d64b789ee26a22dea4052e1f42f951e9154448c931c0e2d16c7a8c5acb33dfb228e8e61da37f13a182ec2e50aeba6434e05e6dcc5d9cab2f1f6ff680"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6ae2e9f62ec52a002b8d8692bd9dadd0",
-      "entity": "niiri:3e1a2f6bc81c7612a4b172dffb80a2c0"
+      "entity_derived": "niiri:66ede7151e2d666315b2d79e13573a47",
+      "entity": "niiri:ceab125faff01ef71a425d244d8dd312"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:6ae2e9f62ec52a002b8d8692bd9dadd0",
-      "activity": "niiri:c6a22989f43b68b871331c4257dd8326"
+      "entity_generated": "niiri:66ede7151e2d666315b2d79e13573a47",
+      "activity": "niiri:b91cbbf6a4f5303474a88b3cbc77d086"
     },
     {
-      "@id": "niiri:a98cb290165a5322b0515231e2e4893d",
-      "@type": ["prov:Entity","nidm_ContrastStandardErrorMap:"],
+      "@id": "niiri:6b4d76daa5ef6289730f139f490051cd",
+      "@type": ["prov:Entity","nidm_ContrastStandardErrorMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ContrastStandardError_0002.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ContrastStandardError_0002.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Contrast Standard Error Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:2041dec7e8e64e30d54afd5c1e5ed5d5"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:21f24d2b86fec337fe05741e4da7e8c3"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "25ba224b75eef1f03b89e808e7b221a122e53101f981cbbc08c77ce9a7890e2e889e3170ff47c10efaf34f13109689d3b14cb13970e62d2fe341b79fd4c01253"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:a98cb290165a5322b0515231e2e4893d",
-      "activity": "niiri:c6a22989f43b68b871331c4257dd8326"
+      "entity_generated": "niiri:6b4d76daa5ef6289730f139f490051cd",
+      "activity": "niiri:b91cbbf6a4f5303474a88b3cbc77d086"
     },
     {
-      "@id": "niiri:75b195bd3ff811210dbca7eb63f1dcfc",
-      "@type": ["prov:Entity","nidm_HeightThreshold:","nidm_PValueUncorrected:"],
-      "rdfs:label": "Height Threshold: p<0.000999 (unc.)",
+      "@id": "niiri:40130c07affd508ab9ba7401250e23da",
+      "@type": ["prov:Entity","nidm_HeightThreshold","nidm_PValueUncorrected"],
+      "rdfs:label": "Height Threshold: p<0.001 (unc.)",
       "prov:value": {"@type": "xsd:float", "@value": "0.000999499935993353"},
-      "nidm_equivalentThreshold:": [{"@id": "niiri:77281d8fb39da565b2d8620d9cdfb81a"},{"@id": "niiri:21fac464625b30a79f9d3ab48f29b5ca"}]
+      "nidm_equivalentThreshold": [{"@id": "niiri:c84125bf0a4147bdec34e8d62a7d8e9b"},{"@id": "niiri:69b20013b8e5b45f8fab306ece980cf8"}]
     },
     {
-      "@id": "niiri:77281d8fb39da565b2d8620d9cdfb81a",
-      "@type": ["prov:Entity","nidm_HeightThreshold:","obo_statistic:"],
-      "rdfs:label": "Height Threshold",
+      "@id": "niiri:c84125bf0a4147bdec34e8d62a7d8e9b",
+      "@type": ["prov:Entity","nidm_HeightThreshold","obo_statistic"],
+      "rdfs:label": "Height Threshold: T=1.878787)",
       "prov:value": {"@type": "xsd:float", "@value": "1.87878728784405"}
     },
     {
-      "@id": "niiri:21fac464625b30a79f9d3ab48f29b5ca",
-      "@type": ["prov:Entity","nidm_HeightThreshold:","obo_FWERadjustedpvalue:"],
-      "rdfs:label": "Height Threshold",
+      "@id": "niiri:69b20013b8e5b45f8fab306ece980cf8",
+      "@type": ["prov:Entity","nidm_HeightThreshold","obo_FWERadjustedpvalue"],
+      "rdfs:label": "Height Threshold: p<1.000000 (FWE)",
       "prov:value": {"@type": "xsd:float", "@value": "1"}
     },
     {
-      "@id": "niiri:9b4709f23eec4aacd96c39f77ce9670a",
-      "@type": ["prov:Entity","nidm_ExtentThreshold:","obo_statistic:"],
+      "@id": "niiri:559eaf01d0bac3504edd2c4d5066dd7b",
+      "@type": ["prov:Entity","nidm_ExtentThreshold","obo_statistic"],
       "rdfs:label": "Extent Threshold: k>=0",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "0"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0"},
-      "nidm_equivalentThreshold:": [{"@id": "niiri:a16bde71d82100d11dee7ac351fcf8ee"},{"@id": "niiri:c0b504a062a42fd948ef14652a061f13"}]
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "0"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0"},
+      "nidm_equivalentThreshold": [{"@id": "niiri:76a9c78f5f4fa409b43bc97e69a2d2f9"},{"@id": "niiri:80a186d719df191589b700394aee0091"}]
     },
     {
-      "@id": "niiri:a16bde71d82100d11dee7ac351fcf8ee",
-      "@type": ["prov:Entity","nidm_ExtentThreshold:","obo_FWERadjustedpvalue:"],
+      "@id": "niiri:76a9c78f5f4fa409b43bc97e69a2d2f9",
+      "@type": ["prov:Entity","nidm_ExtentThreshold","obo_FWERadjustedpvalue"],
       "rdfs:label": "Extent Threshold",
       "prov:value": {"@type": "xsd:float", "@value": "1"}
     },
     {
-      "@id": "niiri:c0b504a062a42fd948ef14652a061f13",
-      "@type": ["prov:Entity","nidm_ExtentThreshold:","nidm_PValueUncorrected:"],
+      "@id": "niiri:80a186d719df191589b700394aee0091",
+      "@type": ["prov:Entity","nidm_ExtentThreshold","nidm_PValueUncorrected"],
       "rdfs:label": "Extent Threshold",
       "prov:value": {"@type": "xsd:float", "@value": "1"}
     },
     {
-      "@id": "niiri:8026c37e29c0f5d6a9c2644a3a842b95",
-      "@type": ["prov:Entity","nidm_PeakDefinitionCriteria:"],
+      "@id": "niiri:b479dc4f3908a8dd60cf9f33a5c34288",
+      "@type": ["prov:Entity","nidm_PeakDefinitionCriteria"],
       "rdfs:label": "Peak Definition Criteria",
-      "nidm_maxNumberOfPeaksPerCluster:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_minDistanceBetweenPeaks:": {"@type": "xsd:float", "@value": "8"}
+      "nidm_maxNumberOfPeaksPerCluster": {"@type": "xsd:int", "@value": "3"},
+      "nidm_minDistanceBetweenPeaks": {"@type": "xsd:float", "@value": "8"}
     },
     {
-      "@id": "niiri:43b529195274fe5d1ce5aecd2a575aef",
-      "@type": ["prov:Entity","nidm_ClusterDefinitionCriteria:"],
+      "@id": "niiri:0e2a9f5b87827358154ae143f1e5c8cb",
+      "@type": ["prov:Entity","nidm_ClusterDefinitionCriteria"],
       "rdfs:label": "Cluster Connectivity Criterion: 18",
-      "nidm_hasConnectivityCriterion:": {"@id": "nidm_voxel18connected:"}
+      "nidm_hasConnectivityCriterion": {"@id": "nidm_voxel18connected"}
     },
     {
-      "@id": "niiri:6fac02f43fd0624921dea58ee65afc62",
-      "@type": ["prov:Activity","spm_PartialConjunctionInference:"],
-      "nidm_hasAlternativeHypothesis:": {"@id": "nidm_OneTailedTest:"},
+      "@id": "niiri:c134406116e621fbf4bcc19eb85f6dec",
+      "@type": ["prov:Activity","spm_PartialConjunctionInference"],
+      "nidm_hasAlternativeHypothesis": {"@id": "nidm_OneTailedTest"},
       "rdfs:label": "Partial Conjunction Inference",
-      "spm_partialConjunctionDegree:": {"@type": "xsd:int", "@value": "2"}
+      "spm_partialConjunctionDegree": {"@type": "xsd:int", "@value": "2"}
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:6fac02f43fd0624921dea58ee65afc62",
-      "agent": "niiri:efa026de268c2c7adcb83113c80feffe"
+      "activity_associated": "niiri:c134406116e621fbf4bcc19eb85f6dec",
+      "agent": "niiri:9d7bdfb1f005a1c77912a13aad1d7cca"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:6fac02f43fd0624921dea58ee65afc62",
-      "entity": "niiri:75b195bd3ff811210dbca7eb63f1dcfc"
+      "activity_using": "niiri:c134406116e621fbf4bcc19eb85f6dec",
+      "entity": "niiri:40130c07affd508ab9ba7401250e23da"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:6fac02f43fd0624921dea58ee65afc62",
-      "entity": "niiri:9b4709f23eec4aacd96c39f77ce9670a"
+      "activity_using": "niiri:c134406116e621fbf4bcc19eb85f6dec",
+      "entity": "niiri:559eaf01d0bac3504edd2c4d5066dd7b"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:6fac02f43fd0624921dea58ee65afc62",
-      "entity": "niiri:35c5be3ff2b46cabb83d5d20de1bbfe3"
+      "activity_using": "niiri:c134406116e621fbf4bcc19eb85f6dec",
+      "entity": "niiri:ef836beafc2e291065c57b3a7e86dc80"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:6fac02f43fd0624921dea58ee65afc62",
-      "entity": "niiri:01987becac1b40cdffe20150c4b33a59"
+      "activity_using": "niiri:c134406116e621fbf4bcc19eb85f6dec",
+      "entity": "niiri:955daf8b5134c9320aad7d629101cc88"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:6fac02f43fd0624921dea58ee65afc62",
-      "entity": "niiri:25cb1d7201060f78fd019e0bb4a23ea3"
+      "activity_using": "niiri:c134406116e621fbf4bcc19eb85f6dec",
+      "entity": "niiri:bc8b436cc11302e4d61399ed8127ddce"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:6fac02f43fd0624921dea58ee65afc62",
-      "entity": "niiri:4a1b25825ebfaf1382fe57aac7e6174c"
+      "activity_using": "niiri:c134406116e621fbf4bcc19eb85f6dec",
+      "entity": "niiri:aba08deba6439b8fd82d98d160e5d070"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:6fac02f43fd0624921dea58ee65afc62",
-      "entity": "niiri:8026c37e29c0f5d6a9c2644a3a842b95"
+      "activity_using": "niiri:c134406116e621fbf4bcc19eb85f6dec",
+      "entity": "niiri:b479dc4f3908a8dd60cf9f33a5c34288"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:6fac02f43fd0624921dea58ee65afc62",
-      "entity": "niiri:43b529195274fe5d1ce5aecd2a575aef"
+      "activity_using": "niiri:c134406116e621fbf4bcc19eb85f6dec",
+      "entity": "niiri:0e2a9f5b87827358154ae143f1e5c8cb"
     },
     {
-      "@id": "niiri:7f4f00382d1ca69143903708b54d2186",
-      "@type": ["prov:Entity","nidm_SearchSpaceMaskMap:"],
+      "@id": "niiri:a251b2ee9dd7a651ce291377b22b331c",
+      "@type": ["prov:Entity","nidm_SearchSpaceMaskMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "SearchSpaceMask.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "SearchSpaceMask.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Search Space Mask Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:2041dec7e8e64e30d54afd5c1e5ed5d5"},
-      "nidm_searchVolumeInVoxels:": {"@type": "xsd:int", "@value": "223057"},
-      "nidm_searchVolumeInUnits:": {"@type": "xsd:float", "@value": "1784456"},
-      "nidm_reselSizeInVoxels:": {"@type": "xsd:float", "@value": "65.5786964036542"},
-      "nidm_searchVolumeInResels:": {"@type": "xsd:float", "@value": "3155.84193266257"},
-      "spm_searchVolumeReselsGeometry:": {"@type": "xsd:string", "@value": "[6, 97.8140592306853, 965.938819261507, 3155.84193266257]"},
-      "nidm_noiseFWHMInVoxels:": {"@type": "xsd:string", "@value": "[4.09118640605185, 4.0346308705955, 3.97291894351243]"},
-      "nidm_noiseFWHMInUnits:": {"@type": "xsd:string", "@value": "[8.18237281210369, 8.069261741191, 7.94583788702486]"},
-      "nidm_randomFieldStationarity:": {"@type": "xsd:boolean", "@value": "true"},
-      "nidm_expectedNumberOfVoxelsPerCluster:": {"@type": "xsd:float", "@value": "4.48720741199687"},
-      "nidm_expectedNumberOfClusters:": {"@type": "xsd:float", "@value": "53.4877161971437"},
-      "nidm_heightCriticalThresholdFWE05:": {"@type": "xsd:float", "@value": "3.40927969090373"},
-      "nidm_heightCriticalThresholdFDR05:": {"@type": "xsd:float", "@value": "3.13529944419861"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:21f24d2b86fec337fe05741e4da7e8c3"},
+      "nidm_searchVolumeInVoxels": {"@type": "xsd:int", "@value": "223057"},
+      "nidm_searchVolumeInUnits": {"@type": "xsd:float", "@value": "1784456"},
+      "nidm_reselSizeInVoxels": {"@type": "xsd:float", "@value": "65.5786964036542"},
+      "nidm_searchVolumeInResels": {"@type": "xsd:float", "@value": "3155.84193266257"},
+      "spm_searchVolumeReselsGeometry": {"@type": "xsd:string", "@value": "[6, 97.8140592306853, 965.938819261507, 3155.84193266257]"},
+      "nidm_noiseFWHMInVoxels": {"@type": "xsd:string", "@value": "[4.09118640605185, 4.0346308705955, 3.97291894351243]"},
+      "nidm_noiseFWHMInUnits": {"@type": "xsd:string", "@value": "[8.18237281210369, 8.069261741191, 7.94583788702486]"},
+      "nidm_randomFieldStationarity": {"@type": "xsd:boolean", "@value": "true"},
+      "nidm_expectedNumberOfVoxelsPerCluster": {"@type": "xsd:float", "@value": "4.48720741199687"},
+      "nidm_expectedNumberOfClusters": {"@type": "xsd:float", "@value": "53.4877161971437"},
+      "nidm_heightCriticalThresholdFWE05": {"@type": "xsd:float", "@value": "3.40927969090373"},
+      "nidm_heightCriticalThresholdFDR05": {"@type": "xsd:float", "@value": "3.13529944419861"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:7f4f00382d1ca69143903708b54d2186",
-      "activity": "niiri:6fac02f43fd0624921dea58ee65afc62"
+      "entity_generated": "niiri:a251b2ee9dd7a651ce291377b22b331c",
+      "activity": "niiri:c134406116e621fbf4bcc19eb85f6dec"
     },
     {
-      "@id": "niiri:d2e82dc2ef1ed65643a5b21509270b91",
-      "@type": ["prov:Entity","nidm_ExcursionSetMap:"],
+      "@id": "niiri:8523ea1215430db79b6d67ec562629a2",
+      "@type": ["prov:Entity","nidm_ExcursionSetMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ExcursionSet.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ExcursionSet.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Excursion Set Map",
-      "nidm_numberOfSupraThresholdClusters:": {"@type": "xsd:int", "@value": "134"},
-      "nidm_pValue:": {"@type": "xsd:float", "@value": "0"},
-      "nidm_hasClusterLabelsMap:": {"@id": "niiri:0c0a065230ec2c9537fec958985a8bbe"},
-      "nidm_hasMaximumIntensityProjection:": {"@id": "niiri:a884453416272ec8d05aef8c00ff9ec9"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:2041dec7e8e64e30d54afd5c1e5ed5d5"},
+      "nidm_numberOfSupraThresholdClusters": {"@type": "xsd:int", "@value": "134"},
+      "nidm_pValue": {"@type": "xsd:float", "@value": "0"},
+      "nidm_hasClusterLabelsMap": {"@id": "niiri:af09603d1be9b472972dc427857a08f5"},
+      "nidm_hasMaximumIntensityProjection": {"@id": "niiri:c51837890dc0834460dea9471719a9de"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:21f24d2b86fec337fe05741e4da7e8c3"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "cf57cbfbb81ca96369b3e2527d0e6705441089b119d0cc15f3355ae7c3de2b6c17c3185f6664cd5c9a9f7bb25112d87c762671c4061a04dacad4674fe7e19086"}
     },
     {
-      "@id": "niiri:0c0a065230ec2c9537fec958985a8bbe",
-      "@type": ["prov:Entity","nidm_ClusterLabelsMap:"],
+      "@id": "niiri:af09603d1be9b472972dc427857a08f5",
+      "@type": ["prov:Entity","nidm_ClusterLabelsMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ClusterLabels.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ClusterLabels.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Cluster Labels Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:2041dec7e8e64e30d54afd5c1e5ed5d5"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:21f24d2b86fec337fe05741e4da7e8c3"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "33456d0efb388a323fb05180352e48d0ded234d80fb937b966c0a2109eb1117bb43213ec4702cf2796847b35ad2eb181cac47b0d81190b774e1fb76e8f404828"}
     },
     {
-      "@id": "niiri:a884453416272ec8d05aef8c00ff9ec9",
+      "@id": "niiri:c51837890dc0834460dea9471719a9de",
       "@type": ["prov:Entity","dctype:Image"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "MaximumIntensityProjection.png"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "MaximumIntensityProjection.png"},
@@ -861,5672 +861,5672 @@
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:d2e82dc2ef1ed65643a5b21509270b91",
-      "activity": "niiri:6fac02f43fd0624921dea58ee65afc62"
+      "entity_generated": "niiri:8523ea1215430db79b6d67ec562629a2",
+      "activity": "niiri:c134406116e621fbf4bcc19eb85f6dec"
     },
     {
-      "@id": "niiri:513895e5db5c23441d24f7a6b36af026",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:212a130c85dc60414b3a3ae20326ccc1",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0001",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "569"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "8.67659821259109"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.59059333148921e-14"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "2.9902746945254e-12"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "1"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "569"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "8.67659821259109"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.59059333148921e-14"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "2.9902746945254e-12"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "1"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:513895e5db5c23441d24f7a6b36af026",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:212a130c85dc60414b3a3ae20326ccc1",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:200353b62d6c59c05f378e37920581d1",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:b6f31947ea1d789fff0bd7ebbd8d5aa3",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0002",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "72"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.0979175242646"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000456822125239121"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0241382695122647"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "2"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "72"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.0979175242646"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000456822125239121"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0241382695122647"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "2"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:200353b62d6c59c05f378e37920581d1",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:b6f31947ea1d789fff0bd7ebbd8d5aa3",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:0347896da596f5297388dcc20e03b25d",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:171c8ac1a84198593464a36bac244ff0",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0003",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4084"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "62.2763217930088"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.88095587224324e-50"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "3"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4084"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "62.2763217930088"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.88095587224324e-50"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "3"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0347896da596f5297388dcc20e03b25d",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:171c8ac1a84198593464a36bac244ff0",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:4c63f433fea86c4902ef28b8a4e0b83b",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:7174a23494a5602d1cf5b80e0b3957b3",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0004",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "127"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.93660452196673"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.32942985629811e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.000710828909921357"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "4"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "127"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.93660452196673"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.32942985629811e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.000710828909921357"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "4"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4c63f433fea86c4902ef28b8a4e0b83b",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:7174a23494a5602d1cf5b80e0b3957b3",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:ca1279119038c6ed3aa8da5ae36104c5",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:2cd32bc92eb7dd286253f06b6c4516f9",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0005",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "243"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "3.70547164439303"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.05092156231224e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1.63186693513673e-06"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "5"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "243"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "3.70547164439303"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.05092156231224e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1.63186693513673e-06"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "5"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ca1279119038c6ed3aa8da5ae36104c5",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:2cd32bc92eb7dd286253f06b6c4516f9",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:3b8c64c3b6fac5debb91f848b6310ef3",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:6438830b93a9866c5a8c4cb39850d977",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0006",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "71"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.08266866976093"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000490622471602205"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0259009393395414"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "6"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "71"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.08266866976093"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000490622471602205"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0259009393395414"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "6"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3b8c64c3b6fac5debb91f848b6310ef3",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:6438830b93a9866c5a8c4cb39850d977",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:f62ecbcce6abff98c7b382218c0d5dde",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:58fb2509f9d4dbc78a02bfcd61bb139b",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0007",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "159"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "2.42456786608433"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.16558815218048e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.000115825656174406"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "7"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "159"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "2.42456786608433"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.16558815218048e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.000115825656174406"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "7"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f62ecbcce6abff98c7b382218c0d5dde",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:58fb2509f9d4dbc78a02bfcd61bb139b",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:f7b92a750ed72932f6060531d3264928",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:2657e564e7bba015b389e0943b63badb",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0008",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "106"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.61637857738955"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.75592881772267e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00254060489524977"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "8"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "106"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.61637857738955"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.75592881772267e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00254060489524977"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "8"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f7b92a750ed72932f6060531d3264928",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:2657e564e7bba015b389e0943b63badb",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:d4fb506965250f1ee35f6781f8eaf2e4",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:a8bb66759e4caade20c1a9e56f9516ec",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0009",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "99"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.50963659586383"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.40805683281378e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00395456046436182"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "9"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "99"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.50963659586383"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.40805683281378e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00395456046436182"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "9"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d4fb506965250f1ee35f6781f8eaf2e4",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:a8bb66759e4caade20c1a9e56f9516ec",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:ac21817310afb3594d085b280a7c7fad",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:7f817d4ab9fea049a6960806e46dae6f",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0010",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "190"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "2.89728235569826"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.18195857892405e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "2.23680911922708e-05"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "10"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "190"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "2.89728235569826"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.18195857892405e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "2.23680911922708e-05"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "10"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ac21817310afb3594d085b280a7c7fad",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:7f817d4ab9fea049a6960806e46dae6f",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:65f83d4775835650d295d792beafeab5",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:a088090c906271f3f2487f7339f0082c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0011",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "38"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.579456471139651"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00658479944411763"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.296864657161"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "11"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "38"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.579456471139651"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00658479944411763"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.296864657161"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "11"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:65f83d4775835650d295d792beafeab5",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:a088090c906271f3f2487f7339f0082c",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:fe501796991210fa8e9d37e811545e85",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:5cb5cd73033206c0daaf4927462a1873",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0012",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "59"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.899682415716827"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0011885055655797"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0615919923617647"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "12"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "59"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.899682415716827"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0011885055655797"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0615919923617647"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "12"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:fe501796991210fa8e9d37e811545e85",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:5cb5cd73033206c0daaf4927462a1873",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:12095dcddf9a636e0d1c65eafed705e8",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f4def9a581b3c307c2f4fb9e2e226d0e",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0013",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "62"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.945428979227852"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000947699277992949"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0494269540893172"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "13"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "62"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.945428979227852"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000947699277992949"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0494269540893172"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "13"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:12095dcddf9a636e0d1c65eafed705e8",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:f4def9a581b3c307c2f4fb9e2e226d0e",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:a0871d458c113ff7db6ea00222d681b6",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:dfdffb6b309c9dbdb7e869a40c441373",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0014",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "10"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.15248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.127107912598347"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.998884789335864"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "14"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "10"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.15248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.127107912598347"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.998884789335864"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "14"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a0871d458c113ff7db6ea00222d681b6",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:dfdffb6b309c9dbdb7e869a40c441373",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:ede417a6186510bb468637a2fa74953b",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:51dff688583f66b2d156042da2e15fbc",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0015",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "32"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.487963344117601"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0113417541818962"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.454822870496334"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "15"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "32"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.487963344117601"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0113417541818962"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.454822870496334"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "15"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ede417a6186510bb468637a2fa74953b",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:51dff688583f66b2d156042da2e15fbc",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:e1877410437181ca152c635a1b1ae370",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:e56f07808adb058d01196164f0775b64",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0016",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "28"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.426967926102901"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0166100165318646"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.588699772362037"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "16"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "28"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.426967926102901"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0166100165318646"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.588699772362037"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "16"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e1877410437181ca152c635a1b1ae370",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:e56f07808adb058d01196164f0775b64",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:cc0c5a448ad27b2c29ff4af6af9b334c",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:14930f43331616f26135da44caf5ca49",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0017",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "34"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.518461053124951"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00942859389252268"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.396080250089626"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "17"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "34"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.518461053124951"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00942859389252268"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.396080250089626"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "17"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cc0c5a448ad27b2c29ff4af6af9b334c",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:14930f43331616f26135da44caf5ca49",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:c66319cb5f126bcbc275fb9a118d21ec",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:d6ab9aad7ae91e9a945d6044d0e1d6cd",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0018",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "38"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.579456471139651"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00658479944411763"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.296864657161"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "18"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "38"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.579456471139651"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00658479944411763"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.296864657161"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "18"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c66319cb5f126bcbc275fb9a118d21ec",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:d6ab9aad7ae91e9a945d6044d0e1d6cd",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:df2f9512a8de3749a0b69fde9e1d74e6",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:950bb8c15f6d86506fdad52c1ea79861",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0019",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "13"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.198235108547775"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0856930391599127"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.989781188153603"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "19"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "13"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.198235108547775"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0856930391599127"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.989781188153603"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "19"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:df2f9512a8de3749a0b69fde9e1d74e6",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:950bb8c15f6d86506fdad52c1ea79861",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:ff4a3dc3ae673c7d96c375c14f00511e",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f4783b6466e014e6e52055bae529f918",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0020",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "33"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.503212198621276"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0103362007698988"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.424697778316067"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "20"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "33"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.503212198621276"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0103362007698988"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.424697778316067"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "20"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ff4a3dc3ae673c7d96c375c14f00511e",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:f4783b6466e014e6e52055bae529f918",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:abd64927c551fbbd20950624a69aa36d",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:e493acb406e5cff7f2b3bdae4a6c7854",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0021",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "8"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.1219908360294"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.169043835402863"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999881638693591"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "21"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "8"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.1219908360294"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.169043835402863"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999881638693591"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "21"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:abd64927c551fbbd20950624a69aa36d",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:e493acb406e5cff7f2b3bdae4a6c7854",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:38307cfb7180ba187f2a9da76b2278a7",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:0337643db0192f78f5b32cbf7ed520a4",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0022",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "71"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.08266866976093"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000490622471602205"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0259009393395414"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "22"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "71"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.08266866976093"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000490622471602205"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0259009393395414"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "22"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:38307cfb7180ba187f2a9da76b2278a7",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:0337643db0192f78f5b32cbf7ed520a4",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:a23fb16f5011d68723f436a695655a4b",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:1a04d969a09af1e47b83e8c89999ecc0",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0023",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "46"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.701447307169051"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00332827413277407"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.163075806793513"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "23"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "46"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.701447307169051"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00332827413277407"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.163075806793513"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "23"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a23fb16f5011d68723f436a695655a4b",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:1a04d969a09af1e47b83e8c89999ecc0",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:dd24018042f78d315dbd6726698ec521",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:cad3a1438e0a5950942cd5ed7b22e997",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0024",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "13"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.198235108547775"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0856930391599127"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.989781188153603"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "24"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "13"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.198235108547775"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0856930391599127"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.989781188153603"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "24"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:dd24018042f78d315dbd6726698ec521",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:cad3a1438e0a5950942cd5ed7b22e997",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:08d22242c39ac4379d79b33f1f2f58d6",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:aa48c521a0de3bccee7d00f6ba89c3cf",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0025",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0609954180147001"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.32633981091806"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999973738745"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "25"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0609954180147001"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.32633981091806"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999973738745"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "25"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:08d22242c39ac4379d79b33f1f2f58d6",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:aa48c521a0de3bccee7d00f6ba89c3cf",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:61b56883c58ef13be768c931fffde95f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:666175487bab3267d4af86f55ff4bd3b",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0026",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "10"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.15248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.127107912598347"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.998884789335864"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "26"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "10"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.15248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.127107912598347"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.998884789335864"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "26"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:61b56883c58ef13be768c931fffde95f",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:666175487bab3267d4af86f55ff4bd3b",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:7d6ccb38dbccc63215a5fdd98139915c",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:6951754ac73a67bbeeec0a4f76595341",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0027",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "8"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.1219908360294"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.169043835402863"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999881638693591"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "27"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "8"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.1219908360294"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.169043835402863"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999881638693591"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "27"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7d6ccb38dbccc63215a5fdd98139915c",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:6951754ac73a67bbeeec0a4f76595341",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:823399669e7b2b8c54db148364839dc3",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:92c69844c448bad6dc16185f863b358e",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0028",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "25"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.381221362591876"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0223806036413691"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.697927243750861"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "28"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "25"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.381221362591876"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0223806036413691"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.697927243750861"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "28"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:823399669e7b2b8c54db148364839dc3",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:92c69844c448bad6dc16185f863b358e",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:d81a7a910431ac9a1979f323b4b791c2",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:177bfa600d85757ea0c4626517c44033",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0029",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "41"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.625203034650676"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00507211415165039"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.237609053919574"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "29"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "41"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.625203034650676"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00507211415165039"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.237609053919574"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "29"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d81a7a910431ac9a1979f323b4b791c2",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:177bfa600d85757ea0c4626517c44033",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:dabab8dbebf83a48079048945d816fe5",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:746b0b97599bb9118ebd954e679a2576",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0030",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "8"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.1219908360294"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.169043835402863"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999881638693591"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "30"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "8"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.1219908360294"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.169043835402863"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999881638693591"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "30"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:dabab8dbebf83a48079048945d816fe5",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:746b0b97599bb9118ebd954e679a2576",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:5842093feb2c4b86fc255ab1795f6409",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:54c365a30f25bdcc066a52c171908849",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0031",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "8"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.1219908360294"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.169043835402863"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999881638693591"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "31"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "8"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.1219908360294"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.169043835402863"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999881638693591"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "31"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5842093feb2c4b86fc255ab1795f6409",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:54c365a30f25bdcc066a52c171908849",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:2498df410b841338c0adda91711ed606",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:b9e88b2bbae3b722fa155ba8e9501a86",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0032",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "17"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.259230526562475"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0529640912194042"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.941159699711307"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "32"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "17"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.259230526562475"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0529640912194042"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.941159699711307"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "32"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2498df410b841338c0adda91711ed606",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:b9e88b2bbae3b722fa155ba8e9501a86",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:4e803c8ae9b4739d7433ebb1a14e59ad",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:6b8826bcc0a021bc10b09d6a6d4302fd",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0033",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "9"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.137239690533075"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.146196434998771"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999598263205668"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "33"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "9"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.137239690533075"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.146196434998771"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999598263205668"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "33"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4e803c8ae9b4739d7433ebb1a14e59ad",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:6b8826bcc0a021bc10b09d6a6d4302fd",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:59ee3c1181a6931549c7f2a8d5a010d9",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:cc1d6ba65b10195363d6da601013d7a1",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0034",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "15"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.228732817555125"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0670091344004676"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.972240178220986"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "34"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "15"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.228732817555125"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0670091344004676"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.972240178220986"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "34"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:59ee3c1181a6931549c7f2a8d5a010d9",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:cc1d6ba65b10195363d6da601013d7a1",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:d5b0a3e5aceb6afc5f0beca22061d358",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:82933f30610ef29a453f4b374990b32f",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0035",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "5"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0762442725183751"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.272686785534213"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999536932681"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "35"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "5"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0762442725183751"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.272686785534213"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999536932681"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "35"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d5b0a3e5aceb6afc5f0beca22061d358",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:82933f30610ef29a453f4b374990b32f",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:f93d82501705ce2feae40e77d940aa42",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:14f8555b74f38f3e8db5c662f1a8015c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0036",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "12"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.1829862540441"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0973627773701174"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.994525819003439"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "36"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "12"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.1829862540441"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0973627773701174"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.994525819003439"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "36"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f93d82501705ce2feae40e77d940aa42",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:14f8555b74f38f3e8db5c662f1a8015c",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:e087977e9e8a8b501c9a28c9869554a6",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:8c06ba2c370d4dda4947f0cbe66ca91e",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0037",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "10"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.15248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.127107912598347"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.998884789335864"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "37"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "10"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.15248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.127107912598347"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.998884789335864"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "37"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e087977e9e8a8b501c9a28c9869554a6",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:8c06ba2c370d4dda4947f0cbe66ca91e",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:a2144fa83ecfa43f689763a4c0b15ca8",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:337d987921a53a135ec5d7ccac93719b",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0038",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "31"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.472714489613926"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0124572388764659"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.486399348250455"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "38"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "31"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.472714489613926"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0124572388764659"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.486399348250455"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "38"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a2144fa83ecfa43f689763a4c0b15ca8",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:337d987921a53a135ec5d7ccac93719b",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:575376d8b1a60c68f57a2629ca1c6f57",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:8b64f56916b41aba13f0c3626eccb6c6",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0039",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "33"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.503212198621276"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0103362007698988"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.424697778316067"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "39"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "33"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.503212198621276"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0103362007698988"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.424697778316067"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "39"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:575376d8b1a60c68f57a2629ca1c6f57",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:8b64f56916b41aba13f0c3626eccb6c6",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:e7cf6cf6e829a4522b12ecb22c64da50",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:7167233a4e5f287b27d1ea49b05f5e73",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0040",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "29"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.442216780606576"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.015074614560243"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.553495904109026"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "40"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "29"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.442216780606576"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.015074614560243"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.553495904109026"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "40"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e7cf6cf6e829a4522b12ecb22c64da50",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:7167233a4e5f287b27d1ea49b05f5e73",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:f34dda9711be5249376de56aa5f55bb0",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:9bcff3c8230d1d562436a59af916d435",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0041",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "59"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.899682415716827"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0011885055655797"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0615919923617647"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "41"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "59"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.899682415716827"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0011885055655797"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0615919923617647"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "41"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f34dda9711be5249376de56aa5f55bb0",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:9bcff3c8230d1d562436a59af916d435",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:3d8865c6fb016a8704775ebaf2435091",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:1f551e5f86fc52cb27432b3822b69ca7",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0042",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "15"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.228732817555125"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0670091344004676"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.972240178220986"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "42"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "15"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.228732817555125"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0670091344004676"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.972240178220986"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "42"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3d8865c6fb016a8704775ebaf2435091",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:1f551e5f86fc52cb27432b3822b69ca7",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:16a6c15579df8b38a23d9ad0e739425a",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:222cf8fd43a488444ee6a32847bc1d9a",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0043",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "12"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.1829862540441"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0973627773701174"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.994525819003439"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "43"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "12"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.1829862540441"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0973627773701174"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.994525819003439"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "43"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:16a6c15579df8b38a23d9ad0e739425a",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:222cf8fd43a488444ee6a32847bc1d9a",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:c2f8c271d456bfd2eff8e6eb839c91ba",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:944e97172e0a25bb481c848ff69da03e",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0044",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "11"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.167737399540425"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.111020787763232"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.997363356013822"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "44"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "11"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.167737399540425"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.111020787763232"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.997363356013822"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "44"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c2f8c271d456bfd2eff8e6eb839c91ba",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:944e97172e0a25bb481c848ff69da03e",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:84844c35c8e8d08a6e00bf67a2f849ff",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f16d0ba2c74c51bb5e78d2245c00a45f",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0045",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "5"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0762442725183751"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.272686785534213"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999536932681"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "45"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "5"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0762442725183751"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.272686785534213"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999536932681"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "45"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:84844c35c8e8d08a6e00bf67a2f849ff",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:f16d0ba2c74c51bb5e78d2245c00a45f",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:dfda6f4a6ad2d61f37aadf0fa7507a7f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:209a4a28e55d93fc75c92925f0f7d71b",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0046",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "33"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.503212198621276"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0103362007698988"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.424697778316067"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "46"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "33"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.503212198621276"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0103362007698988"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.424697778316067"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "46"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:dfda6f4a6ad2d61f37aadf0fa7507a7f",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:209a4a28e55d93fc75c92925f0f7d71b",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:261c5b8cb671c9ccd262aae82e498512",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:357268aff375a1c533059d48c5f8dcb0",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0047",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "13"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.198235108547775"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0856930391599127"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.989781188153603"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "47"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "13"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.198235108547775"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0856930391599127"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.989781188153603"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "47"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:261c5b8cb671c9ccd262aae82e498512",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:357268aff375a1c533059d48c5f8dcb0",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:504a0642ac3cd38acd0d64ccc15fc9e6",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:0a39de1cb252a793d03ed45aa12d8950",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0048",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "7"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.106741981525725"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.196676917108917"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999973003386476"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "48"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "7"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.106741981525725"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.196676917108917"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999973003386476"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "48"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:504a0642ac3cd38acd0d64ccc15fc9e6",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:0a39de1cb252a793d03ed45aa12d8950",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:30d04637933701595f908aeb4100a23e",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:2ce7fa7ad1d0a7052668df06aeeb62b3",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0049",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "24"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.365972508088201"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0247841432800404"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.734369018761218"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "49"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "24"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.365972508088201"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0247841432800404"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.734369018761218"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "49"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:30d04637933701595f908aeb4100a23e",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:2ce7fa7ad1d0a7052668df06aeeb62b3",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:3abca6b1ac25766b2a6217f3ab065c91",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:837c632e63a40a2ac1469c8d1ba1b864",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0050",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.49389125238231"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999996633"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "50"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.49389125238231"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999996633"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "50"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3abca6b1ac25766b2a6217f3ab065c91",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:837c632e63a40a2ac1469c8d1ba1b864",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:779bcdad447bb00d9bdb1d38c48f9eb7",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:47f25a919baaf59e7867aa98557a23e4",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0051",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "6"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0914931270220502"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.230530023375576"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999995585095987"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "51"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "6"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0914931270220502"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.230530023375576"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999995585095987"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "51"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:779bcdad447bb00d9bdb1d38c48f9eb7",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:47f25a919baaf59e7867aa98557a23e4",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:bea578e87145baa9fef8f57831c0c5fe",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:82870fabf2e7a1a9a595fb88debeb7ef",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0052",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "5"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0762442725183751"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.272686785534213"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999536932681"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "52"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "5"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0762442725183751"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.272686785534213"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999536932681"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "52"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:bea578e87145baa9fef8f57831c0c5fe",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:82870fabf2e7a1a9a595fb88debeb7ef",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:0416871505a4f68a8b0a05803d7fe0e1",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:54fe9c7a58c48364f79822c24b7f0a36",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0053",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "20"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0378410014811752"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.867877895229885"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "53"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "20"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0378410014811752"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.867877895229885"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "53"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0416871505a4f68a8b0a05803d7fe0e1",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:54fe9c7a58c48364f79822c24b7f0a36",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:03e0bc451aca56b2f70fb660afdf1e84",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:9f649ce7c963c614e6fb0b5f0f441d80",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0054",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "9"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.137239690533075"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.146196434998771"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999598263205668"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "54"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "9"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.137239690533075"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.146196434998771"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999598263205668"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "54"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:03e0bc451aca56b2f70fb660afdf1e84",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:9f649ce7c963c614e6fb0b5f0f441d80",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:94477c176a303cb05b6cf25392b272ff",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:aa6b7754ff9629fdf69c2b137c4af89e",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0055",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "20"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0378410014811752"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.867877895229885"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "55"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "20"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0378410014811752"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.867877895229885"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "55"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:94477c176a303cb05b6cf25392b272ff",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:aa6b7754ff9629fdf69c2b137c4af89e",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:ccac343137c6a1606bfad900f0384914",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:992eba93ccac4ef864d1e4c888fef260",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0056",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "26"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.396470217095551"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0202374895099589"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.661237868692417"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "56"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "26"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.396470217095551"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0202374895099589"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.661237868692417"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "56"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ccac343137c6a1606bfad900f0384914",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:992eba93ccac4ef864d1e4c888fef260",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:74289f8090f7da1b2e9c2d274cc0f956",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:2913f23a1813eb7942fb6b12aea56fda",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0057",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "15"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.228732817555125"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0670091344004676"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.972240178220986"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "57"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "15"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.228732817555125"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0670091344004676"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.972240178220986"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "57"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:74289f8090f7da1b2e9c2d274cc0f956",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:2913f23a1813eb7942fb6b12aea56fda",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:aa9f984347d25d8bedc780b7865258c6",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:1c4944ab6edec9e1dbd0763deb0ea5f5",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0058",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "17"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.259230526562475"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0529640912194042"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.941159699711307"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "58"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "17"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.259230526562475"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0529640912194042"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.941159699711307"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "58"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:aa9f984347d25d8bedc780b7865258c6",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:1c4944ab6edec9e1dbd0763deb0ea5f5",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:2835e70d80bc47f846977da52697749b",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:807decf567867596e9ede288b13f016a",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0059",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "31"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.472714489613926"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0124572388764659"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.486399348250455"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "59"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "31"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.472714489613926"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0124572388764659"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.486399348250455"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "59"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2835e70d80bc47f846977da52697749b",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:807decf567867596e9ede288b13f016a",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:87c4af2a8f65ce6e67f250f40b44790b",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:106990f64fdbe0a92e78b55484d984e7",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0060",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "5"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0762442725183751"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.272686785534213"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999536932681"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "60"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "5"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0762442725183751"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.272686785534213"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999536932681"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "60"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:87c4af2a8f65ce6e67f250f40b44790b",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:106990f64fdbe0a92e78b55484d984e7",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:b96f891a7f3546406e623e46139187e6",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:9a89982690b205094ce375806ee327d2",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0061",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "7"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.106741981525725"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.196676917108917"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999973003386476"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "61"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "7"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.106741981525725"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.196676917108917"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999973003386476"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "61"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b96f891a7f3546406e623e46139187e6",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:9a89982690b205094ce375806ee327d2",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:4c9cbb438c61ca24784015872ad9fbc0",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:86396384ac8248dc2499f53d12283a2f",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0062",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "23"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.350723653584526"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0274850060586512"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.770099852065948"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "62"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "23"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.350723653584526"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0274850060586512"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.770099852065948"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "62"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4c9cbb438c61ca24784015872ad9fbc0",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:86396384ac8248dc2499f53d12283a2f",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:39af3e7a68fb53b5aaa4d4380994d93a",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:2ead289cc63835350630bfc68f2d003d",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0063",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "6"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0914931270220502"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.230530023375576"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999995585095987"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "63"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "6"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0914931270220502"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.230530023375576"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999995585095987"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "63"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:39af3e7a68fb53b5aaa4d4380994d93a",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:2ead289cc63835350630bfc68f2d003d",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:e854d05d0fd68a980bd27218bb6f2d9f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:0ff3515dad74fb4659ac475f78bb2c0d",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0064",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0609954180147001"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.32633981091806"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999973738745"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "64"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0609954180147001"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.32633981091806"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999973738745"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "64"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e854d05d0fd68a980bd27218bb6f2d9f",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:0ff3515dad74fb4659ac475f78bb2c0d",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:919d23712d157543b918d601a201b7d7",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:e28eff3b2e060f982dbfeec40075736b",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0065",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0457465635110251"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.396774248526764"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999393034"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "65"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0457465635110251"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.396774248526764"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999393034"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "65"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:919d23712d157543b918d601a201b7d7",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:e28eff3b2e060f982dbfeec40075736b",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:bac84e2b7b3296e6a7b45e5dd897eaa1",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:5621f89640fa5a0a90c32a936e6e0a8d",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0066",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "8"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.1219908360294"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.169043835402863"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999881638693591"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "66"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "8"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.1219908360294"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.169043835402863"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999881638693591"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "66"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:bac84e2b7b3296e6a7b45e5dd897eaa1",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:5621f89640fa5a0a90c32a936e6e0a8d",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:79c33267bc7a50246dc768c737d6daae",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f6474f5545e9725192cc8b6256e5bfb0",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0067",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "6"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0914931270220502"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.230530023375576"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999995585095987"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "67"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "6"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0914931270220502"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.230530023375576"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999995585095987"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "67"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:79c33267bc7a50246dc768c737d6daae",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:f6474f5545e9725192cc8b6256e5bfb0",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:2c2f8c53ef38453b53a97c311972275b",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:2f15ad69e6c9c21540fd55e8e1488dca",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0068",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "6"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0914931270220502"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.230530023375576"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999995585095987"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "68"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "6"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0914931270220502"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.230530023375576"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999995585095987"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "68"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2c2f8c53ef38453b53a97c311972275b",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:2f15ad69e6c9c21540fd55e8e1488dca",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:5250d6f799a090681ee8888a86a64f2e",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:42ca52d223a11cd4060ba3459f14c1ab",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0069",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "14"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.21348396305145"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0756664557235371"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.982529227014855"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "69"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "14"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.21348396305145"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0756664557235371"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.982529227014855"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "69"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5250d6f799a090681ee8888a86a64f2e",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:42ca52d223a11cd4060ba3459f14c1ab",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:891b4e7e5f232af9ce39592173fed719",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:29b8562f8375bc52056233a05357c8ba",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0070",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "7"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.106741981525725"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.196676917108917"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999973003386476"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "70"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "7"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.106741981525725"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.196676917108917"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999973003386476"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "70"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:891b4e7e5f232af9ce39592173fed719",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:29b8562f8375bc52056233a05357c8ba",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:4cd96b91a9bff0c27f9a1cf0ccb9533d",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:39feea9bf256b35cba29d53ba142d102",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0071",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "7"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.106741981525725"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.196676917108917"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999973003386476"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "71"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "7"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.106741981525725"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.196676917108917"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999973003386476"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "71"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4cd96b91a9bff0c27f9a1cf0ccb9533d",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:39feea9bf256b35cba29d53ba142d102",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:63335f473373e0606d5e19a26d54947f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:aeed349c1d870c766c3846139baddfcf",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0072",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "5"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0762442725183751"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.272686785534213"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999536932681"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "72"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "5"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0762442725183751"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.272686785534213"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999536932681"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "72"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:63335f473373e0606d5e19a26d54947f",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:aeed349c1d870c766c3846139baddfcf",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:a5b7e29d2b4e7df102d4c218a8e2de79",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:fb34b9243fbfd4d52f33195ad11fa75e",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0073",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "7"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.106741981525725"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.196676917108917"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999973003386476"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "73"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "7"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.106741981525725"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.196676917108917"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999973003386476"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "73"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a5b7e29d2b4e7df102d4c218a8e2de79",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:fb34b9243fbfd4d52f33195ad11fa75e",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:bc8ae88a4964bdb4f03808829f923a38",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:ae4e3431e53d6bb86cb5f49df3e1dd3c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0074",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0457465635110251"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.396774248526764"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999393034"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "74"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0457465635110251"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.396774248526764"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999393034"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "74"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:bc8ae88a4964bdb4f03808829f923a38",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:ae4e3431e53d6bb86cb5f49df3e1dd3c",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:8635bd60e838e70448a683e4c2731fb0",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:3ae2d61c89fb13f4e75319093956440c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0075",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0609954180147001"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.32633981091806"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999973738745"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "75"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0609954180147001"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.32633981091806"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999973738745"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "75"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8635bd60e838e70448a683e4c2731fb0",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:3ae2d61c89fb13f4e75319093956440c",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:76761290d259c6c26ed92cd02b7a8ffd",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:b9c3425be7ea99b14efce8bce592b25b",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0076",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "5"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0762442725183751"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.272686785534213"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999536932681"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "76"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "5"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0762442725183751"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.272686785534213"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999536932681"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "76"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:76761290d259c6c26ed92cd02b7a8ffd",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:b9c3425be7ea99b14efce8bce592b25b",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:2447692cf3c13cbbdafc3a665370603f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:53c378a2e0ca3196fa50b2b2030c0fcc",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0077",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "7"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.106741981525725"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.196676917108917"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999973003386476"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "77"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "7"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.106741981525725"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.196676917108917"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999973003386476"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "77"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2447692cf3c13cbbdafc3a665370603f",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:53c378a2e0ca3196fa50b2b2030c0fcc",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:e4dcddb5ab6095be427ee660b9fc5d2f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:43e5c93bebd29ba8da99711ae8d9c3e1",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0078",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.49389125238231"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999996633"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "78"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.49389125238231"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999996633"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "78"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e4dcddb5ab6095be427ee660b9fc5d2f",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:43e5c93bebd29ba8da99711ae8d9c3e1",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:343fa8f57e7adfcd961ea3af67b24ad0",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:7fd1e3a607dbe6cfba8a4e086242d6b7",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0079",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0457465635110251"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.396774248526764"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999393034"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "79"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0457465635110251"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.396774248526764"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999393034"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "79"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:343fa8f57e7adfcd961ea3af67b24ad0",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:7fd1e3a607dbe6cfba8a4e086242d6b7",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:59cba60adf480535a1c969d6d64e23b9",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:d2c986d4849a217bf93ccf9e1e40ff7d",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0080",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "8"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.1219908360294"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.169043835402863"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999881638693591"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "80"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "8"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.1219908360294"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.169043835402863"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999881638693591"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "80"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:59cba60adf480535a1c969d6d64e23b9",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:d2c986d4849a217bf93ccf9e1e40ff7d",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:8e3b014c96a9933ebe866f62a5fc3a5c",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:bac839d7d5a8f71351fbf0af9d7d237d",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0081",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0457465635110251"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.396774248526764"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999393034"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "81"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0457465635110251"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.396774248526764"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999393034"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "81"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8e3b014c96a9933ebe866f62a5fc3a5c",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:bac839d7d5a8f71351fbf0af9d7d237d",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:7adf18789eb65028169817bb70133720",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:950ebb223c0553663a2925b4cebca2f2",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0082",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "10"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.15248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.127107912598347"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.998884789335864"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "82"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "10"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.15248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.127107912598347"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.998884789335864"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "82"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7adf18789eb65028169817bb70133720",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:950ebb223c0553663a2925b4cebca2f2",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:3e769257b2ca300ac5c4d33e8539ea3e",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:9a52ab95dd907c0f7f51fb102fd28f70",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0083",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "10"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.15248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.127107912598347"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.998884789335864"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "83"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "10"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.15248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.127107912598347"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.998884789335864"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "83"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3e769257b2ca300ac5c4d33e8539ea3e",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:9a52ab95dd907c0f7f51fb102fd28f70",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:66df3519712f78df7f53bbfefe65db57",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f6d437c16c83f9a147b1bb4222d3abc6",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0084",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0457465635110251"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.396774248526764"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999393034"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "84"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0457465635110251"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.396774248526764"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999393034"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "84"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:66df3519712f78df7f53bbfefe65db57",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:f6d437c16c83f9a147b1bb4222d3abc6",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:122fe3b47ae88833c8f3dcb366c4f353",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:8837f9a734738e041b5341b9172fb036",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0085",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0457465635110251"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.396774248526764"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999393034"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "85"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0457465635110251"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.396774248526764"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999393034"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "85"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:122fe3b47ae88833c8f3dcb366c4f353",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:8837f9a734738e041b5341b9172fb036",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:5a3a2dbf66bf4901aa498d3c0495df01",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:8b57160e5bbb28c42ed70eb49e48b412",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0086",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "7"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.106741981525725"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.196676917108917"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999973003386476"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "86"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "7"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.106741981525725"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.196676917108917"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999973003386476"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "86"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5a3a2dbf66bf4901aa498d3c0495df01",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:8b57160e5bbb28c42ed70eb49e48b412",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:d09cb3827a1f341bbeb1a77f474f6e6a",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c45c033aff250585c0df5bd7ebfa55c2",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0087",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "6"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0914931270220502"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.230530023375576"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999995585095987"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "87"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "6"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0914931270220502"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.230530023375576"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999995585095987"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "87"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d09cb3827a1f341bbeb1a77f474f6e6a",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:c45c033aff250585c0df5bd7ebfa55c2",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:df984c734f06f169195b0bbaee6143c6",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:95162bceebb39a10b64eb05d8de3fd22",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0088",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "11"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.167737399540425"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.111020787763232"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.997363356013822"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "88"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "11"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.167737399540425"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.111020787763232"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.997363356013822"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "88"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:df984c734f06f169195b0bbaee6143c6",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:95162bceebb39a10b64eb05d8de3fd22",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:3bf753720b3412e5689330bba1dbe1cf",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:3ed2c390b2b8ba7d7280d7aaf1f7a0e5",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0089",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0457465635110251"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.396774248526764"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999393034"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "89"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0457465635110251"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.396774248526764"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999393034"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "89"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3bf753720b3412e5689330bba1dbe1cf",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:3ed2c390b2b8ba7d7280d7aaf1f7a0e5",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:002c13dfe076dd8552445efc13f91b3d",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:a7eac8bb5c994b37b60795763e4a8b47",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0090",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.49389125238231"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999996633"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "90"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.49389125238231"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999996633"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "90"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:002c13dfe076dd8552445efc13f91b3d",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:a7eac8bb5c994b37b60795763e4a8b47",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:9a0b88bb0f2e1591fd4c0a65c1e565f2",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:df913e2209fc5cbf0b94dbb97361067d",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0091",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "6"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0914931270220502"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.230530023375576"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999995585095987"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "91"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "6"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0914931270220502"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.230530023375576"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999995585095987"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "91"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9a0b88bb0f2e1591fd4c0a65c1e565f2",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:df913e2209fc5cbf0b94dbb97361067d",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:5c85689f9d81af447c3f8df3048c263a",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:20e5d869565077dcc873c4847e343626",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0092",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "5"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0762442725183751"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.272686785534213"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999536932681"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "92"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "5"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0762442725183751"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.272686785534213"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999536932681"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "92"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5c85689f9d81af447c3f8df3048c263a",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:20e5d869565077dcc873c4847e343626",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:ee254d71e90697d1d1a39f5a3df69e4f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:b53c18c408c426d6208825bc03bda76c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0093",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "8"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.1219908360294"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.169043835402863"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999881638693591"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "93"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "8"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.1219908360294"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.169043835402863"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999881638693591"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "93"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ee254d71e90697d1d1a39f5a3df69e4f",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:b53c18c408c426d6208825bc03bda76c",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:d7e6ee1864f4fe14f463aecb07ee9b99",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:5040d4f96058237b55074ccbae780c73",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0094",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.641209332153058"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999999"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "94"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.641209332153058"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999999"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "94"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d7e6ee1864f4fe14f463aecb07ee9b99",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:5040d4f96058237b55074ccbae780c73",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:de906422e6143ba14adec0aefe299e8c",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:dc90ccd75e3ef3f441e343a64ffc8a53",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0095",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "7"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.106741981525725"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.196676917108917"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999973003386476"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "95"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "7"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.106741981525725"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.196676917108917"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999973003386476"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "95"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:de906422e6143ba14adec0aefe299e8c",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:dc90ccd75e3ef3f441e343a64ffc8a53",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:cc05429585cad5ec4458634a29892454",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:92eaf289a4d8a69bb8c61dcf57734f87",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0096",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.49389125238231"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999996633"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "96"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.49389125238231"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999996633"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "96"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cc05429585cad5ec4458634a29892454",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:92eaf289a4d8a69bb8c61dcf57734f87",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:f8f459cc5e943c333944b0423cc623a2",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c40c3a11ae575e327a69951e39f7cf1e",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0097",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0609954180147001"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.32633981091806"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999973738745"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "97"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0609954180147001"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.32633981091806"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999973738745"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "97"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f8f459cc5e943c333944b0423cc623a2",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:c40c3a11ae575e327a69951e39f7cf1e",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:be7c69bccd607857ab4a3b06e884b72d",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:004221f4a994d829f5e16e54483a92e9",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0098",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "21"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.320225944577176"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0339584497531345"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.837383388101696"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "98"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "21"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.320225944577176"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0339584497531345"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.837383388101696"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "98"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:be7c69bccd607857ab4a3b06e884b72d",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:004221f4a994d829f5e16e54483a92e9",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:a5b505175149fb44eaa5bccb967891c3",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:996665a23456cb618780744372406eba",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0099",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0609954180147001"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.32633981091806"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999973738745"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "99"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0609954180147001"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.32633981091806"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999973738745"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "99"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a5b505175149fb44eaa5bccb967891c3",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:996665a23456cb618780744372406eba",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:d03fcb703af0be07c63c073c3c59f291",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:09c11fea29165ff889d59486cc998f06",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0100",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0457465635110251"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.396774248526764"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999393034"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "100"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0457465635110251"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.396774248526764"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999393034"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "100"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d03fcb703af0be07c63c073c3c59f291",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:09c11fea29165ff889d59486cc998f06",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:6a8c63619c891d6d617b0e6030a35936",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:10c4f42b041516447c28674dab2cde5b",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0101",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.641209332153058"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999999"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "101"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.641209332153058"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999999"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "101"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6a8c63619c891d6d617b0e6030a35936",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:10c4f42b041516447c28674dab2cde5b",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:12507a0af7ca022693fcfe481576aa45",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c39f3e559dae9a5d556ae9b5045842da",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0102",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.641209332153058"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999999"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "102"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.641209332153058"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999999"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "102"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:12507a0af7ca022693fcfe481576aa45",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:c39f3e559dae9a5d556ae9b5045842da",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:308103904b8257fddf3a4611eaa9b395",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:231b63a3acf5fa6923ad638c6827b93e",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0103",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.49389125238231"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999996633"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "103"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.49389125238231"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999996633"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "103"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:308103904b8257fddf3a4611eaa9b395",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:231b63a3acf5fa6923ad638c6827b93e",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:8b5a3b06127829c3d92a63e07d1c594d",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:7a2a292e9fd06f3e19425b30b04888ad",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0104",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0457465635110251"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.396774248526764"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999393034"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "104"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0457465635110251"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.396774248526764"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999393034"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "104"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8b5a3b06127829c3d92a63e07d1c594d",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:7a2a292e9fd06f3e19425b30b04888ad",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:24c2094ec130702f9601c371533bf8d4",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f7777aa15969e9f0700b324454e85979",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0105",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.641209332153058"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999999"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "105"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.641209332153058"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999999"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "105"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:24c2094ec130702f9601c371533bf8d4",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:f7777aa15969e9f0700b324454e85979",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:e0fb0b6fe7935f93d9ab789f37f5ba17",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:8005738cdc3c09b780e2ba1a36547702",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0106",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0457465635110251"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.396774248526764"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999393034"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "106"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0457465635110251"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.396774248526764"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999393034"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "106"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e0fb0b6fe7935f93d9ab789f37f5ba17",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:8005738cdc3c09b780e2ba1a36547702",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:8cf845d47cedee91dcbc9b5f4add50e4",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:bd14daedcd6c35f47c42f6681a25a48e",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0107",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.641209332153058"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999999"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "107"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.641209332153058"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999999"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "107"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8cf845d47cedee91dcbc9b5f4add50e4",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:bd14daedcd6c35f47c42f6681a25a48e",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:51fdd8b821079d1b5dc1b6834e5fb0af",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:30ebc4167834c5d88670b4e8b93ee950",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0108",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0457465635110251"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.396774248526764"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999393034"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "108"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0457465635110251"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.396774248526764"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999393034"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "108"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:51fdd8b821079d1b5dc1b6834e5fb0af",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:30ebc4167834c5d88670b4e8b93ee950",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:a85e4f97fb1baa4a0c741f94e4bfc112",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:5d3db32c6d2773404bb204393a96f250",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0109",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.49389125238231"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999996633"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "109"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.49389125238231"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999996633"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "109"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a85e4f97fb1baa4a0c741f94e4bfc112",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:5d3db32c6d2773404bb204393a96f250",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:7a8a9b5c480a5adb8ea8cce6dede2941",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:6d6e5cd089cb7ce9b9715c42e896cd46",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0110",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.641209332153058"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999999"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "110"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.641209332153058"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999999"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "110"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7a8a9b5c480a5adb8ea8cce6dede2941",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:6d6e5cd089cb7ce9b9715c42e896cd46",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:c1f4268606ddda131fdee326fe51797d",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:189cb4ae2ff1cc4b031011345ea5e5b0",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0111",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0457465635110251"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.396774248526764"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999393034"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "111"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0457465635110251"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.396774248526764"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999393034"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "111"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c1f4268606ddda131fdee326fe51797d",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:189cb4ae2ff1cc4b031011345ea5e5b0",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:50e9a0153fd5b58dfd6867a7820e429b",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:697f2d7f340407941e5a743646226280",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0112",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.49389125238231"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999996633"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "112"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.49389125238231"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999996633"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "112"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:50e9a0153fd5b58dfd6867a7820e429b",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:697f2d7f340407941e5a743646226280",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:9fe72cde6498f2f7dfe77dfb89b501c0",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:15af37e0e71211cb9816e08cc4cd0b88",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0113",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.641209332153058"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999999"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "113"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.641209332153058"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999999"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "113"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9fe72cde6498f2f7dfe77dfb89b501c0",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:15af37e0e71211cb9816e08cc4cd0b88",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:4316bec42f97f257669a294c8fd0898f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:3fb8aaff3e01f2366b6d14baa9559ec9",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0114",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.641209332153058"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999999"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "114"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.641209332153058"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999999"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "114"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4316bec42f97f257669a294c8fd0898f",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:3fb8aaff3e01f2366b6d14baa9559ec9",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:80346292a2b394403637328758a9b61a",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:557d4e957f05b5913d7a77c829b15561",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0115",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.641209332153058"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999999"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "115"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.641209332153058"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999999"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "115"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:80346292a2b394403637328758a9b61a",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:557d4e957f05b5913d7a77c829b15561",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:a8192adc0f3eb7c0e3ebb68c9944ac3b",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:73719d062893a763bcb9efcf192d5c98",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0116",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.641209332153058"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999999"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "116"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.641209332153058"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999999"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "116"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a8192adc0f3eb7c0e3ebb68c9944ac3b",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:73719d062893a763bcb9efcf192d5c98",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:a9c299e42713dde6d9d2880ee2d4dc18",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:254124ed2b4a8c1c5be4de8f4c74580d",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0117",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.49389125238231"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999996633"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "117"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.49389125238231"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999996633"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "117"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a9c299e42713dde6d9d2880ee2d4dc18",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:254124ed2b4a8c1c5be4de8f4c74580d",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:03911a1948dcd4aa2ec73ec06aafd889",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:a0c4e98f01e68139790391bbf8725466",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0118",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.49389125238231"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999996633"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "118"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.49389125238231"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999996633"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "118"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:03911a1948dcd4aa2ec73ec06aafd889",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:a0c4e98f01e68139790391bbf8725466",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:5114d29fe7a8bba54bb5318e7211dbb7",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:98295b38fd8a93e7e4ee1dfd88c76887",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0119",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.641209332153058"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999999"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "119"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.641209332153058"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999999"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "119"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5114d29fe7a8bba54bb5318e7211dbb7",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:98295b38fd8a93e7e4ee1dfd88c76887",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:cf393803c8dfe5f95ebba7fb00f78d36",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:33a90732b73cfec988bd66955a0c2126",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0120",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.641209332153058"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999999"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "120"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.641209332153058"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999999"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "120"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cf393803c8dfe5f95ebba7fb00f78d36",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:33a90732b73cfec988bd66955a0c2126",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:313761c03f2118d6c60dd97a4be2bd9d",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:ec3bd6715d891de0f42ba2dc11f9430c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0121",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.641209332153058"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999999"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "121"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.641209332153058"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999999"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "121"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:313761c03f2118d6c60dd97a4be2bd9d",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:ec3bd6715d891de0f42ba2dc11f9430c",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:f80911af8d0e7423917d1703bda349c3",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:8aa002c426d46d7b9d4dc5e2c38279d3",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0122",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.641209332153058"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999999"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "122"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.641209332153058"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999999"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "122"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f80911af8d0e7423917d1703bda349c3",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:8aa002c426d46d7b9d4dc5e2c38279d3",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:b2335168bac5f013fca6c3119b31817e",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:5d895214e17bb9af3199b1f47611a048",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0123",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.641209332153058"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999999"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "123"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.641209332153058"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999999"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "123"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b2335168bac5f013fca6c3119b31817e",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:5d895214e17bb9af3199b1f47611a048",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:c6d9b891da12e7c0dafddbc99f7cd3bd",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:781f6f173dae32b1495eaef04f1b405a",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0124",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.641209332153058"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999999"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "124"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.641209332153058"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999999"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "124"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c6d9b891da12e7c0dafddbc99f7cd3bd",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:781f6f173dae32b1495eaef04f1b405a",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:02d752fd02bb32b544f85decb2637acb",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:d98430357b786f52e1aba172bbfea688",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0125",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0457465635110251"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.396774248526764"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999393034"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "125"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0457465635110251"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.396774248526764"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999393034"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "125"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:02d752fd02bb32b544f85decb2637acb",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:d98430357b786f52e1aba172bbfea688",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:ca6249ceeaf778daf8955f1721d9b3bc",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:fe57af8773140946a4555792ccdee632",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0126",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.641209332153058"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999999"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "126"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.641209332153058"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999999"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "126"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ca6249ceeaf778daf8955f1721d9b3bc",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:fe57af8773140946a4555792ccdee632",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:f5165ff916468849a9e8f0f984156ae0",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:678cf59b6ed563cbae258da7bd9a2417",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0127",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.641209332153058"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999999"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "127"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.641209332153058"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999999"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "127"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f5165ff916468849a9e8f0f984156ae0",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:678cf59b6ed563cbae258da7bd9a2417",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:3c77b0eab26aadf473051def81f975f1",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:fb40247362abead8bfd05d8c0f86fcc6",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0128",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.641209332153058"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999999"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "128"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.641209332153058"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999999"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "128"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3c77b0eab26aadf473051def81f975f1",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:fb40247362abead8bfd05d8c0f86fcc6",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:74f854bba7b4563710f1c71fe1bb4d87",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f0413bd7869f1537bac196460adb50ad",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0129",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.641209332153058"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999999"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "129"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.641209332153058"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999999"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "129"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:74f854bba7b4563710f1c71fe1bb4d87",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:f0413bd7869f1537bac196460adb50ad",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:f0f6386c19242334018be62b5253762f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:fd3eca9e0c356a0d39da224ef34ff7aa",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0130",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.641209332153058"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999999"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "130"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.641209332153058"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999999"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "130"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f0f6386c19242334018be62b5253762f",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:fd3eca9e0c356a0d39da224ef34ff7aa",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:79f57cc3d9c8ce9cf2ddf678b180fec2",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:b2244e3b33c0159757aa93c2de26c3a1",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0131",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.641209332153058"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999999"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "131"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.641209332153058"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999999"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "131"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:79f57cc3d9c8ce9cf2ddf678b180fec2",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:b2244e3b33c0159757aa93c2de26c3a1",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:ac75e1b81a1c6524011de1087ab61a81",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:8b70b13ee54cf4407e3be646e313b866",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0132",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.641209332153058"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999999"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "132"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.641209332153058"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999999"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "132"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ac75e1b81a1c6524011de1087ab61a81",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:8b70b13ee54cf4407e3be646e313b866",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:8006697d9195e3c3171a1c00415399c0",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:cfc211e4c6c91ecd22c4f0f2f0075044",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0133",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.641209332153058"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999999"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "133"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.641209332153058"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999999"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "133"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8006697d9195e3c3171a1c00415399c0",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:cfc211e4c6c91ecd22c4f0f2f0075044",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:8ea603bc4b1eabe8a8b1f02e165eef5e",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f00195d4acadb18083e5d9b4023ca225",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0134",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.641209332153058"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999999"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "134"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.641209332153058"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999999"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "134"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8ea603bc4b1eabe8a8b1f02e165eef5e",
-      "entity": "niiri:d2e82dc2ef1ed65643a5b21509270b91"
+      "entity_derived": "niiri:f00195d4acadb18083e5d9b4023ca225",
+      "entity": "niiri:8523ea1215430db79b6d67ec562629a2"
     },
     {
-      "@id": "niiri:a76cdd5bcbde48124848b3c5de9557fd",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f2c008500acb79baf9b5ce05210f9bb9",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0001",
-      "prov:atLocation": {"@id": "niiri:87439a144e63d239d7e95d83cc2b3570"},
+      "prov:atLocation": {"@id": "niiri:83ef927efc7de9ab53de628e0e4eba1b"},
       "prov:value": {"@type": "xsd:float", "@value": "4.61011266708374"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "6.51265120547007"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.69179131709529e-11"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "8.23475922277556e-06"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000129439334006007"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "6.51265120547007"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.69179131709529e-11"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "8.23475922277556e-06"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000129439334006007"}
     },
     {
-      "@id": "niiri:87439a144e63d239d7e95d83cc2b3570",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:83ef927efc7de9ab53de628e0e4eba1b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0001",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-46,-66,-8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-46,-66,-8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a76cdd5bcbde48124848b3c5de9557fd",
-      "entity": "niiri:513895e5db5c23441d24f7a6b36af026"
+      "entity_derived": "niiri:f2c008500acb79baf9b5ce05210f9bb9",
+      "entity": "niiri:212a130c85dc60414b3a3ae20326ccc1"
     },
     {
-      "@id": "niiri:6f096bd903544a895a7fa0b1e9dc9592",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:1fa4a48ba4a927736beae3c9f786d502",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0002",
-      "prov:atLocation": {"@id": "niiri:01a873ba01f58760c3bf086b56c2b979"},
+      "prov:atLocation": {"@id": "niiri:36d111a494f38a79183bc43c5d3c8dc6"},
       "prov:value": {"@type": "xsd:float", "@value": "4.14067697525024"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.94920489177576"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.3472408744164e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.000300511459932193"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0016296513076278"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.94920489177576"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.3472408744164e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.000300511459932193"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0016296513076278"}
     },
     {
-      "@id": "niiri:01a873ba01f58760c3bf086b56c2b979",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:36d111a494f38a79183bc43c5d3c8dc6",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0002",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-34,-72,-16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-34,-72,-16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6f096bd903544a895a7fa0b1e9dc9592",
-      "entity": "niiri:513895e5db5c23441d24f7a6b36af026"
+      "entity_derived": "niiri:1fa4a48ba4a927736beae3c9f786d502",
+      "entity": "niiri:212a130c85dc60414b3a3ae20326ccc1"
     },
     {
-      "@id": "niiri:ac7252b1859ceba90e220bac1b2667bf",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:6a83a6584dca6366715d149902302674",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0003",
-      "prov:atLocation": {"@id": "niiri:dae374bdf6e469dbff8ce016a9389e83"},
+      "prov:atLocation": {"@id": "niiri:553889dbf2e240f257cb6fc52f945311"},
       "prov:value": {"@type": "xsd:float", "@value": "3.39726591110229"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.03216968185068"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.42479864742684e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0540868376963655"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0144418464851922"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.03216968185068"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.42479864742684e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0540868376963655"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0144418464851922"}
     },
     {
-      "@id": "niiri:dae374bdf6e469dbff8ce016a9389e83",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:553889dbf2e240f257cb6fc52f945311",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0003",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-40,-48,-14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-40,-48,-14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ac7252b1859ceba90e220bac1b2667bf",
-      "entity": "niiri:513895e5db5c23441d24f7a6b36af026"
+      "entity_derived": "niiri:6a83a6584dca6366715d149902302674",
+      "entity": "niiri:212a130c85dc60414b3a3ae20326ccc1"
     },
     {
-      "@id": "niiri:cbe75c6155718d2c43fc92f0e06a4a90",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:32f1a2c6ca2ddb9829b059ddbe234078",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0004",
-      "prov:atLocation": {"@id": "niiri:31921bf119f52b8d20b02f58eed2b9bd"},
+      "prov:atLocation": {"@id": "niiri:6028c33dcc61afb7c773a2c95eb048c1"},
       "prov:value": {"@type": "xsd:float", "@value": "4.07992362976074"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.87535600284606"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.10967798786044e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.000470578397640152"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0016296513076278"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.87535600284606"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.10967798786044e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.000470578397640152"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0016296513076278"}
     },
     {
-      "@id": "niiri:31921bf119f52b8d20b02f58eed2b9bd",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6028c33dcc61afb7c773a2c95eb048c1",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0004",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[34,-86,10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[34,-86,10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cbe75c6155718d2c43fc92f0e06a4a90",
-      "entity": "niiri:200353b62d6c59c05f378e37920581d1"
+      "entity_derived": "niiri:32f1a2c6ca2ddb9829b059ddbe234078",
+      "entity": "niiri:b6f31947ea1d789fff0bd7ebbd8d5aa3"
     },
     {
-      "@id": "niiri:4387e1f94ac93199293e0d4a31778e56",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b514d16779b8ecd93200134e45991536",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0005",
-      "prov:atLocation": {"@id": "niiri:3919a845111f67517bba32f473e08053"},
+      "prov:atLocation": {"@id": "niiri:1230bad84e8f2bfea468396bc431e6ec"},
       "prov:value": {"@type": "xsd:float", "@value": "2.95166039466858"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.47003158157261"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.91040240832474e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.497269375153304"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0815933520961271"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.47003158157261"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.91040240832474e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.497269375153304"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0815933520961271"}
     },
     {
-      "@id": "niiri:3919a845111f67517bba32f473e08053",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:1230bad84e8f2bfea468396bc431e6ec",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0005",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[42,-86,12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[42,-86,12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4387e1f94ac93199293e0d4a31778e56",
-      "entity": "niiri:200353b62d6c59c05f378e37920581d1"
+      "entity_derived": "niiri:b514d16779b8ecd93200134e45991536",
+      "entity": "niiri:b6f31947ea1d789fff0bd7ebbd8d5aa3"
     },
     {
-      "@id": "niiri:957270d19f1d43dcfc587e393706213c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:23faf3bc0650966493e9f36e0ca600b8",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0006",
-      "prov:atLocation": {"@id": "niiri:41bbabf30972e821ea30ef31c9bf6285"},
+      "prov:atLocation": {"@id": "niiri:c7f4a3b9045d9f445d2145b126d0e4fd"},
       "prov:value": {"@type": "xsd:float", "@value": "2.85145282745361"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.34253727556279"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.04232894899182e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.676230493527593"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.107852519413958"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.34253727556279"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.04232894899182e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.676230493527593"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.107852519413958"}
     },
     {
-      "@id": "niiri:41bbabf30972e821ea30ef31c9bf6285",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c7f4a3b9045d9f445d2145b126d0e4fd",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0006",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[38,-84,2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[38,-84,2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:957270d19f1d43dcfc587e393706213c",
-      "entity": "niiri:200353b62d6c59c05f378e37920581d1"
+      "entity_derived": "niiri:23faf3bc0650966493e9f36e0ca600b8",
+      "entity": "niiri:b6f31947ea1d789fff0bd7ebbd8d5aa3"
     },
     {
-      "@id": "niiri:13bade8d76fd2f2355d89d778e215817",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:8779cf8885e2bb57f1eb0502089c61a7",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0007",
-      "prov:atLocation": {"@id": "niiri:013e06f64b6ff1181f14f4b4607024b1"},
+      "prov:atLocation": {"@id": "niiri:96fce76485c81a95e0c5588233442fcc"},
       "prov:value": {"@type": "xsd:float", "@value": "3.96536254882812"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.73554616923849"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.85993045806765e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00108404146331869"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00195763806925102"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.73554616923849"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.85993045806765e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00108404146331869"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00195763806925102"}
     },
     {
-      "@id": "niiri:013e06f64b6ff1181f14f4b4607024b1",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:96fce76485c81a95e0c5588233442fcc",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0007",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[8,6,-4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[8,6,-4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:13bade8d76fd2f2355d89d778e215817",
-      "entity": "niiri:0347896da596f5297388dcc20e03b25d"
+      "entity_derived": "niiri:8779cf8885e2bb57f1eb0502089c61a7",
+      "entity": "niiri:171c8ac1a84198593464a36bac244ff0"
     },
     {
-      "@id": "niiri:c779a46f88109c01ad1a341d88903f4a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f617e967f1244bd4a0ee551172e05935",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0008",
-      "prov:atLocation": {"@id": "niiri:cf4dc49d4fe6c2c4254e338eb7d30979"},
+      "prov:atLocation": {"@id": "niiri:119da361d8cff441d6a0ef67380f70b3"},
       "prov:value": {"@type": "xsd:float", "@value": "3.76170587539673"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.4852660945335"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.06423748094764e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00460442620206421"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0037086909867648"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.4852660945335"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.06423748094764e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00460442620206421"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0037086909867648"}
     },
     {
-      "@id": "niiri:cf4dc49d4fe6c2c4254e338eb7d30979",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:119da361d8cff441d6a0ef67380f70b3",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0008",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[20,16,6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[20,16,6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c779a46f88109c01ad1a341d88903f4a",
-      "entity": "niiri:0347896da596f5297388dcc20e03b25d"
+      "entity_derived": "niiri:f617e967f1244bd4a0ee551172e05935",
+      "entity": "niiri:171c8ac1a84198593464a36bac244ff0"
     },
     {
-      "@id": "niiri:6d3d1c02d434061e55c5d461d8cd0c3a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:09a006cc070777c7bc9ff02587a9475f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0009",
-      "prov:atLocation": {"@id": "niiri:015ea7513c292f2097769db95a5877ab"},
+      "prov:atLocation": {"@id": "niiri:5829801409b541d6efa67494d24ec16a"},
       "prov:value": {"@type": "xsd:float", "@value": "3.67560243606567"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.3788042778508"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.74910847922294e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00836264901674123"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00496133762447783"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.3788042778508"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.74910847922294e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00836264901674123"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00496133762447783"}
     },
     {
-      "@id": "niiri:015ea7513c292f2097769db95a5877ab",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:5829801409b541d6efa67494d24ec16a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0009",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-32,24,2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-32,24,2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6d3d1c02d434061e55c5d461d8cd0c3a",
-      "entity": "niiri:0347896da596f5297388dcc20e03b25d"
+      "entity_derived": "niiri:09a006cc070777c7bc9ff02587a9475f",
+      "entity": "niiri:171c8ac1a84198593464a36bac244ff0"
     },
     {
-      "@id": "niiri:f462bea92037dce5b98545cabc1d527d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ec49a9f4a91ebfee81f8ba5ab02662d0",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0010",
-      "prov:atLocation": {"@id": "niiri:2c9fc23530b53213ebc02029be997b73"},
+      "prov:atLocation": {"@id": "niiri:613b7228e65741491fdbfb7f9b4fbb1e"},
       "prov:value": {"@type": "xsd:float", "@value": "3.89568662643433"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.65016589891917"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.01465316335737e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00178772445204086"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00218637116402122"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.65016589891917"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.01465316335737e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00178772445204086"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00218637116402122"}
     },
     {
-      "@id": "niiri:2c9fc23530b53213ebc02029be997b73",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:613b7228e65741491fdbfb7f9b4fbb1e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0010",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[36,-76,-14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[36,-76,-14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f462bea92037dce5b98545cabc1d527d",
-      "entity": "niiri:4c63f433fea86c4902ef28b8a4e0b83b"
+      "entity_derived": "niiri:ec49a9f4a91ebfee81f8ba5ab02662d0",
+      "entity": "niiri:7174a23494a5602d1cf5b80e0b3957b3"
     },
     {
-      "@id": "niiri:f11268ecaa8c62c061de58b2048beaa6",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d7db9d99f9156bfd0c9e6482f6b282d1",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0011",
-      "prov:atLocation": {"@id": "niiri:394dd3dde180f863041fa610fc4d735c"},
+      "prov:atLocation": {"@id": "niiri:6e6dfcb4a088e040e68b43aa9dae945a"},
       "prov:value": {"@type": "xsd:float", "@value": "3.36620903015137"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.99326640019021"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.9683290059257e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0662106660868522"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0150086130881337"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.99326640019021"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.9683290059257e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0662106660868522"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0150086130881337"}
     },
     {
-      "@id": "niiri:394dd3dde180f863041fa610fc4d735c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6e6dfcb4a088e040e68b43aa9dae945a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0011",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[26,-78,-12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[26,-78,-12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f11268ecaa8c62c061de58b2048beaa6",
-      "entity": "niiri:4c63f433fea86c4902ef28b8a4e0b83b"
+      "entity_derived": "niiri:d7db9d99f9156bfd0c9e6482f6b282d1",
+      "entity": "niiri:7174a23494a5602d1cf5b80e0b3957b3"
     },
     {
-      "@id": "niiri:ca30e6eb0689fb2b23309714f134d928",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b1965951f77cadf6336644280d9e0eb2",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0012",
-      "prov:atLocation": {"@id": "niiri:fcb6c8887a68ee924c4a3ae06c9851e6"},
+      "prov:atLocation": {"@id": "niiri:b0bcc363e13905c0cec9abc9a5f926cd"},
       "prov:value": {"@type": "xsd:float", "@value": "2.82210826873779"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.30513434912561"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.34422125894907e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.727285909061263"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.11336333992572"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.30513434912561"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.34422125894907e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.727285909061263"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.11336333992572"}
     },
     {
-      "@id": "niiri:fcb6c8887a68ee924c4a3ae06c9851e6",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b0bcc363e13905c0cec9abc9a5f926cd",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0012",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[44,-70,-14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[44,-70,-14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ca30e6eb0689fb2b23309714f134d928",
-      "entity": "niiri:4c63f433fea86c4902ef28b8a4e0b83b"
+      "entity_derived": "niiri:b1965951f77cadf6336644280d9e0eb2",
+      "entity": "niiri:7174a23494a5602d1cf5b80e0b3957b3"
     },
     {
-      "@id": "niiri:852d04c205f9067346f2596853527a0e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:95c8fcf40d4086295dd49408d12a5369",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0013",
-      "prov:atLocation": {"@id": "niiri:6d80114ee61ef182fef71e2d792bac90"},
+      "prov:atLocation": {"@id": "niiri:6858d0c8f88e8fe9c91135874f2b7ea0"},
       "prov:value": {"@type": "xsd:float", "@value": "3.87710690498352"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.62735471926077"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "9.14970854637431e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00204090649550025"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00218637116402122"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.62735471926077"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "9.14970854637431e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00204090649550025"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00218637116402122"}
     },
     {
-      "@id": "niiri:6d80114ee61ef182fef71e2d792bac90",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6858d0c8f88e8fe9c91135874f2b7ea0",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0013",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[38,-64,52]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[38,-64,52]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:852d04c205f9067346f2596853527a0e",
-      "entity": "niiri:ca1279119038c6ed3aa8da5ae36104c5"
+      "entity_derived": "niiri:95c8fcf40d4086295dd49408d12a5369",
+      "entity": "niiri:2cd32bc92eb7dd286253f06b6c4516f9"
     },
     {
-      "@id": "niiri:91f6f0c163e804f9c6c930f0b69330fd",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:6a44a9a24517109ec3074ac91077f376",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0014",
-      "prov:atLocation": {"@id": "niiri:15084e5bc5edb1aea933ecc637b78f9c"},
+      "prov:atLocation": {"@id": "niiri:beea954b53ac5e2e78c8261689528de9"},
       "prov:value": {"@type": "xsd:float", "@value": "2.83855104446411"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.32609620488621"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.58875776796231e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.698927552906607"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.107852519413958"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.32609620488621"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.58875776796231e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.698927552906607"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.107852519413958"}
     },
     {
-      "@id": "niiri:15084e5bc5edb1aea933ecc637b78f9c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:beea954b53ac5e2e78c8261689528de9",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0014",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[46,-58,44]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[46,-58,44]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:91f6f0c163e804f9c6c930f0b69330fd",
-      "entity": "niiri:ca1279119038c6ed3aa8da5ae36104c5"
+      "entity_derived": "niiri:6a44a9a24517109ec3074ac91077f376",
+      "entity": "niiri:2cd32bc92eb7dd286253f06b6c4516f9"
     },
     {
-      "@id": "niiri:654b54ae222a2b620d369cb39a760e69",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:75efdb8848f89afcfba1a207d71a6086",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0015",
-      "prov:atLocation": {"@id": "niiri:a8d9417d1cabedb98b3c424654d77140"},
+      "prov:atLocation": {"@id": "niiri:9c9662a0587b95df451773773737bc67"},
       "prov:value": {"@type": "xsd:float", "@value": "2.7466766834259"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.2088532772211"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.28334991591483e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.843938187211889"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.138131675608108"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.2088532772211"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.28334991591483e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.843938187211889"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.138131675608108"}
     },
     {
-      "@id": "niiri:a8d9417d1cabedb98b3c424654d77140",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:9c9662a0587b95df451773773737bc67",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0015",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[36,-56,38]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[36,-56,38]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:654b54ae222a2b620d369cb39a760e69",
-      "entity": "niiri:ca1279119038c6ed3aa8da5ae36104c5"
+      "entity_derived": "niiri:75efdb8848f89afcfba1a207d71a6086",
+      "entity": "niiri:2cd32bc92eb7dd286253f06b6c4516f9"
     },
     {
-      "@id": "niiri:1520938c89a75870b5a1a10cdcd97d21",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:7f82efbbcbb2b7ca685a4c40df6d517f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0016",
-      "prov:atLocation": {"@id": "niiri:133f392c5f08ecb3aa4f29e69abcd030"},
+      "prov:atLocation": {"@id": "niiri:9991f49a01ab3c078e441bc6d0aafc88"},
       "prov:value": {"@type": "xsd:float", "@value": "3.65790581703186"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.35687718443792"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.23363166746071e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00944341194070347"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00515918806035713"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.35687718443792"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.23363166746071e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00944341194070347"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00515918806035713"}
     },
     {
-      "@id": "niiri:133f392c5f08ecb3aa4f29e69abcd030",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:9991f49a01ab3c078e441bc6d0aafc88",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0016",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[52,-46,-12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[52,-46,-12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1520938c89a75870b5a1a10cdcd97d21",
-      "entity": "niiri:3b8c64c3b6fac5debb91f848b6310ef3"
+      "entity_derived": "niiri:7f82efbbcbb2b7ca685a4c40df6d517f",
+      "entity": "niiri:6438830b93a9866c5a8c4cb39850d977"
     },
     {
-      "@id": "niiri:ce53ac8c24182b97a423b73ed01935a7",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3957970d9b8be40cdba7d77e9fc1af08",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0017",
-      "prov:atLocation": {"@id": "niiri:4c28b43c252d1b7a9e266d8ab9bed502"},
+      "prov:atLocation": {"@id": "niiri:4e6a4d59eabe77a5d46c722f954d7dc8"},
       "prov:value": {"@type": "xsd:float", "@value": "3.61188387870789"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.29978067068531"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.79709378278892e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0129308238104803"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00597334524948961"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.29978067068531"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.79709378278892e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0129308238104803"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00597334524948961"}
     },
     {
-      "@id": "niiri:4c28b43c252d1b7a9e266d8ab9bed502",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4e6a4d59eabe77a5d46c722f954d7dc8",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0017",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-44,4,34]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-44,4,34]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ce53ac8c24182b97a423b73ed01935a7",
-      "entity": "niiri:f62ecbcce6abff98c7b382218c0d5dde"
+      "entity_derived": "niiri:3957970d9b8be40cdba7d77e9fc1af08",
+      "entity": "niiri:58fb2509f9d4dbc78a02bfcd61bb139b"
     },
     {
-      "@id": "niiri:1f7cc2c7e379dca859827b8cf687fc25",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ebbf36d0c0f06a153cfcf5a4d5d87c41",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0018",
-      "prov:atLocation": {"@id": "niiri:60f07da4189f3dedfbf0a9dd40afc971"},
+      "prov:atLocation": {"@id": "niiri:1b7890a36a01ed5e0fdb9f9a5a6e12e4"},
       "prov:value": {"@type": "xsd:float", "@value": "3.4259147644043"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.06801755102317"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.0099017394859e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0448322696793468"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.013317352840512"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.06801755102317"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.0099017394859e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0448322696793468"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.013317352840512"}
     },
     {
-      "@id": "niiri:60f07da4189f3dedfbf0a9dd40afc971",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:1b7890a36a01ed5e0fdb9f9a5a6e12e4",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0018",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-32,-4,56]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-32,-4,56]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1f7cc2c7e379dca859827b8cf687fc25",
-      "entity": "niiri:f7b92a750ed72932f6060531d3264928"
+      "entity_derived": "niiri:ebbf36d0c0f06a153cfcf5a4d5d87c41",
+      "entity": "niiri:2657e564e7bba015b389e0943b63badb"
     },
     {
-      "@id": "niiri:eb7ed4e83d4473bc4275d53cc4e647d3",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:31ec0b3be00fd80d126fc2af1ce352dd",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0019",
-      "prov:atLocation": {"@id": "niiri:6f16c5059854a8c4f4c0812d4ae23f88"},
+      "prov:atLocation": {"@id": "niiri:f40c694ee792eefb7eec37d13ca8cb2a"},
       "prov:value": {"@type": "xsd:float", "@value": "2.66663575172424"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.10648471595799"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.00863015121788e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.931784139682597"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.179785700482736"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.10648471595799"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.00863015121788e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.931784139682597"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.179785700482736"}
     },
     {
-      "@id": "niiri:6f16c5059854a8c4f4c0812d4ae23f88",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f40c694ee792eefb7eec37d13ca8cb2a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0019",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-32,-4,46]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-32,-4,46]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:eb7ed4e83d4473bc4275d53cc4e647d3",
-      "entity": "niiri:f7b92a750ed72932f6060531d3264928"
+      "entity_derived": "niiri:31ec0b3be00fd80d126fc2af1ce352dd",
+      "entity": "niiri:2657e564e7bba015b389e0943b63badb"
     },
     {
-      "@id": "niiri:34e8a1732024e1af87f50f8bea36ad67",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:2c6257c20ce92f4d4b1e41e803eef7b2",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0020",
-      "prov:atLocation": {"@id": "niiri:45c98424a2bdff1c08167e6304d05cbf"},
+      "prov:atLocation": {"@id": "niiri:c005427742dbeae90aefba064639c45c"},
       "prov:value": {"@type": "xsd:float", "@value": "2.37134194374084"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.72719680893962"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "9.68106320935469e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999922876108057"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.368886365441825"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.72719680893962"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "9.68106320935469e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999922876108057"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.368886365441825"}
     },
     {
-      "@id": "niiri:45c98424a2bdff1c08167e6304d05cbf",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c005427742dbeae90aefba064639c45c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0020",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-30,4,50]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-30,4,50]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:34e8a1732024e1af87f50f8bea36ad67",
-      "entity": "niiri:f7b92a750ed72932f6060531d3264928"
+      "entity_derived": "niiri:2c6257c20ce92f4d4b1e41e803eef7b2",
+      "entity": "niiri:2657e564e7bba015b389e0943b63badb"
     },
     {
-      "@id": "niiri:2d37b4ef6d7171d361f4010bd431fca7",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:108d6134cb55a8d7a0a3b38e0911631f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0021",
-      "prov:atLocation": {"@id": "niiri:3e7c1ce992d678c6edc1f5c39217f870"},
+      "prov:atLocation": {"@id": "niiri:d7fdf8001a1fc850f4cddb011811e7a0"},
       "prov:value": {"@type": "xsd:float", "@value": "3.41093230247498"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.04927492203708"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.21745057982226e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0494617928204381"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0139107162783319"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.04927492203708"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.21745057982226e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0494617928204381"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0139107162783319"}
     },
     {
-      "@id": "niiri:3e7c1ce992d678c6edc1f5c39217f870",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d7fdf8001a1fc850f4cddb011811e7a0",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0021",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[36,-56,-16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[36,-56,-16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2d37b4ef6d7171d361f4010bd431fca7",
-      "entity": "niiri:d4fb506965250f1ee35f6781f8eaf2e4"
+      "entity_derived": "niiri:108d6134cb55a8d7a0a3b38e0911631f",
+      "entity": "niiri:a8bb66759e4caade20c1a9e56f9516ec"
     },
     {
-      "@id": "niiri:84c4601cfd5e8ef9679114b16dec246c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f3b0431eda7e1bbfb898867a9c5f20db",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0022",
-      "prov:atLocation": {"@id": "niiri:9668bd697241825ab37eb454365a6d9d"},
+      "prov:atLocation": {"@id": "niiri:9e301d0fec3b6d6b3f6b0358a11f4b0c"},
       "prov:value": {"@type": "xsd:float", "@value": "2.56456685066223"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.97565696467545"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.50926166180487e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.98538798365609"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.231754253732683"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.97565696467545"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.50926166180487e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.98538798365609"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.231754253732683"}
     },
     {
-      "@id": "niiri:9668bd697241825ab37eb454365a6d9d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:9e301d0fec3b6d6b3f6b0358a11f4b0c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0022",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[22,-64,-18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[22,-64,-18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:84c4601cfd5e8ef9679114b16dec246c",
-      "entity": "niiri:d4fb506965250f1ee35f6781f8eaf2e4"
+      "entity_derived": "niiri:f3b0431eda7e1bbfb898867a9c5f20db",
+      "entity": "niiri:a8bb66759e4caade20c1a9e56f9516ec"
     },
     {
-      "@id": "niiri:31e57993c0df6fa66d3b559298e257a2",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:6914d04832f348c47b11f7e72bf95b91",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0023",
-      "prov:atLocation": {"@id": "niiri:a084c04a3431d9d3ef23ef91f1de2ff2"},
+      "prov:atLocation": {"@id": "niiri:ab7b2f582e75105be0c5b2aaec2daa19"},
       "prov:value": {"@type": "xsd:float", "@value": "3.23492169380188"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.82833550427561"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.88394970027595e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.144038846632802"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0248776371912962"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.82833550427561"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.88394970027595e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.144038846632802"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0248776371912962"}
     },
     {
-      "@id": "niiri:a084c04a3431d9d3ef23ef91f1de2ff2",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ab7b2f582e75105be0c5b2aaec2daa19",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0023",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[42,12,26]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[42,12,26]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:31e57993c0df6fa66d3b559298e257a2",
-      "entity": "niiri:ac21817310afb3594d085b280a7c7fad"
+      "entity_derived": "niiri:6914d04832f348c47b11f7e72bf95b91",
+      "entity": "niiri:7f817d4ab9fea049a6960806e46dae6f"
     },
     {
-      "@id": "niiri:180e30cb7ff449134fe50b8e0e78da77",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:bedd2a1fe4cc40fb4348c1e3f84fe4ce",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0024",
-      "prov:atLocation": {"@id": "niiri:b5dde6cd513642edd0a7398fde0a3aa2"},
+      "prov:atLocation": {"@id": "niiri:2c68c2c5f82c2c4469180668066cc07d"},
       "prov:value": {"@type": "xsd:float", "@value": "2.61081290245056"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.03497166916066"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.73044431503555e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.9682181756112"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.211273225680016"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.03497166916066"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.73044431503555e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.9682181756112"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.211273225680016"}
     },
     {
-      "@id": "niiri:b5dde6cd513642edd0a7398fde0a3aa2",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:2c68c2c5f82c2c4469180668066cc07d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0024",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[42,16,38]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[42,16,38]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:180e30cb7ff449134fe50b8e0e78da77",
-      "entity": "niiri:ac21817310afb3594d085b280a7c7fad"
+      "entity_derived": "niiri:bedd2a1fe4cc40fb4348c1e3f84fe4ce",
+      "entity": "niiri:7f817d4ab9fea049a6960806e46dae6f"
     },
     {
-      "@id": "niiri:406966b92fbe5970c29221501cbefe32",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:489fe008583f9540151b81533b9acb5e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0025",
-      "prov:atLocation": {"@id": "niiri:a7c517c3c9d7e0ce082baaa28b4caf36"},
+      "prov:atLocation": {"@id": "niiri:87fc4ec7f9fd634eb08dad6106d9ce4c"},
       "prov:value": {"@type": "xsd:float", "@value": "2.52718925476074"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.92767211706964"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.288601775293e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.993030331302132"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.253783543711115"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.92767211706964"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.288601775293e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.993030331302132"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.253783543711115"}
     },
     {
-      "@id": "niiri:a7c517c3c9d7e0ce082baaa28b4caf36",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:87fc4ec7f9fd634eb08dad6106d9ce4c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0025",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[34,8,26]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[34,8,26]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:406966b92fbe5970c29221501cbefe32",
-      "entity": "niiri:ac21817310afb3594d085b280a7c7fad"
+      "entity_derived": "niiri:489fe008583f9540151b81533b9acb5e",
+      "entity": "niiri:7f817d4ab9fea049a6960806e46dae6f"
     },
     {
-      "@id": "niiri:0cecaae3e1b26ecf4e4d49d578f1e8a9",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a5a33f4d819b8eb7632b4b1e5316ae25",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0026",
-      "prov:atLocation": {"@id": "niiri:d27131be4c5d31476b87eadb004a8ea2"},
+      "prov:atLocation": {"@id": "niiri:6c61922e9036d2efdfaea284d524d0c0"},
       "prov:value": {"@type": "xsd:float", "@value": "3.19025158882141"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.77204817208862"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "9.11809358350446e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.179866253319972"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0295002808813131"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.77204817208862"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "9.11809358350446e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.179866253319972"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0295002808813131"}
     },
     {
-      "@id": "niiri:d27131be4c5d31476b87eadb004a8ea2",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6c61922e9036d2efdfaea284d524d0c0",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0026",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-54,-32,42]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-54,-32,42]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0cecaae3e1b26ecf4e4d49d578f1e8a9",
-      "entity": "niiri:65f83d4775835650d295d792beafeab5"
+      "entity_derived": "niiri:a5a33f4d819b8eb7632b4b1e5316ae25",
+      "entity": "niiri:a088090c906271f3f2487f7339f0082c"
     },
     {
-      "@id": "niiri:b85cd3205202df2292eb9b9df9abc589",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3dbba6caca10b3238c9bd1b6e4ac3ff1",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0027",
-      "prov:atLocation": {"@id": "niiri:ec663137656a69ec672e5558fb15d0a0"},
+      "prov:atLocation": {"@id": "niiri:7b6a8a30f2afb4cffe0e6d51e5acbab6"},
       "prov:value": {"@type": "xsd:float", "@value": "3.01900839805603"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.55550961951652"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.61293619352454e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.38653459603819"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0625267026051373"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.55550961951652"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.61293619352454e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.38653459603819"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0625267026051373"}
     },
     {
-      "@id": "niiri:ec663137656a69ec672e5558fb15d0a0",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7b6a8a30f2afb4cffe0e6d51e5acbab6",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0027",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-40,46,26]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-40,46,26]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b85cd3205202df2292eb9b9df9abc589",
-      "entity": "niiri:fe501796991210fa8e9d37e811545e85"
+      "entity_derived": "niiri:3dbba6caca10b3238c9bd1b6e4ac3ff1",
+      "entity": "niiri:5cb5cd73033206c0daaf4927462a1873"
     },
     {
-      "@id": "niiri:46542211dacd3e8bdf9273ae7237c5dd",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:6edb5d4ccd344696f8f8a3ed75c82f37",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0028",
-      "prov:atLocation": {"@id": "niiri:f83d45ea6b9383d65bfb6cb896ea4847"},
+      "prov:atLocation": {"@id": "niiri:44d61d9d7c7c707923228503bfa247b4"},
       "prov:value": {"@type": "xsd:float", "@value": "2.89200973510742"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.39418165104258"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.55954066971953e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.603469212296398"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0986382553356101"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.39418165104258"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.55954066971953e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.603469212296398"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0986382553356101"}
     },
     {
-      "@id": "niiri:f83d45ea6b9383d65bfb6cb896ea4847",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:44d61d9d7c7c707923228503bfa247b4",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0028",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-16,-66,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-16,-66,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:46542211dacd3e8bdf9273ae7237c5dd",
-      "entity": "niiri:12095dcddf9a636e0d1c65eafed705e8"
+      "entity_derived": "niiri:6edb5d4ccd344696f8f8a3ed75c82f37",
+      "entity": "niiri:f4def9a581b3c307c2f4fb9e2e226d0e"
     },
     {
-      "@id": "niiri:3cd7c15623b43ad3fa6d34e91f363f74",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:4021174e55dc807e3de6628bf8eb04e4",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0029",
-      "prov:atLocation": {"@id": "niiri:76bc34d64d71bd23a786e34b7c0e0d3a"},
+      "prov:atLocation": {"@id": "niiri:f83aa6697a4e460e152625e9ddb5dc97"},
       "prov:value": {"@type": "xsd:float", "@value": "2.35510396957397"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.7062743430358"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000105165232115123"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999959028289625"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.368886365441825"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.7062743430358"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000105165232115123"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999959028289625"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.368886365441825"}
     },
     {
-      "@id": "niiri:76bc34d64d71bd23a786e34b7c0e0d3a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f83aa6697a4e460e152625e9ddb5dc97",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0029",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-28,-56,52]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-28,-56,52]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3cd7c15623b43ad3fa6d34e91f363f74",
-      "entity": "niiri:12095dcddf9a636e0d1c65eafed705e8"
+      "entity_derived": "niiri:4021174e55dc807e3de6628bf8eb04e4",
+      "entity": "niiri:f4def9a581b3c307c2f4fb9e2e226d0e"
     },
     {
-      "@id": "niiri:0a5b6501891f6f1bf835ab4cce6981b0",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0ae175b8baba9cf71436e5d6fd22e350",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0030",
-      "prov:atLocation": {"@id": "niiri:1a2a74ecadf8ea280abae49c7adfe4d5"},
+      "prov:atLocation": {"@id": "niiri:3b217402d63aa3747829c99e4b9d2316"},
       "prov:value": {"@type": "xsd:float", "@value": "2.8795006275177"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.3782590505152"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.98155518916066e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.626033894289313"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.101663811457838"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.3782590505152"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.98155518916066e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.626033894289313"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.101663811457838"}
     },
     {
-      "@id": "niiri:1a2a74ecadf8ea280abae49c7adfe4d5",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:3b217402d63aa3747829c99e4b9d2316",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0030",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[24,-80,52]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[24,-80,52]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0a5b6501891f6f1bf835ab4cce6981b0",
-      "entity": "niiri:a0871d458c113ff7db6ea00222d681b6"
+      "entity_derived": "niiri:0ae175b8baba9cf71436e5d6fd22e350",
+      "entity": "niiri:dfdffb6b309c9dbdb7e869a40c441373"
     },
     {
-      "@id": "niiri:e52c13b08642a31c47013d5d665f3cc3",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5678d8d6c35ed00e4d4e18d18efb6ece",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0031",
-      "prov:atLocation": {"@id": "niiri:b4a50efcf2a42a3d767b16b45dffb033"},
+      "prov:atLocation": {"@id": "niiri:e4c5369a0d51a9a3ff7813c71f43d5a7"},
       "prov:value": {"@type": "xsd:float", "@value": "2.87628078460693"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.37415966779458"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.09505679249889e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.631833416620066"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.101663811457838"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.37415966779458"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.09505679249889e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.631833416620066"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.101663811457838"}
     },
     {
-      "@id": "niiri:b4a50efcf2a42a3d767b16b45dffb033",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e4c5369a0d51a9a3ff7813c71f43d5a7",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0031",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[54,-26,-6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[54,-26,-6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e52c13b08642a31c47013d5d665f3cc3",
-      "entity": "niiri:ede417a6186510bb468637a2fa74953b"
+      "entity_derived": "niiri:5678d8d6c35ed00e4d4e18d18efb6ece",
+      "entity": "niiri:51dff688583f66b2d156042da2e15fbc"
     },
     {
-      "@id": "niiri:971a98269dd58af38ef9b8d2a1970a4b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:42466a1a262537fe1909213e41f7608f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0032",
-      "prov:atLocation": {"@id": "niiri:b1ebbd8debcd5a17e636fb3af5c8a749"},
+      "prov:atLocation": {"@id": "niiri:2322f7716f2993b1fd0d53ab1bfae19c"},
       "prov:value": {"@type": "xsd:float", "@value": "2.84026718139648"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.32828345765019"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.51379916874573e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.695928446009514"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.107852519413958"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.32828345765019"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.51379916874573e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.695928446009514"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.107852519413958"}
     },
     {
-      "@id": "niiri:b1ebbd8debcd5a17e636fb3af5c8a749",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:2322f7716f2993b1fd0d53ab1bfae19c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0032",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[48,-30,42]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[48,-30,42]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:971a98269dd58af38ef9b8d2a1970a4b",
-      "entity": "niiri:e1877410437181ca152c635a1b1ae370"
+      "entity_derived": "niiri:42466a1a262537fe1909213e41f7608f",
+      "entity": "niiri:e56f07808adb058d01196164f0775b64"
     },
     {
-      "@id": "niiri:271de41f649e27c04daa475fdae8db9f",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f9b9bbd2555a0f9eff6c0d4a46615477",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0033",
-      "prov:atLocation": {"@id": "niiri:f866479248db6f6baeceff2ecc110f30"},
+      "prov:atLocation": {"@id": "niiri:946da552af58194fc6edde9153721a83"},
       "prov:value": {"@type": "xsd:float", "@value": "2.78784370422363"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.26142274674112"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.01564786331165e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.783507209855174"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.124104049442798"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.26142274674112"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.01564786331165e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.783507209855174"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.124104049442798"}
     },
     {
-      "@id": "niiri:f866479248db6f6baeceff2ecc110f30",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:946da552af58194fc6edde9153721a83",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0033",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[38,32,50]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[38,32,50]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:271de41f649e27c04daa475fdae8db9f",
-      "entity": "niiri:cc0c5a448ad27b2c29ff4af6af9b334c"
+      "entity_derived": "niiri:f9b9bbd2555a0f9eff6c0d4a46615477",
+      "entity": "niiri:14930f43331616f26135da44caf5ca49"
     },
     {
-      "@id": "niiri:096cfc0b0fdc48bd50b06a85db31787c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5d8297107655c470b20029a7607b59d6",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0034",
-      "prov:atLocation": {"@id": "niiri:9a97c475fe04c61c7758dbb97b742d39"},
+      "prov:atLocation": {"@id": "niiri:eb06915f3583668239f7287af4563b3a"},
       "prov:value": {"@type": "xsd:float", "@value": "2.75120162963867"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.21463429501137"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.2509162441221e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.837748139540634"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.137791224379057"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.21463429501137"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.2509162441221e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.837748139540634"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.137791224379057"}
     },
     {
-      "@id": "niiri:9a97c475fe04c61c7758dbb97b742d39",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:eb06915f3583668239f7287af4563b3a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0034",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[18,-58,32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[18,-58,32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:096cfc0b0fdc48bd50b06a85db31787c",
-      "entity": "niiri:c66319cb5f126bcbc275fb9a118d21ec"
+      "entity_derived": "niiri:5d8297107655c470b20029a7607b59d6",
+      "entity": "niiri:d6ab9aad7ae91e9a945d6044d0e1d6cd"
     },
     {
-      "@id": "niiri:1321801f3bc667f5ac86d45ed5d8ab1c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:8a6ddd866c065982183951ef56d075a5",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0035",
-      "prov:atLocation": {"@id": "niiri:f72173f433b0fff6c4f10737768b564c"},
+      "prov:atLocation": {"@id": "niiri:7670ea31408ac573f533b63db34e12c8"},
       "prov:value": {"@type": "xsd:float", "@value": "2.30655765533447"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.64368706323795"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000134380079716223"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999995072124642"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.411522109968619"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.64368706323795"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000134380079716223"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999995072124642"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.411522109968619"}
     },
     {
-      "@id": "niiri:f72173f433b0fff6c4f10737768b564c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7670ea31408ac573f533b63db34e12c8",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0035",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[20,-68,32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[20,-68,32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1321801f3bc667f5ac86d45ed5d8ab1c",
-      "entity": "niiri:c66319cb5f126bcbc275fb9a118d21ec"
+      "entity_derived": "niiri:8a6ddd866c065982183951ef56d075a5",
+      "entity": "niiri:d6ab9aad7ae91e9a945d6044d0e1d6cd"
     },
     {
-      "@id": "niiri:ac906b333b8b531d47a7756e6dd3f3f6",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ebeb5e8cbd97a7c980eb6e8048e3aa7d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0036",
-      "prov:atLocation": {"@id": "niiri:c69571c1f1fab4090a821e3eab98c3fb"},
+      "prov:atLocation": {"@id": "niiri:c8066704e7c4e7181a0ae455141068fa"},
       "prov:value": {"@type": "xsd:float", "@value": "2.7451183795929"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.20686225088754"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.2947043287137e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.846041948741843"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.138131675608108"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.20686225088754"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.2947043287137e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.846041948741843"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.138131675608108"}
     },
     {
-      "@id": "niiri:c69571c1f1fab4090a821e3eab98c3fb",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c8066704e7c4e7181a0ae455141068fa",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0036",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-14,-96,0]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-14,-96,0]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ac906b333b8b531d47a7756e6dd3f3f6",
-      "entity": "niiri:df2f9512a8de3749a0b69fde9e1d74e6"
+      "entity_derived": "niiri:ebeb5e8cbd97a7c980eb6e8048e3aa7d",
+      "entity": "niiri:950bb8c15f6d86506fdad52c1ea79861"
     },
     {
-      "@id": "niiri:512969f1ebb20a2805ba2267d49fdf6b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f0a3195f5086136d59542c82017b3a01",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0037",
-      "prov:atLocation": {"@id": "niiri:9287549d198a09a7f86361cc05785e40"},
+      "prov:atLocation": {"@id": "niiri:a7dea9a67fc3b6b8b46c2229ae066f85"},
       "prov:value": {"@type": "xsd:float", "@value": "2.71638298034668"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.17013318145876"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.52210841696254e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.88214338657563"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.152011884720848"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.17013318145876"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.52210841696254e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.88214338657563"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.152011884720848"}
     },
     {
-      "@id": "niiri:9287549d198a09a7f86361cc05785e40",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a7dea9a67fc3b6b8b46c2229ae066f85",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0037",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-32,-72,58]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-32,-72,58]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:512969f1ebb20a2805ba2267d49fdf6b",
-      "entity": "niiri:ff4a3dc3ae673c7d96c375c14f00511e"
+      "entity_derived": "niiri:f0a3195f5086136d59542c82017b3a01",
+      "entity": "niiri:f4783b6466e014e6e52055bae529f918"
     },
     {
-      "@id": "niiri:b79aa4e2dd228b0e0d9c914ac65ea6d5",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e93ed6c3aa25b233cb79929e574105d9",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0038",
-      "prov:atLocation": {"@id": "niiri:f0f4c2af1c2de0476e7e77c05aeafbeb"},
+      "prov:atLocation": {"@id": "niiri:831b8e76702d7b18f1caa06765d78f13"},
       "prov:value": {"@type": "xsd:float", "@value": "2.08894777297974"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.36255760699966"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000386120057750849"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999998331"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.636831894546098"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.36255760699966"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000386120057750849"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999998331"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.636831894546098"}
     },
     {
-      "@id": "niiri:f0f4c2af1c2de0476e7e77c05aeafbeb",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:831b8e76702d7b18f1caa06765d78f13",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0038",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-20,-74,58]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-20,-74,58]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b79aa4e2dd228b0e0d9c914ac65ea6d5",
-      "entity": "niiri:ff4a3dc3ae673c7d96c375c14f00511e"
+      "entity_derived": "niiri:e93ed6c3aa25b233cb79929e574105d9",
+      "entity": "niiri:f4783b6466e014e6e52055bae529f918"
     },
     {
-      "@id": "niiri:5ece7fa3ef29b3f54b994482a80b9119",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e515516c5ff1d233ae675e7803ccd1db",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0039",
-      "prov:atLocation": {"@id": "niiri:8c8b7312a2d06ddb150d87a437581a77"},
+      "prov:atLocation": {"@id": "niiri:71a18ae0067f3eb6f488e73a8eed631d"},
       "prov:value": {"@type": "xsd:float", "@value": "2.68441557884216"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.12924185142476"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.81980698354955e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.915958567777936"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.169764205739198"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.12924185142476"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.81980698354955e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.915958567777936"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.169764205739198"}
     },
     {
-      "@id": "niiri:8c8b7312a2d06ddb150d87a437581a77",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:71a18ae0067f3eb6f488e73a8eed631d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0039",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-48,-42,8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-48,-42,8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5ece7fa3ef29b3f54b994482a80b9119",
-      "entity": "niiri:abd64927c551fbbd20950624a69aa36d"
+      "entity_derived": "niiri:e515516c5ff1d233ae675e7803ccd1db",
+      "entity": "niiri:e493acb406e5cff7f2b3bdae4a6c7854"
     },
     {
-      "@id": "niiri:e2652296eb9d97ffffca1509a9026339",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b165c84e39ed0a56c6fcfe2cf6485d45",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0040",
-      "prov:atLocation": {"@id": "niiri:8c3895f16059640a97c019e9952dc277"},
+      "prov:atLocation": {"@id": "niiri:c59aa6c2583c6162213161db59c0cdfa"},
       "prov:value": {"@type": "xsd:float", "@value": "2.66335368156433"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.10228278327608"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.04546926624305e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.934473772130028"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.180381705425717"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.10228278327608"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.04546926624305e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.934473772130028"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.180381705425717"}
     },
     {
-      "@id": "niiri:8c3895f16059640a97c019e9952dc277",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c59aa6c2583c6162213161db59c0cdfa",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0040",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[48,-52,-24]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[48,-52,-24]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e2652296eb9d97ffffca1509a9026339",
-      "entity": "niiri:38307cfb7180ba187f2a9da76b2278a7"
+      "entity_derived": "niiri:b165c84e39ed0a56c6fcfe2cf6485d45",
+      "entity": "niiri:0337643db0192f78f5b32cbf7ed520a4"
     },
     {
-      "@id": "niiri:d18db9d2cf5ed2028588cfefd0e5cbf1",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ff9ae21e91aa2853a4df2c66190d9a69",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0041",
-      "prov:atLocation": {"@id": "niiri:5390f1d922339e9cd9dc5096c14b6d8d"},
+      "prov:atLocation": {"@id": "niiri:d006be9910c4fdf007dcb927133b1b34"},
       "prov:value": {"@type": "xsd:float", "@value": "2.27386736869812"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.60151277214208"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000158185438331238"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999040177611"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.418270156640619"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.60151277214208"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000158185438331238"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999040177611"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.418270156640619"}
     },
     {
-      "@id": "niiri:5390f1d922339e9cd9dc5096c14b6d8d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d006be9910c4fdf007dcb927133b1b34",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0041",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[44,-44,-28]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[44,-44,-28]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d18db9d2cf5ed2028588cfefd0e5cbf1",
-      "entity": "niiri:38307cfb7180ba187f2a9da76b2278a7"
+      "entity_derived": "niiri:ff9ae21e91aa2853a4df2c66190d9a69",
+      "entity": "niiri:0337643db0192f78f5b32cbf7ed520a4"
     },
     {
-      "@id": "niiri:460fe6e2bb01ece180e670e159b94fc1",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:07dafc52bdbe3bac0a138605d2cfa21e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0042",
-      "prov:atLocation": {"@id": "niiri:4b7d51aadadb43a99b13d49b3e8f1842"},
+      "prov:atLocation": {"@id": "niiri:5424fb677782b73cf78964d910cc0921"},
       "prov:value": {"@type": "xsd:float", "@value": "2.64867973327637"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.08349211971756"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.21819671972767e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.945632017925947"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.1898401047323"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.08349211971756"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.21819671972767e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.945632017925947"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.1898401047323"}
     },
     {
-      "@id": "niiri:4b7d51aadadb43a99b13d49b3e8f1842",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:5424fb677782b73cf78964d910cc0921",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0042",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-50,-58,52]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-50,-58,52]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:460fe6e2bb01ece180e670e159b94fc1",
-      "entity": "niiri:a23fb16f5011d68723f436a695655a4b"
+      "entity_derived": "niiri:07dafc52bdbe3bac0a138605d2cfa21e",
+      "entity": "niiri:1a04d969a09af1e47b83e8c89999ecc0"
     },
     {
-      "@id": "niiri:06f1c2193ea4e339615fd481c7ec74a0",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:8bbb069d9a8a8deae00856c0bac1dca3",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0043",
-      "prov:atLocation": {"@id": "niiri:5e4673efdf3328029b42f5b816c6f378"},
+      "prov:atLocation": {"@id": "niiri:8959c9a0a8c3ec7c7ef746684cae1e87"},
       "prov:value": {"@type": "xsd:float", "@value": "2.64205074310303"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.07500123020084"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.30070519045e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.950216866218648"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.1898401047323"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.07500123020084"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.30070519045e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.950216866218648"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.1898401047323"}
     },
     {
-      "@id": "niiri:5e4673efdf3328029b42f5b816c6f378",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:8959c9a0a8c3ec7c7ef746684cae1e87",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0043",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-16,-62,32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-16,-62,32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:06f1c2193ea4e339615fd481c7ec74a0",
-      "entity": "niiri:dd24018042f78d315dbd6726698ec521"
+      "entity_derived": "niiri:8bbb069d9a8a8deae00856c0bac1dca3",
+      "entity": "niiri:cad3a1438e0a5950942cd5ed7b22e997"
     },
     {
-      "@id": "niiri:4589ec081f3010df41b7d2a53eb95b22",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:83820e300b8ac064252e16de139eccae",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0044",
-      "prov:atLocation": {"@id": "niiri:e8bb384848965da01f0eb9969d8d6dd8"},
+      "prov:atLocation": {"@id": "niiri:b6d09fc20724d7c85a681cd22742edf4"},
       "prov:value": {"@type": "xsd:float", "@value": "2.03684568405151"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.29512938083033"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000491881875043121"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999991"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.71408368346076"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.29512938083033"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000491881875043121"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999991"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.71408368346076"}
     },
     {
-      "@id": "niiri:e8bb384848965da01f0eb9969d8d6dd8",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b6d09fc20724d7c85a681cd22742edf4",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0044",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-24,-60,36]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-24,-60,36]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4589ec081f3010df41b7d2a53eb95b22",
-      "entity": "niiri:dd24018042f78d315dbd6726698ec521"
+      "entity_derived": "niiri:83820e300b8ac064252e16de139eccae",
+      "entity": "niiri:cad3a1438e0a5950942cd5ed7b22e997"
     },
     {
-      "@id": "niiri:f2f4cfd152c8dabf51e02932307b8aef",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:96dad918bf5b91086582f2216b436cf1",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0045",
-      "prov:atLocation": {"@id": "niiri:efc3e0cf7e7dde592e605ccb4146bf19"},
+      "prov:atLocation": {"@id": "niiri:d9c26099c0e501b5aea3bea542119b22"},
       "prov:value": {"@type": "xsd:float", "@value": "2.62229943275452"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.0496944261574"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.56422773555753e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.962265585786802"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.205120702581303"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.0496944261574"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.56422773555753e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.962265585786802"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.205120702581303"}
     },
     {
-      "@id": "niiri:efc3e0cf7e7dde592e605ccb4146bf19",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d9c26099c0e501b5aea3bea542119b22",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0045",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-42,-86,16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-42,-86,16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f2f4cfd152c8dabf51e02932307b8aef",
-      "entity": "niiri:08d22242c39ac4379d79b33f1f2f58d6"
+      "entity_derived": "niiri:96dad918bf5b91086582f2216b436cf1",
+      "entity": "niiri:aa48c521a0de3bccee7d00f6ba89c3cf"
     },
     {
-      "@id": "niiri:4ad99dbaeccddb46f360b62292ba323b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b36997cc891aca5718ab9e08f9f432be",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0046",
-      "prov:atLocation": {"@id": "niiri:a2a7efdd41886d31985c7e4877b2d490"},
+      "prov:atLocation": {"@id": "niiri:0ef0527a41b5e316ed802defc1b39a56"},
       "prov:value": {"@type": "xsd:float", "@value": "2.59810495376587"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.01867880935315"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.92626931942541e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.97396448920475"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.21596866367834"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.01867880935315"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.92626931942541e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.97396448920475"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.21596866367834"}
     },
     {
-      "@id": "niiri:a2a7efdd41886d31985c7e4877b2d490",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0ef0527a41b5e316ed802defc1b39a56",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0046",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[50,12,-12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[50,12,-12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4ad99dbaeccddb46f360b62292ba323b",
-      "entity": "niiri:61b56883c58ef13be768c931fffde95f"
+      "entity_derived": "niiri:b36997cc891aca5718ab9e08f9f432be",
+      "entity": "niiri:666175487bab3267d4af86f55ff4bd3b"
     },
     {
-      "@id": "niiri:3af0dfd188fb42472ea5f27ee64ecbb0",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:25c1c6fe5473de8cd328924f02807315",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0047",
-      "prov:atLocation": {"@id": "niiri:19c62f4777efecf49e62e5c5830bd1e3"},
+      "prov:atLocation": {"@id": "niiri:36a4bb29de9bb248d7239d223f1f865c"},
       "prov:value": {"@type": "xsd:float", "@value": "2.58033466339111"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.99588757924215"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.22261580589789e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.98064397547503"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.22269791282493"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.99588757924215"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.22261580589789e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.98064397547503"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.22269791282493"}
     },
     {
-      "@id": "niiri:19c62f4777efecf49e62e5c5830bd1e3",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:36a4bb29de9bb248d7239d223f1f865c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0047",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[10,56,-20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[10,56,-20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3af0dfd188fb42472ea5f27ee64ecbb0",
-      "entity": "niiri:7d6ccb38dbccc63215a5fdd98139915c"
+      "entity_derived": "niiri:25c1c6fe5473de8cd328924f02807315",
+      "entity": "niiri:6951754ac73a67bbeeec0a4f76595341"
     },
     {
-      "@id": "niiri:3b08e4069702cf26e30d860fc5759ad6",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:289a61918b6511cb6b776c8ac53da1fb",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0048",
-      "prov:atLocation": {"@id": "niiri:d1caa86519573cfe8c598f42e81c1a3c"},
+      "prov:atLocation": {"@id": "niiri:5207732da4f07346337949bb54bf30d8"},
       "prov:value": {"@type": "xsd:float", "@value": "2.57430815696716"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.98815622046766"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.32944052300332e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.982580167470916"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.22642798795628"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.98815622046766"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.32944052300332e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.982580167470916"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.22642798795628"}
     },
     {
-      "@id": "niiri:d1caa86519573cfe8c598f42e81c1a3c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:5207732da4f07346337949bb54bf30d8",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0048",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-58,-46,-2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-58,-46,-2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3b08e4069702cf26e30d860fc5759ad6",
-      "entity": "niiri:823399669e7b2b8c54db148364839dc3"
+      "entity_derived": "niiri:289a61918b6511cb6b776c8ac53da1fb",
+      "entity": "niiri:92c69844c448bad6dc16185f863b358e"
     },
     {
-      "@id": "niiri:88f7b17cafef0abbf1a9369d2a2e9265",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5b892640561d323072506be428e65c2c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0049",
-      "prov:atLocation": {"@id": "niiri:58563b5fb32600cfdb5cc5575c0c8d33"},
+      "prov:atLocation": {"@id": "niiri:d240e37d1a3ccee80381d4a0ccec305b"},
       "prov:value": {"@type": "xsd:float", "@value": "2.56071877479553"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.97071867739396"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.58280756852514e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.986393731480231"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.23304271385756"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.97071867739396"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.58280756852514e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.986393731480231"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.23304271385756"}
     },
     {
-      "@id": "niiri:58563b5fb32600cfdb5cc5575c0c8d33",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d240e37d1a3ccee80381d4a0ccec305b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0049",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[46,-40,2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[46,-40,2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:88f7b17cafef0abbf1a9369d2a2e9265",
-      "entity": "niiri:d81a7a910431ac9a1979f323b4b791c2"
+      "entity_derived": "niiri:5b892640561d323072506be428e65c2c",
+      "entity": "niiri:177bfa600d85757ea0c4626517c44033"
     },
     {
-      "@id": "niiri:15a7d7fc5260775e0bc5b07373fc4ef1",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:70699d653df50cd6d5e59c21dedb8323",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0050",
-      "prov:atLocation": {"@id": "niiri:cdc77e12c154a87dfa2a6f954e93432e"},
+      "prov:atLocation": {"@id": "niiri:81dca2f2f612f00b789df6e3ebb1af42"},
       "prov:value": {"@type": "xsd:float", "@value": "2.54513788223267"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.95071921672779"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.89583464949217e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.989920329912446"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.240658196026741"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.95071921672779"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.89583464949217e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.989920329912446"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.240658196026741"}
     },
     {
-      "@id": "niiri:cdc77e12c154a87dfa2a6f954e93432e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:81dca2f2f612f00b789df6e3ebb1af42",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0050",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[48,14,52]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[48,14,52]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:15a7d7fc5260775e0bc5b07373fc4ef1",
-      "entity": "niiri:dabab8dbebf83a48079048945d816fe5"
+      "entity_derived": "niiri:70699d653df50cd6d5e59c21dedb8323",
+      "entity": "niiri:746b0b97599bb9118ebd954e679a2576"
     },
     {
-      "@id": "niiri:5e4488db7d8bf5c97b0e775342a98808",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:201264c80972dcebd2c7ea04534507f6",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0051",
-      "prov:atLocation": {"@id": "niiri:f75e896f16e49d81110d3b8913b2f636"},
+      "prov:atLocation": {"@id": "niiri:a7b889f37c8fdd43f35c04b78cc226b2"},
       "prov:value": {"@type": "xsd:float", "@value": "2.51254177093506"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.90885728034341"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.63668626720093e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.994942233722668"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.267046680534214"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.90885728034341"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.63668626720093e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.994942233722668"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.267046680534214"}
     },
     {
-      "@id": "niiri:f75e896f16e49d81110d3b8913b2f636",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a7b889f37c8fdd43f35c04b78cc226b2",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0051",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-52,-44,56]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-52,-44,56]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5e4488db7d8bf5c97b0e775342a98808",
-      "entity": "niiri:5842093feb2c4b86fc255ab1795f6409"
+      "entity_derived": "niiri:201264c80972dcebd2c7ea04534507f6",
+      "entity": "niiri:54c365a30f25bdcc066a52c171908849"
     },
     {
-      "@id": "niiri:443dc8c05f410cbf2673553c716fb321",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b44f502f04b58f2cf2d267fb394a2207",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0052",
-      "prov:atLocation": {"@id": "niiri:0b07b0a3088f9e2862e3b217fe18f90a"},
+      "prov:atLocation": {"@id": "niiri:87c7b6e56ec1bbda155c55cec46b9a8c"},
       "prov:value": {"@type": "xsd:float", "@value": "2.50266766548157"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.89617059063353"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.88627843049372e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.995967498491102"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.267780274176525"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.89617059063353"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.88627843049372e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.995967498491102"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.267780274176525"}
     },
     {
-      "@id": "niiri:0b07b0a3088f9e2862e3b217fe18f90a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:87c7b6e56ec1bbda155c55cec46b9a8c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0052",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-12,36,-18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-12,36,-18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:443dc8c05f410cbf2673553c716fb321",
-      "entity": "niiri:2498df410b841338c0adda91711ed606"
+      "entity_derived": "niiri:b44f502f04b58f2cf2d267fb394a2207",
+      "entity": "niiri:b9e88b2bbae3b722fa155ba8e9501a86"
     },
     {
-      "@id": "niiri:a5927ab3169e28dc23d5cb893a815928",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:1f6b053553d3aeb85e957aa471ba1b95",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0053",
-      "prov:atLocation": {"@id": "niiri:d20ca65782ced7404c210699b4e7a236"},
+      "prov:atLocation": {"@id": "niiri:57a35110569fb6d0b6a603c14633ce79"},
       "prov:value": {"@type": "xsd:float", "@value": "1.89663207530975"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.11350866317858"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000924385411494866"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.962543829897604"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.11350866317858"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000924385411494866"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.962543829897604"}
     },
     {
-      "@id": "niiri:d20ca65782ced7404c210699b4e7a236",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:57a35110569fb6d0b6a603c14633ce79",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0053",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-6,48,-16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-6,48,-16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a5927ab3169e28dc23d5cb893a815928",
-      "entity": "niiri:2498df410b841338c0adda91711ed606"
+      "entity_derived": "niiri:1f6b053553d3aeb85e957aa471ba1b95",
+      "entity": "niiri:b9e88b2bbae3b722fa155ba8e9501a86"
     },
     {
-      "@id": "niiri:9a55de42084b0000da1147f72d1cd53a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:6ba4d4daf1fd511897ca0be0927d8a89",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0054",
-      "prov:atLocation": {"@id": "niiri:bce44a82c1d5983238e1a86d11fe8256"},
+      "prov:atLocation": {"@id": "niiri:944364ab4b3104947bddc393f78f4442"},
       "prov:value": {"@type": "xsd:float", "@value": "2.47411036491394"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.85946417006895"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.68179580313632e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.998007647418056"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.292256519682192"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.85946417006895"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.68179580313632e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.998007647418056"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.292256519682192"}
     },
     {
-      "@id": "niiri:bce44a82c1d5983238e1a86d11fe8256",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:944364ab4b3104947bddc393f78f4442",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0054",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-20,-94,24]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-20,-94,24]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9a55de42084b0000da1147f72d1cd53a",
-      "entity": "niiri:4e803c8ae9b4739d7433ebb1a14e59ad"
+      "entity_derived": "niiri:6ba4d4daf1fd511897ca0be0927d8a89",
+      "entity": "niiri:6b8826bcc0a021bc10b09d6a6d4302fd"
     },
     {
-      "@id": "niiri:f43c402921675aa91ae5240840cda507",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:74e91aadd62ca24aff8ec843f5b9cf73",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0055",
-      "prov:atLocation": {"@id": "niiri:07d4ec7becd43d0737a4671ddc6dc04f"},
+      "prov:atLocation": {"@id": "niiri:b56f1032a996acfee4bdb230b29e91d6"},
       "prov:value": {"@type": "xsd:float", "@value": "2.47011852264404"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.85433149398881"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.80231377617091e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.998205767610089"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.293636732712391"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.85433149398881"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.80231377617091e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.998205767610089"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.293636732712391"}
     },
     {
-      "@id": "niiri:07d4ec7becd43d0737a4671ddc6dc04f",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b56f1032a996acfee4bdb230b29e91d6",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0055",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-12,18,42]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-12,18,42]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f43c402921675aa91ae5240840cda507",
-      "entity": "niiri:59ee3c1181a6931549c7f2a8d5a010d9"
+      "entity_derived": "niiri:74e91aadd62ca24aff8ec843f5b9cf73",
+      "entity": "niiri:cc1d6ba65b10195363d6da601013d7a1"
     },
     {
-      "@id": "niiri:42f0ef94a70b0427ad4f366c62fc739c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:20009017f6e554d7929aee14c3cb2b0a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0056",
-      "prov:atLocation": {"@id": "niiri:19bef40580c68b029328a9f62633eb9d"},
+      "prov:atLocation": {"@id": "niiri:4098b8dc55187d1b591a67c566c304d1"},
       "prov:value": {"@type": "xsd:float", "@value": "2.46635222434998"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.8494884380349"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.91823851514572e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.998376942414084"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.294187599254207"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.8494884380349"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.91823851514572e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.998376942414084"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.294187599254207"}
     },
     {
-      "@id": "niiri:19bef40580c68b029328a9f62633eb9d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4098b8dc55187d1b591a67c566c304d1",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0056",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[48,-76,0]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[48,-76,0]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:42f0ef94a70b0427ad4f366c62fc739c",
-      "entity": "niiri:d5b0a3e5aceb6afc5f0beca22061d358"
+      "entity_derived": "niiri:20009017f6e554d7929aee14c3cb2b0a",
+      "entity": "niiri:82933f30610ef29a453f4b374990b32f"
     },
     {
-      "@id": "niiri:13b6ec4cfe801811e2f8e1cd1c35009b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:50726c9e381e8c0cadcb5c25bfce42c4",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0057",
-      "prov:atLocation": {"@id": "niiri:2bde26670c824d875bd09aa4031c9d99"},
+      "prov:atLocation": {"@id": "niiri:eac87d7000647e4f1c4c33f0fccd4ba6"},
       "prov:value": {"@type": "xsd:float", "@value": "2.44098949432373"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.81686512377712"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.75790026252177e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999204444055832"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.321048096330285"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.81686512377712"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.75790026252177e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999204444055832"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.321048096330285"}
     },
     {
-      "@id": "niiri:2bde26670c824d875bd09aa4031c9d99",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:eac87d7000647e4f1c4c33f0fccd4ba6",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0057",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-52,24,18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-52,24,18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:13b6ec4cfe801811e2f8e1cd1c35009b",
-      "entity": "niiri:f93d82501705ce2feae40e77d940aa42"
+      "entity_derived": "niiri:50726c9e381e8c0cadcb5c25bfce42c4",
+      "entity": "niiri:14f8555b74f38f3e8db5c662f1a8015c"
     },
     {
-      "@id": "niiri:65c9b827c7a9619a328db498fa06b408",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f65e0cae04132c7a84d5a8f11123339a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0058",
-      "prov:atLocation": {"@id": "niiri:d1dec038dc233f71e2e4ab715d691db7"},
+      "prov:atLocation": {"@id": "niiri:c7f2ef37f7f022ac15cc88574f9d27c7"},
       "prov:value": {"@type": "xsd:float", "@value": "2.43735671043396"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.81219103522413"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.88701755224841e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999285679399569"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.321708874973631"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.81219103522413"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.88701755224841e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999285679399569"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.321708874973631"}
     },
     {
-      "@id": "niiri:d1dec038dc233f71e2e4ab715d691db7",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c7f2ef37f7f022ac15cc88574f9d27c7",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0058",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-26,-74,24]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-26,-74,24]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:65c9b827c7a9619a328db498fa06b408",
-      "entity": "niiri:e087977e9e8a8b501c9a28c9869554a6"
+      "entity_derived": "niiri:f65e0cae04132c7a84d5a8f11123339a",
+      "entity": "niiri:8c06ba2c370d4dda4947f0cbe66ca91e"
     },
     {
-      "@id": "niiri:0181954e43d1adadd9462628b9c60d76",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f7a1eeb8810d3507d311591e2f7997ab",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0059",
-      "prov:atLocation": {"@id": "niiri:64277aae3a6a57c7fee1c9c41ae69ad7"},
+      "prov:atLocation": {"@id": "niiri:841e0f6ceb12de956b666f63bb8438ca"},
       "prov:value": {"@type": "xsd:float", "@value": "2.43673038482666"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.81138514524412"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.90951304638254e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999298924132454"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.321708874973631"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.81138514524412"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.90951304638254e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999298924132454"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.321708874973631"}
     },
     {
-      "@id": "niiri:64277aae3a6a57c7fee1c9c41ae69ad7",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:841e0f6ceb12de956b666f63bb8438ca",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0059",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[12,50,-10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[12,50,-10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0181954e43d1adadd9462628b9c60d76",
-      "entity": "niiri:a2144fa83ecfa43f689763a4c0b15ca8"
+      "entity_derived": "niiri:f7a1eeb8810d3507d311591e2f7997ab",
+      "entity": "niiri:337d987921a53a135ec5d7ccac93719b"
     },
     {
-      "@id": "niiri:231f9934a1286cdf4d40a29a439ba0f4",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:1f1e980431dd78b887d46d0d999586d6",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0060",
-      "prov:atLocation": {"@id": "niiri:a2ea8153c611eef128fac52119962da0"},
+      "prov:atLocation": {"@id": "niiri:0b3bc38c6284016e53a9355a01069eb7"},
       "prov:value": {"@type": "xsd:float", "@value": "2.43038630485535"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.8032216915074"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.14132165696713e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999421405677481"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.325210886758063"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.8032216915074"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.14132165696713e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999421405677481"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.325210886758063"}
     },
     {
-      "@id": "niiri:a2ea8153c611eef128fac52119962da0",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0b3bc38c6284016e53a9355a01069eb7",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0060",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-42,-38,44]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-42,-38,44]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:231f9934a1286cdf4d40a29a439ba0f4",
-      "entity": "niiri:575376d8b1a60c68f57a2629ca1c6f57"
+      "entity_derived": "niiri:1f1e980431dd78b887d46d0d999586d6",
+      "entity": "niiri:8b64f56916b41aba13f0c3626eccb6c6"
     },
     {
-      "@id": "niiri:2f0f6fb149bb83bbdc4f66c77db8de17",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:dac1b7a25e803b8443975ee1030a9b0e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0061",
-      "prov:atLocation": {"@id": "niiri:03fb4e9872c3f8a52bf682373dd79113"},
+      "prov:atLocation": {"@id": "niiri:fdfbbbc1a393300697b91e0c5b685119"},
       "prov:value": {"@type": "xsd:float", "@value": "2.40943622589111"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.77625633974215"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.96015746719059e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999702913851826"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.343869281784496"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.77625633974215"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.96015746719059e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999702913851826"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.343869281784496"}
     },
     {
-      "@id": "niiri:03fb4e9872c3f8a52bf682373dd79113",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:fdfbbbc1a393300697b91e0c5b685119",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0061",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[0,10,34]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[0,10,34]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2f0f6fb149bb83bbdc4f66c77db8de17",
-      "entity": "niiri:e7cf6cf6e829a4522b12ecb22c64da50"
+      "entity_derived": "niiri:dac1b7a25e803b8443975ee1030a9b0e",
+      "entity": "niiri:7167233a4e5f287b27d1ea49b05f5e73"
     },
     {
-      "@id": "niiri:556eaeaa78dfbb32a05958b55023fc13",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d5b79c346d3f077001fa066fa2d1a90d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0062",
-      "prov:atLocation": {"@id": "niiri:121158b0a3c590dd60c5c39ebb6dda3b"},
+      "prov:atLocation": {"@id": "niiri:15a6f00994c97e4acbaee735fb13fdc7"},
       "prov:value": {"@type": "xsd:float", "@value": "2.40475845336914"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.77023398434736"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.15472821792396e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999745792273193"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.347513578737157"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.77023398434736"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.15472821792396e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999745792273193"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.347513578737157"}
     },
     {
-      "@id": "niiri:121158b0a3c590dd60c5c39ebb6dda3b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:15a6f00994c97e4acbaee735fb13fdc7",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0062",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[44,-42,18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[44,-42,18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:556eaeaa78dfbb32a05958b55023fc13",
-      "entity": "niiri:f34dda9711be5249376de56aa5f55bb0"
+      "entity_derived": "niiri:d5b79c346d3f077001fa066fa2d1a90d",
+      "entity": "niiri:9bcff3c8230d1d562436a59af916d435"
     },
     {
-      "@id": "niiri:c95aee4950d5ff34ca4c2b4c00db0277",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:199023e997d45cf3233e578d536f4c5c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0063",
-      "prov:atLocation": {"@id": "niiri:07e4fb55cd102eea4944ce5bab249015"},
+      "prov:atLocation": {"@id": "niiri:0d56a8634361bb98f6349ca40ded5b4d"},
       "prov:value": {"@type": "xsd:float", "@value": "2.40324783325195"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.76828903590742"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.21851578610699e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999758407620262"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.347513578737157"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.76828903590742"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.21851578610699e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999758407620262"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.347513578737157"}
     },
     {
-      "@id": "niiri:07e4fb55cd102eea4944ce5bab249015",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0d56a8634361bb98f6349ca40ded5b4d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0063",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[58,-60,20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[58,-60,20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c95aee4950d5ff34ca4c2b4c00db0277",
-      "entity": "niiri:3d8865c6fb016a8704775ebaf2435091"
+      "entity_derived": "niiri:199023e997d45cf3233e578d536f4c5c",
+      "entity": "niiri:1f551e5f86fc52cb27432b3822b69ca7"
     },
     {
-      "@id": "niiri:28daede7297ff75fc061e2a9969d9aa4",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:cc258c6487aa920075b8a9d74a761b48",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0064",
-      "prov:atLocation": {"@id": "niiri:508f73e9f217034eddd43e0bbb435a7c"},
+      "prov:atLocation": {"@id": "niiri:3c7c457d319c1fc2fa269d1baabb4067"},
       "prov:value": {"@type": "xsd:float", "@value": "2.39750051498413"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.76088876011273"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.46553582728449e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999801447697793"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.353141402062803"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.76088876011273"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.46553582728449e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999801447697793"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.353141402062803"}
     },
     {
-      "@id": "niiri:508f73e9f217034eddd43e0bbb435a7c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:3c7c457d319c1fc2fa269d1baabb4067",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0064",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[18,56,30]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[18,56,30]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:28daede7297ff75fc061e2a9969d9aa4",
-      "entity": "niiri:16a6c15579df8b38a23d9ad0e739425a"
+      "entity_derived": "niiri:cc258c6487aa920075b8a9d74a761b48",
+      "entity": "niiri:222cf8fd43a488444ee6a32847bc1d9a"
     },
     {
-      "@id": "niiri:f06248d5e8d94b80fe21258e8ce73e9f",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:64b4dccdedec0a80f2fe74dd14cc1002",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0065",
-      "prov:atLocation": {"@id": "niiri:e5f1e3748fc22a13ebb88b9ed8e9b8ba"},
+      "prov:atLocation": {"@id": "niiri:5a441cb24733925f0b14a28f79922340"},
       "prov:value": {"@type": "xsd:float", "@value": "2.39031767845154"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.75163897818956"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.78411611173746e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999845514728957"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.360940928701093"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.75163897818956"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.78411611173746e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999845514728957"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.360940928701093"}
     },
     {
-      "@id": "niiri:e5f1e3748fc22a13ebb88b9ed8e9b8ba",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:5a441cb24733925f0b14a28f79922340",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0065",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-34,20,-34]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-34,20,-34]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f06248d5e8d94b80fe21258e8ce73e9f",
-      "entity": "niiri:c2f8c271d456bfd2eff8e6eb839c91ba"
+      "entity_derived": "niiri:64b4dccdedec0a80f2fe74dd14cc1002",
+      "entity": "niiri:944e97172e0a25bb481c848ff69da03e"
     },
     {
-      "@id": "niiri:8cc61d9b83229492245024fd78c1917a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d3b936a394a469d3174e0f8343bd463f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0066",
-      "prov:atLocation": {"@id": "niiri:d18b998f0fba94f5aee71a8ef389f096"},
+      "prov:atLocation": {"@id": "niiri:d2aa8e04105ae05392733434b72a496a"},
       "prov:value": {"@type": "xsd:float", "@value": "2.38168978691101"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.74052666970635"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "9.18175293811441e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999886700884216"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.36651035415338"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.74052666970635"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "9.18175293811441e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999886700884216"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.36651035415338"}
     },
     {
-      "@id": "niiri:d18b998f0fba94f5aee71a8ef389f096",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d2aa8e04105ae05392733434b72a496a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0066",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[22,0,0]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[22,0,0]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8cc61d9b83229492245024fd78c1917a",
-      "entity": "niiri:84844c35c8e8d08a6e00bf67a2f849ff"
+      "entity_derived": "niiri:d3b936a394a469d3174e0f8343bd463f",
+      "entity": "niiri:f16d0ba2c74c51bb5e78d2245c00a45f"
     },
     {
-      "@id": "niiri:555c9f9f85cc6287487521e402886b0d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f51500ecaf58b3d1cd1042a40b408879",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0067",
-      "prov:atLocation": {"@id": "niiri:4e24f9198fcbe0ce60d16396d27e39af"},
+      "prov:atLocation": {"@id": "niiri:936515ba136a6b86b620bbefc5690e0e"},
       "prov:value": {"@type": "xsd:float", "@value": "2.37978529930115"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.73807354189968"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "9.27178550079732e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999894332475117"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.36651035415338"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.73807354189968"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "9.27178550079732e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999894332475117"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.36651035415338"}
     },
     {
-      "@id": "niiri:4e24f9198fcbe0ce60d16396d27e39af",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:936515ba136a6b86b620bbefc5690e0e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0067",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-48,-44,-34]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-48,-44,-34]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:555c9f9f85cc6287487521e402886b0d",
-      "entity": "niiri:dfda6f4a6ad2d61f37aadf0fa7507a7f"
+      "entity_derived": "niiri:f51500ecaf58b3d1cd1042a40b408879",
+      "entity": "niiri:209a4a28e55d93fc75c92925f0f7d71b"
     },
     {
-      "@id": "niiri:5f02fc79c235c892deb102a64bef4145",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:4ff8360d7fc12f9cfc4bcd4dfe7c00dd",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0068",
-      "prov:atLocation": {"@id": "niiri:2acd5c8536840207ef632d8af3fa4975"},
+      "prov:atLocation": {"@id": "niiri:e0facfeceef20219293cb21eee4ddb30"},
       "prov:value": {"@type": "xsd:float", "@value": "2.37950778007507"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.73771606840228"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "9.28497425036756e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999895404897798"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.36651035415338"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.73771606840228"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "9.28497425036756e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999895404897798"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.36651035415338"}
     },
     {
-      "@id": "niiri:2acd5c8536840207ef632d8af3fa4975",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e0facfeceef20219293cb21eee4ddb30",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0068",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-62,-22,46]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-62,-22,46]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5f02fc79c235c892deb102a64bef4145",
-      "entity": "niiri:261c5b8cb671c9ccd262aae82e498512"
+      "entity_derived": "niiri:4ff8360d7fc12f9cfc4bcd4dfe7c00dd",
+      "entity": "niiri:357268aff375a1c533059d48c5f8dcb0"
     },
     {
-      "@id": "niiri:65267326a5928afd50a46660bbc192d0",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:73e236d5a6d25c17dd9cded1da30b954",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0069",
-      "prov:atLocation": {"@id": "niiri:cda2f37a719ff171e42bbbda2e25a5e8"},
+      "prov:atLocation": {"@id": "niiri:5e77ae62f461f7d159dbf41101989ed2"},
       "prov:value": {"@type": "xsd:float", "@value": "2.12179732322693"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.40504947037839"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000330760343973724"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999968743"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.587708479280999"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.40504947037839"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000330760343973724"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999968743"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.587708479280999"}
     },
     {
-      "@id": "niiri:cda2f37a719ff171e42bbbda2e25a5e8",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:5e77ae62f461f7d159dbf41101989ed2",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0069",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-62,-32,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-62,-32,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:65267326a5928afd50a46660bbc192d0",
-      "entity": "niiri:261c5b8cb671c9ccd262aae82e498512"
+      "entity_derived": "niiri:73e236d5a6d25c17dd9cded1da30b954",
+      "entity": "niiri:357268aff375a1c533059d48c5f8dcb0"
     },
     {
-      "@id": "niiri:ba7eacf309e859f6a5edbd1c0cd3eb3e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e9e3416cc410461e50330f128b2e5ef5",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0070",
-      "prov:atLocation": {"@id": "niiri:6300fbe84004a20009b5f57561b3e619"},
+      "prov:atLocation": {"@id": "niiri:5c701d285e118964f4e84c6e7d6537c1"},
       "prov:value": {"@type": "xsd:float", "@value": "2.36615061759949"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.72050850696656"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "9.94110221242961e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999936749755425"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.368886365441825"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.72050850696656"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "9.94110221242961e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999936749755425"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.368886365441825"}
     },
     {
-      "@id": "niiri:6300fbe84004a20009b5f57561b3e619",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:5c701d285e118964f4e84c6e7d6537c1",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0070",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[28,18,-20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[28,18,-20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ba7eacf309e859f6a5edbd1c0cd3eb3e",
-      "entity": "niiri:504a0642ac3cd38acd0d64ccc15fc9e6"
+      "entity_derived": "niiri:e9e3416cc410461e50330f128b2e5ef5",
+      "entity": "niiri:0a39de1cb252a793d03ed45aa12d8950"
     },
     {
-      "@id": "niiri:9134cb0143a6fc7aa85fb6ae8ee54ee6",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:680d3d98098fe3304954deff21a29e7b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0071",
-      "prov:atLocation": {"@id": "niiri:4019b2f4e0dd57cc8b536908c5479b29"},
+      "prov:atLocation": {"@id": "niiri:2b83a17bd863606f8500314b2def6d23"},
       "prov:value": {"@type": "xsd:float", "@value": "2.35984563827515"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.71238457004225"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000102657853048083"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999950532037692"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.368886365441825"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.71238457004225"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000102657853048083"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999950532037692"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.368886365441825"}
     },
     {
-      "@id": "niiri:4019b2f4e0dd57cc8b536908c5479b29",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:2b83a17bd863606f8500314b2def6d23",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0071",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[4,-4,-14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[4,-4,-14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9134cb0143a6fc7aa85fb6ae8ee54ee6",
-      "entity": "niiri:30d04637933701595f908aeb4100a23e"
+      "entity_derived": "niiri:680d3d98098fe3304954deff21a29e7b",
+      "entity": "niiri:2ce7fa7ad1d0a7052668df06aeeb62b3"
     },
     {
-      "@id": "niiri:bf080a6f2cb7d99a6e2fe08645f54b7d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:47943ba3e02dcae014366323aa4ab25f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0072",
-      "prov:atLocation": {"@id": "niiri:bc18dc61c0deb40f5ec9883893bb8fc0"},
+      "prov:atLocation": {"@id": "niiri:f09814cccec0ffd89a77db71136e90a2"},
       "prov:value": {"@type": "xsd:float", "@value": "2.24515843391418"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.56445653816859"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000182305428946816"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999804294694"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.444734823272248"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.56445653816859"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000182305428946816"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999804294694"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.444734823272248"}
     },
     {
-      "@id": "niiri:bc18dc61c0deb40f5ec9883893bb8fc0",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f09814cccec0ffd89a77db71136e90a2",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0072",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-6,-6,-14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-6,-6,-14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:bf080a6f2cb7d99a6e2fe08645f54b7d",
-      "entity": "niiri:30d04637933701595f908aeb4100a23e"
+      "entity_derived": "niiri:47943ba3e02dcae014366323aa4ab25f",
+      "entity": "niiri:2ce7fa7ad1d0a7052668df06aeeb62b3"
     },
     {
-      "@id": "niiri:9ded65cbb773cfce86de7e6f1870273f",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d2e4b7191441a73d13865ac94f555793",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0073",
-      "prov:atLocation": {"@id": "niiri:9017b984654e4c4db3a73f0718be2b1f"},
+      "prov:atLocation": {"@id": "niiri:9b72a267f0038b95d676e5cc83318080"},
       "prov:value": {"@type": "xsd:float", "@value": "2.33331298828125"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.67818733586012"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000117448705507006"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999983460313748"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.391344305962907"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.67818733586012"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000117448705507006"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999983460313748"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.391344305962907"}
     },
     {
-      "@id": "niiri:9017b984654e4c4db3a73f0718be2b1f",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:9b72a267f0038b95d676e5cc83318080",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0073",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-20,-88,-10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-20,-88,-10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9ded65cbb773cfce86de7e6f1870273f",
-      "entity": "niiri:3abca6b1ac25766b2a6217f3ab065c91"
+      "entity_derived": "niiri:d2e4b7191441a73d13865ac94f555793",
+      "entity": "niiri:837c632e63a40a2ac1469c8d1ba1b864"
     },
     {
-      "@id": "niiri:0502857f563277a156c3ceb30ffe4756",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:8cf5f9af5ca1975fc1c28c8c1557d889",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0074",
-      "prov:atLocation": {"@id": "niiri:f30d58e04a2c2a6c0d91c9e243e7a9ed"},
+      "prov:atLocation": {"@id": "niiri:537726e1a04c94675e66e07efbc28e13"},
       "prov:value": {"@type": "xsd:float", "@value": "2.33159112930298"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.67596752451816"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000118474833320836"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999984649789011"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.391580012304676"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.67596752451816"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000118474833320836"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999984649789011"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.391580012304676"}
     },
     {
-      "@id": "niiri:f30d58e04a2c2a6c0d91c9e243e7a9ed",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:537726e1a04c94675e66e07efbc28e13",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0074",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-10,-84,-10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-10,-84,-10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0502857f563277a156c3ceb30ffe4756",
-      "entity": "niiri:779bcdad447bb00d9bdb1d38c48f9eb7"
+      "entity_derived": "niiri:8cf5f9af5ca1975fc1c28c8c1557d889",
+      "entity": "niiri:47f25a919baaf59e7867aa98557a23e4"
     },
     {
-      "@id": "niiri:cfbf859f3c0ec6034e078c754596ee0d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:45eef5c14e0789f2e938b481f651929c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0075",
-      "prov:atLocation": {"@id": "niiri:c47c5a2a5239b1376eaedefa2ff2699f"},
+      "prov:atLocation": {"@id": "niiri:46c9e214eec026cee9cbc592615480de"},
       "prov:value": {"@type": "xsd:float", "@value": "2.32321286201477"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.66516536058509"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000123589411157754"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999989391962664"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.39972936309914"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.66516536058509"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000123589411157754"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999989391962664"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.39972936309914"}
     },
     {
-      "@id": "niiri:c47c5a2a5239b1376eaedefa2ff2699f",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:46c9e214eec026cee9cbc592615480de",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0075",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[30,20,-38]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[30,20,-38]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cfbf859f3c0ec6034e078c754596ee0d",
-      "entity": "niiri:bea578e87145baa9fef8f57831c0c5fe"
+      "entity_derived": "niiri:45eef5c14e0789f2e938b481f651929c",
+      "entity": "niiri:82870fabf2e7a1a9a595fb88debeb7ef"
     },
     {
-      "@id": "niiri:e12bf0481530c748cb0a35468b822b88",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:788812e3c1a5e8e9dc131a6099bb1cc2",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0076",
-      "prov:atLocation": {"@id": "niiri:7ea9d842203fe3fbf34da0469ed5ed9a"},
+      "prov:atLocation": {"@id": "niiri:332da0b388b9ea6a8859b4b2d788ad6f"},
       "prov:value": {"@type": "xsd:float", "@value": "2.3199303150177"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.66093272184923"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000125649373061587"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999990848449071"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.402380964108359"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.66093272184923"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000125649373061587"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999990848449071"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.402380964108359"}
     },
     {
-      "@id": "niiri:7ea9d842203fe3fbf34da0469ed5ed9a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:332da0b388b9ea6a8859b4b2d788ad6f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0076",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-32,-74,-34]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-32,-74,-34]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e12bf0481530c748cb0a35468b822b88",
-      "entity": "niiri:0416871505a4f68a8b0a05803d7fe0e1"
+      "entity_derived": "niiri:788812e3c1a5e8e9dc131a6099bb1cc2",
+      "entity": "niiri:54fe9c7a58c48364f79822c24b7f0a36"
     },
     {
-      "@id": "niiri:26273f7f8f82fbadf3f958a731788002",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3e2507719bb8e8cec2153c1d7c6d11f9",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0077",
-      "prov:atLocation": {"@id": "niiri:a619338ac199d532a1ec79efcfa4209c"},
+      "prov:atLocation": {"@id": "niiri:ae757bdf540f21b90dc47b8794c934d9"},
       "prov:value": {"@type": "xsd:float", "@value": "2.31843018531799"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.65899831919211"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00012660150034427"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999991450468149"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.402380964108359"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.65899831919211"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00012660150034427"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999991450468149"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.402380964108359"}
     },
     {
-      "@id": "niiri:a619338ac199d532a1ec79efcfa4209c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ae757bdf540f21b90dc47b8794c934d9",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0077",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[64,-48,34]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[64,-48,34]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:26273f7f8f82fbadf3f958a731788002",
-      "entity": "niiri:03e0bc451aca56b2f70fb660afdf1e84"
+      "entity_derived": "niiri:3e2507719bb8e8cec2153c1d7c6d11f9",
+      "entity": "niiri:9f649ce7c963c614e6fb0b5f0f441d80"
     },
     {
-      "@id": "niiri:ce68d24217b6596ee8fc6778125be00a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a5458865e5677ec6fc83283980aaada6",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0078",
-      "prov:atLocation": {"@id": "niiri:02cbfc710ea3d2d8b9c43217dda96a20"},
+      "prov:atLocation": {"@id": "niiri:0dcf4ce843f00cd9033a7e2afd199a20"},
       "prov:value": {"@type": "xsd:float", "@value": "2.31528902053833"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.65494765701128"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00012861722720714"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999992594228668"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.404908421693631"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.65494765701128"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00012861722720714"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999992594228668"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.404908421693631"}
     },
     {
-      "@id": "niiri:02cbfc710ea3d2d8b9c43217dda96a20",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0dcf4ce843f00cd9033a7e2afd199a20",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0078",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-12,-12,2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-12,-12,2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ce68d24217b6596ee8fc6778125be00a",
-      "entity": "niiri:94477c176a303cb05b6cf25392b272ff"
+      "entity_derived": "niiri:a5458865e5677ec6fc83283980aaada6",
+      "entity": "niiri:aa6b7754ff9629fdf69c2b137c4af89e"
     },
     {
-      "@id": "niiri:a6de3c3831590e1de613edc7269f52fc",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0bad50db6253e7c03b817887ef216040",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0079",
-      "prov:atLocation": {"@id": "niiri:7a5bf4276118c7c71b56aad6028247a3"},
+      "prov:atLocation": {"@id": "niiri:4389f2b6c2b6084518dcf9c6e3e274ec"},
       "prov:value": {"@type": "xsd:float", "@value": "2.30988264083862"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.64797539896827"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000132157469679206"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999994237019437"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.41105817784359"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.64797539896827"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000132157469679206"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999994237019437"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.41105817784359"}
     },
     {
-      "@id": "niiri:7a5bf4276118c7c71b56aad6028247a3",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4389f2b6c2b6084518dcf9c6e3e274ec",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0079",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-48,-44,20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-48,-44,20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a6de3c3831590e1de613edc7269f52fc",
-      "entity": "niiri:ccac343137c6a1606bfad900f0384914"
+      "entity_derived": "niiri:0bad50db6253e7c03b817887ef216040",
+      "entity": "niiri:992eba93ccac4ef864d1e4c888fef260"
     },
     {
-      "@id": "niiri:766c0e2c813aa658998a61081105bba5",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a6b4a34fb40ee0a15bffe18d35ac9f31",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0080",
-      "prov:atLocation": {"@id": "niiri:21b68820dc82135a768a58f6334b864b"},
+      "prov:atLocation": {"@id": "niiri:c56830dc76f0cf45f60a678fce7533c9"},
       "prov:value": {"@type": "xsd:float", "@value": "2.30309462547302"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.63922043208072"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000136732321226352"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999582138664"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.412454685345903"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.63922043208072"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000136732321226352"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999582138664"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.412454685345903"}
     },
     {
-      "@id": "niiri:21b68820dc82135a768a58f6334b864b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c56830dc76f0cf45f60a678fce7533c9",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0080",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-52,-52,20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-52,-52,20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:766c0e2c813aa658998a61081105bba5",
-      "entity": "niiri:ccac343137c6a1606bfad900f0384914"
+      "entity_derived": "niiri:a6b4a34fb40ee0a15bffe18d35ac9f31",
+      "entity": "niiri:992eba93ccac4ef864d1e4c888fef260"
     },
     {
-      "@id": "niiri:05647ca8991e4a0a95bd2fc1b2c62ae7",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:78892fc1529eb6f3ae71eda0c5cb75dc",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0081",
-      "prov:atLocation": {"@id": "niiri:e2558d5e5571a464c52b03590c9450a0"},
+      "prov:atLocation": {"@id": "niiri:f399f79c516833e75e018feb17e33afb"},
       "prov:value": {"@type": "xsd:float", "@value": "2.30742883682251"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.64481067597732"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000133794356756312"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999994864920274"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.411522109968619"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.64481067597732"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000133794356756312"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999994864920274"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.411522109968619"}
     },
     {
-      "@id": "niiri:e2558d5e5571a464c52b03590c9450a0",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f399f79c516833e75e018feb17e33afb",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0081",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-8,-4,68]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-8,-4,68]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:05647ca8991e4a0a95bd2fc1b2c62ae7",
-      "entity": "niiri:74289f8090f7da1b2e9c2d274cc0f956"
+      "entity_derived": "niiri:78892fc1529eb6f3ae71eda0c5cb75dc",
+      "entity": "niiri:2913f23a1813eb7942fb6b12aea56fda"
     },
     {
-      "@id": "niiri:455d4d02f780914df4f8c9a3b0f95760",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d2d93102aaafa6fbf39c89330edf7d36",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0082",
-      "prov:atLocation": {"@id": "niiri:fa01ecd26ef11b88bbe32f583e59d274"},
+      "prov:atLocation": {"@id": "niiri:54139976336939af57421f288b0e9dab"},
       "prov:value": {"@type": "xsd:float", "@value": "2.30296897888184"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.63905836767043"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000136818389668947"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999995846467612"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.412454685345903"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.63905836767043"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000136818389668947"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999995846467612"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.412454685345903"}
     },
     {
-      "@id": "niiri:fa01ecd26ef11b88bbe32f583e59d274",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:54139976336939af57421f288b0e9dab",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0082",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[24,36,34]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[24,36,34]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:455d4d02f780914df4f8c9a3b0f95760",
-      "entity": "niiri:aa9f984347d25d8bedc780b7865258c6"
+      "entity_derived": "niiri:d2d93102aaafa6fbf39c89330edf7d36",
+      "entity": "niiri:1c4944ab6edec9e1dbd0763deb0ea5f5"
     },
     {
-      "@id": "niiri:d1a6ea8476f2fafe540cddbd6ffba6a4",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f9d5a38c2897f37b953727849193451c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0083",
-      "prov:atLocation": {"@id": "niiri:6a8e3c79d857ce68341185e8d990f337"},
+      "prov:atLocation": {"@id": "niiri:50e5e469d6707c527eb94fd063197ff7"},
       "prov:value": {"@type": "xsd:float", "@value": "2.30046772956848"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.63583207709644"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000138542396657115"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999631754215"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.413429132458979"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.63583207709644"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000138542396657115"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999631754215"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.413429132458979"}
     },
     {
-      "@id": "niiri:6a8e3c79d857ce68341185e8d990f337",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:50e5e469d6707c527eb94fd063197ff7",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0083",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[46,-42,46]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[46,-42,46]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d1a6ea8476f2fafe540cddbd6ffba6a4",
-      "entity": "niiri:2835e70d80bc47f846977da52697749b"
+      "entity_derived": "niiri:f9d5a38c2897f37b953727849193451c",
+      "entity": "niiri:807decf567867596e9ede288b13f016a"
     },
     {
-      "@id": "niiri:427cdba5928d6cfb873e4ffc7099ef1d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e69b435cb561850d5bb26d896306c312",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0084",
-      "prov:atLocation": {"@id": "niiri:086d66aa1f058a88938ed5f762f0aca6"},
+      "prov:atLocation": {"@id": "niiri:f81bff3e58fea6964d48c247d09b95ed"},
       "prov:value": {"@type": "xsd:float", "@value": "2.14905881881714"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.44029990384982"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000290534960819211"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999971054"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.554694102883098"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.44029990384982"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000290534960819211"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999971054"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.554694102883098"}
     },
     {
-      "@id": "niiri:086d66aa1f058a88938ed5f762f0aca6",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f81bff3e58fea6964d48c247d09b95ed",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0084",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[42,-48,38]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[42,-48,38]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:427cdba5928d6cfb873e4ffc7099ef1d",
-      "entity": "niiri:2835e70d80bc47f846977da52697749b"
+      "entity_derived": "niiri:e69b435cb561850d5bb26d896306c312",
+      "entity": "niiri:807decf567867596e9ede288b13f016a"
     },
     {
-      "@id": "niiri:d070456b3f0edeb7698db59b60ddd833",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:6f25ec29f560c0501f2c9be49ad80287",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0085",
-      "prov:atLocation": {"@id": "niiri:debd4d18a46062c4b904a29039083b38"},
+      "prov:atLocation": {"@id": "niiri:d5f0e8cf4ef0c2d23df21b39a0a7ce72"},
       "prov:value": {"@type": "xsd:float", "@value": "2.29290223121643"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.62607273627958"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000143882164975628"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999997457251428"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.416670883231346"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.62607273627958"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000143882164975628"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999997457251428"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.416670883231346"}
     },
     {
-      "@id": "niiri:debd4d18a46062c4b904a29039083b38",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d5f0e8cf4ef0c2d23df21b39a0a7ce72",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0085",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[8,-54,72]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[8,-54,72]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d070456b3f0edeb7698db59b60ddd833",
-      "entity": "niiri:87c4af2a8f65ce6e67f250f40b44790b"
+      "entity_derived": "niiri:6f25ec29f560c0501f2c9be49ad80287",
+      "entity": "niiri:106990f64fdbe0a92e78b55484d984e7"
     },
     {
-      "@id": "niiri:1c2334f989dbf42de0d9d0673eded9fd",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:1c087be2a968de7ac0a2bea646c020cb",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0086",
-      "prov:atLocation": {"@id": "niiri:e5a41979fd64c5a5e9bf6c0f4ce9202c"},
+      "prov:atLocation": {"@id": "niiri:e7806e0fcab4c0eb3a7f57e5ee03788b"},
       "prov:value": {"@type": "xsd:float", "@value": "2.28387594223022"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.61442740814864"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000150506069076406"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999998385622597"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.418270156640619"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.61442740814864"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000150506069076406"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999998385622597"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.418270156640619"}
     },
     {
-      "@id": "niiri:e5a41979fd64c5a5e9bf6c0f4ce9202c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e7806e0fcab4c0eb3a7f57e5ee03788b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0086",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-50,-40,30]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-50,-40,30]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1c2334f989dbf42de0d9d0673eded9fd",
-      "entity": "niiri:b96f891a7f3546406e623e46139187e6"
+      "entity_derived": "niiri:1c087be2a968de7ac0a2bea646c020cb",
+      "entity": "niiri:9a89982690b205094ce375806ee327d2"
     },
     {
-      "@id": "niiri:39efddb8b434a13530f3ccc1f0e4a691",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:fb0dd18eb34c8e74b938fd5ddf517ce5",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0087",
-      "prov:atLocation": {"@id": "niiri:da180f80322b4b1da7197b8a08f5e6a4"},
+      "prov:atLocation": {"@id": "niiri:aa3855fba367b0ad316c27d8b09af4d1"},
       "prov:value": {"@type": "xsd:float", "@value": "2.27538919448853"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.60347660612369"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000156994509713848"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999998960052528"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.418270156640619"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.60347660612369"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000156994509713848"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999998960052528"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.418270156640619"}
     },
     {
-      "@id": "niiri:da180f80322b4b1da7197b8a08f5e6a4",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:aa3855fba367b0ad316c27d8b09af4d1",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0087",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[40,-2,-10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[40,-2,-10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:39efddb8b434a13530f3ccc1f0e4a691",
-      "entity": "niiri:4c9cbb438c61ca24784015872ad9fbc0"
+      "entity_derived": "niiri:fb0dd18eb34c8e74b938fd5ddf517ce5",
+      "entity": "niiri:86396384ac8248dc2499f53d12283a2f"
     },
     {
-      "@id": "niiri:57fc12f11ad2c09e088b9fb77c584d5f",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:2f736c7d40b35980222068c405413bae",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0088",
-      "prov:atLocation": {"@id": "niiri:94bb6b91a2796abac7e7ff52313ab016"},
+      "prov:atLocation": {"@id": "niiri:53e1ecfd3011d4d05f60ec3d43f5cdf3"},
       "prov:value": {"@type": "xsd:float", "@value": "2.27404403686523"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.60174075534084"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000158046749744623"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999031182047"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.418270156640619"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.60174075534084"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000158046749744623"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999031182047"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.418270156640619"}
     },
     {
-      "@id": "niiri:94bb6b91a2796abac7e7ff52313ab016",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:53e1ecfd3011d4d05f60ec3d43f5cdf3",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0088",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-42,-22,70]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-42,-22,70]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:57fc12f11ad2c09e088b9fb77c584d5f",
-      "entity": "niiri:39af3e7a68fb53b5aaa4d4380994d93a"
+      "entity_derived": "niiri:2f736c7d40b35980222068c405413bae",
+      "entity": "niiri:2ead289cc63835350630bfc68f2d003d"
     },
     {
-      "@id": "niiri:ec692b5057a43580a035e84f59cb6d74",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:7980b5dd38316b9b2ecbc76101c2a0b5",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0089",
-      "prov:atLocation": {"@id": "niiri:169ad4a3513af46ef9a4693426b43637"},
+      "prov:atLocation": {"@id": "niiri:8b38f2871372df699f2f367c731b12a3"},
       "prov:value": {"@type": "xsd:float", "@value": "2.27214431762695"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.59928920970321"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000159544081014595"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999123899245"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.418270156640619"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.59928920970321"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000159544081014595"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999123899245"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.418270156640619"}
     },
     {
-      "@id": "niiri:169ad4a3513af46ef9a4693426b43637",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:8b38f2871372df699f2f367c731b12a3",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0089",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-40,-86,28]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-40,-86,28]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ec692b5057a43580a035e84f59cb6d74",
-      "entity": "niiri:e854d05d0fd68a980bd27218bb6f2d9f"
+      "entity_derived": "niiri:7980b5dd38316b9b2ecbc76101c2a0b5",
+      "entity": "niiri:0ff3515dad74fb4659ac475f78bb2c0d"
     },
     {
-      "@id": "niiri:7fd3d4ac82d781b1cc29aa421106eee0",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b05ecaea88de142b8ca1773ff4972f5e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0090",
-      "prov:atLocation": {"@id": "niiri:eb16585959f71157b322ab347206a01e"},
+      "prov:atLocation": {"@id": "niiri:f22fe5774a94e8360abdcf02dd02e53d"},
       "prov:value": {"@type": "xsd:float", "@value": "2.27202653884888"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.59913721633081"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000159637349828712"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999129364364"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.418270156640619"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.59913721633081"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000159637349828712"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999129364364"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.418270156640619"}
     },
     {
-      "@id": "niiri:eb16585959f71157b322ab347206a01e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f22fe5774a94e8360abdcf02dd02e53d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0090",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[32,58,22]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[32,58,22]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7fd3d4ac82d781b1cc29aa421106eee0",
-      "entity": "niiri:919d23712d157543b918d601a201b7d7"
+      "entity_derived": "niiri:b05ecaea88de142b8ca1773ff4972f5e",
+      "entity": "niiri:e28eff3b2e060f982dbfeec40075736b"
     },
     {
-      "@id": "niiri:3f7ecbaac628282113885ba2bcc840fd",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:47d4cfe6ec57e882523a5f15411848d2",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0091",
-      "prov:atLocation": {"@id": "niiri:e0f24cc6ffa224ba72060ff91f1a6d68"},
+      "prov:atLocation": {"@id": "niiri:5495296622af4ad50502b8b2f7e08245"},
       "prov:value": {"@type": "xsd:float", "@value": "2.27080631256104"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.59756249884937"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000160606663523355"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999184134104"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.418270156640619"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.59756249884937"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000160606663523355"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999184134104"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.418270156640619"}
     },
     {
-      "@id": "niiri:e0f24cc6ffa224ba72060ff91f1a6d68",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:5495296622af4ad50502b8b2f7e08245",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0091",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[44,-62,-36]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[44,-62,-36]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3f7ecbaac628282113885ba2bcc840fd",
-      "entity": "niiri:bac84e2b7b3296e6a7b45e5dd897eaa1"
+      "entity_derived": "niiri:47d4cfe6ec57e882523a5f15411848d2",
+      "entity": "niiri:5621f89640fa5a0a90c32a936e6e0a8d"
     },
     {
-      "@id": "niiri:4ddc5955a7227a8307edc5dd686ecd66",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:4dc1e5e65b8110f5c3d324caa9587124",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0092",
-      "prov:atLocation": {"@id": "niiri:b94c39ac7ab0fd3eb81a6fa1a39a4144"},
+      "prov:atLocation": {"@id": "niiri:08507e5bd6094aa94b8ccf63d7df9415"},
       "prov:value": {"@type": "xsd:float", "@value": "2.25528573989868"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.57753033271362"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000173427989261232"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999651142222"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.432415839107375"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.57753033271362"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000173427989261232"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999651142222"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.432415839107375"}
     },
     {
-      "@id": "niiri:b94c39ac7ab0fd3eb81a6fa1a39a4144",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:08507e5bd6094aa94b8ccf63d7df9415",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0092",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-56,-34,-18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-56,-34,-18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4ddc5955a7227a8307edc5dd686ecd66",
-      "entity": "niiri:79c33267bc7a50246dc768c737d6daae"
+      "entity_derived": "niiri:4dc1e5e65b8110f5c3d324caa9587124",
+      "entity": "niiri:f6474f5545e9725192cc8b6256e5bfb0"
     },
     {
-      "@id": "niiri:2c80bf28d04d08f3d90110861ee4f12b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:8c3105cb051b8d67f47a2e2e97720b1f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0093",
-      "prov:atLocation": {"@id": "niiri:3fdca379e3d8b5c9e451308c60e988b5"},
+      "prov:atLocation": {"@id": "niiri:5fa31ed28407d8ef344d786db87d0ab2"},
       "prov:value": {"@type": "xsd:float", "@value": "2.24145913124084"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.55968043051933"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00018565317676611"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999842303019"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.448708397422201"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.55968043051933"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00018565317676611"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999842303019"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.448708397422201"}
     },
     {
-      "@id": "niiri:3fdca379e3d8b5c9e451308c60e988b5",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:5fa31ed28407d8ef344d786db87d0ab2",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0093",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[42,16,6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[42,16,6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2c80bf28d04d08f3d90110861ee4f12b",
-      "entity": "niiri:2c2f8c53ef38453b53a97c311972275b"
+      "entity_derived": "niiri:8c3105cb051b8d67f47a2e2e97720b1f",
+      "entity": "niiri:2f15ad69e6c9c21540fd55e8e1488dca"
     },
     {
-      "@id": "niiri:6aa4da50308d4f29e4e9c77498b3ad5b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:cbd485923e06556ee8d61eae7a353bc3",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0094",
-      "prov:atLocation": {"@id": "niiri:3c1f4dcab3f0f860ac48e18be2e761a0"},
+      "prov:atLocation": {"@id": "niiri:13e7354b0f59c7b5993f11f6d72cdacc"},
       "prov:value": {"@type": "xsd:float", "@value": "2.2288510799408"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.54340035775212"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000197501273445089"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999925925981"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.461177773590418"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.54340035775212"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000197501273445089"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999925925981"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.461177773590418"}
     },
     {
-      "@id": "niiri:3c1f4dcab3f0f860ac48e18be2e761a0",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:13e7354b0f59c7b5993f11f6d72cdacc",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0094",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[14,58,10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[14,58,10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6aa4da50308d4f29e4e9c77498b3ad5b",
-      "entity": "niiri:5250d6f799a090681ee8888a86a64f2e"
+      "entity_derived": "niiri:cbd485923e06556ee8d61eae7a353bc3",
+      "entity": "niiri:42ca52d223a11cd4060ba3459f14c1ab"
     },
     {
-      "@id": "niiri:3dc0eb091c90cffce879cf8e8bfd47b2",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:18b3136cd14e6ff7733c13a8bdaa6346",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0095",
-      "prov:atLocation": {"@id": "niiri:bb8174cf7fa8ca0405ee8f32057d2649"},
+      "prov:atLocation": {"@id": "niiri:39d7636932e3d3377734bf37ba671d26"},
       "prov:value": {"@type": "xsd:float", "@value": "2.22417545318604"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.53736219289604"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000202072513955764"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999944466357"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.466991649207176"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.53736219289604"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000202072513955764"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999944466357"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.466991649207176"}
     },
     {
-      "@id": "niiri:bb8174cf7fa8ca0405ee8f32057d2649",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:39d7636932e3d3377734bf37ba671d26",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0095",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[20,36,56]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[20,36,56]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3dc0eb091c90cffce879cf8e8bfd47b2",
-      "entity": "niiri:891b4e7e5f232af9ce39592173fed719"
+      "entity_derived": "niiri:18b3136cd14e6ff7733c13a8bdaa6346",
+      "entity": "niiri:29b8562f8375bc52056233a05357c8ba"
     },
     {
-      "@id": "niiri:2cdf49c51570fade008ce72059cc1692",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f83fcb8aadbc17649f8866d0a02e98f2",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0096",
-      "prov:atLocation": {"@id": "niiri:f3aa9de381f51cfb08738385524151a8"},
+      "prov:atLocation": {"@id": "niiri:823ebff49a536adfb982018013149f69"},
       "prov:value": {"@type": "xsd:float", "@value": "2.21693515777588"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.5280111500348"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000209347259857662"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999996475463"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.474122401075389"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.5280111500348"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000209347259857662"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999996475463"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.474122401075389"}
     },
     {
-      "@id": "niiri:f3aa9de381f51cfb08738385524151a8",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:823ebff49a536adfb982018013149f69",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0096",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-46,-16,-26]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-46,-16,-26]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2cdf49c51570fade008ce72059cc1692",
-      "entity": "niiri:4cd96b91a9bff0c27f9a1cf0ccb9533d"
+      "entity_derived": "niiri:f83fcb8aadbc17649f8866d0a02e98f2",
+      "entity": "niiri:39feea9bf256b35cba29d53ba142d102"
     },
     {
-      "@id": "niiri:45dffba72653cbb4f68a95a678413b05",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:6ac9a02ed616ed9c5160a35845282afa",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0097",
-      "prov:atLocation": {"@id": "niiri:c34cd792677b6d6b8875ee707b844911"},
+      "prov:atLocation": {"@id": "niiri:dbf3fb337eb7a2ddb7d78423e621f1bd"},
       "prov:value": {"@type": "xsd:float", "@value": "2.21399617195129"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.52421508195077"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000212369663955547"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999970782305"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.474122401075389"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.52421508195077"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000212369663955547"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999970782305"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.474122401075389"}
     },
     {
-      "@id": "niiri:c34cd792677b6d6b8875ee707b844911",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:dbf3fb337eb7a2ddb7d78423e621f1bd",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0097",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-36,-48,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-36,-48,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:45dffba72653cbb4f68a95a678413b05",
-      "entity": "niiri:63335f473373e0606d5e19a26d54947f"
+      "entity_derived": "niiri:6ac9a02ed616ed9c5160a35845282afa",
+      "entity": "niiri:aeed349c1d870c766c3846139baddfcf"
     },
     {
-      "@id": "niiri:db448d238977143a1b0073a8ab816137",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a3bf33e6499e7a0a31c9702c6d60fc3c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0098",
-      "prov:atLocation": {"@id": "niiri:c619a9542f5c0ade5cdaf352fb682062"},
+      "prov:atLocation": {"@id": "niiri:5cb10b840a952460027010421de8c620"},
       "prov:value": {"@type": "xsd:float", "@value": "2.21233320236206"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.5220670758195"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000214097893396659"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999973744615"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.474122401075389"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.5220670758195"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000214097893396659"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999973744615"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.474122401075389"}
     },
     {
-      "@id": "niiri:c619a9542f5c0ade5cdaf352fb682062",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:5cb10b840a952460027010421de8c620",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0098",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[64,-48,22]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[64,-48,22]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:db448d238977143a1b0073a8ab816137",
-      "entity": "niiri:a5b7e29d2b4e7df102d4c218a8e2de79"
+      "entity_derived": "niiri:a3bf33e6499e7a0a31c9702c6d60fc3c",
+      "entity": "niiri:fb34b9243fbfd4d52f33195ad11fa75e"
     },
     {
-      "@id": "niiri:ced2f179d1d5b872001a41328c302cd3",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0de985ab54c7b41ae1d397bc56243722",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0099",
-      "prov:atLocation": {"@id": "niiri:0418a68382ced7c0f5f47a8b5c68f529"},
+      "prov:atLocation": {"@id": "niiri:2448323ca81528a1cd5e1421cfb4745c"},
       "prov:value": {"@type": "xsd:float", "@value": "2.19926238059998"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.50518208844769"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000228147544614088"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999988890482"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.490541911210553"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.50518208844769"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000228147544614088"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999988890482"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.490541911210553"}
     },
     {
-      "@id": "niiri:0418a68382ced7c0f5f47a8b5c68f529",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:2448323ca81528a1cd5e1421cfb4745c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0099",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-62,-16,30]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-62,-16,30]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ced2f179d1d5b872001a41328c302cd3",
-      "entity": "niiri:bc8ae88a4964bdb4f03808829f923a38"
+      "entity_derived": "niiri:0de985ab54c7b41ae1d397bc56243722",
+      "entity": "niiri:ae4e3431e53d6bb86cb5f49df3e1dd3c"
     },
     {
-      "@id": "niiri:0589344fd5b39e0079f0eacd1bdea959",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:dafae508abe6b629f3a5b25e99e2b8a6",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0100",
-      "prov:atLocation": {"@id": "niiri:5a4911001d38715d5a57289ed467423a"},
+      "prov:atLocation": {"@id": "niiri:0f59e5f95827337c606de13c426760b3"},
       "prov:value": {"@type": "xsd:float", "@value": "2.17726922035217"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.47676404129424"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000253752120226602"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999997591668"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.522483308971289"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.47676404129424"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000253752120226602"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999997591668"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.522483308971289"}
     },
     {
-      "@id": "niiri:5a4911001d38715d5a57289ed467423a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0f59e5f95827337c606de13c426760b3",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0100",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[60,16,4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[60,16,4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0589344fd5b39e0079f0eacd1bdea959",
-      "entity": "niiri:8635bd60e838e70448a683e4c2731fb0"
+      "entity_derived": "niiri:dafae508abe6b629f3a5b25e99e2b8a6",
+      "entity": "niiri:3ae2d61c89fb13f4e75319093956440c"
     },
     {
-      "@id": "niiri:b2528dbd26b9220db5c6eefa25e32914",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:9f241776c24bfec38480e757272c95ef",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0101",
-      "prov:atLocation": {"@id": "niiri:abe269d6ae4b9336647e7a744bebe347"},
+      "prov:atLocation": {"@id": "niiri:475f99b85d7b3507277fe4cc199d02da"},
       "prov:value": {"@type": "xsd:float", "@value": "2.17222547531128"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.47024563153578"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000259991300800011"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999998329023"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.528007569567315"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.47024563153578"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000259991300800011"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999998329023"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.528007569567315"}
     },
     {
-      "@id": "niiri:abe269d6ae4b9336647e7a744bebe347",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:475f99b85d7b3507277fe4cc199d02da",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0101",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-38,16,16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-38,16,16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b2528dbd26b9220db5c6eefa25e32914",
-      "entity": "niiri:76761290d259c6c26ed92cd02b7a8ffd"
+      "entity_derived": "niiri:9f241776c24bfec38480e757272c95ef",
+      "entity": "niiri:b9c3425be7ea99b14efce8bce592b25b"
     },
     {
-      "@id": "niiri:367ca6f93deb273a4eb2286708dd547c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:64e9f022bd6687a619e8398b70936591",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0102",
-      "prov:atLocation": {"@id": "niiri:f372eacca52daa0c35f19074b35fd390"},
+      "prov:atLocation": {"@id": "niiri:ab9a9062532d2e24f71d5f942396e83c"},
       "prov:value": {"@type": "xsd:float", "@value": "2.17077469825745"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.46837060004652"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000261812316486365"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999998497371"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.528007569567315"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.46837060004652"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000261812316486365"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999998497371"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.528007569567315"}
     },
     {
-      "@id": "niiri:f372eacca52daa0c35f19074b35fd390",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ab9a9062532d2e24f71d5f942396e83c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0102",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[30,8,54]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[30,8,54]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:367ca6f93deb273a4eb2286708dd547c",
-      "entity": "niiri:2447692cf3c13cbbdafc3a665370603f"
+      "entity_derived": "niiri:64e9f022bd6687a619e8398b70936591",
+      "entity": "niiri:53c378a2e0ca3196fa50b2b2030c0fcc"
     },
     {
-      "@id": "niiri:ca18afbcea7ead88af7f4b4b0859d0fc",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f39083490c271135692376a9b6145545",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0103",
-      "prov:atLocation": {"@id": "niiri:aa6d0b0673242c4bbd69bc3b26cb7360"},
+      "prov:atLocation": {"@id": "niiri:fc43ea1ac52f1f092d78f8698757e2c9"},
       "prov:value": {"@type": "xsd:float", "@value": "2.16687154769897"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.46332585702272"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000266770915118508"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999998873444"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.532041442688517"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.46332585702272"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000266770915118508"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999998873444"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.532041442688517"}
     },
     {
-      "@id": "niiri:aa6d0b0673242c4bbd69bc3b26cb7360",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:fc43ea1ac52f1f092d78f8698757e2c9",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0103",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[4,-74,40]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[4,-74,40]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ca18afbcea7ead88af7f4b4b0859d0fc",
-      "entity": "niiri:e4dcddb5ab6095be427ee660b9fc5d2f"
+      "entity_derived": "niiri:f39083490c271135692376a9b6145545",
+      "entity": "niiri:43e5c93bebd29ba8da99711ae8d9c3e1"
     },
     {
-      "@id": "niiri:42b6fdc5b4a6b24eb1a2b9cc382bb638",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5fb2a670883af294357a4ab2154ab6b1",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0104",
-      "prov:atLocation": {"@id": "niiri:545e4f447d4cc4c012c7dd505904ffc1"},
+      "prov:atLocation": {"@id": "niiri:063b2c2ce28d037a1a6851fbbcbb9e62"},
       "prov:value": {"@type": "xsd:float", "@value": "2.16552972793579"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.46159152037966"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000268495752957176"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999998980469"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.532232376423935"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.46159152037966"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000268495752957176"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999998980469"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.532232376423935"}
     },
     {
-      "@id": "niiri:545e4f447d4cc4c012c7dd505904ffc1",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:063b2c2ce28d037a1a6851fbbcbb9e62",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0104",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-18,-94,4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-18,-94,4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:42b6fdc5b4a6b24eb1a2b9cc382bb638",
-      "entity": "niiri:343fa8f57e7adfcd961ea3af67b24ad0"
+      "entity_derived": "niiri:5fb2a670883af294357a4ab2154ab6b1",
+      "entity": "niiri:7fd1e3a607dbe6cfba8a4e086242d6b7"
     },
     {
-      "@id": "niiri:a1b9a65fc1049ceeb5ded8769ae3f508",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ee341bb063e9247becec364805165eb3",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0105",
-      "prov:atLocation": {"@id": "niiri:48ce6a5d07af9b11b1807d555d4cea5c"},
+      "prov:atLocation": {"@id": "niiri:3caf76e9df39a2dd7c3751565762561b"},
       "prov:value": {"@type": "xsd:float", "@value": "2.15602898597717"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.44931067015382"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000281009846776592"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999503037"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.54825725843418"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.44931067015382"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000281009846776592"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999503037"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.54825725843418"}
     },
     {
-      "@id": "niiri:48ce6a5d07af9b11b1807d555d4cea5c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:3caf76e9df39a2dd7c3751565762561b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0105",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[32,46,18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[32,46,18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a1b9a65fc1049ceeb5ded8769ae3f508",
-      "entity": "niiri:59cba60adf480535a1c969d6d64e23b9"
+      "entity_derived": "niiri:ee341bb063e9247becec364805165eb3",
+      "entity": "niiri:d2c986d4849a217bf93ccf9e1e40ff7d"
     },
     {
-      "@id": "niiri:4683c57b038885e94fa01e20e9d774b5",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:db4b88ce7955c87529d9cdcac1067e5c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0106",
-      "prov:atLocation": {"@id": "niiri:995e395a213465c06ce2db1292745d05"},
+      "prov:atLocation": {"@id": "niiri:32da5de8e2d1066fafe66482f6376ce8"},
       "prov:value": {"@type": "xsd:float", "@value": "2.1544976234436"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.44733105425233"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000283077187230862"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999558251"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.548832170867961"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.44733105425233"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000283077187230862"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999558251"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.548832170867961"}
     },
     {
-      "@id": "niiri:995e395a213465c06ce2db1292745d05",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:32da5de8e2d1066fafe66482f6376ce8",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0106",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-6,34,-4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-6,34,-4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4683c57b038885e94fa01e20e9d774b5",
-      "entity": "niiri:8e3b014c96a9933ebe866f62a5fc3a5c"
+      "entity_derived": "niiri:db4b88ce7955c87529d9cdcac1067e5c",
+      "entity": "niiri:bac839d7d5a8f71351fbf0af9d7d237d"
     },
     {
-      "@id": "niiri:0d420046241672771ad46ff9a2282f00",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:6ab66734fa9b63bf93c3eb233efd164e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0107",
-      "prov:atLocation": {"@id": "niiri:bd12bce700e8c3a2c620c0bd152b9a5c"},
+      "prov:atLocation": {"@id": "niiri:439a96c6b9c8da3c658cd86b4f5faa7c"},
       "prov:value": {"@type": "xsd:float", "@value": "2.14432787895203"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.43418345508983"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000297170899168919"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999800735"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.559218724487036"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.43418345508983"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000297170899168919"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999800735"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.559218724487036"}
     },
     {
-      "@id": "niiri:bd12bce700e8c3a2c620c0bd152b9a5c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:439a96c6b9c8da3c658cd86b4f5faa7c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0107",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[26,12,-28]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[26,12,-28]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0d420046241672771ad46ff9a2282f00",
-      "entity": "niiri:7adf18789eb65028169817bb70133720"
+      "entity_derived": "niiri:6ab66734fa9b63bf93c3eb233efd164e",
+      "entity": "niiri:950ebb223c0553663a2925b4cebca2f2"
     },
     {
-      "@id": "niiri:c3bd8f705a61e6d7802588f2cdec4ed1",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:7a920cc103779299492bdd1b7abf0d4c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0108",
-      "prov:atLocation": {"@id": "niiri:fa86ac39d092f7b1a3921944a2ba940c"},
+      "prov:atLocation": {"@id": "niiri:62a9547c589c74225214f116b688bb4f"},
       "prov:value": {"@type": "xsd:float", "@value": "2.13841390609741"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.42653698017951"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000305665256597809"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999875989"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.566169265576836"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.42653698017951"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000305665256597809"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999875989"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.566169265576836"}
     },
     {
-      "@id": "niiri:fa86ac39d092f7b1a3921944a2ba940c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:62a9547c589c74225214f116b688bb4f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0108",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[62,8,26]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[62,8,26]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c3bd8f705a61e6d7802588f2cdec4ed1",
-      "entity": "niiri:3e769257b2ca300ac5c4d33e8539ea3e"
+      "entity_derived": "niiri:7a920cc103779299492bdd1b7abf0d4c",
+      "entity": "niiri:9a52ab95dd907c0f7f51fb102fd28f70"
     },
     {
-      "@id": "niiri:5e93a5a814da6e509ad7165c91c9fc95",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0091960b7df9e3b2ee0b995c7a9fee2e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0109",
-      "prov:atLocation": {"@id": "niiri:041839fc4b2773472bb6dbe9c849f76a"},
+      "prov:atLocation": {"@id": "niiri:dd731654874737e36a1145e73ec3c503"},
       "prov:value": {"@type": "xsd:float", "@value": "2.13535809516907"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.42258573937654"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00031014265931506"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999903261"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.56744192975625"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.42258573937654"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00031014265931506"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999903261"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.56744192975625"}
     },
     {
-      "@id": "niiri:041839fc4b2773472bb6dbe9c849f76a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:dd731654874737e36a1145e73ec3c503",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0109",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[46,-14,-28]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[46,-14,-28]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5e93a5a814da6e509ad7165c91c9fc95",
-      "entity": "niiri:66df3519712f78df7f53bbfefe65db57"
+      "entity_derived": "niiri:0091960b7df9e3b2ee0b995c7a9fee2e",
+      "entity": "niiri:f6d437c16c83f9a147b1bb4222d3abc6"
     },
     {
-      "@id": "niiri:f720878e1741c8b1f6939071321d56d7",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:be68a46819185a1181faf0074de880e1",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0110",
-      "prov:atLocation": {"@id": "niiri:142905eb74c66aaa5e57abac3ea373e1"},
+      "prov:atLocation": {"@id": "niiri:4f894d57ccb0687917202eb233a2d0b4"},
       "prov:value": {"@type": "xsd:float", "@value": "2.10883116722107"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.38827937085858"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000351662935259678"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999989834"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.612415661510894"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.38827937085858"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000351662935259678"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999989834"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.612415661510894"}
     },
     {
-      "@id": "niiri:142905eb74c66aaa5e57abac3ea373e1",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4f894d57ccb0687917202eb233a2d0b4",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0110",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[36,-74,-26]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[36,-74,-26]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f720878e1741c8b1f6939071321d56d7",
-      "entity": "niiri:122fe3b47ae88833c8f3dcb366c4f353"
+      "entity_derived": "niiri:be68a46819185a1181faf0074de880e1",
+      "entity": "niiri:8837f9a734738e041b5341b9172fb036"
     },
     {
-      "@id": "niiri:efc1a416c436d254523da1dc7a3a5da0",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:9c1ebb72f8df3bd670dd7093690f96e7",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0111",
-      "prov:atLocation": {"@id": "niiri:23a7c4a4e38c8a241f6aa7e01342c83c"},
+      "prov:atLocation": {"@id": "niiri:f54e09b1927d965f6e9d8e3ab8911024"},
       "prov:value": {"@type": "xsd:float", "@value": "2.09861969947815"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.3750702611999"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000368984236825298"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999995928"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.628845185882367"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.3750702611999"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000368984236825298"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999995928"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.628845185882367"}
     },
     {
-      "@id": "niiri:23a7c4a4e38c8a241f6aa7e01342c83c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f54e09b1927d965f6e9d8e3ab8911024",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0111",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-46,-62,-30]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-46,-62,-30]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:efc1a416c436d254523da1dc7a3a5da0",
-      "entity": "niiri:5a3a2dbf66bf4901aa498d3c0495df01"
+      "entity_derived": "niiri:9c1ebb72f8df3bd670dd7093690f96e7",
+      "entity": "niiri:8b57160e5bbb28c42ed70eb49e48b412"
     },
     {
-      "@id": "niiri:9666a3ca5c742682db0769b09b96f536",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:13a5abfae24999f832ff63e132d71526",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0112",
-      "prov:atLocation": {"@id": "niiri:ff4a59f5a5ebb1dba222a00f6fd30959"},
+      "prov:atLocation": {"@id": "niiri:45414be04daca1ed9416e031c998e67c"},
       "prov:value": {"@type": "xsd:float", "@value": "2.0976128578186"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.37376776772589"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000370734464924194"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999996285"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.628845185882367"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.37376776772589"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000370734464924194"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999996285"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.628845185882367"}
     },
     {
-      "@id": "niiri:ff4a59f5a5ebb1dba222a00f6fd30959",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:45414be04daca1ed9416e031c998e67c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0112",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[48,2,46]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[48,2,46]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9666a3ca5c742682db0769b09b96f536",
-      "entity": "niiri:d09cb3827a1f341bbeb1a77f474f6e6a"
+      "entity_derived": "niiri:13a5abfae24999f832ff63e132d71526",
+      "entity": "niiri:c45c033aff250585c0df5bd7ebfa55c2"
     },
     {
-      "@id": "niiri:b5378739f8aef4037f96960420b04eef",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0db89c6238aa0a65c9a6789ba0981b57",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0113",
-      "prov:atLocation": {"@id": "niiri:da71b8f3f5a034f02920c32f2939b22a"},
+      "prov:atLocation": {"@id": "niiri:16e32bd5f320f75cf3ad9cfb6feb184b"},
       "prov:value": {"@type": "xsd:float", "@value": "2.09218430519104"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.36674489388815"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000380305072376852"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999997744"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.636831894546098"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.36674489388815"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000380305072376852"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999997744"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.636831894546098"}
     },
     {
-      "@id": "niiri:da71b8f3f5a034f02920c32f2939b22a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:16e32bd5f320f75cf3ad9cfb6feb184b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0113",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-8,6,56]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-8,6,56]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b5378739f8aef4037f96960420b04eef",
-      "entity": "niiri:df984c734f06f169195b0bbaee6143c6"
+      "entity_derived": "niiri:0db89c6238aa0a65c9a6789ba0981b57",
+      "entity": "niiri:95162bceebb39a10b64eb05d8de3fd22"
     },
     {
-      "@id": "niiri:8812de022492a64799c82a33c19f3f11",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3cef58b75474f5f62c6e5f17b7eb47a4",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0114",
-      "prov:atLocation": {"@id": "niiri:9df003d74dd5288329afa1839609e094"},
+      "prov:atLocation": {"@id": "niiri:9c0c51b01429787a73fcf756db784b5f"},
       "prov:value": {"@type": "xsd:float", "@value": "2.09025764465332"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.36425228187917"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000383756749400832"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999998114"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.636831894546098"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.36425228187917"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000383756749400832"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999998114"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.636831894546098"}
     },
     {
-      "@id": "niiri:9df003d74dd5288329afa1839609e094",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:9c0c51b01429787a73fcf756db784b5f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0114",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[34,4,38]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[34,4,38]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8812de022492a64799c82a33c19f3f11",
-      "entity": "niiri:3bf753720b3412e5689330bba1dbe1cf"
+      "entity_derived": "niiri:3cef58b75474f5f62c6e5f17b7eb47a4",
+      "entity": "niiri:3ed2c390b2b8ba7d7280d7aaf1f7a0e5"
     },
     {
-      "@id": "niiri:cd1d0726bfbfd0c8dcf44e488847af21",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:7f48dee052c9626e7e52439acf0f2384",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0115",
-      "prov:atLocation": {"@id": "niiri:d8e7b7fa7fb7e7092c042bb009e8db72"},
+      "prov:atLocation": {"@id": "niiri:a1e1bf42329e82bb1986471311192a86"},
       "prov:value": {"@type": "xsd:float", "@value": "2.08849263191223"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.36196875235771"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000386944402984701"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999998401"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.636831894546098"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.36196875235771"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000386944402984701"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999998401"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.636831894546098"}
     },
     {
-      "@id": "niiri:d8e7b7fa7fb7e7092c042bb009e8db72",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a1e1bf42329e82bb1986471311192a86",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0115",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[46,36,38]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[46,36,38]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cd1d0726bfbfd0c8dcf44e488847af21",
-      "entity": "niiri:002c13dfe076dd8552445efc13f91b3d"
+      "entity_derived": "niiri:7f48dee052c9626e7e52439acf0f2384",
+      "entity": "niiri:a7eac8bb5c994b37b60795763e4a8b47"
     },
     {
-      "@id": "niiri:17fa3bf584ad6f7ea20184d3034a22a6",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:4d3efcbf06221edd111b9ececccbf578",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0116",
-      "prov:atLocation": {"@id": "niiri:9050d4ad77c29dfda22d2d055fe0629d"},
+      "prov:atLocation": {"@id": "niiri:5a4dc409a4f82fe2fbd2adb378f0236f"},
       "prov:value": {"@type": "xsd:float", "@value": "2.08788776397705"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.36118617856085"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000388042466764382"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999998489"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.636831894546098"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.36118617856085"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000388042466764382"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999998489"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.636831894546098"}
     },
     {
-      "@id": "niiri:9050d4ad77c29dfda22d2d055fe0629d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:5a4dc409a4f82fe2fbd2adb378f0236f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0116",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-54,6,42]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-54,6,42]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:17fa3bf584ad6f7ea20184d3034a22a6",
-      "entity": "niiri:9a0b88bb0f2e1591fd4c0a65c1e565f2"
+      "entity_derived": "niiri:4d3efcbf06221edd111b9ececccbf578",
+      "entity": "niiri:df913e2209fc5cbf0b94dbb97361067d"
     },
     {
-      "@id": "niiri:9285e0a2ee7e0627d9fd74b3efb08113",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:559d842aee52f555e32eaea8e5f6af4d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0117",
-      "prov:atLocation": {"@id": "niiri:c7c4b7d3510c53b86bd5cb10b8f9905e"},
+      "prov:atLocation": {"@id": "niiri:342a55c31a6fd1e19f7882456cd37086"},
       "prov:value": {"@type": "xsd:float", "@value": "2.08684039115906"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.35983108220205"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000389950706039088"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999999863"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.636831894546098"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.35983108220205"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000389950706039088"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999999863"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.636831894546098"}
     },
     {
-      "@id": "niiri:c7c4b7d3510c53b86bd5cb10b8f9905e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:342a55c31a6fd1e19f7882456cd37086",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0117",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-34,-40,-40]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-34,-40,-40]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9285e0a2ee7e0627d9fd74b3efb08113",
-      "entity": "niiri:5c85689f9d81af447c3f8df3048c263a"
+      "entity_derived": "niiri:559d842aee52f555e32eaea8e5f6af4d",
+      "entity": "niiri:20e5d869565077dcc873c4847e343626"
     },
     {
-      "@id": "niiri:6c9cfc1e05c5dc7987619c61e02edaab",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:9bfa3d4282d5fe49d0a5d7837246515a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0118",
-      "prov:atLocation": {"@id": "niiri:1ebfa3ca523132a3093dc7f3c39990d5"},
+      "prov:atLocation": {"@id": "niiri:167f928519ef5a6d9da97ba177d7a184"},
       "prov:value": {"@type": "xsd:float", "@value": "2.08542251586914"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.35799660180066"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000392547891568396"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999998802"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.637367081876291"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.35799660180066"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000392547891568396"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999998802"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.637367081876291"}
     },
     {
-      "@id": "niiri:1ebfa3ca523132a3093dc7f3c39990d5",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:167f928519ef5a6d9da97ba177d7a184",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0118",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-4,8,62]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-4,8,62]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6c9cfc1e05c5dc7987619c61e02edaab",
-      "entity": "niiri:ee254d71e90697d1d1a39f5a3df69e4f"
+      "entity_derived": "niiri:9bfa3d4282d5fe49d0a5d7837246515a",
+      "entity": "niiri:b53c18c408c426d6208825bc03bda76c"
     },
     {
-      "@id": "niiri:3df29400a892f88119dbe17233278be3",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ed129b762540244ebbab654eba8430b6",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0119",
-      "prov:atLocation": {"@id": "niiri:d38839054a2a64a7c97fbfca0836339c"},
+      "prov:atLocation": {"@id": "niiri:0b74a6907723aa376792f985e57be958"},
       "prov:value": {"@type": "xsd:float", "@value": "2.07837462425232"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.34887743272549"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000405698407881738"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999388"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.647755183120289"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.34887743272549"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000405698407881738"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999388"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.647755183120289"}
     },
     {
-      "@id": "niiri:d38839054a2a64a7c97fbfca0836339c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0b74a6907723aa376792f985e57be958",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0119",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-66,-48,8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-66,-48,8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3df29400a892f88119dbe17233278be3",
-      "entity": "niiri:d7e6ee1864f4fe14f463aecb07ee9b99"
+      "entity_derived": "niiri:ed129b762540244ebbab654eba8430b6",
+      "entity": "niiri:5040d4f96058237b55074ccbae780c73"
     },
     {
-      "@id": "niiri:49eb20197d83d498cea456dcb6b038af",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:aa361f26f45828a6bf37d7fa0ef9e035",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0120",
-      "prov:atLocation": {"@id": "niiri:de4598ba76fddda51f2024149c6901b7"},
+      "prov:atLocation": {"@id": "niiri:e7a563685357fbfa9c1ec890f67b4177"},
       "prov:value": {"@type": "xsd:float", "@value": "2.07339262962341"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.34243086058129"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000415240207444101"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999623"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.656030294621312"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.34243086058129"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000415240207444101"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999623"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.656030294621312"}
     },
     {
-      "@id": "niiri:de4598ba76fddda51f2024149c6901b7",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e7a563685357fbfa9c1ec890f67b4177",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0120",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[8,8,58]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[8,8,58]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:49eb20197d83d498cea456dcb6b038af",
-      "entity": "niiri:de906422e6143ba14adec0aefe299e8c"
+      "entity_derived": "niiri:aa361f26f45828a6bf37d7fa0ef9e035",
+      "entity": "niiri:dc90ccd75e3ef3f441e343a64ffc8a53"
     },
     {
-      "@id": "niiri:937511163efff646fa513c15bc70be96",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:50115084698b0f76f38b7c1104d53bc9",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0121",
-      "prov:atLocation": {"@id": "niiri:0302d7ce60cd462a2082cd34e536d9cc"},
+      "prov:atLocation": {"@id": "niiri:36a59a6bca96123bd24e4f7fb86b1265"},
       "prov:value": {"@type": "xsd:float", "@value": "2.07233357429504"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.34106042406055"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000417295287676644"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999999966"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.656030294621312"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.34106042406055"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000417295287676644"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999999966"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.656030294621312"}
     },
     {
-      "@id": "niiri:0302d7ce60cd462a2082cd34e536d9cc",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:36a59a6bca96123bd24e4f7fb86b1265",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0121",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[28,2,42]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[28,2,42]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:937511163efff646fa513c15bc70be96",
-      "entity": "niiri:cc05429585cad5ec4458634a29892454"
+      "entity_derived": "niiri:50115084698b0f76f38b7c1104d53bc9",
+      "entity": "niiri:92eaf289a4d8a69bb8c61dcf57734f87"
     },
     {
-      "@id": "niiri:b21d942c173e824002b2772382da9840",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:371a172468bf76afe6aadb917ee05964",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0122",
-      "prov:atLocation": {"@id": "niiri:3f141491b7a8bbcb749b9ea922b98902"},
+      "prov:atLocation": {"@id": "niiri:1fdf380fc216afd4e474f786711ae4a3"},
       "prov:value": {"@type": "xsd:float", "@value": "2.07037234306335"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.33852251317794"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000421126024625074"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999999972"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.656638431383812"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.33852251317794"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000421126024625074"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999999972"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.656638431383812"}
     },
     {
-      "@id": "niiri:3f141491b7a8bbcb749b9ea922b98902",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:1fdf380fc216afd4e474f786711ae4a3",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0122",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-26,-62,38]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-26,-62,38]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b21d942c173e824002b2772382da9840",
-      "entity": "niiri:f8f459cc5e943c333944b0423cc623a2"
+      "entity_derived": "niiri:371a172468bf76afe6aadb917ee05964",
+      "entity": "niiri:c40c3a11ae575e327a69951e39f7cf1e"
     },
     {
-      "@id": "niiri:8b6ced60e5b47931d4187c836abb1dfe",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:dbaab492fac4e6b9eab8dcfc58c98506",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0123",
-      "prov:atLocation": {"@id": "niiri:8ff1c298a3fec8667e82520696ac6166"},
+      "prov:atLocation": {"@id": "niiri:bf121c922c17087120c57855bde78999"},
       "prov:value": {"@type": "xsd:float", "@value": "2.06974482536316"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.33771046876864"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000422358600173256"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999736"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.656638431383812"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.33771046876864"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000422358600173256"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999736"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.656638431383812"}
     },
     {
-      "@id": "niiri:8ff1c298a3fec8667e82520696ac6166",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:bf121c922c17087120c57855bde78999",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0123",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-26,42,32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-26,42,32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8b6ced60e5b47931d4187c836abb1dfe",
-      "entity": "niiri:be7c69bccd607857ab4a3b06e884b72d"
+      "entity_derived": "niiri:dbaab492fac4e6b9eab8dcfc58c98506",
+      "entity": "niiri:004221f4a994d829f5e16e54483a92e9"
     },
     {
-      "@id": "niiri:3989dda2297cd77495e3051c4de50150",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ffed331acd64084a30d48b98739e86bc",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0124",
-      "prov:atLocation": {"@id": "niiri:ae72d094af2f8c422748cab031da52ef"},
+      "prov:atLocation": {"@id": "niiri:922a9bfb72c5e23ead8d55c367f66e58"},
       "prov:value": {"@type": "xsd:float", "@value": "2.03006720542908"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.28635424154638"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000507466425831105"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999996"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.719385736915496"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.28635424154638"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000507466425831105"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999996"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.719385736915496"}
     },
     {
-      "@id": "niiri:ae72d094af2f8c422748cab031da52ef",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:922a9bfb72c5e23ead8d55c367f66e58",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0124",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-24,52,30]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-24,52,30]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3989dda2297cd77495e3051c4de50150",
-      "entity": "niiri:be7c69bccd607857ab4a3b06e884b72d"
+      "entity_derived": "niiri:ffed331acd64084a30d48b98739e86bc",
+      "entity": "niiri:004221f4a994d829f5e16e54483a92e9"
     },
     {
-      "@id": "niiri:943d8ea65a34b33a47976e062f6a368f",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3d0a016a27aa65b6bbbd681333dcc446",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0125",
-      "prov:atLocation": {"@id": "niiri:048e657a7227e7e329425dc2055e6be6"},
+      "prov:atLocation": {"@id": "niiri:f67405bdcbba3036ce596ecbe71d55f6"},
       "prov:value": {"@type": "xsd:float", "@value": "2.06143498420715"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.32695652276829"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000439000355666241"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999885"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.670181351155627"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.32695652276829"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000439000355666241"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999885"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.670181351155627"}
     },
     {
-      "@id": "niiri:048e657a7227e7e329425dc2055e6be6",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f67405bdcbba3036ce596ecbe71d55f6",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0125",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[18,38,14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[18,38,14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:943d8ea65a34b33a47976e062f6a368f",
-      "entity": "niiri:a5b505175149fb44eaa5bccb967891c3"
+      "entity_derived": "niiri:3d0a016a27aa65b6bbbd681333dcc446",
+      "entity": "niiri:996665a23456cb618780744372406eba"
     },
     {
-      "@id": "niiri:60958ed45d1baa949b1cd8d6a591a985",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:86b63b6d4bdec0c181ff785f7344f2f7",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0126",
-      "prov:atLocation": {"@id": "niiri:5c219ed33cb5d814bdb651ebd08f745f"},
+      "prov:atLocation": {"@id": "niiri:55bcafcdb10ff4c30819df223c6bb9f9"},
       "prov:value": {"@type": "xsd:float", "@value": "2.05234718322754"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.31519469431882"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000457896584486805"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999955"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.688415587572674"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.31519469431882"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000457896584486805"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999955"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.688415587572674"}
     },
     {
-      "@id": "niiri:5c219ed33cb5d814bdb651ebd08f745f",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:55bcafcdb10ff4c30819df223c6bb9f9",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0126",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[24,22,-26]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[24,22,-26]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:60958ed45d1baa949b1cd8d6a591a985",
-      "entity": "niiri:d03fcb703af0be07c63c073c3c59f291"
+      "entity_derived": "niiri:86b63b6d4bdec0c181ff785f7344f2f7",
+      "entity": "niiri:09c11fea29165ff889d59486cc998f06"
     },
     {
-      "@id": "niiri:28795c7a70521ea48ad2b2773eaff88a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e8710216ba3ec832f617a9e1b98c0bf3",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0127",
-      "prov:atLocation": {"@id": "niiri:73f36a5c652363f8af24b39474bb7ca8"},
+      "prov:atLocation": {"@id": "niiri:503f728df63ec6878c21347bf151b385"},
       "prov:value": {"@type": "xsd:float", "@value": "2.04952502250671"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.31154189928606"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000463916722561963"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999966"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.689628882399469"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.31154189928606"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000463916722561963"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999966"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.689628882399469"}
     },
     {
-      "@id": "niiri:73f36a5c652363f8af24b39474bb7ca8",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:503f728df63ec6878c21347bf151b385",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0127",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[62,-42,26]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[62,-42,26]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:28795c7a70521ea48ad2b2773eaff88a",
-      "entity": "niiri:6a8c63619c891d6d617b0e6030a35936"
+      "entity_derived": "niiri:e8710216ba3ec832f617a9e1b98c0bf3",
+      "entity": "niiri:10c4f42b041516447c28674dab2cde5b"
     },
     {
-      "@id": "niiri:2f6f37924ebaeb962fce392c98fae6d9",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:6c4a7be328ce49c5e98564e34076236c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0128",
-      "prov:atLocation": {"@id": "niiri:dce6e5d4a844922801571f0c371032e3"},
+      "prov:atLocation": {"@id": "niiri:2802bfbc4d5696139c24254736b2ec6e"},
       "prov:value": {"@type": "xsd:float", "@value": "2.04026675224304"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.29955792608204"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000484186200885861"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999987"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.708672597818405"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.29955792608204"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000484186200885861"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999987"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.708672597818405"}
     },
     {
-      "@id": "niiri:dce6e5d4a844922801571f0c371032e3",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:2802bfbc4d5696139c24254736b2ec6e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0128",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[54,28,-8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[54,28,-8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2f6f37924ebaeb962fce392c98fae6d9",
-      "entity": "niiri:12507a0af7ca022693fcfe481576aa45"
+      "entity_derived": "niiri:6c4a7be328ce49c5e98564e34076236c",
+      "entity": "niiri:c39f3e559dae9a5d556ae9b5045842da"
     },
     {
-      "@id": "niiri:d367cf8389c97c1ad25198640830b20e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b8b143f3a3bab02055f06c8fa221c1c4",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0129",
-      "prov:atLocation": {"@id": "niiri:476b54688070916766e3919a28c9c947"},
+      "prov:atLocation": {"@id": "niiri:7074580d5d21e58a02ca62c86ceee8a4"},
       "prov:value": {"@type": "xsd:float", "@value": "2.03539657592773"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.2932534755313"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000495175737833864"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999992"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.714810085213215"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.2932534755313"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000495175737833864"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999992"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.714810085213215"}
     },
     {
-      "@id": "niiri:476b54688070916766e3919a28c9c947",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7074580d5d21e58a02ca62c86ceee8a4",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0129",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[26,18,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[26,18,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d367cf8389c97c1ad25198640830b20e",
-      "entity": "niiri:308103904b8257fddf3a4611eaa9b395"
+      "entity_derived": "niiri:b8b143f3a3bab02055f06c8fa221c1c4",
+      "entity": "niiri:231b63a3acf5fa6923ad638c6827b93e"
     },
     {
-      "@id": "niiri:f826c6e194984f9c58b034165b203112",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:bbb810096180dab5916a19ea19eb4d52",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0130",
-      "prov:atLocation": {"@id": "niiri:3a87641dfd87d4889ef813b341d6b8b2"},
+      "prov:atLocation": {"@id": "niiri:dc3f0897a248b50a8c972c3fe31b0be6"},
       "prov:value": {"@type": "xsd:float", "@value": "2.03219079971313"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.28910342358113"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000502535420826677"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999995"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.717697062544172"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.28910342358113"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000502535420826677"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999995"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.717697062544172"}
     },
     {
-      "@id": "niiri:3a87641dfd87d4889ef813b341d6b8b2",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:dc3f0897a248b50a8c972c3fe31b0be6",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0130",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[56,4,-36]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[56,4,-36]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f826c6e194984f9c58b034165b203112",
-      "entity": "niiri:8b5a3b06127829c3d92a63e07d1c594d"
+      "entity_derived": "niiri:bbb810096180dab5916a19ea19eb4d52",
+      "entity": "niiri:7a2a292e9fd06f3e19425b30b04888ad"
     },
     {
-      "@id": "niiri:052883bbfd04c4c83f00204a80507ae3",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5ad6239481925bf6bc3a6ffbd30cf7e6",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0131",
-      "prov:atLocation": {"@id": "niiri:5b4f61b279b53dacfaa5ced8b12ab0d1"},
+      "prov:atLocation": {"@id": "niiri:0f51826584cb999e63e872c756b90d6c"},
       "prov:value": {"@type": "xsd:float", "@value": "2.0319082736969"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.28873767184649"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000503188874995342"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999995"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.717697062544172"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.28873767184649"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000503188874995342"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999995"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.717697062544172"}
     },
     {
-      "@id": "niiri:5b4f61b279b53dacfaa5ced8b12ab0d1",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0f51826584cb999e63e872c756b90d6c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0131",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[14,-92,24]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[14,-92,24]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:052883bbfd04c4c83f00204a80507ae3",
-      "entity": "niiri:24c2094ec130702f9601c371533bf8d4"
+      "entity_derived": "niiri:5ad6239481925bf6bc3a6ffbd30cf7e6",
+      "entity": "niiri:f7777aa15969e9f0700b324454e85979"
     },
     {
-      "@id": "niiri:70640009a4f983a49b074a694de146c9",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:29763b527003432a0c2b21c172ec4a81",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0132",
-      "prov:atLocation": {"@id": "niiri:5bf615edd3cb908169b24663bf3790c9"},
+      "prov:atLocation": {"@id": "niiri:b5b1c2b39a254a42755330020659e9d8"},
       "prov:value": {"@type": "xsd:float", "@value": "2.02607893943787"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.2811909187824"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000516848742881382"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999997"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.724198294562932"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.2811909187824"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000516848742881382"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999997"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.724198294562932"}
     },
     {
-      "@id": "niiri:5bf615edd3cb908169b24663bf3790c9",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b5b1c2b39a254a42755330020659e9d8",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0132",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[12,56,0]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[12,56,0]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:70640009a4f983a49b074a694de146c9",
-      "entity": "niiri:e0fb0b6fe7935f93d9ab789f37f5ba17"
+      "entity_derived": "niiri:29763b527003432a0c2b21c172ec4a81",
+      "entity": "niiri:8005738cdc3c09b780e2ba1a36547702"
     },
     {
-      "@id": "niiri:3013598eebb8d30aeaf7fe1e9354e1d2",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b10c8559c8983dbf10bcbbd87ba3a30b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0133",
-      "prov:atLocation": {"@id": "niiri:2d17d5edb780d63141de80727c097471"},
+      "prov:atLocation": {"@id": "niiri:f883d32b205932078c22794402ab6d7d"},
       "prov:value": {"@type": "xsd:float", "@value": "2.01380300521851"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.26529688051921"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000546747002303394"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999999"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.745134331831463"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.26529688051921"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000546747002303394"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999999"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.745134331831463"}
     },
     {
-      "@id": "niiri:2d17d5edb780d63141de80727c097471",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f883d32b205932078c22794402ab6d7d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0133",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[62,32,-12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[62,32,-12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3013598eebb8d30aeaf7fe1e9354e1d2",
-      "entity": "niiri:8cf845d47cedee91dcbc9b5f4add50e4"
+      "entity_derived": "niiri:b10c8559c8983dbf10bcbbd87ba3a30b",
+      "entity": "niiri:bd14daedcd6c35f47c42f6681a25a48e"
     },
     {
-      "@id": "niiri:3e99f0369731d3c2777ef51eb04932bc",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b4e1b1ca0ed3d9d8f28f683410396141",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0134",
-      "prov:atLocation": {"@id": "niiri:d8b80850bbe10a9d38347e6f796cb907"},
+      "prov:atLocation": {"@id": "niiri:fb5f8c42764e6c71abadc95704e8f2c2"},
       "prov:value": {"@type": "xsd:float", "@value": "2.00120663642883"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.24898603700399"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000579085815334945"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.768049313732932"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.24898603700399"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000579085815334945"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.768049313732932"}
     },
     {
-      "@id": "niiri:d8b80850bbe10a9d38347e6f796cb907",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:fb5f8c42764e6c71abadc95704e8f2c2",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0134",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[38,-74,26]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[38,-74,26]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3e99f0369731d3c2777ef51eb04932bc",
-      "entity": "niiri:51fdd8b821079d1b5dc1b6834e5fb0af"
+      "entity_derived": "niiri:b4e1b1ca0ed3d9d8f28f683410396141",
+      "entity": "niiri:30ebc4167834c5d88670b4e8b93ee950"
     },
     {
-      "@id": "niiri:fac48b92d9cbec66e0c2918bbd816c8a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:2c97f5daab495771999c9c6ed9658dae",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0135",
-      "prov:atLocation": {"@id": "niiri:6c36d95ebac8c804899be9e393edf5ac"},
+      "prov:atLocation": {"@id": "niiri:2aa43c399b59790e4dfbf04b8fbd8f94"},
       "prov:value": {"@type": "xsd:float", "@value": "1.99859607219696"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.24560542001545"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000586005808283274"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.771799008009002"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.24560542001545"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000586005808283274"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.771799008009002"}
     },
     {
-      "@id": "niiri:6c36d95ebac8c804899be9e393edf5ac",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:2aa43c399b59790e4dfbf04b8fbd8f94",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0135",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-12,-96,24]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-12,-96,24]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:fac48b92d9cbec66e0c2918bbd816c8a",
-      "entity": "niiri:a85e4f97fb1baa4a0c741f94e4bfc112"
+      "entity_derived": "niiri:2c97f5daab495771999c9c6ed9658dae",
+      "entity": "niiri:5d3db32c6d2773404bb204393a96f250"
     },
     {
-      "@id": "niiri:7125176cd7d21112e80e9abe57d013a1",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f1ee6434b4e9e350b5883b0db78d72fc",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0136",
-      "prov:atLocation": {"@id": "niiri:6e00e681e2511f3462c826f406f52e3d"},
+      "prov:atLocation": {"@id": "niiri:baca96ed8f0f9063a0508601dbbfaec3"},
       "prov:value": {"@type": "xsd:float", "@value": "1.99211156368256"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.2372077945609"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000603527423333361"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.784349992009541"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.2372077945609"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000603527423333361"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.784349992009541"}
     },
     {
-      "@id": "niiri:6e00e681e2511f3462c826f406f52e3d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:baca96ed8f0f9063a0508601dbbfaec3",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0136",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-30,-56,-20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-30,-56,-20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7125176cd7d21112e80e9abe57d013a1",
-      "entity": "niiri:7a8a9b5c480a5adb8ea8cce6dede2941"
+      "entity_derived": "niiri:f1ee6434b4e9e350b5883b0db78d72fc",
+      "entity": "niiri:6d6e5cd089cb7ce9b9715c42e896cd46"
     },
     {
-      "@id": "niiri:fdd0d41920ca415d3db0737c9245d96c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:08fdef8ced896bffb0a9f513bb82f661",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0137",
-      "prov:atLocation": {"@id": "niiri:8ed32c08d5d0d7a41c874b8f70eef474"},
+      "prov:atLocation": {"@id": "niiri:55b8ab77a10b3e815abd7fdaf9da8c21"},
       "prov:value": {"@type": "xsd:float", "@value": "1.97817039489746"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.21915195379217"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00064285166979039"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.812778132844403"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.21915195379217"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00064285166979039"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.812778132844403"}
     },
     {
-      "@id": "niiri:8ed32c08d5d0d7a41c874b8f70eef474",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:55b8ab77a10b3e815abd7fdaf9da8c21",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0137",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-32,-6,-6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-32,-6,-6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:fdd0d41920ca415d3db0737c9245d96c",
-      "entity": "niiri:c1f4268606ddda131fdee326fe51797d"
+      "entity_derived": "niiri:08fdef8ced896bffb0a9f513bb82f661",
+      "entity": "niiri:189cb4ae2ff1cc4b031011345ea5e5b0"
     },
     {
-      "@id": "niiri:cecedd5748ebd882e2bb17572676c7ab",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:33e039efa523781d074f8709e436c6c1",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0138",
-      "prov:atLocation": {"@id": "niiri:9ee407270638d05d844c960e0301a7f5"},
+      "prov:atLocation": {"@id": "niiri:8c6f1b0f1ca84fc63bf1d797146a2970"},
       "prov:value": {"@type": "xsd:float", "@value": "1.96776080131531"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.20566861907462"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000673745357239186"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.83480060265404"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.20566861907462"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000673745357239186"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.83480060265404"}
     },
     {
-      "@id": "niiri:9ee407270638d05d844c960e0301a7f5",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:8c6f1b0f1ca84fc63bf1d797146a2970",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0138",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[60,-46,44]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[60,-46,44]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cecedd5748ebd882e2bb17572676c7ab",
-      "entity": "niiri:50e9a0153fd5b58dfd6867a7820e429b"
+      "entity_derived": "niiri:33e039efa523781d074f8709e436c6c1",
+      "entity": "niiri:697f2d7f340407941e5a743646226280"
     },
     {
-      "@id": "niiri:4c5f85ea11aa48bf3b2ddf631a950f00",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:7d85e08ff8a27a219706a4be288209f2",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0139",
-      "prov:atLocation": {"@id": "niiri:2c9fc95c3608633b670c9073da4f7682"},
+      "prov:atLocation": {"@id": "niiri:df69c761e2c334ab7f7bc845d48eff42"},
       "prov:value": {"@type": "xsd:float", "@value": "1.96240246295929"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.19872762272311"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000690177580666695"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.842166706625736"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.19872762272311"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000690177580666695"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.842166706625736"}
     },
     {
-      "@id": "niiri:2c9fc95c3608633b670c9073da4f7682",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:df69c761e2c334ab7f7bc845d48eff42",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0139",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-52,12,-8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-52,12,-8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4c5f85ea11aa48bf3b2ddf631a950f00",
-      "entity": "niiri:9fe72cde6498f2f7dfe77dfb89b501c0"
+      "entity_derived": "niiri:7d85e08ff8a27a219706a4be288209f2",
+      "entity": "niiri:15af37e0e71211cb9816e08cc4cd0b88"
     },
     {
-      "@id": "niiri:935ece2cf4bb43334306912c68963843",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:1952a27691fae0a16a11d4d1da1b6ab0",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0140",
-      "prov:atLocation": {"@id": "niiri:49f78a6659b3182e5edfcacd463fa87f"},
+      "prov:atLocation": {"@id": "niiri:4a129fd0910d8fcc9ed909a91502fe25"},
       "prov:value": {"@type": "xsd:float", "@value": "1.96232461929321"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.19862678466389"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00069041900707012"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.842166706625736"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.19862678466389"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00069041900707012"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.842166706625736"}
     },
     {
-      "@id": "niiri:49f78a6659b3182e5edfcacd463fa87f",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4a129fd0910d8fcc9ed909a91502fe25",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0140",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-14,2,46]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-14,2,46]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:935ece2cf4bb43334306912c68963843",
-      "entity": "niiri:4316bec42f97f257669a294c8fd0898f"
+      "entity_derived": "niiri:1952a27691fae0a16a11d4d1da1b6ab0",
+      "entity": "niiri:3fb8aaff3e01f2366b6d14baa9559ec9"
     },
     {
-      "@id": "niiri:63f3b74085b3f8b9cc4abea248909bc4",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:28fc29227a7d0e7b676cba34c11619a0",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0141",
-      "prov:atLocation": {"@id": "niiri:b29fbc36547d77044d403e3bcffe4569"},
+      "prov:atLocation": {"@id": "niiri:5844e4e8f06aabbaf3dc89083886f1be"},
       "prov:value": {"@type": "xsd:float", "@value": "1.96151995658875"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.19758442738721"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000692919185722674"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.842166706625736"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.19758442738721"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000692919185722674"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.842166706625736"}
     },
     {
-      "@id": "niiri:b29fbc36547d77044d403e3bcffe4569",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:5844e4e8f06aabbaf3dc89083886f1be",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0141",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[34,-60,-32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[34,-60,-32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:63f3b74085b3f8b9cc4abea248909bc4",
-      "entity": "niiri:80346292a2b394403637328758a9b61a"
+      "entity_derived": "niiri:28fc29227a7d0e7b676cba34c11619a0",
+      "entity": "niiri:557d4e957f05b5913d7a77c829b15561"
     },
     {
-      "@id": "niiri:af8b6a131b6c3af534271c4ca1f18c32",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:4969976c6b8f566ff774a986d7a36a79",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0142",
-      "prov:atLocation": {"@id": "niiri:ea3df53306d01ec8088b4b689f76170f"},
+      "prov:atLocation": {"@id": "niiri:146d39b6994eeae0540ab9b27e8c09be"},
       "prov:value": {"@type": "xsd:float", "@value": "1.95875000953674"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.19399619652422"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000701589830133797"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.843663873798835"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.19399619652422"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000701589830133797"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.843663873798835"}
     },
     {
-      "@id": "niiri:ea3df53306d01ec8088b4b689f76170f",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:146d39b6994eeae0540ab9b27e8c09be",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0142",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[12,-10,8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[12,-10,8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:af8b6a131b6c3af534271c4ca1f18c32",
-      "entity": "niiri:a8192adc0f3eb7c0e3ebb68c9944ac3b"
+      "entity_derived": "niiri:4969976c6b8f566ff774a986d7a36a79",
+      "entity": "niiri:73719d062893a763bcb9efcf192d5c98"
     },
     {
-      "@id": "niiri:8b9185341402a11991efde670e9e6f66",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:9601c3a9c37cd454e282dd247386189b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0143",
-      "prov:atLocation": {"@id": "niiri:ffa93c68ea8659ed2a7db6e4d7ae25a4"},
+      "prov:atLocation": {"@id": "niiri:8ba20ce09c34b99a2b6902f97564b1d0"},
       "prov:value": {"@type": "xsd:float", "@value": "1.9506379365921"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.1834872473508"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000727562614758925"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.859623644795425"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.1834872473508"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000727562614758925"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.859623644795425"}
     },
     {
-      "@id": "niiri:ffa93c68ea8659ed2a7db6e4d7ae25a4",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:8ba20ce09c34b99a2b6902f97564b1d0",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0143",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[44,42,-18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[44,42,-18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8b9185341402a11991efde670e9e6f66",
-      "entity": "niiri:a9c299e42713dde6d9d2880ee2d4dc18"
+      "entity_derived": "niiri:9601c3a9c37cd454e282dd247386189b",
+      "entity": "niiri:254124ed2b4a8c1c5be4de8f4c74580d"
     },
     {
-      "@id": "niiri:bd5d0f8606686eea25c5615845c925d6",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:4fe52494e0e2ce9d3cab8ce7ef9c43a2",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0144",
-      "prov:atLocation": {"@id": "niiri:06f32fa93951ec4535d97c02f2eee40c"},
+      "prov:atLocation": {"@id": "niiri:1ffc820e35aa9baee7e0c3ed0d901ab2"},
       "prov:value": {"@type": "xsd:float", "@value": "1.94860780239105"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.18085716601903"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00073420004030933"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.86202414328266"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.18085716601903"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00073420004030933"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.86202414328266"}
     },
     {
-      "@id": "niiri:06f32fa93951ec4535d97c02f2eee40c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:1ffc820e35aa9baee7e0c3ed0d901ab2",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0144",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[18,56,2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[18,56,2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:bd5d0f8606686eea25c5615845c925d6",
-      "entity": "niiri:03911a1948dcd4aa2ec73ec06aafd889"
+      "entity_derived": "niiri:4fe52494e0e2ce9d3cab8ce7ef9c43a2",
+      "entity": "niiri:a0c4e98f01e68139790391bbf8725466"
     },
     {
-      "@id": "niiri:65f979b51ad4e0ee65d1ee4f18530b2b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:6a53d2070def16165db38789830277ca",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0145",
-      "prov:atLocation": {"@id": "niiri:601c8057e29626ca32504027ce0a5dd4"},
+      "prov:atLocation": {"@id": "niiri:95aae888c2d85975406eda8841e11c3f"},
       "prov:value": {"@type": "xsd:float", "@value": "1.94670081138611"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.1783865823579"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000740485731772766"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.86202414328266"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.1783865823579"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000740485731772766"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.86202414328266"}
     },
     {
-      "@id": "niiri:601c8057e29626ca32504027ce0a5dd4",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:95aae888c2d85975406eda8841e11c3f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0145",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[50,24,40]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[50,24,40]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:65f979b51ad4e0ee65d1ee4f18530b2b",
-      "entity": "niiri:5114d29fe7a8bba54bb5318e7211dbb7"
+      "entity_derived": "niiri:6a53d2070def16165db38789830277ca",
+      "entity": "niiri:98295b38fd8a93e7e4ee1dfd88c76887"
     },
     {
-      "@id": "niiri:a80a6832ad5a92aaf0d96af2e158f184",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:78ecf12590514c80a21b976921614adc",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0146",
-      "prov:atLocation": {"@id": "niiri:f4636a13417610438687a50e8f2ad971"},
+      "prov:atLocation": {"@id": "niiri:dca356aa3b54948ba75d86da6cafa306"},
       "prov:value": {"@type": "xsd:float", "@value": "1.93218469619751"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.1595792273601"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0007899856837843"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.892323800210792"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.1595792273601"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0007899856837843"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.892323800210792"}
     },
     {
-      "@id": "niiri:f4636a13417610438687a50e8f2ad971",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:dca356aa3b54948ba75d86da6cafa306",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0146",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-26,-90,28]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-26,-90,28]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a80a6832ad5a92aaf0d96af2e158f184",
-      "entity": "niiri:cf393803c8dfe5f95ebba7fb00f78d36"
+      "entity_derived": "niiri:78ecf12590514c80a21b976921614adc",
+      "entity": "niiri:33a90732b73cfec988bd66955a0c2126"
     },
     {
-      "@id": "niiri:f73ffa6cf0d3710798aa60a39cdde82b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:2cc54cd7893515b53af0b26c486419e8",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0147",
-      "prov:atLocation": {"@id": "niiri:b65dbf5c193a7f3a2f2a971b17e6575c"},
+      "prov:atLocation": {"@id": "niiri:55ddd3faba6b02c3055057f36f9a40ba"},
       "prov:value": {"@type": "xsd:float", "@value": "1.9286732673645"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.15502945825559"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000802409503939616"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.899089242384032"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.15502945825559"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000802409503939616"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.899089242384032"}
     },
     {
-      "@id": "niiri:b65dbf5c193a7f3a2f2a971b17e6575c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:55ddd3faba6b02c3055057f36f9a40ba",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0147",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-54,-12,44]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-54,-12,44]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f73ffa6cf0d3710798aa60a39cdde82b",
-      "entity": "niiri:313761c03f2118d6c60dd97a4be2bd9d"
+      "entity_derived": "niiri:2cc54cd7893515b53af0b26c486419e8",
+      "entity": "niiri:ec3bd6715d891de0f42ba2dc11f9430c"
     },
     {
-      "@id": "niiri:8d12964daed2141b417b82a940db9902",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:383e2e40e4478c46a885723e580540e9",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0148",
-      "prov:atLocation": {"@id": "niiri:65eea2de7637f9413802bc4dce794b1b"},
+      "prov:atLocation": {"@id": "niiri:cfd86c6efe2ad2bbacea8ddaa77f7b0f"},
       "prov:value": {"@type": "xsd:float", "@value": "1.9261577129364"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.15176997808161"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000811420301080279"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.903090399433177"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.15176997808161"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000811420301080279"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.903090399433177"}
     },
     {
-      "@id": "niiri:65eea2de7637f9413802bc4dce794b1b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:cfd86c6efe2ad2bbacea8ddaa77f7b0f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0148",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-48,-38,-12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-48,-38,-12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8d12964daed2141b417b82a940db9902",
-      "entity": "niiri:f80911af8d0e7423917d1703bda349c3"
+      "entity_derived": "niiri:383e2e40e4478c46a885723e580540e9",
+      "entity": "niiri:8aa002c426d46d7b9d4dc5e2c38279d3"
     },
     {
-      "@id": "niiri:21f542b06ffdb017ec14021bc35dd49e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d6f790d81f1079150604aaa16ea4f5c7",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0149",
-      "prov:atLocation": {"@id": "niiri:a67ce5a503588268d5747d9e23641a20"},
+      "prov:atLocation": {"@id": "niiri:a57f977529bc658a16c9ca211d898787"},
       "prov:value": {"@type": "xsd:float", "@value": "1.92179548740387"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.14611757652157"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00082726738760952"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.909690617648608"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.14611757652157"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00082726738760952"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.909690617648608"}
     },
     {
-      "@id": "niiri:a67ce5a503588268d5747d9e23641a20",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a57f977529bc658a16c9ca211d898787",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0149",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[64,-36,16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[64,-36,16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:21f542b06ffdb017ec14021bc35dd49e",
-      "entity": "niiri:b2335168bac5f013fca6c3119b31817e"
+      "entity_derived": "niiri:d6f790d81f1079150604aaa16ea4f5c7",
+      "entity": "niiri:5d895214e17bb9af3199b1f47611a048"
     },
     {
-      "@id": "niiri:ff3e0a672bdc9ce11edf9d4e634e7f23",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:61c1675e82feee3a2ba070ebd84e8f84",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0150",
-      "prov:atLocation": {"@id": "niiri:d8210fda037302069bc7c8849638ad45"},
+      "prov:atLocation": {"@id": "niiri:01c04a79b15ce0c1fb943eeaf3cba959"},
       "prov:value": {"@type": "xsd:float", "@value": "1.92164015769958"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.1459163032625"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000827836893399936"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.909690617648608"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.1459163032625"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000827836893399936"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.909690617648608"}
     },
     {
-      "@id": "niiri:d8210fda037302069bc7c8849638ad45",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:01c04a79b15ce0c1fb943eeaf3cba959",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0150",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[34,-22,68]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[34,-22,68]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ff3e0a672bdc9ce11edf9d4e634e7f23",
-      "entity": "niiri:c6d9b891da12e7c0dafddbc99f7cd3bd"
+      "entity_derived": "niiri:61c1675e82feee3a2ba070ebd84e8f84",
+      "entity": "niiri:781f6f173dae32b1495eaef04f1b405a"
     },
     {
-      "@id": "niiri:29e7942ca7e7b2881d65ee2187b7774a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b21afe1ebc2946d76e1feed501da0a13",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0151",
-      "prov:atLocation": {"@id": "niiri:74d0bdac6b9120cd8558e71fb6190fd3"},
+      "prov:atLocation": {"@id": "niiri:7228805920f29320ea05f2cac92707d8"},
       "prov:value": {"@type": "xsd:float", "@value": "1.91999924182892"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.14379002300768"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000833875309880328"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.911263261101385"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.14379002300768"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000833875309880328"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.911263261101385"}
     },
     {
-      "@id": "niiri:74d0bdac6b9120cd8558e71fb6190fd3",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7228805920f29320ea05f2cac92707d8",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0151",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-8,-78,38]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-8,-78,38]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:29e7942ca7e7b2881d65ee2187b7774a",
-      "entity": "niiri:02d752fd02bb32b544f85decb2637acb"
+      "entity_derived": "niiri:b21afe1ebc2946d76e1feed501da0a13",
+      "entity": "niiri:d98430357b786f52e1aba172bbfea688"
     },
     {
-      "@id": "niiri:b2c659fc604f4686862e8ea0bab8d778",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:2c07a6ac701630dbce313c1c9311af3a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0152",
-      "prov:atLocation": {"@id": "niiri:c47c33fd8876bdb2f0a4d5f5592fcfbf"},
+      "prov:atLocation": {"@id": "niiri:4960f9500adb74ecfb4ca0a6db8f59ab"},
       "prov:value": {"@type": "xsd:float", "@value": "1.91007256507874"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.13092665544988"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000871278372345574"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.936494724004281"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.13092665544988"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000871278372345574"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.936494724004281"}
     },
     {
-      "@id": "niiri:c47c33fd8876bdb2f0a4d5f5592fcfbf",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4960f9500adb74ecfb4ca0a6db8f59ab",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0152",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[2,-62,6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[2,-62,6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b2c659fc604f4686862e8ea0bab8d778",
-      "entity": "niiri:ca6249ceeaf778daf8955f1721d9b3bc"
+      "entity_derived": "niiri:2c07a6ac701630dbce313c1c9311af3a",
+      "entity": "niiri:fe57af8773140946a4555792ccdee632"
     },
     {
-      "@id": "niiri:8f19e13ce047783521c6821695258868",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:491c487f7a368b1aa7a2a4d48952759c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0153",
-      "prov:atLocation": {"@id": "niiri:43a6ca876100f41c7ef3926e23fb20d0"},
+      "prov:atLocation": {"@id": "niiri:6e76cea4d9ee60e95c20e1e738bf0ac3"},
       "prov:value": {"@type": "xsd:float", "@value": "1.90749907493591"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.12759169376378"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000881224174023254"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.940790144374657"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.12759169376378"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000881224174023254"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.940790144374657"}
     },
     {
-      "@id": "niiri:43a6ca876100f41c7ef3926e23fb20d0",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6e76cea4d9ee60e95c20e1e738bf0ac3",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0153",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[50,26,-16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[50,26,-16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8f19e13ce047783521c6821695258868",
-      "entity": "niiri:f5165ff916468849a9e8f0f984156ae0"
+      "entity_derived": "niiri:491c487f7a368b1aa7a2a4d48952759c",
+      "entity": "niiri:678cf59b6ed563cbae258da7bd9a2417"
     },
     {
-      "@id": "niiri:ea3d0ed5afeaf42e3e0a4e346d3fa4cf",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:fcca986bd2deab6ef39bb2525ae730c8",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0154",
-      "prov:atLocation": {"@id": "niiri:707d4e54013fc2135528a4bf96dfac54"},
+      "prov:atLocation": {"@id": "niiri:109a15fd9ceb50e814d71b953c67ae72"},
       "prov:value": {"@type": "xsd:float", "@value": "1.90495073795319"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.12428927452869"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000891175681828393"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.945029582142648"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.12428927452869"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000891175681828393"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.945029582142648"}
     },
     {
-      "@id": "niiri:707d4e54013fc2135528a4bf96dfac54",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:109a15fd9ceb50e814d71b953c67ae72",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0154",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-34,-36,38]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-34,-36,38]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ea3d0ed5afeaf42e3e0a4e346d3fa4cf",
-      "entity": "niiri:3c77b0eab26aadf473051def81f975f1"
+      "entity_derived": "niiri:fcca986bd2deab6ef39bb2525ae730c8",
+      "entity": "niiri:fb40247362abead8bfd05d8c0f86fcc6"
     },
     {
-      "@id": "niiri:7e1d2d825b7d3dacc015bd494ea8d5e2",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:358a334c1617e7ce360e2f5605342b32",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0155",
-      "prov:atLocation": {"@id": "niiri:1842cedd79001489b321ec541b8e98d3"},
+      "prov:atLocation": {"@id": "niiri:a6038e05091afb020d82c47e5d7b134c"},
       "prov:value": {"@type": "xsd:float", "@value": "1.90267658233643"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.1213421258659"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000900143739462567"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.948488792214144"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.1213421258659"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000900143739462567"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.948488792214144"}
     },
     {
-      "@id": "niiri:1842cedd79001489b321ec541b8e98d3",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a6038e05091afb020d82c47e5d7b134c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0155",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[14,-22,54]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[14,-22,54]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7e1d2d825b7d3dacc015bd494ea8d5e2",
-      "entity": "niiri:74f854bba7b4563710f1c71fe1bb4d87"
+      "entity_derived": "niiri:358a334c1617e7ce360e2f5605342b32",
+      "entity": "niiri:f0413bd7869f1537bac196460adb50ad"
     },
     {
-      "@id": "niiri:89070c5be87cc773e2698db540d64a2b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0e6bfffafd9d245f4dd49561f6c28e08",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0156",
-      "prov:atLocation": {"@id": "niiri:621713e5530af80a01c3a2b7aac9e629"},
+      "prov:atLocation": {"@id": "niiri:37db3664c9849d417bb8a0681cc58067"},
       "prov:value": {"@type": "xsd:float", "@value": "1.89570164680481"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.11230283620396"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000928169828270153"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.962543829897604"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.11230283620396"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000928169828270153"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.962543829897604"}
     },
     {
-      "@id": "niiri:621713e5530af80a01c3a2b7aac9e629",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:37db3664c9849d417bb8a0681cc58067",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0156",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[16,-8,36]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[16,-8,36]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:89070c5be87cc773e2698db540d64a2b",
-      "entity": "niiri:f0f6386c19242334018be62b5253762f"
+      "entity_derived": "niiri:0e6bfffafd9d245f4dd49561f6c28e08",
+      "entity": "niiri:fd3eca9e0c356a0d39da224ef34ff7aa"
     },
     {
-      "@id": "niiri:ce200de37fdbe8adf37894545907a465",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f45794d952959fc21a4f15a7662b0673",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0157",
-      "prov:atLocation": {"@id": "niiri:91a65d554778579b61ea2ff28c80fbc4"},
+      "prov:atLocation": {"@id": "niiri:596817d06440ee2934239c14263f4174"},
       "prov:value": {"@type": "xsd:float", "@value": "1.88845551013947"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.10291168362407"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000958134082593487"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.98075710938733"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.10291168362407"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000958134082593487"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.98075710938733"}
     },
     {
-      "@id": "niiri:91a65d554778579b61ea2ff28c80fbc4",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:596817d06440ee2934239c14263f4174",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0157",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[52,24,-14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[52,24,-14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ce200de37fdbe8adf37894545907a465",
-      "entity": "niiri:79f57cc3d9c8ce9cf2ddf678b180fec2"
+      "entity_derived": "niiri:f45794d952959fc21a4f15a7662b0673",
+      "entity": "niiri:b2244e3b33c0159757aa93c2de26c3a1"
     },
     {
-      "@id": "niiri:4fe2dc602f36bd67fd8bab5d7da32791",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ec709d3ce148902d8c0bd7af6efd254a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0158",
-      "prov:atLocation": {"@id": "niiri:70d5bff05c6dc7acac92ddd5f1ef2a79"},
+      "prov:atLocation": {"@id": "niiri:20a2d53484d9fe5f16ed0cf8192effdb"},
       "prov:value": {"@type": "xsd:float", "@value": "1.88693702220917"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.10094364030331"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000964525016047491"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.982061324215166"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.10094364030331"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000964525016047491"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.982061324215166"}
     },
     {
-      "@id": "niiri:70d5bff05c6dc7acac92ddd5f1ef2a79",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:20a2d53484d9fe5f16ed0cf8192effdb",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0158",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-32,-78,-6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-32,-78,-6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4fe2dc602f36bd67fd8bab5d7da32791",
-      "entity": "niiri:ac75e1b81a1c6524011de1087ab61a81"
+      "entity_derived": "niiri:ec709d3ce148902d8c0bd7af6efd254a",
+      "entity": "niiri:8b70b13ee54cf4407e3be646e313b866"
     },
     {
-      "@id": "niiri:922fdbc101a4d473eaf0d7104176114f",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:44179ac71aa6a866710bacec2f633862",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0159",
-      "prov:atLocation": {"@id": "niiri:3c2c76068027fe718f26d4c1d5abb690"},
+      "prov:atLocation": {"@id": "niiri:9a7ff27b1b6b41cb81e8847242b24fed"},
       "prov:value": {"@type": "xsd:float", "@value": "1.88384366035461"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.09693442242366"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000977665622006629"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.988067762617164"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.09693442242366"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000977665622006629"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.988067762617164"}
     },
     {
-      "@id": "niiri:3c2c76068027fe718f26d4c1d5abb690",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:9a7ff27b1b6b41cb81e8847242b24fed",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0159",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-20,36,46]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-20,36,46]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:922fdbc101a4d473eaf0d7104176114f",
-      "entity": "niiri:8006697d9195e3c3171a1c00415399c0"
+      "entity_derived": "niiri:44179ac71aa6a866710bacec2f633862",
+      "entity": "niiri:cfc211e4c6c91ecd22c4f0f2f0075044"
     },
     {
-      "@id": "niiri:b92d7dc441672c44a26b8109f1c47f0f",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:fdea430f757b7b55cda702759b054832",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0160",
-      "prov:atLocation": {"@id": "niiri:88597f469f050fbb7e74469503342c8e"},
+      "prov:atLocation": {"@id": "niiri:386e33278e20d303c4d3f45997d793bf"},
       "prov:value": {"@type": "xsd:float", "@value": "1.88228130340576"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.09490947009333"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000984364888377609"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.989519036052045"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.09490947009333"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000984364888377609"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.989519036052045"}
     },
     {
-      "@id": "niiri:88597f469f050fbb7e74469503342c8e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:386e33278e20d303c4d3f45997d793bf",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0160",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[42,24,-40]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[42,24,-40]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b92d7dc441672c44a26b8109f1c47f0f",
-      "entity": "niiri:8ea603bc4b1eabe8a8b1f02e165eef5e"
+      "entity_derived": "niiri:fdea430f757b7b55cda702759b054832",
+      "entity": "niiri:f00195d4acadb18083e5d9b4023ca225"
     }
   ]
 }

--- a/spmexport/ex_spm_partial_conjunction/nidm.ttl
+++ b/spmexport/ex_spm_partial_conjunction/nidm.ttl
@@ -4,7 +4,7 @@
 @prefix niiri: <http://iri.nidash.org/> .
 @prefix spm: <http://purl.org/nidash/spm#> .
 @prefix neurolex: <http://neurolex.org/wiki/> .
-@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#> .
+@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
@@ -17,27 +17,27 @@
 @prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-niiri:1e805678e8d91a4581c0bed1666665ec
+niiri:ba1fb3597bc0b59f859a3efc40c4f95b
   a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
   rdfs:label "NIDM-Results" ;
   nidm_version: "1.3.0"^^xsd:string .
 
-niiri:9c6891309f399ec96286e6577bc877cf
+niiri:36ef4229b87d0546f0547127a62087a2
   a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
   rdfs:label "spm_results_nidm" ;
-  nidm_softwareVersion: "12.6903"^^xsd:string .
+  nidm_softwareVersion: "12.7057"^^xsd:string .
 
-niiri:25cb52028c9f0280dca0e45a2dda8352
+niiri:d5312e2f7b2e014fe0e8c544933bdd34
   a prov:Activity, nidm_NIDMResultsExport: ; 
   rdfs:label "NIDM-Results export" .
 
-niiri:25cb52028c9f0280dca0e45a2dda8352 prov:wasAssociatedWith niiri:9c6891309f399ec96286e6577bc877cf .
+niiri:d5312e2f7b2e014fe0e8c544933bdd34 prov:wasAssociatedWith niiri:36ef4229b87d0546f0547127a62087a2 .
 
 _:blank5 a prov:Generation .
 
-niiri:1e805678e8d91a4581c0bed1666665ec prov:qualifiedGeneration _:blank5 .
+niiri:ba1fb3597bc0b59f859a3efc40c4f95b prov:qualifiedGeneration _:blank5 .
 
-_:blank5 prov:atTime "2016-12-07T16:09:15"^^xsd:dateTime .
+_:blank5 prov:atTime "2017-04-19T12:18:44"^^xsd:dateTime .
 
 @prefix nidm_Ixi549CoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000050> .
 @prefix src_SPM: <http://scicrunch.org/resolver/SCR_007037> .
@@ -141,12 +141,12 @@ _:blank5 prov:atTime "2016-12-07T16:09:15"^^xsd:dateTime .
 @prefix nidm_Coordinate: <http://purl.org/nidash/nidm#NIDM_0000015> .
 @prefix nidm_coordinateVector: <http://purl.org/nidash/nidm#NIDM_0000086> .
 
-niiri:efa026de268c2c7adcb83113c80feffe
+niiri:9d7bdfb1f005a1c77912a13aad1d7cca
     a prov:Agent, src_SPM:, prov:SoftwareAgent ; 
     rdfs:label "SPM" ;
-    nidm_softwareVersion: "12.12.2"^^xsd:string .
+    nidm_softwareVersion: "12.6906"^^xsd:string .
 
-niiri:2041dec7e8e64e30d54afd5c1e5ed5d5
+niiri:21f24d2b86fec337fe05741e4da7e8c3
     a prov:Entity, nidm_CoordinateSpace: ; 
     rdfs:label "Coordinate space 1" ;
     nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
@@ -156,48 +156,48 @@ niiri:2041dec7e8e64e30d54afd5c1e5ed5d5
     nidm_numberOfDimensions: "3"^^xsd:int ;
     nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
 
-niiri:e542fdfb0839ca0528cef73de2652f98
+niiri:4dd802783f824c7aacfc4e4e4ee26461
     a prov:Agent, nlx_Imaginginstrument:, nlx_Magneticresonanceimagingscanner: ; 
     rdfs:label "MRI Scanner" .
 
-niiri:927fa72d7b5ce13647f6c65adbbf6bf7
+niiri:37dff96025f813fa2cae9c2f2ab20af0
     a prov:Agent, prov:Person ; 
     rdfs:label "Person" .
 
-niiri:6681bf626b7371145c7895482260b2a1
+niiri:b0407acb83b2703b82444e30fcac401b
     a prov:Entity, prov:Collection, nidm_Data: ; 
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "true"^^xsd:boolean ;
     nidm_targetIntensity: "100"^^xsd:float ;
     nidm_hasMRIProtocol: nlx_FunctionalMRIprotocol: .
 
-niiri:6681bf626b7371145c7895482260b2a1 prov:wasAttributedTo niiri:e542fdfb0839ca0528cef73de2652f98 .
+niiri:b0407acb83b2703b82444e30fcac401b prov:wasAttributedTo niiri:4dd802783f824c7aacfc4e4e4ee26461 .
 
-niiri:6681bf626b7371145c7895482260b2a1 prov:wasAttributedTo niiri:927fa72d7b5ce13647f6c65adbbf6bf7 .
+niiri:b0407acb83b2703b82444e30fcac401b prov:wasAttributedTo niiri:37dff96025f813fa2cae9c2f2ab20af0 .
 
-niiri:38e737c30e2fb759db92d8bc4268e81b
+niiri:b557e098b34f31a9e2f16762e818990f
     a prov:Entity, spm_DCTDriftModel: ; 
     rdfs:label "SPM's DCT Drift Model" ;
     spm_SPMsDriftCutoffPeriod: "128"^^xsd:float .
 
-niiri:e1a0227db35f62505199c7caf2715949
+niiri:59859d0ad01111bc8ee8288526aae37d
     a prov:Entity, nidm_DesignMatrix: ; 
     prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.csv"^^xsd:string ;
     dct:format "text/csv"^^xsd:string ;
-    dc:description niiri:200cebbb19189fc612ba6efcaba103f0 ;
+    dc:description niiri:606e0581bbcbad8b686c00155e95f5a0 ;
     rdfs:label "Design Matrix" ;
     nidm_regressorNames: "[\"Sn(1) to*bf(1)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) constant\"]"^^xsd:string ;
-    nidm_hasDriftModel: niiri:38e737c30e2fb759db92d8bc4268e81b ;
+    nidm_hasDriftModel: niiri:b557e098b34f31a9e2f16762e818990f ;
     nidm_hasHRFBasis: spm_SPMsCanonicalHRF: .
 
-niiri:200cebbb19189fc612ba6efcaba103f0
+niiri:606e0581bbcbad8b686c00155e95f5a0
     a prov:Entity, dctype:Image ; 
     prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:d1b295db79dc87c49bb51479ebdee218
+niiri:16eb1e414b6a4247bd1b7cfca669048c
     a prov:Entity, nidm_ErrorModel: ; 
     nidm_hasErrorDistribution: obo_normaldistribution: ;
     nidm_hasErrorDependence: obo_Toeplitzcovariancestructure: ;
@@ -205,174 +205,174 @@ niiri:d1b295db79dc87c49bb51479ebdee218
     nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
     nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
 
-niiri:7acaa5ee9bfb239b4c336845cc77e1ad
+niiri:10b49e4617715cf283ca55ab051c7161
     a prov:Activity, nidm_ModelParametersEstimation: ; 
     rdfs:label "Model parameters estimation" ;
     nidm_withEstimationMethod: obo_generalizedleastsquaresestimation: .
 
-niiri:7acaa5ee9bfb239b4c336845cc77e1ad prov:wasAssociatedWith niiri:efa026de268c2c7adcb83113c80feffe .
+niiri:10b49e4617715cf283ca55ab051c7161 prov:wasAssociatedWith niiri:9d7bdfb1f005a1c77912a13aad1d7cca .
 
-niiri:7acaa5ee9bfb239b4c336845cc77e1ad prov:used niiri:e1a0227db35f62505199c7caf2715949 .
+niiri:10b49e4617715cf283ca55ab051c7161 prov:used niiri:59859d0ad01111bc8ee8288526aae37d .
 
-niiri:7acaa5ee9bfb239b4c336845cc77e1ad prov:used niiri:6681bf626b7371145c7895482260b2a1 .
+niiri:10b49e4617715cf283ca55ab051c7161 prov:used niiri:b0407acb83b2703b82444e30fcac401b .
 
-niiri:7acaa5ee9bfb239b4c336845cc77e1ad prov:used niiri:d1b295db79dc87c49bb51479ebdee218 .
+niiri:10b49e4617715cf283ca55ab051c7161 prov:used niiri:16eb1e414b6a4247bd1b7cfca669048c .
 
-niiri:4a1b25825ebfaf1382fe57aac7e6174c
+niiri:aba08deba6439b8fd82d98d160e5d070
     a prov:Entity, nidm_MaskMap: ; 
     prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
     nidm_isUserDefined: "false"^^xsd:boolean ;
     nfo:fileName "Mask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Mask" ;
-    nidm_inCoordinateSpace: niiri:2041dec7e8e64e30d54afd5c1e5ed5d5 ;
+    nidm_inCoordinateSpace: niiri:21f24d2b86fec337fe05741e4da7e8c3 ;
     crypto:sha512 "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876"^^xsd:string .
 
-niiri:16f899a6f193249b767a93ea52a8290c
+niiri:b3f11481d93002948ba4265eb6fc7a17
     a prov:Entity, nidm_MaskMap: ; 
     nfo:fileName "mask.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "36929e1f5f4143bd9cc818cd896a25f129961fab208c3a4438555f40444c08347b359142ee8c53ece6e8cca1627f49db0788a1fd3b9e2ecaef61999c6c6c67ac"^^xsd:string .
 
-niiri:4a1b25825ebfaf1382fe57aac7e6174c prov:wasDerivedFrom niiri:16f899a6f193249b767a93ea52a8290c .
+niiri:aba08deba6439b8fd82d98d160e5d070 prov:wasDerivedFrom niiri:b3f11481d93002948ba4265eb6fc7a17 .
 
-niiri:4a1b25825ebfaf1382fe57aac7e6174c prov:wasGeneratedBy niiri:7acaa5ee9bfb239b4c336845cc77e1ad .
+niiri:aba08deba6439b8fd82d98d160e5d070 prov:wasGeneratedBy niiri:10b49e4617715cf283ca55ab051c7161 .
 
-niiri:dc34026c4b4c9e6d2afb7d3f79aedd00
+niiri:4f4a4075f1bc1968a80b2f594b2a5ef9
     a prov:Entity, nidm_GrandMeanMap: ; 
     prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
     nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Grand Mean Map" ;
     nidm_maskedMedian: "111.557487487793"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:2041dec7e8e64e30d54afd5c1e5ed5d5 ;
+    nidm_inCoordinateSpace: niiri:21f24d2b86fec337fe05741e4da7e8c3 ;
     crypto:sha512 "512157cc6bff89d9343a09b4068226eb3edd64a8cbcee861f06231767fae6f8d4819921182adebee083a9bf309afd65529ab04a92f0aa6b0038c8098550f6124"^^xsd:string .
 
-niiri:dc34026c4b4c9e6d2afb7d3f79aedd00 prov:wasGeneratedBy niiri:7acaa5ee9bfb239b4c336845cc77e1ad .
+niiri:4f4a4075f1bc1968a80b2f594b2a5ef9 prov:wasGeneratedBy niiri:10b49e4617715cf283ca55ab051c7161 .
 
-niiri:03d5307ba8e51d1aad0db72fb88d6549
+niiri:a5c5180e35f868db315e52abaf2ab6cf
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0001.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0001.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 1" ;
-    nidm_inCoordinateSpace: niiri:2041dec7e8e64e30d54afd5c1e5ed5d5 ;
+    nidm_inCoordinateSpace: niiri:21f24d2b86fec337fe05741e4da7e8c3 ;
     crypto:sha512 "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd"^^xsd:string .
 
-niiri:bc25474037aee5bb4f0ce9ca2c6bb584
+niiri:5ff4045c3fb225d6d68fbb0c98b08a69
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd"^^xsd:string .
 
-niiri:03d5307ba8e51d1aad0db72fb88d6549 prov:wasDerivedFrom niiri:bc25474037aee5bb4f0ce9ca2c6bb584 .
+niiri:a5c5180e35f868db315e52abaf2ab6cf prov:wasDerivedFrom niiri:5ff4045c3fb225d6d68fbb0c98b08a69 .
 
-niiri:03d5307ba8e51d1aad0db72fb88d6549 prov:wasGeneratedBy niiri:7acaa5ee9bfb239b4c336845cc77e1ad .
+niiri:a5c5180e35f868db315e52abaf2ab6cf prov:wasGeneratedBy niiri:10b49e4617715cf283ca55ab051c7161 .
 
-niiri:a8816b2cfe85140efa0620be4aab5614
+niiri:109842e828160f2f74424c94fa31d3ac
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0002.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0002.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 2" ;
-    nidm_inCoordinateSpace: niiri:2041dec7e8e64e30d54afd5c1e5ed5d5 ;
+    nidm_inCoordinateSpace: niiri:21f24d2b86fec337fe05741e4da7e8c3 ;
     crypto:sha512 "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c"^^xsd:string .
 
-niiri:245ffc0843b07513d2b4f41431b2ac4e
+niiri:9237a7292e50834f847b622ac8097d47
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0002.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c"^^xsd:string .
 
-niiri:a8816b2cfe85140efa0620be4aab5614 prov:wasDerivedFrom niiri:245ffc0843b07513d2b4f41431b2ac4e .
+niiri:109842e828160f2f74424c94fa31d3ac prov:wasDerivedFrom niiri:9237a7292e50834f847b622ac8097d47 .
 
-niiri:a8816b2cfe85140efa0620be4aab5614 prov:wasGeneratedBy niiri:7acaa5ee9bfb239b4c336845cc77e1ad .
+niiri:109842e828160f2f74424c94fa31d3ac prov:wasGeneratedBy niiri:10b49e4617715cf283ca55ab051c7161 .
 
-niiri:4e97093a58d33a65dc12233b6c898b62
+niiri:670abeebbed6d1e906338a6a7b6e100d
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0003.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0003.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 3" ;
-    nidm_inCoordinateSpace: niiri:2041dec7e8e64e30d54afd5c1e5ed5d5 ;
+    nidm_inCoordinateSpace: niiri:21f24d2b86fec337fe05741e4da7e8c3 ;
     crypto:sha512 "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373"^^xsd:string .
 
-niiri:115b809113660156811cf73cdcf32fce
+niiri:e1ead41ef090189a9edc014566d7fa8a
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0003.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373"^^xsd:string .
 
-niiri:4e97093a58d33a65dc12233b6c898b62 prov:wasDerivedFrom niiri:115b809113660156811cf73cdcf32fce .
+niiri:670abeebbed6d1e906338a6a7b6e100d prov:wasDerivedFrom niiri:e1ead41ef090189a9edc014566d7fa8a .
 
-niiri:4e97093a58d33a65dc12233b6c898b62 prov:wasGeneratedBy niiri:7acaa5ee9bfb239b4c336845cc77e1ad .
+niiri:670abeebbed6d1e906338a6a7b6e100d prov:wasGeneratedBy niiri:10b49e4617715cf283ca55ab051c7161 .
 
-niiri:30f40812f50fccb6b59091ec7c587071
+niiri:9d50bf99d1eb9b3e0c264b87fd74b224
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Residual Mean Squares Map" ;
-    nidm_inCoordinateSpace: niiri:2041dec7e8e64e30d54afd5c1e5ed5d5 ;
+    nidm_inCoordinateSpace: niiri:21f24d2b86fec337fe05741e4da7e8c3 ;
     crypto:sha512 "991abf563d795a43b1e2eef8643e57023f2e0b090b2031f05f839321fc0643df6f71d423486a1021519b6dc82f6b0f563e19f3fbd50cb16063bed54a0e192d3e"^^xsd:string .
 
-niiri:a303f4f3614814399a66413d10ad60b1
+niiri:0ecf4a4c4ca5a416fa2e7555c094ddb6
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     nfo:fileName "ResMS.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "40b28d03fcf9a2f60b11f10d7fb83bf3618b234fb5aedf09df644cb7cbb6aab8c9f468897c1078166d455a3d04a83f4e3bf762cfca0b4ea982d7a4e406849f18"^^xsd:string .
 
-niiri:30f40812f50fccb6b59091ec7c587071 prov:wasDerivedFrom niiri:a303f4f3614814399a66413d10ad60b1 .
+niiri:9d50bf99d1eb9b3e0c264b87fd74b224 prov:wasDerivedFrom niiri:0ecf4a4c4ca5a416fa2e7555c094ddb6 .
 
-niiri:30f40812f50fccb6b59091ec7c587071 prov:wasGeneratedBy niiri:7acaa5ee9bfb239b4c336845cc77e1ad .
+niiri:9d50bf99d1eb9b3e0c264b87fd74b224 prov:wasGeneratedBy niiri:10b49e4617715cf283ca55ab051c7161 .
 
-niiri:25cb1d7201060f78fd019e0bb4a23ea3
+niiri:bc8b436cc11302e4d61399ed8127ddce
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Resels per Voxel Map" ;
-    nidm_inCoordinateSpace: niiri:2041dec7e8e64e30d54afd5c1e5ed5d5 ;
+    nidm_inCoordinateSpace: niiri:21f24d2b86fec337fe05741e4da7e8c3 ;
     crypto:sha512 "1a3f9216e145249ccc0b14b2bc337d6b38b81ad45e32768001fb22b35f0c2c0f3e2bce013b40c85f7dc0fc62723ac761ee7f7e1e6aff128a05f0ba7b8b8202a3"^^xsd:string .
 
-niiri:91241afaf3a7f86610c092094ce1fd43
+niiri:4d7372ca3c6f7a39fc98bc6a82293781
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     nfo:fileName "RPV.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "4f76663162857f6b38b2a45a63b15a23b2ca8b338c283b69c1e71f2ea2f43797d045a733cd14e845be9c12f8b8f84d3931c599a08e8f6d77e99fab46ad87ab8f"^^xsd:string .
 
-niiri:25cb1d7201060f78fd019e0bb4a23ea3 prov:wasDerivedFrom niiri:91241afaf3a7f86610c092094ce1fd43 .
+niiri:bc8b436cc11302e4d61399ed8127ddce prov:wasDerivedFrom niiri:4d7372ca3c6f7a39fc98bc6a82293781 .
 
-niiri:25cb1d7201060f78fd019e0bb4a23ea3 prov:wasGeneratedBy niiri:7acaa5ee9bfb239b4c336845cc77e1ad .
+niiri:bc8b436cc11302e4d61399ed8127ddce prov:wasGeneratedBy niiri:10b49e4617715cf283ca55ab051c7161 .
 
-niiri:d83fd950805feda98418d40b12d3a3f0
+niiri:e12b3b920d0b0e8c6be817754a69ec93
     a prov:Entity, obo_contrastweightmatrix: ; 
     nidm_statisticType: obo_tstatistic: ;
     nidm_contrastName: "tone counting vs baseline"^^xsd:string ;
     rdfs:label "Contrast: tone counting vs baseline" ;
     prov:value "[1, 0, 0]"^^xsd:string .
 
-niiri:5abe791cb79edc4cccac6abf5a11e076
+niiri:dd06c607e32f76dc0e4ff497c11b759c
     a prov:Activity, nidm_ContrastEstimation: ; 
     rdfs:label "Contrast estimation 1" .
 
-niiri:5abe791cb79edc4cccac6abf5a11e076 prov:wasAssociatedWith niiri:efa026de268c2c7adcb83113c80feffe .
+niiri:dd06c607e32f76dc0e4ff497c11b759c prov:wasAssociatedWith niiri:9d7bdfb1f005a1c77912a13aad1d7cca .
 
-niiri:5abe791cb79edc4cccac6abf5a11e076 prov:used niiri:4a1b25825ebfaf1382fe57aac7e6174c .
+niiri:dd06c607e32f76dc0e4ff497c11b759c prov:used niiri:aba08deba6439b8fd82d98d160e5d070 .
 
-niiri:5abe791cb79edc4cccac6abf5a11e076 prov:used niiri:30f40812f50fccb6b59091ec7c587071 .
+niiri:dd06c607e32f76dc0e4ff497c11b759c prov:used niiri:9d50bf99d1eb9b3e0c264b87fd74b224 .
 
-niiri:5abe791cb79edc4cccac6abf5a11e076 prov:used niiri:e1a0227db35f62505199c7caf2715949 .
+niiri:dd06c607e32f76dc0e4ff497c11b759c prov:used niiri:59859d0ad01111bc8ee8288526aae37d .
 
-niiri:5abe791cb79edc4cccac6abf5a11e076 prov:used niiri:d83fd950805feda98418d40b12d3a3f0 .
+niiri:dd06c607e32f76dc0e4ff497c11b759c prov:used niiri:e12b3b920d0b0e8c6be817754a69ec93 .
 
-niiri:5abe791cb79edc4cccac6abf5a11e076 prov:used niiri:03d5307ba8e51d1aad0db72fb88d6549 .
+niiri:dd06c607e32f76dc0e4ff497c11b759c prov:used niiri:a5c5180e35f868db315e52abaf2ab6cf .
 
-niiri:5abe791cb79edc4cccac6abf5a11e076 prov:used niiri:a8816b2cfe85140efa0620be4aab5614 .
+niiri:dd06c607e32f76dc0e4ff497c11b759c prov:used niiri:109842e828160f2f74424c94fa31d3ac .
 
-niiri:5abe791cb79edc4cccac6abf5a11e076 prov:used niiri:4e97093a58d33a65dc12233b6c898b62 .
+niiri:dd06c607e32f76dc0e4ff497c11b759c prov:used niiri:670abeebbed6d1e906338a6a7b6e100d .
 
-niiri:35c5be3ff2b46cabb83d5d20de1bbfe3
+niiri:ef836beafc2e291065c57b3a7e86dc80
     a prov:Entity, nidm_StatisticMap: ; 
     prov:atLocation "TStatistic_0001.nii.gz"^^xsd:anyURI ;
     nfo:fileName "TStatistic_0001.nii.gz"^^xsd:string ;
@@ -382,78 +382,78 @@ niiri:35c5be3ff2b46cabb83d5d20de1bbfe3
     nidm_contrastName: "tone counting vs baseline"^^xsd:string ;
     nidm_errorDegreesOfFreedom: "97.9999999998522"^^xsd:float ;
     nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:2041dec7e8e64e30d54afd5c1e5ed5d5 ;
+    nidm_inCoordinateSpace: niiri:21f24d2b86fec337fe05741e4da7e8c3 ;
     crypto:sha512 "90a7b52d7e93a959aa14734abe286d20002ca269bfa11f4ad798c65573c0912e923220c2dbcd25ac59c7dff26c3685907c0b8083db510ee63663d534206e0f96"^^xsd:string .
 
-niiri:fbb31560904631bd3afe3b59b74e14be
+niiri:49749ebbcacba1baa8e79e02c1938189
     a prov:Entity, nidm_StatisticMap: ; 
     nfo:fileName "spmT_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "d288b1b0f117f64502555da13c5398dffa5bf5ff0b58951510e43d5388755bc185798802a92e98a07c7e313c6991066d2908f2a44aa5153ba23433da1335970f"^^xsd:string .
 
-niiri:35c5be3ff2b46cabb83d5d20de1bbfe3 prov:wasDerivedFrom niiri:fbb31560904631bd3afe3b59b74e14be .
+niiri:ef836beafc2e291065c57b3a7e86dc80 prov:wasDerivedFrom niiri:49749ebbcacba1baa8e79e02c1938189 .
 
-niiri:35c5be3ff2b46cabb83d5d20de1bbfe3 prov:wasGeneratedBy niiri:5abe791cb79edc4cccac6abf5a11e076 .
+niiri:ef836beafc2e291065c57b3a7e86dc80 prov:wasGeneratedBy niiri:dd06c607e32f76dc0e4ff497c11b759c .
 
-niiri:61ec0f02bd4bb0e15edd816988222775
+niiri:9d77bd5bfcea339e1308f2f57159142a
     a prov:Entity, nidm_ContrastMap: ; 
     prov:atLocation "Contrast_0001.nii.gz"^^xsd:anyURI ;
     nfo:fileName "Contrast_0001.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Map: tone counting vs baseline" ;
     nidm_contrastName: "tone counting vs baseline"^^xsd:string ;
-    nidm_inCoordinateSpace: niiri:2041dec7e8e64e30d54afd5c1e5ed5d5 ;
+    nidm_inCoordinateSpace: niiri:21f24d2b86fec337fe05741e4da7e8c3 ;
     crypto:sha512 "fc5e2ad175243ee496db98f9b2e1b235c4c3bae1a8d7122ce461c897b537e40c49dfee5d6cf20f71c6a2bb9b5f0760fcb4ecd8fe2e9428910ef3d60d8f3c56a9"^^xsd:string .
 
-niiri:ba752875ff6ce17c2871d56a45b924e7
+niiri:05afb3605ef5b9f0b252b00b89bc58c8
     a prov:Entity, nidm_ContrastMap: ; 
     nfo:fileName "con_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "d4aa46b3603ba508578e39751262d528cf6d1ed2e722ec46f1cd8194c50591e46b229deb8cb4f72d1b7e0e2640f3e6604be7a335301c5c8357f453e5d0d4daf2"^^xsd:string .
 
-niiri:61ec0f02bd4bb0e15edd816988222775 prov:wasDerivedFrom niiri:ba752875ff6ce17c2871d56a45b924e7 .
+niiri:9d77bd5bfcea339e1308f2f57159142a prov:wasDerivedFrom niiri:05afb3605ef5b9f0b252b00b89bc58c8 .
 
-niiri:61ec0f02bd4bb0e15edd816988222775 prov:wasGeneratedBy niiri:5abe791cb79edc4cccac6abf5a11e076 .
+niiri:9d77bd5bfcea339e1308f2f57159142a prov:wasGeneratedBy niiri:dd06c607e32f76dc0e4ff497c11b759c .
 
-niiri:2fd2006e149f67aefe1d282c5fd6cf4c
+niiri:2fcd23f1ed3c1835696b5f3f6c067474
     a prov:Entity, nidm_ContrastStandardErrorMap: ; 
     prov:atLocation "ContrastStandardError_0001.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ContrastStandardError_0001.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Standard Error Map" ;
-    nidm_inCoordinateSpace: niiri:2041dec7e8e64e30d54afd5c1e5ed5d5 ;
+    nidm_inCoordinateSpace: niiri:21f24d2b86fec337fe05741e4da7e8c3 ;
     crypto:sha512 "791d48f5d1adb15079a5289271ce0c4b95c56d69bfdb3e5d41b0d24eb538d3075e1cdd15502494b5a5a18c16eaa2153cb4847a996043fa48cdaf26e938a2576d"^^xsd:string .
 
-niiri:2fd2006e149f67aefe1d282c5fd6cf4c prov:wasGeneratedBy niiri:5abe791cb79edc4cccac6abf5a11e076 .
+niiri:2fcd23f1ed3c1835696b5f3f6c067474 prov:wasGeneratedBy niiri:dd06c607e32f76dc0e4ff497c11b759c .
 
-niiri:30ce6fd109cd2ceea8faa079a66d9f5c
+niiri:ba7f4a78f7bfc8dfe15e84f017dffc6f
     a prov:Entity, obo_contrastweightmatrix: ; 
     nidm_statisticType: obo_tstatistic: ;
     nidm_contrastName: "tone counting probe vs baseline (orth. w.r.t {1})"^^xsd:string ;
     rdfs:label "Contrast: tone counting probe vs baseline (orth. w.r.t {1})" ;
     prov:value "[-0.919333604280958, 1, 0]"^^xsd:string .
 
-niiri:c6a22989f43b68b871331c4257dd8326
+niiri:b91cbbf6a4f5303474a88b3cbc77d086
     a prov:Activity, nidm_ContrastEstimation: ; 
     rdfs:label "Contrast estimation 2" .
 
-niiri:c6a22989f43b68b871331c4257dd8326 prov:wasAssociatedWith niiri:efa026de268c2c7adcb83113c80feffe .
+niiri:b91cbbf6a4f5303474a88b3cbc77d086 prov:wasAssociatedWith niiri:9d7bdfb1f005a1c77912a13aad1d7cca .
 
-niiri:c6a22989f43b68b871331c4257dd8326 prov:used niiri:4a1b25825ebfaf1382fe57aac7e6174c .
+niiri:b91cbbf6a4f5303474a88b3cbc77d086 prov:used niiri:aba08deba6439b8fd82d98d160e5d070 .
 
-niiri:c6a22989f43b68b871331c4257dd8326 prov:used niiri:30f40812f50fccb6b59091ec7c587071 .
+niiri:b91cbbf6a4f5303474a88b3cbc77d086 prov:used niiri:9d50bf99d1eb9b3e0c264b87fd74b224 .
 
-niiri:c6a22989f43b68b871331c4257dd8326 prov:used niiri:e1a0227db35f62505199c7caf2715949 .
+niiri:b91cbbf6a4f5303474a88b3cbc77d086 prov:used niiri:59859d0ad01111bc8ee8288526aae37d .
 
-niiri:c6a22989f43b68b871331c4257dd8326 prov:used niiri:30ce6fd109cd2ceea8faa079a66d9f5c .
+niiri:b91cbbf6a4f5303474a88b3cbc77d086 prov:used niiri:ba7f4a78f7bfc8dfe15e84f017dffc6f .
 
-niiri:c6a22989f43b68b871331c4257dd8326 prov:used niiri:03d5307ba8e51d1aad0db72fb88d6549 .
+niiri:b91cbbf6a4f5303474a88b3cbc77d086 prov:used niiri:a5c5180e35f868db315e52abaf2ab6cf .
 
-niiri:c6a22989f43b68b871331c4257dd8326 prov:used niiri:a8816b2cfe85140efa0620be4aab5614 .
+niiri:b91cbbf6a4f5303474a88b3cbc77d086 prov:used niiri:109842e828160f2f74424c94fa31d3ac .
 
-niiri:c6a22989f43b68b871331c4257dd8326 prov:used niiri:4e97093a58d33a65dc12233b6c898b62 .
+niiri:b91cbbf6a4f5303474a88b3cbc77d086 prov:used niiri:670abeebbed6d1e906338a6a7b6e100d .
 
-niiri:01987becac1b40cdffe20150c4b33a59
+niiri:955daf8b5134c9320aad7d629101cc88
     a prov:Entity, nidm_StatisticMap: ; 
     prov:atLocation "TStatistic_0002.nii.gz"^^xsd:anyURI ;
     nfo:fileName "TStatistic_0002.nii.gz"^^xsd:string ;
@@ -463,127 +463,127 @@ niiri:01987becac1b40cdffe20150c4b33a59
     nidm_contrastName: "tone counting probe vs baseline (orth. w.r.t {1})"^^xsd:string ;
     nidm_errorDegreesOfFreedom: "97.9999999998522"^^xsd:float ;
     nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:2041dec7e8e64e30d54afd5c1e5ed5d5 ;
+    nidm_inCoordinateSpace: niiri:21f24d2b86fec337fe05741e4da7e8c3 ;
     crypto:sha512 "d90b7e100f85bd13206e5074638371c2e4559ff1a748aa67a42ac9d0da802b9f2b04df108d32f3ea375017805784a9814b9b2eb515bbe8930b1fe39eb68e6299"^^xsd:string .
 
-niiri:e1bccab747dae000113e66e77ec4821f
+niiri:de187bcb23967e7a4b132bd43bbb2d3c
     a prov:Entity, nidm_StatisticMap: ; 
     nfo:fileName "spmT_0003.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "16529d1636b3f7868ae8acaee472adf6ad23cebc0fdbb7412821197d62029e7d5b1dd078621353bca152fba21256adb888cd718b194876faaa82995ffe653e74"^^xsd:string .
 
-niiri:01987becac1b40cdffe20150c4b33a59 prov:wasDerivedFrom niiri:e1bccab747dae000113e66e77ec4821f .
+niiri:955daf8b5134c9320aad7d629101cc88 prov:wasDerivedFrom niiri:de187bcb23967e7a4b132bd43bbb2d3c .
 
-niiri:01987becac1b40cdffe20150c4b33a59 prov:wasGeneratedBy niiri:c6a22989f43b68b871331c4257dd8326 .
+niiri:955daf8b5134c9320aad7d629101cc88 prov:wasGeneratedBy niiri:b91cbbf6a4f5303474a88b3cbc77d086 .
 
-niiri:6ae2e9f62ec52a002b8d8692bd9dadd0
+niiri:66ede7151e2d666315b2d79e13573a47
     a prov:Entity, nidm_ContrastMap: ; 
     prov:atLocation "Contrast_0002.nii.gz"^^xsd:anyURI ;
     nfo:fileName "Contrast_0002.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Map: tone counting probe vs baseline (orth. w.r.t {1})" ;
     nidm_contrastName: "tone counting probe vs baseline (orth. w.r.t {1})"^^xsd:string ;
-    nidm_inCoordinateSpace: niiri:2041dec7e8e64e30d54afd5c1e5ed5d5 ;
+    nidm_inCoordinateSpace: niiri:21f24d2b86fec337fe05741e4da7e8c3 ;
     crypto:sha512 "89f2233bd64ee40c2ceb5f4e9d0bcbb9a681ad9fa298da4fbdec7173edf186ce33efe3dd331eab07bdbeb7283538e62798692680031d672e724fd90e790439fd"^^xsd:string .
 
-niiri:3e1a2f6bc81c7612a4b172dffb80a2c0
+niiri:ceab125faff01ef71a425d244d8dd312
     a prov:Entity, nidm_ContrastMap: ; 
     nfo:fileName "con_0003.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "2c14d615d64b789ee26a22dea4052e1f42f951e9154448c931c0e2d16c7a8c5acb33dfb228e8e61da37f13a182ec2e50aeba6434e05e6dcc5d9cab2f1f6ff680"^^xsd:string .
 
-niiri:6ae2e9f62ec52a002b8d8692bd9dadd0 prov:wasDerivedFrom niiri:3e1a2f6bc81c7612a4b172dffb80a2c0 .
+niiri:66ede7151e2d666315b2d79e13573a47 prov:wasDerivedFrom niiri:ceab125faff01ef71a425d244d8dd312 .
 
-niiri:6ae2e9f62ec52a002b8d8692bd9dadd0 prov:wasGeneratedBy niiri:c6a22989f43b68b871331c4257dd8326 .
+niiri:66ede7151e2d666315b2d79e13573a47 prov:wasGeneratedBy niiri:b91cbbf6a4f5303474a88b3cbc77d086 .
 
-niiri:a98cb290165a5322b0515231e2e4893d
+niiri:6b4d76daa5ef6289730f139f490051cd
     a prov:Entity, nidm_ContrastStandardErrorMap: ; 
     prov:atLocation "ContrastStandardError_0002.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ContrastStandardError_0002.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Standard Error Map" ;
-    nidm_inCoordinateSpace: niiri:2041dec7e8e64e30d54afd5c1e5ed5d5 ;
+    nidm_inCoordinateSpace: niiri:21f24d2b86fec337fe05741e4da7e8c3 ;
     crypto:sha512 "25ba224b75eef1f03b89e808e7b221a122e53101f981cbbc08c77ce9a7890e2e889e3170ff47c10efaf34f13109689d3b14cb13970e62d2fe341b79fd4c01253"^^xsd:string .
 
-niiri:a98cb290165a5322b0515231e2e4893d prov:wasGeneratedBy niiri:c6a22989f43b68b871331c4257dd8326 .
+niiri:6b4d76daa5ef6289730f139f490051cd prov:wasGeneratedBy niiri:b91cbbf6a4f5303474a88b3cbc77d086 .
 
-niiri:75b195bd3ff811210dbca7eb63f1dcfc
+niiri:40130c07affd508ab9ba7401250e23da
     a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
-    rdfs:label "Height Threshold: p<0.000999 (unc.)" ;
+    rdfs:label "Height Threshold: p<0.001 (unc.)" ;
     prov:value "0.000999499935993353"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:77281d8fb39da565b2d8620d9cdfb81a ;
-    nidm_equivalentThreshold: niiri:21fac464625b30a79f9d3ab48f29b5ca .
+    nidm_equivalentThreshold: niiri:c84125bf0a4147bdec34e8d62a7d8e9b ;
+    nidm_equivalentThreshold: niiri:69b20013b8e5b45f8fab306ece980cf8 .
 
-niiri:77281d8fb39da565b2d8620d9cdfb81a
+niiri:c84125bf0a4147bdec34e8d62a7d8e9b
     a prov:Entity, nidm_HeightThreshold:, obo_statistic: ; 
-    rdfs:label "Height Threshold" ;
+    rdfs:label "Height Threshold: T=1.878787)" ;
     prov:value "1.87878728784405"^^xsd:float .
 
-niiri:21fac464625b30a79f9d3ab48f29b5ca
+niiri:69b20013b8e5b45f8fab306ece980cf8
     a prov:Entity, nidm_HeightThreshold:, obo_FWERadjustedpvalue: ; 
-    rdfs:label "Height Threshold" ;
+    rdfs:label "Height Threshold: p<1.000000 (FWE)" ;
     prov:value "1"^^xsd:float .
 
-niiri:9b4709f23eec4aacd96c39f77ce9670a
+niiri:559eaf01d0bac3504edd2c4d5066dd7b
     a prov:Entity, nidm_ExtentThreshold:, obo_statistic: ; 
     rdfs:label "Extent Threshold: k>=0" ;
     nidm_clusterSizeInVoxels: "0"^^xsd:int ;
     nidm_clusterSizeInResels: "0"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:a16bde71d82100d11dee7ac351fcf8ee ;
-    nidm_equivalentThreshold: niiri:c0b504a062a42fd948ef14652a061f13 .
+    nidm_equivalentThreshold: niiri:76a9c78f5f4fa409b43bc97e69a2d2f9 ;
+    nidm_equivalentThreshold: niiri:80a186d719df191589b700394aee0091 .
 
-niiri:a16bde71d82100d11dee7ac351fcf8ee
+niiri:76a9c78f5f4fa409b43bc97e69a2d2f9
     a prov:Entity, nidm_ExtentThreshold:, obo_FWERadjustedpvalue: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:c0b504a062a42fd948ef14652a061f13
+niiri:80a186d719df191589b700394aee0091
     a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:8026c37e29c0f5d6a9c2644a3a842b95
+niiri:b479dc4f3908a8dd60cf9f33a5c34288
     a prov:Entity, nidm_PeakDefinitionCriteria: ; 
     rdfs:label "Peak Definition Criteria" ;
     nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
     nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
 
-niiri:43b529195274fe5d1ce5aecd2a575aef
+niiri:0e2a9f5b87827358154ae143f1e5c8cb
     a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
     rdfs:label "Cluster Connectivity Criterion: 18" ;
     nidm_hasConnectivityCriterion: nidm_voxel18connected: .
 
-niiri:6fac02f43fd0624921dea58ee65afc62
+niiri:c134406116e621fbf4bcc19eb85f6dec
     a prov:Activity, spm_PartialConjunctionInference: ; 
     nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
     rdfs:label "Partial Conjunction Inference" ;
     spm_partialConjunctionDegree: "2"^^xsd:int .
 
-niiri:6fac02f43fd0624921dea58ee65afc62 prov:wasAssociatedWith niiri:efa026de268c2c7adcb83113c80feffe .
+niiri:c134406116e621fbf4bcc19eb85f6dec prov:wasAssociatedWith niiri:9d7bdfb1f005a1c77912a13aad1d7cca .
 
-niiri:6fac02f43fd0624921dea58ee65afc62 prov:used niiri:75b195bd3ff811210dbca7eb63f1dcfc .
+niiri:c134406116e621fbf4bcc19eb85f6dec prov:used niiri:40130c07affd508ab9ba7401250e23da .
 
-niiri:6fac02f43fd0624921dea58ee65afc62 prov:used niiri:9b4709f23eec4aacd96c39f77ce9670a .
+niiri:c134406116e621fbf4bcc19eb85f6dec prov:used niiri:559eaf01d0bac3504edd2c4d5066dd7b .
 
-niiri:6fac02f43fd0624921dea58ee65afc62 prov:used niiri:35c5be3ff2b46cabb83d5d20de1bbfe3 .
+niiri:c134406116e621fbf4bcc19eb85f6dec prov:used niiri:ef836beafc2e291065c57b3a7e86dc80 .
 
-niiri:6fac02f43fd0624921dea58ee65afc62 prov:used niiri:01987becac1b40cdffe20150c4b33a59 .
+niiri:c134406116e621fbf4bcc19eb85f6dec prov:used niiri:955daf8b5134c9320aad7d629101cc88 .
 
-niiri:6fac02f43fd0624921dea58ee65afc62 prov:used niiri:25cb1d7201060f78fd019e0bb4a23ea3 .
+niiri:c134406116e621fbf4bcc19eb85f6dec prov:used niiri:bc8b436cc11302e4d61399ed8127ddce .
 
-niiri:6fac02f43fd0624921dea58ee65afc62 prov:used niiri:4a1b25825ebfaf1382fe57aac7e6174c .
+niiri:c134406116e621fbf4bcc19eb85f6dec prov:used niiri:aba08deba6439b8fd82d98d160e5d070 .
 
-niiri:6fac02f43fd0624921dea58ee65afc62 prov:used niiri:8026c37e29c0f5d6a9c2644a3a842b95 .
+niiri:c134406116e621fbf4bcc19eb85f6dec prov:used niiri:b479dc4f3908a8dd60cf9f33a5c34288 .
 
-niiri:6fac02f43fd0624921dea58ee65afc62 prov:used niiri:43b529195274fe5d1ce5aecd2a575aef .
+niiri:c134406116e621fbf4bcc19eb85f6dec prov:used niiri:0e2a9f5b87827358154ae143f1e5c8cb .
 
-niiri:7f4f00382d1ca69143903708b54d2186
+niiri:a251b2ee9dd7a651ce291377b22b331c
     a prov:Entity, nidm_SearchSpaceMaskMap: ; 
     prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
     nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Search Space Mask Map" ;
-    nidm_inCoordinateSpace: niiri:2041dec7e8e64e30d54afd5c1e5ed5d5 ;
+    nidm_inCoordinateSpace: niiri:21f24d2b86fec337fe05741e4da7e8c3 ;
     nidm_searchVolumeInVoxels: "223057"^^xsd:int ;
     nidm_searchVolumeInUnits: "1784456"^^xsd:float ;
     nidm_reselSizeInVoxels: "65.5786964036542"^^xsd:float ;
@@ -598,9 +598,9 @@ niiri:7f4f00382d1ca69143903708b54d2186
     nidm_heightCriticalThresholdFDR05: "3.13529944419861"^^xsd:float ;
     crypto:sha512 "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876"^^xsd:string .
 
-niiri:7f4f00382d1ca69143903708b54d2186 prov:wasGeneratedBy niiri:6fac02f43fd0624921dea58ee65afc62 .
+niiri:a251b2ee9dd7a651ce291377b22b331c prov:wasGeneratedBy niiri:c134406116e621fbf4bcc19eb85f6dec .
 
-niiri:d2e82dc2ef1ed65643a5b21509270b91
+niiri:8523ea1215430db79b6d67ec562629a2
     a prov:Entity, nidm_ExcursionSetMap: ; 
     prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
@@ -608,29 +608,29 @@ niiri:d2e82dc2ef1ed65643a5b21509270b91
     rdfs:label "Excursion Set Map" ;
     nidm_numberOfSupraThresholdClusters: "134"^^xsd:int ;
     nidm_pValue: "0"^^xsd:float ;
-    nidm_hasClusterLabelsMap: niiri:0c0a065230ec2c9537fec958985a8bbe ;
-    nidm_hasMaximumIntensityProjection: niiri:a884453416272ec8d05aef8c00ff9ec9 ;
-    nidm_inCoordinateSpace: niiri:2041dec7e8e64e30d54afd5c1e5ed5d5 ;
+    nidm_hasClusterLabelsMap: niiri:af09603d1be9b472972dc427857a08f5 ;
+    nidm_hasMaximumIntensityProjection: niiri:c51837890dc0834460dea9471719a9de ;
+    nidm_inCoordinateSpace: niiri:21f24d2b86fec337fe05741e4da7e8c3 ;
     crypto:sha512 "cf57cbfbb81ca96369b3e2527d0e6705441089b119d0cc15f3355ae7c3de2b6c17c3185f6664cd5c9a9f7bb25112d87c762671c4061a04dacad4674fe7e19086"^^xsd:string .
 
-niiri:0c0a065230ec2c9537fec958985a8bbe
+niiri:af09603d1be9b472972dc427857a08f5
     a prov:Entity, nidm_ClusterLabelsMap: ; 
     prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Cluster Labels Map" ;
-    nidm_inCoordinateSpace: niiri:2041dec7e8e64e30d54afd5c1e5ed5d5 ;
+    nidm_inCoordinateSpace: niiri:21f24d2b86fec337fe05741e4da7e8c3 ;
     crypto:sha512 "33456d0efb388a323fb05180352e48d0ded234d80fb937b966c0a2109eb1117bb43213ec4702cf2796847b35ad2eb181cac47b0d81190b774e1fb76e8f404828"^^xsd:string .
 
-niiri:a884453416272ec8d05aef8c00ff9ec9
+niiri:c51837890dc0834460dea9471719a9de
     a prov:Entity, dctype:Image ; 
     prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
     nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:d2e82dc2ef1ed65643a5b21509270b91 prov:wasGeneratedBy niiri:6fac02f43fd0624921dea58ee65afc62 .
+niiri:8523ea1215430db79b6d67ec562629a2 prov:wasGeneratedBy niiri:c134406116e621fbf4bcc19eb85f6dec .
 
-niiri:513895e5db5c23441d24f7a6b36af026
+niiri:212a130c85dc60414b3a3ae20326ccc1
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0001" ;
     nidm_clusterSizeInVoxels: "569"^^xsd:int ;
@@ -640,9 +640,9 @@ niiri:513895e5db5c23441d24f7a6b36af026
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "1"^^xsd:int .
 
-niiri:513895e5db5c23441d24f7a6b36af026 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:212a130c85dc60414b3a3ae20326ccc1 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:200353b62d6c59c05f378e37920581d1
+niiri:b6f31947ea1d789fff0bd7ebbd8d5aa3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0002" ;
     nidm_clusterSizeInVoxels: "72"^^xsd:int ;
@@ -652,9 +652,9 @@ niiri:200353b62d6c59c05f378e37920581d1
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "2"^^xsd:int .
 
-niiri:200353b62d6c59c05f378e37920581d1 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:b6f31947ea1d789fff0bd7ebbd8d5aa3 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:0347896da596f5297388dcc20e03b25d
+niiri:171c8ac1a84198593464a36bac244ff0
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0003" ;
     nidm_clusterSizeInVoxels: "4084"^^xsd:int ;
@@ -664,9 +664,9 @@ niiri:0347896da596f5297388dcc20e03b25d
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "3"^^xsd:int .
 
-niiri:0347896da596f5297388dcc20e03b25d prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:171c8ac1a84198593464a36bac244ff0 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:4c63f433fea86c4902ef28b8a4e0b83b
+niiri:7174a23494a5602d1cf5b80e0b3957b3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0004" ;
     nidm_clusterSizeInVoxels: "127"^^xsd:int ;
@@ -676,9 +676,9 @@ niiri:4c63f433fea86c4902ef28b8a4e0b83b
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "4"^^xsd:int .
 
-niiri:4c63f433fea86c4902ef28b8a4e0b83b prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:7174a23494a5602d1cf5b80e0b3957b3 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:ca1279119038c6ed3aa8da5ae36104c5
+niiri:2cd32bc92eb7dd286253f06b6c4516f9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0005" ;
     nidm_clusterSizeInVoxels: "243"^^xsd:int ;
@@ -688,9 +688,9 @@ niiri:ca1279119038c6ed3aa8da5ae36104c5
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "5"^^xsd:int .
 
-niiri:ca1279119038c6ed3aa8da5ae36104c5 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:2cd32bc92eb7dd286253f06b6c4516f9 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:3b8c64c3b6fac5debb91f848b6310ef3
+niiri:6438830b93a9866c5a8c4cb39850d977
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0006" ;
     nidm_clusterSizeInVoxels: "71"^^xsd:int ;
@@ -700,9 +700,9 @@ niiri:3b8c64c3b6fac5debb91f848b6310ef3
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "6"^^xsd:int .
 
-niiri:3b8c64c3b6fac5debb91f848b6310ef3 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:6438830b93a9866c5a8c4cb39850d977 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:f62ecbcce6abff98c7b382218c0d5dde
+niiri:58fb2509f9d4dbc78a02bfcd61bb139b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0007" ;
     nidm_clusterSizeInVoxels: "159"^^xsd:int ;
@@ -712,9 +712,9 @@ niiri:f62ecbcce6abff98c7b382218c0d5dde
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "7"^^xsd:int .
 
-niiri:f62ecbcce6abff98c7b382218c0d5dde prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:58fb2509f9d4dbc78a02bfcd61bb139b prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:f7b92a750ed72932f6060531d3264928
+niiri:2657e564e7bba015b389e0943b63badb
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0008" ;
     nidm_clusterSizeInVoxels: "106"^^xsd:int ;
@@ -724,9 +724,9 @@ niiri:f7b92a750ed72932f6060531d3264928
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "8"^^xsd:int .
 
-niiri:f7b92a750ed72932f6060531d3264928 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:2657e564e7bba015b389e0943b63badb prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:d4fb506965250f1ee35f6781f8eaf2e4
+niiri:a8bb66759e4caade20c1a9e56f9516ec
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0009" ;
     nidm_clusterSizeInVoxels: "99"^^xsd:int ;
@@ -736,9 +736,9 @@ niiri:d4fb506965250f1ee35f6781f8eaf2e4
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "9"^^xsd:int .
 
-niiri:d4fb506965250f1ee35f6781f8eaf2e4 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:a8bb66759e4caade20c1a9e56f9516ec prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:ac21817310afb3594d085b280a7c7fad
+niiri:7f817d4ab9fea049a6960806e46dae6f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0010" ;
     nidm_clusterSizeInVoxels: "190"^^xsd:int ;
@@ -748,9 +748,9 @@ niiri:ac21817310afb3594d085b280a7c7fad
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "10"^^xsd:int .
 
-niiri:ac21817310afb3594d085b280a7c7fad prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:7f817d4ab9fea049a6960806e46dae6f prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:65f83d4775835650d295d792beafeab5
+niiri:a088090c906271f3f2487f7339f0082c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0011" ;
     nidm_clusterSizeInVoxels: "38"^^xsd:int ;
@@ -760,9 +760,9 @@ niiri:65f83d4775835650d295d792beafeab5
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "11"^^xsd:int .
 
-niiri:65f83d4775835650d295d792beafeab5 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:a088090c906271f3f2487f7339f0082c prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:fe501796991210fa8e9d37e811545e85
+niiri:5cb5cd73033206c0daaf4927462a1873
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0012" ;
     nidm_clusterSizeInVoxels: "59"^^xsd:int ;
@@ -772,9 +772,9 @@ niiri:fe501796991210fa8e9d37e811545e85
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "12"^^xsd:int .
 
-niiri:fe501796991210fa8e9d37e811545e85 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:5cb5cd73033206c0daaf4927462a1873 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:12095dcddf9a636e0d1c65eafed705e8
+niiri:f4def9a581b3c307c2f4fb9e2e226d0e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0013" ;
     nidm_clusterSizeInVoxels: "62"^^xsd:int ;
@@ -784,9 +784,9 @@ niiri:12095dcddf9a636e0d1c65eafed705e8
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "13"^^xsd:int .
 
-niiri:12095dcddf9a636e0d1c65eafed705e8 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:f4def9a581b3c307c2f4fb9e2e226d0e prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:a0871d458c113ff7db6ea00222d681b6
+niiri:dfdffb6b309c9dbdb7e869a40c441373
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0014" ;
     nidm_clusterSizeInVoxels: "10"^^xsd:int ;
@@ -796,9 +796,9 @@ niiri:a0871d458c113ff7db6ea00222d681b6
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "14"^^xsd:int .
 
-niiri:a0871d458c113ff7db6ea00222d681b6 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:dfdffb6b309c9dbdb7e869a40c441373 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:ede417a6186510bb468637a2fa74953b
+niiri:51dff688583f66b2d156042da2e15fbc
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0015" ;
     nidm_clusterSizeInVoxels: "32"^^xsd:int ;
@@ -808,9 +808,9 @@ niiri:ede417a6186510bb468637a2fa74953b
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "15"^^xsd:int .
 
-niiri:ede417a6186510bb468637a2fa74953b prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:51dff688583f66b2d156042da2e15fbc prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:e1877410437181ca152c635a1b1ae370
+niiri:e56f07808adb058d01196164f0775b64
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0016" ;
     nidm_clusterSizeInVoxels: "28"^^xsd:int ;
@@ -820,9 +820,9 @@ niiri:e1877410437181ca152c635a1b1ae370
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "16"^^xsd:int .
 
-niiri:e1877410437181ca152c635a1b1ae370 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:e56f07808adb058d01196164f0775b64 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:cc0c5a448ad27b2c29ff4af6af9b334c
+niiri:14930f43331616f26135da44caf5ca49
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0017" ;
     nidm_clusterSizeInVoxels: "34"^^xsd:int ;
@@ -832,9 +832,9 @@ niiri:cc0c5a448ad27b2c29ff4af6af9b334c
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "17"^^xsd:int .
 
-niiri:cc0c5a448ad27b2c29ff4af6af9b334c prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:14930f43331616f26135da44caf5ca49 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:c66319cb5f126bcbc275fb9a118d21ec
+niiri:d6ab9aad7ae91e9a945d6044d0e1d6cd
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0018" ;
     nidm_clusterSizeInVoxels: "38"^^xsd:int ;
@@ -844,9 +844,9 @@ niiri:c66319cb5f126bcbc275fb9a118d21ec
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "18"^^xsd:int .
 
-niiri:c66319cb5f126bcbc275fb9a118d21ec prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:d6ab9aad7ae91e9a945d6044d0e1d6cd prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:df2f9512a8de3749a0b69fde9e1d74e6
+niiri:950bb8c15f6d86506fdad52c1ea79861
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0019" ;
     nidm_clusterSizeInVoxels: "13"^^xsd:int ;
@@ -856,9 +856,9 @@ niiri:df2f9512a8de3749a0b69fde9e1d74e6
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "19"^^xsd:int .
 
-niiri:df2f9512a8de3749a0b69fde9e1d74e6 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:950bb8c15f6d86506fdad52c1ea79861 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:ff4a3dc3ae673c7d96c375c14f00511e
+niiri:f4783b6466e014e6e52055bae529f918
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0020" ;
     nidm_clusterSizeInVoxels: "33"^^xsd:int ;
@@ -868,9 +868,9 @@ niiri:ff4a3dc3ae673c7d96c375c14f00511e
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "20"^^xsd:int .
 
-niiri:ff4a3dc3ae673c7d96c375c14f00511e prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:f4783b6466e014e6e52055bae529f918 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:abd64927c551fbbd20950624a69aa36d
+niiri:e493acb406e5cff7f2b3bdae4a6c7854
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0021" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -880,9 +880,9 @@ niiri:abd64927c551fbbd20950624a69aa36d
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "21"^^xsd:int .
 
-niiri:abd64927c551fbbd20950624a69aa36d prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:e493acb406e5cff7f2b3bdae4a6c7854 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:38307cfb7180ba187f2a9da76b2278a7
+niiri:0337643db0192f78f5b32cbf7ed520a4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0022" ;
     nidm_clusterSizeInVoxels: "71"^^xsd:int ;
@@ -892,9 +892,9 @@ niiri:38307cfb7180ba187f2a9da76b2278a7
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "22"^^xsd:int .
 
-niiri:38307cfb7180ba187f2a9da76b2278a7 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:0337643db0192f78f5b32cbf7ed520a4 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:a23fb16f5011d68723f436a695655a4b
+niiri:1a04d969a09af1e47b83e8c89999ecc0
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0023" ;
     nidm_clusterSizeInVoxels: "46"^^xsd:int ;
@@ -904,9 +904,9 @@ niiri:a23fb16f5011d68723f436a695655a4b
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "23"^^xsd:int .
 
-niiri:a23fb16f5011d68723f436a695655a4b prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:1a04d969a09af1e47b83e8c89999ecc0 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:dd24018042f78d315dbd6726698ec521
+niiri:cad3a1438e0a5950942cd5ed7b22e997
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0024" ;
     nidm_clusterSizeInVoxels: "13"^^xsd:int ;
@@ -916,9 +916,9 @@ niiri:dd24018042f78d315dbd6726698ec521
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "24"^^xsd:int .
 
-niiri:dd24018042f78d315dbd6726698ec521 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:cad3a1438e0a5950942cd5ed7b22e997 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:08d22242c39ac4379d79b33f1f2f58d6
+niiri:aa48c521a0de3bccee7d00f6ba89c3cf
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0025" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -928,9 +928,9 @@ niiri:08d22242c39ac4379d79b33f1f2f58d6
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "25"^^xsd:int .
 
-niiri:08d22242c39ac4379d79b33f1f2f58d6 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:aa48c521a0de3bccee7d00f6ba89c3cf prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:61b56883c58ef13be768c931fffde95f
+niiri:666175487bab3267d4af86f55ff4bd3b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0026" ;
     nidm_clusterSizeInVoxels: "10"^^xsd:int ;
@@ -940,9 +940,9 @@ niiri:61b56883c58ef13be768c931fffde95f
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "26"^^xsd:int .
 
-niiri:61b56883c58ef13be768c931fffde95f prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:666175487bab3267d4af86f55ff4bd3b prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:7d6ccb38dbccc63215a5fdd98139915c
+niiri:6951754ac73a67bbeeec0a4f76595341
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0027" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -952,9 +952,9 @@ niiri:7d6ccb38dbccc63215a5fdd98139915c
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "27"^^xsd:int .
 
-niiri:7d6ccb38dbccc63215a5fdd98139915c prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:6951754ac73a67bbeeec0a4f76595341 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:823399669e7b2b8c54db148364839dc3
+niiri:92c69844c448bad6dc16185f863b358e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0028" ;
     nidm_clusterSizeInVoxels: "25"^^xsd:int ;
@@ -964,9 +964,9 @@ niiri:823399669e7b2b8c54db148364839dc3
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "28"^^xsd:int .
 
-niiri:823399669e7b2b8c54db148364839dc3 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:92c69844c448bad6dc16185f863b358e prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:d81a7a910431ac9a1979f323b4b791c2
+niiri:177bfa600d85757ea0c4626517c44033
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0029" ;
     nidm_clusterSizeInVoxels: "41"^^xsd:int ;
@@ -976,9 +976,9 @@ niiri:d81a7a910431ac9a1979f323b4b791c2
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "29"^^xsd:int .
 
-niiri:d81a7a910431ac9a1979f323b4b791c2 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:177bfa600d85757ea0c4626517c44033 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:dabab8dbebf83a48079048945d816fe5
+niiri:746b0b97599bb9118ebd954e679a2576
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0030" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -988,9 +988,9 @@ niiri:dabab8dbebf83a48079048945d816fe5
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "30"^^xsd:int .
 
-niiri:dabab8dbebf83a48079048945d816fe5 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:746b0b97599bb9118ebd954e679a2576 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:5842093feb2c4b86fc255ab1795f6409
+niiri:54c365a30f25bdcc066a52c171908849
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0031" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -1000,9 +1000,9 @@ niiri:5842093feb2c4b86fc255ab1795f6409
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "31"^^xsd:int .
 
-niiri:5842093feb2c4b86fc255ab1795f6409 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:54c365a30f25bdcc066a52c171908849 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:2498df410b841338c0adda91711ed606
+niiri:b9e88b2bbae3b722fa155ba8e9501a86
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0032" ;
     nidm_clusterSizeInVoxels: "17"^^xsd:int ;
@@ -1012,9 +1012,9 @@ niiri:2498df410b841338c0adda91711ed606
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "32"^^xsd:int .
 
-niiri:2498df410b841338c0adda91711ed606 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:b9e88b2bbae3b722fa155ba8e9501a86 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:4e803c8ae9b4739d7433ebb1a14e59ad
+niiri:6b8826bcc0a021bc10b09d6a6d4302fd
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0033" ;
     nidm_clusterSizeInVoxels: "9"^^xsd:int ;
@@ -1024,9 +1024,9 @@ niiri:4e803c8ae9b4739d7433ebb1a14e59ad
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "33"^^xsd:int .
 
-niiri:4e803c8ae9b4739d7433ebb1a14e59ad prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:6b8826bcc0a021bc10b09d6a6d4302fd prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:59ee3c1181a6931549c7f2a8d5a010d9
+niiri:cc1d6ba65b10195363d6da601013d7a1
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0034" ;
     nidm_clusterSizeInVoxels: "15"^^xsd:int ;
@@ -1036,9 +1036,9 @@ niiri:59ee3c1181a6931549c7f2a8d5a010d9
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "34"^^xsd:int .
 
-niiri:59ee3c1181a6931549c7f2a8d5a010d9 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:cc1d6ba65b10195363d6da601013d7a1 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:d5b0a3e5aceb6afc5f0beca22061d358
+niiri:82933f30610ef29a453f4b374990b32f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0035" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -1048,9 +1048,9 @@ niiri:d5b0a3e5aceb6afc5f0beca22061d358
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "35"^^xsd:int .
 
-niiri:d5b0a3e5aceb6afc5f0beca22061d358 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:82933f30610ef29a453f4b374990b32f prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:f93d82501705ce2feae40e77d940aa42
+niiri:14f8555b74f38f3e8db5c662f1a8015c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0036" ;
     nidm_clusterSizeInVoxels: "12"^^xsd:int ;
@@ -1060,9 +1060,9 @@ niiri:f93d82501705ce2feae40e77d940aa42
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "36"^^xsd:int .
 
-niiri:f93d82501705ce2feae40e77d940aa42 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:14f8555b74f38f3e8db5c662f1a8015c prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:e087977e9e8a8b501c9a28c9869554a6
+niiri:8c06ba2c370d4dda4947f0cbe66ca91e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0037" ;
     nidm_clusterSizeInVoxels: "10"^^xsd:int ;
@@ -1072,9 +1072,9 @@ niiri:e087977e9e8a8b501c9a28c9869554a6
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "37"^^xsd:int .
 
-niiri:e087977e9e8a8b501c9a28c9869554a6 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:8c06ba2c370d4dda4947f0cbe66ca91e prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:a2144fa83ecfa43f689763a4c0b15ca8
+niiri:337d987921a53a135ec5d7ccac93719b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0038" ;
     nidm_clusterSizeInVoxels: "31"^^xsd:int ;
@@ -1084,9 +1084,9 @@ niiri:a2144fa83ecfa43f689763a4c0b15ca8
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "38"^^xsd:int .
 
-niiri:a2144fa83ecfa43f689763a4c0b15ca8 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:337d987921a53a135ec5d7ccac93719b prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:575376d8b1a60c68f57a2629ca1c6f57
+niiri:8b64f56916b41aba13f0c3626eccb6c6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0039" ;
     nidm_clusterSizeInVoxels: "33"^^xsd:int ;
@@ -1096,9 +1096,9 @@ niiri:575376d8b1a60c68f57a2629ca1c6f57
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "39"^^xsd:int .
 
-niiri:575376d8b1a60c68f57a2629ca1c6f57 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:8b64f56916b41aba13f0c3626eccb6c6 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:e7cf6cf6e829a4522b12ecb22c64da50
+niiri:7167233a4e5f287b27d1ea49b05f5e73
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0040" ;
     nidm_clusterSizeInVoxels: "29"^^xsd:int ;
@@ -1108,9 +1108,9 @@ niiri:e7cf6cf6e829a4522b12ecb22c64da50
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "40"^^xsd:int .
 
-niiri:e7cf6cf6e829a4522b12ecb22c64da50 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:7167233a4e5f287b27d1ea49b05f5e73 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:f34dda9711be5249376de56aa5f55bb0
+niiri:9bcff3c8230d1d562436a59af916d435
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0041" ;
     nidm_clusterSizeInVoxels: "59"^^xsd:int ;
@@ -1120,9 +1120,9 @@ niiri:f34dda9711be5249376de56aa5f55bb0
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "41"^^xsd:int .
 
-niiri:f34dda9711be5249376de56aa5f55bb0 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:9bcff3c8230d1d562436a59af916d435 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:3d8865c6fb016a8704775ebaf2435091
+niiri:1f551e5f86fc52cb27432b3822b69ca7
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0042" ;
     nidm_clusterSizeInVoxels: "15"^^xsd:int ;
@@ -1132,9 +1132,9 @@ niiri:3d8865c6fb016a8704775ebaf2435091
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "42"^^xsd:int .
 
-niiri:3d8865c6fb016a8704775ebaf2435091 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:1f551e5f86fc52cb27432b3822b69ca7 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:16a6c15579df8b38a23d9ad0e739425a
+niiri:222cf8fd43a488444ee6a32847bc1d9a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0043" ;
     nidm_clusterSizeInVoxels: "12"^^xsd:int ;
@@ -1144,9 +1144,9 @@ niiri:16a6c15579df8b38a23d9ad0e739425a
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "43"^^xsd:int .
 
-niiri:16a6c15579df8b38a23d9ad0e739425a prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:222cf8fd43a488444ee6a32847bc1d9a prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:c2f8c271d456bfd2eff8e6eb839c91ba
+niiri:944e97172e0a25bb481c848ff69da03e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0044" ;
     nidm_clusterSizeInVoxels: "11"^^xsd:int ;
@@ -1156,9 +1156,9 @@ niiri:c2f8c271d456bfd2eff8e6eb839c91ba
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "44"^^xsd:int .
 
-niiri:c2f8c271d456bfd2eff8e6eb839c91ba prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:944e97172e0a25bb481c848ff69da03e prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:84844c35c8e8d08a6e00bf67a2f849ff
+niiri:f16d0ba2c74c51bb5e78d2245c00a45f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0045" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -1168,9 +1168,9 @@ niiri:84844c35c8e8d08a6e00bf67a2f849ff
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "45"^^xsd:int .
 
-niiri:84844c35c8e8d08a6e00bf67a2f849ff prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:f16d0ba2c74c51bb5e78d2245c00a45f prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:dfda6f4a6ad2d61f37aadf0fa7507a7f
+niiri:209a4a28e55d93fc75c92925f0f7d71b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0046" ;
     nidm_clusterSizeInVoxels: "33"^^xsd:int ;
@@ -1180,9 +1180,9 @@ niiri:dfda6f4a6ad2d61f37aadf0fa7507a7f
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "46"^^xsd:int .
 
-niiri:dfda6f4a6ad2d61f37aadf0fa7507a7f prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:209a4a28e55d93fc75c92925f0f7d71b prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:261c5b8cb671c9ccd262aae82e498512
+niiri:357268aff375a1c533059d48c5f8dcb0
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0047" ;
     nidm_clusterSizeInVoxels: "13"^^xsd:int ;
@@ -1192,9 +1192,9 @@ niiri:261c5b8cb671c9ccd262aae82e498512
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "47"^^xsd:int .
 
-niiri:261c5b8cb671c9ccd262aae82e498512 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:357268aff375a1c533059d48c5f8dcb0 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:504a0642ac3cd38acd0d64ccc15fc9e6
+niiri:0a39de1cb252a793d03ed45aa12d8950
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0048" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -1204,9 +1204,9 @@ niiri:504a0642ac3cd38acd0d64ccc15fc9e6
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "48"^^xsd:int .
 
-niiri:504a0642ac3cd38acd0d64ccc15fc9e6 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:0a39de1cb252a793d03ed45aa12d8950 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:30d04637933701595f908aeb4100a23e
+niiri:2ce7fa7ad1d0a7052668df06aeeb62b3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0049" ;
     nidm_clusterSizeInVoxels: "24"^^xsd:int ;
@@ -1216,9 +1216,9 @@ niiri:30d04637933701595f908aeb4100a23e
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "49"^^xsd:int .
 
-niiri:30d04637933701595f908aeb4100a23e prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:2ce7fa7ad1d0a7052668df06aeeb62b3 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:3abca6b1ac25766b2a6217f3ab065c91
+niiri:837c632e63a40a2ac1469c8d1ba1b864
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0050" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1228,9 +1228,9 @@ niiri:3abca6b1ac25766b2a6217f3ab065c91
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "50"^^xsd:int .
 
-niiri:3abca6b1ac25766b2a6217f3ab065c91 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:837c632e63a40a2ac1469c8d1ba1b864 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:779bcdad447bb00d9bdb1d38c48f9eb7
+niiri:47f25a919baaf59e7867aa98557a23e4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0051" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -1240,9 +1240,9 @@ niiri:779bcdad447bb00d9bdb1d38c48f9eb7
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "51"^^xsd:int .
 
-niiri:779bcdad447bb00d9bdb1d38c48f9eb7 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:47f25a919baaf59e7867aa98557a23e4 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:bea578e87145baa9fef8f57831c0c5fe
+niiri:82870fabf2e7a1a9a595fb88debeb7ef
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0052" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -1252,9 +1252,9 @@ niiri:bea578e87145baa9fef8f57831c0c5fe
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "52"^^xsd:int .
 
-niiri:bea578e87145baa9fef8f57831c0c5fe prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:82870fabf2e7a1a9a595fb88debeb7ef prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:0416871505a4f68a8b0a05803d7fe0e1
+niiri:54fe9c7a58c48364f79822c24b7f0a36
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0053" ;
     nidm_clusterSizeInVoxels: "20"^^xsd:int ;
@@ -1264,9 +1264,9 @@ niiri:0416871505a4f68a8b0a05803d7fe0e1
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "53"^^xsd:int .
 
-niiri:0416871505a4f68a8b0a05803d7fe0e1 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:54fe9c7a58c48364f79822c24b7f0a36 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:03e0bc451aca56b2f70fb660afdf1e84
+niiri:9f649ce7c963c614e6fb0b5f0f441d80
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0054" ;
     nidm_clusterSizeInVoxels: "9"^^xsd:int ;
@@ -1276,9 +1276,9 @@ niiri:03e0bc451aca56b2f70fb660afdf1e84
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "54"^^xsd:int .
 
-niiri:03e0bc451aca56b2f70fb660afdf1e84 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:9f649ce7c963c614e6fb0b5f0f441d80 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:94477c176a303cb05b6cf25392b272ff
+niiri:aa6b7754ff9629fdf69c2b137c4af89e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0055" ;
     nidm_clusterSizeInVoxels: "20"^^xsd:int ;
@@ -1288,9 +1288,9 @@ niiri:94477c176a303cb05b6cf25392b272ff
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "55"^^xsd:int .
 
-niiri:94477c176a303cb05b6cf25392b272ff prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:aa6b7754ff9629fdf69c2b137c4af89e prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:ccac343137c6a1606bfad900f0384914
+niiri:992eba93ccac4ef864d1e4c888fef260
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0056" ;
     nidm_clusterSizeInVoxels: "26"^^xsd:int ;
@@ -1300,9 +1300,9 @@ niiri:ccac343137c6a1606bfad900f0384914
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "56"^^xsd:int .
 
-niiri:ccac343137c6a1606bfad900f0384914 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:992eba93ccac4ef864d1e4c888fef260 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:74289f8090f7da1b2e9c2d274cc0f956
+niiri:2913f23a1813eb7942fb6b12aea56fda
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0057" ;
     nidm_clusterSizeInVoxels: "15"^^xsd:int ;
@@ -1312,9 +1312,9 @@ niiri:74289f8090f7da1b2e9c2d274cc0f956
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "57"^^xsd:int .
 
-niiri:74289f8090f7da1b2e9c2d274cc0f956 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:2913f23a1813eb7942fb6b12aea56fda prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:aa9f984347d25d8bedc780b7865258c6
+niiri:1c4944ab6edec9e1dbd0763deb0ea5f5
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0058" ;
     nidm_clusterSizeInVoxels: "17"^^xsd:int ;
@@ -1324,9 +1324,9 @@ niiri:aa9f984347d25d8bedc780b7865258c6
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "58"^^xsd:int .
 
-niiri:aa9f984347d25d8bedc780b7865258c6 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:1c4944ab6edec9e1dbd0763deb0ea5f5 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:2835e70d80bc47f846977da52697749b
+niiri:807decf567867596e9ede288b13f016a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0059" ;
     nidm_clusterSizeInVoxels: "31"^^xsd:int ;
@@ -1336,9 +1336,9 @@ niiri:2835e70d80bc47f846977da52697749b
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "59"^^xsd:int .
 
-niiri:2835e70d80bc47f846977da52697749b prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:807decf567867596e9ede288b13f016a prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:87c4af2a8f65ce6e67f250f40b44790b
+niiri:106990f64fdbe0a92e78b55484d984e7
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0060" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -1348,9 +1348,9 @@ niiri:87c4af2a8f65ce6e67f250f40b44790b
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "60"^^xsd:int .
 
-niiri:87c4af2a8f65ce6e67f250f40b44790b prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:106990f64fdbe0a92e78b55484d984e7 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:b96f891a7f3546406e623e46139187e6
+niiri:9a89982690b205094ce375806ee327d2
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0061" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -1360,9 +1360,9 @@ niiri:b96f891a7f3546406e623e46139187e6
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "61"^^xsd:int .
 
-niiri:b96f891a7f3546406e623e46139187e6 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:9a89982690b205094ce375806ee327d2 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:4c9cbb438c61ca24784015872ad9fbc0
+niiri:86396384ac8248dc2499f53d12283a2f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0062" ;
     nidm_clusterSizeInVoxels: "23"^^xsd:int ;
@@ -1372,9 +1372,9 @@ niiri:4c9cbb438c61ca24784015872ad9fbc0
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "62"^^xsd:int .
 
-niiri:4c9cbb438c61ca24784015872ad9fbc0 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:86396384ac8248dc2499f53d12283a2f prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:39af3e7a68fb53b5aaa4d4380994d93a
+niiri:2ead289cc63835350630bfc68f2d003d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0063" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -1384,9 +1384,9 @@ niiri:39af3e7a68fb53b5aaa4d4380994d93a
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "63"^^xsd:int .
 
-niiri:39af3e7a68fb53b5aaa4d4380994d93a prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:2ead289cc63835350630bfc68f2d003d prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:e854d05d0fd68a980bd27218bb6f2d9f
+niiri:0ff3515dad74fb4659ac475f78bb2c0d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0064" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1396,9 +1396,9 @@ niiri:e854d05d0fd68a980bd27218bb6f2d9f
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "64"^^xsd:int .
 
-niiri:e854d05d0fd68a980bd27218bb6f2d9f prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:0ff3515dad74fb4659ac475f78bb2c0d prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:919d23712d157543b918d601a201b7d7
+niiri:e28eff3b2e060f982dbfeec40075736b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0065" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1408,9 +1408,9 @@ niiri:919d23712d157543b918d601a201b7d7
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "65"^^xsd:int .
 
-niiri:919d23712d157543b918d601a201b7d7 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:e28eff3b2e060f982dbfeec40075736b prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:bac84e2b7b3296e6a7b45e5dd897eaa1
+niiri:5621f89640fa5a0a90c32a936e6e0a8d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0066" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -1420,9 +1420,9 @@ niiri:bac84e2b7b3296e6a7b45e5dd897eaa1
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "66"^^xsd:int .
 
-niiri:bac84e2b7b3296e6a7b45e5dd897eaa1 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:5621f89640fa5a0a90c32a936e6e0a8d prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:79c33267bc7a50246dc768c737d6daae
+niiri:f6474f5545e9725192cc8b6256e5bfb0
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0067" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -1432,9 +1432,9 @@ niiri:79c33267bc7a50246dc768c737d6daae
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "67"^^xsd:int .
 
-niiri:79c33267bc7a50246dc768c737d6daae prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:f6474f5545e9725192cc8b6256e5bfb0 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:2c2f8c53ef38453b53a97c311972275b
+niiri:2f15ad69e6c9c21540fd55e8e1488dca
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0068" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -1444,9 +1444,9 @@ niiri:2c2f8c53ef38453b53a97c311972275b
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "68"^^xsd:int .
 
-niiri:2c2f8c53ef38453b53a97c311972275b prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:2f15ad69e6c9c21540fd55e8e1488dca prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:5250d6f799a090681ee8888a86a64f2e
+niiri:42ca52d223a11cd4060ba3459f14c1ab
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0069" ;
     nidm_clusterSizeInVoxels: "14"^^xsd:int ;
@@ -1456,9 +1456,9 @@ niiri:5250d6f799a090681ee8888a86a64f2e
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "69"^^xsd:int .
 
-niiri:5250d6f799a090681ee8888a86a64f2e prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:42ca52d223a11cd4060ba3459f14c1ab prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:891b4e7e5f232af9ce39592173fed719
+niiri:29b8562f8375bc52056233a05357c8ba
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0070" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -1468,9 +1468,9 @@ niiri:891b4e7e5f232af9ce39592173fed719
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "70"^^xsd:int .
 
-niiri:891b4e7e5f232af9ce39592173fed719 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:29b8562f8375bc52056233a05357c8ba prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:4cd96b91a9bff0c27f9a1cf0ccb9533d
+niiri:39feea9bf256b35cba29d53ba142d102
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0071" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -1480,9 +1480,9 @@ niiri:4cd96b91a9bff0c27f9a1cf0ccb9533d
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "71"^^xsd:int .
 
-niiri:4cd96b91a9bff0c27f9a1cf0ccb9533d prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:39feea9bf256b35cba29d53ba142d102 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:63335f473373e0606d5e19a26d54947f
+niiri:aeed349c1d870c766c3846139baddfcf
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0072" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -1492,9 +1492,9 @@ niiri:63335f473373e0606d5e19a26d54947f
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "72"^^xsd:int .
 
-niiri:63335f473373e0606d5e19a26d54947f prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:aeed349c1d870c766c3846139baddfcf prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:a5b7e29d2b4e7df102d4c218a8e2de79
+niiri:fb34b9243fbfd4d52f33195ad11fa75e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0073" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -1504,9 +1504,9 @@ niiri:a5b7e29d2b4e7df102d4c218a8e2de79
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "73"^^xsd:int .
 
-niiri:a5b7e29d2b4e7df102d4c218a8e2de79 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:fb34b9243fbfd4d52f33195ad11fa75e prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:bc8ae88a4964bdb4f03808829f923a38
+niiri:ae4e3431e53d6bb86cb5f49df3e1dd3c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0074" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1516,9 +1516,9 @@ niiri:bc8ae88a4964bdb4f03808829f923a38
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "74"^^xsd:int .
 
-niiri:bc8ae88a4964bdb4f03808829f923a38 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:ae4e3431e53d6bb86cb5f49df3e1dd3c prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:8635bd60e838e70448a683e4c2731fb0
+niiri:3ae2d61c89fb13f4e75319093956440c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0075" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1528,9 +1528,9 @@ niiri:8635bd60e838e70448a683e4c2731fb0
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "75"^^xsd:int .
 
-niiri:8635bd60e838e70448a683e4c2731fb0 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:3ae2d61c89fb13f4e75319093956440c prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:76761290d259c6c26ed92cd02b7a8ffd
+niiri:b9c3425be7ea99b14efce8bce592b25b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0076" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -1540,9 +1540,9 @@ niiri:76761290d259c6c26ed92cd02b7a8ffd
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "76"^^xsd:int .
 
-niiri:76761290d259c6c26ed92cd02b7a8ffd prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:b9c3425be7ea99b14efce8bce592b25b prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:2447692cf3c13cbbdafc3a665370603f
+niiri:53c378a2e0ca3196fa50b2b2030c0fcc
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0077" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -1552,9 +1552,9 @@ niiri:2447692cf3c13cbbdafc3a665370603f
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "77"^^xsd:int .
 
-niiri:2447692cf3c13cbbdafc3a665370603f prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:53c378a2e0ca3196fa50b2b2030c0fcc prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:e4dcddb5ab6095be427ee660b9fc5d2f
+niiri:43e5c93bebd29ba8da99711ae8d9c3e1
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0078" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1564,9 +1564,9 @@ niiri:e4dcddb5ab6095be427ee660b9fc5d2f
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "78"^^xsd:int .
 
-niiri:e4dcddb5ab6095be427ee660b9fc5d2f prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:43e5c93bebd29ba8da99711ae8d9c3e1 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:343fa8f57e7adfcd961ea3af67b24ad0
+niiri:7fd1e3a607dbe6cfba8a4e086242d6b7
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0079" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1576,9 +1576,9 @@ niiri:343fa8f57e7adfcd961ea3af67b24ad0
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "79"^^xsd:int .
 
-niiri:343fa8f57e7adfcd961ea3af67b24ad0 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:7fd1e3a607dbe6cfba8a4e086242d6b7 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:59cba60adf480535a1c969d6d64e23b9
+niiri:d2c986d4849a217bf93ccf9e1e40ff7d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0080" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -1588,9 +1588,9 @@ niiri:59cba60adf480535a1c969d6d64e23b9
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "80"^^xsd:int .
 
-niiri:59cba60adf480535a1c969d6d64e23b9 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:d2c986d4849a217bf93ccf9e1e40ff7d prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:8e3b014c96a9933ebe866f62a5fc3a5c
+niiri:bac839d7d5a8f71351fbf0af9d7d237d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0081" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1600,9 +1600,9 @@ niiri:8e3b014c96a9933ebe866f62a5fc3a5c
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "81"^^xsd:int .
 
-niiri:8e3b014c96a9933ebe866f62a5fc3a5c prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:bac839d7d5a8f71351fbf0af9d7d237d prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:7adf18789eb65028169817bb70133720
+niiri:950ebb223c0553663a2925b4cebca2f2
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0082" ;
     nidm_clusterSizeInVoxels: "10"^^xsd:int ;
@@ -1612,9 +1612,9 @@ niiri:7adf18789eb65028169817bb70133720
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "82"^^xsd:int .
 
-niiri:7adf18789eb65028169817bb70133720 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:950ebb223c0553663a2925b4cebca2f2 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:3e769257b2ca300ac5c4d33e8539ea3e
+niiri:9a52ab95dd907c0f7f51fb102fd28f70
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0083" ;
     nidm_clusterSizeInVoxels: "10"^^xsd:int ;
@@ -1624,9 +1624,9 @@ niiri:3e769257b2ca300ac5c4d33e8539ea3e
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "83"^^xsd:int .
 
-niiri:3e769257b2ca300ac5c4d33e8539ea3e prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:9a52ab95dd907c0f7f51fb102fd28f70 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:66df3519712f78df7f53bbfefe65db57
+niiri:f6d437c16c83f9a147b1bb4222d3abc6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0084" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1636,9 +1636,9 @@ niiri:66df3519712f78df7f53bbfefe65db57
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "84"^^xsd:int .
 
-niiri:66df3519712f78df7f53bbfefe65db57 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:f6d437c16c83f9a147b1bb4222d3abc6 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:122fe3b47ae88833c8f3dcb366c4f353
+niiri:8837f9a734738e041b5341b9172fb036
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0085" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1648,9 +1648,9 @@ niiri:122fe3b47ae88833c8f3dcb366c4f353
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "85"^^xsd:int .
 
-niiri:122fe3b47ae88833c8f3dcb366c4f353 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:8837f9a734738e041b5341b9172fb036 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:5a3a2dbf66bf4901aa498d3c0495df01
+niiri:8b57160e5bbb28c42ed70eb49e48b412
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0086" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -1660,9 +1660,9 @@ niiri:5a3a2dbf66bf4901aa498d3c0495df01
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "86"^^xsd:int .
 
-niiri:5a3a2dbf66bf4901aa498d3c0495df01 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:8b57160e5bbb28c42ed70eb49e48b412 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:d09cb3827a1f341bbeb1a77f474f6e6a
+niiri:c45c033aff250585c0df5bd7ebfa55c2
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0087" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -1672,9 +1672,9 @@ niiri:d09cb3827a1f341bbeb1a77f474f6e6a
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "87"^^xsd:int .
 
-niiri:d09cb3827a1f341bbeb1a77f474f6e6a prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:c45c033aff250585c0df5bd7ebfa55c2 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:df984c734f06f169195b0bbaee6143c6
+niiri:95162bceebb39a10b64eb05d8de3fd22
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0088" ;
     nidm_clusterSizeInVoxels: "11"^^xsd:int ;
@@ -1684,9 +1684,9 @@ niiri:df984c734f06f169195b0bbaee6143c6
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "88"^^xsd:int .
 
-niiri:df984c734f06f169195b0bbaee6143c6 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:95162bceebb39a10b64eb05d8de3fd22 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:3bf753720b3412e5689330bba1dbe1cf
+niiri:3ed2c390b2b8ba7d7280d7aaf1f7a0e5
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0089" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1696,9 +1696,9 @@ niiri:3bf753720b3412e5689330bba1dbe1cf
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "89"^^xsd:int .
 
-niiri:3bf753720b3412e5689330bba1dbe1cf prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:3ed2c390b2b8ba7d7280d7aaf1f7a0e5 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:002c13dfe076dd8552445efc13f91b3d
+niiri:a7eac8bb5c994b37b60795763e4a8b47
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0090" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1708,9 +1708,9 @@ niiri:002c13dfe076dd8552445efc13f91b3d
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "90"^^xsd:int .
 
-niiri:002c13dfe076dd8552445efc13f91b3d prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:a7eac8bb5c994b37b60795763e4a8b47 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:9a0b88bb0f2e1591fd4c0a65c1e565f2
+niiri:df913e2209fc5cbf0b94dbb97361067d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0091" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -1720,9 +1720,9 @@ niiri:9a0b88bb0f2e1591fd4c0a65c1e565f2
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "91"^^xsd:int .
 
-niiri:9a0b88bb0f2e1591fd4c0a65c1e565f2 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:df913e2209fc5cbf0b94dbb97361067d prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:5c85689f9d81af447c3f8df3048c263a
+niiri:20e5d869565077dcc873c4847e343626
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0092" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -1732,9 +1732,9 @@ niiri:5c85689f9d81af447c3f8df3048c263a
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "92"^^xsd:int .
 
-niiri:5c85689f9d81af447c3f8df3048c263a prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:20e5d869565077dcc873c4847e343626 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:ee254d71e90697d1d1a39f5a3df69e4f
+niiri:b53c18c408c426d6208825bc03bda76c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0093" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -1744,9 +1744,9 @@ niiri:ee254d71e90697d1d1a39f5a3df69e4f
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "93"^^xsd:int .
 
-niiri:ee254d71e90697d1d1a39f5a3df69e4f prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:b53c18c408c426d6208825bc03bda76c prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:d7e6ee1864f4fe14f463aecb07ee9b99
+niiri:5040d4f96058237b55074ccbae780c73
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0094" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1756,9 +1756,9 @@ niiri:d7e6ee1864f4fe14f463aecb07ee9b99
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "94"^^xsd:int .
 
-niiri:d7e6ee1864f4fe14f463aecb07ee9b99 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:5040d4f96058237b55074ccbae780c73 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:de906422e6143ba14adec0aefe299e8c
+niiri:dc90ccd75e3ef3f441e343a64ffc8a53
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0095" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -1768,9 +1768,9 @@ niiri:de906422e6143ba14adec0aefe299e8c
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "95"^^xsd:int .
 
-niiri:de906422e6143ba14adec0aefe299e8c prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:dc90ccd75e3ef3f441e343a64ffc8a53 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:cc05429585cad5ec4458634a29892454
+niiri:92eaf289a4d8a69bb8c61dcf57734f87
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0096" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1780,9 +1780,9 @@ niiri:cc05429585cad5ec4458634a29892454
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "96"^^xsd:int .
 
-niiri:cc05429585cad5ec4458634a29892454 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:92eaf289a4d8a69bb8c61dcf57734f87 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:f8f459cc5e943c333944b0423cc623a2
+niiri:c40c3a11ae575e327a69951e39f7cf1e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0097" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1792,9 +1792,9 @@ niiri:f8f459cc5e943c333944b0423cc623a2
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "97"^^xsd:int .
 
-niiri:f8f459cc5e943c333944b0423cc623a2 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:c40c3a11ae575e327a69951e39f7cf1e prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:be7c69bccd607857ab4a3b06e884b72d
+niiri:004221f4a994d829f5e16e54483a92e9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0098" ;
     nidm_clusterSizeInVoxels: "21"^^xsd:int ;
@@ -1804,9 +1804,9 @@ niiri:be7c69bccd607857ab4a3b06e884b72d
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "98"^^xsd:int .
 
-niiri:be7c69bccd607857ab4a3b06e884b72d prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:004221f4a994d829f5e16e54483a92e9 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:a5b505175149fb44eaa5bccb967891c3
+niiri:996665a23456cb618780744372406eba
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0099" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1816,9 +1816,9 @@ niiri:a5b505175149fb44eaa5bccb967891c3
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "99"^^xsd:int .
 
-niiri:a5b505175149fb44eaa5bccb967891c3 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:996665a23456cb618780744372406eba prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:d03fcb703af0be07c63c073c3c59f291
+niiri:09c11fea29165ff889d59486cc998f06
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0100" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1828,9 +1828,9 @@ niiri:d03fcb703af0be07c63c073c3c59f291
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "100"^^xsd:int .
 
-niiri:d03fcb703af0be07c63c073c3c59f291 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:09c11fea29165ff889d59486cc998f06 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:6a8c63619c891d6d617b0e6030a35936
+niiri:10c4f42b041516447c28674dab2cde5b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0101" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1840,9 +1840,9 @@ niiri:6a8c63619c891d6d617b0e6030a35936
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "101"^^xsd:int .
 
-niiri:6a8c63619c891d6d617b0e6030a35936 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:10c4f42b041516447c28674dab2cde5b prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:12507a0af7ca022693fcfe481576aa45
+niiri:c39f3e559dae9a5d556ae9b5045842da
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0102" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1852,9 +1852,9 @@ niiri:12507a0af7ca022693fcfe481576aa45
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "102"^^xsd:int .
 
-niiri:12507a0af7ca022693fcfe481576aa45 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:c39f3e559dae9a5d556ae9b5045842da prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:308103904b8257fddf3a4611eaa9b395
+niiri:231b63a3acf5fa6923ad638c6827b93e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0103" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1864,9 +1864,9 @@ niiri:308103904b8257fddf3a4611eaa9b395
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "103"^^xsd:int .
 
-niiri:308103904b8257fddf3a4611eaa9b395 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:231b63a3acf5fa6923ad638c6827b93e prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:8b5a3b06127829c3d92a63e07d1c594d
+niiri:7a2a292e9fd06f3e19425b30b04888ad
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0104" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1876,9 +1876,9 @@ niiri:8b5a3b06127829c3d92a63e07d1c594d
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "104"^^xsd:int .
 
-niiri:8b5a3b06127829c3d92a63e07d1c594d prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:7a2a292e9fd06f3e19425b30b04888ad prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:24c2094ec130702f9601c371533bf8d4
+niiri:f7777aa15969e9f0700b324454e85979
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0105" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1888,9 +1888,9 @@ niiri:24c2094ec130702f9601c371533bf8d4
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "105"^^xsd:int .
 
-niiri:24c2094ec130702f9601c371533bf8d4 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:f7777aa15969e9f0700b324454e85979 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:e0fb0b6fe7935f93d9ab789f37f5ba17
+niiri:8005738cdc3c09b780e2ba1a36547702
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0106" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1900,9 +1900,9 @@ niiri:e0fb0b6fe7935f93d9ab789f37f5ba17
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "106"^^xsd:int .
 
-niiri:e0fb0b6fe7935f93d9ab789f37f5ba17 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:8005738cdc3c09b780e2ba1a36547702 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:8cf845d47cedee91dcbc9b5f4add50e4
+niiri:bd14daedcd6c35f47c42f6681a25a48e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0107" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1912,9 +1912,9 @@ niiri:8cf845d47cedee91dcbc9b5f4add50e4
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "107"^^xsd:int .
 
-niiri:8cf845d47cedee91dcbc9b5f4add50e4 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:bd14daedcd6c35f47c42f6681a25a48e prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:51fdd8b821079d1b5dc1b6834e5fb0af
+niiri:30ebc4167834c5d88670b4e8b93ee950
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0108" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1924,9 +1924,9 @@ niiri:51fdd8b821079d1b5dc1b6834e5fb0af
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "108"^^xsd:int .
 
-niiri:51fdd8b821079d1b5dc1b6834e5fb0af prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:30ebc4167834c5d88670b4e8b93ee950 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:a85e4f97fb1baa4a0c741f94e4bfc112
+niiri:5d3db32c6d2773404bb204393a96f250
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0109" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1936,9 +1936,9 @@ niiri:a85e4f97fb1baa4a0c741f94e4bfc112
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "109"^^xsd:int .
 
-niiri:a85e4f97fb1baa4a0c741f94e4bfc112 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:5d3db32c6d2773404bb204393a96f250 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:7a8a9b5c480a5adb8ea8cce6dede2941
+niiri:6d6e5cd089cb7ce9b9715c42e896cd46
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0110" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1948,9 +1948,9 @@ niiri:7a8a9b5c480a5adb8ea8cce6dede2941
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "110"^^xsd:int .
 
-niiri:7a8a9b5c480a5adb8ea8cce6dede2941 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:6d6e5cd089cb7ce9b9715c42e896cd46 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:c1f4268606ddda131fdee326fe51797d
+niiri:189cb4ae2ff1cc4b031011345ea5e5b0
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0111" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1960,9 +1960,9 @@ niiri:c1f4268606ddda131fdee326fe51797d
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "111"^^xsd:int .
 
-niiri:c1f4268606ddda131fdee326fe51797d prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:189cb4ae2ff1cc4b031011345ea5e5b0 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:50e9a0153fd5b58dfd6867a7820e429b
+niiri:697f2d7f340407941e5a743646226280
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0112" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1972,9 +1972,9 @@ niiri:50e9a0153fd5b58dfd6867a7820e429b
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "112"^^xsd:int .
 
-niiri:50e9a0153fd5b58dfd6867a7820e429b prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:697f2d7f340407941e5a743646226280 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:9fe72cde6498f2f7dfe77dfb89b501c0
+niiri:15af37e0e71211cb9816e08cc4cd0b88
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0113" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1984,9 +1984,9 @@ niiri:9fe72cde6498f2f7dfe77dfb89b501c0
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "113"^^xsd:int .
 
-niiri:9fe72cde6498f2f7dfe77dfb89b501c0 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:15af37e0e71211cb9816e08cc4cd0b88 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:4316bec42f97f257669a294c8fd0898f
+niiri:3fb8aaff3e01f2366b6d14baa9559ec9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0114" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1996,9 +1996,9 @@ niiri:4316bec42f97f257669a294c8fd0898f
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "114"^^xsd:int .
 
-niiri:4316bec42f97f257669a294c8fd0898f prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:3fb8aaff3e01f2366b6d14baa9559ec9 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:80346292a2b394403637328758a9b61a
+niiri:557d4e957f05b5913d7a77c829b15561
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0115" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2008,9 +2008,9 @@ niiri:80346292a2b394403637328758a9b61a
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "115"^^xsd:int .
 
-niiri:80346292a2b394403637328758a9b61a prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:557d4e957f05b5913d7a77c829b15561 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:a8192adc0f3eb7c0e3ebb68c9944ac3b
+niiri:73719d062893a763bcb9efcf192d5c98
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0116" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2020,9 +2020,9 @@ niiri:a8192adc0f3eb7c0e3ebb68c9944ac3b
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "116"^^xsd:int .
 
-niiri:a8192adc0f3eb7c0e3ebb68c9944ac3b prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:73719d062893a763bcb9efcf192d5c98 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:a9c299e42713dde6d9d2880ee2d4dc18
+niiri:254124ed2b4a8c1c5be4de8f4c74580d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0117" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2032,9 +2032,9 @@ niiri:a9c299e42713dde6d9d2880ee2d4dc18
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "117"^^xsd:int .
 
-niiri:a9c299e42713dde6d9d2880ee2d4dc18 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:254124ed2b4a8c1c5be4de8f4c74580d prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:03911a1948dcd4aa2ec73ec06aafd889
+niiri:a0c4e98f01e68139790391bbf8725466
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0118" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -2044,9 +2044,9 @@ niiri:03911a1948dcd4aa2ec73ec06aafd889
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "118"^^xsd:int .
 
-niiri:03911a1948dcd4aa2ec73ec06aafd889 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:a0c4e98f01e68139790391bbf8725466 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:5114d29fe7a8bba54bb5318e7211dbb7
+niiri:98295b38fd8a93e7e4ee1dfd88c76887
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0119" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2056,9 +2056,9 @@ niiri:5114d29fe7a8bba54bb5318e7211dbb7
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "119"^^xsd:int .
 
-niiri:5114d29fe7a8bba54bb5318e7211dbb7 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:98295b38fd8a93e7e4ee1dfd88c76887 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:cf393803c8dfe5f95ebba7fb00f78d36
+niiri:33a90732b73cfec988bd66955a0c2126
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0120" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2068,9 +2068,9 @@ niiri:cf393803c8dfe5f95ebba7fb00f78d36
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "120"^^xsd:int .
 
-niiri:cf393803c8dfe5f95ebba7fb00f78d36 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:33a90732b73cfec988bd66955a0c2126 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:313761c03f2118d6c60dd97a4be2bd9d
+niiri:ec3bd6715d891de0f42ba2dc11f9430c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0121" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2080,9 +2080,9 @@ niiri:313761c03f2118d6c60dd97a4be2bd9d
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "121"^^xsd:int .
 
-niiri:313761c03f2118d6c60dd97a4be2bd9d prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:ec3bd6715d891de0f42ba2dc11f9430c prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:f80911af8d0e7423917d1703bda349c3
+niiri:8aa002c426d46d7b9d4dc5e2c38279d3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0122" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2092,9 +2092,9 @@ niiri:f80911af8d0e7423917d1703bda349c3
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "122"^^xsd:int .
 
-niiri:f80911af8d0e7423917d1703bda349c3 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:8aa002c426d46d7b9d4dc5e2c38279d3 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:b2335168bac5f013fca6c3119b31817e
+niiri:5d895214e17bb9af3199b1f47611a048
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0123" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2104,9 +2104,9 @@ niiri:b2335168bac5f013fca6c3119b31817e
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "123"^^xsd:int .
 
-niiri:b2335168bac5f013fca6c3119b31817e prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:5d895214e17bb9af3199b1f47611a048 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:c6d9b891da12e7c0dafddbc99f7cd3bd
+niiri:781f6f173dae32b1495eaef04f1b405a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0124" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2116,9 +2116,9 @@ niiri:c6d9b891da12e7c0dafddbc99f7cd3bd
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "124"^^xsd:int .
 
-niiri:c6d9b891da12e7c0dafddbc99f7cd3bd prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:781f6f173dae32b1495eaef04f1b405a prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:02d752fd02bb32b544f85decb2637acb
+niiri:d98430357b786f52e1aba172bbfea688
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0125" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -2128,9 +2128,9 @@ niiri:02d752fd02bb32b544f85decb2637acb
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "125"^^xsd:int .
 
-niiri:02d752fd02bb32b544f85decb2637acb prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:d98430357b786f52e1aba172bbfea688 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:ca6249ceeaf778daf8955f1721d9b3bc
+niiri:fe57af8773140946a4555792ccdee632
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0126" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2140,9 +2140,9 @@ niiri:ca6249ceeaf778daf8955f1721d9b3bc
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "126"^^xsd:int .
 
-niiri:ca6249ceeaf778daf8955f1721d9b3bc prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:fe57af8773140946a4555792ccdee632 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:f5165ff916468849a9e8f0f984156ae0
+niiri:678cf59b6ed563cbae258da7bd9a2417
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0127" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2152,9 +2152,9 @@ niiri:f5165ff916468849a9e8f0f984156ae0
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "127"^^xsd:int .
 
-niiri:f5165ff916468849a9e8f0f984156ae0 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:678cf59b6ed563cbae258da7bd9a2417 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:3c77b0eab26aadf473051def81f975f1
+niiri:fb40247362abead8bfd05d8c0f86fcc6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0128" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2164,9 +2164,9 @@ niiri:3c77b0eab26aadf473051def81f975f1
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "128"^^xsd:int .
 
-niiri:3c77b0eab26aadf473051def81f975f1 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:fb40247362abead8bfd05d8c0f86fcc6 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:74f854bba7b4563710f1c71fe1bb4d87
+niiri:f0413bd7869f1537bac196460adb50ad
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0129" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2176,9 +2176,9 @@ niiri:74f854bba7b4563710f1c71fe1bb4d87
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "129"^^xsd:int .
 
-niiri:74f854bba7b4563710f1c71fe1bb4d87 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:f0413bd7869f1537bac196460adb50ad prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:f0f6386c19242334018be62b5253762f
+niiri:fd3eca9e0c356a0d39da224ef34ff7aa
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0130" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2188,9 +2188,9 @@ niiri:f0f6386c19242334018be62b5253762f
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "130"^^xsd:int .
 
-niiri:f0f6386c19242334018be62b5253762f prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:fd3eca9e0c356a0d39da224ef34ff7aa prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:79f57cc3d9c8ce9cf2ddf678b180fec2
+niiri:b2244e3b33c0159757aa93c2de26c3a1
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0131" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2200,9 +2200,9 @@ niiri:79f57cc3d9c8ce9cf2ddf678b180fec2
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "131"^^xsd:int .
 
-niiri:79f57cc3d9c8ce9cf2ddf678b180fec2 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:b2244e3b33c0159757aa93c2de26c3a1 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:ac75e1b81a1c6524011de1087ab61a81
+niiri:8b70b13ee54cf4407e3be646e313b866
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0132" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2212,9 +2212,9 @@ niiri:ac75e1b81a1c6524011de1087ab61a81
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "132"^^xsd:int .
 
-niiri:ac75e1b81a1c6524011de1087ab61a81 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:8b70b13ee54cf4407e3be646e313b866 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:8006697d9195e3c3171a1c00415399c0
+niiri:cfc211e4c6c91ecd22c4f0f2f0075044
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0133" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2224,9 +2224,9 @@ niiri:8006697d9195e3c3171a1c00415399c0
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "133"^^xsd:int .
 
-niiri:8006697d9195e3c3171a1c00415399c0 prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:cfc211e4c6c91ecd22c4f0f2f0075044 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:8ea603bc4b1eabe8a8b1f02e165eef5e
+niiri:f00195d4acadb18083e5d9b4023ca225
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0134" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -2236,2725 +2236,2725 @@ niiri:8ea603bc4b1eabe8a8b1f02e165eef5e
     nidm_qValueFDR: "1"^^xsd:float ;
     nidm_clusterLabelId: "134"^^xsd:int .
 
-niiri:8ea603bc4b1eabe8a8b1f02e165eef5e prov:wasDerivedFrom niiri:d2e82dc2ef1ed65643a5b21509270b91 .
+niiri:f00195d4acadb18083e5d9b4023ca225 prov:wasDerivedFrom niiri:8523ea1215430db79b6d67ec562629a2 .
 
-niiri:a76cdd5bcbde48124848b3c5de9557fd
+niiri:f2c008500acb79baf9b5ce05210f9bb9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0001" ;
-    prov:atLocation niiri:87439a144e63d239d7e95d83cc2b3570 ;
+    prov:atLocation niiri:83ef927efc7de9ab53de628e0e4eba1b ;
     prov:value "4.61011266708374"^^xsd:float ;
     nidm_equivalentZStatistic: "6.51265120547007"^^xsd:float ;
     nidm_pValueUncorrected: "3.69179131709529e-11"^^xsd:float ;
     nidm_pValueFWER: "8.23475922277556e-06"^^xsd:float ;
     nidm_qValueFDR: "0.000129439334006007"^^xsd:float .
 
-niiri:87439a144e63d239d7e95d83cc2b3570
+niiri:83ef927efc7de9ab53de628e0e4eba1b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0001" ;
     nidm_coordinateVector: "[-46,-66,-8]"^^xsd:string .
 
-niiri:a76cdd5bcbde48124848b3c5de9557fd prov:wasDerivedFrom niiri:513895e5db5c23441d24f7a6b36af026 .
+niiri:f2c008500acb79baf9b5ce05210f9bb9 prov:wasDerivedFrom niiri:212a130c85dc60414b3a3ae20326ccc1 .
 
-niiri:6f096bd903544a895a7fa0b1e9dc9592
+niiri:1fa4a48ba4a927736beae3c9f786d502
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0002" ;
-    prov:atLocation niiri:01a873ba01f58760c3bf086b56c2b979 ;
+    prov:atLocation niiri:36d111a494f38a79183bc43c5d3c8dc6 ;
     prov:value "4.14067697525024"^^xsd:float ;
     nidm_equivalentZStatistic: "5.94920489177576"^^xsd:float ;
     nidm_pValueUncorrected: "1.3472408744164e-09"^^xsd:float ;
     nidm_pValueFWER: "0.000300511459932193"^^xsd:float ;
     nidm_qValueFDR: "0.0016296513076278"^^xsd:float .
 
-niiri:01a873ba01f58760c3bf086b56c2b979
+niiri:36d111a494f38a79183bc43c5d3c8dc6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0002" ;
     nidm_coordinateVector: "[-34,-72,-16]"^^xsd:string .
 
-niiri:6f096bd903544a895a7fa0b1e9dc9592 prov:wasDerivedFrom niiri:513895e5db5c23441d24f7a6b36af026 .
+niiri:1fa4a48ba4a927736beae3c9f786d502 prov:wasDerivedFrom niiri:212a130c85dc60414b3a3ae20326ccc1 .
 
-niiri:ac7252b1859ceba90e220bac1b2667bf
+niiri:6a83a6584dca6366715d149902302674
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0003" ;
-    prov:atLocation niiri:dae374bdf6e469dbff8ce016a9389e83 ;
+    prov:atLocation niiri:553889dbf2e240f257cb6fc52f945311 ;
     prov:value "3.39726591110229"^^xsd:float ;
     nidm_equivalentZStatistic: "5.03216968185068"^^xsd:float ;
     nidm_pValueUncorrected: "2.42479864742684e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0540868376963655"^^xsd:float ;
     nidm_qValueFDR: "0.0144418464851922"^^xsd:float .
 
-niiri:dae374bdf6e469dbff8ce016a9389e83
+niiri:553889dbf2e240f257cb6fc52f945311
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0003" ;
     nidm_coordinateVector: "[-40,-48,-14]"^^xsd:string .
 
-niiri:ac7252b1859ceba90e220bac1b2667bf prov:wasDerivedFrom niiri:513895e5db5c23441d24f7a6b36af026 .
+niiri:6a83a6584dca6366715d149902302674 prov:wasDerivedFrom niiri:212a130c85dc60414b3a3ae20326ccc1 .
 
-niiri:cbe75c6155718d2c43fc92f0e06a4a90
+niiri:32f1a2c6ca2ddb9829b059ddbe234078
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0004" ;
-    prov:atLocation niiri:31921bf119f52b8d20b02f58eed2b9bd ;
+    prov:atLocation niiri:6028c33dcc61afb7c773a2c95eb048c1 ;
     prov:value "4.07992362976074"^^xsd:float ;
     nidm_equivalentZStatistic: "5.87535600284606"^^xsd:float ;
     nidm_pValueUncorrected: "2.10967798786044e-09"^^xsd:float ;
     nidm_pValueFWER: "0.000470578397640152"^^xsd:float ;
     nidm_qValueFDR: "0.0016296513076278"^^xsd:float .
 
-niiri:31921bf119f52b8d20b02f58eed2b9bd
+niiri:6028c33dcc61afb7c773a2c95eb048c1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0004" ;
     nidm_coordinateVector: "[34,-86,10]"^^xsd:string .
 
-niiri:cbe75c6155718d2c43fc92f0e06a4a90 prov:wasDerivedFrom niiri:200353b62d6c59c05f378e37920581d1 .
+niiri:32f1a2c6ca2ddb9829b059ddbe234078 prov:wasDerivedFrom niiri:b6f31947ea1d789fff0bd7ebbd8d5aa3 .
 
-niiri:4387e1f94ac93199293e0d4a31778e56
+niiri:b514d16779b8ecd93200134e45991536
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0005" ;
-    prov:atLocation niiri:3919a845111f67517bba32f473e08053 ;
+    prov:atLocation niiri:1230bad84e8f2bfea468396bc431e6ec ;
     prov:value "2.95166039466858"^^xsd:float ;
     nidm_equivalentZStatistic: "4.47003158157261"^^xsd:float ;
     nidm_pValueUncorrected: "3.91040240832474e-06"^^xsd:float ;
     nidm_pValueFWER: "0.497269375153304"^^xsd:float ;
     nidm_qValueFDR: "0.0815933520961271"^^xsd:float .
 
-niiri:3919a845111f67517bba32f473e08053
+niiri:1230bad84e8f2bfea468396bc431e6ec
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0005" ;
     nidm_coordinateVector: "[42,-86,12]"^^xsd:string .
 
-niiri:4387e1f94ac93199293e0d4a31778e56 prov:wasDerivedFrom niiri:200353b62d6c59c05f378e37920581d1 .
+niiri:b514d16779b8ecd93200134e45991536 prov:wasDerivedFrom niiri:b6f31947ea1d789fff0bd7ebbd8d5aa3 .
 
-niiri:957270d19f1d43dcfc587e393706213c
+niiri:23faf3bc0650966493e9f36e0ca600b8
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0006" ;
-    prov:atLocation niiri:41bbabf30972e821ea30ef31c9bf6285 ;
+    prov:atLocation niiri:c7f4a3b9045d9f445d2145b126d0e4fd ;
     prov:value "2.85145282745361"^^xsd:float ;
     nidm_equivalentZStatistic: "4.34253727556279"^^xsd:float ;
     nidm_pValueUncorrected: "7.04232894899182e-06"^^xsd:float ;
     nidm_pValueFWER: "0.676230493527593"^^xsd:float ;
     nidm_qValueFDR: "0.107852519413958"^^xsd:float .
 
-niiri:41bbabf30972e821ea30ef31c9bf6285
+niiri:c7f4a3b9045d9f445d2145b126d0e4fd
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0006" ;
     nidm_coordinateVector: "[38,-84,2]"^^xsd:string .
 
-niiri:957270d19f1d43dcfc587e393706213c prov:wasDerivedFrom niiri:200353b62d6c59c05f378e37920581d1 .
+niiri:23faf3bc0650966493e9f36e0ca600b8 prov:wasDerivedFrom niiri:b6f31947ea1d789fff0bd7ebbd8d5aa3 .
 
-niiri:13bade8d76fd2f2355d89d778e215817
+niiri:8779cf8885e2bb57f1eb0502089c61a7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0007" ;
-    prov:atLocation niiri:013e06f64b6ff1181f14f4b4607024b1 ;
+    prov:atLocation niiri:96fce76485c81a95e0c5588233442fcc ;
     prov:value "3.96536254882812"^^xsd:float ;
     nidm_equivalentZStatistic: "5.73554616923849"^^xsd:float ;
     nidm_pValueUncorrected: "4.85993045806765e-09"^^xsd:float ;
     nidm_pValueFWER: "0.00108404146331869"^^xsd:float ;
     nidm_qValueFDR: "0.00195763806925102"^^xsd:float .
 
-niiri:013e06f64b6ff1181f14f4b4607024b1
+niiri:96fce76485c81a95e0c5588233442fcc
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0007" ;
     nidm_coordinateVector: "[8,6,-4]"^^xsd:string .
 
-niiri:13bade8d76fd2f2355d89d778e215817 prov:wasDerivedFrom niiri:0347896da596f5297388dcc20e03b25d .
+niiri:8779cf8885e2bb57f1eb0502089c61a7 prov:wasDerivedFrom niiri:171c8ac1a84198593464a36bac244ff0 .
 
-niiri:c779a46f88109c01ad1a341d88903f4a
+niiri:f617e967f1244bd4a0ee551172e05935
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0008" ;
-    prov:atLocation niiri:cf4dc49d4fe6c2c4254e338eb7d30979 ;
+    prov:atLocation niiri:119da361d8cff441d6a0ef67380f70b3 ;
     prov:value "3.76170587539673"^^xsd:float ;
     nidm_equivalentZStatistic: "5.4852660945335"^^xsd:float ;
     nidm_pValueUncorrected: "2.06423748094764e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00460442620206421"^^xsd:float ;
     nidm_qValueFDR: "0.0037086909867648"^^xsd:float .
 
-niiri:cf4dc49d4fe6c2c4254e338eb7d30979
+niiri:119da361d8cff441d6a0ef67380f70b3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0008" ;
     nidm_coordinateVector: "[20,16,6]"^^xsd:string .
 
-niiri:c779a46f88109c01ad1a341d88903f4a prov:wasDerivedFrom niiri:0347896da596f5297388dcc20e03b25d .
+niiri:f617e967f1244bd4a0ee551172e05935 prov:wasDerivedFrom niiri:171c8ac1a84198593464a36bac244ff0 .
 
-niiri:6d3d1c02d434061e55c5d461d8cd0c3a
+niiri:09a006cc070777c7bc9ff02587a9475f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0009" ;
-    prov:atLocation niiri:015ea7513c292f2097769db95a5877ab ;
+    prov:atLocation niiri:5829801409b541d6efa67494d24ec16a ;
     prov:value "3.67560243606567"^^xsd:float ;
     nidm_equivalentZStatistic: "5.3788042778508"^^xsd:float ;
     nidm_pValueUncorrected: "3.74910847922294e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00836264901674123"^^xsd:float ;
     nidm_qValueFDR: "0.00496133762447783"^^xsd:float .
 
-niiri:015ea7513c292f2097769db95a5877ab
+niiri:5829801409b541d6efa67494d24ec16a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0009" ;
     nidm_coordinateVector: "[-32,24,2]"^^xsd:string .
 
-niiri:6d3d1c02d434061e55c5d461d8cd0c3a prov:wasDerivedFrom niiri:0347896da596f5297388dcc20e03b25d .
+niiri:09a006cc070777c7bc9ff02587a9475f prov:wasDerivedFrom niiri:171c8ac1a84198593464a36bac244ff0 .
 
-niiri:f462bea92037dce5b98545cabc1d527d
+niiri:ec49a9f4a91ebfee81f8ba5ab02662d0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0010" ;
-    prov:atLocation niiri:2c9fc23530b53213ebc02029be997b73 ;
+    prov:atLocation niiri:613b7228e65741491fdbfb7f9b4fbb1e ;
     prov:value "3.89568662643433"^^xsd:float ;
     nidm_equivalentZStatistic: "5.65016589891917"^^xsd:float ;
     nidm_pValueUncorrected: "8.01465316335737e-09"^^xsd:float ;
     nidm_pValueFWER: "0.00178772445204086"^^xsd:float ;
     nidm_qValueFDR: "0.00218637116402122"^^xsd:float .
 
-niiri:2c9fc23530b53213ebc02029be997b73
+niiri:613b7228e65741491fdbfb7f9b4fbb1e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0010" ;
     nidm_coordinateVector: "[36,-76,-14]"^^xsd:string .
 
-niiri:f462bea92037dce5b98545cabc1d527d prov:wasDerivedFrom niiri:4c63f433fea86c4902ef28b8a4e0b83b .
+niiri:ec49a9f4a91ebfee81f8ba5ab02662d0 prov:wasDerivedFrom niiri:7174a23494a5602d1cf5b80e0b3957b3 .
 
-niiri:f11268ecaa8c62c061de58b2048beaa6
+niiri:d7db9d99f9156bfd0c9e6482f6b282d1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0011" ;
-    prov:atLocation niiri:394dd3dde180f863041fa610fc4d735c ;
+    prov:atLocation niiri:6e6dfcb4a088e040e68b43aa9dae945a ;
     prov:value "3.36620903015137"^^xsd:float ;
     nidm_equivalentZStatistic: "4.99326640019021"^^xsd:float ;
     nidm_pValueUncorrected: "2.9683290059257e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0662106660868522"^^xsd:float ;
     nidm_qValueFDR: "0.0150086130881337"^^xsd:float .
 
-niiri:394dd3dde180f863041fa610fc4d735c
+niiri:6e6dfcb4a088e040e68b43aa9dae945a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0011" ;
     nidm_coordinateVector: "[26,-78,-12]"^^xsd:string .
 
-niiri:f11268ecaa8c62c061de58b2048beaa6 prov:wasDerivedFrom niiri:4c63f433fea86c4902ef28b8a4e0b83b .
+niiri:d7db9d99f9156bfd0c9e6482f6b282d1 prov:wasDerivedFrom niiri:7174a23494a5602d1cf5b80e0b3957b3 .
 
-niiri:ca30e6eb0689fb2b23309714f134d928
+niiri:b1965951f77cadf6336644280d9e0eb2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0012" ;
-    prov:atLocation niiri:fcb6c8887a68ee924c4a3ae06c9851e6 ;
+    prov:atLocation niiri:b0bcc363e13905c0cec9abc9a5f926cd ;
     prov:value "2.82210826873779"^^xsd:float ;
     nidm_equivalentZStatistic: "4.30513434912561"^^xsd:float ;
     nidm_pValueUncorrected: "8.34422125894907e-06"^^xsd:float ;
     nidm_pValueFWER: "0.727285909061263"^^xsd:float ;
     nidm_qValueFDR: "0.11336333992572"^^xsd:float .
 
-niiri:fcb6c8887a68ee924c4a3ae06c9851e6
+niiri:b0bcc363e13905c0cec9abc9a5f926cd
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0012" ;
     nidm_coordinateVector: "[44,-70,-14]"^^xsd:string .
 
-niiri:ca30e6eb0689fb2b23309714f134d928 prov:wasDerivedFrom niiri:4c63f433fea86c4902ef28b8a4e0b83b .
+niiri:b1965951f77cadf6336644280d9e0eb2 prov:wasDerivedFrom niiri:7174a23494a5602d1cf5b80e0b3957b3 .
 
-niiri:852d04c205f9067346f2596853527a0e
+niiri:95c8fcf40d4086295dd49408d12a5369
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0013" ;
-    prov:atLocation niiri:6d80114ee61ef182fef71e2d792bac90 ;
+    prov:atLocation niiri:6858d0c8f88e8fe9c91135874f2b7ea0 ;
     prov:value "3.87710690498352"^^xsd:float ;
     nidm_equivalentZStatistic: "5.62735471926077"^^xsd:float ;
     nidm_pValueUncorrected: "9.14970854637431e-09"^^xsd:float ;
     nidm_pValueFWER: "0.00204090649550025"^^xsd:float ;
     nidm_qValueFDR: "0.00218637116402122"^^xsd:float .
 
-niiri:6d80114ee61ef182fef71e2d792bac90
+niiri:6858d0c8f88e8fe9c91135874f2b7ea0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0013" ;
     nidm_coordinateVector: "[38,-64,52]"^^xsd:string .
 
-niiri:852d04c205f9067346f2596853527a0e prov:wasDerivedFrom niiri:ca1279119038c6ed3aa8da5ae36104c5 .
+niiri:95c8fcf40d4086295dd49408d12a5369 prov:wasDerivedFrom niiri:2cd32bc92eb7dd286253f06b6c4516f9 .
 
-niiri:91f6f0c163e804f9c6c930f0b69330fd
+niiri:6a44a9a24517109ec3074ac91077f376
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0014" ;
-    prov:atLocation niiri:15084e5bc5edb1aea933ecc637b78f9c ;
+    prov:atLocation niiri:beea954b53ac5e2e78c8261689528de9 ;
     prov:value "2.83855104446411"^^xsd:float ;
     nidm_equivalentZStatistic: "4.32609620488621"^^xsd:float ;
     nidm_pValueUncorrected: "7.58875776796231e-06"^^xsd:float ;
     nidm_pValueFWER: "0.698927552906607"^^xsd:float ;
     nidm_qValueFDR: "0.107852519413958"^^xsd:float .
 
-niiri:15084e5bc5edb1aea933ecc637b78f9c
+niiri:beea954b53ac5e2e78c8261689528de9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0014" ;
     nidm_coordinateVector: "[46,-58,44]"^^xsd:string .
 
-niiri:91f6f0c163e804f9c6c930f0b69330fd prov:wasDerivedFrom niiri:ca1279119038c6ed3aa8da5ae36104c5 .
+niiri:6a44a9a24517109ec3074ac91077f376 prov:wasDerivedFrom niiri:2cd32bc92eb7dd286253f06b6c4516f9 .
 
-niiri:654b54ae222a2b620d369cb39a760e69
+niiri:75efdb8848f89afcfba1a207d71a6086
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0015" ;
-    prov:atLocation niiri:a8d9417d1cabedb98b3c424654d77140 ;
+    prov:atLocation niiri:9c9662a0587b95df451773773737bc67 ;
     prov:value "2.7466766834259"^^xsd:float ;
     nidm_equivalentZStatistic: "4.2088532772211"^^xsd:float ;
     nidm_pValueUncorrected: "1.28334991591483e-05"^^xsd:float ;
     nidm_pValueFWER: "0.843938187211889"^^xsd:float ;
     nidm_qValueFDR: "0.138131675608108"^^xsd:float .
 
-niiri:a8d9417d1cabedb98b3c424654d77140
+niiri:9c9662a0587b95df451773773737bc67
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0015" ;
     nidm_coordinateVector: "[36,-56,38]"^^xsd:string .
 
-niiri:654b54ae222a2b620d369cb39a760e69 prov:wasDerivedFrom niiri:ca1279119038c6ed3aa8da5ae36104c5 .
+niiri:75efdb8848f89afcfba1a207d71a6086 prov:wasDerivedFrom niiri:2cd32bc92eb7dd286253f06b6c4516f9 .
 
-niiri:1520938c89a75870b5a1a10cdcd97d21
+niiri:7f82efbbcbb2b7ca685a4c40df6d517f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0016" ;
-    prov:atLocation niiri:133f392c5f08ecb3aa4f29e69abcd030 ;
+    prov:atLocation niiri:9991f49a01ab3c078e441bc6d0aafc88 ;
     prov:value "3.65790581703186"^^xsd:float ;
     nidm_equivalentZStatistic: "5.35687718443792"^^xsd:float ;
     nidm_pValueUncorrected: "4.23363166746071e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00944341194070347"^^xsd:float ;
     nidm_qValueFDR: "0.00515918806035713"^^xsd:float .
 
-niiri:133f392c5f08ecb3aa4f29e69abcd030
+niiri:9991f49a01ab3c078e441bc6d0aafc88
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0016" ;
     nidm_coordinateVector: "[52,-46,-12]"^^xsd:string .
 
-niiri:1520938c89a75870b5a1a10cdcd97d21 prov:wasDerivedFrom niiri:3b8c64c3b6fac5debb91f848b6310ef3 .
+niiri:7f82efbbcbb2b7ca685a4c40df6d517f prov:wasDerivedFrom niiri:6438830b93a9866c5a8c4cb39850d977 .
 
-niiri:ce53ac8c24182b97a423b73ed01935a7
+niiri:3957970d9b8be40cdba7d77e9fc1af08
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0017" ;
-    prov:atLocation niiri:4c28b43c252d1b7a9e266d8ab9bed502 ;
+    prov:atLocation niiri:4e6a4d59eabe77a5d46c722f954d7dc8 ;
     prov:value "3.61188387870789"^^xsd:float ;
     nidm_equivalentZStatistic: "5.29978067068531"^^xsd:float ;
     nidm_pValueUncorrected: "5.79709378278892e-08"^^xsd:float ;
     nidm_pValueFWER: "0.0129308238104803"^^xsd:float ;
     nidm_qValueFDR: "0.00597334524948961"^^xsd:float .
 
-niiri:4c28b43c252d1b7a9e266d8ab9bed502
+niiri:4e6a4d59eabe77a5d46c722f954d7dc8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0017" ;
     nidm_coordinateVector: "[-44,4,34]"^^xsd:string .
 
-niiri:ce53ac8c24182b97a423b73ed01935a7 prov:wasDerivedFrom niiri:f62ecbcce6abff98c7b382218c0d5dde .
+niiri:3957970d9b8be40cdba7d77e9fc1af08 prov:wasDerivedFrom niiri:58fb2509f9d4dbc78a02bfcd61bb139b .
 
-niiri:1f7cc2c7e379dca859827b8cf687fc25
+niiri:ebbf36d0c0f06a153cfcf5a4d5d87c41
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0018" ;
-    prov:atLocation niiri:60f07da4189f3dedfbf0a9dd40afc971 ;
+    prov:atLocation niiri:1b7890a36a01ed5e0fdb9f9a5a6e12e4 ;
     prov:value "3.4259147644043"^^xsd:float ;
     nidm_equivalentZStatistic: "5.06801755102317"^^xsd:float ;
     nidm_pValueUncorrected: "2.0099017394859e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0448322696793468"^^xsd:float ;
     nidm_qValueFDR: "0.013317352840512"^^xsd:float .
 
-niiri:60f07da4189f3dedfbf0a9dd40afc971
+niiri:1b7890a36a01ed5e0fdb9f9a5a6e12e4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0018" ;
     nidm_coordinateVector: "[-32,-4,56]"^^xsd:string .
 
-niiri:1f7cc2c7e379dca859827b8cf687fc25 prov:wasDerivedFrom niiri:f7b92a750ed72932f6060531d3264928 .
+niiri:ebbf36d0c0f06a153cfcf5a4d5d87c41 prov:wasDerivedFrom niiri:2657e564e7bba015b389e0943b63badb .
 
-niiri:eb7ed4e83d4473bc4275d53cc4e647d3
+niiri:31ec0b3be00fd80d126fc2af1ce352dd
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0019" ;
-    prov:atLocation niiri:6f16c5059854a8c4f4c0812d4ae23f88 ;
+    prov:atLocation niiri:f40c694ee792eefb7eec37d13ca8cb2a ;
     prov:value "2.66663575172424"^^xsd:float ;
     nidm_equivalentZStatistic: "4.10648471595799"^^xsd:float ;
     nidm_pValueUncorrected: "2.00863015121788e-05"^^xsd:float ;
     nidm_pValueFWER: "0.931784139682597"^^xsd:float ;
     nidm_qValueFDR: "0.179785700482736"^^xsd:float .
 
-niiri:6f16c5059854a8c4f4c0812d4ae23f88
+niiri:f40c694ee792eefb7eec37d13ca8cb2a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0019" ;
     nidm_coordinateVector: "[-32,-4,46]"^^xsd:string .
 
-niiri:eb7ed4e83d4473bc4275d53cc4e647d3 prov:wasDerivedFrom niiri:f7b92a750ed72932f6060531d3264928 .
+niiri:31ec0b3be00fd80d126fc2af1ce352dd prov:wasDerivedFrom niiri:2657e564e7bba015b389e0943b63badb .
 
-niiri:34e8a1732024e1af87f50f8bea36ad67
+niiri:2c6257c20ce92f4d4b1e41e803eef7b2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0020" ;
-    prov:atLocation niiri:45c98424a2bdff1c08167e6304d05cbf ;
+    prov:atLocation niiri:c005427742dbeae90aefba064639c45c ;
     prov:value "2.37134194374084"^^xsd:float ;
     nidm_equivalentZStatistic: "3.72719680893962"^^xsd:float ;
     nidm_pValueUncorrected: "9.68106320935469e-05"^^xsd:float ;
     nidm_pValueFWER: "0.999922876108057"^^xsd:float ;
     nidm_qValueFDR: "0.368886365441825"^^xsd:float .
 
-niiri:45c98424a2bdff1c08167e6304d05cbf
+niiri:c005427742dbeae90aefba064639c45c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0020" ;
     nidm_coordinateVector: "[-30,4,50]"^^xsd:string .
 
-niiri:34e8a1732024e1af87f50f8bea36ad67 prov:wasDerivedFrom niiri:f7b92a750ed72932f6060531d3264928 .
+niiri:2c6257c20ce92f4d4b1e41e803eef7b2 prov:wasDerivedFrom niiri:2657e564e7bba015b389e0943b63badb .
 
-niiri:2d37b4ef6d7171d361f4010bd431fca7
+niiri:108d6134cb55a8d7a0a3b38e0911631f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0021" ;
-    prov:atLocation niiri:3e7c1ce992d678c6edc1f5c39217f870 ;
+    prov:atLocation niiri:d7fdf8001a1fc850f4cddb011811e7a0 ;
     prov:value "3.41093230247498"^^xsd:float ;
     nidm_equivalentZStatistic: "5.04927492203708"^^xsd:float ;
     nidm_pValueUncorrected: "2.21745057982226e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0494617928204381"^^xsd:float ;
     nidm_qValueFDR: "0.0139107162783319"^^xsd:float .
 
-niiri:3e7c1ce992d678c6edc1f5c39217f870
+niiri:d7fdf8001a1fc850f4cddb011811e7a0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0021" ;
     nidm_coordinateVector: "[36,-56,-16]"^^xsd:string .
 
-niiri:2d37b4ef6d7171d361f4010bd431fca7 prov:wasDerivedFrom niiri:d4fb506965250f1ee35f6781f8eaf2e4 .
+niiri:108d6134cb55a8d7a0a3b38e0911631f prov:wasDerivedFrom niiri:a8bb66759e4caade20c1a9e56f9516ec .
 
-niiri:84c4601cfd5e8ef9679114b16dec246c
+niiri:f3b0431eda7e1bbfb898867a9c5f20db
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0022" ;
-    prov:atLocation niiri:9668bd697241825ab37eb454365a6d9d ;
+    prov:atLocation niiri:9e301d0fec3b6d6b3f6b0358a11f4b0c ;
     prov:value "2.56456685066223"^^xsd:float ;
     nidm_equivalentZStatistic: "3.97565696467545"^^xsd:float ;
     nidm_pValueUncorrected: "3.50926166180487e-05"^^xsd:float ;
     nidm_pValueFWER: "0.98538798365609"^^xsd:float ;
     nidm_qValueFDR: "0.231754253732683"^^xsd:float .
 
-niiri:9668bd697241825ab37eb454365a6d9d
+niiri:9e301d0fec3b6d6b3f6b0358a11f4b0c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0022" ;
     nidm_coordinateVector: "[22,-64,-18]"^^xsd:string .
 
-niiri:84c4601cfd5e8ef9679114b16dec246c prov:wasDerivedFrom niiri:d4fb506965250f1ee35f6781f8eaf2e4 .
+niiri:f3b0431eda7e1bbfb898867a9c5f20db prov:wasDerivedFrom niiri:a8bb66759e4caade20c1a9e56f9516ec .
 
-niiri:31e57993c0df6fa66d3b559298e257a2
+niiri:6914d04832f348c47b11f7e72bf95b91
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0023" ;
-    prov:atLocation niiri:a084c04a3431d9d3ef23ef91f1de2ff2 ;
+    prov:atLocation niiri:ab7b2f582e75105be0c5b2aaec2daa19 ;
     prov:value "3.23492169380188"^^xsd:float ;
     nidm_equivalentZStatistic: "4.82833550427561"^^xsd:float ;
     nidm_pValueUncorrected: "6.88394970027595e-07"^^xsd:float ;
     nidm_pValueFWER: "0.144038846632802"^^xsd:float ;
     nidm_qValueFDR: "0.0248776371912962"^^xsd:float .
 
-niiri:a084c04a3431d9d3ef23ef91f1de2ff2
+niiri:ab7b2f582e75105be0c5b2aaec2daa19
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0023" ;
     nidm_coordinateVector: "[42,12,26]"^^xsd:string .
 
-niiri:31e57993c0df6fa66d3b559298e257a2 prov:wasDerivedFrom niiri:ac21817310afb3594d085b280a7c7fad .
+niiri:6914d04832f348c47b11f7e72bf95b91 prov:wasDerivedFrom niiri:7f817d4ab9fea049a6960806e46dae6f .
 
-niiri:180e30cb7ff449134fe50b8e0e78da77
+niiri:bedd2a1fe4cc40fb4348c1e3f84fe4ce
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0024" ;
-    prov:atLocation niiri:b5dde6cd513642edd0a7398fde0a3aa2 ;
+    prov:atLocation niiri:2c68c2c5f82c2c4469180668066cc07d ;
     prov:value "2.61081290245056"^^xsd:float ;
     nidm_equivalentZStatistic: "4.03497166916066"^^xsd:float ;
     nidm_pValueUncorrected: "2.73044431503555e-05"^^xsd:float ;
     nidm_pValueFWER: "0.9682181756112"^^xsd:float ;
     nidm_qValueFDR: "0.211273225680016"^^xsd:float .
 
-niiri:b5dde6cd513642edd0a7398fde0a3aa2
+niiri:2c68c2c5f82c2c4469180668066cc07d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0024" ;
     nidm_coordinateVector: "[42,16,38]"^^xsd:string .
 
-niiri:180e30cb7ff449134fe50b8e0e78da77 prov:wasDerivedFrom niiri:ac21817310afb3594d085b280a7c7fad .
+niiri:bedd2a1fe4cc40fb4348c1e3f84fe4ce prov:wasDerivedFrom niiri:7f817d4ab9fea049a6960806e46dae6f .
 
-niiri:406966b92fbe5970c29221501cbefe32
+niiri:489fe008583f9540151b81533b9acb5e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0025" ;
-    prov:atLocation niiri:a7c517c3c9d7e0ce082baaa28b4caf36 ;
+    prov:atLocation niiri:87fc4ec7f9fd634eb08dad6106d9ce4c ;
     prov:value "2.52718925476074"^^xsd:float ;
     nidm_equivalentZStatistic: "3.92767211706964"^^xsd:float ;
     nidm_pValueUncorrected: "4.288601775293e-05"^^xsd:float ;
     nidm_pValueFWER: "0.993030331302132"^^xsd:float ;
     nidm_qValueFDR: "0.253783543711115"^^xsd:float .
 
-niiri:a7c517c3c9d7e0ce082baaa28b4caf36
+niiri:87fc4ec7f9fd634eb08dad6106d9ce4c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0025" ;
     nidm_coordinateVector: "[34,8,26]"^^xsd:string .
 
-niiri:406966b92fbe5970c29221501cbefe32 prov:wasDerivedFrom niiri:ac21817310afb3594d085b280a7c7fad .
+niiri:489fe008583f9540151b81533b9acb5e prov:wasDerivedFrom niiri:7f817d4ab9fea049a6960806e46dae6f .
 
-niiri:0cecaae3e1b26ecf4e4d49d578f1e8a9
+niiri:a5a33f4d819b8eb7632b4b1e5316ae25
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0026" ;
-    prov:atLocation niiri:d27131be4c5d31476b87eadb004a8ea2 ;
+    prov:atLocation niiri:6c61922e9036d2efdfaea284d524d0c0 ;
     prov:value "3.19025158882141"^^xsd:float ;
     nidm_equivalentZStatistic: "4.77204817208862"^^xsd:float ;
     nidm_pValueUncorrected: "9.11809358350446e-07"^^xsd:float ;
     nidm_pValueFWER: "0.179866253319972"^^xsd:float ;
     nidm_qValueFDR: "0.0295002808813131"^^xsd:float .
 
-niiri:d27131be4c5d31476b87eadb004a8ea2
+niiri:6c61922e9036d2efdfaea284d524d0c0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0026" ;
     nidm_coordinateVector: "[-54,-32,42]"^^xsd:string .
 
-niiri:0cecaae3e1b26ecf4e4d49d578f1e8a9 prov:wasDerivedFrom niiri:65f83d4775835650d295d792beafeab5 .
+niiri:a5a33f4d819b8eb7632b4b1e5316ae25 prov:wasDerivedFrom niiri:a088090c906271f3f2487f7339f0082c .
 
-niiri:b85cd3205202df2292eb9b9df9abc589
+niiri:3dbba6caca10b3238c9bd1b6e4ac3ff1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0027" ;
-    prov:atLocation niiri:ec663137656a69ec672e5558fb15d0a0 ;
+    prov:atLocation niiri:7b6a8a30f2afb4cffe0e6d51e5acbab6 ;
     prov:value "3.01900839805603"^^xsd:float ;
     nidm_equivalentZStatistic: "4.55550961951652"^^xsd:float ;
     nidm_pValueUncorrected: "2.61293619352454e-06"^^xsd:float ;
     nidm_pValueFWER: "0.38653459603819"^^xsd:float ;
     nidm_qValueFDR: "0.0625267026051373"^^xsd:float .
 
-niiri:ec663137656a69ec672e5558fb15d0a0
+niiri:7b6a8a30f2afb4cffe0e6d51e5acbab6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0027" ;
     nidm_coordinateVector: "[-40,46,26]"^^xsd:string .
 
-niiri:b85cd3205202df2292eb9b9df9abc589 prov:wasDerivedFrom niiri:fe501796991210fa8e9d37e811545e85 .
+niiri:3dbba6caca10b3238c9bd1b6e4ac3ff1 prov:wasDerivedFrom niiri:5cb5cd73033206c0daaf4927462a1873 .
 
-niiri:46542211dacd3e8bdf9273ae7237c5dd
+niiri:6edb5d4ccd344696f8f8a3ed75c82f37
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0028" ;
-    prov:atLocation niiri:f83d45ea6b9383d65bfb6cb896ea4847 ;
+    prov:atLocation niiri:44d61d9d7c7c707923228503bfa247b4 ;
     prov:value "2.89200973510742"^^xsd:float ;
     nidm_equivalentZStatistic: "4.39418165104258"^^xsd:float ;
     nidm_pValueUncorrected: "5.55954066971953e-06"^^xsd:float ;
     nidm_pValueFWER: "0.603469212296398"^^xsd:float ;
     nidm_qValueFDR: "0.0986382553356101"^^xsd:float .
 
-niiri:f83d45ea6b9383d65bfb6cb896ea4847
+niiri:44d61d9d7c7c707923228503bfa247b4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0028" ;
     nidm_coordinateVector: "[-16,-66,48]"^^xsd:string .
 
-niiri:46542211dacd3e8bdf9273ae7237c5dd prov:wasDerivedFrom niiri:12095dcddf9a636e0d1c65eafed705e8 .
+niiri:6edb5d4ccd344696f8f8a3ed75c82f37 prov:wasDerivedFrom niiri:f4def9a581b3c307c2f4fb9e2e226d0e .
 
-niiri:3cd7c15623b43ad3fa6d34e91f363f74
+niiri:4021174e55dc807e3de6628bf8eb04e4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0029" ;
-    prov:atLocation niiri:76bc34d64d71bd23a786e34b7c0e0d3a ;
+    prov:atLocation niiri:f83aa6697a4e460e152625e9ddb5dc97 ;
     prov:value "2.35510396957397"^^xsd:float ;
     nidm_equivalentZStatistic: "3.7062743430358"^^xsd:float ;
     nidm_pValueUncorrected: "0.000105165232115123"^^xsd:float ;
     nidm_pValueFWER: "0.999959028289625"^^xsd:float ;
     nidm_qValueFDR: "0.368886365441825"^^xsd:float .
 
-niiri:76bc34d64d71bd23a786e34b7c0e0d3a
+niiri:f83aa6697a4e460e152625e9ddb5dc97
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0029" ;
     nidm_coordinateVector: "[-28,-56,52]"^^xsd:string .
 
-niiri:3cd7c15623b43ad3fa6d34e91f363f74 prov:wasDerivedFrom niiri:12095dcddf9a636e0d1c65eafed705e8 .
+niiri:4021174e55dc807e3de6628bf8eb04e4 prov:wasDerivedFrom niiri:f4def9a581b3c307c2f4fb9e2e226d0e .
 
-niiri:0a5b6501891f6f1bf835ab4cce6981b0
+niiri:0ae175b8baba9cf71436e5d6fd22e350
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0030" ;
-    prov:atLocation niiri:1a2a74ecadf8ea280abae49c7adfe4d5 ;
+    prov:atLocation niiri:3b217402d63aa3747829c99e4b9d2316 ;
     prov:value "2.8795006275177"^^xsd:float ;
     nidm_equivalentZStatistic: "4.3782590505152"^^xsd:float ;
     nidm_pValueUncorrected: "5.98155518916066e-06"^^xsd:float ;
     nidm_pValueFWER: "0.626033894289313"^^xsd:float ;
     nidm_qValueFDR: "0.101663811457838"^^xsd:float .
 
-niiri:1a2a74ecadf8ea280abae49c7adfe4d5
+niiri:3b217402d63aa3747829c99e4b9d2316
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0030" ;
     nidm_coordinateVector: "[24,-80,52]"^^xsd:string .
 
-niiri:0a5b6501891f6f1bf835ab4cce6981b0 prov:wasDerivedFrom niiri:a0871d458c113ff7db6ea00222d681b6 .
+niiri:0ae175b8baba9cf71436e5d6fd22e350 prov:wasDerivedFrom niiri:dfdffb6b309c9dbdb7e869a40c441373 .
 
-niiri:e52c13b08642a31c47013d5d665f3cc3
+niiri:5678d8d6c35ed00e4d4e18d18efb6ece
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0031" ;
-    prov:atLocation niiri:b4a50efcf2a42a3d767b16b45dffb033 ;
+    prov:atLocation niiri:e4c5369a0d51a9a3ff7813c71f43d5a7 ;
     prov:value "2.87628078460693"^^xsd:float ;
     nidm_equivalentZStatistic: "4.37415966779458"^^xsd:float ;
     nidm_pValueUncorrected: "6.09505679249889e-06"^^xsd:float ;
     nidm_pValueFWER: "0.631833416620066"^^xsd:float ;
     nidm_qValueFDR: "0.101663811457838"^^xsd:float .
 
-niiri:b4a50efcf2a42a3d767b16b45dffb033
+niiri:e4c5369a0d51a9a3ff7813c71f43d5a7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0031" ;
     nidm_coordinateVector: "[54,-26,-6]"^^xsd:string .
 
-niiri:e52c13b08642a31c47013d5d665f3cc3 prov:wasDerivedFrom niiri:ede417a6186510bb468637a2fa74953b .
+niiri:5678d8d6c35ed00e4d4e18d18efb6ece prov:wasDerivedFrom niiri:51dff688583f66b2d156042da2e15fbc .
 
-niiri:971a98269dd58af38ef9b8d2a1970a4b
+niiri:42466a1a262537fe1909213e41f7608f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0032" ;
-    prov:atLocation niiri:b1ebbd8debcd5a17e636fb3af5c8a749 ;
+    prov:atLocation niiri:2322f7716f2993b1fd0d53ab1bfae19c ;
     prov:value "2.84026718139648"^^xsd:float ;
     nidm_equivalentZStatistic: "4.32828345765019"^^xsd:float ;
     nidm_pValueUncorrected: "7.51379916874573e-06"^^xsd:float ;
     nidm_pValueFWER: "0.695928446009514"^^xsd:float ;
     nidm_qValueFDR: "0.107852519413958"^^xsd:float .
 
-niiri:b1ebbd8debcd5a17e636fb3af5c8a749
+niiri:2322f7716f2993b1fd0d53ab1bfae19c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0032" ;
     nidm_coordinateVector: "[48,-30,42]"^^xsd:string .
 
-niiri:971a98269dd58af38ef9b8d2a1970a4b prov:wasDerivedFrom niiri:e1877410437181ca152c635a1b1ae370 .
+niiri:42466a1a262537fe1909213e41f7608f prov:wasDerivedFrom niiri:e56f07808adb058d01196164f0775b64 .
 
-niiri:271de41f649e27c04daa475fdae8db9f
+niiri:f9b9bbd2555a0f9eff6c0d4a46615477
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0033" ;
-    prov:atLocation niiri:f866479248db6f6baeceff2ecc110f30 ;
+    prov:atLocation niiri:946da552af58194fc6edde9153721a83 ;
     prov:value "2.78784370422363"^^xsd:float ;
     nidm_equivalentZStatistic: "4.26142274674112"^^xsd:float ;
     nidm_pValueUncorrected: "1.01564786331165e-05"^^xsd:float ;
     nidm_pValueFWER: "0.783507209855174"^^xsd:float ;
     nidm_qValueFDR: "0.124104049442798"^^xsd:float .
 
-niiri:f866479248db6f6baeceff2ecc110f30
+niiri:946da552af58194fc6edde9153721a83
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0033" ;
     nidm_coordinateVector: "[38,32,50]"^^xsd:string .
 
-niiri:271de41f649e27c04daa475fdae8db9f prov:wasDerivedFrom niiri:cc0c5a448ad27b2c29ff4af6af9b334c .
+niiri:f9b9bbd2555a0f9eff6c0d4a46615477 prov:wasDerivedFrom niiri:14930f43331616f26135da44caf5ca49 .
 
-niiri:096cfc0b0fdc48bd50b06a85db31787c
+niiri:5d8297107655c470b20029a7607b59d6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0034" ;
-    prov:atLocation niiri:9a97c475fe04c61c7758dbb97b742d39 ;
+    prov:atLocation niiri:eb06915f3583668239f7287af4563b3a ;
     prov:value "2.75120162963867"^^xsd:float ;
     nidm_equivalentZStatistic: "4.21463429501137"^^xsd:float ;
     nidm_pValueUncorrected: "1.2509162441221e-05"^^xsd:float ;
     nidm_pValueFWER: "0.837748139540634"^^xsd:float ;
     nidm_qValueFDR: "0.137791224379057"^^xsd:float .
 
-niiri:9a97c475fe04c61c7758dbb97b742d39
+niiri:eb06915f3583668239f7287af4563b3a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0034" ;
     nidm_coordinateVector: "[18,-58,32]"^^xsd:string .
 
-niiri:096cfc0b0fdc48bd50b06a85db31787c prov:wasDerivedFrom niiri:c66319cb5f126bcbc275fb9a118d21ec .
+niiri:5d8297107655c470b20029a7607b59d6 prov:wasDerivedFrom niiri:d6ab9aad7ae91e9a945d6044d0e1d6cd .
 
-niiri:1321801f3bc667f5ac86d45ed5d8ab1c
+niiri:8a6ddd866c065982183951ef56d075a5
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0035" ;
-    prov:atLocation niiri:f72173f433b0fff6c4f10737768b564c ;
+    prov:atLocation niiri:7670ea31408ac573f533b63db34e12c8 ;
     prov:value "2.30655765533447"^^xsd:float ;
     nidm_equivalentZStatistic: "3.64368706323795"^^xsd:float ;
     nidm_pValueUncorrected: "0.000134380079716223"^^xsd:float ;
     nidm_pValueFWER: "0.999995072124642"^^xsd:float ;
     nidm_qValueFDR: "0.411522109968619"^^xsd:float .
 
-niiri:f72173f433b0fff6c4f10737768b564c
+niiri:7670ea31408ac573f533b63db34e12c8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0035" ;
     nidm_coordinateVector: "[20,-68,32]"^^xsd:string .
 
-niiri:1321801f3bc667f5ac86d45ed5d8ab1c prov:wasDerivedFrom niiri:c66319cb5f126bcbc275fb9a118d21ec .
+niiri:8a6ddd866c065982183951ef56d075a5 prov:wasDerivedFrom niiri:d6ab9aad7ae91e9a945d6044d0e1d6cd .
 
-niiri:ac906b333b8b531d47a7756e6dd3f3f6
+niiri:ebeb5e8cbd97a7c980eb6e8048e3aa7d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0036" ;
-    prov:atLocation niiri:c69571c1f1fab4090a821e3eab98c3fb ;
+    prov:atLocation niiri:c8066704e7c4e7181a0ae455141068fa ;
     prov:value "2.7451183795929"^^xsd:float ;
     nidm_equivalentZStatistic: "4.20686225088754"^^xsd:float ;
     nidm_pValueUncorrected: "1.2947043287137e-05"^^xsd:float ;
     nidm_pValueFWER: "0.846041948741843"^^xsd:float ;
     nidm_qValueFDR: "0.138131675608108"^^xsd:float .
 
-niiri:c69571c1f1fab4090a821e3eab98c3fb
+niiri:c8066704e7c4e7181a0ae455141068fa
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0036" ;
     nidm_coordinateVector: "[-14,-96,0]"^^xsd:string .
 
-niiri:ac906b333b8b531d47a7756e6dd3f3f6 prov:wasDerivedFrom niiri:df2f9512a8de3749a0b69fde9e1d74e6 .
+niiri:ebeb5e8cbd97a7c980eb6e8048e3aa7d prov:wasDerivedFrom niiri:950bb8c15f6d86506fdad52c1ea79861 .
 
-niiri:512969f1ebb20a2805ba2267d49fdf6b
+niiri:f0a3195f5086136d59542c82017b3a01
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0037" ;
-    prov:atLocation niiri:9287549d198a09a7f86361cc05785e40 ;
+    prov:atLocation niiri:a7dea9a67fc3b6b8b46c2229ae066f85 ;
     prov:value "2.71638298034668"^^xsd:float ;
     nidm_equivalentZStatistic: "4.17013318145876"^^xsd:float ;
     nidm_pValueUncorrected: "1.52210841696254e-05"^^xsd:float ;
     nidm_pValueFWER: "0.88214338657563"^^xsd:float ;
     nidm_qValueFDR: "0.152011884720848"^^xsd:float .
 
-niiri:9287549d198a09a7f86361cc05785e40
+niiri:a7dea9a67fc3b6b8b46c2229ae066f85
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0037" ;
     nidm_coordinateVector: "[-32,-72,58]"^^xsd:string .
 
-niiri:512969f1ebb20a2805ba2267d49fdf6b prov:wasDerivedFrom niiri:ff4a3dc3ae673c7d96c375c14f00511e .
+niiri:f0a3195f5086136d59542c82017b3a01 prov:wasDerivedFrom niiri:f4783b6466e014e6e52055bae529f918 .
 
-niiri:b79aa4e2dd228b0e0d9c914ac65ea6d5
+niiri:e93ed6c3aa25b233cb79929e574105d9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0038" ;
-    prov:atLocation niiri:f0f4c2af1c2de0476e7e77c05aeafbeb ;
+    prov:atLocation niiri:831b8e76702d7b18f1caa06765d78f13 ;
     prov:value "2.08894777297974"^^xsd:float ;
     nidm_equivalentZStatistic: "3.36255760699966"^^xsd:float ;
     nidm_pValueUncorrected: "0.000386120057750849"^^xsd:float ;
     nidm_pValueFWER: "0.999999999998331"^^xsd:float ;
     nidm_qValueFDR: "0.636831894546098"^^xsd:float .
 
-niiri:f0f4c2af1c2de0476e7e77c05aeafbeb
+niiri:831b8e76702d7b18f1caa06765d78f13
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0038" ;
     nidm_coordinateVector: "[-20,-74,58]"^^xsd:string .
 
-niiri:b79aa4e2dd228b0e0d9c914ac65ea6d5 prov:wasDerivedFrom niiri:ff4a3dc3ae673c7d96c375c14f00511e .
+niiri:e93ed6c3aa25b233cb79929e574105d9 prov:wasDerivedFrom niiri:f4783b6466e014e6e52055bae529f918 .
 
-niiri:5ece7fa3ef29b3f54b994482a80b9119
+niiri:e515516c5ff1d233ae675e7803ccd1db
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0039" ;
-    prov:atLocation niiri:8c8b7312a2d06ddb150d87a437581a77 ;
+    prov:atLocation niiri:71a18ae0067f3eb6f488e73a8eed631d ;
     prov:value "2.68441557884216"^^xsd:float ;
     nidm_equivalentZStatistic: "4.12924185142476"^^xsd:float ;
     nidm_pValueUncorrected: "1.81980698354955e-05"^^xsd:float ;
     nidm_pValueFWER: "0.915958567777936"^^xsd:float ;
     nidm_qValueFDR: "0.169764205739198"^^xsd:float .
 
-niiri:8c8b7312a2d06ddb150d87a437581a77
+niiri:71a18ae0067f3eb6f488e73a8eed631d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0039" ;
     nidm_coordinateVector: "[-48,-42,8]"^^xsd:string .
 
-niiri:5ece7fa3ef29b3f54b994482a80b9119 prov:wasDerivedFrom niiri:abd64927c551fbbd20950624a69aa36d .
+niiri:e515516c5ff1d233ae675e7803ccd1db prov:wasDerivedFrom niiri:e493acb406e5cff7f2b3bdae4a6c7854 .
 
-niiri:e2652296eb9d97ffffca1509a9026339
+niiri:b165c84e39ed0a56c6fcfe2cf6485d45
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0040" ;
-    prov:atLocation niiri:8c3895f16059640a97c019e9952dc277 ;
+    prov:atLocation niiri:c59aa6c2583c6162213161db59c0cdfa ;
     prov:value "2.66335368156433"^^xsd:float ;
     nidm_equivalentZStatistic: "4.10228278327608"^^xsd:float ;
     nidm_pValueUncorrected: "2.04546926624305e-05"^^xsd:float ;
     nidm_pValueFWER: "0.934473772130028"^^xsd:float ;
     nidm_qValueFDR: "0.180381705425717"^^xsd:float .
 
-niiri:8c3895f16059640a97c019e9952dc277
+niiri:c59aa6c2583c6162213161db59c0cdfa
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0040" ;
     nidm_coordinateVector: "[48,-52,-24]"^^xsd:string .
 
-niiri:e2652296eb9d97ffffca1509a9026339 prov:wasDerivedFrom niiri:38307cfb7180ba187f2a9da76b2278a7 .
+niiri:b165c84e39ed0a56c6fcfe2cf6485d45 prov:wasDerivedFrom niiri:0337643db0192f78f5b32cbf7ed520a4 .
 
-niiri:d18db9d2cf5ed2028588cfefd0e5cbf1
+niiri:ff9ae21e91aa2853a4df2c66190d9a69
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0041" ;
-    prov:atLocation niiri:5390f1d922339e9cd9dc5096c14b6d8d ;
+    prov:atLocation niiri:d006be9910c4fdf007dcb927133b1b34 ;
     prov:value "2.27386736869812"^^xsd:float ;
     nidm_equivalentZStatistic: "3.60151277214208"^^xsd:float ;
     nidm_pValueUncorrected: "0.000158185438331238"^^xsd:float ;
     nidm_pValueFWER: "0.999999040177611"^^xsd:float ;
     nidm_qValueFDR: "0.418270156640619"^^xsd:float .
 
-niiri:5390f1d922339e9cd9dc5096c14b6d8d
+niiri:d006be9910c4fdf007dcb927133b1b34
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0041" ;
     nidm_coordinateVector: "[44,-44,-28]"^^xsd:string .
 
-niiri:d18db9d2cf5ed2028588cfefd0e5cbf1 prov:wasDerivedFrom niiri:38307cfb7180ba187f2a9da76b2278a7 .
+niiri:ff9ae21e91aa2853a4df2c66190d9a69 prov:wasDerivedFrom niiri:0337643db0192f78f5b32cbf7ed520a4 .
 
-niiri:460fe6e2bb01ece180e670e159b94fc1
+niiri:07dafc52bdbe3bac0a138605d2cfa21e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0042" ;
-    prov:atLocation niiri:4b7d51aadadb43a99b13d49b3e8f1842 ;
+    prov:atLocation niiri:5424fb677782b73cf78964d910cc0921 ;
     prov:value "2.64867973327637"^^xsd:float ;
     nidm_equivalentZStatistic: "4.08349211971756"^^xsd:float ;
     nidm_pValueUncorrected: "2.21819671972767e-05"^^xsd:float ;
     nidm_pValueFWER: "0.945632017925947"^^xsd:float ;
     nidm_qValueFDR: "0.1898401047323"^^xsd:float .
 
-niiri:4b7d51aadadb43a99b13d49b3e8f1842
+niiri:5424fb677782b73cf78964d910cc0921
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0042" ;
     nidm_coordinateVector: "[-50,-58,52]"^^xsd:string .
 
-niiri:460fe6e2bb01ece180e670e159b94fc1 prov:wasDerivedFrom niiri:a23fb16f5011d68723f436a695655a4b .
+niiri:07dafc52bdbe3bac0a138605d2cfa21e prov:wasDerivedFrom niiri:1a04d969a09af1e47b83e8c89999ecc0 .
 
-niiri:06f1c2193ea4e339615fd481c7ec74a0
+niiri:8bbb069d9a8a8deae00856c0bac1dca3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0043" ;
-    prov:atLocation niiri:5e4673efdf3328029b42f5b816c6f378 ;
+    prov:atLocation niiri:8959c9a0a8c3ec7c7ef746684cae1e87 ;
     prov:value "2.64205074310303"^^xsd:float ;
     nidm_equivalentZStatistic: "4.07500123020084"^^xsd:float ;
     nidm_pValueUncorrected: "2.30070519045e-05"^^xsd:float ;
     nidm_pValueFWER: "0.950216866218648"^^xsd:float ;
     nidm_qValueFDR: "0.1898401047323"^^xsd:float .
 
-niiri:5e4673efdf3328029b42f5b816c6f378
+niiri:8959c9a0a8c3ec7c7ef746684cae1e87
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0043" ;
     nidm_coordinateVector: "[-16,-62,32]"^^xsd:string .
 
-niiri:06f1c2193ea4e339615fd481c7ec74a0 prov:wasDerivedFrom niiri:dd24018042f78d315dbd6726698ec521 .
+niiri:8bbb069d9a8a8deae00856c0bac1dca3 prov:wasDerivedFrom niiri:cad3a1438e0a5950942cd5ed7b22e997 .
 
-niiri:4589ec081f3010df41b7d2a53eb95b22
+niiri:83820e300b8ac064252e16de139eccae
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0044" ;
-    prov:atLocation niiri:e8bb384848965da01f0eb9969d8d6dd8 ;
+    prov:atLocation niiri:b6d09fc20724d7c85a681cd22742edf4 ;
     prov:value "2.03684568405151"^^xsd:float ;
     nidm_equivalentZStatistic: "3.29512938083033"^^xsd:float ;
     nidm_pValueUncorrected: "0.000491881875043121"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999991"^^xsd:float ;
     nidm_qValueFDR: "0.71408368346076"^^xsd:float .
 
-niiri:e8bb384848965da01f0eb9969d8d6dd8
+niiri:b6d09fc20724d7c85a681cd22742edf4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0044" ;
     nidm_coordinateVector: "[-24,-60,36]"^^xsd:string .
 
-niiri:4589ec081f3010df41b7d2a53eb95b22 prov:wasDerivedFrom niiri:dd24018042f78d315dbd6726698ec521 .
+niiri:83820e300b8ac064252e16de139eccae prov:wasDerivedFrom niiri:cad3a1438e0a5950942cd5ed7b22e997 .
 
-niiri:f2f4cfd152c8dabf51e02932307b8aef
+niiri:96dad918bf5b91086582f2216b436cf1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0045" ;
-    prov:atLocation niiri:efc3e0cf7e7dde592e605ccb4146bf19 ;
+    prov:atLocation niiri:d9c26099c0e501b5aea3bea542119b22 ;
     prov:value "2.62229943275452"^^xsd:float ;
     nidm_equivalentZStatistic: "4.0496944261574"^^xsd:float ;
     nidm_pValueUncorrected: "2.56422773555753e-05"^^xsd:float ;
     nidm_pValueFWER: "0.962265585786802"^^xsd:float ;
     nidm_qValueFDR: "0.205120702581303"^^xsd:float .
 
-niiri:efc3e0cf7e7dde592e605ccb4146bf19
+niiri:d9c26099c0e501b5aea3bea542119b22
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0045" ;
     nidm_coordinateVector: "[-42,-86,16]"^^xsd:string .
 
-niiri:f2f4cfd152c8dabf51e02932307b8aef prov:wasDerivedFrom niiri:08d22242c39ac4379d79b33f1f2f58d6 .
+niiri:96dad918bf5b91086582f2216b436cf1 prov:wasDerivedFrom niiri:aa48c521a0de3bccee7d00f6ba89c3cf .
 
-niiri:4ad99dbaeccddb46f360b62292ba323b
+niiri:b36997cc891aca5718ab9e08f9f432be
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0046" ;
-    prov:atLocation niiri:a2a7efdd41886d31985c7e4877b2d490 ;
+    prov:atLocation niiri:0ef0527a41b5e316ed802defc1b39a56 ;
     prov:value "2.59810495376587"^^xsd:float ;
     nidm_equivalentZStatistic: "4.01867880935315"^^xsd:float ;
     nidm_pValueUncorrected: "2.92626931942541e-05"^^xsd:float ;
     nidm_pValueFWER: "0.97396448920475"^^xsd:float ;
     nidm_qValueFDR: "0.21596866367834"^^xsd:float .
 
-niiri:a2a7efdd41886d31985c7e4877b2d490
+niiri:0ef0527a41b5e316ed802defc1b39a56
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0046" ;
     nidm_coordinateVector: "[50,12,-12]"^^xsd:string .
 
-niiri:4ad99dbaeccddb46f360b62292ba323b prov:wasDerivedFrom niiri:61b56883c58ef13be768c931fffde95f .
+niiri:b36997cc891aca5718ab9e08f9f432be prov:wasDerivedFrom niiri:666175487bab3267d4af86f55ff4bd3b .
 
-niiri:3af0dfd188fb42472ea5f27ee64ecbb0
+niiri:25c1c6fe5473de8cd328924f02807315
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0047" ;
-    prov:atLocation niiri:19c62f4777efecf49e62e5c5830bd1e3 ;
+    prov:atLocation niiri:36a4bb29de9bb248d7239d223f1f865c ;
     prov:value "2.58033466339111"^^xsd:float ;
     nidm_equivalentZStatistic: "3.99588757924215"^^xsd:float ;
     nidm_pValueUncorrected: "3.22261580589789e-05"^^xsd:float ;
     nidm_pValueFWER: "0.98064397547503"^^xsd:float ;
     nidm_qValueFDR: "0.22269791282493"^^xsd:float .
 
-niiri:19c62f4777efecf49e62e5c5830bd1e3
+niiri:36a4bb29de9bb248d7239d223f1f865c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0047" ;
     nidm_coordinateVector: "[10,56,-20]"^^xsd:string .
 
-niiri:3af0dfd188fb42472ea5f27ee64ecbb0 prov:wasDerivedFrom niiri:7d6ccb38dbccc63215a5fdd98139915c .
+niiri:25c1c6fe5473de8cd328924f02807315 prov:wasDerivedFrom niiri:6951754ac73a67bbeeec0a4f76595341 .
 
-niiri:3b08e4069702cf26e30d860fc5759ad6
+niiri:289a61918b6511cb6b776c8ac53da1fb
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0048" ;
-    prov:atLocation niiri:d1caa86519573cfe8c598f42e81c1a3c ;
+    prov:atLocation niiri:5207732da4f07346337949bb54bf30d8 ;
     prov:value "2.57430815696716"^^xsd:float ;
     nidm_equivalentZStatistic: "3.98815622046766"^^xsd:float ;
     nidm_pValueUncorrected: "3.32944052300332e-05"^^xsd:float ;
     nidm_pValueFWER: "0.982580167470916"^^xsd:float ;
     nidm_qValueFDR: "0.22642798795628"^^xsd:float .
 
-niiri:d1caa86519573cfe8c598f42e81c1a3c
+niiri:5207732da4f07346337949bb54bf30d8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0048" ;
     nidm_coordinateVector: "[-58,-46,-2]"^^xsd:string .
 
-niiri:3b08e4069702cf26e30d860fc5759ad6 prov:wasDerivedFrom niiri:823399669e7b2b8c54db148364839dc3 .
+niiri:289a61918b6511cb6b776c8ac53da1fb prov:wasDerivedFrom niiri:92c69844c448bad6dc16185f863b358e .
 
-niiri:88f7b17cafef0abbf1a9369d2a2e9265
+niiri:5b892640561d323072506be428e65c2c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0049" ;
-    prov:atLocation niiri:58563b5fb32600cfdb5cc5575c0c8d33 ;
+    prov:atLocation niiri:d240e37d1a3ccee80381d4a0ccec305b ;
     prov:value "2.56071877479553"^^xsd:float ;
     nidm_equivalentZStatistic: "3.97071867739396"^^xsd:float ;
     nidm_pValueUncorrected: "3.58280756852514e-05"^^xsd:float ;
     nidm_pValueFWER: "0.986393731480231"^^xsd:float ;
     nidm_qValueFDR: "0.23304271385756"^^xsd:float .
 
-niiri:58563b5fb32600cfdb5cc5575c0c8d33
+niiri:d240e37d1a3ccee80381d4a0ccec305b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0049" ;
     nidm_coordinateVector: "[46,-40,2]"^^xsd:string .
 
-niiri:88f7b17cafef0abbf1a9369d2a2e9265 prov:wasDerivedFrom niiri:d81a7a910431ac9a1979f323b4b791c2 .
+niiri:5b892640561d323072506be428e65c2c prov:wasDerivedFrom niiri:177bfa600d85757ea0c4626517c44033 .
 
-niiri:15a7d7fc5260775e0bc5b07373fc4ef1
+niiri:70699d653df50cd6d5e59c21dedb8323
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0050" ;
-    prov:atLocation niiri:cdc77e12c154a87dfa2a6f954e93432e ;
+    prov:atLocation niiri:81dca2f2f612f00b789df6e3ebb1af42 ;
     prov:value "2.54513788223267"^^xsd:float ;
     nidm_equivalentZStatistic: "3.95071921672779"^^xsd:float ;
     nidm_pValueUncorrected: "3.89583464949217e-05"^^xsd:float ;
     nidm_pValueFWER: "0.989920329912446"^^xsd:float ;
     nidm_qValueFDR: "0.240658196026741"^^xsd:float .
 
-niiri:cdc77e12c154a87dfa2a6f954e93432e
+niiri:81dca2f2f612f00b789df6e3ebb1af42
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0050" ;
     nidm_coordinateVector: "[48,14,52]"^^xsd:string .
 
-niiri:15a7d7fc5260775e0bc5b07373fc4ef1 prov:wasDerivedFrom niiri:dabab8dbebf83a48079048945d816fe5 .
+niiri:70699d653df50cd6d5e59c21dedb8323 prov:wasDerivedFrom niiri:746b0b97599bb9118ebd954e679a2576 .
 
-niiri:5e4488db7d8bf5c97b0e775342a98808
+niiri:201264c80972dcebd2c7ea04534507f6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0051" ;
-    prov:atLocation niiri:f75e896f16e49d81110d3b8913b2f636 ;
+    prov:atLocation niiri:a7b889f37c8fdd43f35c04b78cc226b2 ;
     prov:value "2.51254177093506"^^xsd:float ;
     nidm_equivalentZStatistic: "3.90885728034341"^^xsd:float ;
     nidm_pValueUncorrected: "4.63668626720093e-05"^^xsd:float ;
     nidm_pValueFWER: "0.994942233722668"^^xsd:float ;
     nidm_qValueFDR: "0.267046680534214"^^xsd:float .
 
-niiri:f75e896f16e49d81110d3b8913b2f636
+niiri:a7b889f37c8fdd43f35c04b78cc226b2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0051" ;
     nidm_coordinateVector: "[-52,-44,56]"^^xsd:string .
 
-niiri:5e4488db7d8bf5c97b0e775342a98808 prov:wasDerivedFrom niiri:5842093feb2c4b86fc255ab1795f6409 .
+niiri:201264c80972dcebd2c7ea04534507f6 prov:wasDerivedFrom niiri:54c365a30f25bdcc066a52c171908849 .
 
-niiri:443dc8c05f410cbf2673553c716fb321
+niiri:b44f502f04b58f2cf2d267fb394a2207
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0052" ;
-    prov:atLocation niiri:0b07b0a3088f9e2862e3b217fe18f90a ;
+    prov:atLocation niiri:87c7b6e56ec1bbda155c55cec46b9a8c ;
     prov:value "2.50266766548157"^^xsd:float ;
     nidm_equivalentZStatistic: "3.89617059063353"^^xsd:float ;
     nidm_pValueUncorrected: "4.88627843049372e-05"^^xsd:float ;
     nidm_pValueFWER: "0.995967498491102"^^xsd:float ;
     nidm_qValueFDR: "0.267780274176525"^^xsd:float .
 
-niiri:0b07b0a3088f9e2862e3b217fe18f90a
+niiri:87c7b6e56ec1bbda155c55cec46b9a8c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0052" ;
     nidm_coordinateVector: "[-12,36,-18]"^^xsd:string .
 
-niiri:443dc8c05f410cbf2673553c716fb321 prov:wasDerivedFrom niiri:2498df410b841338c0adda91711ed606 .
+niiri:b44f502f04b58f2cf2d267fb394a2207 prov:wasDerivedFrom niiri:b9e88b2bbae3b722fa155ba8e9501a86 .
 
-niiri:a5927ab3169e28dc23d5cb893a815928
+niiri:1f6b053553d3aeb85e957aa471ba1b95
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0053" ;
-    prov:atLocation niiri:d20ca65782ced7404c210699b4e7a236 ;
+    prov:atLocation niiri:57a35110569fb6d0b6a603c14633ce79 ;
     prov:value "1.89663207530975"^^xsd:float ;
     nidm_equivalentZStatistic: "3.11350866317858"^^xsd:float ;
     nidm_pValueUncorrected: "0.000924385411494866"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.962543829897604"^^xsd:float .
 
-niiri:d20ca65782ced7404c210699b4e7a236
+niiri:57a35110569fb6d0b6a603c14633ce79
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0053" ;
     nidm_coordinateVector: "[-6,48,-16]"^^xsd:string .
 
-niiri:a5927ab3169e28dc23d5cb893a815928 prov:wasDerivedFrom niiri:2498df410b841338c0adda91711ed606 .
+niiri:1f6b053553d3aeb85e957aa471ba1b95 prov:wasDerivedFrom niiri:b9e88b2bbae3b722fa155ba8e9501a86 .
 
-niiri:9a55de42084b0000da1147f72d1cd53a
+niiri:6ba4d4daf1fd511897ca0be0927d8a89
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0054" ;
-    prov:atLocation niiri:bce44a82c1d5983238e1a86d11fe8256 ;
+    prov:atLocation niiri:944364ab4b3104947bddc393f78f4442 ;
     prov:value "2.47411036491394"^^xsd:float ;
     nidm_equivalentZStatistic: "3.85946417006895"^^xsd:float ;
     nidm_pValueUncorrected: "5.68179580313632e-05"^^xsd:float ;
     nidm_pValueFWER: "0.998007647418056"^^xsd:float ;
     nidm_qValueFDR: "0.292256519682192"^^xsd:float .
 
-niiri:bce44a82c1d5983238e1a86d11fe8256
+niiri:944364ab4b3104947bddc393f78f4442
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0054" ;
     nidm_coordinateVector: "[-20,-94,24]"^^xsd:string .
 
-niiri:9a55de42084b0000da1147f72d1cd53a prov:wasDerivedFrom niiri:4e803c8ae9b4739d7433ebb1a14e59ad .
+niiri:6ba4d4daf1fd511897ca0be0927d8a89 prov:wasDerivedFrom niiri:6b8826bcc0a021bc10b09d6a6d4302fd .
 
-niiri:f43c402921675aa91ae5240840cda507
+niiri:74e91aadd62ca24aff8ec843f5b9cf73
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0055" ;
-    prov:atLocation niiri:07d4ec7becd43d0737a4671ddc6dc04f ;
+    prov:atLocation niiri:b56f1032a996acfee4bdb230b29e91d6 ;
     prov:value "2.47011852264404"^^xsd:float ;
     nidm_equivalentZStatistic: "3.85433149398881"^^xsd:float ;
     nidm_pValueUncorrected: "5.80231377617091e-05"^^xsd:float ;
     nidm_pValueFWER: "0.998205767610089"^^xsd:float ;
     nidm_qValueFDR: "0.293636732712391"^^xsd:float .
 
-niiri:07d4ec7becd43d0737a4671ddc6dc04f
+niiri:b56f1032a996acfee4bdb230b29e91d6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0055" ;
     nidm_coordinateVector: "[-12,18,42]"^^xsd:string .
 
-niiri:f43c402921675aa91ae5240840cda507 prov:wasDerivedFrom niiri:59ee3c1181a6931549c7f2a8d5a010d9 .
+niiri:74e91aadd62ca24aff8ec843f5b9cf73 prov:wasDerivedFrom niiri:cc1d6ba65b10195363d6da601013d7a1 .
 
-niiri:42f0ef94a70b0427ad4f366c62fc739c
+niiri:20009017f6e554d7929aee14c3cb2b0a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0056" ;
-    prov:atLocation niiri:19bef40580c68b029328a9f62633eb9d ;
+    prov:atLocation niiri:4098b8dc55187d1b591a67c566c304d1 ;
     prov:value "2.46635222434998"^^xsd:float ;
     nidm_equivalentZStatistic: "3.8494884380349"^^xsd:float ;
     nidm_pValueUncorrected: "5.91823851514572e-05"^^xsd:float ;
     nidm_pValueFWER: "0.998376942414084"^^xsd:float ;
     nidm_qValueFDR: "0.294187599254207"^^xsd:float .
 
-niiri:19bef40580c68b029328a9f62633eb9d
+niiri:4098b8dc55187d1b591a67c566c304d1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0056" ;
     nidm_coordinateVector: "[48,-76,0]"^^xsd:string .
 
-niiri:42f0ef94a70b0427ad4f366c62fc739c prov:wasDerivedFrom niiri:d5b0a3e5aceb6afc5f0beca22061d358 .
+niiri:20009017f6e554d7929aee14c3cb2b0a prov:wasDerivedFrom niiri:82933f30610ef29a453f4b374990b32f .
 
-niiri:13b6ec4cfe801811e2f8e1cd1c35009b
+niiri:50726c9e381e8c0cadcb5c25bfce42c4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0057" ;
-    prov:atLocation niiri:2bde26670c824d875bd09aa4031c9d99 ;
+    prov:atLocation niiri:eac87d7000647e4f1c4c33f0fccd4ba6 ;
     prov:value "2.44098949432373"^^xsd:float ;
     nidm_equivalentZStatistic: "3.81686512377712"^^xsd:float ;
     nidm_pValueUncorrected: "6.75790026252177e-05"^^xsd:float ;
     nidm_pValueFWER: "0.999204444055832"^^xsd:float ;
     nidm_qValueFDR: "0.321048096330285"^^xsd:float .
 
-niiri:2bde26670c824d875bd09aa4031c9d99
+niiri:eac87d7000647e4f1c4c33f0fccd4ba6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0057" ;
     nidm_coordinateVector: "[-52,24,18]"^^xsd:string .
 
-niiri:13b6ec4cfe801811e2f8e1cd1c35009b prov:wasDerivedFrom niiri:f93d82501705ce2feae40e77d940aa42 .
+niiri:50726c9e381e8c0cadcb5c25bfce42c4 prov:wasDerivedFrom niiri:14f8555b74f38f3e8db5c662f1a8015c .
 
-niiri:65c9b827c7a9619a328db498fa06b408
+niiri:f65e0cae04132c7a84d5a8f11123339a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0058" ;
-    prov:atLocation niiri:d1dec038dc233f71e2e4ab715d691db7 ;
+    prov:atLocation niiri:c7f2ef37f7f022ac15cc88574f9d27c7 ;
     prov:value "2.43735671043396"^^xsd:float ;
     nidm_equivalentZStatistic: "3.81219103522413"^^xsd:float ;
     nidm_pValueUncorrected: "6.88701755224841e-05"^^xsd:float ;
     nidm_pValueFWER: "0.999285679399569"^^xsd:float ;
     nidm_qValueFDR: "0.321708874973631"^^xsd:float .
 
-niiri:d1dec038dc233f71e2e4ab715d691db7
+niiri:c7f2ef37f7f022ac15cc88574f9d27c7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0058" ;
     nidm_coordinateVector: "[-26,-74,24]"^^xsd:string .
 
-niiri:65c9b827c7a9619a328db498fa06b408 prov:wasDerivedFrom niiri:e087977e9e8a8b501c9a28c9869554a6 .
+niiri:f65e0cae04132c7a84d5a8f11123339a prov:wasDerivedFrom niiri:8c06ba2c370d4dda4947f0cbe66ca91e .
 
-niiri:0181954e43d1adadd9462628b9c60d76
+niiri:f7a1eeb8810d3507d311591e2f7997ab
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0059" ;
-    prov:atLocation niiri:64277aae3a6a57c7fee1c9c41ae69ad7 ;
+    prov:atLocation niiri:841e0f6ceb12de956b666f63bb8438ca ;
     prov:value "2.43673038482666"^^xsd:float ;
     nidm_equivalentZStatistic: "3.81138514524412"^^xsd:float ;
     nidm_pValueUncorrected: "6.90951304638254e-05"^^xsd:float ;
     nidm_pValueFWER: "0.999298924132454"^^xsd:float ;
     nidm_qValueFDR: "0.321708874973631"^^xsd:float .
 
-niiri:64277aae3a6a57c7fee1c9c41ae69ad7
+niiri:841e0f6ceb12de956b666f63bb8438ca
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0059" ;
     nidm_coordinateVector: "[12,50,-10]"^^xsd:string .
 
-niiri:0181954e43d1adadd9462628b9c60d76 prov:wasDerivedFrom niiri:a2144fa83ecfa43f689763a4c0b15ca8 .
+niiri:f7a1eeb8810d3507d311591e2f7997ab prov:wasDerivedFrom niiri:337d987921a53a135ec5d7ccac93719b .
 
-niiri:231f9934a1286cdf4d40a29a439ba0f4
+niiri:1f1e980431dd78b887d46d0d999586d6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0060" ;
-    prov:atLocation niiri:a2ea8153c611eef128fac52119962da0 ;
+    prov:atLocation niiri:0b3bc38c6284016e53a9355a01069eb7 ;
     prov:value "2.43038630485535"^^xsd:float ;
     nidm_equivalentZStatistic: "3.8032216915074"^^xsd:float ;
     nidm_pValueUncorrected: "7.14132165696713e-05"^^xsd:float ;
     nidm_pValueFWER: "0.999421405677481"^^xsd:float ;
     nidm_qValueFDR: "0.325210886758063"^^xsd:float .
 
-niiri:a2ea8153c611eef128fac52119962da0
+niiri:0b3bc38c6284016e53a9355a01069eb7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0060" ;
     nidm_coordinateVector: "[-42,-38,44]"^^xsd:string .
 
-niiri:231f9934a1286cdf4d40a29a439ba0f4 prov:wasDerivedFrom niiri:575376d8b1a60c68f57a2629ca1c6f57 .
+niiri:1f1e980431dd78b887d46d0d999586d6 prov:wasDerivedFrom niiri:8b64f56916b41aba13f0c3626eccb6c6 .
 
-niiri:2f0f6fb149bb83bbdc4f66c77db8de17
+niiri:dac1b7a25e803b8443975ee1030a9b0e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0061" ;
-    prov:atLocation niiri:03fb4e9872c3f8a52bf682373dd79113 ;
+    prov:atLocation niiri:fdfbbbc1a393300697b91e0c5b685119 ;
     prov:value "2.40943622589111"^^xsd:float ;
     nidm_equivalentZStatistic: "3.77625633974215"^^xsd:float ;
     nidm_pValueUncorrected: "7.96015746719059e-05"^^xsd:float ;
     nidm_pValueFWER: "0.999702913851826"^^xsd:float ;
     nidm_qValueFDR: "0.343869281784496"^^xsd:float .
 
-niiri:03fb4e9872c3f8a52bf682373dd79113
+niiri:fdfbbbc1a393300697b91e0c5b685119
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0061" ;
     nidm_coordinateVector: "[0,10,34]"^^xsd:string .
 
-niiri:2f0f6fb149bb83bbdc4f66c77db8de17 prov:wasDerivedFrom niiri:e7cf6cf6e829a4522b12ecb22c64da50 .
+niiri:dac1b7a25e803b8443975ee1030a9b0e prov:wasDerivedFrom niiri:7167233a4e5f287b27d1ea49b05f5e73 .
 
-niiri:556eaeaa78dfbb32a05958b55023fc13
+niiri:d5b79c346d3f077001fa066fa2d1a90d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0062" ;
-    prov:atLocation niiri:121158b0a3c590dd60c5c39ebb6dda3b ;
+    prov:atLocation niiri:15a6f00994c97e4acbaee735fb13fdc7 ;
     prov:value "2.40475845336914"^^xsd:float ;
     nidm_equivalentZStatistic: "3.77023398434736"^^xsd:float ;
     nidm_pValueUncorrected: "8.15472821792396e-05"^^xsd:float ;
     nidm_pValueFWER: "0.999745792273193"^^xsd:float ;
     nidm_qValueFDR: "0.347513578737157"^^xsd:float .
 
-niiri:121158b0a3c590dd60c5c39ebb6dda3b
+niiri:15a6f00994c97e4acbaee735fb13fdc7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0062" ;
     nidm_coordinateVector: "[44,-42,18]"^^xsd:string .
 
-niiri:556eaeaa78dfbb32a05958b55023fc13 prov:wasDerivedFrom niiri:f34dda9711be5249376de56aa5f55bb0 .
+niiri:d5b79c346d3f077001fa066fa2d1a90d prov:wasDerivedFrom niiri:9bcff3c8230d1d562436a59af916d435 .
 
-niiri:c95aee4950d5ff34ca4c2b4c00db0277
+niiri:199023e997d45cf3233e578d536f4c5c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0063" ;
-    prov:atLocation niiri:07e4fb55cd102eea4944ce5bab249015 ;
+    prov:atLocation niiri:0d56a8634361bb98f6349ca40ded5b4d ;
     prov:value "2.40324783325195"^^xsd:float ;
     nidm_equivalentZStatistic: "3.76828903590742"^^xsd:float ;
     nidm_pValueUncorrected: "8.21851578610699e-05"^^xsd:float ;
     nidm_pValueFWER: "0.999758407620262"^^xsd:float ;
     nidm_qValueFDR: "0.347513578737157"^^xsd:float .
 
-niiri:07e4fb55cd102eea4944ce5bab249015
+niiri:0d56a8634361bb98f6349ca40ded5b4d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0063" ;
     nidm_coordinateVector: "[58,-60,20]"^^xsd:string .
 
-niiri:c95aee4950d5ff34ca4c2b4c00db0277 prov:wasDerivedFrom niiri:3d8865c6fb016a8704775ebaf2435091 .
+niiri:199023e997d45cf3233e578d536f4c5c prov:wasDerivedFrom niiri:1f551e5f86fc52cb27432b3822b69ca7 .
 
-niiri:28daede7297ff75fc061e2a9969d9aa4
+niiri:cc258c6487aa920075b8a9d74a761b48
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0064" ;
-    prov:atLocation niiri:508f73e9f217034eddd43e0bbb435a7c ;
+    prov:atLocation niiri:3c7c457d319c1fc2fa269d1baabb4067 ;
     prov:value "2.39750051498413"^^xsd:float ;
     nidm_equivalentZStatistic: "3.76088876011273"^^xsd:float ;
     nidm_pValueUncorrected: "8.46553582728449e-05"^^xsd:float ;
     nidm_pValueFWER: "0.999801447697793"^^xsd:float ;
     nidm_qValueFDR: "0.353141402062803"^^xsd:float .
 
-niiri:508f73e9f217034eddd43e0bbb435a7c
+niiri:3c7c457d319c1fc2fa269d1baabb4067
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0064" ;
     nidm_coordinateVector: "[18,56,30]"^^xsd:string .
 
-niiri:28daede7297ff75fc061e2a9969d9aa4 prov:wasDerivedFrom niiri:16a6c15579df8b38a23d9ad0e739425a .
+niiri:cc258c6487aa920075b8a9d74a761b48 prov:wasDerivedFrom niiri:222cf8fd43a488444ee6a32847bc1d9a .
 
-niiri:f06248d5e8d94b80fe21258e8ce73e9f
+niiri:64b4dccdedec0a80f2fe74dd14cc1002
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0065" ;
-    prov:atLocation niiri:e5f1e3748fc22a13ebb88b9ed8e9b8ba ;
+    prov:atLocation niiri:5a441cb24733925f0b14a28f79922340 ;
     prov:value "2.39031767845154"^^xsd:float ;
     nidm_equivalentZStatistic: "3.75163897818956"^^xsd:float ;
     nidm_pValueUncorrected: "8.78411611173746e-05"^^xsd:float ;
     nidm_pValueFWER: "0.999845514728957"^^xsd:float ;
     nidm_qValueFDR: "0.360940928701093"^^xsd:float .
 
-niiri:e5f1e3748fc22a13ebb88b9ed8e9b8ba
+niiri:5a441cb24733925f0b14a28f79922340
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0065" ;
     nidm_coordinateVector: "[-34,20,-34]"^^xsd:string .
 
-niiri:f06248d5e8d94b80fe21258e8ce73e9f prov:wasDerivedFrom niiri:c2f8c271d456bfd2eff8e6eb839c91ba .
+niiri:64b4dccdedec0a80f2fe74dd14cc1002 prov:wasDerivedFrom niiri:944e97172e0a25bb481c848ff69da03e .
 
-niiri:8cc61d9b83229492245024fd78c1917a
+niiri:d3b936a394a469d3174e0f8343bd463f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0066" ;
-    prov:atLocation niiri:d18b998f0fba94f5aee71a8ef389f096 ;
+    prov:atLocation niiri:d2aa8e04105ae05392733434b72a496a ;
     prov:value "2.38168978691101"^^xsd:float ;
     nidm_equivalentZStatistic: "3.74052666970635"^^xsd:float ;
     nidm_pValueUncorrected: "9.18175293811441e-05"^^xsd:float ;
     nidm_pValueFWER: "0.999886700884216"^^xsd:float ;
     nidm_qValueFDR: "0.36651035415338"^^xsd:float .
 
-niiri:d18b998f0fba94f5aee71a8ef389f096
+niiri:d2aa8e04105ae05392733434b72a496a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0066" ;
     nidm_coordinateVector: "[22,0,0]"^^xsd:string .
 
-niiri:8cc61d9b83229492245024fd78c1917a prov:wasDerivedFrom niiri:84844c35c8e8d08a6e00bf67a2f849ff .
+niiri:d3b936a394a469d3174e0f8343bd463f prov:wasDerivedFrom niiri:f16d0ba2c74c51bb5e78d2245c00a45f .
 
-niiri:555c9f9f85cc6287487521e402886b0d
+niiri:f51500ecaf58b3d1cd1042a40b408879
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0067" ;
-    prov:atLocation niiri:4e24f9198fcbe0ce60d16396d27e39af ;
+    prov:atLocation niiri:936515ba136a6b86b620bbefc5690e0e ;
     prov:value "2.37978529930115"^^xsd:float ;
     nidm_equivalentZStatistic: "3.73807354189968"^^xsd:float ;
     nidm_pValueUncorrected: "9.27178550079732e-05"^^xsd:float ;
     nidm_pValueFWER: "0.999894332475117"^^xsd:float ;
     nidm_qValueFDR: "0.36651035415338"^^xsd:float .
 
-niiri:4e24f9198fcbe0ce60d16396d27e39af
+niiri:936515ba136a6b86b620bbefc5690e0e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0067" ;
     nidm_coordinateVector: "[-48,-44,-34]"^^xsd:string .
 
-niiri:555c9f9f85cc6287487521e402886b0d prov:wasDerivedFrom niiri:dfda6f4a6ad2d61f37aadf0fa7507a7f .
+niiri:f51500ecaf58b3d1cd1042a40b408879 prov:wasDerivedFrom niiri:209a4a28e55d93fc75c92925f0f7d71b .
 
-niiri:5f02fc79c235c892deb102a64bef4145
+niiri:4ff8360d7fc12f9cfc4bcd4dfe7c00dd
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0068" ;
-    prov:atLocation niiri:2acd5c8536840207ef632d8af3fa4975 ;
+    prov:atLocation niiri:e0facfeceef20219293cb21eee4ddb30 ;
     prov:value "2.37950778007507"^^xsd:float ;
     nidm_equivalentZStatistic: "3.73771606840228"^^xsd:float ;
     nidm_pValueUncorrected: "9.28497425036756e-05"^^xsd:float ;
     nidm_pValueFWER: "0.999895404897798"^^xsd:float ;
     nidm_qValueFDR: "0.36651035415338"^^xsd:float .
 
-niiri:2acd5c8536840207ef632d8af3fa4975
+niiri:e0facfeceef20219293cb21eee4ddb30
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0068" ;
     nidm_coordinateVector: "[-62,-22,46]"^^xsd:string .
 
-niiri:5f02fc79c235c892deb102a64bef4145 prov:wasDerivedFrom niiri:261c5b8cb671c9ccd262aae82e498512 .
+niiri:4ff8360d7fc12f9cfc4bcd4dfe7c00dd prov:wasDerivedFrom niiri:357268aff375a1c533059d48c5f8dcb0 .
 
-niiri:65267326a5928afd50a46660bbc192d0
+niiri:73e236d5a6d25c17dd9cded1da30b954
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0069" ;
-    prov:atLocation niiri:cda2f37a719ff171e42bbbda2e25a5e8 ;
+    prov:atLocation niiri:5e77ae62f461f7d159dbf41101989ed2 ;
     prov:value "2.12179732322693"^^xsd:float ;
     nidm_equivalentZStatistic: "3.40504947037839"^^xsd:float ;
     nidm_pValueUncorrected: "0.000330760343973724"^^xsd:float ;
     nidm_pValueFWER: "0.999999999968743"^^xsd:float ;
     nidm_qValueFDR: "0.587708479280999"^^xsd:float .
 
-niiri:cda2f37a719ff171e42bbbda2e25a5e8
+niiri:5e77ae62f461f7d159dbf41101989ed2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0069" ;
     nidm_coordinateVector: "[-62,-32,48]"^^xsd:string .
 
-niiri:65267326a5928afd50a46660bbc192d0 prov:wasDerivedFrom niiri:261c5b8cb671c9ccd262aae82e498512 .
+niiri:73e236d5a6d25c17dd9cded1da30b954 prov:wasDerivedFrom niiri:357268aff375a1c533059d48c5f8dcb0 .
 
-niiri:ba7eacf309e859f6a5edbd1c0cd3eb3e
+niiri:e9e3416cc410461e50330f128b2e5ef5
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0070" ;
-    prov:atLocation niiri:6300fbe84004a20009b5f57561b3e619 ;
+    prov:atLocation niiri:5c701d285e118964f4e84c6e7d6537c1 ;
     prov:value "2.36615061759949"^^xsd:float ;
     nidm_equivalentZStatistic: "3.72050850696656"^^xsd:float ;
     nidm_pValueUncorrected: "9.94110221242961e-05"^^xsd:float ;
     nidm_pValueFWER: "0.999936749755425"^^xsd:float ;
     nidm_qValueFDR: "0.368886365441825"^^xsd:float .
 
-niiri:6300fbe84004a20009b5f57561b3e619
+niiri:5c701d285e118964f4e84c6e7d6537c1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0070" ;
     nidm_coordinateVector: "[28,18,-20]"^^xsd:string .
 
-niiri:ba7eacf309e859f6a5edbd1c0cd3eb3e prov:wasDerivedFrom niiri:504a0642ac3cd38acd0d64ccc15fc9e6 .
+niiri:e9e3416cc410461e50330f128b2e5ef5 prov:wasDerivedFrom niiri:0a39de1cb252a793d03ed45aa12d8950 .
 
-niiri:9134cb0143a6fc7aa85fb6ae8ee54ee6
+niiri:680d3d98098fe3304954deff21a29e7b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0071" ;
-    prov:atLocation niiri:4019b2f4e0dd57cc8b536908c5479b29 ;
+    prov:atLocation niiri:2b83a17bd863606f8500314b2def6d23 ;
     prov:value "2.35984563827515"^^xsd:float ;
     nidm_equivalentZStatistic: "3.71238457004225"^^xsd:float ;
     nidm_pValueUncorrected: "0.000102657853048083"^^xsd:float ;
     nidm_pValueFWER: "0.999950532037692"^^xsd:float ;
     nidm_qValueFDR: "0.368886365441825"^^xsd:float .
 
-niiri:4019b2f4e0dd57cc8b536908c5479b29
+niiri:2b83a17bd863606f8500314b2def6d23
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0071" ;
     nidm_coordinateVector: "[4,-4,-14]"^^xsd:string .
 
-niiri:9134cb0143a6fc7aa85fb6ae8ee54ee6 prov:wasDerivedFrom niiri:30d04637933701595f908aeb4100a23e .
+niiri:680d3d98098fe3304954deff21a29e7b prov:wasDerivedFrom niiri:2ce7fa7ad1d0a7052668df06aeeb62b3 .
 
-niiri:bf080a6f2cb7d99a6e2fe08645f54b7d
+niiri:47943ba3e02dcae014366323aa4ab25f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0072" ;
-    prov:atLocation niiri:bc18dc61c0deb40f5ec9883893bb8fc0 ;
+    prov:atLocation niiri:f09814cccec0ffd89a77db71136e90a2 ;
     prov:value "2.24515843391418"^^xsd:float ;
     nidm_equivalentZStatistic: "3.56445653816859"^^xsd:float ;
     nidm_pValueUncorrected: "0.000182305428946816"^^xsd:float ;
     nidm_pValueFWER: "0.999999804294694"^^xsd:float ;
     nidm_qValueFDR: "0.444734823272248"^^xsd:float .
 
-niiri:bc18dc61c0deb40f5ec9883893bb8fc0
+niiri:f09814cccec0ffd89a77db71136e90a2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0072" ;
     nidm_coordinateVector: "[-6,-6,-14]"^^xsd:string .
 
-niiri:bf080a6f2cb7d99a6e2fe08645f54b7d prov:wasDerivedFrom niiri:30d04637933701595f908aeb4100a23e .
+niiri:47943ba3e02dcae014366323aa4ab25f prov:wasDerivedFrom niiri:2ce7fa7ad1d0a7052668df06aeeb62b3 .
 
-niiri:9ded65cbb773cfce86de7e6f1870273f
+niiri:d2e4b7191441a73d13865ac94f555793
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0073" ;
-    prov:atLocation niiri:9017b984654e4c4db3a73f0718be2b1f ;
+    prov:atLocation niiri:9b72a267f0038b95d676e5cc83318080 ;
     prov:value "2.33331298828125"^^xsd:float ;
     nidm_equivalentZStatistic: "3.67818733586012"^^xsd:float ;
     nidm_pValueUncorrected: "0.000117448705507006"^^xsd:float ;
     nidm_pValueFWER: "0.999983460313748"^^xsd:float ;
     nidm_qValueFDR: "0.391344305962907"^^xsd:float .
 
-niiri:9017b984654e4c4db3a73f0718be2b1f
+niiri:9b72a267f0038b95d676e5cc83318080
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0073" ;
     nidm_coordinateVector: "[-20,-88,-10]"^^xsd:string .
 
-niiri:9ded65cbb773cfce86de7e6f1870273f prov:wasDerivedFrom niiri:3abca6b1ac25766b2a6217f3ab065c91 .
+niiri:d2e4b7191441a73d13865ac94f555793 prov:wasDerivedFrom niiri:837c632e63a40a2ac1469c8d1ba1b864 .
 
-niiri:0502857f563277a156c3ceb30ffe4756
+niiri:8cf5f9af5ca1975fc1c28c8c1557d889
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0074" ;
-    prov:atLocation niiri:f30d58e04a2c2a6c0d91c9e243e7a9ed ;
+    prov:atLocation niiri:537726e1a04c94675e66e07efbc28e13 ;
     prov:value "2.33159112930298"^^xsd:float ;
     nidm_equivalentZStatistic: "3.67596752451816"^^xsd:float ;
     nidm_pValueUncorrected: "0.000118474833320836"^^xsd:float ;
     nidm_pValueFWER: "0.999984649789011"^^xsd:float ;
     nidm_qValueFDR: "0.391580012304676"^^xsd:float .
 
-niiri:f30d58e04a2c2a6c0d91c9e243e7a9ed
+niiri:537726e1a04c94675e66e07efbc28e13
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0074" ;
     nidm_coordinateVector: "[-10,-84,-10]"^^xsd:string .
 
-niiri:0502857f563277a156c3ceb30ffe4756 prov:wasDerivedFrom niiri:779bcdad447bb00d9bdb1d38c48f9eb7 .
+niiri:8cf5f9af5ca1975fc1c28c8c1557d889 prov:wasDerivedFrom niiri:47f25a919baaf59e7867aa98557a23e4 .
 
-niiri:cfbf859f3c0ec6034e078c754596ee0d
+niiri:45eef5c14e0789f2e938b481f651929c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0075" ;
-    prov:atLocation niiri:c47c5a2a5239b1376eaedefa2ff2699f ;
+    prov:atLocation niiri:46c9e214eec026cee9cbc592615480de ;
     prov:value "2.32321286201477"^^xsd:float ;
     nidm_equivalentZStatistic: "3.66516536058509"^^xsd:float ;
     nidm_pValueUncorrected: "0.000123589411157754"^^xsd:float ;
     nidm_pValueFWER: "0.999989391962664"^^xsd:float ;
     nidm_qValueFDR: "0.39972936309914"^^xsd:float .
 
-niiri:c47c5a2a5239b1376eaedefa2ff2699f
+niiri:46c9e214eec026cee9cbc592615480de
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0075" ;
     nidm_coordinateVector: "[30,20,-38]"^^xsd:string .
 
-niiri:cfbf859f3c0ec6034e078c754596ee0d prov:wasDerivedFrom niiri:bea578e87145baa9fef8f57831c0c5fe .
+niiri:45eef5c14e0789f2e938b481f651929c prov:wasDerivedFrom niiri:82870fabf2e7a1a9a595fb88debeb7ef .
 
-niiri:e12bf0481530c748cb0a35468b822b88
+niiri:788812e3c1a5e8e9dc131a6099bb1cc2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0076" ;
-    prov:atLocation niiri:7ea9d842203fe3fbf34da0469ed5ed9a ;
+    prov:atLocation niiri:332da0b388b9ea6a8859b4b2d788ad6f ;
     prov:value "2.3199303150177"^^xsd:float ;
     nidm_equivalentZStatistic: "3.66093272184923"^^xsd:float ;
     nidm_pValueUncorrected: "0.000125649373061587"^^xsd:float ;
     nidm_pValueFWER: "0.999990848449071"^^xsd:float ;
     nidm_qValueFDR: "0.402380964108359"^^xsd:float .
 
-niiri:7ea9d842203fe3fbf34da0469ed5ed9a
+niiri:332da0b388b9ea6a8859b4b2d788ad6f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0076" ;
     nidm_coordinateVector: "[-32,-74,-34]"^^xsd:string .
 
-niiri:e12bf0481530c748cb0a35468b822b88 prov:wasDerivedFrom niiri:0416871505a4f68a8b0a05803d7fe0e1 .
+niiri:788812e3c1a5e8e9dc131a6099bb1cc2 prov:wasDerivedFrom niiri:54fe9c7a58c48364f79822c24b7f0a36 .
 
-niiri:26273f7f8f82fbadf3f958a731788002
+niiri:3e2507719bb8e8cec2153c1d7c6d11f9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0077" ;
-    prov:atLocation niiri:a619338ac199d532a1ec79efcfa4209c ;
+    prov:atLocation niiri:ae757bdf540f21b90dc47b8794c934d9 ;
     prov:value "2.31843018531799"^^xsd:float ;
     nidm_equivalentZStatistic: "3.65899831919211"^^xsd:float ;
     nidm_pValueUncorrected: "0.00012660150034427"^^xsd:float ;
     nidm_pValueFWER: "0.999991450468149"^^xsd:float ;
     nidm_qValueFDR: "0.402380964108359"^^xsd:float .
 
-niiri:a619338ac199d532a1ec79efcfa4209c
+niiri:ae757bdf540f21b90dc47b8794c934d9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0077" ;
     nidm_coordinateVector: "[64,-48,34]"^^xsd:string .
 
-niiri:26273f7f8f82fbadf3f958a731788002 prov:wasDerivedFrom niiri:03e0bc451aca56b2f70fb660afdf1e84 .
+niiri:3e2507719bb8e8cec2153c1d7c6d11f9 prov:wasDerivedFrom niiri:9f649ce7c963c614e6fb0b5f0f441d80 .
 
-niiri:ce68d24217b6596ee8fc6778125be00a
+niiri:a5458865e5677ec6fc83283980aaada6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0078" ;
-    prov:atLocation niiri:02cbfc710ea3d2d8b9c43217dda96a20 ;
+    prov:atLocation niiri:0dcf4ce843f00cd9033a7e2afd199a20 ;
     prov:value "2.31528902053833"^^xsd:float ;
     nidm_equivalentZStatistic: "3.65494765701128"^^xsd:float ;
     nidm_pValueUncorrected: "0.00012861722720714"^^xsd:float ;
     nidm_pValueFWER: "0.999992594228668"^^xsd:float ;
     nidm_qValueFDR: "0.404908421693631"^^xsd:float .
 
-niiri:02cbfc710ea3d2d8b9c43217dda96a20
+niiri:0dcf4ce843f00cd9033a7e2afd199a20
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0078" ;
     nidm_coordinateVector: "[-12,-12,2]"^^xsd:string .
 
-niiri:ce68d24217b6596ee8fc6778125be00a prov:wasDerivedFrom niiri:94477c176a303cb05b6cf25392b272ff .
+niiri:a5458865e5677ec6fc83283980aaada6 prov:wasDerivedFrom niiri:aa6b7754ff9629fdf69c2b137c4af89e .
 
-niiri:a6de3c3831590e1de613edc7269f52fc
+niiri:0bad50db6253e7c03b817887ef216040
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0079" ;
-    prov:atLocation niiri:7a5bf4276118c7c71b56aad6028247a3 ;
+    prov:atLocation niiri:4389f2b6c2b6084518dcf9c6e3e274ec ;
     prov:value "2.30988264083862"^^xsd:float ;
     nidm_equivalentZStatistic: "3.64797539896827"^^xsd:float ;
     nidm_pValueUncorrected: "0.000132157469679206"^^xsd:float ;
     nidm_pValueFWER: "0.999994237019437"^^xsd:float ;
     nidm_qValueFDR: "0.41105817784359"^^xsd:float .
 
-niiri:7a5bf4276118c7c71b56aad6028247a3
+niiri:4389f2b6c2b6084518dcf9c6e3e274ec
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0079" ;
     nidm_coordinateVector: "[-48,-44,20]"^^xsd:string .
 
-niiri:a6de3c3831590e1de613edc7269f52fc prov:wasDerivedFrom niiri:ccac343137c6a1606bfad900f0384914 .
+niiri:0bad50db6253e7c03b817887ef216040 prov:wasDerivedFrom niiri:992eba93ccac4ef864d1e4c888fef260 .
 
-niiri:766c0e2c813aa658998a61081105bba5
+niiri:a6b4a34fb40ee0a15bffe18d35ac9f31
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0080" ;
-    prov:atLocation niiri:21b68820dc82135a768a58f6334b864b ;
+    prov:atLocation niiri:c56830dc76f0cf45f60a678fce7533c9 ;
     prov:value "2.30309462547302"^^xsd:float ;
     nidm_equivalentZStatistic: "3.63922043208072"^^xsd:float ;
     nidm_pValueUncorrected: "0.000136732321226352"^^xsd:float ;
     nidm_pValueFWER: "0.99999582138664"^^xsd:float ;
     nidm_qValueFDR: "0.412454685345903"^^xsd:float .
 
-niiri:21b68820dc82135a768a58f6334b864b
+niiri:c56830dc76f0cf45f60a678fce7533c9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0080" ;
     nidm_coordinateVector: "[-52,-52,20]"^^xsd:string .
 
-niiri:766c0e2c813aa658998a61081105bba5 prov:wasDerivedFrom niiri:ccac343137c6a1606bfad900f0384914 .
+niiri:a6b4a34fb40ee0a15bffe18d35ac9f31 prov:wasDerivedFrom niiri:992eba93ccac4ef864d1e4c888fef260 .
 
-niiri:05647ca8991e4a0a95bd2fc1b2c62ae7
+niiri:78892fc1529eb6f3ae71eda0c5cb75dc
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0081" ;
-    prov:atLocation niiri:e2558d5e5571a464c52b03590c9450a0 ;
+    prov:atLocation niiri:f399f79c516833e75e018feb17e33afb ;
     prov:value "2.30742883682251"^^xsd:float ;
     nidm_equivalentZStatistic: "3.64481067597732"^^xsd:float ;
     nidm_pValueUncorrected: "0.000133794356756312"^^xsd:float ;
     nidm_pValueFWER: "0.999994864920274"^^xsd:float ;
     nidm_qValueFDR: "0.411522109968619"^^xsd:float .
 
-niiri:e2558d5e5571a464c52b03590c9450a0
+niiri:f399f79c516833e75e018feb17e33afb
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0081" ;
     nidm_coordinateVector: "[-8,-4,68]"^^xsd:string .
 
-niiri:05647ca8991e4a0a95bd2fc1b2c62ae7 prov:wasDerivedFrom niiri:74289f8090f7da1b2e9c2d274cc0f956 .
+niiri:78892fc1529eb6f3ae71eda0c5cb75dc prov:wasDerivedFrom niiri:2913f23a1813eb7942fb6b12aea56fda .
 
-niiri:455d4d02f780914df4f8c9a3b0f95760
+niiri:d2d93102aaafa6fbf39c89330edf7d36
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0082" ;
-    prov:atLocation niiri:fa01ecd26ef11b88bbe32f583e59d274 ;
+    prov:atLocation niiri:54139976336939af57421f288b0e9dab ;
     prov:value "2.30296897888184"^^xsd:float ;
     nidm_equivalentZStatistic: "3.63905836767043"^^xsd:float ;
     nidm_pValueUncorrected: "0.000136818389668947"^^xsd:float ;
     nidm_pValueFWER: "0.999995846467612"^^xsd:float ;
     nidm_qValueFDR: "0.412454685345903"^^xsd:float .
 
-niiri:fa01ecd26ef11b88bbe32f583e59d274
+niiri:54139976336939af57421f288b0e9dab
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0082" ;
     nidm_coordinateVector: "[24,36,34]"^^xsd:string .
 
-niiri:455d4d02f780914df4f8c9a3b0f95760 prov:wasDerivedFrom niiri:aa9f984347d25d8bedc780b7865258c6 .
+niiri:d2d93102aaafa6fbf39c89330edf7d36 prov:wasDerivedFrom niiri:1c4944ab6edec9e1dbd0763deb0ea5f5 .
 
-niiri:d1a6ea8476f2fafe540cddbd6ffba6a4
+niiri:f9d5a38c2897f37b953727849193451c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0083" ;
-    prov:atLocation niiri:6a8e3c79d857ce68341185e8d990f337 ;
+    prov:atLocation niiri:50e5e469d6707c527eb94fd063197ff7 ;
     prov:value "2.30046772956848"^^xsd:float ;
     nidm_equivalentZStatistic: "3.63583207709644"^^xsd:float ;
     nidm_pValueUncorrected: "0.000138542396657115"^^xsd:float ;
     nidm_pValueFWER: "0.99999631754215"^^xsd:float ;
     nidm_qValueFDR: "0.413429132458979"^^xsd:float .
 
-niiri:6a8e3c79d857ce68341185e8d990f337
+niiri:50e5e469d6707c527eb94fd063197ff7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0083" ;
     nidm_coordinateVector: "[46,-42,46]"^^xsd:string .
 
-niiri:d1a6ea8476f2fafe540cddbd6ffba6a4 prov:wasDerivedFrom niiri:2835e70d80bc47f846977da52697749b .
+niiri:f9d5a38c2897f37b953727849193451c prov:wasDerivedFrom niiri:807decf567867596e9ede288b13f016a .
 
-niiri:427cdba5928d6cfb873e4ffc7099ef1d
+niiri:e69b435cb561850d5bb26d896306c312
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0084" ;
-    prov:atLocation niiri:086d66aa1f058a88938ed5f762f0aca6 ;
+    prov:atLocation niiri:f81bff3e58fea6964d48c247d09b95ed ;
     prov:value "2.14905881881714"^^xsd:float ;
     nidm_equivalentZStatistic: "3.44029990384982"^^xsd:float ;
     nidm_pValueUncorrected: "0.000290534960819211"^^xsd:float ;
     nidm_pValueFWER: "0.99999999971054"^^xsd:float ;
     nidm_qValueFDR: "0.554694102883098"^^xsd:float .
 
-niiri:086d66aa1f058a88938ed5f762f0aca6
+niiri:f81bff3e58fea6964d48c247d09b95ed
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0084" ;
     nidm_coordinateVector: "[42,-48,38]"^^xsd:string .
 
-niiri:427cdba5928d6cfb873e4ffc7099ef1d prov:wasDerivedFrom niiri:2835e70d80bc47f846977da52697749b .
+niiri:e69b435cb561850d5bb26d896306c312 prov:wasDerivedFrom niiri:807decf567867596e9ede288b13f016a .
 
-niiri:d070456b3f0edeb7698db59b60ddd833
+niiri:6f25ec29f560c0501f2c9be49ad80287
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0085" ;
-    prov:atLocation niiri:debd4d18a46062c4b904a29039083b38 ;
+    prov:atLocation niiri:d5f0e8cf4ef0c2d23df21b39a0a7ce72 ;
     prov:value "2.29290223121643"^^xsd:float ;
     nidm_equivalentZStatistic: "3.62607273627958"^^xsd:float ;
     nidm_pValueUncorrected: "0.000143882164975628"^^xsd:float ;
     nidm_pValueFWER: "0.999997457251428"^^xsd:float ;
     nidm_qValueFDR: "0.416670883231346"^^xsd:float .
 
-niiri:debd4d18a46062c4b904a29039083b38
+niiri:d5f0e8cf4ef0c2d23df21b39a0a7ce72
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0085" ;
     nidm_coordinateVector: "[8,-54,72]"^^xsd:string .
 
-niiri:d070456b3f0edeb7698db59b60ddd833 prov:wasDerivedFrom niiri:87c4af2a8f65ce6e67f250f40b44790b .
+niiri:6f25ec29f560c0501f2c9be49ad80287 prov:wasDerivedFrom niiri:106990f64fdbe0a92e78b55484d984e7 .
 
-niiri:1c2334f989dbf42de0d9d0673eded9fd
+niiri:1c087be2a968de7ac0a2bea646c020cb
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0086" ;
-    prov:atLocation niiri:e5a41979fd64c5a5e9bf6c0f4ce9202c ;
+    prov:atLocation niiri:e7806e0fcab4c0eb3a7f57e5ee03788b ;
     prov:value "2.28387594223022"^^xsd:float ;
     nidm_equivalentZStatistic: "3.61442740814864"^^xsd:float ;
     nidm_pValueUncorrected: "0.000150506069076406"^^xsd:float ;
     nidm_pValueFWER: "0.999998385622597"^^xsd:float ;
     nidm_qValueFDR: "0.418270156640619"^^xsd:float .
 
-niiri:e5a41979fd64c5a5e9bf6c0f4ce9202c
+niiri:e7806e0fcab4c0eb3a7f57e5ee03788b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0086" ;
     nidm_coordinateVector: "[-50,-40,30]"^^xsd:string .
 
-niiri:1c2334f989dbf42de0d9d0673eded9fd prov:wasDerivedFrom niiri:b96f891a7f3546406e623e46139187e6 .
+niiri:1c087be2a968de7ac0a2bea646c020cb prov:wasDerivedFrom niiri:9a89982690b205094ce375806ee327d2 .
 
-niiri:39efddb8b434a13530f3ccc1f0e4a691
+niiri:fb0dd18eb34c8e74b938fd5ddf517ce5
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0087" ;
-    prov:atLocation niiri:da180f80322b4b1da7197b8a08f5e6a4 ;
+    prov:atLocation niiri:aa3855fba367b0ad316c27d8b09af4d1 ;
     prov:value "2.27538919448853"^^xsd:float ;
     nidm_equivalentZStatistic: "3.60347660612369"^^xsd:float ;
     nidm_pValueUncorrected: "0.000156994509713848"^^xsd:float ;
     nidm_pValueFWER: "0.999998960052528"^^xsd:float ;
     nidm_qValueFDR: "0.418270156640619"^^xsd:float .
 
-niiri:da180f80322b4b1da7197b8a08f5e6a4
+niiri:aa3855fba367b0ad316c27d8b09af4d1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0087" ;
     nidm_coordinateVector: "[40,-2,-10]"^^xsd:string .
 
-niiri:39efddb8b434a13530f3ccc1f0e4a691 prov:wasDerivedFrom niiri:4c9cbb438c61ca24784015872ad9fbc0 .
+niiri:fb0dd18eb34c8e74b938fd5ddf517ce5 prov:wasDerivedFrom niiri:86396384ac8248dc2499f53d12283a2f .
 
-niiri:57fc12f11ad2c09e088b9fb77c584d5f
+niiri:2f736c7d40b35980222068c405413bae
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0088" ;
-    prov:atLocation niiri:94bb6b91a2796abac7e7ff52313ab016 ;
+    prov:atLocation niiri:53e1ecfd3011d4d05f60ec3d43f5cdf3 ;
     prov:value "2.27404403686523"^^xsd:float ;
     nidm_equivalentZStatistic: "3.60174075534084"^^xsd:float ;
     nidm_pValueUncorrected: "0.000158046749744623"^^xsd:float ;
     nidm_pValueFWER: "0.999999031182047"^^xsd:float ;
     nidm_qValueFDR: "0.418270156640619"^^xsd:float .
 
-niiri:94bb6b91a2796abac7e7ff52313ab016
+niiri:53e1ecfd3011d4d05f60ec3d43f5cdf3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0088" ;
     nidm_coordinateVector: "[-42,-22,70]"^^xsd:string .
 
-niiri:57fc12f11ad2c09e088b9fb77c584d5f prov:wasDerivedFrom niiri:39af3e7a68fb53b5aaa4d4380994d93a .
+niiri:2f736c7d40b35980222068c405413bae prov:wasDerivedFrom niiri:2ead289cc63835350630bfc68f2d003d .
 
-niiri:ec692b5057a43580a035e84f59cb6d74
+niiri:7980b5dd38316b9b2ecbc76101c2a0b5
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0089" ;
-    prov:atLocation niiri:169ad4a3513af46ef9a4693426b43637 ;
+    prov:atLocation niiri:8b38f2871372df699f2f367c731b12a3 ;
     prov:value "2.27214431762695"^^xsd:float ;
     nidm_equivalentZStatistic: "3.59928920970321"^^xsd:float ;
     nidm_pValueUncorrected: "0.000159544081014595"^^xsd:float ;
     nidm_pValueFWER: "0.999999123899245"^^xsd:float ;
     nidm_qValueFDR: "0.418270156640619"^^xsd:float .
 
-niiri:169ad4a3513af46ef9a4693426b43637
+niiri:8b38f2871372df699f2f367c731b12a3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0089" ;
     nidm_coordinateVector: "[-40,-86,28]"^^xsd:string .
 
-niiri:ec692b5057a43580a035e84f59cb6d74 prov:wasDerivedFrom niiri:e854d05d0fd68a980bd27218bb6f2d9f .
+niiri:7980b5dd38316b9b2ecbc76101c2a0b5 prov:wasDerivedFrom niiri:0ff3515dad74fb4659ac475f78bb2c0d .
 
-niiri:7fd3d4ac82d781b1cc29aa421106eee0
+niiri:b05ecaea88de142b8ca1773ff4972f5e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0090" ;
-    prov:atLocation niiri:eb16585959f71157b322ab347206a01e ;
+    prov:atLocation niiri:f22fe5774a94e8360abdcf02dd02e53d ;
     prov:value "2.27202653884888"^^xsd:float ;
     nidm_equivalentZStatistic: "3.59913721633081"^^xsd:float ;
     nidm_pValueUncorrected: "0.000159637349828712"^^xsd:float ;
     nidm_pValueFWER: "0.999999129364364"^^xsd:float ;
     nidm_qValueFDR: "0.418270156640619"^^xsd:float .
 
-niiri:eb16585959f71157b322ab347206a01e
+niiri:f22fe5774a94e8360abdcf02dd02e53d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0090" ;
     nidm_coordinateVector: "[32,58,22]"^^xsd:string .
 
-niiri:7fd3d4ac82d781b1cc29aa421106eee0 prov:wasDerivedFrom niiri:919d23712d157543b918d601a201b7d7 .
+niiri:b05ecaea88de142b8ca1773ff4972f5e prov:wasDerivedFrom niiri:e28eff3b2e060f982dbfeec40075736b .
 
-niiri:3f7ecbaac628282113885ba2bcc840fd
+niiri:47d4cfe6ec57e882523a5f15411848d2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0091" ;
-    prov:atLocation niiri:e0f24cc6ffa224ba72060ff91f1a6d68 ;
+    prov:atLocation niiri:5495296622af4ad50502b8b2f7e08245 ;
     prov:value "2.27080631256104"^^xsd:float ;
     nidm_equivalentZStatistic: "3.59756249884937"^^xsd:float ;
     nidm_pValueUncorrected: "0.000160606663523355"^^xsd:float ;
     nidm_pValueFWER: "0.999999184134104"^^xsd:float ;
     nidm_qValueFDR: "0.418270156640619"^^xsd:float .
 
-niiri:e0f24cc6ffa224ba72060ff91f1a6d68
+niiri:5495296622af4ad50502b8b2f7e08245
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0091" ;
     nidm_coordinateVector: "[44,-62,-36]"^^xsd:string .
 
-niiri:3f7ecbaac628282113885ba2bcc840fd prov:wasDerivedFrom niiri:bac84e2b7b3296e6a7b45e5dd897eaa1 .
+niiri:47d4cfe6ec57e882523a5f15411848d2 prov:wasDerivedFrom niiri:5621f89640fa5a0a90c32a936e6e0a8d .
 
-niiri:4ddc5955a7227a8307edc5dd686ecd66
+niiri:4dc1e5e65b8110f5c3d324caa9587124
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0092" ;
-    prov:atLocation niiri:b94c39ac7ab0fd3eb81a6fa1a39a4144 ;
+    prov:atLocation niiri:08507e5bd6094aa94b8ccf63d7df9415 ;
     prov:value "2.25528573989868"^^xsd:float ;
     nidm_equivalentZStatistic: "3.57753033271362"^^xsd:float ;
     nidm_pValueUncorrected: "0.000173427989261232"^^xsd:float ;
     nidm_pValueFWER: "0.999999651142222"^^xsd:float ;
     nidm_qValueFDR: "0.432415839107375"^^xsd:float .
 
-niiri:b94c39ac7ab0fd3eb81a6fa1a39a4144
+niiri:08507e5bd6094aa94b8ccf63d7df9415
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0092" ;
     nidm_coordinateVector: "[-56,-34,-18]"^^xsd:string .
 
-niiri:4ddc5955a7227a8307edc5dd686ecd66 prov:wasDerivedFrom niiri:79c33267bc7a50246dc768c737d6daae .
+niiri:4dc1e5e65b8110f5c3d324caa9587124 prov:wasDerivedFrom niiri:f6474f5545e9725192cc8b6256e5bfb0 .
 
-niiri:2c80bf28d04d08f3d90110861ee4f12b
+niiri:8c3105cb051b8d67f47a2e2e97720b1f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0093" ;
-    prov:atLocation niiri:3fdca379e3d8b5c9e451308c60e988b5 ;
+    prov:atLocation niiri:5fa31ed28407d8ef344d786db87d0ab2 ;
     prov:value "2.24145913124084"^^xsd:float ;
     nidm_equivalentZStatistic: "3.55968043051933"^^xsd:float ;
     nidm_pValueUncorrected: "0.00018565317676611"^^xsd:float ;
     nidm_pValueFWER: "0.999999842303019"^^xsd:float ;
     nidm_qValueFDR: "0.448708397422201"^^xsd:float .
 
-niiri:3fdca379e3d8b5c9e451308c60e988b5
+niiri:5fa31ed28407d8ef344d786db87d0ab2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0093" ;
     nidm_coordinateVector: "[42,16,6]"^^xsd:string .
 
-niiri:2c80bf28d04d08f3d90110861ee4f12b prov:wasDerivedFrom niiri:2c2f8c53ef38453b53a97c311972275b .
+niiri:8c3105cb051b8d67f47a2e2e97720b1f prov:wasDerivedFrom niiri:2f15ad69e6c9c21540fd55e8e1488dca .
 
-niiri:6aa4da50308d4f29e4e9c77498b3ad5b
+niiri:cbd485923e06556ee8d61eae7a353bc3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0094" ;
-    prov:atLocation niiri:3c1f4dcab3f0f860ac48e18be2e761a0 ;
+    prov:atLocation niiri:13e7354b0f59c7b5993f11f6d72cdacc ;
     prov:value "2.2288510799408"^^xsd:float ;
     nidm_equivalentZStatistic: "3.54340035775212"^^xsd:float ;
     nidm_pValueUncorrected: "0.000197501273445089"^^xsd:float ;
     nidm_pValueFWER: "0.999999925925981"^^xsd:float ;
     nidm_qValueFDR: "0.461177773590418"^^xsd:float .
 
-niiri:3c1f4dcab3f0f860ac48e18be2e761a0
+niiri:13e7354b0f59c7b5993f11f6d72cdacc
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0094" ;
     nidm_coordinateVector: "[14,58,10]"^^xsd:string .
 
-niiri:6aa4da50308d4f29e4e9c77498b3ad5b prov:wasDerivedFrom niiri:5250d6f799a090681ee8888a86a64f2e .
+niiri:cbd485923e06556ee8d61eae7a353bc3 prov:wasDerivedFrom niiri:42ca52d223a11cd4060ba3459f14c1ab .
 
-niiri:3dc0eb091c90cffce879cf8e8bfd47b2
+niiri:18b3136cd14e6ff7733c13a8bdaa6346
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0095" ;
-    prov:atLocation niiri:bb8174cf7fa8ca0405ee8f32057d2649 ;
+    prov:atLocation niiri:39d7636932e3d3377734bf37ba671d26 ;
     prov:value "2.22417545318604"^^xsd:float ;
     nidm_equivalentZStatistic: "3.53736219289604"^^xsd:float ;
     nidm_pValueUncorrected: "0.000202072513955764"^^xsd:float ;
     nidm_pValueFWER: "0.999999944466357"^^xsd:float ;
     nidm_qValueFDR: "0.466991649207176"^^xsd:float .
 
-niiri:bb8174cf7fa8ca0405ee8f32057d2649
+niiri:39d7636932e3d3377734bf37ba671d26
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0095" ;
     nidm_coordinateVector: "[20,36,56]"^^xsd:string .
 
-niiri:3dc0eb091c90cffce879cf8e8bfd47b2 prov:wasDerivedFrom niiri:891b4e7e5f232af9ce39592173fed719 .
+niiri:18b3136cd14e6ff7733c13a8bdaa6346 prov:wasDerivedFrom niiri:29b8562f8375bc52056233a05357c8ba .
 
-niiri:2cdf49c51570fade008ce72059cc1692
+niiri:f83fcb8aadbc17649f8866d0a02e98f2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0096" ;
-    prov:atLocation niiri:f3aa9de381f51cfb08738385524151a8 ;
+    prov:atLocation niiri:823ebff49a536adfb982018013149f69 ;
     prov:value "2.21693515777588"^^xsd:float ;
     nidm_equivalentZStatistic: "3.5280111500348"^^xsd:float ;
     nidm_pValueUncorrected: "0.000209347259857662"^^xsd:float ;
     nidm_pValueFWER: "0.99999996475463"^^xsd:float ;
     nidm_qValueFDR: "0.474122401075389"^^xsd:float .
 
-niiri:f3aa9de381f51cfb08738385524151a8
+niiri:823ebff49a536adfb982018013149f69
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0096" ;
     nidm_coordinateVector: "[-46,-16,-26]"^^xsd:string .
 
-niiri:2cdf49c51570fade008ce72059cc1692 prov:wasDerivedFrom niiri:4cd96b91a9bff0c27f9a1cf0ccb9533d .
+niiri:f83fcb8aadbc17649f8866d0a02e98f2 prov:wasDerivedFrom niiri:39feea9bf256b35cba29d53ba142d102 .
 
-niiri:45dffba72653cbb4f68a95a678413b05
+niiri:6ac9a02ed616ed9c5160a35845282afa
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0097" ;
-    prov:atLocation niiri:c34cd792677b6d6b8875ee707b844911 ;
+    prov:atLocation niiri:dbf3fb337eb7a2ddb7d78423e621f1bd ;
     prov:value "2.21399617195129"^^xsd:float ;
     nidm_equivalentZStatistic: "3.52421508195077"^^xsd:float ;
     nidm_pValueUncorrected: "0.000212369663955547"^^xsd:float ;
     nidm_pValueFWER: "0.999999970782305"^^xsd:float ;
     nidm_qValueFDR: "0.474122401075389"^^xsd:float .
 
-niiri:c34cd792677b6d6b8875ee707b844911
+niiri:dbf3fb337eb7a2ddb7d78423e621f1bd
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0097" ;
     nidm_coordinateVector: "[-36,-48,48]"^^xsd:string .
 
-niiri:45dffba72653cbb4f68a95a678413b05 prov:wasDerivedFrom niiri:63335f473373e0606d5e19a26d54947f .
+niiri:6ac9a02ed616ed9c5160a35845282afa prov:wasDerivedFrom niiri:aeed349c1d870c766c3846139baddfcf .
 
-niiri:db448d238977143a1b0073a8ab816137
+niiri:a3bf33e6499e7a0a31c9702c6d60fc3c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0098" ;
-    prov:atLocation niiri:c619a9542f5c0ade5cdaf352fb682062 ;
+    prov:atLocation niiri:5cb10b840a952460027010421de8c620 ;
     prov:value "2.21233320236206"^^xsd:float ;
     nidm_equivalentZStatistic: "3.5220670758195"^^xsd:float ;
     nidm_pValueUncorrected: "0.000214097893396659"^^xsd:float ;
     nidm_pValueFWER: "0.999999973744615"^^xsd:float ;
     nidm_qValueFDR: "0.474122401075389"^^xsd:float .
 
-niiri:c619a9542f5c0ade5cdaf352fb682062
+niiri:5cb10b840a952460027010421de8c620
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0098" ;
     nidm_coordinateVector: "[64,-48,22]"^^xsd:string .
 
-niiri:db448d238977143a1b0073a8ab816137 prov:wasDerivedFrom niiri:a5b7e29d2b4e7df102d4c218a8e2de79 .
+niiri:a3bf33e6499e7a0a31c9702c6d60fc3c prov:wasDerivedFrom niiri:fb34b9243fbfd4d52f33195ad11fa75e .
 
-niiri:ced2f179d1d5b872001a41328c302cd3
+niiri:0de985ab54c7b41ae1d397bc56243722
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0099" ;
-    prov:atLocation niiri:0418a68382ced7c0f5f47a8b5c68f529 ;
+    prov:atLocation niiri:2448323ca81528a1cd5e1421cfb4745c ;
     prov:value "2.19926238059998"^^xsd:float ;
     nidm_equivalentZStatistic: "3.50518208844769"^^xsd:float ;
     nidm_pValueUncorrected: "0.000228147544614088"^^xsd:float ;
     nidm_pValueFWER: "0.999999988890482"^^xsd:float ;
     nidm_qValueFDR: "0.490541911210553"^^xsd:float .
 
-niiri:0418a68382ced7c0f5f47a8b5c68f529
+niiri:2448323ca81528a1cd5e1421cfb4745c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0099" ;
     nidm_coordinateVector: "[-62,-16,30]"^^xsd:string .
 
-niiri:ced2f179d1d5b872001a41328c302cd3 prov:wasDerivedFrom niiri:bc8ae88a4964bdb4f03808829f923a38 .
+niiri:0de985ab54c7b41ae1d397bc56243722 prov:wasDerivedFrom niiri:ae4e3431e53d6bb86cb5f49df3e1dd3c .
 
-niiri:0589344fd5b39e0079f0eacd1bdea959
+niiri:dafae508abe6b629f3a5b25e99e2b8a6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0100" ;
-    prov:atLocation niiri:5a4911001d38715d5a57289ed467423a ;
+    prov:atLocation niiri:0f59e5f95827337c606de13c426760b3 ;
     prov:value "2.17726922035217"^^xsd:float ;
     nidm_equivalentZStatistic: "3.47676404129424"^^xsd:float ;
     nidm_pValueUncorrected: "0.000253752120226602"^^xsd:float ;
     nidm_pValueFWER: "0.999999997591668"^^xsd:float ;
     nidm_qValueFDR: "0.522483308971289"^^xsd:float .
 
-niiri:5a4911001d38715d5a57289ed467423a
+niiri:0f59e5f95827337c606de13c426760b3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0100" ;
     nidm_coordinateVector: "[60,16,4]"^^xsd:string .
 
-niiri:0589344fd5b39e0079f0eacd1bdea959 prov:wasDerivedFrom niiri:8635bd60e838e70448a683e4c2731fb0 .
+niiri:dafae508abe6b629f3a5b25e99e2b8a6 prov:wasDerivedFrom niiri:3ae2d61c89fb13f4e75319093956440c .
 
-niiri:b2528dbd26b9220db5c6eefa25e32914
+niiri:9f241776c24bfec38480e757272c95ef
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0101" ;
-    prov:atLocation niiri:abe269d6ae4b9336647e7a744bebe347 ;
+    prov:atLocation niiri:475f99b85d7b3507277fe4cc199d02da ;
     prov:value "2.17222547531128"^^xsd:float ;
     nidm_equivalentZStatistic: "3.47024563153578"^^xsd:float ;
     nidm_pValueUncorrected: "0.000259991300800011"^^xsd:float ;
     nidm_pValueFWER: "0.999999998329023"^^xsd:float ;
     nidm_qValueFDR: "0.528007569567315"^^xsd:float .
 
-niiri:abe269d6ae4b9336647e7a744bebe347
+niiri:475f99b85d7b3507277fe4cc199d02da
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0101" ;
     nidm_coordinateVector: "[-38,16,16]"^^xsd:string .
 
-niiri:b2528dbd26b9220db5c6eefa25e32914 prov:wasDerivedFrom niiri:76761290d259c6c26ed92cd02b7a8ffd .
+niiri:9f241776c24bfec38480e757272c95ef prov:wasDerivedFrom niiri:b9c3425be7ea99b14efce8bce592b25b .
 
-niiri:367ca6f93deb273a4eb2286708dd547c
+niiri:64e9f022bd6687a619e8398b70936591
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0102" ;
-    prov:atLocation niiri:f372eacca52daa0c35f19074b35fd390 ;
+    prov:atLocation niiri:ab9a9062532d2e24f71d5f942396e83c ;
     prov:value "2.17077469825745"^^xsd:float ;
     nidm_equivalentZStatistic: "3.46837060004652"^^xsd:float ;
     nidm_pValueUncorrected: "0.000261812316486365"^^xsd:float ;
     nidm_pValueFWER: "0.999999998497371"^^xsd:float ;
     nidm_qValueFDR: "0.528007569567315"^^xsd:float .
 
-niiri:f372eacca52daa0c35f19074b35fd390
+niiri:ab9a9062532d2e24f71d5f942396e83c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0102" ;
     nidm_coordinateVector: "[30,8,54]"^^xsd:string .
 
-niiri:367ca6f93deb273a4eb2286708dd547c prov:wasDerivedFrom niiri:2447692cf3c13cbbdafc3a665370603f .
+niiri:64e9f022bd6687a619e8398b70936591 prov:wasDerivedFrom niiri:53c378a2e0ca3196fa50b2b2030c0fcc .
 
-niiri:ca18afbcea7ead88af7f4b4b0859d0fc
+niiri:f39083490c271135692376a9b6145545
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0103" ;
-    prov:atLocation niiri:aa6d0b0673242c4bbd69bc3b26cb7360 ;
+    prov:atLocation niiri:fc43ea1ac52f1f092d78f8698757e2c9 ;
     prov:value "2.16687154769897"^^xsd:float ;
     nidm_equivalentZStatistic: "3.46332585702272"^^xsd:float ;
     nidm_pValueUncorrected: "0.000266770915118508"^^xsd:float ;
     nidm_pValueFWER: "0.999999998873444"^^xsd:float ;
     nidm_qValueFDR: "0.532041442688517"^^xsd:float .
 
-niiri:aa6d0b0673242c4bbd69bc3b26cb7360
+niiri:fc43ea1ac52f1f092d78f8698757e2c9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0103" ;
     nidm_coordinateVector: "[4,-74,40]"^^xsd:string .
 
-niiri:ca18afbcea7ead88af7f4b4b0859d0fc prov:wasDerivedFrom niiri:e4dcddb5ab6095be427ee660b9fc5d2f .
+niiri:f39083490c271135692376a9b6145545 prov:wasDerivedFrom niiri:43e5c93bebd29ba8da99711ae8d9c3e1 .
 
-niiri:42b6fdc5b4a6b24eb1a2b9cc382bb638
+niiri:5fb2a670883af294357a4ab2154ab6b1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0104" ;
-    prov:atLocation niiri:545e4f447d4cc4c012c7dd505904ffc1 ;
+    prov:atLocation niiri:063b2c2ce28d037a1a6851fbbcbb9e62 ;
     prov:value "2.16552972793579"^^xsd:float ;
     nidm_equivalentZStatistic: "3.46159152037966"^^xsd:float ;
     nidm_pValueUncorrected: "0.000268495752957176"^^xsd:float ;
     nidm_pValueFWER: "0.999999998980469"^^xsd:float ;
     nidm_qValueFDR: "0.532232376423935"^^xsd:float .
 
-niiri:545e4f447d4cc4c012c7dd505904ffc1
+niiri:063b2c2ce28d037a1a6851fbbcbb9e62
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0104" ;
     nidm_coordinateVector: "[-18,-94,4]"^^xsd:string .
 
-niiri:42b6fdc5b4a6b24eb1a2b9cc382bb638 prov:wasDerivedFrom niiri:343fa8f57e7adfcd961ea3af67b24ad0 .
+niiri:5fb2a670883af294357a4ab2154ab6b1 prov:wasDerivedFrom niiri:7fd1e3a607dbe6cfba8a4e086242d6b7 .
 
-niiri:a1b9a65fc1049ceeb5ded8769ae3f508
+niiri:ee341bb063e9247becec364805165eb3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0105" ;
-    prov:atLocation niiri:48ce6a5d07af9b11b1807d555d4cea5c ;
+    prov:atLocation niiri:3caf76e9df39a2dd7c3751565762561b ;
     prov:value "2.15602898597717"^^xsd:float ;
     nidm_equivalentZStatistic: "3.44931067015382"^^xsd:float ;
     nidm_pValueUncorrected: "0.000281009846776592"^^xsd:float ;
     nidm_pValueFWER: "0.999999999503037"^^xsd:float ;
     nidm_qValueFDR: "0.54825725843418"^^xsd:float .
 
-niiri:48ce6a5d07af9b11b1807d555d4cea5c
+niiri:3caf76e9df39a2dd7c3751565762561b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0105" ;
     nidm_coordinateVector: "[32,46,18]"^^xsd:string .
 
-niiri:a1b9a65fc1049ceeb5ded8769ae3f508 prov:wasDerivedFrom niiri:59cba60adf480535a1c969d6d64e23b9 .
+niiri:ee341bb063e9247becec364805165eb3 prov:wasDerivedFrom niiri:d2c986d4849a217bf93ccf9e1e40ff7d .
 
-niiri:4683c57b038885e94fa01e20e9d774b5
+niiri:db4b88ce7955c87529d9cdcac1067e5c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0106" ;
-    prov:atLocation niiri:995e395a213465c06ce2db1292745d05 ;
+    prov:atLocation niiri:32da5de8e2d1066fafe66482f6376ce8 ;
     prov:value "2.1544976234436"^^xsd:float ;
     nidm_equivalentZStatistic: "3.44733105425233"^^xsd:float ;
     nidm_pValueUncorrected: "0.000283077187230862"^^xsd:float ;
     nidm_pValueFWER: "0.999999999558251"^^xsd:float ;
     nidm_qValueFDR: "0.548832170867961"^^xsd:float .
 
-niiri:995e395a213465c06ce2db1292745d05
+niiri:32da5de8e2d1066fafe66482f6376ce8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0106" ;
     nidm_coordinateVector: "[-6,34,-4]"^^xsd:string .
 
-niiri:4683c57b038885e94fa01e20e9d774b5 prov:wasDerivedFrom niiri:8e3b014c96a9933ebe866f62a5fc3a5c .
+niiri:db4b88ce7955c87529d9cdcac1067e5c prov:wasDerivedFrom niiri:bac839d7d5a8f71351fbf0af9d7d237d .
 
-niiri:0d420046241672771ad46ff9a2282f00
+niiri:6ab66734fa9b63bf93c3eb233efd164e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0107" ;
-    prov:atLocation niiri:bd12bce700e8c3a2c620c0bd152b9a5c ;
+    prov:atLocation niiri:439a96c6b9c8da3c658cd86b4f5faa7c ;
     prov:value "2.14432787895203"^^xsd:float ;
     nidm_equivalentZStatistic: "3.43418345508983"^^xsd:float ;
     nidm_pValueUncorrected: "0.000297170899168919"^^xsd:float ;
     nidm_pValueFWER: "0.999999999800735"^^xsd:float ;
     nidm_qValueFDR: "0.559218724487036"^^xsd:float .
 
-niiri:bd12bce700e8c3a2c620c0bd152b9a5c
+niiri:439a96c6b9c8da3c658cd86b4f5faa7c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0107" ;
     nidm_coordinateVector: "[26,12,-28]"^^xsd:string .
 
-niiri:0d420046241672771ad46ff9a2282f00 prov:wasDerivedFrom niiri:7adf18789eb65028169817bb70133720 .
+niiri:6ab66734fa9b63bf93c3eb233efd164e prov:wasDerivedFrom niiri:950ebb223c0553663a2925b4cebca2f2 .
 
-niiri:c3bd8f705a61e6d7802588f2cdec4ed1
+niiri:7a920cc103779299492bdd1b7abf0d4c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0108" ;
-    prov:atLocation niiri:fa86ac39d092f7b1a3921944a2ba940c ;
+    prov:atLocation niiri:62a9547c589c74225214f116b688bb4f ;
     prov:value "2.13841390609741"^^xsd:float ;
     nidm_equivalentZStatistic: "3.42653698017951"^^xsd:float ;
     nidm_pValueUncorrected: "0.000305665256597809"^^xsd:float ;
     nidm_pValueFWER: "0.999999999875989"^^xsd:float ;
     nidm_qValueFDR: "0.566169265576836"^^xsd:float .
 
-niiri:fa86ac39d092f7b1a3921944a2ba940c
+niiri:62a9547c589c74225214f116b688bb4f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0108" ;
     nidm_coordinateVector: "[62,8,26]"^^xsd:string .
 
-niiri:c3bd8f705a61e6d7802588f2cdec4ed1 prov:wasDerivedFrom niiri:3e769257b2ca300ac5c4d33e8539ea3e .
+niiri:7a920cc103779299492bdd1b7abf0d4c prov:wasDerivedFrom niiri:9a52ab95dd907c0f7f51fb102fd28f70 .
 
-niiri:5e93a5a814da6e509ad7165c91c9fc95
+niiri:0091960b7df9e3b2ee0b995c7a9fee2e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0109" ;
-    prov:atLocation niiri:041839fc4b2773472bb6dbe9c849f76a ;
+    prov:atLocation niiri:dd731654874737e36a1145e73ec3c503 ;
     prov:value "2.13535809516907"^^xsd:float ;
     nidm_equivalentZStatistic: "3.42258573937654"^^xsd:float ;
     nidm_pValueUncorrected: "0.00031014265931506"^^xsd:float ;
     nidm_pValueFWER: "0.999999999903261"^^xsd:float ;
     nidm_qValueFDR: "0.56744192975625"^^xsd:float .
 
-niiri:041839fc4b2773472bb6dbe9c849f76a
+niiri:dd731654874737e36a1145e73ec3c503
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0109" ;
     nidm_coordinateVector: "[46,-14,-28]"^^xsd:string .
 
-niiri:5e93a5a814da6e509ad7165c91c9fc95 prov:wasDerivedFrom niiri:66df3519712f78df7f53bbfefe65db57 .
+niiri:0091960b7df9e3b2ee0b995c7a9fee2e prov:wasDerivedFrom niiri:f6d437c16c83f9a147b1bb4222d3abc6 .
 
-niiri:f720878e1741c8b1f6939071321d56d7
+niiri:be68a46819185a1181faf0074de880e1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0110" ;
-    prov:atLocation niiri:142905eb74c66aaa5e57abac3ea373e1 ;
+    prov:atLocation niiri:4f894d57ccb0687917202eb233a2d0b4 ;
     prov:value "2.10883116722107"^^xsd:float ;
     nidm_equivalentZStatistic: "3.38827937085858"^^xsd:float ;
     nidm_pValueUncorrected: "0.000351662935259678"^^xsd:float ;
     nidm_pValueFWER: "0.999999999989834"^^xsd:float ;
     nidm_qValueFDR: "0.612415661510894"^^xsd:float .
 
-niiri:142905eb74c66aaa5e57abac3ea373e1
+niiri:4f894d57ccb0687917202eb233a2d0b4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0110" ;
     nidm_coordinateVector: "[36,-74,-26]"^^xsd:string .
 
-niiri:f720878e1741c8b1f6939071321d56d7 prov:wasDerivedFrom niiri:122fe3b47ae88833c8f3dcb366c4f353 .
+niiri:be68a46819185a1181faf0074de880e1 prov:wasDerivedFrom niiri:8837f9a734738e041b5341b9172fb036 .
 
-niiri:efc1a416c436d254523da1dc7a3a5da0
+niiri:9c1ebb72f8df3bd670dd7093690f96e7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0111" ;
-    prov:atLocation niiri:23a7c4a4e38c8a241f6aa7e01342c83c ;
+    prov:atLocation niiri:f54e09b1927d965f6e9d8e3ab8911024 ;
     prov:value "2.09861969947815"^^xsd:float ;
     nidm_equivalentZStatistic: "3.3750702611999"^^xsd:float ;
     nidm_pValueUncorrected: "0.000368984236825298"^^xsd:float ;
     nidm_pValueFWER: "0.999999999995928"^^xsd:float ;
     nidm_qValueFDR: "0.628845185882367"^^xsd:float .
 
-niiri:23a7c4a4e38c8a241f6aa7e01342c83c
+niiri:f54e09b1927d965f6e9d8e3ab8911024
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0111" ;
     nidm_coordinateVector: "[-46,-62,-30]"^^xsd:string .
 
-niiri:efc1a416c436d254523da1dc7a3a5da0 prov:wasDerivedFrom niiri:5a3a2dbf66bf4901aa498d3c0495df01 .
+niiri:9c1ebb72f8df3bd670dd7093690f96e7 prov:wasDerivedFrom niiri:8b57160e5bbb28c42ed70eb49e48b412 .
 
-niiri:9666a3ca5c742682db0769b09b96f536
+niiri:13a5abfae24999f832ff63e132d71526
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0112" ;
-    prov:atLocation niiri:ff4a59f5a5ebb1dba222a00f6fd30959 ;
+    prov:atLocation niiri:45414be04daca1ed9416e031c998e67c ;
     prov:value "2.0976128578186"^^xsd:float ;
     nidm_equivalentZStatistic: "3.37376776772589"^^xsd:float ;
     nidm_pValueUncorrected: "0.000370734464924194"^^xsd:float ;
     nidm_pValueFWER: "0.999999999996285"^^xsd:float ;
     nidm_qValueFDR: "0.628845185882367"^^xsd:float .
 
-niiri:ff4a59f5a5ebb1dba222a00f6fd30959
+niiri:45414be04daca1ed9416e031c998e67c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0112" ;
     nidm_coordinateVector: "[48,2,46]"^^xsd:string .
 
-niiri:9666a3ca5c742682db0769b09b96f536 prov:wasDerivedFrom niiri:d09cb3827a1f341bbeb1a77f474f6e6a .
+niiri:13a5abfae24999f832ff63e132d71526 prov:wasDerivedFrom niiri:c45c033aff250585c0df5bd7ebfa55c2 .
 
-niiri:b5378739f8aef4037f96960420b04eef
+niiri:0db89c6238aa0a65c9a6789ba0981b57
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0113" ;
-    prov:atLocation niiri:da71b8f3f5a034f02920c32f2939b22a ;
+    prov:atLocation niiri:16e32bd5f320f75cf3ad9cfb6feb184b ;
     prov:value "2.09218430519104"^^xsd:float ;
     nidm_equivalentZStatistic: "3.36674489388815"^^xsd:float ;
     nidm_pValueUncorrected: "0.000380305072376852"^^xsd:float ;
     nidm_pValueFWER: "0.999999999997744"^^xsd:float ;
     nidm_qValueFDR: "0.636831894546098"^^xsd:float .
 
-niiri:da71b8f3f5a034f02920c32f2939b22a
+niiri:16e32bd5f320f75cf3ad9cfb6feb184b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0113" ;
     nidm_coordinateVector: "[-8,6,56]"^^xsd:string .
 
-niiri:b5378739f8aef4037f96960420b04eef prov:wasDerivedFrom niiri:df984c734f06f169195b0bbaee6143c6 .
+niiri:0db89c6238aa0a65c9a6789ba0981b57 prov:wasDerivedFrom niiri:95162bceebb39a10b64eb05d8de3fd22 .
 
-niiri:8812de022492a64799c82a33c19f3f11
+niiri:3cef58b75474f5f62c6e5f17b7eb47a4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0114" ;
-    prov:atLocation niiri:9df003d74dd5288329afa1839609e094 ;
+    prov:atLocation niiri:9c0c51b01429787a73fcf756db784b5f ;
     prov:value "2.09025764465332"^^xsd:float ;
     nidm_equivalentZStatistic: "3.36425228187917"^^xsd:float ;
     nidm_pValueUncorrected: "0.000383756749400832"^^xsd:float ;
     nidm_pValueFWER: "0.999999999998114"^^xsd:float ;
     nidm_qValueFDR: "0.636831894546098"^^xsd:float .
 
-niiri:9df003d74dd5288329afa1839609e094
+niiri:9c0c51b01429787a73fcf756db784b5f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0114" ;
     nidm_coordinateVector: "[34,4,38]"^^xsd:string .
 
-niiri:8812de022492a64799c82a33c19f3f11 prov:wasDerivedFrom niiri:3bf753720b3412e5689330bba1dbe1cf .
+niiri:3cef58b75474f5f62c6e5f17b7eb47a4 prov:wasDerivedFrom niiri:3ed2c390b2b8ba7d7280d7aaf1f7a0e5 .
 
-niiri:cd1d0726bfbfd0c8dcf44e488847af21
+niiri:7f48dee052c9626e7e52439acf0f2384
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0115" ;
-    prov:atLocation niiri:d8e7b7fa7fb7e7092c042bb009e8db72 ;
+    prov:atLocation niiri:a1e1bf42329e82bb1986471311192a86 ;
     prov:value "2.08849263191223"^^xsd:float ;
     nidm_equivalentZStatistic: "3.36196875235771"^^xsd:float ;
     nidm_pValueUncorrected: "0.000386944402984701"^^xsd:float ;
     nidm_pValueFWER: "0.999999999998401"^^xsd:float ;
     nidm_qValueFDR: "0.636831894546098"^^xsd:float .
 
-niiri:d8e7b7fa7fb7e7092c042bb009e8db72
+niiri:a1e1bf42329e82bb1986471311192a86
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0115" ;
     nidm_coordinateVector: "[46,36,38]"^^xsd:string .
 
-niiri:cd1d0726bfbfd0c8dcf44e488847af21 prov:wasDerivedFrom niiri:002c13dfe076dd8552445efc13f91b3d .
+niiri:7f48dee052c9626e7e52439acf0f2384 prov:wasDerivedFrom niiri:a7eac8bb5c994b37b60795763e4a8b47 .
 
-niiri:17fa3bf584ad6f7ea20184d3034a22a6
+niiri:4d3efcbf06221edd111b9ececccbf578
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0116" ;
-    prov:atLocation niiri:9050d4ad77c29dfda22d2d055fe0629d ;
+    prov:atLocation niiri:5a4dc409a4f82fe2fbd2adb378f0236f ;
     prov:value "2.08788776397705"^^xsd:float ;
     nidm_equivalentZStatistic: "3.36118617856085"^^xsd:float ;
     nidm_pValueUncorrected: "0.000388042466764382"^^xsd:float ;
     nidm_pValueFWER: "0.999999999998489"^^xsd:float ;
     nidm_qValueFDR: "0.636831894546098"^^xsd:float .
 
-niiri:9050d4ad77c29dfda22d2d055fe0629d
+niiri:5a4dc409a4f82fe2fbd2adb378f0236f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0116" ;
     nidm_coordinateVector: "[-54,6,42]"^^xsd:string .
 
-niiri:17fa3bf584ad6f7ea20184d3034a22a6 prov:wasDerivedFrom niiri:9a0b88bb0f2e1591fd4c0a65c1e565f2 .
+niiri:4d3efcbf06221edd111b9ececccbf578 prov:wasDerivedFrom niiri:df913e2209fc5cbf0b94dbb97361067d .
 
-niiri:9285e0a2ee7e0627d9fd74b3efb08113
+niiri:559d842aee52f555e32eaea8e5f6af4d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0117" ;
-    prov:atLocation niiri:c7c4b7d3510c53b86bd5cb10b8f9905e ;
+    prov:atLocation niiri:342a55c31a6fd1e19f7882456cd37086 ;
     prov:value "2.08684039115906"^^xsd:float ;
     nidm_equivalentZStatistic: "3.35983108220205"^^xsd:float ;
     nidm_pValueUncorrected: "0.000389950706039088"^^xsd:float ;
     nidm_pValueFWER: "0.99999999999863"^^xsd:float ;
     nidm_qValueFDR: "0.636831894546098"^^xsd:float .
 
-niiri:c7c4b7d3510c53b86bd5cb10b8f9905e
+niiri:342a55c31a6fd1e19f7882456cd37086
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0117" ;
     nidm_coordinateVector: "[-34,-40,-40]"^^xsd:string .
 
-niiri:9285e0a2ee7e0627d9fd74b3efb08113 prov:wasDerivedFrom niiri:5c85689f9d81af447c3f8df3048c263a .
+niiri:559d842aee52f555e32eaea8e5f6af4d prov:wasDerivedFrom niiri:20e5d869565077dcc873c4847e343626 .
 
-niiri:6c9cfc1e05c5dc7987619c61e02edaab
+niiri:9bfa3d4282d5fe49d0a5d7837246515a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0118" ;
-    prov:atLocation niiri:1ebfa3ca523132a3093dc7f3c39990d5 ;
+    prov:atLocation niiri:167f928519ef5a6d9da97ba177d7a184 ;
     prov:value "2.08542251586914"^^xsd:float ;
     nidm_equivalentZStatistic: "3.35799660180066"^^xsd:float ;
     nidm_pValueUncorrected: "0.000392547891568396"^^xsd:float ;
     nidm_pValueFWER: "0.999999999998802"^^xsd:float ;
     nidm_qValueFDR: "0.637367081876291"^^xsd:float .
 
-niiri:1ebfa3ca523132a3093dc7f3c39990d5
+niiri:167f928519ef5a6d9da97ba177d7a184
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0118" ;
     nidm_coordinateVector: "[-4,8,62]"^^xsd:string .
 
-niiri:6c9cfc1e05c5dc7987619c61e02edaab prov:wasDerivedFrom niiri:ee254d71e90697d1d1a39f5a3df69e4f .
+niiri:9bfa3d4282d5fe49d0a5d7837246515a prov:wasDerivedFrom niiri:b53c18c408c426d6208825bc03bda76c .
 
-niiri:3df29400a892f88119dbe17233278be3
+niiri:ed129b762540244ebbab654eba8430b6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0119" ;
-    prov:atLocation niiri:d38839054a2a64a7c97fbfca0836339c ;
+    prov:atLocation niiri:0b74a6907723aa376792f985e57be958 ;
     prov:value "2.07837462425232"^^xsd:float ;
     nidm_equivalentZStatistic: "3.34887743272549"^^xsd:float ;
     nidm_pValueUncorrected: "0.000405698407881738"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999388"^^xsd:float ;
     nidm_qValueFDR: "0.647755183120289"^^xsd:float .
 
-niiri:d38839054a2a64a7c97fbfca0836339c
+niiri:0b74a6907723aa376792f985e57be958
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0119" ;
     nidm_coordinateVector: "[-66,-48,8]"^^xsd:string .
 
-niiri:3df29400a892f88119dbe17233278be3 prov:wasDerivedFrom niiri:d7e6ee1864f4fe14f463aecb07ee9b99 .
+niiri:ed129b762540244ebbab654eba8430b6 prov:wasDerivedFrom niiri:5040d4f96058237b55074ccbae780c73 .
 
-niiri:49eb20197d83d498cea456dcb6b038af
+niiri:aa361f26f45828a6bf37d7fa0ef9e035
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0120" ;
-    prov:atLocation niiri:de4598ba76fddda51f2024149c6901b7 ;
+    prov:atLocation niiri:e7a563685357fbfa9c1ec890f67b4177 ;
     prov:value "2.07339262962341"^^xsd:float ;
     nidm_equivalentZStatistic: "3.34243086058129"^^xsd:float ;
     nidm_pValueUncorrected: "0.000415240207444101"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999623"^^xsd:float ;
     nidm_qValueFDR: "0.656030294621312"^^xsd:float .
 
-niiri:de4598ba76fddda51f2024149c6901b7
+niiri:e7a563685357fbfa9c1ec890f67b4177
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0120" ;
     nidm_coordinateVector: "[8,8,58]"^^xsd:string .
 
-niiri:49eb20197d83d498cea456dcb6b038af prov:wasDerivedFrom niiri:de906422e6143ba14adec0aefe299e8c .
+niiri:aa361f26f45828a6bf37d7fa0ef9e035 prov:wasDerivedFrom niiri:dc90ccd75e3ef3f441e343a64ffc8a53 .
 
-niiri:937511163efff646fa513c15bc70be96
+niiri:50115084698b0f76f38b7c1104d53bc9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0121" ;
-    prov:atLocation niiri:0302d7ce60cd462a2082cd34e536d9cc ;
+    prov:atLocation niiri:36a59a6bca96123bd24e4f7fb86b1265 ;
     prov:value "2.07233357429504"^^xsd:float ;
     nidm_equivalentZStatistic: "3.34106042406055"^^xsd:float ;
     nidm_pValueUncorrected: "0.000417295287676644"^^xsd:float ;
     nidm_pValueFWER: "0.99999999999966"^^xsd:float ;
     nidm_qValueFDR: "0.656030294621312"^^xsd:float .
 
-niiri:0302d7ce60cd462a2082cd34e536d9cc
+niiri:36a59a6bca96123bd24e4f7fb86b1265
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0121" ;
     nidm_coordinateVector: "[28,2,42]"^^xsd:string .
 
-niiri:937511163efff646fa513c15bc70be96 prov:wasDerivedFrom niiri:cc05429585cad5ec4458634a29892454 .
+niiri:50115084698b0f76f38b7c1104d53bc9 prov:wasDerivedFrom niiri:92eaf289a4d8a69bb8c61dcf57734f87 .
 
-niiri:b21d942c173e824002b2772382da9840
+niiri:371a172468bf76afe6aadb917ee05964
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0122" ;
-    prov:atLocation niiri:3f141491b7a8bbcb749b9ea922b98902 ;
+    prov:atLocation niiri:1fdf380fc216afd4e474f786711ae4a3 ;
     prov:value "2.07037234306335"^^xsd:float ;
     nidm_equivalentZStatistic: "3.33852251317794"^^xsd:float ;
     nidm_pValueUncorrected: "0.000421126024625074"^^xsd:float ;
     nidm_pValueFWER: "0.99999999999972"^^xsd:float ;
     nidm_qValueFDR: "0.656638431383812"^^xsd:float .
 
-niiri:3f141491b7a8bbcb749b9ea922b98902
+niiri:1fdf380fc216afd4e474f786711ae4a3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0122" ;
     nidm_coordinateVector: "[-26,-62,38]"^^xsd:string .
 
-niiri:b21d942c173e824002b2772382da9840 prov:wasDerivedFrom niiri:f8f459cc5e943c333944b0423cc623a2 .
+niiri:371a172468bf76afe6aadb917ee05964 prov:wasDerivedFrom niiri:c40c3a11ae575e327a69951e39f7cf1e .
 
-niiri:8b6ced60e5b47931d4187c836abb1dfe
+niiri:dbaab492fac4e6b9eab8dcfc58c98506
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0123" ;
-    prov:atLocation niiri:8ff1c298a3fec8667e82520696ac6166 ;
+    prov:atLocation niiri:bf121c922c17087120c57855bde78999 ;
     prov:value "2.06974482536316"^^xsd:float ;
     nidm_equivalentZStatistic: "3.33771046876864"^^xsd:float ;
     nidm_pValueUncorrected: "0.000422358600173256"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999736"^^xsd:float ;
     nidm_qValueFDR: "0.656638431383812"^^xsd:float .
 
-niiri:8ff1c298a3fec8667e82520696ac6166
+niiri:bf121c922c17087120c57855bde78999
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0123" ;
     nidm_coordinateVector: "[-26,42,32]"^^xsd:string .
 
-niiri:8b6ced60e5b47931d4187c836abb1dfe prov:wasDerivedFrom niiri:be7c69bccd607857ab4a3b06e884b72d .
+niiri:dbaab492fac4e6b9eab8dcfc58c98506 prov:wasDerivedFrom niiri:004221f4a994d829f5e16e54483a92e9 .
 
-niiri:3989dda2297cd77495e3051c4de50150
+niiri:ffed331acd64084a30d48b98739e86bc
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0124" ;
-    prov:atLocation niiri:ae72d094af2f8c422748cab031da52ef ;
+    prov:atLocation niiri:922a9bfb72c5e23ead8d55c367f66e58 ;
     prov:value "2.03006720542908"^^xsd:float ;
     nidm_equivalentZStatistic: "3.28635424154638"^^xsd:float ;
     nidm_pValueUncorrected: "0.000507466425831105"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999996"^^xsd:float ;
     nidm_qValueFDR: "0.719385736915496"^^xsd:float .
 
-niiri:ae72d094af2f8c422748cab031da52ef
+niiri:922a9bfb72c5e23ead8d55c367f66e58
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0124" ;
     nidm_coordinateVector: "[-24,52,30]"^^xsd:string .
 
-niiri:3989dda2297cd77495e3051c4de50150 prov:wasDerivedFrom niiri:be7c69bccd607857ab4a3b06e884b72d .
+niiri:ffed331acd64084a30d48b98739e86bc prov:wasDerivedFrom niiri:004221f4a994d829f5e16e54483a92e9 .
 
-niiri:943d8ea65a34b33a47976e062f6a368f
+niiri:3d0a016a27aa65b6bbbd681333dcc446
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0125" ;
-    prov:atLocation niiri:048e657a7227e7e329425dc2055e6be6 ;
+    prov:atLocation niiri:f67405bdcbba3036ce596ecbe71d55f6 ;
     prov:value "2.06143498420715"^^xsd:float ;
     nidm_equivalentZStatistic: "3.32695652276829"^^xsd:float ;
     nidm_pValueUncorrected: "0.000439000355666241"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999885"^^xsd:float ;
     nidm_qValueFDR: "0.670181351155627"^^xsd:float .
 
-niiri:048e657a7227e7e329425dc2055e6be6
+niiri:f67405bdcbba3036ce596ecbe71d55f6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0125" ;
     nidm_coordinateVector: "[18,38,14]"^^xsd:string .
 
-niiri:943d8ea65a34b33a47976e062f6a368f prov:wasDerivedFrom niiri:a5b505175149fb44eaa5bccb967891c3 .
+niiri:3d0a016a27aa65b6bbbd681333dcc446 prov:wasDerivedFrom niiri:996665a23456cb618780744372406eba .
 
-niiri:60958ed45d1baa949b1cd8d6a591a985
+niiri:86b63b6d4bdec0c181ff785f7344f2f7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0126" ;
-    prov:atLocation niiri:5c219ed33cb5d814bdb651ebd08f745f ;
+    prov:atLocation niiri:55bcafcdb10ff4c30819df223c6bb9f9 ;
     prov:value "2.05234718322754"^^xsd:float ;
     nidm_equivalentZStatistic: "3.31519469431882"^^xsd:float ;
     nidm_pValueUncorrected: "0.000457896584486805"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999955"^^xsd:float ;
     nidm_qValueFDR: "0.688415587572674"^^xsd:float .
 
-niiri:5c219ed33cb5d814bdb651ebd08f745f
+niiri:55bcafcdb10ff4c30819df223c6bb9f9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0126" ;
     nidm_coordinateVector: "[24,22,-26]"^^xsd:string .
 
-niiri:60958ed45d1baa949b1cd8d6a591a985 prov:wasDerivedFrom niiri:d03fcb703af0be07c63c073c3c59f291 .
+niiri:86b63b6d4bdec0c181ff785f7344f2f7 prov:wasDerivedFrom niiri:09c11fea29165ff889d59486cc998f06 .
 
-niiri:28795c7a70521ea48ad2b2773eaff88a
+niiri:e8710216ba3ec832f617a9e1b98c0bf3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0127" ;
-    prov:atLocation niiri:73f36a5c652363f8af24b39474bb7ca8 ;
+    prov:atLocation niiri:503f728df63ec6878c21347bf151b385 ;
     prov:value "2.04952502250671"^^xsd:float ;
     nidm_equivalentZStatistic: "3.31154189928606"^^xsd:float ;
     nidm_pValueUncorrected: "0.000463916722561963"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999966"^^xsd:float ;
     nidm_qValueFDR: "0.689628882399469"^^xsd:float .
 
-niiri:73f36a5c652363f8af24b39474bb7ca8
+niiri:503f728df63ec6878c21347bf151b385
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0127" ;
     nidm_coordinateVector: "[62,-42,26]"^^xsd:string .
 
-niiri:28795c7a70521ea48ad2b2773eaff88a prov:wasDerivedFrom niiri:6a8c63619c891d6d617b0e6030a35936 .
+niiri:e8710216ba3ec832f617a9e1b98c0bf3 prov:wasDerivedFrom niiri:10c4f42b041516447c28674dab2cde5b .
 
-niiri:2f6f37924ebaeb962fce392c98fae6d9
+niiri:6c4a7be328ce49c5e98564e34076236c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0128" ;
-    prov:atLocation niiri:dce6e5d4a844922801571f0c371032e3 ;
+    prov:atLocation niiri:2802bfbc4d5696139c24254736b2ec6e ;
     prov:value "2.04026675224304"^^xsd:float ;
     nidm_equivalentZStatistic: "3.29955792608204"^^xsd:float ;
     nidm_pValueUncorrected: "0.000484186200885861"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999987"^^xsd:float ;
     nidm_qValueFDR: "0.708672597818405"^^xsd:float .
 
-niiri:dce6e5d4a844922801571f0c371032e3
+niiri:2802bfbc4d5696139c24254736b2ec6e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0128" ;
     nidm_coordinateVector: "[54,28,-8]"^^xsd:string .
 
-niiri:2f6f37924ebaeb962fce392c98fae6d9 prov:wasDerivedFrom niiri:12507a0af7ca022693fcfe481576aa45 .
+niiri:6c4a7be328ce49c5e98564e34076236c prov:wasDerivedFrom niiri:c39f3e559dae9a5d556ae9b5045842da .
 
-niiri:d367cf8389c97c1ad25198640830b20e
+niiri:b8b143f3a3bab02055f06c8fa221c1c4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0129" ;
-    prov:atLocation niiri:476b54688070916766e3919a28c9c947 ;
+    prov:atLocation niiri:7074580d5d21e58a02ca62c86ceee8a4 ;
     prov:value "2.03539657592773"^^xsd:float ;
     nidm_equivalentZStatistic: "3.2932534755313"^^xsd:float ;
     nidm_pValueUncorrected: "0.000495175737833864"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999992"^^xsd:float ;
     nidm_qValueFDR: "0.714810085213215"^^xsd:float .
 
-niiri:476b54688070916766e3919a28c9c947
+niiri:7074580d5d21e58a02ca62c86ceee8a4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0129" ;
     nidm_coordinateVector: "[26,18,48]"^^xsd:string .
 
-niiri:d367cf8389c97c1ad25198640830b20e prov:wasDerivedFrom niiri:308103904b8257fddf3a4611eaa9b395 .
+niiri:b8b143f3a3bab02055f06c8fa221c1c4 prov:wasDerivedFrom niiri:231b63a3acf5fa6923ad638c6827b93e .
 
-niiri:f826c6e194984f9c58b034165b203112
+niiri:bbb810096180dab5916a19ea19eb4d52
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0130" ;
-    prov:atLocation niiri:3a87641dfd87d4889ef813b341d6b8b2 ;
+    prov:atLocation niiri:dc3f0897a248b50a8c972c3fe31b0be6 ;
     prov:value "2.03219079971313"^^xsd:float ;
     nidm_equivalentZStatistic: "3.28910342358113"^^xsd:float ;
     nidm_pValueUncorrected: "0.000502535420826677"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999995"^^xsd:float ;
     nidm_qValueFDR: "0.717697062544172"^^xsd:float .
 
-niiri:3a87641dfd87d4889ef813b341d6b8b2
+niiri:dc3f0897a248b50a8c972c3fe31b0be6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0130" ;
     nidm_coordinateVector: "[56,4,-36]"^^xsd:string .
 
-niiri:f826c6e194984f9c58b034165b203112 prov:wasDerivedFrom niiri:8b5a3b06127829c3d92a63e07d1c594d .
+niiri:bbb810096180dab5916a19ea19eb4d52 prov:wasDerivedFrom niiri:7a2a292e9fd06f3e19425b30b04888ad .
 
-niiri:052883bbfd04c4c83f00204a80507ae3
+niiri:5ad6239481925bf6bc3a6ffbd30cf7e6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0131" ;
-    prov:atLocation niiri:5b4f61b279b53dacfaa5ced8b12ab0d1 ;
+    prov:atLocation niiri:0f51826584cb999e63e872c756b90d6c ;
     prov:value "2.0319082736969"^^xsd:float ;
     nidm_equivalentZStatistic: "3.28873767184649"^^xsd:float ;
     nidm_pValueUncorrected: "0.000503188874995342"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999995"^^xsd:float ;
     nidm_qValueFDR: "0.717697062544172"^^xsd:float .
 
-niiri:5b4f61b279b53dacfaa5ced8b12ab0d1
+niiri:0f51826584cb999e63e872c756b90d6c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0131" ;
     nidm_coordinateVector: "[14,-92,24]"^^xsd:string .
 
-niiri:052883bbfd04c4c83f00204a80507ae3 prov:wasDerivedFrom niiri:24c2094ec130702f9601c371533bf8d4 .
+niiri:5ad6239481925bf6bc3a6ffbd30cf7e6 prov:wasDerivedFrom niiri:f7777aa15969e9f0700b324454e85979 .
 
-niiri:70640009a4f983a49b074a694de146c9
+niiri:29763b527003432a0c2b21c172ec4a81
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0132" ;
-    prov:atLocation niiri:5bf615edd3cb908169b24663bf3790c9 ;
+    prov:atLocation niiri:b5b1c2b39a254a42755330020659e9d8 ;
     prov:value "2.02607893943787"^^xsd:float ;
     nidm_equivalentZStatistic: "3.2811909187824"^^xsd:float ;
     nidm_pValueUncorrected: "0.000516848742881382"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999997"^^xsd:float ;
     nidm_qValueFDR: "0.724198294562932"^^xsd:float .
 
-niiri:5bf615edd3cb908169b24663bf3790c9
+niiri:b5b1c2b39a254a42755330020659e9d8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0132" ;
     nidm_coordinateVector: "[12,56,0]"^^xsd:string .
 
-niiri:70640009a4f983a49b074a694de146c9 prov:wasDerivedFrom niiri:e0fb0b6fe7935f93d9ab789f37f5ba17 .
+niiri:29763b527003432a0c2b21c172ec4a81 prov:wasDerivedFrom niiri:8005738cdc3c09b780e2ba1a36547702 .
 
-niiri:3013598eebb8d30aeaf7fe1e9354e1d2
+niiri:b10c8559c8983dbf10bcbbd87ba3a30b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0133" ;
-    prov:atLocation niiri:2d17d5edb780d63141de80727c097471 ;
+    prov:atLocation niiri:f883d32b205932078c22794402ab6d7d ;
     prov:value "2.01380300521851"^^xsd:float ;
     nidm_equivalentZStatistic: "3.26529688051921"^^xsd:float ;
     nidm_pValueUncorrected: "0.000546747002303394"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999999"^^xsd:float ;
     nidm_qValueFDR: "0.745134331831463"^^xsd:float .
 
-niiri:2d17d5edb780d63141de80727c097471
+niiri:f883d32b205932078c22794402ab6d7d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0133" ;
     nidm_coordinateVector: "[62,32,-12]"^^xsd:string .
 
-niiri:3013598eebb8d30aeaf7fe1e9354e1d2 prov:wasDerivedFrom niiri:8cf845d47cedee91dcbc9b5f4add50e4 .
+niiri:b10c8559c8983dbf10bcbbd87ba3a30b prov:wasDerivedFrom niiri:bd14daedcd6c35f47c42f6681a25a48e .
 
-niiri:3e99f0369731d3c2777ef51eb04932bc
+niiri:b4e1b1ca0ed3d9d8f28f683410396141
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0134" ;
-    prov:atLocation niiri:d8b80850bbe10a9d38347e6f796cb907 ;
+    prov:atLocation niiri:fb5f8c42764e6c71abadc95704e8f2c2 ;
     prov:value "2.00120663642883"^^xsd:float ;
     nidm_equivalentZStatistic: "3.24898603700399"^^xsd:float ;
     nidm_pValueUncorrected: "0.000579085815334945"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.768049313732932"^^xsd:float .
 
-niiri:d8b80850bbe10a9d38347e6f796cb907
+niiri:fb5f8c42764e6c71abadc95704e8f2c2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0134" ;
     nidm_coordinateVector: "[38,-74,26]"^^xsd:string .
 
-niiri:3e99f0369731d3c2777ef51eb04932bc prov:wasDerivedFrom niiri:51fdd8b821079d1b5dc1b6834e5fb0af .
+niiri:b4e1b1ca0ed3d9d8f28f683410396141 prov:wasDerivedFrom niiri:30ebc4167834c5d88670b4e8b93ee950 .
 
-niiri:fac48b92d9cbec66e0c2918bbd816c8a
+niiri:2c97f5daab495771999c9c6ed9658dae
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0135" ;
-    prov:atLocation niiri:6c36d95ebac8c804899be9e393edf5ac ;
+    prov:atLocation niiri:2aa43c399b59790e4dfbf04b8fbd8f94 ;
     prov:value "1.99859607219696"^^xsd:float ;
     nidm_equivalentZStatistic: "3.24560542001545"^^xsd:float ;
     nidm_pValueUncorrected: "0.000586005808283274"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.771799008009002"^^xsd:float .
 
-niiri:6c36d95ebac8c804899be9e393edf5ac
+niiri:2aa43c399b59790e4dfbf04b8fbd8f94
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0135" ;
     nidm_coordinateVector: "[-12,-96,24]"^^xsd:string .
 
-niiri:fac48b92d9cbec66e0c2918bbd816c8a prov:wasDerivedFrom niiri:a85e4f97fb1baa4a0c741f94e4bfc112 .
+niiri:2c97f5daab495771999c9c6ed9658dae prov:wasDerivedFrom niiri:5d3db32c6d2773404bb204393a96f250 .
 
-niiri:7125176cd7d21112e80e9abe57d013a1
+niiri:f1ee6434b4e9e350b5883b0db78d72fc
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0136" ;
-    prov:atLocation niiri:6e00e681e2511f3462c826f406f52e3d ;
+    prov:atLocation niiri:baca96ed8f0f9063a0508601dbbfaec3 ;
     prov:value "1.99211156368256"^^xsd:float ;
     nidm_equivalentZStatistic: "3.2372077945609"^^xsd:float ;
     nidm_pValueUncorrected: "0.000603527423333361"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.784349992009541"^^xsd:float .
 
-niiri:6e00e681e2511f3462c826f406f52e3d
+niiri:baca96ed8f0f9063a0508601dbbfaec3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0136" ;
     nidm_coordinateVector: "[-30,-56,-20]"^^xsd:string .
 
-niiri:7125176cd7d21112e80e9abe57d013a1 prov:wasDerivedFrom niiri:7a8a9b5c480a5adb8ea8cce6dede2941 .
+niiri:f1ee6434b4e9e350b5883b0db78d72fc prov:wasDerivedFrom niiri:6d6e5cd089cb7ce9b9715c42e896cd46 .
 
-niiri:fdd0d41920ca415d3db0737c9245d96c
+niiri:08fdef8ced896bffb0a9f513bb82f661
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0137" ;
-    prov:atLocation niiri:8ed32c08d5d0d7a41c874b8f70eef474 ;
+    prov:atLocation niiri:55b8ab77a10b3e815abd7fdaf9da8c21 ;
     prov:value "1.97817039489746"^^xsd:float ;
     nidm_equivalentZStatistic: "3.21915195379217"^^xsd:float ;
     nidm_pValueUncorrected: "0.00064285166979039"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.812778132844403"^^xsd:float .
 
-niiri:8ed32c08d5d0d7a41c874b8f70eef474
+niiri:55b8ab77a10b3e815abd7fdaf9da8c21
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0137" ;
     nidm_coordinateVector: "[-32,-6,-6]"^^xsd:string .
 
-niiri:fdd0d41920ca415d3db0737c9245d96c prov:wasDerivedFrom niiri:c1f4268606ddda131fdee326fe51797d .
+niiri:08fdef8ced896bffb0a9f513bb82f661 prov:wasDerivedFrom niiri:189cb4ae2ff1cc4b031011345ea5e5b0 .
 
-niiri:cecedd5748ebd882e2bb17572676c7ab
+niiri:33e039efa523781d074f8709e436c6c1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0138" ;
-    prov:atLocation niiri:9ee407270638d05d844c960e0301a7f5 ;
+    prov:atLocation niiri:8c6f1b0f1ca84fc63bf1d797146a2970 ;
     prov:value "1.96776080131531"^^xsd:float ;
     nidm_equivalentZStatistic: "3.20566861907462"^^xsd:float ;
     nidm_pValueUncorrected: "0.000673745357239186"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.83480060265404"^^xsd:float .
 
-niiri:9ee407270638d05d844c960e0301a7f5
+niiri:8c6f1b0f1ca84fc63bf1d797146a2970
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0138" ;
     nidm_coordinateVector: "[60,-46,44]"^^xsd:string .
 
-niiri:cecedd5748ebd882e2bb17572676c7ab prov:wasDerivedFrom niiri:50e9a0153fd5b58dfd6867a7820e429b .
+niiri:33e039efa523781d074f8709e436c6c1 prov:wasDerivedFrom niiri:697f2d7f340407941e5a743646226280 .
 
-niiri:4c5f85ea11aa48bf3b2ddf631a950f00
+niiri:7d85e08ff8a27a219706a4be288209f2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0139" ;
-    prov:atLocation niiri:2c9fc95c3608633b670c9073da4f7682 ;
+    prov:atLocation niiri:df69c761e2c334ab7f7bc845d48eff42 ;
     prov:value "1.96240246295929"^^xsd:float ;
     nidm_equivalentZStatistic: "3.19872762272311"^^xsd:float ;
     nidm_pValueUncorrected: "0.000690177580666695"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.842166706625736"^^xsd:float .
 
-niiri:2c9fc95c3608633b670c9073da4f7682
+niiri:df69c761e2c334ab7f7bc845d48eff42
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0139" ;
     nidm_coordinateVector: "[-52,12,-8]"^^xsd:string .
 
-niiri:4c5f85ea11aa48bf3b2ddf631a950f00 prov:wasDerivedFrom niiri:9fe72cde6498f2f7dfe77dfb89b501c0 .
+niiri:7d85e08ff8a27a219706a4be288209f2 prov:wasDerivedFrom niiri:15af37e0e71211cb9816e08cc4cd0b88 .
 
-niiri:935ece2cf4bb43334306912c68963843
+niiri:1952a27691fae0a16a11d4d1da1b6ab0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0140" ;
-    prov:atLocation niiri:49f78a6659b3182e5edfcacd463fa87f ;
+    prov:atLocation niiri:4a129fd0910d8fcc9ed909a91502fe25 ;
     prov:value "1.96232461929321"^^xsd:float ;
     nidm_equivalentZStatistic: "3.19862678466389"^^xsd:float ;
     nidm_pValueUncorrected: "0.00069041900707012"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.842166706625736"^^xsd:float .
 
-niiri:49f78a6659b3182e5edfcacd463fa87f
+niiri:4a129fd0910d8fcc9ed909a91502fe25
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0140" ;
     nidm_coordinateVector: "[-14,2,46]"^^xsd:string .
 
-niiri:935ece2cf4bb43334306912c68963843 prov:wasDerivedFrom niiri:4316bec42f97f257669a294c8fd0898f .
+niiri:1952a27691fae0a16a11d4d1da1b6ab0 prov:wasDerivedFrom niiri:3fb8aaff3e01f2366b6d14baa9559ec9 .
 
-niiri:63f3b74085b3f8b9cc4abea248909bc4
+niiri:28fc29227a7d0e7b676cba34c11619a0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0141" ;
-    prov:atLocation niiri:b29fbc36547d77044d403e3bcffe4569 ;
+    prov:atLocation niiri:5844e4e8f06aabbaf3dc89083886f1be ;
     prov:value "1.96151995658875"^^xsd:float ;
     nidm_equivalentZStatistic: "3.19758442738721"^^xsd:float ;
     nidm_pValueUncorrected: "0.000692919185722674"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.842166706625736"^^xsd:float .
 
-niiri:b29fbc36547d77044d403e3bcffe4569
+niiri:5844e4e8f06aabbaf3dc89083886f1be
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0141" ;
     nidm_coordinateVector: "[34,-60,-32]"^^xsd:string .
 
-niiri:63f3b74085b3f8b9cc4abea248909bc4 prov:wasDerivedFrom niiri:80346292a2b394403637328758a9b61a .
+niiri:28fc29227a7d0e7b676cba34c11619a0 prov:wasDerivedFrom niiri:557d4e957f05b5913d7a77c829b15561 .
 
-niiri:af8b6a131b6c3af534271c4ca1f18c32
+niiri:4969976c6b8f566ff774a986d7a36a79
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0142" ;
-    prov:atLocation niiri:ea3df53306d01ec8088b4b689f76170f ;
+    prov:atLocation niiri:146d39b6994eeae0540ab9b27e8c09be ;
     prov:value "1.95875000953674"^^xsd:float ;
     nidm_equivalentZStatistic: "3.19399619652422"^^xsd:float ;
     nidm_pValueUncorrected: "0.000701589830133797"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.843663873798835"^^xsd:float .
 
-niiri:ea3df53306d01ec8088b4b689f76170f
+niiri:146d39b6994eeae0540ab9b27e8c09be
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0142" ;
     nidm_coordinateVector: "[12,-10,8]"^^xsd:string .
 
-niiri:af8b6a131b6c3af534271c4ca1f18c32 prov:wasDerivedFrom niiri:a8192adc0f3eb7c0e3ebb68c9944ac3b .
+niiri:4969976c6b8f566ff774a986d7a36a79 prov:wasDerivedFrom niiri:73719d062893a763bcb9efcf192d5c98 .
 
-niiri:8b9185341402a11991efde670e9e6f66
+niiri:9601c3a9c37cd454e282dd247386189b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0143" ;
-    prov:atLocation niiri:ffa93c68ea8659ed2a7db6e4d7ae25a4 ;
+    prov:atLocation niiri:8ba20ce09c34b99a2b6902f97564b1d0 ;
     prov:value "1.9506379365921"^^xsd:float ;
     nidm_equivalentZStatistic: "3.1834872473508"^^xsd:float ;
     nidm_pValueUncorrected: "0.000727562614758925"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.859623644795425"^^xsd:float .
 
-niiri:ffa93c68ea8659ed2a7db6e4d7ae25a4
+niiri:8ba20ce09c34b99a2b6902f97564b1d0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0143" ;
     nidm_coordinateVector: "[44,42,-18]"^^xsd:string .
 
-niiri:8b9185341402a11991efde670e9e6f66 prov:wasDerivedFrom niiri:a9c299e42713dde6d9d2880ee2d4dc18 .
+niiri:9601c3a9c37cd454e282dd247386189b prov:wasDerivedFrom niiri:254124ed2b4a8c1c5be4de8f4c74580d .
 
-niiri:bd5d0f8606686eea25c5615845c925d6
+niiri:4fe52494e0e2ce9d3cab8ce7ef9c43a2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0144" ;
-    prov:atLocation niiri:06f32fa93951ec4535d97c02f2eee40c ;
+    prov:atLocation niiri:1ffc820e35aa9baee7e0c3ed0d901ab2 ;
     prov:value "1.94860780239105"^^xsd:float ;
     nidm_equivalentZStatistic: "3.18085716601903"^^xsd:float ;
     nidm_pValueUncorrected: "0.00073420004030933"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.86202414328266"^^xsd:float .
 
-niiri:06f32fa93951ec4535d97c02f2eee40c
+niiri:1ffc820e35aa9baee7e0c3ed0d901ab2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0144" ;
     nidm_coordinateVector: "[18,56,2]"^^xsd:string .
 
-niiri:bd5d0f8606686eea25c5615845c925d6 prov:wasDerivedFrom niiri:03911a1948dcd4aa2ec73ec06aafd889 .
+niiri:4fe52494e0e2ce9d3cab8ce7ef9c43a2 prov:wasDerivedFrom niiri:a0c4e98f01e68139790391bbf8725466 .
 
-niiri:65f979b51ad4e0ee65d1ee4f18530b2b
+niiri:6a53d2070def16165db38789830277ca
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0145" ;
-    prov:atLocation niiri:601c8057e29626ca32504027ce0a5dd4 ;
+    prov:atLocation niiri:95aae888c2d85975406eda8841e11c3f ;
     prov:value "1.94670081138611"^^xsd:float ;
     nidm_equivalentZStatistic: "3.1783865823579"^^xsd:float ;
     nidm_pValueUncorrected: "0.000740485731772766"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.86202414328266"^^xsd:float .
 
-niiri:601c8057e29626ca32504027ce0a5dd4
+niiri:95aae888c2d85975406eda8841e11c3f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0145" ;
     nidm_coordinateVector: "[50,24,40]"^^xsd:string .
 
-niiri:65f979b51ad4e0ee65d1ee4f18530b2b prov:wasDerivedFrom niiri:5114d29fe7a8bba54bb5318e7211dbb7 .
+niiri:6a53d2070def16165db38789830277ca prov:wasDerivedFrom niiri:98295b38fd8a93e7e4ee1dfd88c76887 .
 
-niiri:a80a6832ad5a92aaf0d96af2e158f184
+niiri:78ecf12590514c80a21b976921614adc
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0146" ;
-    prov:atLocation niiri:f4636a13417610438687a50e8f2ad971 ;
+    prov:atLocation niiri:dca356aa3b54948ba75d86da6cafa306 ;
     prov:value "1.93218469619751"^^xsd:float ;
     nidm_equivalentZStatistic: "3.1595792273601"^^xsd:float ;
     nidm_pValueUncorrected: "0.0007899856837843"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.892323800210792"^^xsd:float .
 
-niiri:f4636a13417610438687a50e8f2ad971
+niiri:dca356aa3b54948ba75d86da6cafa306
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0146" ;
     nidm_coordinateVector: "[-26,-90,28]"^^xsd:string .
 
-niiri:a80a6832ad5a92aaf0d96af2e158f184 prov:wasDerivedFrom niiri:cf393803c8dfe5f95ebba7fb00f78d36 .
+niiri:78ecf12590514c80a21b976921614adc prov:wasDerivedFrom niiri:33a90732b73cfec988bd66955a0c2126 .
 
-niiri:f73ffa6cf0d3710798aa60a39cdde82b
+niiri:2cc54cd7893515b53af0b26c486419e8
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0147" ;
-    prov:atLocation niiri:b65dbf5c193a7f3a2f2a971b17e6575c ;
+    prov:atLocation niiri:55ddd3faba6b02c3055057f36f9a40ba ;
     prov:value "1.9286732673645"^^xsd:float ;
     nidm_equivalentZStatistic: "3.15502945825559"^^xsd:float ;
     nidm_pValueUncorrected: "0.000802409503939616"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.899089242384032"^^xsd:float .
 
-niiri:b65dbf5c193a7f3a2f2a971b17e6575c
+niiri:55ddd3faba6b02c3055057f36f9a40ba
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0147" ;
     nidm_coordinateVector: "[-54,-12,44]"^^xsd:string .
 
-niiri:f73ffa6cf0d3710798aa60a39cdde82b prov:wasDerivedFrom niiri:313761c03f2118d6c60dd97a4be2bd9d .
+niiri:2cc54cd7893515b53af0b26c486419e8 prov:wasDerivedFrom niiri:ec3bd6715d891de0f42ba2dc11f9430c .
 
-niiri:8d12964daed2141b417b82a940db9902
+niiri:383e2e40e4478c46a885723e580540e9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0148" ;
-    prov:atLocation niiri:65eea2de7637f9413802bc4dce794b1b ;
+    prov:atLocation niiri:cfd86c6efe2ad2bbacea8ddaa77f7b0f ;
     prov:value "1.9261577129364"^^xsd:float ;
     nidm_equivalentZStatistic: "3.15176997808161"^^xsd:float ;
     nidm_pValueUncorrected: "0.000811420301080279"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.903090399433177"^^xsd:float .
 
-niiri:65eea2de7637f9413802bc4dce794b1b
+niiri:cfd86c6efe2ad2bbacea8ddaa77f7b0f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0148" ;
     nidm_coordinateVector: "[-48,-38,-12]"^^xsd:string .
 
-niiri:8d12964daed2141b417b82a940db9902 prov:wasDerivedFrom niiri:f80911af8d0e7423917d1703bda349c3 .
+niiri:383e2e40e4478c46a885723e580540e9 prov:wasDerivedFrom niiri:8aa002c426d46d7b9d4dc5e2c38279d3 .
 
-niiri:21f542b06ffdb017ec14021bc35dd49e
+niiri:d6f790d81f1079150604aaa16ea4f5c7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0149" ;
-    prov:atLocation niiri:a67ce5a503588268d5747d9e23641a20 ;
+    prov:atLocation niiri:a57f977529bc658a16c9ca211d898787 ;
     prov:value "1.92179548740387"^^xsd:float ;
     nidm_equivalentZStatistic: "3.14611757652157"^^xsd:float ;
     nidm_pValueUncorrected: "0.00082726738760952"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.909690617648608"^^xsd:float .
 
-niiri:a67ce5a503588268d5747d9e23641a20
+niiri:a57f977529bc658a16c9ca211d898787
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0149" ;
     nidm_coordinateVector: "[64,-36,16]"^^xsd:string .
 
-niiri:21f542b06ffdb017ec14021bc35dd49e prov:wasDerivedFrom niiri:b2335168bac5f013fca6c3119b31817e .
+niiri:d6f790d81f1079150604aaa16ea4f5c7 prov:wasDerivedFrom niiri:5d895214e17bb9af3199b1f47611a048 .
 
-niiri:ff3e0a672bdc9ce11edf9d4e634e7f23
+niiri:61c1675e82feee3a2ba070ebd84e8f84
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0150" ;
-    prov:atLocation niiri:d8210fda037302069bc7c8849638ad45 ;
+    prov:atLocation niiri:01c04a79b15ce0c1fb943eeaf3cba959 ;
     prov:value "1.92164015769958"^^xsd:float ;
     nidm_equivalentZStatistic: "3.1459163032625"^^xsd:float ;
     nidm_pValueUncorrected: "0.000827836893399936"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.909690617648608"^^xsd:float .
 
-niiri:d8210fda037302069bc7c8849638ad45
+niiri:01c04a79b15ce0c1fb943eeaf3cba959
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0150" ;
     nidm_coordinateVector: "[34,-22,68]"^^xsd:string .
 
-niiri:ff3e0a672bdc9ce11edf9d4e634e7f23 prov:wasDerivedFrom niiri:c6d9b891da12e7c0dafddbc99f7cd3bd .
+niiri:61c1675e82feee3a2ba070ebd84e8f84 prov:wasDerivedFrom niiri:781f6f173dae32b1495eaef04f1b405a .
 
-niiri:29e7942ca7e7b2881d65ee2187b7774a
+niiri:b21afe1ebc2946d76e1feed501da0a13
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0151" ;
-    prov:atLocation niiri:74d0bdac6b9120cd8558e71fb6190fd3 ;
+    prov:atLocation niiri:7228805920f29320ea05f2cac92707d8 ;
     prov:value "1.91999924182892"^^xsd:float ;
     nidm_equivalentZStatistic: "3.14379002300768"^^xsd:float ;
     nidm_pValueUncorrected: "0.000833875309880328"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.911263261101385"^^xsd:float .
 
-niiri:74d0bdac6b9120cd8558e71fb6190fd3
+niiri:7228805920f29320ea05f2cac92707d8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0151" ;
     nidm_coordinateVector: "[-8,-78,38]"^^xsd:string .
 
-niiri:29e7942ca7e7b2881d65ee2187b7774a prov:wasDerivedFrom niiri:02d752fd02bb32b544f85decb2637acb .
+niiri:b21afe1ebc2946d76e1feed501da0a13 prov:wasDerivedFrom niiri:d98430357b786f52e1aba172bbfea688 .
 
-niiri:b2c659fc604f4686862e8ea0bab8d778
+niiri:2c07a6ac701630dbce313c1c9311af3a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0152" ;
-    prov:atLocation niiri:c47c33fd8876bdb2f0a4d5f5592fcfbf ;
+    prov:atLocation niiri:4960f9500adb74ecfb4ca0a6db8f59ab ;
     prov:value "1.91007256507874"^^xsd:float ;
     nidm_equivalentZStatistic: "3.13092665544988"^^xsd:float ;
     nidm_pValueUncorrected: "0.000871278372345574"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.936494724004281"^^xsd:float .
 
-niiri:c47c33fd8876bdb2f0a4d5f5592fcfbf
+niiri:4960f9500adb74ecfb4ca0a6db8f59ab
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0152" ;
     nidm_coordinateVector: "[2,-62,6]"^^xsd:string .
 
-niiri:b2c659fc604f4686862e8ea0bab8d778 prov:wasDerivedFrom niiri:ca6249ceeaf778daf8955f1721d9b3bc .
+niiri:2c07a6ac701630dbce313c1c9311af3a prov:wasDerivedFrom niiri:fe57af8773140946a4555792ccdee632 .
 
-niiri:8f19e13ce047783521c6821695258868
+niiri:491c487f7a368b1aa7a2a4d48952759c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0153" ;
-    prov:atLocation niiri:43a6ca876100f41c7ef3926e23fb20d0 ;
+    prov:atLocation niiri:6e76cea4d9ee60e95c20e1e738bf0ac3 ;
     prov:value "1.90749907493591"^^xsd:float ;
     nidm_equivalentZStatistic: "3.12759169376378"^^xsd:float ;
     nidm_pValueUncorrected: "0.000881224174023254"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.940790144374657"^^xsd:float .
 
-niiri:43a6ca876100f41c7ef3926e23fb20d0
+niiri:6e76cea4d9ee60e95c20e1e738bf0ac3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0153" ;
     nidm_coordinateVector: "[50,26,-16]"^^xsd:string .
 
-niiri:8f19e13ce047783521c6821695258868 prov:wasDerivedFrom niiri:f5165ff916468849a9e8f0f984156ae0 .
+niiri:491c487f7a368b1aa7a2a4d48952759c prov:wasDerivedFrom niiri:678cf59b6ed563cbae258da7bd9a2417 .
 
-niiri:ea3d0ed5afeaf42e3e0a4e346d3fa4cf
+niiri:fcca986bd2deab6ef39bb2525ae730c8
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0154" ;
-    prov:atLocation niiri:707d4e54013fc2135528a4bf96dfac54 ;
+    prov:atLocation niiri:109a15fd9ceb50e814d71b953c67ae72 ;
     prov:value "1.90495073795319"^^xsd:float ;
     nidm_equivalentZStatistic: "3.12428927452869"^^xsd:float ;
     nidm_pValueUncorrected: "0.000891175681828393"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.945029582142648"^^xsd:float .
 
-niiri:707d4e54013fc2135528a4bf96dfac54
+niiri:109a15fd9ceb50e814d71b953c67ae72
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0154" ;
     nidm_coordinateVector: "[-34,-36,38]"^^xsd:string .
 
-niiri:ea3d0ed5afeaf42e3e0a4e346d3fa4cf prov:wasDerivedFrom niiri:3c77b0eab26aadf473051def81f975f1 .
+niiri:fcca986bd2deab6ef39bb2525ae730c8 prov:wasDerivedFrom niiri:fb40247362abead8bfd05d8c0f86fcc6 .
 
-niiri:7e1d2d825b7d3dacc015bd494ea8d5e2
+niiri:358a334c1617e7ce360e2f5605342b32
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0155" ;
-    prov:atLocation niiri:1842cedd79001489b321ec541b8e98d3 ;
+    prov:atLocation niiri:a6038e05091afb020d82c47e5d7b134c ;
     prov:value "1.90267658233643"^^xsd:float ;
     nidm_equivalentZStatistic: "3.1213421258659"^^xsd:float ;
     nidm_pValueUncorrected: "0.000900143739462567"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.948488792214144"^^xsd:float .
 
-niiri:1842cedd79001489b321ec541b8e98d3
+niiri:a6038e05091afb020d82c47e5d7b134c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0155" ;
     nidm_coordinateVector: "[14,-22,54]"^^xsd:string .
 
-niiri:7e1d2d825b7d3dacc015bd494ea8d5e2 prov:wasDerivedFrom niiri:74f854bba7b4563710f1c71fe1bb4d87 .
+niiri:358a334c1617e7ce360e2f5605342b32 prov:wasDerivedFrom niiri:f0413bd7869f1537bac196460adb50ad .
 
-niiri:89070c5be87cc773e2698db540d64a2b
+niiri:0e6bfffafd9d245f4dd49561f6c28e08
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0156" ;
-    prov:atLocation niiri:621713e5530af80a01c3a2b7aac9e629 ;
+    prov:atLocation niiri:37db3664c9849d417bb8a0681cc58067 ;
     prov:value "1.89570164680481"^^xsd:float ;
     nidm_equivalentZStatistic: "3.11230283620396"^^xsd:float ;
     nidm_pValueUncorrected: "0.000928169828270153"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.962543829897604"^^xsd:float .
 
-niiri:621713e5530af80a01c3a2b7aac9e629
+niiri:37db3664c9849d417bb8a0681cc58067
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0156" ;
     nidm_coordinateVector: "[16,-8,36]"^^xsd:string .
 
-niiri:89070c5be87cc773e2698db540d64a2b prov:wasDerivedFrom niiri:f0f6386c19242334018be62b5253762f .
+niiri:0e6bfffafd9d245f4dd49561f6c28e08 prov:wasDerivedFrom niiri:fd3eca9e0c356a0d39da224ef34ff7aa .
 
-niiri:ce200de37fdbe8adf37894545907a465
+niiri:f45794d952959fc21a4f15a7662b0673
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0157" ;
-    prov:atLocation niiri:91a65d554778579b61ea2ff28c80fbc4 ;
+    prov:atLocation niiri:596817d06440ee2934239c14263f4174 ;
     prov:value "1.88845551013947"^^xsd:float ;
     nidm_equivalentZStatistic: "3.10291168362407"^^xsd:float ;
     nidm_pValueUncorrected: "0.000958134082593487"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.98075710938733"^^xsd:float .
 
-niiri:91a65d554778579b61ea2ff28c80fbc4
+niiri:596817d06440ee2934239c14263f4174
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0157" ;
     nidm_coordinateVector: "[52,24,-14]"^^xsd:string .
 
-niiri:ce200de37fdbe8adf37894545907a465 prov:wasDerivedFrom niiri:79f57cc3d9c8ce9cf2ddf678b180fec2 .
+niiri:f45794d952959fc21a4f15a7662b0673 prov:wasDerivedFrom niiri:b2244e3b33c0159757aa93c2de26c3a1 .
 
-niiri:4fe2dc602f36bd67fd8bab5d7da32791
+niiri:ec709d3ce148902d8c0bd7af6efd254a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0158" ;
-    prov:atLocation niiri:70d5bff05c6dc7acac92ddd5f1ef2a79 ;
+    prov:atLocation niiri:20a2d53484d9fe5f16ed0cf8192effdb ;
     prov:value "1.88693702220917"^^xsd:float ;
     nidm_equivalentZStatistic: "3.10094364030331"^^xsd:float ;
     nidm_pValueUncorrected: "0.000964525016047491"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.982061324215166"^^xsd:float .
 
-niiri:70d5bff05c6dc7acac92ddd5f1ef2a79
+niiri:20a2d53484d9fe5f16ed0cf8192effdb
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0158" ;
     nidm_coordinateVector: "[-32,-78,-6]"^^xsd:string .
 
-niiri:4fe2dc602f36bd67fd8bab5d7da32791 prov:wasDerivedFrom niiri:ac75e1b81a1c6524011de1087ab61a81 .
+niiri:ec709d3ce148902d8c0bd7af6efd254a prov:wasDerivedFrom niiri:8b70b13ee54cf4407e3be646e313b866 .
 
-niiri:922fdbc101a4d473eaf0d7104176114f
+niiri:44179ac71aa6a866710bacec2f633862
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0159" ;
-    prov:atLocation niiri:3c2c76068027fe718f26d4c1d5abb690 ;
+    prov:atLocation niiri:9a7ff27b1b6b41cb81e8847242b24fed ;
     prov:value "1.88384366035461"^^xsd:float ;
     nidm_equivalentZStatistic: "3.09693442242366"^^xsd:float ;
     nidm_pValueUncorrected: "0.000977665622006629"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.988067762617164"^^xsd:float .
 
-niiri:3c2c76068027fe718f26d4c1d5abb690
+niiri:9a7ff27b1b6b41cb81e8847242b24fed
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0159" ;
     nidm_coordinateVector: "[-20,36,46]"^^xsd:string .
 
-niiri:922fdbc101a4d473eaf0d7104176114f prov:wasDerivedFrom niiri:8006697d9195e3c3171a1c00415399c0 .
+niiri:44179ac71aa6a866710bacec2f633862 prov:wasDerivedFrom niiri:cfc211e4c6c91ecd22c4f0f2f0075044 .
 
-niiri:b92d7dc441672c44a26b8109f1c47f0f
+niiri:fdea430f757b7b55cda702759b054832
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0160" ;
-    prov:atLocation niiri:88597f469f050fbb7e74469503342c8e ;
+    prov:atLocation niiri:386e33278e20d303c4d3f45997d793bf ;
     prov:value "1.88228130340576"^^xsd:float ;
     nidm_equivalentZStatistic: "3.09490947009333"^^xsd:float ;
     nidm_pValueUncorrected: "0.000984364888377609"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.989519036052045"^^xsd:float .
 
-niiri:88597f469f050fbb7e74469503342c8e
+niiri:386e33278e20d303c4d3f45997d793bf
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0160" ;
     nidm_coordinateVector: "[42,24,-40]"^^xsd:string .
 
-niiri:b92d7dc441672c44a26b8109f1c47f0f prov:wasDerivedFrom niiri:8ea603bc4b1eabe8a8b1f02e165eef5e .
+niiri:fdea430f757b7b55cda702759b054832 prov:wasDerivedFrom niiri:f00195d4acadb18083e5d9b4023ca225 .
 

--- a/spmexport/ex_spm_temporal_derivative/nidm.json
+++ b/spmexport/ex_spm_temporal_derivative/nidm.json
@@ -1,0 +1,11169 @@
+{
+  "prefix": {
+    "nidm": "http://purl.org/nidash/nidm#",
+    "niiri": "http://iri.nidash.org/",
+    "spm": "http://purl.org/nidash/spm#",
+    "neurolex": "http://neurolex.org/wiki/",
+    "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/",
+    "dct": "http://purl.org/dc/terms/",
+    "nfo": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#",
+    "dc": "http://purl.org/dc/elements/1.1/",
+    "dctype": "http://purl.org/dc/dcmitype/",
+    "obo": "http://purl.obolibrary.org/obo/",
+    "nidm_NIDMResults": "http://purl.org/nidash/nidm#NIDM_0000027",
+    "nidm_version": "http://purl.org/nidash/nidm#NIDM_0000127",
+    "nidm_spm_results_nidm": "http://purl.org/nidash/nidm#NIDM_0000168",
+    "nidm_softwareVersion": "http://purl.org/nidash/nidm#NIDM_0000122",
+    "nidm_NIDMResultsExport": "http://purl.org/nidash/nidm#NIDM_0000166"
+  },
+  "entity": {
+    "niiri:e80fdd02e6c9b8a432f69b8cd870cc7e": {
+      "prov:type": [
+        {
+        "$": "prov:Bundle",
+        "type": "xsd:QName"
+        },
+        {
+        "$": "nidm_NIDMResults:",
+        "type": "xsd:QName"
+        }
+      ],
+      "prov:label": {
+        "$": "NIDM-Results",
+        "type": "xsd:string"
+      },
+      "nidm_version:": {
+        "$": "1.3.0",
+        "type": "xsd:string"
+      }
+    }
+  },
+  "activity": {
+    "niiri:ce8ee76d421d7195cb9a3077c3f493ea": {
+      "prov:type": {
+        "$": "nidm_NIDMResultsExport:",
+        "type": "xsd:QName"
+      },
+      "prov:label": {
+        "$": "NIDM-Results export",
+        "type": "xsd:string"
+      }
+    }
+  },
+  "agent": {
+    "niiri:1987d1dc27e5d0c86458fed59bf44fa8": {
+      "prov:type": [
+        {
+        "$": "nidm_spm_results_nidm:",
+        "type": "xsd:QName"
+        },
+        {
+        "$": "prov:SoftwareAgent",
+        "type": "xsd:QName"
+        }
+      ],
+      "prov:label": {
+        "$": "spm_results_nidm",
+        "type": "xsd:string"
+      },
+      "nidm_softwareVersion:": {
+        "$": "12.7057",
+        "type": "xsd:string"
+      }
+    }
+  },
+  "wasGeneratedBy": {
+    "_:wGB5": {
+      "prov:entity": "niiri:e80fdd02e6c9b8a432f69b8cd870cc7e",
+      "prov:activity": "niiri:ce8ee76d421d7195cb9a3077c3f493ea",
+      "prov:time": "2017-04-19T12:18:53"
+    }
+  },
+  "wasAssociatedWith": {
+    "_:wAW4": {
+      "prov:activity": "niiri:ce8ee76d421d7195cb9a3077c3f493ea",
+      "prov:agent": "niiri:1987d1dc27e5d0c86458fed59bf44fa8"
+    }
+  },
+  "bundle": {
+    "niiri:e80fdd02e6c9b8a432f69b8cd870cc7e": {
+    "prefix": {
+        "nidm_softwareVersion": "http://purl.org/nidash/nidm#NIDM_0000122",
+        "nidm_CoordinateSpace": "http://purl.org/nidash/nidm#NIDM_0000016",
+        "nidm_voxelToWorldMapping": "http://purl.org/nidash/nidm#NIDM_0000132",
+        "nidm_voxelUnits": "http://purl.org/nidash/nidm#NIDM_0000133",
+        "nidm_voxelSize": "http://purl.org/nidash/nidm#NIDM_0000131",
+        "nidm_inWorldCoordinateSystem": "http://purl.org/nidash/nidm#NIDM_0000105",
+        "nidm_numberOfDimensions": "http://purl.org/nidash/nidm#NIDM_0000112",
+        "nidm_dimensionsInVoxels": "http://purl.org/nidash/nidm#NIDM_0000090",
+        "nlx_Imaginginstrument": "http://uri.neuinfo.org/nif/nifstd/birnlex_2094",
+        "nlx_Magneticresonanceimagingscanner": "http://uri.neuinfo.org/nif/nifstd/birnlex_2100",
+        "nidm_grandMeanScaling": "http://purl.org/nidash/nidm#NIDM_0000096",
+        "nidm_targetIntensity": "http://purl.org/nidash/nidm#NIDM_0000124",
+        "nidm_hasMRIProtocol": "http://purl.org/nidash/nidm#NIDM_0000172",
+        "nlx_FunctionalMRIprotocol": "http://uri.neuinfo.org/nif/nifstd/birnlex_2250",
+        "nidm_Data": "http://purl.org/nidash/nidm#NIDM_0000169",
+        "spm_DCTDriftModel": "http://purl.org/nidash/spm#SPM_0000002",
+        "spm_SPMsDriftCutoffPeriod": "http://purl.org/nidash/spm#SPM_0000001",
+        "nidm_hasDriftModel": "http://purl.org/nidash/nidm#NIDM_0000088",
+        "nidm_hasHRFBasis": "http://purl.org/nidash/nidm#NIDM_0000102",
+        "spm_SPMsCanonicalHRF": "http://purl.org/nidash/spm#SPM_0000004",
+        "spm_SPMsTemporalDerivative": "http://purl.org/nidash/spm#SPM_0000006",
+        "nidm_DesignMatrix": "http://purl.org/nidash/nidm#NIDM_0000019",
+        "nidm_regressorNames": "http://purl.org/nidash/nidm#NIDM_0000021",
+        "nidm_hasErrorDependence": "http://purl.org/nidash/nidm#NIDM_0000100",
+        "obo_Toeplitzcovariancestructure": "http://purl.obolibrary.org/obo/STATO_0000357",
+        "nidm_dependenceMapWiseDependence": "http://purl.org/nidash/nidm#NIDM_0000089",
+        "nidm_ConstantParameter": "http://purl.org/nidash/nidm#NIDM_0000072",
+        "nidm_errorVarianceHomogeneous": "http://purl.org/nidash/nidm#NIDM_0000094",
+        "nidm_varianceMapWiseDependence": "http://purl.org/nidash/nidm#NIDM_0000126",
+        "nidm_IndependentParameter": "http://purl.org/nidash/nidm#NIDM_0000073",
+        "nidm_withEstimationMethod": "http://purl.org/nidash/nidm#NIDM_0000134",
+        "obo_generalizedleastsquaresestimation": "http://purl.obolibrary.org/obo/STATO_0000372",
+        "nidm_ErrorModel": "http://purl.org/nidash/nidm#NIDM_0000023",
+        "nidm_hasErrorDistribution": "http://purl.org/nidash/nidm#NIDM_0000101",
+        "obo_normaldistribution": "http://purl.obolibrary.org/obo/STATO_0000227",
+        "nidm_ModelParametersEstimation": "http://purl.org/nidash/nidm#NIDM_0000056",
+        "nidm_MaskMap": "http://purl.org/nidash/nidm#NIDM_0000054",
+        "nidm_isUserDefined": "http://purl.org/nidash/nidm#NIDM_0000106",
+        "nidm_inCoordinateSpace": "http://purl.org/nidash/nidm#NIDM_0000104",
+        "nidm_GrandMeanMap": "http://purl.org/nidash/nidm#NIDM_0000033",
+        "nidm_maskedMedian": "http://purl.org/nidash/nidm#NIDM_0000107",
+        "nidm_ParameterEstimateMap": "http://purl.org/nidash/nidm#NIDM_0000061",
+        "nidm_ResidualMeanSquaresMap": "http://purl.org/nidash/nidm#NIDM_0000066",
+        "nidm_ReselsPerVoxelMap": "http://purl.org/nidash/nidm#NIDM_0000144",
+        "obo_contrastweightmatrix": "http://purl.obolibrary.org/obo/STATO_0000323",
+        "nidm_statisticType": "http://purl.org/nidash/nidm#NIDM_0000123",
+        "obo_tstatistic": "http://purl.obolibrary.org/obo/STATO_0000176",
+        "nidm_contrastName": "http://purl.org/nidash/nidm#NIDM_0000085",
+        "nidm_ContrastEstimation": "http://purl.org/nidash/nidm#NIDM_0000001",
+        "nidm_StatisticMap": "http://purl.org/nidash/nidm#NIDM_0000076",
+        "nidm_errorDegreesOfFreedom": "http://purl.org/nidash/nidm#NIDM_0000093",
+        "nidm_effectDegreesOfFreedom": "http://purl.org/nidash/nidm#NIDM_0000091",
+        "nidm_ContrastMap": "http://purl.org/nidash/nidm#NIDM_0000002",
+        "nidm_ContrastStandardErrorMap": "http://purl.org/nidash/nidm#NIDM_0000013",
+        "obo_statistic": "http://purl.obolibrary.org/obo/STATO_0000039",
+        "nidm_PValueUncorrected": "http://purl.org/nidash/nidm#NIDM_0000160",
+        "obo_FWERadjustedpvalue": "http://purl.obolibrary.org/obo/OBI_0001265",
+        "nidm_HeightThreshold": "http://purl.org/nidash/nidm#NIDM_0000034",
+        "nidm_equivalentThreshold": "http://purl.org/nidash/nidm#NIDM_0000161",
+        "nidm_ExtentThreshold": "http://purl.org/nidash/nidm#NIDM_0000026",
+        "nidm_clusterSizeInVoxels": "http://purl.org/nidash/nidm#NIDM_0000084",
+        "nidm_clusterSizeInResels": "http://purl.org/nidash/nidm#NIDM_0000156",
+        "nidm_PeakDefinitionCriteria": "http://purl.org/nidash/nidm#NIDM_0000063",
+        "nidm_maxNumberOfPeaksPerCluster": "http://purl.org/nidash/nidm#NIDM_0000108",
+        "nidm_minDistanceBetweenPeaks": "http://purl.org/nidash/nidm#NIDM_0000109",
+        "nidm_ClusterDefinitionCriteria": "http://purl.org/nidash/nidm#NIDM_0000007",
+        "nidm_hasConnectivityCriterion": "http://purl.org/nidash/nidm#NIDM_0000099",
+        "nidm_voxel18connected": "http://purl.org/nidash/nidm#NIDM_0000128",
+        "nidm_Inference": "http://purl.org/nidash/nidm#NIDM_0000049",
+        "nidm_hasAlternativeHypothesis": "http://purl.org/nidash/nidm#NIDM_0000097",
+        "nidm_OneTailedTest": "http://purl.org/nidash/nidm#NIDM_0000060",
+        "nidm_SearchSpaceMaskMap": "http://purl.org/nidash/nidm#NIDM_0000068",
+        "nidm_searchVolumeInVoxels": "http://purl.org/nidash/nidm#NIDM_0000121",
+        "nidm_searchVolumeInUnits": "http://purl.org/nidash/nidm#NIDM_0000136",
+        "nidm_reselSizeInVoxels": "http://purl.org/nidash/nidm#NIDM_0000148",
+        "nidm_searchVolumeInResels": "http://purl.org/nidash/nidm#NIDM_0000149",
+        "spm_searchVolumeReselsGeometry": "http://purl.org/nidash/spm#SPM_0000010",
+        "nidm_noiseFWHMInVoxels": "http://purl.org/nidash/nidm#NIDM_0000159",
+        "nidm_noiseFWHMInUnits": "http://purl.org/nidash/nidm#NIDM_0000157",
+        "nidm_randomFieldStationarity": "http://purl.org/nidash/nidm#NIDM_0000120",
+        "nidm_expectedNumberOfVoxelsPerCluster": "http://purl.org/nidash/nidm#NIDM_0000143",
+        "nidm_expectedNumberOfClusters": "http://purl.org/nidash/nidm#NIDM_0000141",
+        "nidm_heightCriticalThresholdFWE05": "http://purl.org/nidash/nidm#NIDM_0000147",
+        "nidm_heightCriticalThresholdFDR05": "http://purl.org/nidash/nidm#NIDM_0000146",
+        "spm_smallestSignificantClusterSizeInVoxelsFWE05": "http://purl.org/nidash/spm#SPM_0000014",
+        "spm_smallestSignificantClusterSizeInVoxelsFDR05": "http://purl.org/nidash/spm#SPM_0000013",
+        "nidm_ExcursionSetMap": "http://purl.org/nidash/nidm#NIDM_0000025",
+        "nidm_numberOfSupraThresholdClusters": "http://purl.org/nidash/nidm#NIDM_0000111",
+        "nidm_pValue": "http://purl.org/nidash/nidm#NIDM_0000114",
+        "nidm_hasClusterLabelsMap": "http://purl.org/nidash/nidm#NIDM_0000098",
+        "nidm_hasMaximumIntensityProjection": "http://purl.org/nidash/nidm#NIDM_0000138",
+        "nidm_ClusterLabelsMap": "http://purl.org/nidash/nidm#NIDM_0000008",
+        "nidm_SupraThresholdCluster": "http://purl.org/nidash/nidm#NIDM_0000070",
+        "nidm_pValueUncorrected": "http://purl.org/nidash/nidm#NIDM_0000116",
+        "nidm_pValueFWER": "http://purl.org/nidash/nidm#NIDM_0000115",
+        "nidm_qValueFDR": "http://purl.org/nidash/nidm#NIDM_0000119",
+        "nidm_clusterLabelId": "http://purl.org/nidash/nidm#NIDM_0000082",
+        "nidm_Peak": "http://purl.org/nidash/nidm#NIDM_0000062",
+        "nidm_equivalentZStatistic": "http://purl.org/nidash/nidm#NIDM_0000092",
+        "nidm_Coordinate": "http://purl.org/nidash/nidm#NIDM_0000015",
+        "nidm_coordinateVector": "http://purl.org/nidash/nidm#NIDM_0000086"
+    },
+    "entity": {
+        "niiri:b410708237a32a427489f32ca35c4711": {
+            "prov:type": {
+                "$": "nidm_CoordinateSpace:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Coordinate space 1",
+                "type": "xsd:string"
+            },
+            "nidm_voxelToWorldMapping:": {
+                "$": "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]",
+                "type": "xsd:string"
+            },
+            "nidm_voxelUnits:": {
+                "$": "[\"mm\", \"mm\", \"mm\"]",
+                "type": "xsd:string"
+            },
+            "nidm_voxelSize:": {
+                "$": "[2, 2, 2]",
+                "type": "xsd:string"
+            },
+            "nidm_inWorldCoordinateSystem:": {
+                "$": "nidm_Ixi549CoordinateSystem:",
+                "type": "xsd:string"
+            },
+            "nidm_numberOfDimensions:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_dimensionsInVoxels:": {
+                "$": "[79,95,79]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ef76ace3c4054ff67be710e42fb82df5": {
+            "prov:type": [
+                {
+                "$": "prov:Collection",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Data:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Data",
+                "type": "xsd:string"
+            },
+            "nidm_grandMeanScaling:": {
+                "$": "true",
+                "type": "xsd:boolean"
+            },
+            "nidm_targetIntensity:": {
+                "$": "100",
+                "type": "xsd:float"
+            },
+            "nidm_hasMRIProtocol:": {
+                "$": "nlx_FunctionalMRIprotocol:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1ba26f6e6e02762b1231f47d7d0c5385": {
+            "prov:type": {
+                "$": "spm_DCTDriftModel:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "SPM's DCT Drift Model",
+                "type": "xsd:string"
+            },
+            "spm_SPMsDriftCutoffPeriod:": {
+                "$": "128",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e68475df9e5152b04c95bde006aa28c2": {
+            "prov:type": {
+                "$": "nidm_DesignMatrix:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "DesignMatrix.csv",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "DesignMatrix.csv",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "text/csv",
+                "type": "xsd:string"
+            },
+            "dc:description": {
+                "$": "niiri:1addda2a0d4d8015583267922f5f8509",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Design Matrix",
+                "type": "xsd:string"
+            },
+            "nidm_regressorNames:": {
+                "$": "[\"Sn(1) to*bf(1)\", \"Sn(1) to*bf(2)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) \ntask001 co*bf(2)\", \"Sn(1) constant\"]",
+                "type": "xsd:string"
+            },
+            "nidm_hasDriftModel:": {
+                "$": "niiri:1ba26f6e6e02762b1231f47d7d0c5385",
+                "type": "xsd:string"
+            },
+            "nidm_hasHRFBasis:": [
+                {
+                "$": "spm_SPMsCanonicalHRF:",
+                "type": "xsd:string"
+                },
+                {
+                "$": "spm_SPMsTemporalDerivative:",
+                "type": "xsd:string"
+                }
+            ]
+        },
+        "niiri:1addda2a0d4d8015583267922f5f8509": {
+            "prov:type": {
+                "$": "dctype:Image",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "DesignMatrix.png",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "DesignMatrix.png",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/png",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:fe3aee97e82c6b81a5edb0430f731daf": {
+            "prov:type": {
+                "$": "nidm_ErrorModel:",
+                "type": "xsd:QName"
+            },
+            "nidm_hasErrorDistribution:": {
+                "$": "obo_normaldistribution:",
+                "type": "xsd:string"
+            },
+            "nidm_hasErrorDependence:": {
+                "$": "obo_Toeplitzcovariancestructure:",
+                "type": "xsd:string"
+            },
+            "nidm_dependenceMapWiseDependence:": {
+                "$": "nidm_ConstantParameter:",
+                "type": "xsd:string"
+            },
+            "nidm_errorVarianceHomogeneous:": {
+                "$": "true",
+                "type": "xsd:boolean"
+            },
+            "nidm_varianceMapWiseDependence:": {
+                "$": "nidm_IndependentParameter:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:07485f81ffa874bdd72e7579bb4e934b": {
+            "prov:type": {
+                "$": "nidm_MaskMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "Mask.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nidm_isUserDefined:": {
+                "$": "false",
+                "type": "xsd:boolean"
+            },
+            "nfo:fileName": {
+                "$": "Mask.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Mask",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b410708237a32a427489f32ca35c4711",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9588fe052df37634cce35de2c4c0e782": {
+            "prov:type": {
+                "$": "nidm_MaskMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "mask.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "36929e1f5f4143bd9cc818cd896a25f129961fab208c3a4438555f40444c08347b359142ee8c53ece6e8cca1627f49db0788a1fd3b9e2ecaef61999c6c6c67ac",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b365bb411ced2017b69b3dbafa0e85f3": {
+            "prov:type": {
+                "$": "nidm_GrandMeanMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "GrandMean.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "GrandMean.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Grand Mean Map",
+                "type": "xsd:string"
+            },
+            "nidm_maskedMedian:": {
+                "$": "116.092018127441",
+                "type": "xsd:float"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b410708237a32a427489f32ca35c4711",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "7bcbd0dbf511033ee5ce279852f073e8a82d6254329e78285b8e4948a17585a46457d5a65704e08e0524b91f02aec7c3c012f4222da246177f172afbc7eb65d5",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3cc1a4d9e0dbae0ea522ae6e6bee7809": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0001.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0001.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 1",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b410708237a32a427489f32ca35c4711",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "41593a1a82624e6c05f8214f64595e596b33c664304743792797665b1b36762a46e7e883d9aaaa3324fc62bf7a43261c8ed39f0ee575a4b451533dfe3eed89d7",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e44f0f19f822ee7f804728a0a9835c26": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0001.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "41593a1a82624e6c05f8214f64595e596b33c664304743792797665b1b36762a46e7e883d9aaaa3324fc62bf7a43261c8ed39f0ee575a4b451533dfe3eed89d7",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8de1184852768964088718dab52c75f6": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0002.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0002.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 2",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b410708237a32a427489f32ca35c4711",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "7a0d86a340516306df21786c1cbe22427b70ba2cfdea9ec8f384718104f8a3d5221ec0164e884662a96dec28f194814dabb605f0c8f8b37ef7828f7ecf45701f",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:954f92fad652775f12537d62ef353a73": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0002.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "7a0d86a340516306df21786c1cbe22427b70ba2cfdea9ec8f384718104f8a3d5221ec0164e884662a96dec28f194814dabb605f0c8f8b37ef7828f7ecf45701f",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:814e7ed06d738c9f3a585f4228558207": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0003.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0003.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 3",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b410708237a32a427489f32ca35c4711",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "683d243642dd44e2be739b6da7c49cfdb8fb66a8a58d8f12be426a80ba5f27f4d786217804c8f3b88a8f0e123111d57886b1f6f977b082d84bf55d4289f652a8",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:103821464851111f6bca4c68fe70a82a": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0003.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "683d243642dd44e2be739b6da7c49cfdb8fb66a8a58d8f12be426a80ba5f27f4d786217804c8f3b88a8f0e123111d57886b1f6f977b082d84bf55d4289f652a8",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:055713a7baa36cc6f47d02b18892edab": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0004.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0004.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 4",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b410708237a32a427489f32ca35c4711",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "dba26c065cb5d6ae4f7597010da0ea7329adf2177d3b8019871beb79506a47e902c8f23f4e4beb69f3a8cfa2067e28add1ff90054bab0d1ebf39c556e58a1c60",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4ec71cdc1dd74a4d7e5dbf9c950e3969": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0004.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "dba26c065cb5d6ae4f7597010da0ea7329adf2177d3b8019871beb79506a47e902c8f23f4e4beb69f3a8cfa2067e28add1ff90054bab0d1ebf39c556e58a1c60",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9e2b1e2183fda70e5c8eaa09275db3b7": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0005.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0005.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 5",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b410708237a32a427489f32ca35c4711",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "9760c5863f41702fba7b69b0eccde533fdb276d89380f514b5bf01691639531f18dfda8348c4e1f37fb030b0b81b3c348697e5e920b450e99796f8a22652bfb3",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5ee11adfe4ab413ef5516242c7951078": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0005.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "9760c5863f41702fba7b69b0eccde533fdb276d89380f514b5bf01691639531f18dfda8348c4e1f37fb030b0b81b3c348697e5e920b450e99796f8a22652bfb3",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:43a89bc0051da8157a5bff983ba89bc5": {
+            "prov:type": {
+                "$": "nidm_ResidualMeanSquaresMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ResidualMeanSquares.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ResidualMeanSquares.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Residual Mean Squares Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b410708237a32a427489f32ca35c4711",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "77eca9b40d48cdbed5705dcfa828c6ff7693ecb43c305cfb0ef28660d8c7d60df8819bfcfaf0be6d223b0aa760c0114165d48afb8338fae9929f2700ae3eba82",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:60f4af728d95c8bc6e63352f6e049770": {
+            "prov:type": {
+                "$": "nidm_ResidualMeanSquaresMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "ResMS.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "cd5c1a79918d35ce4774b90a7801056e74cfb5cf68f49240a51d713c455d63895d394dd8a8f15d2b73eee86c0828b6cbc862d038d5a4d1cc299171d25ad8d4dc",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:08f53b8611d5bdec5c8de0c449a1db6f": {
+            "prov:type": {
+                "$": "nidm_ReselsPerVoxelMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ReselsPerVoxel.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ReselsPerVoxel.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Resels per Voxel Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b410708237a32a427489f32ca35c4711",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "e34e4eeb83555ac00c097e516f70bf3aa83f22b775b1eaa1034c5de67c3703afa41546b0dea1a061178282b842559420d773d1c8817e44adec7ed4cc01b195f4",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f9e38aef778cfa4bf78b01f51a10f4eb": {
+            "prov:type": {
+                "$": "nidm_ReselsPerVoxelMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "RPV.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "1b9e3df7665e35441c1e98ddfa9aa90576563c0f976179e331a78cb43a3a52d7252e97899b6ba800b68a5eed479a81d3c29ac5a75e27aaaec451c69b48c29faf",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f0323f01131105dbd3d84869ff50e9ae": {
+            "prov:type": {
+                "$": "obo_contrastweightmatrix:",
+                "type": "xsd:QName"
+            },
+            "nidm_statisticType:": {
+                "$": "obo_tstatistic:",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast: tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "[1, 0, 0, 0, 0]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:aa1effb702cc7db6a16eac195236db09": {
+            "prov:type": {
+                "$": "nidm_StatisticMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "TStatistic.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "TStatistic.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "T-Statistic Map: tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "nidm_statisticType:": {
+                "$": "obo_tstatistic:",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "nidm_errorDegreesOfFreedom:": {
+                "$": "95.9999999999612",
+                "type": "xsd:float"
+            },
+            "nidm_effectDegreesOfFreedom:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b410708237a32a427489f32ca35c4711",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "559b9991a86bb27d60af713860b88249f0a74bb9a7be767d1bc0ab2af4c8c206308434fd6f0549578121151d43d71ebc4e4d72cf6e825b3f82f095fd308832c5",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:612caf1dd2e842956fc81ba14de59582": {
+            "prov:type": {
+                "$": "nidm_StatisticMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "spmT_0001.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "4d4f039b6b55f49d46991f6fffd3e0e7f933b3708d1a955f3c949863480dba89dd5fb4466b8e0f711eff753fbeb3c16c52cef9d24e13c9f494f6607dd379f64e",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:243b7b4df25be507aa622f4c9754d427": {
+            "prov:type": {
+                "$": "nidm_ContrastMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "Contrast.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "Contrast.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast Map: tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b410708237a32a427489f32ca35c4711",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "e9762825614822a23109b51b645e4397695352f3bd0fa37407e2ad0998f9acb23becd4f15698cd622b50687e083d6b94e71c696959b1175560e3ac0e50056f61",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:08a567ac0816c0a0aceb2ed59aeea49b": {
+            "prov:type": {
+                "$": "nidm_ContrastMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "con_0001.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "f4f1aed8094bcdf691de6bccc404a792e4cef66bb2eed29472a7b663276509857a23bfd24e7d92e4a0aaf513da4980f632094021b2ca048cf9b6ad21f481b20f",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:57e63fdc854e959fb8423a4f086ce703": {
+            "prov:type": {
+                "$": "nidm_ContrastStandardErrorMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ContrastStandardError.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ContrastStandardError.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast Standard Error Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b410708237a32a427489f32ca35c4711",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "403792ebe042c165a2310a4ffac22fb225f87abecb96d927bb5b582d00ead23c9bb13ca9423963c5100a171f36d9ec7a4c0c04d20818088613d61d250ef45dd6",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3dc9d42cdfae6ad474927bdb0e9bdc21": {
+            "prov:type": [
+                {
+                "$": "nidm_HeightThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_PValueUncorrected:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Height Threshold: p<0.001 (unc.)",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "0.000999499965079309",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentThreshold:": [
+                {
+                "$": "niiri:c48ee5e9869243c5ee3ef5d8de4d9211",
+                "type": "xsd:string"
+                },
+                {
+                "$": "niiri:5c238cdd746fbc26bd9ddecfb9e7fc15",
+                "type": "xsd:string"
+                }
+            ]
+        },
+        "niiri:c48ee5e9869243c5ee3ef5d8de4d9211": {
+            "prov:type": [
+                {
+                "$": "nidm_HeightThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_statistic:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Height Threshold: T=3.177308)",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.17730776622277",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:5c238cdd746fbc26bd9ddecfb9e7fc15": {
+            "prov:type": [
+                {
+                "$": "nidm_HeightThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_FWERadjustedpvalue:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Height Threshold: p<1.000000 (FWE)",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "0.999999999999999",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:102fecaa14caf589304b204290d2ae40": {
+            "prov:type": [
+                {
+                "$": "nidm_ExtentThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_statistic:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Extent Threshold: k>=0",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "0",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentThreshold:": [
+                {
+                "$": "niiri:6995399cabf336da2a6296280269642f",
+                "type": "xsd:string"
+                },
+                {
+                "$": "niiri:c6aa5eb71f55d9e8b0ed842961179eb0",
+                "type": "xsd:string"
+                }
+            ]
+        },
+        "niiri:6995399cabf336da2a6296280269642f": {
+            "prov:type": [
+                {
+                "$": "nidm_ExtentThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_FWERadjustedpvalue:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Extent Threshold",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c6aa5eb71f55d9e8b0ed842961179eb0": {
+            "prov:type": [
+                {
+                "$": "nidm_ExtentThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_PValueUncorrected:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Extent Threshold",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:161fb640ca5be8910668e6da2f030000": {
+            "prov:type": {
+                "$": "nidm_PeakDefinitionCriteria:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak Definition Criteria",
+                "type": "xsd:string"
+            },
+            "nidm_maxNumberOfPeaksPerCluster:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_minDistanceBetweenPeaks:": {
+                "$": "8",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:95a4466fd86f8eb162d7c71ec577da13": {
+            "prov:type": {
+                "$": "nidm_ClusterDefinitionCriteria:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Cluster Connectivity Criterion: 18",
+                "type": "xsd:string"
+            },
+            "nidm_hasConnectivityCriterion:": {
+                "$": "nidm_voxel18connected:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1ade20198bb3c55969610ae99f5a7dcb": {
+            "prov:type": {
+                "$": "nidm_SearchSpaceMaskMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "SearchSpaceMask.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "SearchSpaceMask.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Search Space Mask Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b410708237a32a427489f32ca35c4711",
+                "type": "xsd:string"
+            },
+            "nidm_searchVolumeInVoxels:": {
+                "$": "223057",
+                "type": "xsd:int"
+            },
+            "nidm_searchVolumeInUnits:": {
+                "$": "1784456",
+                "type": "xsd:float"
+            },
+            "nidm_reselSizeInVoxels:": {
+                "$": "64.3564266652164",
+                "type": "xsd:float"
+            },
+            "nidm_searchVolumeInResels:": {
+                "$": "3215.77829478616",
+                "type": "xsd:float"
+            },
+            "spm_searchVolumeReselsGeometry:": {
+                "$": "[6, 98.4147965253735, 978.080986305661, 3215.77829478616]",
+                "type": "xsd:string"
+            },
+            "nidm_noiseFWHMInVoxels:": {
+                "$": "[4.05874991505852, 4.0064022682226, 3.95772010097722]",
+                "type": "xsd:string"
+            },
+            "nidm_noiseFWHMInUnits:": {
+                "$": "[8.11749983011705, 8.01280453644521, 7.91544020195443]",
+                "type": "xsd:string"
+            },
+            "nidm_randomFieldStationarity:": {
+                "$": "true",
+                "type": "xsd:boolean"
+            },
+            "nidm_expectedNumberOfVoxelsPerCluster:": {
+                "$": "7.07193046610115",
+                "type": "xsd:float"
+            },
+            "nidm_expectedNumberOfClusters:": {
+                "$": "34.219403038192",
+                "type": "xsd:float"
+            },
+            "nidm_heightCriticalThresholdFWE05:": {
+                "$": "5.32326239521668",
+                "type": "xsd:float"
+            },
+            "nidm_heightCriticalThresholdFDR05:": {
+                "$": "4.61261701583862",
+                "type": "xsd:float"
+            },
+            "crypto:sha512": {
+                "$": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876",
+                "type": "xsd:string"
+            },
+            "spm_smallestSignificantClusterSizeInVoxelsFWE05:": {
+                "$": "97",
+                "type": "xsd:int"
+            },
+            "spm_smallestSignificantClusterSizeInVoxelsFDR05:": {
+                "$": "58",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:32d0bf812c17b0e83c10c6b9e47a20d3": {
+            "prov:type": {
+                "$": "nidm_ExcursionSetMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ExcursionSet.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ExcursionSet.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Excursion Set Map",
+                "type": "xsd:string"
+            },
+            "nidm_numberOfSupraThresholdClusters:": {
+                "$": "84",
+                "type": "xsd:int"
+            },
+            "nidm_pValue:": {
+                "$": "5.23248111505836e-13",
+                "type": "xsd:float"
+            },
+            "nidm_hasClusterLabelsMap:": {
+                "$": "niiri:1a46842083eecd60bf7b67f9b6b68ccb",
+                "type": "xsd:string"
+            },
+            "nidm_hasMaximumIntensityProjection:": {
+                "$": "niiri:da6cd8a8a31c5aadfdb433e08d00228b",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b410708237a32a427489f32ca35c4711",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "e3de08e691d68d649233bdce2639a4bbea750162fdb8ba7e29ddfbfd23760faba59f34e347d136b9a0fd9971f48200cb7c30294d1960bd27bd40661b39fe82a5",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1a46842083eecd60bf7b67f9b6b68ccb": {
+            "prov:type": {
+                "$": "nidm_ClusterLabelsMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ClusterLabels.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ClusterLabels.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Cluster Labels Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:b410708237a32a427489f32ca35c4711",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "192b1d648a385a172f839b0c03aab878274f1288c0ae8c12589f2ab0657756cc57b1691a072ba8fbd8c974dee181779696289703ac99d963860bea112a19017e",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:da6cd8a8a31c5aadfdb433e08d00228b": {
+            "prov:type": {
+                "$": "dctype:Image",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "MaximumIntensityProjection.png",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "MaximumIntensityProjection.png",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/png",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d4b353636b454d9def0cc10eaa71d2b8": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0001",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "10733",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "166.774330958947",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.54846604024394e-70",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "3.82071147380491e-68",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "1",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:dabc6f32070848fa7096bac116f4a0d0": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0002",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "433",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "6.7281547847968",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.97291873296552e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "2.38609088043518e-07",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1.31532949289466e-07",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "2",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:4e8b9634c8b43c73966139ed11b75ec8": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0003",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "429",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "6.66600092997189",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.82934221961109e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "2.6791538110249e-07",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1.31532949289466e-07",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "3",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:a731c83f0edffc39ddaeae57a80dc5ba": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0004",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1024",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "15.9113868351777",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.3245902390596e-15",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1.13797860024079e-13",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1.39632790040503e-13",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "4",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:5299ea7c2ff48f8ccb9e3da606289f28": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0005",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "153",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "2.37738494705291",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.38071971323196e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00286372395349332",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000879975569889356",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "5",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:2152e06e3cb49b34d19eb6146b5817f7": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0006",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "108",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.67815408027264",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000586195670709785",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0198594173433415",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0049240436339622",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "6",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c205169674df01953a0df15ba2cb5f08": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0007",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "513",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "7.97123188129505",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.36876076154881e-10",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "2.52154591651177e-08",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "2.06325301323367e-08",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "7",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f7a0ae64373c9fadcbae5c1ee69af3e7": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0008",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "44",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.68369240307404",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0167428141993664",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.436128622224438",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0740208627761461",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "8",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f78c9c52eb8c41c81b7108fc768afea1": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0009",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "25",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.388461592655704",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.060470582894952",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.87372172153123",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.181411748684856",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "9",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:defff4241093fb74f3bb72454faeb0c8": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0010",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "65",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.01000014090483",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00496736594455957",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.156318560760923",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0298041956673574",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "10",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:a32e7c63a62151c6c42d8b86e0a4c19e": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0011",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "159",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "2.47061572929028",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.56727454077428e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00224475889571929",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000788072944892913",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "11",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f9c64f2f13c1018c1b0c90db5e455972": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0012",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "127",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.97338489069098",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000250790491870153",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00854518152357242",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00234071125745476",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "12",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:2e1d13240b9a458b380045313214b3ba": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0013",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "399",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "6.19984701878504",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.88880680310254e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "6.4633820373583e-07",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "2.64432952434356e-07",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "13",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:76bd6a834aaa05e8f24aef110c831619": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0014",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "50",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.776923185311409",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0116364875650631",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.328468032427177",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0574979385567823",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "14",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:16274414c81621b268626b188f47a6c7": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0015",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "58",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.901230894961234",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00732239299925302",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.221641385754555",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0410054007958169",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "15",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:fb5ba293db82840b5cc150cc15515c24": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0016",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "35",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.543846229717986",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0298638102730271",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.640097371313789",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.10906782882323",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "16",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:aee52ad89a76ef41b6e67f9bca85ad62": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0017",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "87",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.35184634244185",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00159185647310904",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0530153341129462",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.010285841826243",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "17",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:594db02a9d179d5f91a6ed68ca678d59": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0018",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "24",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.372923128949476",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.065201392108969",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.892595448111178",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.188859204729427",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "18",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:6dd3d0166eed8b2fa885aeca84711d27": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0019",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "35",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.543846229717986",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0298638102730271",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.640097371313789",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.10906782882323",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "19",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:17120da53c5050105b9a8ee0e996c32d": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0020",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "30",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.466153911186845",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.042079152107298",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.763054107468119",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.147277032375543",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "20",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:a533e0119aa33105f1f6664ba02c4fcf": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0021",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "19",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.295230810418335",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0966642867392188",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.963403189505409",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.246054548063466",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "21",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:b5ea5e54d015aa2a8403364ed7da486d": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0022",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "18",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.279692346712107",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.105000317164867",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.972485665957631",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.259412548289672",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "22",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:16c2a7e89d0686e69f57bbeea9dc74a5": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0023",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "44",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.68369240307404",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0167428141993664",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.436128622224438",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0740208627761461",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "23",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:325d5f27465210c036cd8d865e80251d": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0024",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "97",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.50723097950413",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000980395231065353",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0329920280381935",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00686276661745747",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "24",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:a77994161041027f0cf04defd7345c50": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0025",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "104",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.61600022544773",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000705252953232431",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0238444546686055",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0053855680065022",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "25",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:78d6f29ff8a7c1f0a21810728ade20ce": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0026",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "10",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.155384637062282",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.218032079946087",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999424877570482",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.436064159892175",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "26",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:ef6fca405f462fa8c50ca4b0f7e48ca2": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0027",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "28",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.435076983774389",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0485199097081292",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.809922300499855",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.156756631364725",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "27",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:6578b8b9d153de72a9648c8488a6ac3f": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0028",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "15",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.233076955593423",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.135899078711517",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.990442081893761",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.308527638155876",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "28",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:aa346a17d504ccda6e8f3483bc7567b5": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0029",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0621538548249127",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.437414950664966",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999968417529",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.622760268743341",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "29",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:edeaef5183ad24011f37f4883d8f953f": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0030",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "38",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.590461620836671",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0245024923053393",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.567624415390469",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.102910467682425",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "30",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:82b6d07ebf78a88f41741c7c0b4d138a": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0031",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "53",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.823538576430093",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0097545787805446",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.283800029608743",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0512115385978591",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "31",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:23d958b69d91f95e528ceb5e2197a63a": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0032",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "29",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.450615447480617",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0451664237178062",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.786809267667146",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.151759183691829",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "32",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:cd749510acee370dec9860a5407637f5": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0033",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "11",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.17092310076851",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.197299441705757",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.998830839273017",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.404223246421551",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "33",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:13d9d29fd974d6893c1726d57a98a10f": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0034",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "7",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.108769245943597",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.300958767772195",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999966320774755",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.515929316180906",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "34",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:0d04d9bc9dd104e43dd556533a5b2159": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0035",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "25",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.388461592655704",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.060470582894952",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.87372172153123",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.181411748684856",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "35",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:7d13eda0d79684f0d63dac1332405064": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0036",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "20",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.310769274124564",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0891182364351059",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.952620841952852",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.241481672920932",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "36",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:9cc2d1c11d4e3b5aec5735ee91c1aca3": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0037",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "11",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.17092310076851",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.197299441705757",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.998830839273017",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.404223246421551",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "37",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:5b5b201251a2cc570135bacff1a480b1": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0038",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "22",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.34184620153702",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0760469924231223",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.925895771502835",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.212931578784742",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "38",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:bbf4ce7e2e67235f45331b2b87133bd7": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0039",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "7",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.108769245943597",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.300958767772195",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999966320774755",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.515929316180906",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "39",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:6a09c31a2cb2399d4dfaa1e9734b3056": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0040",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "7",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.108769245943597",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.300958767772195",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999966320774755",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.515929316180906",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "40",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:19eff7c42f4c5b43b8936b6bb77abf9e": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0041",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "14",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.217538491887194",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.148655664747997",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.993822910702503",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.328607258916625",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "41",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:3a53732749467fad732fc1b126252b83": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0042",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "36",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.559384693424214",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0279406783674385",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.615616041572874",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.10906782882323",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "42",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:4489ae9a89d81f59b4a316f0bc2ca8b8": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0043",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "13",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.202000028180966",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.162961955843832",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.996214059139573",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.350994981817484",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "43",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:20b3e078d59196a48bbdcfae8b039f3e": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0044",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "17",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.264153883005879",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.114231806805604",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.979938329743163",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.266540882546409",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "44",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:87692b796865090154e70657cb33f3fa": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0045",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "6",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0932307822373691",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.338405588448041",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999064909307",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.536340932634632",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "45",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f6aab0b38147783304dd12682b7a862f": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0046",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0310769274124564",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.59398729828926",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999998512086",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.69298518133747",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "46",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:8cfffabbc7e33bc2c585eb4a81ebc159": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0047",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "9",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.139846173356054",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.241762380583414",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999744672708743",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.472279999279227",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "47",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:d93e1967e2b464317bc445a37c7560a2": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0048",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "17",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.264153883005879",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.114231806805604",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.979938329743163",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.266540882546409",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "48",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:80f2f6c335075aedb795e079a5688f2b": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0049",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "5",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0776923185311409",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.383083955082425",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999997972899795",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.574625932623638",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "49",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:ef7d0561535e5e02620497afd1e27f3d": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0050",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "6",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0932307822373691",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.338405588448041",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999064909307",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.536340932634632",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "50",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:29289a4455046f74558f3c81d39ba67b": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0051",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "5",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0776923185311409",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.383083955082425",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999997972899795",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.574625932623638",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "51",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:2821bde2f68ccf372a5e6ea09d4eada7": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0052",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "19",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.295230810418335",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0966642867392188",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.963403189505409",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.246054548063466",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "52",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:5514e5220803aad2c04bbd033aa76695": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0053",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0155384637062282",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.720258744789692",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999980229",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.720258744789692",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "53",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:315fcb9a135fe01c557c732f7f103e94": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0054",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0310769274124564",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.59398729828926",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999998512086",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.69298518133747",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "54",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:fe8e19f11e2bcbf510735d94d7db4251": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0055",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "7",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.108769245943597",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.300958767772195",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999966320774755",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.515929316180906",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "55",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:fec8619ae00ff17ab9a3d3ceb9046f4e": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0056",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "5",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0776923185311409",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.383083955082425",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999997972899795",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.574625932623638",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "56",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:0b442ae9d99b24f7707cb51260201d38": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0057",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0155384637062282",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.720258744789692",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999980229",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.720258744789692",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "57",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:5b35b6fc65311a490ca686dedf246257": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0058",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "7",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.108769245943597",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.300958767772195",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999966320774755",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.515929316180906",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "58",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:8105ee9b0d3cbff0afc4f8e6f6cbaaaa": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0059",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0155384637062282",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.720258744789692",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999980229",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.720258744789692",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "59",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:b133a4090af3a2b167687334a106d130": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0060",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0621538548249127",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.437414950664966",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999968417529",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.622760268743341",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "60",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:4c38fc3cc2a35b74b2036daf823f1c35": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0061",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "7",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.108769245943597",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.300958767772195",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999966320774755",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.515929316180906",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "61",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:9476947ad907c2f9d5c061ead3c8ca5c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0062",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0310769274124564",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.59398729828926",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999998512086",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.69298518133747",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "62",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:eaf5abe818e88775744fc4bc734500da": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0063",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "6",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0932307822373691",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.338405588448041",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999064909307",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.536340932634632",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "63",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:d327e883ddebc9532dc10d806d05ceea": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0064",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0155384637062282",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.720258744789692",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999980229",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.720258744789692",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "64",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:b56a8e6eef495278939c1f07e4b2ec46": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0065",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0310769274124564",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.59398729828926",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999998512086",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.69298518133747",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "65",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:ed00692e64206abf7a48d003e49a172c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0066",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0155384637062282",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.720258744789692",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999980229",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.720258744789692",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "66",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:33f78596b63613a9bb773b49e610c339": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0067",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0310769274124564",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.59398729828926",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999998512086",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.69298518133747",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "67",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:fd773d75cfefece3ae58e4b268b97593": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0068",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0466153911186845",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.505317358341535",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999969073683",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.684623517753047",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "68",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:b1682618b3d8ba951d4fba69d43ace19": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0069",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0155384637062282",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.720258744789692",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999980229",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.720258744789692",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "69",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:4aff58ce7014532950c85678251d820b": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0070",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0310769274124564",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.59398729828926",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999998512086",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.69298518133747",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "70",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:d98d8e8d25b59a9503f694b966d532d9": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0071",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0310769274124564",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.59398729828926",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999998512086",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.69298518133747",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "71",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:5b8cc71e1c4a9af4a428ecbfd59af0c3": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0072",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0621538548249127",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.437414950664966",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999968417529",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.622760268743341",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "72",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:9399cc4d9102dea2381bab7e4de270e7": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0073",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "6",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0932307822373691",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.338405588448041",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999064909307",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.536340932634632",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "73",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:25449e2c897446ebd8a31026fdd28119": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0074",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0155384637062282",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.720258744789692",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999980229",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.720258744789692",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "74",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:0e21ee277152eb058ea4661ca48674d9": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0075",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0466153911186845",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.505317358341535",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999969073683",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.684623517753047",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "75",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:0e8a97e94bdd4af70efd21917168b43e": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0076",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0310769274124564",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.59398729828926",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999998512086",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.69298518133747",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "76",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:5b01f2070bd1d0178ffb33f1582d88a3": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0077",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0310769274124564",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.59398729828926",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999998512086",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.69298518133747",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "77",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:329bc820e22a3a07c45bd811037a5b92": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0078",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0310769274124564",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.59398729828926",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999998512086",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.69298518133747",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "78",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:4121c76a27252e2b2396a4e6040a0baf": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0079",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0466153911186845",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.505317358341535",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999969073683",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.684623517753047",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "79",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:419bb28f6b465c3e5015a6d14e56b223": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0080",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0155384637062282",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.720258744789692",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999980229",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.720258744789692",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "80",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:e64d676ce70ddc69f3b8a79a997afc14": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0081",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0155384637062282",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.720258744789692",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999980229",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.720258744789692",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "81",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:b2fe473551b0d5958d6a1fafaa7495aa": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0082",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0155384637062282",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.720258744789692",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999980229",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.720258744789692",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "82",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:8fc15b04ecd3232fd23805615acbe960": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0083",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0155384637062282",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.720258744789692",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999980229",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.720258744789692",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "83",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:3ba4f4eceb22f4823f915b7f2ea31b71": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0084",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0155384637062282",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.720258744789692",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999980229",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.720258744789692",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "84",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:61bd43e2cb11ead4b85522ae0ab9c70f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0001",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:19fd8a73f42418dd2674d3fea35437a4",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "9.2086353302002",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "7.76768101511643",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.99680288865056e-15",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "8.41986258492966e-10",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1.98279886818782e-08",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:19fd8a73f42418dd2674d3fea35437a4": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0001",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[46,14,22]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:aaefd41c0d243a75bbaf8975589a5d52": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0002",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:76939a99f5c8dab773bec0d17d3e3287",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "7.77265024185181",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "6.82858568121235",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.28779234340482e-12",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "9.56372568139408e-07",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "5.15073725636882e-06",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:76939a99f5c8dab773bec0d17d3e3287": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0002",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[32,24,-6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9c6062c0b908383a480b076e8fb62317": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0003",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:3cb0eeaad7f509be77fbbb3c734b17c8",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "7.7477593421936",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "6.81126740568942",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.83713069598934e-12",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1.07890633305185e-06",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "5.15073725636882e-06",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3cb0eeaad7f509be77fbbb3c734b17c8": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0003",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[8,18,50]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f05f6aec7d624e6197dbd9ac07aef88b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0004",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e4554759a85d8e68a90cbf39443103fe",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "7.59118175506592",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "6.70158988664555",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.03081987390397e-11",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "2.29926635753053e-06",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "7.75261359723548e-06",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e4554759a85d8e68a90cbf39443103fe": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0004",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[34,-88,-2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c11d713034b63a168bdd812994537584": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0005",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d844d02b36a9dc3a0e8ff3270dd100e1",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "7.03135824203491",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "6.29919779546036",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.49595003051672e-10",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "3.33681630670934e-05",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "3.5929708651339e-05",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d844d02b36a9dc3a0e8ff3270dd100e1": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0005",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[42,-72,-10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:db60aac6428eac8ac3baeeff8d9d9a89": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0006",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6db693a2950e3c3898b2016d47b0c085",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.73506736755371",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.30472446220131",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.64216566800724e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0107086846025504",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00182363082319185",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6db693a2950e3c3898b2016d47b0c085": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0006",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[34,-86,12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:da07c9cffdb89f061f471c62455179f6": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0007",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7cbc707f01d3236308dd2e2563f62b70",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.97286987304688",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "6.25622394584082",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.97205141105883e-10",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "4.39879376310515e-05",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "4.20152926830756e-05",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7cbc707f01d3236308dd2e2563f62b70": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0007",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[32,2,46]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f030a501c14ec9c10fe484ff04b4868f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0008",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:069d0ce94e80aac1d9ad38251824f8eb",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.64730930328369",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.23420507732884",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.28482022985355e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0149983527932318",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00232586421758464",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:069d0ce94e80aac1d9ad38251824f8eb": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0008",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[30,4,58]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:32366a46bbf0f9fae450db4ea84aff6d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0009",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d0279504420cdd8ef5cbb33ef8bc17e3",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.40563726425171",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.19368654428063",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.37228586966076e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.702748192357301",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0688715370678382",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d0279504420cdd8ef5cbb33ef8bc17e3": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0009",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[42,4,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8fc9a86e848c24dae11f15925f03b510": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0010",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:1891de7048560b92cd5e00c827fd79cd",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.86515712738037",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "6.17661732625786",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.27447735593012e-10",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "7.3039460029567e-05",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "5.79507633018939e-05",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:1891de7048560b92cd5e00c827fd79cd": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0010",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[40,-62,50]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:661f534ccc7bdcb595c223d462813fb2": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0011",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:45d6dbe200ad3545589d96cbcb3e79ed",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.85877418518066",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "6.17188094462764",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.37411543149813e-10",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "7.52619570517643e-05",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "5.79507633018939e-05",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:45d6dbe200ad3545589d96cbcb3e79ed": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0011",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[52,-32,42]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0439c89a311e9fd92d450045320abef9": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0012",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c68b3dc10dcd6c086fe4ae651da53586",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.75158262252808",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "6.0920231289905",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.57462853656432e-10",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.000124345942219439",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "7.74014448313719e-05",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c68b3dc10dcd6c086fe4ae651da53586": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0012",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[44,-70,50]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f3634f34416055e1f89021e72074c0b8": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0013",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:25d042185f02c49a8254ea541b284e66",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.74185800552368",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "6.08474855499121",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.83371351225992e-10",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.000130125013961813",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "7.74014448313719e-05",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:25d042185f02c49a8254ea541b284e66": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0013",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-34,-2,52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:349a28a9b41a96a17877fc37d66ae69a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0014",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:3d53b41dc35ce105f59d533871035a1b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.66947507858276",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "6.03044660761629",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.17535927843949e-10",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.000182357061928484",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "9.89064171074034e-05",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3d53b41dc35ce105f59d533871035a1b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0014",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-28,-94,4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3e1ef8a3ca25ac8b59d80bd43c358ed4": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0015",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:8d2cea471932539cb762241eca542d48",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.72731781005859",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.47080352419215",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.89631317532224e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.344866937398066",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0306600822692826",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:8d2cea471932539cb762241eca542d48": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0015",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-50,-72,2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:cd8ff33c2ca2918b0a27282345d1bda0": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0016",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4fa4b02b261b8765f2b1916297e8d0ef",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.61547613143921",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.98975768195926",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.05076958245576e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00023438146122523",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000109520618634045",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4fa4b02b261b8765f2b1916297e8d0ef": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0016",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-52,0,38]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:dfbab0b4541c5aa0d17a7fc20cc92006": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0017",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:efbb40cf819ae486eb77486299b67a9e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.67108535766602",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.25335064729294",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.46783984650889e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.013695505906366",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00217066284688228",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:efbb40cf819ae486eb77486299b67a9e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0017",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-46,6,28]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ef8223f420455816c0e95ee6e024db6c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0018",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:561d5625f54e1b5697536c0413529bc8",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.49257516860962",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.10888189288487",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.62035419970508e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0268824268377835",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00349505918676715",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:561d5625f54e1b5697536c0413529bc8": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0018",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-60,8,20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:35bbf8c9030a11e48d1b2dee7e09dc11": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0019",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:5a3e8745d343d64c09a7291cc9599412",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.17608976364136",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.65297947754486",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.88450704725108e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00175869443891008",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000479412815824312",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:5a3e8745d343d64c09a7291cc9599412": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0019",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-58,-30,-18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:27f7bd95d47b079be25c832329669ee6": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0020",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:2152150ffc3b9877675f544c6e8d05b5",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.00111627578735",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.51603694557944",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.7336469926299e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00377055438802265",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000889054456506852",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:2152150ffc3b9877675f544c6e8d05b5": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0020",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-54,-46,58]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c27894706882af29cb375ead129ef8cb": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0021",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:90f9c2bd488287a611152e190f59541c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.88819122314453",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.42680001669675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.86866747023495e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00589533759301752",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00119802154665121",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:90f9c2bd488287a611152e190f59541c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0021",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-62,-38,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c9d1046585f7728d08cc54165c11ff59": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0022",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c169b7364207ba5710701c5015add790",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.44929027557373",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.07359999694323",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.95179594375539e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.031565196414938",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00384073346935762",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c169b7364207ba5710701c5015add790": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0022",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-60,-50,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:03c13f292babfb2b1d3290faffb9e334": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0023",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c1c09ce48f662e61c3ae3b80bce02189",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.43339920043945",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.060622473607",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.08944963109303e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0334714202830716",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0039964071128327",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c1c09ce48f662e61c3ae3b80bce02189": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0023",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-36,-74,-14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4cc88fa1c2d357c36750e5a6a684d7c5": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0024",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0a07fa954d8bab227c98c3596c82c06e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.05177354812622",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.74502150166861",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.04242094267626e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.128300853408892",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0133943818856599",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0a07fa954d8bab227c98c3596c82c06e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0024",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-36,-68,-20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3cf98988c38bad72a5c4221177532d4d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0025",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:212b43414a4117095f4147d02a241fbc",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.12923574447632",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.95150505699521",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.88306154154305e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.94176507916668",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.131281271533869",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:212b43414a4117095f4147d02a241fbc": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0025",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-30,-58,-16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a8c8296f49eb09a8f5f2bc2e7fe30473": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0026",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:5e6ebb25f5bd7a0d3ffd55fc5a8c6ee8",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.30700492858887",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.95693297367533",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.58073340978038e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0530089422098637",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00589411306675136",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:5e6ebb25f5bd7a0d3ffd55fc5a8c6ee8": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0026",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-36,-74,-34]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5f7d79a55e6736946606e61cf06d0fef": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0027",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e3bf7803b46511439f4ae96a9a7dca98",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.51177191734314",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.39749381675455",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000340030624079946",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999824991842",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.523087759562521",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e3bf7803b46511439f4ae96a9a7dca98": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0027",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-44,-62,-32]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9325884a6c8f484b70d3de818aebf275": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0028",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a7d68510d6f28e3c6be8d50b297c9719",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.28576564788818",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.93942736847709",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.91761603713014e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0571951960553233",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00627550171974501",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a7d68510d6f28e3c6be8d50b297c9719": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0028",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[58,-38,6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:60a921fcb727986aa30984a19c231f18": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0029",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:71e187cc3dbc6e62f7d1ac6db011de77",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.67409086227417",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.42530768589333",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.81524595430383e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.396915869709553",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0353779325915568",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:71e187cc3dbc6e62f7d1ac6db011de77": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0029",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[62,-32,-6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b3d0ce5827aa453674fe13aef68e7d16": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0030",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:dbbee4c7d179888417ce4d2b85538f44",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.45858383178711",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.23965208014699",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.11933243143181e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.641045560649102",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0627964060338669",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:dbbee4c7d179888417ce4d2b85538f44": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0030",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[54,-24,-2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:794d4453dd2ad3bd3730dd91ae6b30e9": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0031",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:af634bd5ad9bbec585044c47707b7f32",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.24946975708008",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.9094577193641",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.56642935686702e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0650689222727684",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00706047439822435",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:af634bd5ad9bbec585044c47707b7f32": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0031",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-50,-60,54]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1a0ea80e15936593cdd19a72a1195f48": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0032",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4efa70bd6a3304ba75992adf5bb64efd",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.23662900924683",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.89883869005555",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.82023739367676e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0680871870860791",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00718215508152799",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4efa70bd6a3304ba75992adf5bb64efd": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0032",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-46,-66,-6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0569ccf24fdb31c7eaca9ab9fa246e95": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0033",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d7c5ae76657ceee4fe0930d8038110c3",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.40907335281372",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.19667377576541",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.35431823886645e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.698809001225567",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0687991026397412",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d7c5ae76657ceee4fe0930d8038110c3": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0033",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-54,-64,-8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2a23f426a8d1ce8819ab2ddb003a1fca": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0034",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f576cf1614b186ed87892b67215577f8",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.04332971572876",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.73795333032992",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.07943756555429e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.131940099784902",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0134243353138188",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f576cf1614b186ed87892b67215577f8": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0034",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-60,-16,28]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:375f7b40758a242274e5d254e754d2ea": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0035",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f4854b1ae4228726a13a570242046d52",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.99945306777954",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.70116602240923",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.29340041166159e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.152338396794269",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.014675241706815",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f4854b1ae4228726a13a570242046d52": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0035",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-36,-40,-36]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2bfeae4bd1acb4a2e2656604b5cb7718": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0036",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:1f3ebb15787863a4d572b20cc801c020",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.65380764007568",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.40793303387591",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.21808997933082e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.417896183733559",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0374764670608795",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:1f3ebb15787863a4d572b20cc801c020": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0036",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-50,-46,-32]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0e8711e2fd8d14446a6962527ef6df3a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0037",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:bc7434b50faea15d0f3428e0dacb67d6",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.85420560836792",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.57868324924493",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.33956067374752e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.239914320959961",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0223522363243732",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:bc7434b50faea15d0f3428e0dacb67d6": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0037",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-26,-92,30]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3891a8ece23ee8ae327ba5315f1c8fbe": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0038",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0f81dc717fe65942805f5d193ea9fc3d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.61261701583862",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.37258550039614",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.1391853225512e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.462242958151503",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0413121935538803",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0f81dc717fe65942805f5d193ea9fc3d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0038",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-20,-98,22]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ea7488d0b50894dd4de66796e80748b7": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0039",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7a7d15cade7651c7745d9e603461b155",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.8499321937561",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.57506330130209",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.38038009880981e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.24300196499404",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0224201392740291",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7a7d15cade7651c7745d9e603461b155": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0039",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[34,-54,-16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4331fbbba36aaea44c7a85c25098ab20": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0040",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:682cd9521a1b69e766ac8efe8ede5da3",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.83638429641724",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.56358093042646",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.51442057541684e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.252994517911213",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.023220278156989",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:682cd9521a1b69e766ac8efe8ede5da3": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0040",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-18,-60,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ab0ca88496f4fad69a12f72d809de0f9": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0041",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:de2a4a77e9c99754a28b73a5b8437f70",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.82152557373047",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.55097685331641",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.66987113994865e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.264312575763193",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0238865523925716",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:de2a4a77e9c99754a28b73a5b8437f70": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0041",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[16,-98,6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:217c4b04d55535db719b6c29ed1ff920": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0042",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:1eb03fa5a0b00d4cdae57571d3ef05b1",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.73149728775024",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.47436989109174",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.83184874719333e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.340973924582382",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0306600822692826",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:1eb03fa5a0b00d4cdae57571d3ef05b1": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0042",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-22,-74,60]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7a9ada485db0a1f6554f9ab114f1a05e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0043",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c3c5fa1f2191acb1c8d708293a305572",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.21357154846191",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.0257920609862",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.83919260934962e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.889725031810111",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.110652635086932",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c3c5fa1f2191acb1c8d708293a305572": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0043",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-30,-72,60]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8fed5f4ed36ab7a842539b15f966adc0": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0044",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:80ae6d5477f69a5848ae8d004bebcce2",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.64556264877319",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.40086444790859",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.39102339658371e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.426592793295939",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0381376242551822",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:80ae6d5477f69a5848ae8d004bebcce2": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0044",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-40,-40,44]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a3ad563a699cc4326f49719045069cc7": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0045",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4fd23de23846ef30d2daff0b25a2d2d3",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.63093709945679",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.38831729610845",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.71155195205897e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.442246950226133",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0396432116271416",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4fd23de23846ef30d2daff0b25a2d2d3": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0045",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-46,-56,14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f46c43948a24d962d4b5ed9559dbdf9e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0046",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:348fb68fe1e81a7d2e8118131777d3f5",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.48052835464478",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.25866261513588",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.02826793976218e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.615092838959958",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0606653213752077",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:348fb68fe1e81a7d2e8118131777d3f5": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0046",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-50,-50,20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:32ab5b28df46c33eedc2644958600327": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0047",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7cf03031cc3525780bb00e6d00dbb1ed",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.62564182281494",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.38377187185421",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.83209600213408e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.447983703874853",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0399535201049753",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7cf03031cc3525780bb00e6d00dbb1ed": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0047",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-54,-48,-16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d100c51eef378500eb4feffaffb6838f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0048",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:3b11bab9e0b69b19971b373a7f1603ee",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.39731121063232",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.1864457158313",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.41678330879413e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.712242817080673",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0701395133156884",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3b11bab9e0b69b19971b373a7f1603ee": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0048",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-36,-46,-18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:18a234ca0f5ed1ecc2090e7679e74552": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0049",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:1c7aecbd92310ea0de4913e7e7d71499",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.53011417388916",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.30153087828584",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.48110654050327e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.556525968503526",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0536338708992394",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:1c7aecbd92310ea0de4913e7e7d71499": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0049",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[12,-100,20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9f7600af4f7127e3e35e8956824b24cd": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0050",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:589510f1d277d70bd38e8b41f5208f6d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.43985033035278",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.22340441164883",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.20319728781348e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.663080040726423",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0655195642105904",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:589510f1d277d70bd38e8b41f5208f6d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0050",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-48,2,50]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8603599eaf15b47cfc1747721a7cc043": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0051",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:3808a783cb30debaf04ca96ba0dbfe0b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.42902088165283",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.21400406802287",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.25441381573221e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.675732426251063",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0666653677861119",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3808a783cb30debaf04ca96ba0dbfe0b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0051",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[20,-66,34]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:975035177d9f223d416eac85677dd73e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0052",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e2acd36a46999c63dbedb34bdf074c27",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.34153509140015",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.13785173162383",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.75286391850271e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.773482364050178",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0797247033163797",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e2acd36a46999c63dbedb34bdf074c27": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0052",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[22,-80,54]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d8e002f5cf7541fe9f68b39c0d8728f6": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0053",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:49a3b54ceb9b87ab4cf4da4698244a80",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.31018495559692",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.11047161264349",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.97425911666604e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.805553175655503",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0852768580529791",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:49a3b54ceb9b87ab4cf4da4698244a80": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0053",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[4,8,32]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2159f676fe87211c3a34c5173f62ef52": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0054",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:66764c6a7d0744dbfb27c4acb10e5096",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.27076530456543",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.07597586124442",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.29108861893312e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.842807876097015",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0956335108049698",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:66764c6a7d0744dbfb27c4acb10e5096": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0054",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[44,-48,-26]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d20759428478e6a2ecc5a6ac0336248b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0055",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:92ee6df0fc18e5cad532440d06b401d5",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.24014186859131",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.04912548760248",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.57046875662414e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.869047635745501",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.103527958580522",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:92ee6df0fc18e5cad532440d06b401d5": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0055",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[12,52,-12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:93dad7155ab8df6434cf30dc96e0fec7": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0056",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b31a74eef450f2def5dc49026d2b9709",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.16103744506836",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.97955763826227",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.45218098449784e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.924586885045607",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.124121852318798",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b31a74eef450f2def5dc49026d2b9709": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0056",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-14,-98,-4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:609028d01e5972e824b32d95ae48bf7d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0057",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:594a7521ca57e63a87ec7cde2e7d4ff4",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.15926313400269",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.97799377863742",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.47495948790355e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.925622766117185",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.124121852318798",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:594a7521ca57e63a87ec7cde2e7d4ff4": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0057",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-66,-36,22]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b4946cfd559a49dd59da4eb959fcc3ff": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0058",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:329b7745f4e1247cdc3009fe502edade",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.15127944946289",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.9709551719526",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.57925246584623e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.930169830491485",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.125812633483204",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:329b7745f4e1247cdc3009fe502edade": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0058",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[64,-30,-22]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:90fe65bd993a69b371b497dd0b82c3c9": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0059",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:9152c663953a89724e0ad9d96a65b31b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.68732213973999",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.55676980326808",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000187721434294241",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999949562856829",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.36844208672846",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:9152c663953a89724e0ad9d96a65b31b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0059",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[56,-22,-26]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:829760ac18f565fb23d2dd89751a104f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0060",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:1b86c75e5e0acab33754c3d010276da8",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.1501989364624",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.97000233107989",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.59359643187229e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.930770937360285",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.125812633483204",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:1b86c75e5e0acab33754c3d010276da8": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0060",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-64,-34,8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:11c5084b4dd50bda5192de6afa001779": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0061",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f34f6b3556c1161d085528b512b8676a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.11570262908936",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.93955268733486",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.08168366777817e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.948197934370974",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.135780811447955",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f34f6b3556c1161d085528b512b8676a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0061",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[50,46,-12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3c355638d7475943124ba9c226bfa69e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0062",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:277c0c1b8a9d2a7136d6fb53100f4535",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.06387186050415",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.89369529283678",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.93643251464615e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.968279346551793",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.154561047969304",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:277c0c1b8a9d2a7136d6fb53100f4535": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0062",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-38,-54,-42]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:73c33f38c5fedbbd36089605d2e2bed2": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0063",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4fa8c02bb9d4119aac7ac8a420647cc3",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.63390350341797",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.50844773659595",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000225364892119218",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999988653013371",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.410740156420602",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4fa8c02bb9d4119aac7ac8a420647cc3": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0063",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-30,-64,-40]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:dabeaf7666f754dfe37065b88c4f4b4a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0064",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:dc22bbd3df567f1be35fd703ae919813",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.04323768615723",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.87540363822468",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.32240496489145e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.974420729710188",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.16275733943943",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:dc22bbd3df567f1be35fd703ae919813": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0064",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-14,58,10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a62d0b592d043fda22e569f6cdb71fff": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0065",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b487eb50f6635294ac4f3e02f1fd9c9d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.03806781768799",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.87081752636553",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.4235483319065e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.975809063970924",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.164182416202422",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b487eb50f6635294ac4f3e02f1fd9c9d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0065",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-68,-34,-8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4ac0f9aefed1176b14b9abe74250cbdc": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0066",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a0b34589df34a16d82775f29cdb325a5",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.004225730896",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.84076553938526",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.13256092123482e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.983537497151825",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.17776479000337",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a0b34589df34a16d82775f29cdb325a5": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0066",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[16,60,12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e022009b24cfb049ed10bbfee681d92a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0067",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:2f7b36f5f675f649d99cf764343de5c7",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.97911667823792",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.81843367367204",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.71508406763222e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.987909478842303",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.188766279331586",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:2f7b36f5f675f649d99cf764343de5c7": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0067",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[64,-32,16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:abbe5bd49d9338f66a3af445c1e2372c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0068",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7cce260bd801b5e637a5ae78e7cc6a21",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.96304869651794",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.80412735630895",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.11524784513529e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99018444524646",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.196465422200293",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7cce260bd801b5e637a5ae78e7cc6a21": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0068",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-58,-32,22]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:578bcf6846bd5b49337bc46c4d7b1c7f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0069",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:23bd153efdafbf140cfa0b6666fc959e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.92521071434021",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.77039013890334",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.14962714239531e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.994203174123576",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.214086162162037",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:23bd153efdafbf140cfa0b6666fc959e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0069",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[42,-42,14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:da03712278abfc01eebac38b33e1cf9d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0070",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e876166ff2dceea5230e5d76fbf9f15f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.92441153526306",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.76967685174471",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.17295246882122e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.994270531661465",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.214086162162037",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e876166ff2dceea5230e5d76fbf9f15f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0070",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[54,8,-36]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4776d4c0541b2407f509fe6b2b1c2853": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0071",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:8e80b4015fe341dd35e4a04ffb7bd269",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.83119082450867",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.68627175710081",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000113781673432678",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.998771596988439",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.271448122890309",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:8e80b4015fe341dd35e4a04ffb7bd269": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0071",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-66,-46,8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a0b516d4caa56831926e6d21c58b5dad": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0072",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4543c36bb3fcf5b8005d17cc742876cc",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.80303430557251",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.66100116005044",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000125615810592783",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999284372850148",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.284998670660322",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4543c36bb3fcf5b8005d17cc742876cc": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0072",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-54,-32,42]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6aa0a5cf04dbb3c86c7b7e42153c561d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0073",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b3a94b46b45cb4c4f16342948448b2b1",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.80056810379028",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.65878600275762",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000126706415147559",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999318686068297",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.285311172590102",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b3a94b46b45cb4c4f16342948448b2b1": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0073",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[14,-14,72]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:cd7d7fa3c3a1f73e1c6e18eec54bf367": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0074",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:8e116c5bfb82033d215acceb7790ae6e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.43387007713318",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.32638243729709",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000439905622966141",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999993561311",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.61426970601407",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:8e116c5bfb82033d215acceb7790ae6e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0074",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[12,-16,64]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b77f9f4ee4f5feb949a261a2483aa303": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0075",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:32d8cdce54f1bc815e16b577a65b42f9",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.7976541519165",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.65616831501084",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000128006646334056",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999357362048204",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.285982238829825",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:32d8cdce54f1bc815e16b577a65b42f9": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0075",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-22,-82,0]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d00c21a3d5785cd0c3ace030b952b31e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0076",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0fcf7ece24e31946c54d35e8b1f83339",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.79047918319702",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.64972117706788",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000131262556208656",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999444488129241",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.290021691384508",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0fcf7ece24e31946c54d35e8b1f83339": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0076",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[52,-42,18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:81b14a242118884af4716d1386a49968": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0077",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:796162ee36fddd7fe04fdb52f196a437",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.73172569274902",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.59683942997016",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000161053590001625",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999847623960611",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.333516771702899",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:796162ee36fddd7fe04fdb52f196a437": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0077",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-46,14,2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1b496fdde624ffb7718731dcb5969f61": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0078",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:430af058ffb53b1c5f36dba7ce187964",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.7307436466217",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.59595419684865",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0001616023346106",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999851120393834",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.333516771702899",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:430af058ffb53b1c5f36dba7ce187964": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0078",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-16,4,62]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1949681f598de9abc79f75c80aefff35": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0079",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:5a39b6d66bb64abc65a91ff2a298ca0b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.71718406677246",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.58372690354832",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00016936312213478",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999892552580384",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.343980192781709",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:5a39b6d66bb64abc65a91ff2a298ca0b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0079",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[42,-86,12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:156c0ed1194df2305d443c2e19909212": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0080",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ed2e59615ba0052e7aaa0fa34f891006",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.6839451789856",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.55371881325781",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000189912540090265",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999953853986457",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.369765026721735",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ed2e59615ba0052e7aaa0fa34f891006": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0080",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[56,-66,4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e1346785ea40b70db27ae60f7bdd98cc": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0081",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:96891dbc0a30ebca766e502619edafda",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.65720558166504",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.52954228664317",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000208139586526879",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999977747731185",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.394667961040657",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:96891dbc0a30ebca766e502619edafda": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0081",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-60,-46,0]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f9510499752a4d4a62444e63c5613551": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0082",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a097f126e0b7b865a50e6fbd1ff0446c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.6346263885498",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.50910250251801",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000224810793142627",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999988407105485",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.410740156420602",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a097f126e0b7b865a50e6fbd1ff0446c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0082",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[48,34,-8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8bbd37614dea9f192710357a074c63f1": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0083",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:3ca45b6a52ae0c898f083934ee671939",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.62398386001587",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.49946049887545",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000233100337095449",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999991575586166",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.419299318507116",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3ca45b6a52ae0c898f083934ee671939": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0083",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[32,-80,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:51e60ac16faa51fdca273f7e51c66c23": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0084",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f15c5edf089117c22fd1387c5c6afdd5",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.58678197860718",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.46571659793177",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000264410189540709",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999997407846311",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.449939086167831",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f15c5edf089117c22fd1387c5c6afdd5": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0084",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-28,-64,-4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f868633206589461de78ed5f44c3088b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0085",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:99443289e22800a7b794d7aa4f24f6a7",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.53609657287598",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.41964440308829",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000313515213706594",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999559435381",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.4996866807862",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:99443289e22800a7b794d7aa4f24f6a7": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0085",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-50,-40,32]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ae37176f4228fdcd9909a5c9d8991945": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0086",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b26986f014facbd25376c493db54de06",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.53580570220947",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.41937968187583",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000313820412307875",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999564147392",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.4996866807862",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b26986f014facbd25376c493db54de06": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0086",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-60,-14,10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:dd232f665acbacec710283b33a7ffc6b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0087",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d2cba17eb975b3349a089cd9a6c33464",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.51950573921204",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.40453920275412",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000331378932285298",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999764036674",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.515543012752167",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d2cba17eb975b3349a089cd9a6c33464": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0087",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-18,-92,8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:52c43bf1c9ff74a8799c3b7e6d3a1981": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0088",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:5a482bce8aa9db2111282847cc17f383",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.49318885803223",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.38055434488284",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000361698840550817",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999916401603",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.545280130510157",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:5a482bce8aa9db2111282847cc17f383": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0088",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[12,-86,50]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b5befcd1e1859623d7854488fa7de979": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0089",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:8c0885885f7d3e6a0c5d4d78d7581155",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.47051548957825",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.35986611616874",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000389901261900971",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999967415099",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.574030743367995",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:8c0885885f7d3e6a0c5d4d78d7581155": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0089",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-28,-32,-40]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:fa63e0fc9565564fb8d045ce95dc3fb0": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0090",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7fa3faad18f93a839559601b4d609c22",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.45754051208496",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.34801719030758",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000406959813051277",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999981385599",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.587029984895018",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7fa3faad18f93a839559601b4d609c22": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0090",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[8,-72,42]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b3ffdc96c6bca62445438ff33b6dab0b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0091",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6953a6cf7591ac6178b3e252d77b304c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.43320918083191",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.32577803511444",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000440860566175205",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999993754102",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.61426970601407",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6953a6cf7591ac6178b3e252d77b304c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0091",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-38,-78,8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:63ddfa8767c13e0bf648a86357c0616c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0092",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d2bc2d6192acb2df1303a750a5ea9259",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.43009805679321",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.32293260301119",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000445382166252561",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999994589954",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.616048939476298",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d2bc2d6192acb2df1303a750a5ea9259": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0092",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-56,34,-20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:70cfc0282d991ec2d4a5b55d1fd54d12": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0093",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:5d8529c4069514ea40bb8b8fa6993638",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.424649477005",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.31794834148679",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000453406269446011",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999995802847",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.621361020904295",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:5d8529c4069514ea40bb8b8fa6993638": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0093",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[18,-58,32]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9b72288ab7c77e827d9f1f781adf3151": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0094",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:592fa6eb01f3638945c2086fe68908ae",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.40277910232544",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.29792901961918",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000487003764363392",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999998528515",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.64908702869037",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:592fa6eb01f3638945c2086fe68908ae": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0094",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-32,-76,-2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:88a8cadf94cd28dcac01eb9dbc030af6": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0095",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:089cb2a4ffc88484de7776f0fdffe221",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.3940372467041",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.28992137977698",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000501076897352348",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999044949",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.659842637673888",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:089cb2a4ffc88484de7776f0fdffe221": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0095",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[24,-64,-18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d72cc582c4a89de3d8d56216d7584f90": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0096",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:dc0311045709c90687bf5718110350ae",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.38822054862976",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.28459142797104",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00051065177940457",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999286734",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.663972520258905",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:dc0311045709c90687bf5718110350ae": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0096",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[14,52,24]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e16c4d3e320d40e426df93aee2ca6add": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0097",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:dc54ccf09ba5eabcbeedfec4a1babb63",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.34795022010803",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.24765190787991",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000581807655324229",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999914172",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.723121887342887",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:dc54ccf09ba5eabcbeedfec4a1babb63": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0097",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-64,-24,46]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d70ef29aa1808eec49d1cf3e0a54e0ff": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0098",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:08d1e3f57a3aaac82503778457e03a57",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.33032703399658",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.23146500785458",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000615787011640778",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999967832",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.750358478642178",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:08d1e3f57a3aaac82503778457e03a57": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0098",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-56,24,22]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2188b2e49f6e63679bc313f1b84db925": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0099",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d487a995ae698c5bffe6a334eff5c7c1",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.30043077468872",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.20397578866589",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000677719372958352",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999994377",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.800935685960822",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d487a995ae698c5bffe6a334eff5c7c1": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0099",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-14,4,16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ee6edaf11ccf62cbd5f1fae3293222dd": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0100",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:db7766986aa39069f0e3fb4da12f89d8",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.2954432964325",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.19938627223673",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000688602556676021",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999995838",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.80659749253585",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:db7766986aa39069f0e3fb4da12f89d8": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0100",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[12,-18,52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:15350a82e9c3fc01fd72c2bc7362c921": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0101",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0b730f42d0287a0e641497fcb4468ec4",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.29354763031006",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.19764159673963",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000692781844264911",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999996291",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.80659749253585",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0b730f42d0287a0e641497fcb4468ec4": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0101",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[10,-8,6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:06e844c8b746ab33069a3ac489ba1d42": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0102",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:62c24f999648e906a27d9930430b903e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.27130317687988",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.17715789461409",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000743630203309364",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999069",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.839869575034518",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:62c24f999648e906a27d9930430b903e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0102",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-32,14,60]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0dcdfb141f26fdfb1b6f3ff37ca276eb": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0103",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:aa4caf2f8978443c3ecd0274bb9ae0e1",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.27024936676025",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.17618699537964",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000746123636619966",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999129",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.839869575034518",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:aa4caf2f8978443c3ecd0274bb9ae0e1": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0103",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-34,-84,6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:837e6614e3814f2aedc901891549d812": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0104",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:5cb2949541c80c967fcb899f69618232",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.2392430305481",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.1475998920821",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000823084243901762",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999886",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.897361297935526",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:5cb2949541c80c967fcb899f69618232": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0104",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[36,-58,38]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:db893cc3d08eff94a18a2ded424c27da": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0105",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:1644dc14a37498514a08b1d016af0de4",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.22486090660095",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.13432667345374",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0008612448992944",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999957",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.922927255586177",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:1644dc14a37498514a08b1d016af0de4": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0105",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[50,-42,-44]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0d719d9c0dda162347b33fc762ee9dba": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0106",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c1de986c07ccf82f9e7eec004acec01f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.21566033363342",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.12583111524387",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000886516713776597",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999977",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.938118112536103",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c1de986c07ccf82f9e7eec004acec01f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0106",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-52,-64,-24]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e0efd8540741b57d022a32fe600f4a60": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0107",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:05aa9aebd8dad58a0f2d1603e21cf930",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.21121668815613",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.12172675458225",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000898968641653619",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999984",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.943425557898272",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:05aa9aebd8dad58a0f2d1603e21cf930": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0107",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-42,-24,70]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:984314d1e545f3779d40732df43ac486": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0108",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f32ffd76360ec205c4000b22913ce264",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.19088125228882",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.10293388694787",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00095806220289707",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999996",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.978708956745583",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f32ffd76360ec205c4000b22913ce264": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0108",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-42,-86,16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:441ee164b95e1dde37ae482e9d9d5e83": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0109",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a7ba281dfef3a6043ffbd77f05f7c9c0",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.18322372436523",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.0958529484655",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000981238298823239",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999998",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.987875729427955",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a7ba281dfef3a6043ffbd77f05f7c9c0": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0109",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[8,-2,28]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2319fac2b0bcd7224a1b3319200a5ae7": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0110",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c92676a64fcf679097acf689ece5636c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.18283724784851",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.09549551060057",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000982421736617112",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999998",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.987875729427955",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c92676a64fcf679097acf689ece5636c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0110",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[14,-22,76]",
+                "type": "xsd:string"
+            }
+        }
+    },
+    "activity": {
+        "niiri:690e3f484f6e5f7a6eec1242e70053c5": {
+            "prov:type": {
+                "$": "nidm_ModelParametersEstimation:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Model parameters estimation",
+                "type": "xsd:string"
+            },
+            "nidm_withEstimationMethod:": {
+                "$": "obo_generalizedleastsquaresestimation:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8cff757e6900adeab2b9b8a66b5a61ea": {
+            "prov:type": {
+                "$": "nidm_ContrastEstimation:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Contrast estimation",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:975d5305cd6d906f0149068326afc106": {
+            "prov:type": {
+                "$": "nidm_Inference:",
+                "type": "xsd:QName"
+            },
+            "nidm_hasAlternativeHypothesis:": {
+                "$": "nidm_OneTailedTest:",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Inference",
+                "type": "xsd:string"
+            }
+        }
+    },
+    "agent": {
+        "niiri:65bbe1871e61c631eb812e3b6150407c": {
+            "prov:type": [
+                {
+                "$": "src_SPM:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "prov:SoftwareAgent",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "SPM",
+                "type": "xsd:string"
+            },
+            "nidm_softwareVersion:": {
+                "$": "12.6906",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:181adcf33bc1c55ebfad49dc712d7cd6": {
+            "prov:type": [
+                {
+                "$": "nlx_Imaginginstrument:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nlx_Magneticresonanceimagingscanner:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "MRI Scanner",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:fd83cd08b03cd16aa7c54c67699b8c14": {
+            "prov:type": {
+                "$": "prov:Person",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Person",
+                "type": "xsd:string"
+            }
+        }
+    },
+    "wasGeneratedBy": {
+        "_:wGB20": {
+            "prov:entity": "niiri:07485f81ffa874bdd72e7579bb4e934b",
+            "prov:activity": "niiri:690e3f484f6e5f7a6eec1242e70053c5"
+        },
+        "_:wGB22": {
+            "prov:entity": "niiri:b365bb411ced2017b69b3dbafa0e85f3",
+            "prov:activity": "niiri:690e3f484f6e5f7a6eec1242e70053c5"
+        },
+        "_:wGB26": {
+            "prov:entity": "niiri:3cc1a4d9e0dbae0ea522ae6e6bee7809",
+            "prov:activity": "niiri:690e3f484f6e5f7a6eec1242e70053c5"
+        },
+        "_:wGB30": {
+            "prov:entity": "niiri:8de1184852768964088718dab52c75f6",
+            "prov:activity": "niiri:690e3f484f6e5f7a6eec1242e70053c5"
+        },
+        "_:wGB34": {
+            "prov:entity": "niiri:814e7ed06d738c9f3a585f4228558207",
+            "prov:activity": "niiri:690e3f484f6e5f7a6eec1242e70053c5"
+        },
+        "_:wGB38": {
+            "prov:entity": "niiri:055713a7baa36cc6f47d02b18892edab",
+            "prov:activity": "niiri:690e3f484f6e5f7a6eec1242e70053c5"
+        },
+        "_:wGB42": {
+            "prov:entity": "niiri:9e2b1e2183fda70e5c8eaa09275db3b7",
+            "prov:activity": "niiri:690e3f484f6e5f7a6eec1242e70053c5"
+        },
+        "_:wGB46": {
+            "prov:entity": "niiri:43a89bc0051da8157a5bff983ba89bc5",
+            "prov:activity": "niiri:690e3f484f6e5f7a6eec1242e70053c5"
+        },
+        "_:wGB50": {
+            "prov:entity": "niiri:08f53b8611d5bdec5c8de0c449a1db6f",
+            "prov:activity": "niiri:690e3f484f6e5f7a6eec1242e70053c5"
+        },
+        "_:wGB66": {
+            "prov:entity": "niiri:aa1effb702cc7db6a16eac195236db09",
+            "prov:activity": "niiri:8cff757e6900adeab2b9b8a66b5a61ea"
+        },
+        "_:wGB70": {
+            "prov:entity": "niiri:243b7b4df25be507aa622f4c9754d427",
+            "prov:activity": "niiri:8cff757e6900adeab2b9b8a66b5a61ea"
+        },
+        "_:wGB72": {
+            "prov:entity": "niiri:57e63fdc854e959fb8423a4f086ce703",
+            "prov:activity": "niiri:8cff757e6900adeab2b9b8a66b5a61ea"
+        },
+        "_:wGB91": {
+            "prov:entity": "niiri:1ade20198bb3c55969610ae99f5a7dcb",
+            "prov:activity": "niiri:975d5305cd6d906f0149068326afc106"
+        },
+        "_:wGB95": {
+            "prov:entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3",
+            "prov:activity": "niiri:975d5305cd6d906f0149068326afc106"
+        }
+    },
+    "used": {
+        "_:u14": {
+            "prov:activity": "niiri:690e3f484f6e5f7a6eec1242e70053c5",
+            "prov:entity": "niiri:e68475df9e5152b04c95bde006aa28c2"
+        },
+        "_:u15": {
+            "prov:activity": "niiri:690e3f484f6e5f7a6eec1242e70053c5",
+            "prov:entity": "niiri:ef76ace3c4054ff67be710e42fb82df5"
+        },
+        "_:u16": {
+            "prov:activity": "niiri:690e3f484f6e5f7a6eec1242e70053c5",
+            "prov:entity": "niiri:fe3aee97e82c6b81a5edb0430f731daf"
+        },
+        "_:u54": {
+            "prov:activity": "niiri:8cff757e6900adeab2b9b8a66b5a61ea",
+            "prov:entity": "niiri:07485f81ffa874bdd72e7579bb4e934b"
+        },
+        "_:u55": {
+            "prov:activity": "niiri:8cff757e6900adeab2b9b8a66b5a61ea",
+            "prov:entity": "niiri:43a89bc0051da8157a5bff983ba89bc5"
+        },
+        "_:u56": {
+            "prov:activity": "niiri:8cff757e6900adeab2b9b8a66b5a61ea",
+            "prov:entity": "niiri:e68475df9e5152b04c95bde006aa28c2"
+        },
+        "_:u57": {
+            "prov:activity": "niiri:8cff757e6900adeab2b9b8a66b5a61ea",
+            "prov:entity": "niiri:f0323f01131105dbd3d84869ff50e9ae"
+        },
+        "_:u58": {
+            "prov:activity": "niiri:8cff757e6900adeab2b9b8a66b5a61ea",
+            "prov:entity": "niiri:3cc1a4d9e0dbae0ea522ae6e6bee7809"
+        },
+        "_:u59": {
+            "prov:activity": "niiri:8cff757e6900adeab2b9b8a66b5a61ea",
+            "prov:entity": "niiri:8de1184852768964088718dab52c75f6"
+        },
+        "_:u60": {
+            "prov:activity": "niiri:8cff757e6900adeab2b9b8a66b5a61ea",
+            "prov:entity": "niiri:814e7ed06d738c9f3a585f4228558207"
+        },
+        "_:u61": {
+            "prov:activity": "niiri:8cff757e6900adeab2b9b8a66b5a61ea",
+            "prov:entity": "niiri:055713a7baa36cc6f47d02b18892edab"
+        },
+        "_:u62": {
+            "prov:activity": "niiri:8cff757e6900adeab2b9b8a66b5a61ea",
+            "prov:entity": "niiri:9e2b1e2183fda70e5c8eaa09275db3b7"
+        },
+        "_:u83": {
+            "prov:activity": "niiri:975d5305cd6d906f0149068326afc106",
+            "prov:entity": "niiri:3dc9d42cdfae6ad474927bdb0e9bdc21"
+        },
+        "_:u84": {
+            "prov:activity": "niiri:975d5305cd6d906f0149068326afc106",
+            "prov:entity": "niiri:102fecaa14caf589304b204290d2ae40"
+        },
+        "_:u85": {
+            "prov:activity": "niiri:975d5305cd6d906f0149068326afc106",
+            "prov:entity": "niiri:aa1effb702cc7db6a16eac195236db09"
+        },
+        "_:u86": {
+            "prov:activity": "niiri:975d5305cd6d906f0149068326afc106",
+            "prov:entity": "niiri:08f53b8611d5bdec5c8de0c449a1db6f"
+        },
+        "_:u87": {
+            "prov:activity": "niiri:975d5305cd6d906f0149068326afc106",
+            "prov:entity": "niiri:07485f81ffa874bdd72e7579bb4e934b"
+        },
+        "_:u88": {
+            "prov:activity": "niiri:975d5305cd6d906f0149068326afc106",
+            "prov:entity": "niiri:161fb640ca5be8910668e6da2f030000"
+        },
+        "_:u89": {
+            "prov:activity": "niiri:975d5305cd6d906f0149068326afc106",
+            "prov:entity": "niiri:95a4466fd86f8eb162d7c71ec577da13"
+        }
+    },
+    "wasDerivedFrom": {
+        "_:wDF19": {
+            "prov:generatedEntity": "niiri:07485f81ffa874bdd72e7579bb4e934b",
+            "prov:usedEntity": "niiri:9588fe052df37634cce35de2c4c0e782"
+        },
+        "_:wDF25": {
+            "prov:generatedEntity": "niiri:3cc1a4d9e0dbae0ea522ae6e6bee7809",
+            "prov:usedEntity": "niiri:e44f0f19f822ee7f804728a0a9835c26"
+        },
+        "_:wDF29": {
+            "prov:generatedEntity": "niiri:8de1184852768964088718dab52c75f6",
+            "prov:usedEntity": "niiri:954f92fad652775f12537d62ef353a73"
+        },
+        "_:wDF33": {
+            "prov:generatedEntity": "niiri:814e7ed06d738c9f3a585f4228558207",
+            "prov:usedEntity": "niiri:103821464851111f6bca4c68fe70a82a"
+        },
+        "_:wDF37": {
+            "prov:generatedEntity": "niiri:055713a7baa36cc6f47d02b18892edab",
+            "prov:usedEntity": "niiri:4ec71cdc1dd74a4d7e5dbf9c950e3969"
+        },
+        "_:wDF41": {
+            "prov:generatedEntity": "niiri:9e2b1e2183fda70e5c8eaa09275db3b7",
+            "prov:usedEntity": "niiri:5ee11adfe4ab413ef5516242c7951078"
+        },
+        "_:wDF45": {
+            "prov:generatedEntity": "niiri:43a89bc0051da8157a5bff983ba89bc5",
+            "prov:usedEntity": "niiri:60f4af728d95c8bc6e63352f6e049770"
+        },
+        "_:wDF49": {
+            "prov:generatedEntity": "niiri:08f53b8611d5bdec5c8de0c449a1db6f",
+            "prov:usedEntity": "niiri:f9e38aef778cfa4bf78b01f51a10f4eb"
+        },
+        "_:wDF65": {
+            "prov:generatedEntity": "niiri:aa1effb702cc7db6a16eac195236db09",
+            "prov:usedEntity": "niiri:612caf1dd2e842956fc81ba14de59582"
+        },
+        "_:wDF69": {
+            "prov:generatedEntity": "niiri:243b7b4df25be507aa622f4c9754d427",
+            "prov:usedEntity": "niiri:08a567ac0816c0a0aceb2ed59aeea49b"
+        },
+        "_:wDF97": {
+            "prov:generatedEntity": "niiri:d4b353636b454d9def0cc10eaa71d2b8",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF99": {
+            "prov:generatedEntity": "niiri:dabc6f32070848fa7096bac116f4a0d0",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF101": {
+            "prov:generatedEntity": "niiri:4e8b9634c8b43c73966139ed11b75ec8",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF103": {
+            "prov:generatedEntity": "niiri:a731c83f0edffc39ddaeae57a80dc5ba",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF105": {
+            "prov:generatedEntity": "niiri:5299ea7c2ff48f8ccb9e3da606289f28",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF107": {
+            "prov:generatedEntity": "niiri:2152e06e3cb49b34d19eb6146b5817f7",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF109": {
+            "prov:generatedEntity": "niiri:c205169674df01953a0df15ba2cb5f08",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF111": {
+            "prov:generatedEntity": "niiri:f7a0ae64373c9fadcbae5c1ee69af3e7",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF113": {
+            "prov:generatedEntity": "niiri:f78c9c52eb8c41c81b7108fc768afea1",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF115": {
+            "prov:generatedEntity": "niiri:defff4241093fb74f3bb72454faeb0c8",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF117": {
+            "prov:generatedEntity": "niiri:a32e7c63a62151c6c42d8b86e0a4c19e",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF119": {
+            "prov:generatedEntity": "niiri:f9c64f2f13c1018c1b0c90db5e455972",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF121": {
+            "prov:generatedEntity": "niiri:2e1d13240b9a458b380045313214b3ba",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF123": {
+            "prov:generatedEntity": "niiri:76bd6a834aaa05e8f24aef110c831619",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF125": {
+            "prov:generatedEntity": "niiri:16274414c81621b268626b188f47a6c7",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF127": {
+            "prov:generatedEntity": "niiri:fb5ba293db82840b5cc150cc15515c24",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF129": {
+            "prov:generatedEntity": "niiri:aee52ad89a76ef41b6e67f9bca85ad62",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF131": {
+            "prov:generatedEntity": "niiri:594db02a9d179d5f91a6ed68ca678d59",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF133": {
+            "prov:generatedEntity": "niiri:6dd3d0166eed8b2fa885aeca84711d27",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF135": {
+            "prov:generatedEntity": "niiri:17120da53c5050105b9a8ee0e996c32d",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF137": {
+            "prov:generatedEntity": "niiri:a533e0119aa33105f1f6664ba02c4fcf",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF139": {
+            "prov:generatedEntity": "niiri:b5ea5e54d015aa2a8403364ed7da486d",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF141": {
+            "prov:generatedEntity": "niiri:16c2a7e89d0686e69f57bbeea9dc74a5",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF143": {
+            "prov:generatedEntity": "niiri:325d5f27465210c036cd8d865e80251d",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF145": {
+            "prov:generatedEntity": "niiri:a77994161041027f0cf04defd7345c50",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF147": {
+            "prov:generatedEntity": "niiri:78d6f29ff8a7c1f0a21810728ade20ce",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF149": {
+            "prov:generatedEntity": "niiri:ef6fca405f462fa8c50ca4b0f7e48ca2",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF151": {
+            "prov:generatedEntity": "niiri:6578b8b9d153de72a9648c8488a6ac3f",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF153": {
+            "prov:generatedEntity": "niiri:aa346a17d504ccda6e8f3483bc7567b5",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF155": {
+            "prov:generatedEntity": "niiri:edeaef5183ad24011f37f4883d8f953f",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF157": {
+            "prov:generatedEntity": "niiri:82b6d07ebf78a88f41741c7c0b4d138a",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF159": {
+            "prov:generatedEntity": "niiri:23d958b69d91f95e528ceb5e2197a63a",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF161": {
+            "prov:generatedEntity": "niiri:cd749510acee370dec9860a5407637f5",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF163": {
+            "prov:generatedEntity": "niiri:13d9d29fd974d6893c1726d57a98a10f",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF165": {
+            "prov:generatedEntity": "niiri:0d04d9bc9dd104e43dd556533a5b2159",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF167": {
+            "prov:generatedEntity": "niiri:7d13eda0d79684f0d63dac1332405064",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF169": {
+            "prov:generatedEntity": "niiri:9cc2d1c11d4e3b5aec5735ee91c1aca3",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF171": {
+            "prov:generatedEntity": "niiri:5b5b201251a2cc570135bacff1a480b1",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF173": {
+            "prov:generatedEntity": "niiri:bbf4ce7e2e67235f45331b2b87133bd7",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF175": {
+            "prov:generatedEntity": "niiri:6a09c31a2cb2399d4dfaa1e9734b3056",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF177": {
+            "prov:generatedEntity": "niiri:19eff7c42f4c5b43b8936b6bb77abf9e",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF179": {
+            "prov:generatedEntity": "niiri:3a53732749467fad732fc1b126252b83",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF181": {
+            "prov:generatedEntity": "niiri:4489ae9a89d81f59b4a316f0bc2ca8b8",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF183": {
+            "prov:generatedEntity": "niiri:20b3e078d59196a48bbdcfae8b039f3e",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF185": {
+            "prov:generatedEntity": "niiri:87692b796865090154e70657cb33f3fa",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF187": {
+            "prov:generatedEntity": "niiri:f6aab0b38147783304dd12682b7a862f",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF189": {
+            "prov:generatedEntity": "niiri:8cfffabbc7e33bc2c585eb4a81ebc159",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF191": {
+            "prov:generatedEntity": "niiri:d93e1967e2b464317bc445a37c7560a2",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF193": {
+            "prov:generatedEntity": "niiri:80f2f6c335075aedb795e079a5688f2b",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF195": {
+            "prov:generatedEntity": "niiri:ef7d0561535e5e02620497afd1e27f3d",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF197": {
+            "prov:generatedEntity": "niiri:29289a4455046f74558f3c81d39ba67b",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF199": {
+            "prov:generatedEntity": "niiri:2821bde2f68ccf372a5e6ea09d4eada7",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF201": {
+            "prov:generatedEntity": "niiri:5514e5220803aad2c04bbd033aa76695",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF203": {
+            "prov:generatedEntity": "niiri:315fcb9a135fe01c557c732f7f103e94",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF205": {
+            "prov:generatedEntity": "niiri:fe8e19f11e2bcbf510735d94d7db4251",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF207": {
+            "prov:generatedEntity": "niiri:fec8619ae00ff17ab9a3d3ceb9046f4e",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF209": {
+            "prov:generatedEntity": "niiri:0b442ae9d99b24f7707cb51260201d38",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF211": {
+            "prov:generatedEntity": "niiri:5b35b6fc65311a490ca686dedf246257",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF213": {
+            "prov:generatedEntity": "niiri:8105ee9b0d3cbff0afc4f8e6f6cbaaaa",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF215": {
+            "prov:generatedEntity": "niiri:b133a4090af3a2b167687334a106d130",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF217": {
+            "prov:generatedEntity": "niiri:4c38fc3cc2a35b74b2036daf823f1c35",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF219": {
+            "prov:generatedEntity": "niiri:9476947ad907c2f9d5c061ead3c8ca5c",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF221": {
+            "prov:generatedEntity": "niiri:eaf5abe818e88775744fc4bc734500da",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF223": {
+            "prov:generatedEntity": "niiri:d327e883ddebc9532dc10d806d05ceea",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF225": {
+            "prov:generatedEntity": "niiri:b56a8e6eef495278939c1f07e4b2ec46",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF227": {
+            "prov:generatedEntity": "niiri:ed00692e64206abf7a48d003e49a172c",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF229": {
+            "prov:generatedEntity": "niiri:33f78596b63613a9bb773b49e610c339",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF231": {
+            "prov:generatedEntity": "niiri:fd773d75cfefece3ae58e4b268b97593",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF233": {
+            "prov:generatedEntity": "niiri:b1682618b3d8ba951d4fba69d43ace19",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF235": {
+            "prov:generatedEntity": "niiri:4aff58ce7014532950c85678251d820b",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF237": {
+            "prov:generatedEntity": "niiri:d98d8e8d25b59a9503f694b966d532d9",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF239": {
+            "prov:generatedEntity": "niiri:5b8cc71e1c4a9af4a428ecbfd59af0c3",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF241": {
+            "prov:generatedEntity": "niiri:9399cc4d9102dea2381bab7e4de270e7",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF243": {
+            "prov:generatedEntity": "niiri:25449e2c897446ebd8a31026fdd28119",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF245": {
+            "prov:generatedEntity": "niiri:0e21ee277152eb058ea4661ca48674d9",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF247": {
+            "prov:generatedEntity": "niiri:0e8a97e94bdd4af70efd21917168b43e",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF249": {
+            "prov:generatedEntity": "niiri:5b01f2070bd1d0178ffb33f1582d88a3",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF251": {
+            "prov:generatedEntity": "niiri:329bc820e22a3a07c45bd811037a5b92",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF253": {
+            "prov:generatedEntity": "niiri:4121c76a27252e2b2396a4e6040a0baf",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF255": {
+            "prov:generatedEntity": "niiri:419bb28f6b465c3e5015a6d14e56b223",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF257": {
+            "prov:generatedEntity": "niiri:e64d676ce70ddc69f3b8a79a997afc14",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF259": {
+            "prov:generatedEntity": "niiri:b2fe473551b0d5958d6a1fafaa7495aa",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF261": {
+            "prov:generatedEntity": "niiri:8fc15b04ecd3232fd23805615acbe960",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF263": {
+            "prov:generatedEntity": "niiri:3ba4f4eceb22f4823f915b7f2ea31b71",
+            "prov:usedEntity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
+        },
+        "_:wDF266": {
+            "prov:generatedEntity": "niiri:61bd43e2cb11ead4b85522ae0ab9c70f",
+            "prov:usedEntity": "niiri:d4b353636b454d9def0cc10eaa71d2b8"
+        },
+        "_:wDF269": {
+            "prov:generatedEntity": "niiri:aaefd41c0d243a75bbaf8975589a5d52",
+            "prov:usedEntity": "niiri:d4b353636b454d9def0cc10eaa71d2b8"
+        },
+        "_:wDF272": {
+            "prov:generatedEntity": "niiri:9c6062c0b908383a480b076e8fb62317",
+            "prov:usedEntity": "niiri:d4b353636b454d9def0cc10eaa71d2b8"
+        },
+        "_:wDF275": {
+            "prov:generatedEntity": "niiri:f05f6aec7d624e6197dbd9ac07aef88b",
+            "prov:usedEntity": "niiri:dabc6f32070848fa7096bac116f4a0d0"
+        },
+        "_:wDF278": {
+            "prov:generatedEntity": "niiri:c11d713034b63a168bdd812994537584",
+            "prov:usedEntity": "niiri:dabc6f32070848fa7096bac116f4a0d0"
+        },
+        "_:wDF281": {
+            "prov:generatedEntity": "niiri:db60aac6428eac8ac3baeeff8d9d9a89",
+            "prov:usedEntity": "niiri:dabc6f32070848fa7096bac116f4a0d0"
+        },
+        "_:wDF284": {
+            "prov:generatedEntity": "niiri:da07c9cffdb89f061f471c62455179f6",
+            "prov:usedEntity": "niiri:4e8b9634c8b43c73966139ed11b75ec8"
+        },
+        "_:wDF287": {
+            "prov:generatedEntity": "niiri:f030a501c14ec9c10fe484ff04b4868f",
+            "prov:usedEntity": "niiri:4e8b9634c8b43c73966139ed11b75ec8"
+        },
+        "_:wDF290": {
+            "prov:generatedEntity": "niiri:32366a46bbf0f9fae450db4ea84aff6d",
+            "prov:usedEntity": "niiri:4e8b9634c8b43c73966139ed11b75ec8"
+        },
+        "_:wDF293": {
+            "prov:generatedEntity": "niiri:8fc9a86e848c24dae11f15925f03b510",
+            "prov:usedEntity": "niiri:a731c83f0edffc39ddaeae57a80dc5ba"
+        },
+        "_:wDF296": {
+            "prov:generatedEntity": "niiri:661f534ccc7bdcb595c223d462813fb2",
+            "prov:usedEntity": "niiri:a731c83f0edffc39ddaeae57a80dc5ba"
+        },
+        "_:wDF299": {
+            "prov:generatedEntity": "niiri:0439c89a311e9fd92d450045320abef9",
+            "prov:usedEntity": "niiri:a731c83f0edffc39ddaeae57a80dc5ba"
+        },
+        "_:wDF302": {
+            "prov:generatedEntity": "niiri:f3634f34416055e1f89021e72074c0b8",
+            "prov:usedEntity": "niiri:5299ea7c2ff48f8ccb9e3da606289f28"
+        },
+        "_:wDF305": {
+            "prov:generatedEntity": "niiri:349a28a9b41a96a17877fc37d66ae69a",
+            "prov:usedEntity": "niiri:2152e06e3cb49b34d19eb6146b5817f7"
+        },
+        "_:wDF308": {
+            "prov:generatedEntity": "niiri:3e1ef8a3ca25ac8b59d80bd43c358ed4",
+            "prov:usedEntity": "niiri:2152e06e3cb49b34d19eb6146b5817f7"
+        },
+        "_:wDF311": {
+            "prov:generatedEntity": "niiri:cd8ff33c2ca2918b0a27282345d1bda0",
+            "prov:usedEntity": "niiri:c205169674df01953a0df15ba2cb5f08"
+        },
+        "_:wDF314": {
+            "prov:generatedEntity": "niiri:dfbab0b4541c5aa0d17a7fc20cc92006",
+            "prov:usedEntity": "niiri:c205169674df01953a0df15ba2cb5f08"
+        },
+        "_:wDF317": {
+            "prov:generatedEntity": "niiri:ef8223f420455816c0e95ee6e024db6c",
+            "prov:usedEntity": "niiri:c205169674df01953a0df15ba2cb5f08"
+        },
+        "_:wDF320": {
+            "prov:generatedEntity": "niiri:35bbf8c9030a11e48d1b2dee7e09dc11",
+            "prov:usedEntity": "niiri:f7a0ae64373c9fadcbae5c1ee69af3e7"
+        },
+        "_:wDF323": {
+            "prov:generatedEntity": "niiri:27f7bd95d47b079be25c832329669ee6",
+            "prov:usedEntity": "niiri:f78c9c52eb8c41c81b7108fc768afea1"
+        },
+        "_:wDF326": {
+            "prov:generatedEntity": "niiri:c27894706882af29cb375ead129ef8cb",
+            "prov:usedEntity": "niiri:defff4241093fb74f3bb72454faeb0c8"
+        },
+        "_:wDF329": {
+            "prov:generatedEntity": "niiri:c9d1046585f7728d08cc54165c11ff59",
+            "prov:usedEntity": "niiri:defff4241093fb74f3bb72454faeb0c8"
+        },
+        "_:wDF332": {
+            "prov:generatedEntity": "niiri:03c13f292babfb2b1d3290faffb9e334",
+            "prov:usedEntity": "niiri:a32e7c63a62151c6c42d8b86e0a4c19e"
+        },
+        "_:wDF335": {
+            "prov:generatedEntity": "niiri:4cc88fa1c2d357c36750e5a6a684d7c5",
+            "prov:usedEntity": "niiri:a32e7c63a62151c6c42d8b86e0a4c19e"
+        },
+        "_:wDF338": {
+            "prov:generatedEntity": "niiri:3cf98988c38bad72a5c4221177532d4d",
+            "prov:usedEntity": "niiri:a32e7c63a62151c6c42d8b86e0a4c19e"
+        },
+        "_:wDF341": {
+            "prov:generatedEntity": "niiri:a8c8296f49eb09a8f5f2bc2e7fe30473",
+            "prov:usedEntity": "niiri:f9c64f2f13c1018c1b0c90db5e455972"
+        },
+        "_:wDF344": {
+            "prov:generatedEntity": "niiri:5f7d79a55e6736946606e61cf06d0fef",
+            "prov:usedEntity": "niiri:f9c64f2f13c1018c1b0c90db5e455972"
+        },
+        "_:wDF347": {
+            "prov:generatedEntity": "niiri:9325884a6c8f484b70d3de818aebf275",
+            "prov:usedEntity": "niiri:2e1d13240b9a458b380045313214b3ba"
+        },
+        "_:wDF350": {
+            "prov:generatedEntity": "niiri:60a921fcb727986aa30984a19c231f18",
+            "prov:usedEntity": "niiri:2e1d13240b9a458b380045313214b3ba"
+        },
+        "_:wDF353": {
+            "prov:generatedEntity": "niiri:b3d0ce5827aa453674fe13aef68e7d16",
+            "prov:usedEntity": "niiri:2e1d13240b9a458b380045313214b3ba"
+        },
+        "_:wDF356": {
+            "prov:generatedEntity": "niiri:794d4453dd2ad3bd3730dd91ae6b30e9",
+            "prov:usedEntity": "niiri:76bd6a834aaa05e8f24aef110c831619"
+        },
+        "_:wDF359": {
+            "prov:generatedEntity": "niiri:1a0ea80e15936593cdd19a72a1195f48",
+            "prov:usedEntity": "niiri:16274414c81621b268626b188f47a6c7"
+        },
+        "_:wDF362": {
+            "prov:generatedEntity": "niiri:0569ccf24fdb31c7eaca9ab9fa246e95",
+            "prov:usedEntity": "niiri:16274414c81621b268626b188f47a6c7"
+        },
+        "_:wDF365": {
+            "prov:generatedEntity": "niiri:2a23f426a8d1ce8819ab2ddb003a1fca",
+            "prov:usedEntity": "niiri:fb5ba293db82840b5cc150cc15515c24"
+        },
+        "_:wDF368": {
+            "prov:generatedEntity": "niiri:375f7b40758a242274e5d254e754d2ea",
+            "prov:usedEntity": "niiri:aee52ad89a76ef41b6e67f9bca85ad62"
+        },
+        "_:wDF371": {
+            "prov:generatedEntity": "niiri:2bfeae4bd1acb4a2e2656604b5cb7718",
+            "prov:usedEntity": "niiri:aee52ad89a76ef41b6e67f9bca85ad62"
+        },
+        "_:wDF374": {
+            "prov:generatedEntity": "niiri:0e8711e2fd8d14446a6962527ef6df3a",
+            "prov:usedEntity": "niiri:594db02a9d179d5f91a6ed68ca678d59"
+        },
+        "_:wDF377": {
+            "prov:generatedEntity": "niiri:3891a8ece23ee8ae327ba5315f1c8fbe",
+            "prov:usedEntity": "niiri:594db02a9d179d5f91a6ed68ca678d59"
+        },
+        "_:wDF380": {
+            "prov:generatedEntity": "niiri:ea7488d0b50894dd4de66796e80748b7",
+            "prov:usedEntity": "niiri:6dd3d0166eed8b2fa885aeca84711d27"
+        },
+        "_:wDF383": {
+            "prov:generatedEntity": "niiri:4331fbbba36aaea44c7a85c25098ab20",
+            "prov:usedEntity": "niiri:17120da53c5050105b9a8ee0e996c32d"
+        },
+        "_:wDF386": {
+            "prov:generatedEntity": "niiri:ab0ca88496f4fad69a12f72d809de0f9",
+            "prov:usedEntity": "niiri:a533e0119aa33105f1f6664ba02c4fcf"
+        },
+        "_:wDF389": {
+            "prov:generatedEntity": "niiri:217c4b04d55535db719b6c29ed1ff920",
+            "prov:usedEntity": "niiri:b5ea5e54d015aa2a8403364ed7da486d"
+        },
+        "_:wDF392": {
+            "prov:generatedEntity": "niiri:7a9ada485db0a1f6554f9ab114f1a05e",
+            "prov:usedEntity": "niiri:b5ea5e54d015aa2a8403364ed7da486d"
+        },
+        "_:wDF395": {
+            "prov:generatedEntity": "niiri:8fed5f4ed36ab7a842539b15f966adc0",
+            "prov:usedEntity": "niiri:16c2a7e89d0686e69f57bbeea9dc74a5"
+        },
+        "_:wDF398": {
+            "prov:generatedEntity": "niiri:a3ad563a699cc4326f49719045069cc7",
+            "prov:usedEntity": "niiri:325d5f27465210c036cd8d865e80251d"
+        },
+        "_:wDF401": {
+            "prov:generatedEntity": "niiri:f46c43948a24d962d4b5ed9559dbdf9e",
+            "prov:usedEntity": "niiri:325d5f27465210c036cd8d865e80251d"
+        },
+        "_:wDF404": {
+            "prov:generatedEntity": "niiri:32ab5b28df46c33eedc2644958600327",
+            "prov:usedEntity": "niiri:a77994161041027f0cf04defd7345c50"
+        },
+        "_:wDF407": {
+            "prov:generatedEntity": "niiri:d100c51eef378500eb4feffaffb6838f",
+            "prov:usedEntity": "niiri:a77994161041027f0cf04defd7345c50"
+        },
+        "_:wDF410": {
+            "prov:generatedEntity": "niiri:18a234ca0f5ed1ecc2090e7679e74552",
+            "prov:usedEntity": "niiri:78d6f29ff8a7c1f0a21810728ade20ce"
+        },
+        "_:wDF413": {
+            "prov:generatedEntity": "niiri:9f7600af4f7127e3e35e8956824b24cd",
+            "prov:usedEntity": "niiri:ef6fca405f462fa8c50ca4b0f7e48ca2"
+        },
+        "_:wDF416": {
+            "prov:generatedEntity": "niiri:8603599eaf15b47cfc1747721a7cc043",
+            "prov:usedEntity": "niiri:6578b8b9d153de72a9648c8488a6ac3f"
+        },
+        "_:wDF419": {
+            "prov:generatedEntity": "niiri:975035177d9f223d416eac85677dd73e",
+            "prov:usedEntity": "niiri:aa346a17d504ccda6e8f3483bc7567b5"
+        },
+        "_:wDF422": {
+            "prov:generatedEntity": "niiri:d8e002f5cf7541fe9f68b39c0d8728f6",
+            "prov:usedEntity": "niiri:edeaef5183ad24011f37f4883d8f953f"
+        },
+        "_:wDF425": {
+            "prov:generatedEntity": "niiri:2159f676fe87211c3a34c5173f62ef52",
+            "prov:usedEntity": "niiri:82b6d07ebf78a88f41741c7c0b4d138a"
+        },
+        "_:wDF428": {
+            "prov:generatedEntity": "niiri:d20759428478e6a2ecc5a6ac0336248b",
+            "prov:usedEntity": "niiri:23d958b69d91f95e528ceb5e2197a63a"
+        },
+        "_:wDF431": {
+            "prov:generatedEntity": "niiri:93dad7155ab8df6434cf30dc96e0fec7",
+            "prov:usedEntity": "niiri:cd749510acee370dec9860a5407637f5"
+        },
+        "_:wDF434": {
+            "prov:generatedEntity": "niiri:609028d01e5972e824b32d95ae48bf7d",
+            "prov:usedEntity": "niiri:13d9d29fd974d6893c1726d57a98a10f"
+        },
+        "_:wDF437": {
+            "prov:generatedEntity": "niiri:b4946cfd559a49dd59da4eb959fcc3ff",
+            "prov:usedEntity": "niiri:0d04d9bc9dd104e43dd556533a5b2159"
+        },
+        "_:wDF440": {
+            "prov:generatedEntity": "niiri:90fe65bd993a69b371b497dd0b82c3c9",
+            "prov:usedEntity": "niiri:0d04d9bc9dd104e43dd556533a5b2159"
+        },
+        "_:wDF443": {
+            "prov:generatedEntity": "niiri:829760ac18f565fb23d2dd89751a104f",
+            "prov:usedEntity": "niiri:7d13eda0d79684f0d63dac1332405064"
+        },
+        "_:wDF446": {
+            "prov:generatedEntity": "niiri:11c5084b4dd50bda5192de6afa001779",
+            "prov:usedEntity": "niiri:9cc2d1c11d4e3b5aec5735ee91c1aca3"
+        },
+        "_:wDF449": {
+            "prov:generatedEntity": "niiri:3c355638d7475943124ba9c226bfa69e",
+            "prov:usedEntity": "niiri:5b5b201251a2cc570135bacff1a480b1"
+        },
+        "_:wDF452": {
+            "prov:generatedEntity": "niiri:73c33f38c5fedbbd36089605d2e2bed2",
+            "prov:usedEntity": "niiri:5b5b201251a2cc570135bacff1a480b1"
+        },
+        "_:wDF455": {
+            "prov:generatedEntity": "niiri:dabeaf7666f754dfe37065b88c4f4b4a",
+            "prov:usedEntity": "niiri:bbf4ce7e2e67235f45331b2b87133bd7"
+        },
+        "_:wDF458": {
+            "prov:generatedEntity": "niiri:a62d0b592d043fda22e569f6cdb71fff",
+            "prov:usedEntity": "niiri:6a09c31a2cb2399d4dfaa1e9734b3056"
+        },
+        "_:wDF461": {
+            "prov:generatedEntity": "niiri:4ac0f9aefed1176b14b9abe74250cbdc",
+            "prov:usedEntity": "niiri:19eff7c42f4c5b43b8936b6bb77abf9e"
+        },
+        "_:wDF464": {
+            "prov:generatedEntity": "niiri:e022009b24cfb049ed10bbfee681d92a",
+            "prov:usedEntity": "niiri:3a53732749467fad732fc1b126252b83"
+        },
+        "_:wDF467": {
+            "prov:generatedEntity": "niiri:abbe5bd49d9338f66a3af445c1e2372c",
+            "prov:usedEntity": "niiri:4489ae9a89d81f59b4a316f0bc2ca8b8"
+        },
+        "_:wDF470": {
+            "prov:generatedEntity": "niiri:578bcf6846bd5b49337bc46c4d7b1c7f",
+            "prov:usedEntity": "niiri:20b3e078d59196a48bbdcfae8b039f3e"
+        },
+        "_:wDF473": {
+            "prov:generatedEntity": "niiri:da03712278abfc01eebac38b33e1cf9d",
+            "prov:usedEntity": "niiri:87692b796865090154e70657cb33f3fa"
+        },
+        "_:wDF476": {
+            "prov:generatedEntity": "niiri:4776d4c0541b2407f509fe6b2b1c2853",
+            "prov:usedEntity": "niiri:f6aab0b38147783304dd12682b7a862f"
+        },
+        "_:wDF479": {
+            "prov:generatedEntity": "niiri:a0b516d4caa56831926e6d21c58b5dad",
+            "prov:usedEntity": "niiri:8cfffabbc7e33bc2c585eb4a81ebc159"
+        },
+        "_:wDF482": {
+            "prov:generatedEntity": "niiri:6aa0a5cf04dbb3c86c7b7e42153c561d",
+            "prov:usedEntity": "niiri:d93e1967e2b464317bc445a37c7560a2"
+        },
+        "_:wDF485": {
+            "prov:generatedEntity": "niiri:cd7d7fa3c3a1f73e1c6e18eec54bf367",
+            "prov:usedEntity": "niiri:d93e1967e2b464317bc445a37c7560a2"
+        },
+        "_:wDF488": {
+            "prov:generatedEntity": "niiri:b77f9f4ee4f5feb949a261a2483aa303",
+            "prov:usedEntity": "niiri:80f2f6c335075aedb795e079a5688f2b"
+        },
+        "_:wDF491": {
+            "prov:generatedEntity": "niiri:d00c21a3d5785cd0c3ace030b952b31e",
+            "prov:usedEntity": "niiri:ef7d0561535e5e02620497afd1e27f3d"
+        },
+        "_:wDF494": {
+            "prov:generatedEntity": "niiri:81b14a242118884af4716d1386a49968",
+            "prov:usedEntity": "niiri:29289a4455046f74558f3c81d39ba67b"
+        },
+        "_:wDF497": {
+            "prov:generatedEntity": "niiri:1b496fdde624ffb7718731dcb5969f61",
+            "prov:usedEntity": "niiri:2821bde2f68ccf372a5e6ea09d4eada7"
+        },
+        "_:wDF500": {
+            "prov:generatedEntity": "niiri:1949681f598de9abc79f75c80aefff35",
+            "prov:usedEntity": "niiri:5514e5220803aad2c04bbd033aa76695"
+        },
+        "_:wDF503": {
+            "prov:generatedEntity": "niiri:156c0ed1194df2305d443c2e19909212",
+            "prov:usedEntity": "niiri:315fcb9a135fe01c557c732f7f103e94"
+        },
+        "_:wDF506": {
+            "prov:generatedEntity": "niiri:e1346785ea40b70db27ae60f7bdd98cc",
+            "prov:usedEntity": "niiri:fe8e19f11e2bcbf510735d94d7db4251"
+        },
+        "_:wDF509": {
+            "prov:generatedEntity": "niiri:f9510499752a4d4a62444e63c5613551",
+            "prov:usedEntity": "niiri:fec8619ae00ff17ab9a3d3ceb9046f4e"
+        },
+        "_:wDF512": {
+            "prov:generatedEntity": "niiri:8bbd37614dea9f192710357a074c63f1",
+            "prov:usedEntity": "niiri:0b442ae9d99b24f7707cb51260201d38"
+        },
+        "_:wDF515": {
+            "prov:generatedEntity": "niiri:51e60ac16faa51fdca273f7e51c66c23",
+            "prov:usedEntity": "niiri:5b35b6fc65311a490ca686dedf246257"
+        },
+        "_:wDF518": {
+            "prov:generatedEntity": "niiri:f868633206589461de78ed5f44c3088b",
+            "prov:usedEntity": "niiri:8105ee9b0d3cbff0afc4f8e6f6cbaaaa"
+        },
+        "_:wDF521": {
+            "prov:generatedEntity": "niiri:ae37176f4228fdcd9909a5c9d8991945",
+            "prov:usedEntity": "niiri:b133a4090af3a2b167687334a106d130"
+        },
+        "_:wDF524": {
+            "prov:generatedEntity": "niiri:dd232f665acbacec710283b33a7ffc6b",
+            "prov:usedEntity": "niiri:4c38fc3cc2a35b74b2036daf823f1c35"
+        },
+        "_:wDF527": {
+            "prov:generatedEntity": "niiri:52c43bf1c9ff74a8799c3b7e6d3a1981",
+            "prov:usedEntity": "niiri:9476947ad907c2f9d5c061ead3c8ca5c"
+        },
+        "_:wDF530": {
+            "prov:generatedEntity": "niiri:b5befcd1e1859623d7854488fa7de979",
+            "prov:usedEntity": "niiri:eaf5abe818e88775744fc4bc734500da"
+        },
+        "_:wDF533": {
+            "prov:generatedEntity": "niiri:fa63e0fc9565564fb8d045ce95dc3fb0",
+            "prov:usedEntity": "niiri:d327e883ddebc9532dc10d806d05ceea"
+        },
+        "_:wDF536": {
+            "prov:generatedEntity": "niiri:b3ffdc96c6bca62445438ff33b6dab0b",
+            "prov:usedEntity": "niiri:b56a8e6eef495278939c1f07e4b2ec46"
+        },
+        "_:wDF539": {
+            "prov:generatedEntity": "niiri:63ddfa8767c13e0bf648a86357c0616c",
+            "prov:usedEntity": "niiri:ed00692e64206abf7a48d003e49a172c"
+        },
+        "_:wDF542": {
+            "prov:generatedEntity": "niiri:70cfc0282d991ec2d4a5b55d1fd54d12",
+            "prov:usedEntity": "niiri:33f78596b63613a9bb773b49e610c339"
+        },
+        "_:wDF545": {
+            "prov:generatedEntity": "niiri:9b72288ab7c77e827d9f1f781adf3151",
+            "prov:usedEntity": "niiri:fd773d75cfefece3ae58e4b268b97593"
+        },
+        "_:wDF548": {
+            "prov:generatedEntity": "niiri:88a8cadf94cd28dcac01eb9dbc030af6",
+            "prov:usedEntity": "niiri:b1682618b3d8ba951d4fba69d43ace19"
+        },
+        "_:wDF551": {
+            "prov:generatedEntity": "niiri:d72cc582c4a89de3d8d56216d7584f90",
+            "prov:usedEntity": "niiri:4aff58ce7014532950c85678251d820b"
+        },
+        "_:wDF554": {
+            "prov:generatedEntity": "niiri:e16c4d3e320d40e426df93aee2ca6add",
+            "prov:usedEntity": "niiri:d98d8e8d25b59a9503f694b966d532d9"
+        },
+        "_:wDF557": {
+            "prov:generatedEntity": "niiri:d70ef29aa1808eec49d1cf3e0a54e0ff",
+            "prov:usedEntity": "niiri:5b8cc71e1c4a9af4a428ecbfd59af0c3"
+        },
+        "_:wDF560": {
+            "prov:generatedEntity": "niiri:2188b2e49f6e63679bc313f1b84db925",
+            "prov:usedEntity": "niiri:9399cc4d9102dea2381bab7e4de270e7"
+        },
+        "_:wDF563": {
+            "prov:generatedEntity": "niiri:ee6edaf11ccf62cbd5f1fae3293222dd",
+            "prov:usedEntity": "niiri:25449e2c897446ebd8a31026fdd28119"
+        },
+        "_:wDF566": {
+            "prov:generatedEntity": "niiri:15350a82e9c3fc01fd72c2bc7362c921",
+            "prov:usedEntity": "niiri:0e21ee277152eb058ea4661ca48674d9"
+        },
+        "_:wDF569": {
+            "prov:generatedEntity": "niiri:06e844c8b746ab33069a3ac489ba1d42",
+            "prov:usedEntity": "niiri:0e8a97e94bdd4af70efd21917168b43e"
+        },
+        "_:wDF572": {
+            "prov:generatedEntity": "niiri:0dcdfb141f26fdfb1b6f3ff37ca276eb",
+            "prov:usedEntity": "niiri:5b01f2070bd1d0178ffb33f1582d88a3"
+        },
+        "_:wDF575": {
+            "prov:generatedEntity": "niiri:837e6614e3814f2aedc901891549d812",
+            "prov:usedEntity": "niiri:329bc820e22a3a07c45bd811037a5b92"
+        },
+        "_:wDF578": {
+            "prov:generatedEntity": "niiri:db893cc3d08eff94a18a2ded424c27da",
+            "prov:usedEntity": "niiri:4121c76a27252e2b2396a4e6040a0baf"
+        },
+        "_:wDF581": {
+            "prov:generatedEntity": "niiri:0d719d9c0dda162347b33fc762ee9dba",
+            "prov:usedEntity": "niiri:419bb28f6b465c3e5015a6d14e56b223"
+        },
+        "_:wDF584": {
+            "prov:generatedEntity": "niiri:e0efd8540741b57d022a32fe600f4a60",
+            "prov:usedEntity": "niiri:e64d676ce70ddc69f3b8a79a997afc14"
+        },
+        "_:wDF587": {
+            "prov:generatedEntity": "niiri:984314d1e545f3779d40732df43ac486",
+            "prov:usedEntity": "niiri:b2fe473551b0d5958d6a1fafaa7495aa"
+        },
+        "_:wDF590": {
+            "prov:generatedEntity": "niiri:441ee164b95e1dde37ae482e9d9d5e83",
+            "prov:usedEntity": "niiri:8fc15b04ecd3232fd23805615acbe960"
+        },
+        "_:wDF593": {
+            "prov:generatedEntity": "niiri:2319fac2b0bcd7224a1b3319200a5ae7",
+            "prov:usedEntity": "niiri:3ba4f4eceb22f4823f915b7f2ea31b71"
+        }
+    },
+    "wasAttributedTo": {
+        "_:wAT6": {
+            "prov:entity": "niiri:ef76ace3c4054ff67be710e42fb82df5",
+            "prov:agent": "niiri:181adcf33bc1c55ebfad49dc712d7cd6"
+        },
+        "_:wAT7": {
+            "prov:entity": "niiri:ef76ace3c4054ff67be710e42fb82df5",
+            "prov:agent": "niiri:fd83cd08b03cd16aa7c54c67699b8c14"
+        }
+    },
+    "wasAssociatedWith": {
+        "_:wAW13": {
+            "prov:activity": "niiri:690e3f484f6e5f7a6eec1242e70053c5",
+            "prov:agent": "niiri:65bbe1871e61c631eb812e3b6150407c"
+        },
+        "_:wAW53": {
+            "prov:activity": "niiri:8cff757e6900adeab2b9b8a66b5a61ea",
+            "prov:agent": "niiri:65bbe1871e61c631eb812e3b6150407c"
+        },
+        "_:wAW82": {
+            "prov:activity": "niiri:975d5305cd6d906f0149068326afc106",
+            "prov:agent": "niiri:65bbe1871e61c631eb812e3b6150407c"
+        }
+    }
+    }
+  }
+}

--- a/spmexport/ex_spm_temporal_derivative/nidm.jsonld
+++ b/spmexport/ex_spm_temporal_derivative/nidm.jsonld
@@ -7,7 +7,7 @@
       "niiri": "http://iri.nidash.org/",
       "spm": "http://purl.org/nidash/spm#",
       "neurolex": "http://neurolex.org/wiki/",
-      "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#",
+      "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/",
       "dct": "http://purl.org/dc/terms/",
       "nfo": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#",
       "dc": "http://purl.org/dc/elements/1.1/",
@@ -22,32 +22,32 @@
   ],
   "@graph": [
     {
-      "@id": "niiri:d68280cb6822bab913dcba96aa39a76c",
-      "@type": ["prov:Entity","prov:Bundle","nidm_NIDMResults:"],
+      "@id": "niiri:e80fdd02e6c9b8a432f69b8cd870cc7e",
+      "@type": ["prov:Entity","prov:Bundle","nidm_NIDMResults"],
       "rdfs:label": "NIDM-Results",
-      "nidm_version:": {"@type": "xsd:string", "@value": "1.3.0"}
+      "nidm_version": {"@type": "xsd:string", "@value": "1.3.0"}
     },
     {
-      "@id": "niiri:89ead2eed1218544375f650b92753466",
-      "@type": ["prov:Agent","nidm_spm_results_nidm:","prov:SoftwareAgent"],
+      "@id": "niiri:1987d1dc27e5d0c86458fed59bf44fa8",
+      "@type": ["prov:Agent","nidm_spm_results_nidm","prov:SoftwareAgent"],
       "rdfs:label": "spm_results_nidm",
-      "nidm_softwareVersion:": {"@type": "xsd:string", "@value": "12.6903"}
+      "nidm_softwareVersion": {"@type": "xsd:string", "@value": "12.7057"}
     },
     {
-      "@id": "niiri:03410e5507843b5dc1ff1430fc291929",
-      "@type": ["prov:Activity","nidm_NIDMResultsExport:"],
+      "@id": "niiri:ce8ee76d421d7195cb9a3077c3f493ea",
+      "@type": ["prov:Activity","nidm_NIDMResultsExport"],
       "rdfs:label": "NIDM-Results export"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:03410e5507843b5dc1ff1430fc291929",
-      "agent": "niiri:89ead2eed1218544375f650b92753466"
+      "activity_associated": "niiri:ce8ee76d421d7195cb9a3077c3f493ea",
+      "agent": "niiri:1987d1dc27e5d0c86458fed59bf44fa8"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:d68280cb6822bab913dcba96aa39a76c",
-      "activity": "niiri:03410e5507843b5dc1ff1430fc291929",
-      "atTime": "2016-12-07T16:09:27"
+      "entity_generated": "niiri:e80fdd02e6c9b8a432f69b8cd870cc7e",
+      "activity": "niiri:ce8ee76d421d7195cb9a3077c3f493ea",
+      "atTime": "2017-04-19T12:18:53"
     }
   ]
 },
@@ -159,636 +159,636 @@
       "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
     }
   ],
-  "@id": "niiri:d68280cb6822bab913dcba96aa39a76c",
+  "@id": "niiri:e80fdd02e6c9b8a432f69b8cd870cc7e",
   "@graph": [
     {
-      "@id": "niiri:490e5ab2436b12162f59fedeb9e1e9d8",
-      "@type": ["prov:Agent","src_SPM:","prov:SoftwareAgent"],
+      "@id": "niiri:65bbe1871e61c631eb812e3b6150407c",
+      "@type": ["prov:Agent","src_SPM","prov:SoftwareAgent"],
       "rdfs:label": "SPM",
-      "nidm_softwareVersion:": {"@type": "xsd:string", "@value": "12.12.2"}
+      "nidm_softwareVersion": {"@type": "xsd:string", "@value": "12.6906"}
     },
     {
-      "@id": "niiri:2ada174836b28044a9513f1a34eef87f",
-      "@type": ["prov:Entity","nidm_CoordinateSpace:"],
+      "@id": "niiri:b410708237a32a427489f32ca35c4711",
+      "@type": ["prov:Entity","nidm_CoordinateSpace"],
       "rdfs:label": "Coordinate space 1",
-      "nidm_voxelToWorldMapping:": {"@type": "xsd:string", "@value": "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"},
-      "nidm_voxelUnits:": {"@type": "xsd:string", "@value": "[\"mm\", \"mm\", \"mm\"]"},
-      "nidm_voxelSize:": {"@type": "xsd:string", "@value": "[2, 2, 2]"},
-      "nidm_inWorldCoordinateSystem:": {"@id": "nidm_Ixi549CoordinateSystem:"},
-      "nidm_numberOfDimensions:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_dimensionsInVoxels:": {"@type": "xsd:string", "@value": "[79,95,79]"}
+      "nidm_voxelToWorldMapping": {"@type": "xsd:string", "@value": "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"},
+      "nidm_voxelUnits": {"@type": "xsd:string", "@value": "[\"mm\", \"mm\", \"mm\"]"},
+      "nidm_voxelSize": {"@type": "xsd:string", "@value": "[2, 2, 2]"},
+      "nidm_inWorldCoordinateSystem": {"@id": "nidm_Ixi549CoordinateSystem"},
+      "nidm_numberOfDimensions": {"@type": "xsd:int", "@value": "3"},
+      "nidm_dimensionsInVoxels": {"@type": "xsd:string", "@value": "[79,95,79]"}
     },
     {
-      "@id": "niiri:bdbd8606798b7fde558fcb563c2e6588",
-      "@type": ["prov:Agent","nlx_Imaginginstrument:","nlx_Magneticresonanceimagingscanner:"],
+      "@id": "niiri:181adcf33bc1c55ebfad49dc712d7cd6",
+      "@type": ["prov:Agent","nlx_Imaginginstrument","nlx_Magneticresonanceimagingscanner"],
       "rdfs:label": "MRI Scanner"
     },
     {
-      "@id": "niiri:d001e9075e8cc82b7c6a9c041152e765",
+      "@id": "niiri:fd83cd08b03cd16aa7c54c67699b8c14",
       "@type": ["prov:Agent","prov:Person"],
       "rdfs:label": "Person"
     },
     {
-      "@id": "niiri:41eae4e7c79ff13a7860fdb5e15df324",
-      "@type": ["prov:Entity","prov:Collection","nidm_Data:"],
+      "@id": "niiri:ef76ace3c4054ff67be710e42fb82df5",
+      "@type": ["prov:Entity","prov:Collection","nidm_Data"],
       "rdfs:label": "Data",
-      "nidm_grandMeanScaling:": {"@type": "xsd:boolean", "@value": "true"},
-      "nidm_targetIntensity:": {"@type": "xsd:float", "@value": "100"},
-      "nidm_hasMRIProtocol:": {"@id": "nlx_FunctionalMRIprotocol:"}
+      "nidm_grandMeanScaling": {"@type": "xsd:boolean", "@value": "true"},
+      "nidm_targetIntensity": {"@type": "xsd:float", "@value": "100"},
+      "nidm_hasMRIProtocol": {"@id": "nlx_FunctionalMRIprotocol"}
     },
     {
       "@type": "prov:Attribution",
-      "entity_attributed": "niiri:41eae4e7c79ff13a7860fdb5e15df324",
-      "agent": "niiri:bdbd8606798b7fde558fcb563c2e6588"
+      "entity_attributed": "niiri:ef76ace3c4054ff67be710e42fb82df5",
+      "agent": "niiri:181adcf33bc1c55ebfad49dc712d7cd6"
     },
     {
       "@type": "prov:Attribution",
-      "entity_attributed": "niiri:41eae4e7c79ff13a7860fdb5e15df324",
-      "agent": "niiri:d001e9075e8cc82b7c6a9c041152e765"
+      "entity_attributed": "niiri:ef76ace3c4054ff67be710e42fb82df5",
+      "agent": "niiri:fd83cd08b03cd16aa7c54c67699b8c14"
     },
     {
-      "@id": "niiri:3dd8e44dd2339c934a0f169b3c59b948",
-      "@type": ["prov:Entity","spm_DCTDriftModel:"],
+      "@id": "niiri:1ba26f6e6e02762b1231f47d7d0c5385",
+      "@type": ["prov:Entity","spm_DCTDriftModel"],
       "rdfs:label": "SPM's DCT Drift Model",
-      "spm_SPMsDriftCutoffPeriod:": {"@type": "xsd:float", "@value": "128"}
+      "spm_SPMsDriftCutoffPeriod": {"@type": "xsd:float", "@value": "128"}
     },
     {
-      "@id": "niiri:ded035420e24d45acc47137ac0d3c65c",
-      "@type": ["prov:Entity","nidm_DesignMatrix:"],
+      "@id": "niiri:e68475df9e5152b04c95bde006aa28c2",
+      "@type": ["prov:Entity","nidm_DesignMatrix"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "DesignMatrix.csv"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "DesignMatrix.csv"},
       "dct:format": {"@type": "xsd:string", "@value": "text/csv"},
-      "dc:description": {"@id": "niiri:61cd29e1dac6242111457491dae53b6a"},
+      "dc:description": {"@id": "niiri:1addda2a0d4d8015583267922f5f8509"},
       "rdfs:label": "Design Matrix",
-      "nidm_regressorNames:": {"@type": "xsd:string", "@value": "[\"Sn(1) to*bf(1)\", \"Sn(1) to*bf(2)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) \ntask001 co*bf(2)\", \"Sn(1) constant\"]"},
-      "nidm_hasDriftModel:": {"@id": "niiri:3dd8e44dd2339c934a0f169b3c59b948"},
-      "nidm_hasHRFBasis:": [{"@id": "spm_SPMsCanonicalHRF:"},{"@id": "spm_SPMsTemporalDerivative:"}]
+      "nidm_regressorNames": {"@type": "xsd:string", "@value": "[\"Sn(1) to*bf(1)\", \"Sn(1) to*bf(2)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) \ntask001 co*bf(2)\", \"Sn(1) constant\"]"},
+      "nidm_hasDriftModel": {"@id": "niiri:1ba26f6e6e02762b1231f47d7d0c5385"},
+      "nidm_hasHRFBasis": [{"@id": "spm_SPMsCanonicalHRF"},{"@id": "spm_SPMsTemporalDerivative"}]
     },
     {
-      "@id": "niiri:61cd29e1dac6242111457491dae53b6a",
+      "@id": "niiri:1addda2a0d4d8015583267922f5f8509",
       "@type": ["prov:Entity","dctype:Image"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "DesignMatrix.png"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "DesignMatrix.png"},
       "dct:format": {"@type": "xsd:string", "@value": "image/png"}
     },
     {
-      "@id": "niiri:889f7c969cdf527a22ca3b3c0ce47c70",
-      "@type": ["prov:Entity","nidm_ErrorModel:"],
-      "nidm_hasErrorDistribution:": {"@id": "obo_normaldistribution:"},
-      "nidm_hasErrorDependence:": {"@id": "obo_Toeplitzcovariancestructure:"},
-      "nidm_dependenceMapWiseDependence:": {"@id": "nidm_ConstantParameter:"},
-      "nidm_errorVarianceHomogeneous:": {"@type": "xsd:boolean", "@value": "true"},
-      "nidm_varianceMapWiseDependence:": {"@id": "nidm_IndependentParameter:"}
+      "@id": "niiri:fe3aee97e82c6b81a5edb0430f731daf",
+      "@type": ["prov:Entity","nidm_ErrorModel"],
+      "nidm_hasErrorDistribution": {"@id": "obo_normaldistribution"},
+      "nidm_hasErrorDependence": {"@id": "obo_Toeplitzcovariancestructure"},
+      "nidm_dependenceMapWiseDependence": {"@id": "nidm_ConstantParameter"},
+      "nidm_errorVarianceHomogeneous": {"@type": "xsd:boolean", "@value": "true"},
+      "nidm_varianceMapWiseDependence": {"@id": "nidm_IndependentParameter"}
     },
     {
-      "@id": "niiri:dab7ede7835ef6993526fce9c3b60438",
-      "@type": ["prov:Activity","nidm_ModelParametersEstimation:"],
+      "@id": "niiri:690e3f484f6e5f7a6eec1242e70053c5",
+      "@type": ["prov:Activity","nidm_ModelParametersEstimation"],
       "rdfs:label": "Model parameters estimation",
-      "nidm_withEstimationMethod:": {"@id": "obo_generalizedleastsquaresestimation:"}
+      "nidm_withEstimationMethod": {"@id": "obo_generalizedleastsquaresestimation"}
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:dab7ede7835ef6993526fce9c3b60438",
-      "agent": "niiri:490e5ab2436b12162f59fedeb9e1e9d8"
+      "activity_associated": "niiri:690e3f484f6e5f7a6eec1242e70053c5",
+      "agent": "niiri:65bbe1871e61c631eb812e3b6150407c"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:dab7ede7835ef6993526fce9c3b60438",
-      "entity": "niiri:ded035420e24d45acc47137ac0d3c65c"
+      "activity_using": "niiri:690e3f484f6e5f7a6eec1242e70053c5",
+      "entity": "niiri:e68475df9e5152b04c95bde006aa28c2"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:dab7ede7835ef6993526fce9c3b60438",
-      "entity": "niiri:41eae4e7c79ff13a7860fdb5e15df324"
+      "activity_using": "niiri:690e3f484f6e5f7a6eec1242e70053c5",
+      "entity": "niiri:ef76ace3c4054ff67be710e42fb82df5"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:dab7ede7835ef6993526fce9c3b60438",
-      "entity": "niiri:889f7c969cdf527a22ca3b3c0ce47c70"
+      "activity_using": "niiri:690e3f484f6e5f7a6eec1242e70053c5",
+      "entity": "niiri:fe3aee97e82c6b81a5edb0430f731daf"
     },
     {
-      "@id": "niiri:391bfa5f6d92b504b7bbd76dc18b1db4",
-      "@type": ["prov:Entity","nidm_MaskMap:"],
+      "@id": "niiri:07485f81ffa874bdd72e7579bb4e934b",
+      "@type": ["prov:Entity","nidm_MaskMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "Mask.nii.gz"},
-      "nidm_isUserDefined:": {"@type": "xsd:boolean", "@value": "false"},
+      "nidm_isUserDefined": {"@type": "xsd:boolean", "@value": "false"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "Mask.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Mask",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:2ada174836b28044a9513f1a34eef87f"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b410708237a32a427489f32ca35c4711"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876"}
     },
     {
-      "@id": "niiri:844ff796879373fbd4abd17641a0b795",
-      "@type": ["prov:Entity","nidm_MaskMap:"],
+      "@id": "niiri:9588fe052df37634cce35de2c4c0e782",
+      "@type": ["prov:Entity","nidm_MaskMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "mask.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "36929e1f5f4143bd9cc818cd896a25f129961fab208c3a4438555f40444c08347b359142ee8c53ece6e8cca1627f49db0788a1fd3b9e2ecaef61999c6c6c67ac"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:391bfa5f6d92b504b7bbd76dc18b1db4",
-      "entity": "niiri:844ff796879373fbd4abd17641a0b795"
+      "entity_derived": "niiri:07485f81ffa874bdd72e7579bb4e934b",
+      "entity": "niiri:9588fe052df37634cce35de2c4c0e782"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:391bfa5f6d92b504b7bbd76dc18b1db4",
-      "activity": "niiri:dab7ede7835ef6993526fce9c3b60438"
+      "entity_generated": "niiri:07485f81ffa874bdd72e7579bb4e934b",
+      "activity": "niiri:690e3f484f6e5f7a6eec1242e70053c5"
     },
     {
-      "@id": "niiri:2279f304aeeb3c6a736b1270cf7418f1",
-      "@type": ["prov:Entity","nidm_GrandMeanMap:"],
+      "@id": "niiri:b365bb411ced2017b69b3dbafa0e85f3",
+      "@type": ["prov:Entity","nidm_GrandMeanMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "GrandMean.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "GrandMean.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Grand Mean Map",
-      "nidm_maskedMedian:": {"@type": "xsd:float", "@value": "116.092018127441"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:2ada174836b28044a9513f1a34eef87f"},
+      "nidm_maskedMedian": {"@type": "xsd:float", "@value": "116.092018127441"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b410708237a32a427489f32ca35c4711"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "7bcbd0dbf511033ee5ce279852f073e8a82d6254329e78285b8e4948a17585a46457d5a65704e08e0524b91f02aec7c3c012f4222da246177f172afbc7eb65d5"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:2279f304aeeb3c6a736b1270cf7418f1",
-      "activity": "niiri:dab7ede7835ef6993526fce9c3b60438"
+      "entity_generated": "niiri:b365bb411ced2017b69b3dbafa0e85f3",
+      "activity": "niiri:690e3f484f6e5f7a6eec1242e70053c5"
     },
     {
-      "@id": "niiri:abb5e4bf5790aaf850ac3e1cadc1130c",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:3cc1a4d9e0dbae0ea522ae6e6bee7809",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0001.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0001.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 1",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:2ada174836b28044a9513f1a34eef87f"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b410708237a32a427489f32ca35c4711"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "41593a1a82624e6c05f8214f64595e596b33c664304743792797665b1b36762a46e7e883d9aaaa3324fc62bf7a43261c8ed39f0ee575a4b451533dfe3eed89d7"}
     },
     {
-      "@id": "niiri:51a39e56bffb8a149eadd63c7045b5cb",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:e44f0f19f822ee7f804728a0a9835c26",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0001.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "41593a1a82624e6c05f8214f64595e596b33c664304743792797665b1b36762a46e7e883d9aaaa3324fc62bf7a43261c8ed39f0ee575a4b451533dfe3eed89d7"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:abb5e4bf5790aaf850ac3e1cadc1130c",
-      "entity": "niiri:51a39e56bffb8a149eadd63c7045b5cb"
+      "entity_derived": "niiri:3cc1a4d9e0dbae0ea522ae6e6bee7809",
+      "entity": "niiri:e44f0f19f822ee7f804728a0a9835c26"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:abb5e4bf5790aaf850ac3e1cadc1130c",
-      "activity": "niiri:dab7ede7835ef6993526fce9c3b60438"
+      "entity_generated": "niiri:3cc1a4d9e0dbae0ea522ae6e6bee7809",
+      "activity": "niiri:690e3f484f6e5f7a6eec1242e70053c5"
     },
     {
-      "@id": "niiri:cba3c18e10f4767a196f92c51cfb376b",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:8de1184852768964088718dab52c75f6",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0002.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0002.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 2",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:2ada174836b28044a9513f1a34eef87f"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b410708237a32a427489f32ca35c4711"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "7a0d86a340516306df21786c1cbe22427b70ba2cfdea9ec8f384718104f8a3d5221ec0164e884662a96dec28f194814dabb605f0c8f8b37ef7828f7ecf45701f"}
     },
     {
-      "@id": "niiri:d16f41a161b165456881d29024c519d5",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:954f92fad652775f12537d62ef353a73",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0002.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "7a0d86a340516306df21786c1cbe22427b70ba2cfdea9ec8f384718104f8a3d5221ec0164e884662a96dec28f194814dabb605f0c8f8b37ef7828f7ecf45701f"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cba3c18e10f4767a196f92c51cfb376b",
-      "entity": "niiri:d16f41a161b165456881d29024c519d5"
+      "entity_derived": "niiri:8de1184852768964088718dab52c75f6",
+      "entity": "niiri:954f92fad652775f12537d62ef353a73"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:cba3c18e10f4767a196f92c51cfb376b",
-      "activity": "niiri:dab7ede7835ef6993526fce9c3b60438"
+      "entity_generated": "niiri:8de1184852768964088718dab52c75f6",
+      "activity": "niiri:690e3f484f6e5f7a6eec1242e70053c5"
     },
     {
-      "@id": "niiri:43180ee92a7c8b91ce052068207fffeb",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:814e7ed06d738c9f3a585f4228558207",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0003.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0003.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 3",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:2ada174836b28044a9513f1a34eef87f"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b410708237a32a427489f32ca35c4711"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "683d243642dd44e2be739b6da7c49cfdb8fb66a8a58d8f12be426a80ba5f27f4d786217804c8f3b88a8f0e123111d57886b1f6f977b082d84bf55d4289f652a8"}
     },
     {
-      "@id": "niiri:ca7d16e56b6829b233487d24e58f1c7f",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:103821464851111f6bca4c68fe70a82a",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0003.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "683d243642dd44e2be739b6da7c49cfdb8fb66a8a58d8f12be426a80ba5f27f4d786217804c8f3b88a8f0e123111d57886b1f6f977b082d84bf55d4289f652a8"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:43180ee92a7c8b91ce052068207fffeb",
-      "entity": "niiri:ca7d16e56b6829b233487d24e58f1c7f"
+      "entity_derived": "niiri:814e7ed06d738c9f3a585f4228558207",
+      "entity": "niiri:103821464851111f6bca4c68fe70a82a"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:43180ee92a7c8b91ce052068207fffeb",
-      "activity": "niiri:dab7ede7835ef6993526fce9c3b60438"
+      "entity_generated": "niiri:814e7ed06d738c9f3a585f4228558207",
+      "activity": "niiri:690e3f484f6e5f7a6eec1242e70053c5"
     },
     {
-      "@id": "niiri:462859b57f29cc9dc62453fdd40a75ac",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:055713a7baa36cc6f47d02b18892edab",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0004.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0004.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 4",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:2ada174836b28044a9513f1a34eef87f"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b410708237a32a427489f32ca35c4711"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "dba26c065cb5d6ae4f7597010da0ea7329adf2177d3b8019871beb79506a47e902c8f23f4e4beb69f3a8cfa2067e28add1ff90054bab0d1ebf39c556e58a1c60"}
     },
     {
-      "@id": "niiri:10a31df8b6ad7b2fae856ace98f252d6",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:4ec71cdc1dd74a4d7e5dbf9c950e3969",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0004.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "dba26c065cb5d6ae4f7597010da0ea7329adf2177d3b8019871beb79506a47e902c8f23f4e4beb69f3a8cfa2067e28add1ff90054bab0d1ebf39c556e58a1c60"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:462859b57f29cc9dc62453fdd40a75ac",
-      "entity": "niiri:10a31df8b6ad7b2fae856ace98f252d6"
+      "entity_derived": "niiri:055713a7baa36cc6f47d02b18892edab",
+      "entity": "niiri:4ec71cdc1dd74a4d7e5dbf9c950e3969"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:462859b57f29cc9dc62453fdd40a75ac",
-      "activity": "niiri:dab7ede7835ef6993526fce9c3b60438"
+      "entity_generated": "niiri:055713a7baa36cc6f47d02b18892edab",
+      "activity": "niiri:690e3f484f6e5f7a6eec1242e70053c5"
     },
     {
-      "@id": "niiri:ea0a4d3ea65789f29653126c02f37df2",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:9e2b1e2183fda70e5c8eaa09275db3b7",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0005.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0005.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 5",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:2ada174836b28044a9513f1a34eef87f"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b410708237a32a427489f32ca35c4711"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "9760c5863f41702fba7b69b0eccde533fdb276d89380f514b5bf01691639531f18dfda8348c4e1f37fb030b0b81b3c348697e5e920b450e99796f8a22652bfb3"}
     },
     {
-      "@id": "niiri:460a1955876793cd9ac5fab1a251202b",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:5ee11adfe4ab413ef5516242c7951078",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0005.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "9760c5863f41702fba7b69b0eccde533fdb276d89380f514b5bf01691639531f18dfda8348c4e1f37fb030b0b81b3c348697e5e920b450e99796f8a22652bfb3"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ea0a4d3ea65789f29653126c02f37df2",
-      "entity": "niiri:460a1955876793cd9ac5fab1a251202b"
+      "entity_derived": "niiri:9e2b1e2183fda70e5c8eaa09275db3b7",
+      "entity": "niiri:5ee11adfe4ab413ef5516242c7951078"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:ea0a4d3ea65789f29653126c02f37df2",
-      "activity": "niiri:dab7ede7835ef6993526fce9c3b60438"
+      "entity_generated": "niiri:9e2b1e2183fda70e5c8eaa09275db3b7",
+      "activity": "niiri:690e3f484f6e5f7a6eec1242e70053c5"
     },
     {
-      "@id": "niiri:9fc2b1fdcc3756035f503401455ad416",
-      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap:"],
+      "@id": "niiri:43a89bc0051da8157a5bff983ba89bc5",
+      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ResidualMeanSquares.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ResidualMeanSquares.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Residual Mean Squares Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:2ada174836b28044a9513f1a34eef87f"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b410708237a32a427489f32ca35c4711"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "77eca9b40d48cdbed5705dcfa828c6ff7693ecb43c305cfb0ef28660d8c7d60df8819bfcfaf0be6d223b0aa760c0114165d48afb8338fae9929f2700ae3eba82"}
     },
     {
-      "@id": "niiri:46d987ee96393a2e2395c32b2e6f22f8",
-      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap:"],
+      "@id": "niiri:60f4af728d95c8bc6e63352f6e049770",
+      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "ResMS.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "cd5c1a79918d35ce4774b90a7801056e74cfb5cf68f49240a51d713c455d63895d394dd8a8f15d2b73eee86c0828b6cbc862d038d5a4d1cc299171d25ad8d4dc"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9fc2b1fdcc3756035f503401455ad416",
-      "entity": "niiri:46d987ee96393a2e2395c32b2e6f22f8"
+      "entity_derived": "niiri:43a89bc0051da8157a5bff983ba89bc5",
+      "entity": "niiri:60f4af728d95c8bc6e63352f6e049770"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:9fc2b1fdcc3756035f503401455ad416",
-      "activity": "niiri:dab7ede7835ef6993526fce9c3b60438"
+      "entity_generated": "niiri:43a89bc0051da8157a5bff983ba89bc5",
+      "activity": "niiri:690e3f484f6e5f7a6eec1242e70053c5"
     },
     {
-      "@id": "niiri:618d3be01362df0705449588778a62f5",
-      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap:"],
+      "@id": "niiri:08f53b8611d5bdec5c8de0c449a1db6f",
+      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ReselsPerVoxel.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ReselsPerVoxel.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Resels per Voxel Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:2ada174836b28044a9513f1a34eef87f"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b410708237a32a427489f32ca35c4711"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "e34e4eeb83555ac00c097e516f70bf3aa83f22b775b1eaa1034c5de67c3703afa41546b0dea1a061178282b842559420d773d1c8817e44adec7ed4cc01b195f4"}
     },
     {
-      "@id": "niiri:b9e91f6719864b3367404406fc450d7b",
-      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap:"],
+      "@id": "niiri:f9e38aef778cfa4bf78b01f51a10f4eb",
+      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "RPV.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "1b9e3df7665e35441c1e98ddfa9aa90576563c0f976179e331a78cb43a3a52d7252e97899b6ba800b68a5eed479a81d3c29ac5a75e27aaaec451c69b48c29faf"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:618d3be01362df0705449588778a62f5",
-      "entity": "niiri:b9e91f6719864b3367404406fc450d7b"
+      "entity_derived": "niiri:08f53b8611d5bdec5c8de0c449a1db6f",
+      "entity": "niiri:f9e38aef778cfa4bf78b01f51a10f4eb"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:618d3be01362df0705449588778a62f5",
-      "activity": "niiri:dab7ede7835ef6993526fce9c3b60438"
+      "entity_generated": "niiri:08f53b8611d5bdec5c8de0c449a1db6f",
+      "activity": "niiri:690e3f484f6e5f7a6eec1242e70053c5"
     },
     {
-      "@id": "niiri:0e3570df900ab584e89c9d8ac7a6c4f2",
-      "@type": ["prov:Entity","obo_contrastweightmatrix:"],
-      "nidm_statisticType:": {"@id": "obo_tstatistic:"},
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
+      "@id": "niiri:f0323f01131105dbd3d84869ff50e9ae",
+      "@type": ["prov:Entity","obo_contrastweightmatrix"],
+      "nidm_statisticType": {"@id": "obo_tstatistic"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
       "rdfs:label": "Contrast: tone counting vs baseline",
       "prov:value": {"@type": "xsd:string", "@value": "[1, 0, 0, 0, 0]"}
     },
     {
-      "@id": "niiri:73d96604016859b026bef5404df2dc57",
-      "@type": ["prov:Activity","nidm_ContrastEstimation:"],
+      "@id": "niiri:8cff757e6900adeab2b9b8a66b5a61ea",
+      "@type": ["prov:Activity","nidm_ContrastEstimation"],
       "rdfs:label": "Contrast estimation"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:73d96604016859b026bef5404df2dc57",
-      "agent": "niiri:490e5ab2436b12162f59fedeb9e1e9d8"
+      "activity_associated": "niiri:8cff757e6900adeab2b9b8a66b5a61ea",
+      "agent": "niiri:65bbe1871e61c631eb812e3b6150407c"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:73d96604016859b026bef5404df2dc57",
-      "entity": "niiri:391bfa5f6d92b504b7bbd76dc18b1db4"
+      "activity_using": "niiri:8cff757e6900adeab2b9b8a66b5a61ea",
+      "entity": "niiri:07485f81ffa874bdd72e7579bb4e934b"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:73d96604016859b026bef5404df2dc57",
-      "entity": "niiri:9fc2b1fdcc3756035f503401455ad416"
+      "activity_using": "niiri:8cff757e6900adeab2b9b8a66b5a61ea",
+      "entity": "niiri:43a89bc0051da8157a5bff983ba89bc5"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:73d96604016859b026bef5404df2dc57",
-      "entity": "niiri:ded035420e24d45acc47137ac0d3c65c"
+      "activity_using": "niiri:8cff757e6900adeab2b9b8a66b5a61ea",
+      "entity": "niiri:e68475df9e5152b04c95bde006aa28c2"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:73d96604016859b026bef5404df2dc57",
-      "entity": "niiri:0e3570df900ab584e89c9d8ac7a6c4f2"
+      "activity_using": "niiri:8cff757e6900adeab2b9b8a66b5a61ea",
+      "entity": "niiri:f0323f01131105dbd3d84869ff50e9ae"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:73d96604016859b026bef5404df2dc57",
-      "entity": "niiri:abb5e4bf5790aaf850ac3e1cadc1130c"
+      "activity_using": "niiri:8cff757e6900adeab2b9b8a66b5a61ea",
+      "entity": "niiri:3cc1a4d9e0dbae0ea522ae6e6bee7809"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:73d96604016859b026bef5404df2dc57",
-      "entity": "niiri:cba3c18e10f4767a196f92c51cfb376b"
+      "activity_using": "niiri:8cff757e6900adeab2b9b8a66b5a61ea",
+      "entity": "niiri:8de1184852768964088718dab52c75f6"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:73d96604016859b026bef5404df2dc57",
-      "entity": "niiri:43180ee92a7c8b91ce052068207fffeb"
+      "activity_using": "niiri:8cff757e6900adeab2b9b8a66b5a61ea",
+      "entity": "niiri:814e7ed06d738c9f3a585f4228558207"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:73d96604016859b026bef5404df2dc57",
-      "entity": "niiri:462859b57f29cc9dc62453fdd40a75ac"
+      "activity_using": "niiri:8cff757e6900adeab2b9b8a66b5a61ea",
+      "entity": "niiri:055713a7baa36cc6f47d02b18892edab"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:73d96604016859b026bef5404df2dc57",
-      "entity": "niiri:ea0a4d3ea65789f29653126c02f37df2"
+      "activity_using": "niiri:8cff757e6900adeab2b9b8a66b5a61ea",
+      "entity": "niiri:9e2b1e2183fda70e5c8eaa09275db3b7"
     },
     {
-      "@id": "niiri:f68e579c103081f8fc95d5851132f6ab",
-      "@type": ["prov:Entity","nidm_StatisticMap:"],
+      "@id": "niiri:aa1effb702cc7db6a16eac195236db09",
+      "@type": ["prov:Entity","nidm_StatisticMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "TStatistic.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "TStatistic.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "T-Statistic Map: tone counting vs baseline",
-      "nidm_statisticType:": {"@id": "obo_tstatistic:"},
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
-      "nidm_errorDegreesOfFreedom:": {"@type": "xsd:float", "@value": "95.9999999999612"},
-      "nidm_effectDegreesOfFreedom:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:2ada174836b28044a9513f1a34eef87f"},
+      "nidm_statisticType": {"@id": "obo_tstatistic"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
+      "nidm_errorDegreesOfFreedom": {"@type": "xsd:float", "@value": "95.9999999999612"},
+      "nidm_effectDegreesOfFreedom": {"@type": "xsd:float", "@value": "1"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b410708237a32a427489f32ca35c4711"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "559b9991a86bb27d60af713860b88249f0a74bb9a7be767d1bc0ab2af4c8c206308434fd6f0549578121151d43d71ebc4e4d72cf6e825b3f82f095fd308832c5"}
     },
     {
-      "@id": "niiri:f130df501f82aa4d00c50f8ef3d69e06",
-      "@type": ["prov:Entity","nidm_StatisticMap:"],
+      "@id": "niiri:612caf1dd2e842956fc81ba14de59582",
+      "@type": ["prov:Entity","nidm_StatisticMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "spmT_0001.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "4d4f039b6b55f49d46991f6fffd3e0e7f933b3708d1a955f3c949863480dba89dd5fb4466b8e0f711eff753fbeb3c16c52cef9d24e13c9f494f6607dd379f64e"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f68e579c103081f8fc95d5851132f6ab",
-      "entity": "niiri:f130df501f82aa4d00c50f8ef3d69e06"
+      "entity_derived": "niiri:aa1effb702cc7db6a16eac195236db09",
+      "entity": "niiri:612caf1dd2e842956fc81ba14de59582"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:f68e579c103081f8fc95d5851132f6ab",
-      "activity": "niiri:73d96604016859b026bef5404df2dc57"
+      "entity_generated": "niiri:aa1effb702cc7db6a16eac195236db09",
+      "activity": "niiri:8cff757e6900adeab2b9b8a66b5a61ea"
     },
     {
-      "@id": "niiri:5d9e2f8c3ab10dbf5ee342f229e15758",
-      "@type": ["prov:Entity","nidm_ContrastMap:"],
+      "@id": "niiri:243b7b4df25be507aa622f4c9754d427",
+      "@type": ["prov:Entity","nidm_ContrastMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "Contrast.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "Contrast.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Contrast Map: tone counting vs baseline",
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:2ada174836b28044a9513f1a34eef87f"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b410708237a32a427489f32ca35c4711"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "e9762825614822a23109b51b645e4397695352f3bd0fa37407e2ad0998f9acb23becd4f15698cd622b50687e083d6b94e71c696959b1175560e3ac0e50056f61"}
     },
     {
-      "@id": "niiri:d09cfb20d2217f6d9d7b3e4e2f607e15",
-      "@type": ["prov:Entity","nidm_ContrastMap:"],
+      "@id": "niiri:08a567ac0816c0a0aceb2ed59aeea49b",
+      "@type": ["prov:Entity","nidm_ContrastMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "con_0001.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "f4f1aed8094bcdf691de6bccc404a792e4cef66bb2eed29472a7b663276509857a23bfd24e7d92e4a0aaf513da4980f632094021b2ca048cf9b6ad21f481b20f"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5d9e2f8c3ab10dbf5ee342f229e15758",
-      "entity": "niiri:d09cfb20d2217f6d9d7b3e4e2f607e15"
+      "entity_derived": "niiri:243b7b4df25be507aa622f4c9754d427",
+      "entity": "niiri:08a567ac0816c0a0aceb2ed59aeea49b"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:5d9e2f8c3ab10dbf5ee342f229e15758",
-      "activity": "niiri:73d96604016859b026bef5404df2dc57"
+      "entity_generated": "niiri:243b7b4df25be507aa622f4c9754d427",
+      "activity": "niiri:8cff757e6900adeab2b9b8a66b5a61ea"
     },
     {
-      "@id": "niiri:6114eaf8f264daf5c67bf0cac93aee24",
-      "@type": ["prov:Entity","nidm_ContrastStandardErrorMap:"],
+      "@id": "niiri:57e63fdc854e959fb8423a4f086ce703",
+      "@type": ["prov:Entity","nidm_ContrastStandardErrorMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ContrastStandardError.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ContrastStandardError.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Contrast Standard Error Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:2ada174836b28044a9513f1a34eef87f"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b410708237a32a427489f32ca35c4711"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "403792ebe042c165a2310a4ffac22fb225f87abecb96d927bb5b582d00ead23c9bb13ca9423963c5100a171f36d9ec7a4c0c04d20818088613d61d250ef45dd6"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:6114eaf8f264daf5c67bf0cac93aee24",
-      "activity": "niiri:73d96604016859b026bef5404df2dc57"
+      "entity_generated": "niiri:57e63fdc854e959fb8423a4f086ce703",
+      "activity": "niiri:8cff757e6900adeab2b9b8a66b5a61ea"
     },
     {
-      "@id": "niiri:8c0ca80e074a908ed461be6200aa0c16",
-      "@type": ["prov:Entity","nidm_HeightThreshold:","nidm_PValueUncorrected:"],
-      "rdfs:label": "Height Threshold: p<0.000999 (unc.)",
+      "@id": "niiri:3dc9d42cdfae6ad474927bdb0e9bdc21",
+      "@type": ["prov:Entity","nidm_HeightThreshold","nidm_PValueUncorrected"],
+      "rdfs:label": "Height Threshold: p<0.001 (unc.)",
       "prov:value": {"@type": "xsd:float", "@value": "0.000999499965079309"},
-      "nidm_equivalentThreshold:": [{"@id": "niiri:13746686410a8d72161a200356d7336a"},{"@id": "niiri:77660e0999804061c51dab5ad64fcfe1"}]
+      "nidm_equivalentThreshold": [{"@id": "niiri:c48ee5e9869243c5ee3ef5d8de4d9211"},{"@id": "niiri:5c238cdd746fbc26bd9ddecfb9e7fc15"}]
     },
     {
-      "@id": "niiri:13746686410a8d72161a200356d7336a",
-      "@type": ["prov:Entity","nidm_HeightThreshold:","obo_statistic:"],
-      "rdfs:label": "Height Threshold",
+      "@id": "niiri:c48ee5e9869243c5ee3ef5d8de4d9211",
+      "@type": ["prov:Entity","nidm_HeightThreshold","obo_statistic"],
+      "rdfs:label": "Height Threshold: T=3.177308)",
       "prov:value": {"@type": "xsd:float", "@value": "3.17730776622277"}
     },
     {
-      "@id": "niiri:77660e0999804061c51dab5ad64fcfe1",
-      "@type": ["prov:Entity","nidm_HeightThreshold:","obo_FWERadjustedpvalue:"],
-      "rdfs:label": "Height Threshold",
+      "@id": "niiri:5c238cdd746fbc26bd9ddecfb9e7fc15",
+      "@type": ["prov:Entity","nidm_HeightThreshold","obo_FWERadjustedpvalue"],
+      "rdfs:label": "Height Threshold: p<1.000000 (FWE)",
       "prov:value": {"@type": "xsd:float", "@value": "0.999999999999999"}
     },
     {
-      "@id": "niiri:21fa5bd48e4e88c9a9121e1e236cbb5c",
-      "@type": ["prov:Entity","nidm_ExtentThreshold:","obo_statistic:"],
+      "@id": "niiri:102fecaa14caf589304b204290d2ae40",
+      "@type": ["prov:Entity","nidm_ExtentThreshold","obo_statistic"],
       "rdfs:label": "Extent Threshold: k>=0",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "0"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0"},
-      "nidm_equivalentThreshold:": [{"@id": "niiri:f20db2e5c02f93b90e7eae0807e3e491"},{"@id": "niiri:3bffd8f80a4b7186e621386536c18763"}]
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "0"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0"},
+      "nidm_equivalentThreshold": [{"@id": "niiri:6995399cabf336da2a6296280269642f"},{"@id": "niiri:c6aa5eb71f55d9e8b0ed842961179eb0"}]
     },
     {
-      "@id": "niiri:f20db2e5c02f93b90e7eae0807e3e491",
-      "@type": ["prov:Entity","nidm_ExtentThreshold:","obo_FWERadjustedpvalue:"],
+      "@id": "niiri:6995399cabf336da2a6296280269642f",
+      "@type": ["prov:Entity","nidm_ExtentThreshold","obo_FWERadjustedpvalue"],
       "rdfs:label": "Extent Threshold",
       "prov:value": {"@type": "xsd:float", "@value": "1"}
     },
     {
-      "@id": "niiri:3bffd8f80a4b7186e621386536c18763",
-      "@type": ["prov:Entity","nidm_ExtentThreshold:","nidm_PValueUncorrected:"],
+      "@id": "niiri:c6aa5eb71f55d9e8b0ed842961179eb0",
+      "@type": ["prov:Entity","nidm_ExtentThreshold","nidm_PValueUncorrected"],
       "rdfs:label": "Extent Threshold",
       "prov:value": {"@type": "xsd:float", "@value": "1"}
     },
     {
-      "@id": "niiri:24e9f0b05542386f7ba14394c762f9ac",
-      "@type": ["prov:Entity","nidm_PeakDefinitionCriteria:"],
+      "@id": "niiri:161fb640ca5be8910668e6da2f030000",
+      "@type": ["prov:Entity","nidm_PeakDefinitionCriteria"],
       "rdfs:label": "Peak Definition Criteria",
-      "nidm_maxNumberOfPeaksPerCluster:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_minDistanceBetweenPeaks:": {"@type": "xsd:float", "@value": "8"}
+      "nidm_maxNumberOfPeaksPerCluster": {"@type": "xsd:int", "@value": "3"},
+      "nidm_minDistanceBetweenPeaks": {"@type": "xsd:float", "@value": "8"}
     },
     {
-      "@id": "niiri:b658c7bd807d7547789ddf46a3dd33dd",
-      "@type": ["prov:Entity","nidm_ClusterDefinitionCriteria:"],
+      "@id": "niiri:95a4466fd86f8eb162d7c71ec577da13",
+      "@type": ["prov:Entity","nidm_ClusterDefinitionCriteria"],
       "rdfs:label": "Cluster Connectivity Criterion: 18",
-      "nidm_hasConnectivityCriterion:": {"@id": "nidm_voxel18connected:"}
+      "nidm_hasConnectivityCriterion": {"@id": "nidm_voxel18connected"}
     },
     {
-      "@id": "niiri:4b8c75bb59b3e9de0482c23e91e61c11",
-      "@type": ["prov:Activity","nidm_Inference:"],
-      "nidm_hasAlternativeHypothesis:": {"@id": "nidm_OneTailedTest:"},
+      "@id": "niiri:975d5305cd6d906f0149068326afc106",
+      "@type": ["prov:Activity","nidm_Inference"],
+      "nidm_hasAlternativeHypothesis": {"@id": "nidm_OneTailedTest"},
       "rdfs:label": "Inference"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:4b8c75bb59b3e9de0482c23e91e61c11",
-      "agent": "niiri:490e5ab2436b12162f59fedeb9e1e9d8"
+      "activity_associated": "niiri:975d5305cd6d906f0149068326afc106",
+      "agent": "niiri:65bbe1871e61c631eb812e3b6150407c"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:4b8c75bb59b3e9de0482c23e91e61c11",
-      "entity": "niiri:8c0ca80e074a908ed461be6200aa0c16"
+      "activity_using": "niiri:975d5305cd6d906f0149068326afc106",
+      "entity": "niiri:3dc9d42cdfae6ad474927bdb0e9bdc21"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:4b8c75bb59b3e9de0482c23e91e61c11",
-      "entity": "niiri:21fa5bd48e4e88c9a9121e1e236cbb5c"
+      "activity_using": "niiri:975d5305cd6d906f0149068326afc106",
+      "entity": "niiri:102fecaa14caf589304b204290d2ae40"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:4b8c75bb59b3e9de0482c23e91e61c11",
-      "entity": "niiri:f68e579c103081f8fc95d5851132f6ab"
+      "activity_using": "niiri:975d5305cd6d906f0149068326afc106",
+      "entity": "niiri:aa1effb702cc7db6a16eac195236db09"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:4b8c75bb59b3e9de0482c23e91e61c11",
-      "entity": "niiri:618d3be01362df0705449588778a62f5"
+      "activity_using": "niiri:975d5305cd6d906f0149068326afc106",
+      "entity": "niiri:08f53b8611d5bdec5c8de0c449a1db6f"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:4b8c75bb59b3e9de0482c23e91e61c11",
-      "entity": "niiri:391bfa5f6d92b504b7bbd76dc18b1db4"
+      "activity_using": "niiri:975d5305cd6d906f0149068326afc106",
+      "entity": "niiri:07485f81ffa874bdd72e7579bb4e934b"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:4b8c75bb59b3e9de0482c23e91e61c11",
-      "entity": "niiri:24e9f0b05542386f7ba14394c762f9ac"
+      "activity_using": "niiri:975d5305cd6d906f0149068326afc106",
+      "entity": "niiri:161fb640ca5be8910668e6da2f030000"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:4b8c75bb59b3e9de0482c23e91e61c11",
-      "entity": "niiri:b658c7bd807d7547789ddf46a3dd33dd"
+      "activity_using": "niiri:975d5305cd6d906f0149068326afc106",
+      "entity": "niiri:95a4466fd86f8eb162d7c71ec577da13"
     },
     {
-      "@id": "niiri:ba2ed8f06a0d316ea23f5b365ccce2aa",
-      "@type": ["prov:Entity","nidm_SearchSpaceMaskMap:"],
+      "@id": "niiri:1ade20198bb3c55969610ae99f5a7dcb",
+      "@type": ["prov:Entity","nidm_SearchSpaceMaskMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "SearchSpaceMask.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "SearchSpaceMask.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Search Space Mask Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:2ada174836b28044a9513f1a34eef87f"},
-      "nidm_searchVolumeInVoxels:": {"@type": "xsd:int", "@value": "223057"},
-      "nidm_searchVolumeInUnits:": {"@type": "xsd:float", "@value": "1784456"},
-      "nidm_reselSizeInVoxels:": {"@type": "xsd:float", "@value": "64.3564266652164"},
-      "nidm_searchVolumeInResels:": {"@type": "xsd:float", "@value": "3215.77829478616"},
-      "spm_searchVolumeReselsGeometry:": {"@type": "xsd:string", "@value": "[6, 98.4147965253735, 978.080986305661, 3215.77829478616]"},
-      "nidm_noiseFWHMInVoxels:": {"@type": "xsd:string", "@value": "[4.05874991505852, 4.0064022682226, 3.95772010097722]"},
-      "nidm_noiseFWHMInUnits:": {"@type": "xsd:string", "@value": "[8.11749983011705, 8.01280453644521, 7.91544020195443]"},
-      "nidm_randomFieldStationarity:": {"@type": "xsd:boolean", "@value": "true"},
-      "nidm_expectedNumberOfVoxelsPerCluster:": {"@type": "xsd:float", "@value": "7.07193046610115"},
-      "nidm_expectedNumberOfClusters:": {"@type": "xsd:float", "@value": "34.219403038192"},
-      "nidm_heightCriticalThresholdFWE05:": {"@type": "xsd:float", "@value": "5.32326239521668"},
-      "nidm_heightCriticalThresholdFDR05:": {"@type": "xsd:float", "@value": "4.61261701583862"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b410708237a32a427489f32ca35c4711"},
+      "nidm_searchVolumeInVoxels": {"@type": "xsd:int", "@value": "223057"},
+      "nidm_searchVolumeInUnits": {"@type": "xsd:float", "@value": "1784456"},
+      "nidm_reselSizeInVoxels": {"@type": "xsd:float", "@value": "64.3564266652164"},
+      "nidm_searchVolumeInResels": {"@type": "xsd:float", "@value": "3215.77829478616"},
+      "spm_searchVolumeReselsGeometry": {"@type": "xsd:string", "@value": "[6, 98.4147965253735, 978.080986305661, 3215.77829478616]"},
+      "nidm_noiseFWHMInVoxels": {"@type": "xsd:string", "@value": "[4.05874991505852, 4.0064022682226, 3.95772010097722]"},
+      "nidm_noiseFWHMInUnits": {"@type": "xsd:string", "@value": "[8.11749983011705, 8.01280453644521, 7.91544020195443]"},
+      "nidm_randomFieldStationarity": {"@type": "xsd:boolean", "@value": "true"},
+      "nidm_expectedNumberOfVoxelsPerCluster": {"@type": "xsd:float", "@value": "7.07193046610115"},
+      "nidm_expectedNumberOfClusters": {"@type": "xsd:float", "@value": "34.219403038192"},
+      "nidm_heightCriticalThresholdFWE05": {"@type": "xsd:float", "@value": "5.32326239521668"},
+      "nidm_heightCriticalThresholdFDR05": {"@type": "xsd:float", "@value": "4.61261701583862"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876"},
-      "spm_smallestSignificantClusterSizeInVoxelsFWE05:": {"@type": "xsd:int", "@value": "97"},
-      "spm_smallestSignificantClusterSizeInVoxelsFDR05:": {"@type": "xsd:int", "@value": "58"}
+      "spm_smallestSignificantClusterSizeInVoxelsFWE05": {"@type": "xsd:int", "@value": "97"},
+      "spm_smallestSignificantClusterSizeInVoxelsFDR05": {"@type": "xsd:int", "@value": "58"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:ba2ed8f06a0d316ea23f5b365ccce2aa",
-      "activity": "niiri:4b8c75bb59b3e9de0482c23e91e61c11"
+      "entity_generated": "niiri:1ade20198bb3c55969610ae99f5a7dcb",
+      "activity": "niiri:975d5305cd6d906f0149068326afc106"
     },
     {
-      "@id": "niiri:c818225e9c6f166518804d3ab91c1a34",
-      "@type": ["prov:Entity","nidm_ExcursionSetMap:"],
+      "@id": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3",
+      "@type": ["prov:Entity","nidm_ExcursionSetMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ExcursionSet.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ExcursionSet.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Excursion Set Map",
-      "nidm_numberOfSupraThresholdClusters:": {"@type": "xsd:int", "@value": "84"},
-      "nidm_pValue:": {"@type": "xsd:float", "@value": "5.23248111505836e-13"},
-      "nidm_hasClusterLabelsMap:": {"@id": "niiri:6e46e9a4c912d8769ff0718be16640c3"},
-      "nidm_hasMaximumIntensityProjection:": {"@id": "niiri:b90dac405ab103450ed0afca54b1339e"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:2ada174836b28044a9513f1a34eef87f"},
+      "nidm_numberOfSupraThresholdClusters": {"@type": "xsd:int", "@value": "84"},
+      "nidm_pValue": {"@type": "xsd:float", "@value": "5.23248111505836e-13"},
+      "nidm_hasClusterLabelsMap": {"@id": "niiri:1a46842083eecd60bf7b67f9b6b68ccb"},
+      "nidm_hasMaximumIntensityProjection": {"@id": "niiri:da6cd8a8a31c5aadfdb433e08d00228b"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b410708237a32a427489f32ca35c4711"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "e3de08e691d68d649233bdce2639a4bbea750162fdb8ba7e29ddfbfd23760faba59f34e347d136b9a0fd9971f48200cb7c30294d1960bd27bd40661b39fe82a5"}
     },
     {
-      "@id": "niiri:6e46e9a4c912d8769ff0718be16640c3",
-      "@type": ["prov:Entity","nidm_ClusterLabelsMap:"],
+      "@id": "niiri:1a46842083eecd60bf7b67f9b6b68ccb",
+      "@type": ["prov:Entity","nidm_ClusterLabelsMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ClusterLabels.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ClusterLabels.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Cluster Labels Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:2ada174836b28044a9513f1a34eef87f"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:b410708237a32a427489f32ca35c4711"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "192b1d648a385a172f839b0c03aab878274f1288c0ae8c12589f2ab0657756cc57b1691a072ba8fbd8c974dee181779696289703ac99d963860bea112a19017e"}
     },
     {
-      "@id": "niiri:b90dac405ab103450ed0afca54b1339e",
+      "@id": "niiri:da6cd8a8a31c5aadfdb433e08d00228b",
       "@type": ["prov:Entity","dctype:Image"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "MaximumIntensityProjection.png"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "MaximumIntensityProjection.png"},
@@ -796,3772 +796,3772 @@
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:c818225e9c6f166518804d3ab91c1a34",
-      "activity": "niiri:4b8c75bb59b3e9de0482c23e91e61c11"
+      "entity_generated": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3",
+      "activity": "niiri:975d5305cd6d906f0149068326afc106"
     },
     {
-      "@id": "niiri:8f36a85f042f8cc7fc3bd83b628271f2",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:d4b353636b454d9def0cc10eaa71d2b8",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0001",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "10733"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "166.774330958947"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.54846604024394e-70"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "3.82071147380491e-68"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "1"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "10733"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "166.774330958947"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.54846604024394e-70"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "3.82071147380491e-68"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "1"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8f36a85f042f8cc7fc3bd83b628271f2",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:d4b353636b454d9def0cc10eaa71d2b8",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:0571c455c5021749fc8693f5d5c53029",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:dabc6f32070848fa7096bac116f4a0d0",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0002",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "433"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "6.7281547847968"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.97291873296552e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "2.38609088043518e-07"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1.31532949289466e-07"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "2"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "433"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "6.7281547847968"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.97291873296552e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "2.38609088043518e-07"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1.31532949289466e-07"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "2"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0571c455c5021749fc8693f5d5c53029",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:dabc6f32070848fa7096bac116f4a0d0",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:8976f2283c83032c1e6578e393bc1c08",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:4e8b9634c8b43c73966139ed11b75ec8",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0003",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "429"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "6.66600092997189"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.82934221961109e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "2.6791538110249e-07"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1.31532949289466e-07"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "3"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "429"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "6.66600092997189"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.82934221961109e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "2.6791538110249e-07"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1.31532949289466e-07"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "3"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8976f2283c83032c1e6578e393bc1c08",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:4e8b9634c8b43c73966139ed11b75ec8",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:f1f77d0ce1cc3ba5587c7ec07f2eac8d",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:a731c83f0edffc39ddaeae57a80dc5ba",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0004",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1024"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "15.9113868351777"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.3245902390596e-15"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1.13797860024079e-13"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1.39632790040503e-13"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "4"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1024"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "15.9113868351777"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.3245902390596e-15"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1.13797860024079e-13"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1.39632790040503e-13"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "4"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f1f77d0ce1cc3ba5587c7ec07f2eac8d",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:a731c83f0edffc39ddaeae57a80dc5ba",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:efa240525eee79c28032f1f8e966fad3",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:5299ea7c2ff48f8ccb9e3da606289f28",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0005",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "153"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "2.37738494705291"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.38071971323196e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00286372395349332"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000879975569889356"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "5"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "153"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "2.37738494705291"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.38071971323196e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00286372395349332"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000879975569889356"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "5"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:efa240525eee79c28032f1f8e966fad3",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:5299ea7c2ff48f8ccb9e3da606289f28",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:7e9b1ebb227a2ee5938d0545b30aca96",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:2152e06e3cb49b34d19eb6146b5817f7",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0006",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "108"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.67815408027264"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000586195670709785"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0198594173433415"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0049240436339622"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "6"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "108"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.67815408027264"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000586195670709785"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0198594173433415"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0049240436339622"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "6"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7e9b1ebb227a2ee5938d0545b30aca96",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:2152e06e3cb49b34d19eb6146b5817f7",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:1c354e7e3ff502199baf755636f12453",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c205169674df01953a0df15ba2cb5f08",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0007",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "513"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "7.97123188129505"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.36876076154881e-10"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "2.52154591651177e-08"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "2.06325301323367e-08"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "7"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "513"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "7.97123188129505"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.36876076154881e-10"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "2.52154591651177e-08"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "2.06325301323367e-08"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "7"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1c354e7e3ff502199baf755636f12453",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:c205169674df01953a0df15ba2cb5f08",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:7b36354f0687338fb029a58183e4b870",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f7a0ae64373c9fadcbae5c1ee69af3e7",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0008",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "44"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.68369240307404"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0167428141993664"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.436128622224438"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0740208627761461"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "8"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "44"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.68369240307404"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0167428141993664"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.436128622224438"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0740208627761461"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "8"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7b36354f0687338fb029a58183e4b870",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:f7a0ae64373c9fadcbae5c1ee69af3e7",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:f1318eaae736dc28b717174be4e8be03",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f78c9c52eb8c41c81b7108fc768afea1",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0009",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "25"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.388461592655704"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.060470582894952"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.87372172153123"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.181411748684856"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "9"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "25"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.388461592655704"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.060470582894952"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.87372172153123"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.181411748684856"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "9"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f1318eaae736dc28b717174be4e8be03",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:f78c9c52eb8c41c81b7108fc768afea1",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:565e2f7e2e5bde3342f5c45d37979a75",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:defff4241093fb74f3bb72454faeb0c8",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0010",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "65"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.01000014090483"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00496736594455957"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.156318560760923"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0298041956673574"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "10"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "65"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.01000014090483"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00496736594455957"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.156318560760923"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0298041956673574"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "10"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:565e2f7e2e5bde3342f5c45d37979a75",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:defff4241093fb74f3bb72454faeb0c8",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:8447e2fc880db809a273004483217edc",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:a32e7c63a62151c6c42d8b86e0a4c19e",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0011",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "159"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "2.47061572929028"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.56727454077428e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00224475889571929"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000788072944892913"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "11"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "159"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "2.47061572929028"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.56727454077428e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00224475889571929"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000788072944892913"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "11"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8447e2fc880db809a273004483217edc",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:a32e7c63a62151c6c42d8b86e0a4c19e",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:94238ef8670737705b8341502f2746a2",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f9c64f2f13c1018c1b0c90db5e455972",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0012",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "127"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.97338489069098"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000250790491870153"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00854518152357242"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00234071125745476"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "12"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "127"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.97338489069098"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000250790491870153"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00854518152357242"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00234071125745476"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "12"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:94238ef8670737705b8341502f2746a2",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:f9c64f2f13c1018c1b0c90db5e455972",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:56882afdece5437620adade43b7e28ed",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:2e1d13240b9a458b380045313214b3ba",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0013",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "399"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "6.19984701878504"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.88880680310254e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "6.4633820373583e-07"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "2.64432952434356e-07"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "13"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "399"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "6.19984701878504"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.88880680310254e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "6.4633820373583e-07"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "2.64432952434356e-07"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "13"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:56882afdece5437620adade43b7e28ed",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:2e1d13240b9a458b380045313214b3ba",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:80acc2ec15379dd56dd3a4d3c0d4db28",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:76bd6a834aaa05e8f24aef110c831619",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0014",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "50"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.776923185311409"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0116364875650631"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.328468032427177"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0574979385567823"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "14"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "50"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.776923185311409"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0116364875650631"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.328468032427177"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0574979385567823"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "14"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:80acc2ec15379dd56dd3a4d3c0d4db28",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:76bd6a834aaa05e8f24aef110c831619",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:f79d6102313cb9c1b58014d0d7523705",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:16274414c81621b268626b188f47a6c7",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0015",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "58"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.901230894961234"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00732239299925302"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.221641385754555"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0410054007958169"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "15"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "58"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.901230894961234"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00732239299925302"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.221641385754555"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0410054007958169"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "15"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f79d6102313cb9c1b58014d0d7523705",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:16274414c81621b268626b188f47a6c7",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:5c0356c4e08b4f78355f5f21c8c539f6",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:fb5ba293db82840b5cc150cc15515c24",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0016",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "35"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.543846229717986"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0298638102730271"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.640097371313789"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.10906782882323"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "16"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "35"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.543846229717986"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0298638102730271"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.640097371313789"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.10906782882323"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "16"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5c0356c4e08b4f78355f5f21c8c539f6",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:fb5ba293db82840b5cc150cc15515c24",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:5118b94ba0e2ab04227b9b6665cca04e",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:aee52ad89a76ef41b6e67f9bca85ad62",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0017",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "87"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.35184634244185"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00159185647310904"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0530153341129462"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.010285841826243"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "17"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "87"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.35184634244185"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00159185647310904"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0530153341129462"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.010285841826243"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "17"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5118b94ba0e2ab04227b9b6665cca04e",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:aee52ad89a76ef41b6e67f9bca85ad62",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:0d31cfbdb7c4e7ca55a57b1a21ab5433",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:594db02a9d179d5f91a6ed68ca678d59",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0018",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "24"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.372923128949476"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.065201392108969"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.892595448111178"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.188859204729427"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "18"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "24"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.372923128949476"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.065201392108969"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.892595448111178"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.188859204729427"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "18"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0d31cfbdb7c4e7ca55a57b1a21ab5433",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:594db02a9d179d5f91a6ed68ca678d59",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:dc4429e2fc1e2581ade7dee26c4a3192",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:6dd3d0166eed8b2fa885aeca84711d27",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0019",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "35"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.543846229717986"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0298638102730271"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.640097371313789"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.10906782882323"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "19"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "35"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.543846229717986"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0298638102730271"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.640097371313789"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.10906782882323"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "19"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:dc4429e2fc1e2581ade7dee26c4a3192",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:6dd3d0166eed8b2fa885aeca84711d27",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:63325afca9aca401a92169c0b82ecc64",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:17120da53c5050105b9a8ee0e996c32d",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0020",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "30"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.466153911186845"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.042079152107298"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.763054107468119"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.147277032375543"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "20"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "30"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.466153911186845"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.042079152107298"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.763054107468119"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.147277032375543"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "20"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:63325afca9aca401a92169c0b82ecc64",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:17120da53c5050105b9a8ee0e996c32d",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:8b5b90b720b0adec672c0f46135febcd",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:a533e0119aa33105f1f6664ba02c4fcf",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0021",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "19"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.295230810418335"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0966642867392188"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.963403189505409"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.246054548063466"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "21"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "19"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.295230810418335"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0966642867392188"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.963403189505409"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.246054548063466"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "21"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8b5b90b720b0adec672c0f46135febcd",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:a533e0119aa33105f1f6664ba02c4fcf",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:e37885e426d196d0484be86dc5869e7e",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:b5ea5e54d015aa2a8403364ed7da486d",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0022",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "18"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.279692346712107"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.105000317164867"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.972485665957631"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.259412548289672"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "22"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "18"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.279692346712107"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.105000317164867"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.972485665957631"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.259412548289672"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "22"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e37885e426d196d0484be86dc5869e7e",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:b5ea5e54d015aa2a8403364ed7da486d",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:b98e5a23cb840529bde8f8f04eb60352",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:16c2a7e89d0686e69f57bbeea9dc74a5",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0023",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "44"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.68369240307404"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0167428141993664"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.436128622224438"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0740208627761461"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "23"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "44"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.68369240307404"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0167428141993664"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.436128622224438"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0740208627761461"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "23"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b98e5a23cb840529bde8f8f04eb60352",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:16c2a7e89d0686e69f57bbeea9dc74a5",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:08f981dcb0b605dc38e14328cd560d6b",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:325d5f27465210c036cd8d865e80251d",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0024",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "97"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.50723097950413"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000980395231065353"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0329920280381935"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00686276661745747"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "24"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "97"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.50723097950413"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000980395231065353"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0329920280381935"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00686276661745747"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "24"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:08f981dcb0b605dc38e14328cd560d6b",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:325d5f27465210c036cd8d865e80251d",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:d757dae4ee0e2ef151ed77b98cda2382",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:a77994161041027f0cf04defd7345c50",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0025",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "104"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.61600022544773"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000705252953232431"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0238444546686055"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0053855680065022"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "25"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "104"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.61600022544773"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000705252953232431"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0238444546686055"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0053855680065022"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "25"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d757dae4ee0e2ef151ed77b98cda2382",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:a77994161041027f0cf04defd7345c50",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:660ef8a46b7c1f0d47e1dbb95e0879b4",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:78d6f29ff8a7c1f0a21810728ade20ce",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0026",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "10"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.155384637062282"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.218032079946087"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999424877570482"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.436064159892175"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "26"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "10"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.155384637062282"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.218032079946087"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999424877570482"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.436064159892175"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "26"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:660ef8a46b7c1f0d47e1dbb95e0879b4",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:78d6f29ff8a7c1f0a21810728ade20ce",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:376742ba10824087fba971d247dc6783",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:ef6fca405f462fa8c50ca4b0f7e48ca2",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0027",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "28"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.435076983774389"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0485199097081292"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.809922300499855"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.156756631364725"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "27"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "28"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.435076983774389"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0485199097081292"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.809922300499855"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.156756631364725"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "27"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:376742ba10824087fba971d247dc6783",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:ef6fca405f462fa8c50ca4b0f7e48ca2",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:8bb3c55367529f573f350336b59c6b8b",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:6578b8b9d153de72a9648c8488a6ac3f",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0028",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "15"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.233076955593423"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.135899078711517"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.990442081893761"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.308527638155876"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "28"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "15"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.233076955593423"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.135899078711517"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.990442081893761"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.308527638155876"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "28"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8bb3c55367529f573f350336b59c6b8b",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:6578b8b9d153de72a9648c8488a6ac3f",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:ecc219c77c0dd1cbef88e6f794b57b51",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:aa346a17d504ccda6e8f3483bc7567b5",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0029",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0621538548249127"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.437414950664966"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999968417529"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.622760268743341"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "29"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0621538548249127"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.437414950664966"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999968417529"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.622760268743341"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "29"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ecc219c77c0dd1cbef88e6f794b57b51",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:aa346a17d504ccda6e8f3483bc7567b5",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:a1fc6b7fb08f44460fa83f1e82f3fd55",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:edeaef5183ad24011f37f4883d8f953f",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0030",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "38"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.590461620836671"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0245024923053393"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.567624415390469"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.102910467682425"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "30"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "38"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.590461620836671"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0245024923053393"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.567624415390469"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.102910467682425"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "30"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a1fc6b7fb08f44460fa83f1e82f3fd55",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:edeaef5183ad24011f37f4883d8f953f",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:6e25dc1a7cdabbe6238b8c8ba92a299b",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:82b6d07ebf78a88f41741c7c0b4d138a",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0031",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "53"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.823538576430093"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0097545787805446"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.283800029608743"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0512115385978591"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "31"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "53"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.823538576430093"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0097545787805446"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.283800029608743"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0512115385978591"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "31"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6e25dc1a7cdabbe6238b8c8ba92a299b",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:82b6d07ebf78a88f41741c7c0b4d138a",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:b6d54c10be27fe7c4485995dd9f9debb",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:23d958b69d91f95e528ceb5e2197a63a",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0032",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "29"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.450615447480617"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0451664237178062"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.786809267667146"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.151759183691829"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "32"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "29"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.450615447480617"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0451664237178062"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.786809267667146"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.151759183691829"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "32"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b6d54c10be27fe7c4485995dd9f9debb",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:23d958b69d91f95e528ceb5e2197a63a",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:ef72e4c2ccfe576af6dd9f5327bf55b9",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:cd749510acee370dec9860a5407637f5",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0033",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "11"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.17092310076851"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.197299441705757"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.998830839273017"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.404223246421551"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "33"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "11"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.17092310076851"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.197299441705757"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.998830839273017"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.404223246421551"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "33"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ef72e4c2ccfe576af6dd9f5327bf55b9",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:cd749510acee370dec9860a5407637f5",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:13d8b78f07281f4256fd3c0ec01dd4c4",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:13d9d29fd974d6893c1726d57a98a10f",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0034",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "7"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.108769245943597"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.300958767772195"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999966320774755"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.515929316180906"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "34"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "7"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.108769245943597"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.300958767772195"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999966320774755"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.515929316180906"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "34"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:13d8b78f07281f4256fd3c0ec01dd4c4",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:13d9d29fd974d6893c1726d57a98a10f",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:ba735e41f5c81e821d5431a5f33299b3",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:0d04d9bc9dd104e43dd556533a5b2159",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0035",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "25"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.388461592655704"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.060470582894952"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.87372172153123"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.181411748684856"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "35"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "25"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.388461592655704"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.060470582894952"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.87372172153123"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.181411748684856"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "35"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ba735e41f5c81e821d5431a5f33299b3",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:0d04d9bc9dd104e43dd556533a5b2159",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:9d954ccdd2f76e6021425a58f7079443",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:7d13eda0d79684f0d63dac1332405064",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0036",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "20"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.310769274124564"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0891182364351059"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.952620841952852"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.241481672920932"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "36"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "20"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.310769274124564"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0891182364351059"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.952620841952852"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.241481672920932"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "36"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9d954ccdd2f76e6021425a58f7079443",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:7d13eda0d79684f0d63dac1332405064",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:3964078dd1cffc5e5036d7bec9ce573c",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:9cc2d1c11d4e3b5aec5735ee91c1aca3",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0037",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "11"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.17092310076851"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.197299441705757"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.998830839273017"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.404223246421551"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "37"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "11"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.17092310076851"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.197299441705757"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.998830839273017"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.404223246421551"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "37"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3964078dd1cffc5e5036d7bec9ce573c",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:9cc2d1c11d4e3b5aec5735ee91c1aca3",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:53d1ede95ea7c0b47d5a32d1a51fe6f6",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:5b5b201251a2cc570135bacff1a480b1",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0038",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "22"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.34184620153702"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0760469924231223"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.925895771502835"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.212931578784742"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "38"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "22"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.34184620153702"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0760469924231223"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.925895771502835"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.212931578784742"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "38"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:53d1ede95ea7c0b47d5a32d1a51fe6f6",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:5b5b201251a2cc570135bacff1a480b1",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:c603845c76b83d0aac64a7584957c8fb",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:bbf4ce7e2e67235f45331b2b87133bd7",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0039",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "7"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.108769245943597"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.300958767772195"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999966320774755"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.515929316180906"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "39"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "7"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.108769245943597"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.300958767772195"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999966320774755"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.515929316180906"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "39"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c603845c76b83d0aac64a7584957c8fb",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:bbf4ce7e2e67235f45331b2b87133bd7",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:a2777ad5b03729d935f9c97ada730fc3",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:6a09c31a2cb2399d4dfaa1e9734b3056",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0040",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "7"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.108769245943597"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.300958767772195"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999966320774755"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.515929316180906"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "40"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "7"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.108769245943597"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.300958767772195"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999966320774755"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.515929316180906"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "40"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a2777ad5b03729d935f9c97ada730fc3",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:6a09c31a2cb2399d4dfaa1e9734b3056",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:6be135d40f33855edbacae1ce12b09f5",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:19eff7c42f4c5b43b8936b6bb77abf9e",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0041",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "14"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.217538491887194"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.148655664747997"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.993822910702503"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.328607258916625"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "41"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "14"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.217538491887194"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.148655664747997"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.993822910702503"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.328607258916625"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "41"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6be135d40f33855edbacae1ce12b09f5",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:19eff7c42f4c5b43b8936b6bb77abf9e",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:28624557fd946e461b8d82ec16375193",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:3a53732749467fad732fc1b126252b83",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0042",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "36"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.559384693424214"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0279406783674385"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.615616041572874"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.10906782882323"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "42"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "36"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.559384693424214"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0279406783674385"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.615616041572874"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.10906782882323"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "42"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:28624557fd946e461b8d82ec16375193",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:3a53732749467fad732fc1b126252b83",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:553d9ccd8301231daa8b7127b7d9fb7f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:4489ae9a89d81f59b4a316f0bc2ca8b8",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0043",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "13"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.202000028180966"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.162961955843832"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.996214059139573"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.350994981817484"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "43"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "13"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.202000028180966"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.162961955843832"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.996214059139573"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.350994981817484"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "43"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:553d9ccd8301231daa8b7127b7d9fb7f",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:4489ae9a89d81f59b4a316f0bc2ca8b8",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:2a7b2aeea7dc6c0e5169cde436a25f98",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:20b3e078d59196a48bbdcfae8b039f3e",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0044",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "17"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.264153883005879"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.114231806805604"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.979938329743163"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.266540882546409"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "44"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "17"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.264153883005879"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.114231806805604"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.979938329743163"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.266540882546409"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "44"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2a7b2aeea7dc6c0e5169cde436a25f98",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:20b3e078d59196a48bbdcfae8b039f3e",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:e5ed0876efa8e7867992a3e7519d125a",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:87692b796865090154e70657cb33f3fa",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0045",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "6"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0932307822373691"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.338405588448041"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999064909307"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.536340932634632"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "45"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "6"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0932307822373691"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.338405588448041"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999064909307"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.536340932634632"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "45"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e5ed0876efa8e7867992a3e7519d125a",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:87692b796865090154e70657cb33f3fa",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:cc4442623b113667ed11179bf378fa55",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f6aab0b38147783304dd12682b7a862f",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0046",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0310769274124564"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.59398729828926"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999998512086"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.69298518133747"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "46"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0310769274124564"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.59398729828926"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999998512086"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.69298518133747"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "46"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cc4442623b113667ed11179bf378fa55",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:f6aab0b38147783304dd12682b7a862f",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:3bcdad331508ef0bb8c4160e76f8a8dc",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:8cfffabbc7e33bc2c585eb4a81ebc159",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0047",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "9"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.139846173356054"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.241762380583414"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999744672708743"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.472279999279227"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "47"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "9"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.139846173356054"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.241762380583414"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999744672708743"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.472279999279227"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "47"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3bcdad331508ef0bb8c4160e76f8a8dc",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:8cfffabbc7e33bc2c585eb4a81ebc159",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:4f16f2a965f5b74e4ed5dd4273ae236f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:d93e1967e2b464317bc445a37c7560a2",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0048",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "17"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.264153883005879"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.114231806805604"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.979938329743163"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.266540882546409"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "48"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "17"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.264153883005879"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.114231806805604"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.979938329743163"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.266540882546409"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "48"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4f16f2a965f5b74e4ed5dd4273ae236f",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:d93e1967e2b464317bc445a37c7560a2",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:d10cc69571498e5ccb865e70f789b959",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:80f2f6c335075aedb795e079a5688f2b",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0049",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "5"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0776923185311409"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.383083955082425"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999997972899795"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.574625932623638"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "49"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "5"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0776923185311409"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.383083955082425"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999997972899795"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.574625932623638"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "49"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d10cc69571498e5ccb865e70f789b959",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:80f2f6c335075aedb795e079a5688f2b",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:eca18148c6df2bf25a3fb4224b299658",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:ef7d0561535e5e02620497afd1e27f3d",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0050",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "6"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0932307822373691"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.338405588448041"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999064909307"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.536340932634632"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "50"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "6"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0932307822373691"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.338405588448041"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999064909307"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.536340932634632"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "50"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:eca18148c6df2bf25a3fb4224b299658",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:ef7d0561535e5e02620497afd1e27f3d",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:d01136698ec67fb4e47df44c2e197103",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:29289a4455046f74558f3c81d39ba67b",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0051",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "5"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0776923185311409"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.383083955082425"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999997972899795"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.574625932623638"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "51"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "5"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0776923185311409"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.383083955082425"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999997972899795"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.574625932623638"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "51"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d01136698ec67fb4e47df44c2e197103",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:29289a4455046f74558f3c81d39ba67b",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:b1d116fb7eeb859d3c14dbed857c171a",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:2821bde2f68ccf372a5e6ea09d4eada7",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0052",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "19"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.295230810418335"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0966642867392188"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.963403189505409"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.246054548063466"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "52"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "19"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.295230810418335"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0966642867392188"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.963403189505409"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.246054548063466"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "52"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b1d116fb7eeb859d3c14dbed857c171a",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:2821bde2f68ccf372a5e6ea09d4eada7",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:80ebd2b365389e66f0063546e25d7a7f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:5514e5220803aad2c04bbd033aa76695",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0053",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0155384637062282"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.720258744789692"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999980229"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.720258744789692"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "53"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0155384637062282"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.720258744789692"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999980229"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.720258744789692"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "53"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:80ebd2b365389e66f0063546e25d7a7f",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:5514e5220803aad2c04bbd033aa76695",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:f28ff86627fd1b6b8dff8eeb57dda0bf",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:315fcb9a135fe01c557c732f7f103e94",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0054",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0310769274124564"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.59398729828926"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999998512086"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.69298518133747"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "54"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0310769274124564"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.59398729828926"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999998512086"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.69298518133747"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "54"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f28ff86627fd1b6b8dff8eeb57dda0bf",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:315fcb9a135fe01c557c732f7f103e94",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:7410e6e29d61d77d50faa3f92b630f60",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:fe8e19f11e2bcbf510735d94d7db4251",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0055",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "7"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.108769245943597"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.300958767772195"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999966320774755"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.515929316180906"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "55"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "7"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.108769245943597"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.300958767772195"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999966320774755"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.515929316180906"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "55"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7410e6e29d61d77d50faa3f92b630f60",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:fe8e19f11e2bcbf510735d94d7db4251",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:1f58e1cc42099395a446086ee96b8a42",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:fec8619ae00ff17ab9a3d3ceb9046f4e",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0056",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "5"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0776923185311409"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.383083955082425"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999997972899795"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.574625932623638"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "56"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "5"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0776923185311409"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.383083955082425"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999997972899795"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.574625932623638"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "56"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1f58e1cc42099395a446086ee96b8a42",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:fec8619ae00ff17ab9a3d3ceb9046f4e",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:873d10b94cdd2f9974ccfd2cdbfaaefa",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:0b442ae9d99b24f7707cb51260201d38",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0057",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0155384637062282"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.720258744789692"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999980229"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.720258744789692"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "57"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0155384637062282"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.720258744789692"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999980229"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.720258744789692"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "57"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:873d10b94cdd2f9974ccfd2cdbfaaefa",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:0b442ae9d99b24f7707cb51260201d38",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:b90b028a3ab9996de06b07fefc72f518",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:5b35b6fc65311a490ca686dedf246257",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0058",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "7"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.108769245943597"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.300958767772195"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999966320774755"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.515929316180906"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "58"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "7"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.108769245943597"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.300958767772195"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999966320774755"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.515929316180906"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "58"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b90b028a3ab9996de06b07fefc72f518",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:5b35b6fc65311a490ca686dedf246257",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:568f5936427903f7944d3adca7a176de",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:8105ee9b0d3cbff0afc4f8e6f6cbaaaa",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0059",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0155384637062282"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.720258744789692"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999980229"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.720258744789692"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "59"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0155384637062282"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.720258744789692"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999980229"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.720258744789692"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "59"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:568f5936427903f7944d3adca7a176de",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:8105ee9b0d3cbff0afc4f8e6f6cbaaaa",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:8d982136130ad2ce21a159a7d9c1edaa",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:b133a4090af3a2b167687334a106d130",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0060",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0621538548249127"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.437414950664966"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999968417529"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.622760268743341"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "60"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0621538548249127"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.437414950664966"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999968417529"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.622760268743341"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "60"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8d982136130ad2ce21a159a7d9c1edaa",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:b133a4090af3a2b167687334a106d130",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:3aa90bc8976de4ac1c73e9b43c959876",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:4c38fc3cc2a35b74b2036daf823f1c35",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0061",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "7"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.108769245943597"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.300958767772195"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999966320774755"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.515929316180906"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "61"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "7"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.108769245943597"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.300958767772195"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999966320774755"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.515929316180906"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "61"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3aa90bc8976de4ac1c73e9b43c959876",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:4c38fc3cc2a35b74b2036daf823f1c35",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:9905f70b4755853ccd1de257abc32ef8",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:9476947ad907c2f9d5c061ead3c8ca5c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0062",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0310769274124564"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.59398729828926"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999998512086"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.69298518133747"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "62"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0310769274124564"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.59398729828926"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999998512086"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.69298518133747"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "62"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9905f70b4755853ccd1de257abc32ef8",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:9476947ad907c2f9d5c061ead3c8ca5c",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:cfcc37be279ca1493d8aeab64d0f7eb0",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:eaf5abe818e88775744fc4bc734500da",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0063",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "6"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0932307822373691"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.338405588448041"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999064909307"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.536340932634632"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "63"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "6"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0932307822373691"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.338405588448041"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999064909307"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.536340932634632"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "63"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cfcc37be279ca1493d8aeab64d0f7eb0",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:eaf5abe818e88775744fc4bc734500da",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:0725b220f47ead33a4ba9ecc13ada7ae",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:d327e883ddebc9532dc10d806d05ceea",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0064",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0155384637062282"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.720258744789692"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999980229"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.720258744789692"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "64"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0155384637062282"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.720258744789692"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999980229"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.720258744789692"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "64"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0725b220f47ead33a4ba9ecc13ada7ae",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:d327e883ddebc9532dc10d806d05ceea",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:c8f5cfe91a5e1c0eb3a8ce4272e74dc1",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:b56a8e6eef495278939c1f07e4b2ec46",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0065",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0310769274124564"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.59398729828926"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999998512086"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.69298518133747"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "65"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0310769274124564"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.59398729828926"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999998512086"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.69298518133747"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "65"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c8f5cfe91a5e1c0eb3a8ce4272e74dc1",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:b56a8e6eef495278939c1f07e4b2ec46",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:76eeefc962a00f410ca4b176def01aa5",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:ed00692e64206abf7a48d003e49a172c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0066",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0155384637062282"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.720258744789692"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999980229"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.720258744789692"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "66"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0155384637062282"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.720258744789692"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999980229"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.720258744789692"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "66"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:76eeefc962a00f410ca4b176def01aa5",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:ed00692e64206abf7a48d003e49a172c",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:62c2a8527db43def7b959349980d6c02",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:33f78596b63613a9bb773b49e610c339",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0067",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0310769274124564"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.59398729828926"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999998512086"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.69298518133747"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "67"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0310769274124564"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.59398729828926"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999998512086"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.69298518133747"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "67"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:62c2a8527db43def7b959349980d6c02",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:33f78596b63613a9bb773b49e610c339",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:890df2ef7ecc6eafa711940fe2c85892",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:fd773d75cfefece3ae58e4b268b97593",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0068",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0466153911186845"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.505317358341535"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999969073683"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.684623517753047"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "68"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0466153911186845"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.505317358341535"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999969073683"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.684623517753047"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "68"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:890df2ef7ecc6eafa711940fe2c85892",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:fd773d75cfefece3ae58e4b268b97593",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:1fc695464136ac390f15258db075c307",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:b1682618b3d8ba951d4fba69d43ace19",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0069",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0155384637062282"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.720258744789692"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999980229"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.720258744789692"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "69"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0155384637062282"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.720258744789692"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999980229"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.720258744789692"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "69"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1fc695464136ac390f15258db075c307",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:b1682618b3d8ba951d4fba69d43ace19",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:a63c8949e4a3fc9f1f4411a09a294513",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:4aff58ce7014532950c85678251d820b",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0070",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0310769274124564"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.59398729828926"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999998512086"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.69298518133747"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "70"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0310769274124564"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.59398729828926"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999998512086"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.69298518133747"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "70"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a63c8949e4a3fc9f1f4411a09a294513",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:4aff58ce7014532950c85678251d820b",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:df25ac5a53adfde0956454127605d4b6",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:d98d8e8d25b59a9503f694b966d532d9",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0071",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0310769274124564"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.59398729828926"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999998512086"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.69298518133747"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "71"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0310769274124564"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.59398729828926"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999998512086"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.69298518133747"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "71"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:df25ac5a53adfde0956454127605d4b6",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:d98d8e8d25b59a9503f694b966d532d9",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:430b756d7a021f005bd015a459e3abf2",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:5b8cc71e1c4a9af4a428ecbfd59af0c3",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0072",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0621538548249127"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.437414950664966"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999968417529"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.622760268743341"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "72"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0621538548249127"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.437414950664966"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999968417529"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.622760268743341"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "72"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:430b756d7a021f005bd015a459e3abf2",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:5b8cc71e1c4a9af4a428ecbfd59af0c3",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:080141eb52f83c2bae53c858e92b0d56",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:9399cc4d9102dea2381bab7e4de270e7",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0073",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "6"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0932307822373691"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.338405588448041"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999064909307"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.536340932634632"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "73"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "6"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0932307822373691"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.338405588448041"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999064909307"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.536340932634632"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "73"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:080141eb52f83c2bae53c858e92b0d56",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:9399cc4d9102dea2381bab7e4de270e7",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:455661055a3ab874933b9807b54adec0",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:25449e2c897446ebd8a31026fdd28119",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0074",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0155384637062282"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.720258744789692"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999980229"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.720258744789692"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "74"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0155384637062282"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.720258744789692"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999980229"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.720258744789692"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "74"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:455661055a3ab874933b9807b54adec0",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:25449e2c897446ebd8a31026fdd28119",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:a4e79b29ae579ef25088671c40dcd4aa",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:0e21ee277152eb058ea4661ca48674d9",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0075",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0466153911186845"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.505317358341535"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999969073683"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.684623517753047"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "75"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0466153911186845"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.505317358341535"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999969073683"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.684623517753047"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "75"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a4e79b29ae579ef25088671c40dcd4aa",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:0e21ee277152eb058ea4661ca48674d9",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:cf1fb2a622b7b69b2867e5cf7760fe38",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:0e8a97e94bdd4af70efd21917168b43e",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0076",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0310769274124564"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.59398729828926"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999998512086"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.69298518133747"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "76"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0310769274124564"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.59398729828926"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999998512086"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.69298518133747"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "76"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cf1fb2a622b7b69b2867e5cf7760fe38",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:0e8a97e94bdd4af70efd21917168b43e",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:d2c0709213ef56652ef36c9d207acf04",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:5b01f2070bd1d0178ffb33f1582d88a3",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0077",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0310769274124564"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.59398729828926"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999998512086"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.69298518133747"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "77"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0310769274124564"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.59398729828926"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999998512086"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.69298518133747"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "77"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d2c0709213ef56652ef36c9d207acf04",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:5b01f2070bd1d0178ffb33f1582d88a3",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:2945ea3e25037efb18cb1b0c0a9604f5",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:329bc820e22a3a07c45bd811037a5b92",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0078",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0310769274124564"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.59398729828926"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999998512086"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.69298518133747"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "78"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0310769274124564"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.59398729828926"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999998512086"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.69298518133747"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "78"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2945ea3e25037efb18cb1b0c0a9604f5",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:329bc820e22a3a07c45bd811037a5b92",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:81211325ca547298daf652760e8bad87",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:4121c76a27252e2b2396a4e6040a0baf",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0079",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0466153911186845"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.505317358341535"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999969073683"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.684623517753047"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "79"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0466153911186845"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.505317358341535"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999969073683"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.684623517753047"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "79"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:81211325ca547298daf652760e8bad87",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:4121c76a27252e2b2396a4e6040a0baf",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:4b62f251a83aafef65b16eccc82e668e",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:419bb28f6b465c3e5015a6d14e56b223",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0080",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0155384637062282"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.720258744789692"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999980229"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.720258744789692"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "80"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0155384637062282"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.720258744789692"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999980229"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.720258744789692"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "80"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4b62f251a83aafef65b16eccc82e668e",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:419bb28f6b465c3e5015a6d14e56b223",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:773351148f166f1064c72ad4e1f11422",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:e64d676ce70ddc69f3b8a79a997afc14",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0081",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0155384637062282"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.720258744789692"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999980229"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.720258744789692"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "81"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0155384637062282"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.720258744789692"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999980229"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.720258744789692"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "81"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:773351148f166f1064c72ad4e1f11422",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:e64d676ce70ddc69f3b8a79a997afc14",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:eaca7a045a95a69292520d89e15df899",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:b2fe473551b0d5958d6a1fafaa7495aa",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0082",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0155384637062282"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.720258744789692"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999980229"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.720258744789692"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "82"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0155384637062282"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.720258744789692"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999980229"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.720258744789692"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "82"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:eaca7a045a95a69292520d89e15df899",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:b2fe473551b0d5958d6a1fafaa7495aa",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:147f8e061f74d3386fbcc5d348522c64",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:8fc15b04ecd3232fd23805615acbe960",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0083",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0155384637062282"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.720258744789692"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999980229"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.720258744789692"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "83"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0155384637062282"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.720258744789692"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999980229"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.720258744789692"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "83"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:147f8e061f74d3386fbcc5d348522c64",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:8fc15b04ecd3232fd23805615acbe960",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:b140e937ac96257d15f410e255ead183",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:3ba4f4eceb22f4823f915b7f2ea31b71",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0084",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0155384637062282"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.720258744789692"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999980229"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.720258744789692"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "84"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0155384637062282"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.720258744789692"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999980229"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.720258744789692"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "84"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b140e937ac96257d15f410e255ead183",
-      "entity": "niiri:c818225e9c6f166518804d3ab91c1a34"
+      "entity_derived": "niiri:3ba4f4eceb22f4823f915b7f2ea31b71",
+      "entity": "niiri:32d0bf812c17b0e83c10c6b9e47a20d3"
     },
     {
-      "@id": "niiri:cbd10319b485230bd42be33c69190e0b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:61bd43e2cb11ead4b85522ae0ab9c70f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0001",
-      "prov:atLocation": {"@id": "niiri:19c1127e56da22effc8ec6831ccd53c7"},
+      "prov:atLocation": {"@id": "niiri:19fd8a73f42418dd2674d3fea35437a4"},
       "prov:value": {"@type": "xsd:float", "@value": "9.2086353302002"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "7.76768101511643"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.99680288865056e-15"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "8.41986258492966e-10"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1.98279886818782e-08"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "7.76768101511643"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.99680288865056e-15"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "8.41986258492966e-10"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1.98279886818782e-08"}
     },
     {
-      "@id": "niiri:19c1127e56da22effc8ec6831ccd53c7",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:19fd8a73f42418dd2674d3fea35437a4",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0001",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[46,14,22]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[46,14,22]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cbd10319b485230bd42be33c69190e0b",
-      "entity": "niiri:8f36a85f042f8cc7fc3bd83b628271f2"
+      "entity_derived": "niiri:61bd43e2cb11ead4b85522ae0ab9c70f",
+      "entity": "niiri:d4b353636b454d9def0cc10eaa71d2b8"
     },
     {
-      "@id": "niiri:f6627370100a3b64d18799c1d6bee92b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:aaefd41c0d243a75bbaf8975589a5d52",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0002",
-      "prov:atLocation": {"@id": "niiri:bb6e96dff73f6f682be2a93c3f8037b0"},
+      "prov:atLocation": {"@id": "niiri:76939a99f5c8dab773bec0d17d3e3287"},
       "prov:value": {"@type": "xsd:float", "@value": "7.77265024185181"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "6.82858568121235"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.28779234340482e-12"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "9.56372568139408e-07"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "5.15073725636882e-06"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "6.82858568121235"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.28779234340482e-12"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "9.56372568139408e-07"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "5.15073725636882e-06"}
     },
     {
-      "@id": "niiri:bb6e96dff73f6f682be2a93c3f8037b0",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:76939a99f5c8dab773bec0d17d3e3287",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0002",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[32,24,-6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[32,24,-6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f6627370100a3b64d18799c1d6bee92b",
-      "entity": "niiri:8f36a85f042f8cc7fc3bd83b628271f2"
+      "entity_derived": "niiri:aaefd41c0d243a75bbaf8975589a5d52",
+      "entity": "niiri:d4b353636b454d9def0cc10eaa71d2b8"
     },
     {
-      "@id": "niiri:7b9e42461bd57488c28ce61f04157a16",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:9c6062c0b908383a480b076e8fb62317",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0003",
-      "prov:atLocation": {"@id": "niiri:fa44ca794f0d12d4d915c2886a5e614d"},
+      "prov:atLocation": {"@id": "niiri:3cb0eeaad7f509be77fbbb3c734b17c8"},
       "prov:value": {"@type": "xsd:float", "@value": "7.7477593421936"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "6.81126740568942"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.83713069598934e-12"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1.07890633305185e-06"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "5.15073725636882e-06"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "6.81126740568942"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.83713069598934e-12"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1.07890633305185e-06"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "5.15073725636882e-06"}
     },
     {
-      "@id": "niiri:fa44ca794f0d12d4d915c2886a5e614d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:3cb0eeaad7f509be77fbbb3c734b17c8",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0003",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[8,18,50]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[8,18,50]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7b9e42461bd57488c28ce61f04157a16",
-      "entity": "niiri:8f36a85f042f8cc7fc3bd83b628271f2"
+      "entity_derived": "niiri:9c6062c0b908383a480b076e8fb62317",
+      "entity": "niiri:d4b353636b454d9def0cc10eaa71d2b8"
     },
     {
-      "@id": "niiri:41817b9e9d02e04a62572b281bd1703c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f05f6aec7d624e6197dbd9ac07aef88b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0004",
-      "prov:atLocation": {"@id": "niiri:61201c57599cb8e89dd26d9aeb8cbf0b"},
+      "prov:atLocation": {"@id": "niiri:e4554759a85d8e68a90cbf39443103fe"},
       "prov:value": {"@type": "xsd:float", "@value": "7.59118175506592"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "6.70158988664555"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.03081987390397e-11"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "2.29926635753053e-06"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "7.75261359723548e-06"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "6.70158988664555"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.03081987390397e-11"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "2.29926635753053e-06"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "7.75261359723548e-06"}
     },
     {
-      "@id": "niiri:61201c57599cb8e89dd26d9aeb8cbf0b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e4554759a85d8e68a90cbf39443103fe",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0004",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[34,-88,-2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[34,-88,-2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:41817b9e9d02e04a62572b281bd1703c",
-      "entity": "niiri:0571c455c5021749fc8693f5d5c53029"
+      "entity_derived": "niiri:f05f6aec7d624e6197dbd9ac07aef88b",
+      "entity": "niiri:dabc6f32070848fa7096bac116f4a0d0"
     },
     {
-      "@id": "niiri:1642fc731ff715f5797db051685ef81a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c11d713034b63a168bdd812994537584",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0005",
-      "prov:atLocation": {"@id": "niiri:e840a0198f27f08ba380a14487eed616"},
+      "prov:atLocation": {"@id": "niiri:d844d02b36a9dc3a0e8ff3270dd100e1"},
       "prov:value": {"@type": "xsd:float", "@value": "7.03135824203491"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "6.29919779546036"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.49595003051672e-10"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "3.33681630670934e-05"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "3.5929708651339e-05"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "6.29919779546036"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.49595003051672e-10"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "3.33681630670934e-05"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "3.5929708651339e-05"}
     },
     {
-      "@id": "niiri:e840a0198f27f08ba380a14487eed616",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d844d02b36a9dc3a0e8ff3270dd100e1",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0005",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[42,-72,-10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[42,-72,-10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1642fc731ff715f5797db051685ef81a",
-      "entity": "niiri:0571c455c5021749fc8693f5d5c53029"
+      "entity_derived": "niiri:c11d713034b63a168bdd812994537584",
+      "entity": "niiri:dabc6f32070848fa7096bac116f4a0d0"
     },
     {
-      "@id": "niiri:f4fcfa92a45e24ac8ac208b54357bbdf",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:db60aac6428eac8ac3baeeff8d9d9a89",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0006",
-      "prov:atLocation": {"@id": "niiri:e8c6929875c2e296ea59e2df4226246a"},
+      "prov:atLocation": {"@id": "niiri:6db693a2950e3c3898b2016d47b0c085"},
       "prov:value": {"@type": "xsd:float", "@value": "5.73506736755371"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.30472446220131"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.64216566800724e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0107086846025504"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00182363082319185"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.30472446220131"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.64216566800724e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0107086846025504"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00182363082319185"}
     },
     {
-      "@id": "niiri:e8c6929875c2e296ea59e2df4226246a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6db693a2950e3c3898b2016d47b0c085",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0006",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[34,-86,12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[34,-86,12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f4fcfa92a45e24ac8ac208b54357bbdf",
-      "entity": "niiri:0571c455c5021749fc8693f5d5c53029"
+      "entity_derived": "niiri:db60aac6428eac8ac3baeeff8d9d9a89",
+      "entity": "niiri:dabc6f32070848fa7096bac116f4a0d0"
     },
     {
-      "@id": "niiri:44f9881a215a120bf4b329dce020683b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:da07c9cffdb89f061f471c62455179f6",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0007",
-      "prov:atLocation": {"@id": "niiri:397db41518ebd19c94d28370f46f0779"},
+      "prov:atLocation": {"@id": "niiri:7cbc707f01d3236308dd2e2563f62b70"},
       "prov:value": {"@type": "xsd:float", "@value": "6.97286987304688"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "6.25622394584082"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.97205141105883e-10"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "4.39879376310515e-05"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "4.20152926830756e-05"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "6.25622394584082"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.97205141105883e-10"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "4.39879376310515e-05"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "4.20152926830756e-05"}
     },
     {
-      "@id": "niiri:397db41518ebd19c94d28370f46f0779",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7cbc707f01d3236308dd2e2563f62b70",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0007",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[32,2,46]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[32,2,46]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:44f9881a215a120bf4b329dce020683b",
-      "entity": "niiri:8976f2283c83032c1e6578e393bc1c08"
+      "entity_derived": "niiri:da07c9cffdb89f061f471c62455179f6",
+      "entity": "niiri:4e8b9634c8b43c73966139ed11b75ec8"
     },
     {
-      "@id": "niiri:1a453f37de3a7137cc1c2c7d1adec306",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f030a501c14ec9c10fe484ff04b4868f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0008",
-      "prov:atLocation": {"@id": "niiri:315b72d58d02d44f0736dd094bebfa16"},
+      "prov:atLocation": {"@id": "niiri:069d0ce94e80aac1d9ad38251824f8eb"},
       "prov:value": {"@type": "xsd:float", "@value": "5.64730930328369"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.23420507732884"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.28482022985355e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0149983527932318"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00232586421758464"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.23420507732884"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.28482022985355e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0149983527932318"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00232586421758464"}
     },
     {
-      "@id": "niiri:315b72d58d02d44f0736dd094bebfa16",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:069d0ce94e80aac1d9ad38251824f8eb",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0008",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[30,4,58]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[30,4,58]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1a453f37de3a7137cc1c2c7d1adec306",
-      "entity": "niiri:8976f2283c83032c1e6578e393bc1c08"
+      "entity_derived": "niiri:f030a501c14ec9c10fe484ff04b4868f",
+      "entity": "niiri:4e8b9634c8b43c73966139ed11b75ec8"
     },
     {
-      "@id": "niiri:ad8abfc758206e227b5e8ec29ca97227",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:32366a46bbf0f9fae450db4ea84aff6d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0009",
-      "prov:atLocation": {"@id": "niiri:c820d1f4b777306bd48bffa479b9049b"},
+      "prov:atLocation": {"@id": "niiri:d0279504420cdd8ef5cbb33ef8bc17e3"},
       "prov:value": {"@type": "xsd:float", "@value": "4.40563726425171"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.19368654428063"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.37228586966076e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.702748192357301"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0688715370678382"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.19368654428063"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.37228586966076e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.702748192357301"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0688715370678382"}
     },
     {
-      "@id": "niiri:c820d1f4b777306bd48bffa479b9049b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d0279504420cdd8ef5cbb33ef8bc17e3",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0009",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[42,4,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[42,4,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ad8abfc758206e227b5e8ec29ca97227",
-      "entity": "niiri:8976f2283c83032c1e6578e393bc1c08"
+      "entity_derived": "niiri:32366a46bbf0f9fae450db4ea84aff6d",
+      "entity": "niiri:4e8b9634c8b43c73966139ed11b75ec8"
     },
     {
-      "@id": "niiri:49b125058259e4eff03e45f034b27386",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:8fc9a86e848c24dae11f15925f03b510",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0010",
-      "prov:atLocation": {"@id": "niiri:c58f1801199f38300b69084468129a10"},
+      "prov:atLocation": {"@id": "niiri:1891de7048560b92cd5e00c827fd79cd"},
       "prov:value": {"@type": "xsd:float", "@value": "6.86515712738037"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "6.17661732625786"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.27447735593012e-10"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "7.3039460029567e-05"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "5.79507633018939e-05"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "6.17661732625786"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.27447735593012e-10"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "7.3039460029567e-05"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "5.79507633018939e-05"}
     },
     {
-      "@id": "niiri:c58f1801199f38300b69084468129a10",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:1891de7048560b92cd5e00c827fd79cd",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0010",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[40,-62,50]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[40,-62,50]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:49b125058259e4eff03e45f034b27386",
-      "entity": "niiri:f1f77d0ce1cc3ba5587c7ec07f2eac8d"
+      "entity_derived": "niiri:8fc9a86e848c24dae11f15925f03b510",
+      "entity": "niiri:a731c83f0edffc39ddaeae57a80dc5ba"
     },
     {
-      "@id": "niiri:7a28a0868310495da2f8c91ed5ce0f98",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:661f534ccc7bdcb595c223d462813fb2",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0011",
-      "prov:atLocation": {"@id": "niiri:94dfc5baba99c12f7c59e872a5759a60"},
+      "prov:atLocation": {"@id": "niiri:45d6dbe200ad3545589d96cbcb3e79ed"},
       "prov:value": {"@type": "xsd:float", "@value": "6.85877418518066"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "6.17188094462764"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.37411543149813e-10"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "7.52619570517643e-05"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "5.79507633018939e-05"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "6.17188094462764"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.37411543149813e-10"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "7.52619570517643e-05"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "5.79507633018939e-05"}
     },
     {
-      "@id": "niiri:94dfc5baba99c12f7c59e872a5759a60",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:45d6dbe200ad3545589d96cbcb3e79ed",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0011",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[52,-32,42]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[52,-32,42]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7a28a0868310495da2f8c91ed5ce0f98",
-      "entity": "niiri:f1f77d0ce1cc3ba5587c7ec07f2eac8d"
+      "entity_derived": "niiri:661f534ccc7bdcb595c223d462813fb2",
+      "entity": "niiri:a731c83f0edffc39ddaeae57a80dc5ba"
     },
     {
-      "@id": "niiri:a29ed698fe7ba052097f16e1858a3283",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0439c89a311e9fd92d450045320abef9",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0012",
-      "prov:atLocation": {"@id": "niiri:5161bb42084a38ee9f38d527b05d3ad8"},
+      "prov:atLocation": {"@id": "niiri:c68b3dc10dcd6c086fe4ae651da53586"},
       "prov:value": {"@type": "xsd:float", "@value": "6.75158262252808"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "6.0920231289905"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.57462853656432e-10"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.000124345942219439"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "7.74014448313719e-05"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "6.0920231289905"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.57462853656432e-10"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.000124345942219439"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "7.74014448313719e-05"}
     },
     {
-      "@id": "niiri:5161bb42084a38ee9f38d527b05d3ad8",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c68b3dc10dcd6c086fe4ae651da53586",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0012",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[44,-70,50]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[44,-70,50]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a29ed698fe7ba052097f16e1858a3283",
-      "entity": "niiri:f1f77d0ce1cc3ba5587c7ec07f2eac8d"
+      "entity_derived": "niiri:0439c89a311e9fd92d450045320abef9",
+      "entity": "niiri:a731c83f0edffc39ddaeae57a80dc5ba"
     },
     {
-      "@id": "niiri:7fe871a90ba5d65f8651badf91747c71",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f3634f34416055e1f89021e72074c0b8",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0013",
-      "prov:atLocation": {"@id": "niiri:0de60fa9f6849a6f9aaa47c12161ba51"},
+      "prov:atLocation": {"@id": "niiri:25d042185f02c49a8254ea541b284e66"},
       "prov:value": {"@type": "xsd:float", "@value": "6.74185800552368"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "6.08474855499121"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.83371351225992e-10"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.000130125013961813"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "7.74014448313719e-05"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "6.08474855499121"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.83371351225992e-10"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.000130125013961813"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "7.74014448313719e-05"}
     },
     {
-      "@id": "niiri:0de60fa9f6849a6f9aaa47c12161ba51",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:25d042185f02c49a8254ea541b284e66",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0013",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-34,-2,52]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-34,-2,52]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7fe871a90ba5d65f8651badf91747c71",
-      "entity": "niiri:efa240525eee79c28032f1f8e966fad3"
+      "entity_derived": "niiri:f3634f34416055e1f89021e72074c0b8",
+      "entity": "niiri:5299ea7c2ff48f8ccb9e3da606289f28"
     },
     {
-      "@id": "niiri:fa40140dbb79851494c1ddddd5a98188",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:349a28a9b41a96a17877fc37d66ae69a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0014",
-      "prov:atLocation": {"@id": "niiri:3bd6e8b5270e98f2d4237f8bf0c57f6d"},
+      "prov:atLocation": {"@id": "niiri:3d53b41dc35ce105f59d533871035a1b"},
       "prov:value": {"@type": "xsd:float", "@value": "6.66947507858276"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "6.03044660761629"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.17535927843949e-10"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.000182357061928484"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "9.89064171074034e-05"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "6.03044660761629"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.17535927843949e-10"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.000182357061928484"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "9.89064171074034e-05"}
     },
     {
-      "@id": "niiri:3bd6e8b5270e98f2d4237f8bf0c57f6d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:3d53b41dc35ce105f59d533871035a1b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0014",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-28,-94,4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-28,-94,4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:fa40140dbb79851494c1ddddd5a98188",
-      "entity": "niiri:7e9b1ebb227a2ee5938d0545b30aca96"
+      "entity_derived": "niiri:349a28a9b41a96a17877fc37d66ae69a",
+      "entity": "niiri:2152e06e3cb49b34d19eb6146b5817f7"
     },
     {
-      "@id": "niiri:26c8c36656a588e4969a7cc42bbacae5",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3e1ef8a3ca25ac8b59d80bd43c358ed4",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0015",
-      "prov:atLocation": {"@id": "niiri:4f15ec04ef2895aa2492b01cd33e5be6"},
+      "prov:atLocation": {"@id": "niiri:8d2cea471932539cb762241eca542d48"},
       "prov:value": {"@type": "xsd:float", "@value": "4.72731781005859"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.47080352419215"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.89631317532224e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.344866937398066"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0306600822692826"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.47080352419215"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.89631317532224e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.344866937398066"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0306600822692826"}
     },
     {
-      "@id": "niiri:4f15ec04ef2895aa2492b01cd33e5be6",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:8d2cea471932539cb762241eca542d48",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0015",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-50,-72,2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-50,-72,2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:26c8c36656a588e4969a7cc42bbacae5",
-      "entity": "niiri:7e9b1ebb227a2ee5938d0545b30aca96"
+      "entity_derived": "niiri:3e1ef8a3ca25ac8b59d80bd43c358ed4",
+      "entity": "niiri:2152e06e3cb49b34d19eb6146b5817f7"
     },
     {
-      "@id": "niiri:fae924d67a74986d22e106df3a835732",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:cd8ff33c2ca2918b0a27282345d1bda0",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0016",
-      "prov:atLocation": {"@id": "niiri:dadb92913ade3f3d43aaf8fbc814f8d3"},
+      "prov:atLocation": {"@id": "niiri:4fa4b02b261b8765f2b1916297e8d0ef"},
       "prov:value": {"@type": "xsd:float", "@value": "6.61547613143921"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.98975768195926"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.05076958245576e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00023438146122523"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000109520618634045"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.98975768195926"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.05076958245576e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00023438146122523"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000109520618634045"}
     },
     {
-      "@id": "niiri:dadb92913ade3f3d43aaf8fbc814f8d3",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4fa4b02b261b8765f2b1916297e8d0ef",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0016",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-52,0,38]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-52,0,38]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:fae924d67a74986d22e106df3a835732",
-      "entity": "niiri:1c354e7e3ff502199baf755636f12453"
+      "entity_derived": "niiri:cd8ff33c2ca2918b0a27282345d1bda0",
+      "entity": "niiri:c205169674df01953a0df15ba2cb5f08"
     },
     {
-      "@id": "niiri:93b914ea539309faa02f24f4cf1cd643",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:dfbab0b4541c5aa0d17a7fc20cc92006",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0017",
-      "prov:atLocation": {"@id": "niiri:fc112f66da4bc7c44412af4817475dca"},
+      "prov:atLocation": {"@id": "niiri:efbb40cf819ae486eb77486299b67a9e"},
       "prov:value": {"@type": "xsd:float", "@value": "5.67108535766602"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.25335064729294"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.46783984650889e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.013695505906366"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00217066284688228"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.25335064729294"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.46783984650889e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.013695505906366"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00217066284688228"}
     },
     {
-      "@id": "niiri:fc112f66da4bc7c44412af4817475dca",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:efbb40cf819ae486eb77486299b67a9e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0017",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-46,6,28]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-46,6,28]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:93b914ea539309faa02f24f4cf1cd643",
-      "entity": "niiri:1c354e7e3ff502199baf755636f12453"
+      "entity_derived": "niiri:dfbab0b4541c5aa0d17a7fc20cc92006",
+      "entity": "niiri:c205169674df01953a0df15ba2cb5f08"
     },
     {
-      "@id": "niiri:ad07d5767cad0f3c964799f5d96ec3bc",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ef8223f420455816c0e95ee6e024db6c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0018",
-      "prov:atLocation": {"@id": "niiri:17c2cf0f509d7d287303d46e9d956542"},
+      "prov:atLocation": {"@id": "niiri:561d5625f54e1b5697536c0413529bc8"},
       "prov:value": {"@type": "xsd:float", "@value": "5.49257516860962"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.10888189288487"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.62035419970508e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0268824268377835"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00349505918676715"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.10888189288487"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.62035419970508e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0268824268377835"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00349505918676715"}
     },
     {
-      "@id": "niiri:17c2cf0f509d7d287303d46e9d956542",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:561d5625f54e1b5697536c0413529bc8",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0018",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-60,8,20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-60,8,20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ad07d5767cad0f3c964799f5d96ec3bc",
-      "entity": "niiri:1c354e7e3ff502199baf755636f12453"
+      "entity_derived": "niiri:ef8223f420455816c0e95ee6e024db6c",
+      "entity": "niiri:c205169674df01953a0df15ba2cb5f08"
     },
     {
-      "@id": "niiri:1f02a31c29e4c3f51d7e16c1b63edf46",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:35bbf8c9030a11e48d1b2dee7e09dc11",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0019",
-      "prov:atLocation": {"@id": "niiri:023c0b9dc1d125d8056f022800b7a076"},
+      "prov:atLocation": {"@id": "niiri:5a3e8745d343d64c09a7291cc9599412"},
       "prov:value": {"@type": "xsd:float", "@value": "6.17608976364136"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.65297947754486"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.88450704725108e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00175869443891008"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000479412815824312"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.65297947754486"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.88450704725108e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00175869443891008"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000479412815824312"}
     },
     {
-      "@id": "niiri:023c0b9dc1d125d8056f022800b7a076",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:5a3e8745d343d64c09a7291cc9599412",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0019",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-58,-30,-18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-58,-30,-18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1f02a31c29e4c3f51d7e16c1b63edf46",
-      "entity": "niiri:7b36354f0687338fb029a58183e4b870"
+      "entity_derived": "niiri:35bbf8c9030a11e48d1b2dee7e09dc11",
+      "entity": "niiri:f7a0ae64373c9fadcbae5c1ee69af3e7"
     },
     {
-      "@id": "niiri:e16a4cb3173debde9f393e0c367f7fae",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:27f7bd95d47b079be25c832329669ee6",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0020",
-      "prov:atLocation": {"@id": "niiri:ba115bb746c8b44ec654e368f832f0fe"},
+      "prov:atLocation": {"@id": "niiri:2152150ffc3b9877675f544c6e8d05b5"},
       "prov:value": {"@type": "xsd:float", "@value": "6.00111627578735"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.51603694557944"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.7336469926299e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00377055438802265"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000889054456506852"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.51603694557944"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.7336469926299e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00377055438802265"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000889054456506852"}
     },
     {
-      "@id": "niiri:ba115bb746c8b44ec654e368f832f0fe",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:2152150ffc3b9877675f544c6e8d05b5",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0020",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-54,-46,58]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-54,-46,58]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e16a4cb3173debde9f393e0c367f7fae",
-      "entity": "niiri:f1318eaae736dc28b717174be4e8be03"
+      "entity_derived": "niiri:27f7bd95d47b079be25c832329669ee6",
+      "entity": "niiri:f78c9c52eb8c41c81b7108fc768afea1"
     },
     {
-      "@id": "niiri:5a5ef5d63e6684d4d2a5e3b8dedb76ed",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c27894706882af29cb375ead129ef8cb",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0021",
-      "prov:atLocation": {"@id": "niiri:35a4593f1741359cfb89e1740463cb80"},
+      "prov:atLocation": {"@id": "niiri:90f9c2bd488287a611152e190f59541c"},
       "prov:value": {"@type": "xsd:float", "@value": "5.88819122314453"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.42680001669675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.86866747023495e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00589533759301752"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00119802154665121"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.42680001669675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.86866747023495e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00589533759301752"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00119802154665121"}
     },
     {
-      "@id": "niiri:35a4593f1741359cfb89e1740463cb80",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:90f9c2bd488287a611152e190f59541c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0021",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-62,-38,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-62,-38,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5a5ef5d63e6684d4d2a5e3b8dedb76ed",
-      "entity": "niiri:565e2f7e2e5bde3342f5c45d37979a75"
+      "entity_derived": "niiri:c27894706882af29cb375ead129ef8cb",
+      "entity": "niiri:defff4241093fb74f3bb72454faeb0c8"
     },
     {
-      "@id": "niiri:4c895f0e6b277ed749ed6cdcaebf571a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c9d1046585f7728d08cc54165c11ff59",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0022",
-      "prov:atLocation": {"@id": "niiri:6eb49ee48f662f4c29411db54cb9d61c"},
+      "prov:atLocation": {"@id": "niiri:c169b7364207ba5710701c5015add790"},
       "prov:value": {"@type": "xsd:float", "@value": "5.44929027557373"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.07359999694323"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.95179594375539e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.031565196414938"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00384073346935762"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.07359999694323"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.95179594375539e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.031565196414938"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00384073346935762"}
     },
     {
-      "@id": "niiri:6eb49ee48f662f4c29411db54cb9d61c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c169b7364207ba5710701c5015add790",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0022",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-60,-50,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-60,-50,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4c895f0e6b277ed749ed6cdcaebf571a",
-      "entity": "niiri:565e2f7e2e5bde3342f5c45d37979a75"
+      "entity_derived": "niiri:c9d1046585f7728d08cc54165c11ff59",
+      "entity": "niiri:defff4241093fb74f3bb72454faeb0c8"
     },
     {
-      "@id": "niiri:ab8a36df15e3c8b64fda443435e347ef",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:03c13f292babfb2b1d3290faffb9e334",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0023",
-      "prov:atLocation": {"@id": "niiri:483eff7df6af0712e20facb890a46299"},
+      "prov:atLocation": {"@id": "niiri:c1c09ce48f662e61c3ae3b80bce02189"},
       "prov:value": {"@type": "xsd:float", "@value": "5.43339920043945"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.060622473607"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.08944963109303e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0334714202830716"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0039964071128327"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.060622473607"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.08944963109303e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0334714202830716"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0039964071128327"}
     },
     {
-      "@id": "niiri:483eff7df6af0712e20facb890a46299",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c1c09ce48f662e61c3ae3b80bce02189",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0023",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-36,-74,-14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-36,-74,-14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ab8a36df15e3c8b64fda443435e347ef",
-      "entity": "niiri:8447e2fc880db809a273004483217edc"
+      "entity_derived": "niiri:03c13f292babfb2b1d3290faffb9e334",
+      "entity": "niiri:a32e7c63a62151c6c42d8b86e0a4c19e"
     },
     {
-      "@id": "niiri:c8181d0f3dc243173287af823030f8a6",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:4cc88fa1c2d357c36750e5a6a684d7c5",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0024",
-      "prov:atLocation": {"@id": "niiri:05396e3c44a36ced65e0057ce86ff36b"},
+      "prov:atLocation": {"@id": "niiri:0a07fa954d8bab227c98c3596c82c06e"},
       "prov:value": {"@type": "xsd:float", "@value": "5.05177354812622"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.74502150166861"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.04242094267626e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.128300853408892"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0133943818856599"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.74502150166861"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.04242094267626e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.128300853408892"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0133943818856599"}
     },
     {
-      "@id": "niiri:05396e3c44a36ced65e0057ce86ff36b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0a07fa954d8bab227c98c3596c82c06e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0024",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-36,-68,-20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-36,-68,-20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c8181d0f3dc243173287af823030f8a6",
-      "entity": "niiri:8447e2fc880db809a273004483217edc"
+      "entity_derived": "niiri:4cc88fa1c2d357c36750e5a6a684d7c5",
+      "entity": "niiri:a32e7c63a62151c6c42d8b86e0a4c19e"
     },
     {
-      "@id": "niiri:afbf96e3587255c2500918ed9b4aa838",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3cf98988c38bad72a5c4221177532d4d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0025",
-      "prov:atLocation": {"@id": "niiri:0d5b8cdd3918252b4418dda16c6f570b"},
+      "prov:atLocation": {"@id": "niiri:212b43414a4117095f4147d02a241fbc"},
       "prov:value": {"@type": "xsd:float", "@value": "4.12923574447632"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.95150505699521"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.88306154154305e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.94176507916668"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.131281271533869"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.95150505699521"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.88306154154305e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.94176507916668"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.131281271533869"}
     },
     {
-      "@id": "niiri:0d5b8cdd3918252b4418dda16c6f570b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:212b43414a4117095f4147d02a241fbc",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0025",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-30,-58,-16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-30,-58,-16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:afbf96e3587255c2500918ed9b4aa838",
-      "entity": "niiri:8447e2fc880db809a273004483217edc"
+      "entity_derived": "niiri:3cf98988c38bad72a5c4221177532d4d",
+      "entity": "niiri:a32e7c63a62151c6c42d8b86e0a4c19e"
     },
     {
-      "@id": "niiri:06f1be12bfa871726124f544f21c7b69",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a8c8296f49eb09a8f5f2bc2e7fe30473",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0026",
-      "prov:atLocation": {"@id": "niiri:e6b02a724ce3fd161f792f712268561e"},
+      "prov:atLocation": {"@id": "niiri:5e6ebb25f5bd7a0d3ffd55fc5a8c6ee8"},
       "prov:value": {"@type": "xsd:float", "@value": "5.30700492858887"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.95693297367533"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.58073340978038e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0530089422098637"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00589411306675136"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.95693297367533"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.58073340978038e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0530089422098637"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00589411306675136"}
     },
     {
-      "@id": "niiri:e6b02a724ce3fd161f792f712268561e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:5e6ebb25f5bd7a0d3ffd55fc5a8c6ee8",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0026",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-36,-74,-34]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-36,-74,-34]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:06f1be12bfa871726124f544f21c7b69",
-      "entity": "niiri:94238ef8670737705b8341502f2746a2"
+      "entity_derived": "niiri:a8c8296f49eb09a8f5f2bc2e7fe30473",
+      "entity": "niiri:f9c64f2f13c1018c1b0c90db5e455972"
     },
     {
-      "@id": "niiri:47f29222b154f5e5dad9d55f53b4c689",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5f7d79a55e6736946606e61cf06d0fef",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0027",
-      "prov:atLocation": {"@id": "niiri:e8196de7fed425575ae41f959e296985"},
+      "prov:atLocation": {"@id": "niiri:e3bf7803b46511439f4ae96a9a7dca98"},
       "prov:value": {"@type": "xsd:float", "@value": "3.51177191734314"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.39749381675455"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000340030624079946"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999824991842"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.523087759562521"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.39749381675455"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000340030624079946"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999824991842"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.523087759562521"}
     },
     {
-      "@id": "niiri:e8196de7fed425575ae41f959e296985",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e3bf7803b46511439f4ae96a9a7dca98",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0027",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-44,-62,-32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-44,-62,-32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:47f29222b154f5e5dad9d55f53b4c689",
-      "entity": "niiri:94238ef8670737705b8341502f2746a2"
+      "entity_derived": "niiri:5f7d79a55e6736946606e61cf06d0fef",
+      "entity": "niiri:f9c64f2f13c1018c1b0c90db5e455972"
     },
     {
-      "@id": "niiri:a7b836daecc245c7cc52bbf5c95f8bae",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:9325884a6c8f484b70d3de818aebf275",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0028",
-      "prov:atLocation": {"@id": "niiri:475ce32a7e381b3b19ba8dbc8078488b"},
+      "prov:atLocation": {"@id": "niiri:a7d68510d6f28e3c6be8d50b297c9719"},
       "prov:value": {"@type": "xsd:float", "@value": "5.28576564788818"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.93942736847709"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.91761603713014e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0571951960553233"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00627550171974501"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.93942736847709"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.91761603713014e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0571951960553233"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00627550171974501"}
     },
     {
-      "@id": "niiri:475ce32a7e381b3b19ba8dbc8078488b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a7d68510d6f28e3c6be8d50b297c9719",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0028",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[58,-38,6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[58,-38,6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a7b836daecc245c7cc52bbf5c95f8bae",
-      "entity": "niiri:56882afdece5437620adade43b7e28ed"
+      "entity_derived": "niiri:9325884a6c8f484b70d3de818aebf275",
+      "entity": "niiri:2e1d13240b9a458b380045313214b3ba"
     },
     {
-      "@id": "niiri:eb4db314cf8b3b6a98528630e857d5bd",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:60a921fcb727986aa30984a19c231f18",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0029",
-      "prov:atLocation": {"@id": "niiri:96bac1748016c54d2f342b97ac9a054d"},
+      "prov:atLocation": {"@id": "niiri:71e187cc3dbc6e62f7d1ac6db011de77"},
       "prov:value": {"@type": "xsd:float", "@value": "4.67409086227417"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.42530768589333"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.81524595430383e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.396915869709553"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0353779325915568"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.42530768589333"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.81524595430383e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.396915869709553"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0353779325915568"}
     },
     {
-      "@id": "niiri:96bac1748016c54d2f342b97ac9a054d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:71e187cc3dbc6e62f7d1ac6db011de77",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0029",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[62,-32,-6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[62,-32,-6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:eb4db314cf8b3b6a98528630e857d5bd",
-      "entity": "niiri:56882afdece5437620adade43b7e28ed"
+      "entity_derived": "niiri:60a921fcb727986aa30984a19c231f18",
+      "entity": "niiri:2e1d13240b9a458b380045313214b3ba"
     },
     {
-      "@id": "niiri:ccbc96ca1c1e19849232d29d0f7852fc",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b3d0ce5827aa453674fe13aef68e7d16",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0030",
-      "prov:atLocation": {"@id": "niiri:7af0e6e0e1f7dda0083c39e417eaa5ee"},
+      "prov:atLocation": {"@id": "niiri:dbbee4c7d179888417ce4d2b85538f44"},
       "prov:value": {"@type": "xsd:float", "@value": "4.45858383178711"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.23965208014699"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.11933243143181e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.641045560649102"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0627964060338669"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.23965208014699"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.11933243143181e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.641045560649102"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0627964060338669"}
     },
     {
-      "@id": "niiri:7af0e6e0e1f7dda0083c39e417eaa5ee",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:dbbee4c7d179888417ce4d2b85538f44",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0030",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[54,-24,-2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[54,-24,-2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ccbc96ca1c1e19849232d29d0f7852fc",
-      "entity": "niiri:56882afdece5437620adade43b7e28ed"
+      "entity_derived": "niiri:b3d0ce5827aa453674fe13aef68e7d16",
+      "entity": "niiri:2e1d13240b9a458b380045313214b3ba"
     },
     {
-      "@id": "niiri:5177a621d25aa2f0e2c93d7c7232dee5",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:794d4453dd2ad3bd3730dd91ae6b30e9",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0031",
-      "prov:atLocation": {"@id": "niiri:d5a31ec7b2cc7ef38380bc074667a747"},
+      "prov:atLocation": {"@id": "niiri:af634bd5ad9bbec585044c47707b7f32"},
       "prov:value": {"@type": "xsd:float", "@value": "5.24946975708008"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.9094577193641"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.56642935686702e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0650689222727684"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00706047439822435"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.9094577193641"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.56642935686702e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0650689222727684"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00706047439822435"}
     },
     {
-      "@id": "niiri:d5a31ec7b2cc7ef38380bc074667a747",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:af634bd5ad9bbec585044c47707b7f32",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0031",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-50,-60,54]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-50,-60,54]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5177a621d25aa2f0e2c93d7c7232dee5",
-      "entity": "niiri:80acc2ec15379dd56dd3a4d3c0d4db28"
+      "entity_derived": "niiri:794d4453dd2ad3bd3730dd91ae6b30e9",
+      "entity": "niiri:76bd6a834aaa05e8f24aef110c831619"
     },
     {
-      "@id": "niiri:9ddb05b4772809d6c8a6fa21104b3ce4",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:1a0ea80e15936593cdd19a72a1195f48",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0032",
-      "prov:atLocation": {"@id": "niiri:aba5327d5af4da14a38514380253613f"},
+      "prov:atLocation": {"@id": "niiri:4efa70bd6a3304ba75992adf5bb64efd"},
       "prov:value": {"@type": "xsd:float", "@value": "5.23662900924683"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.89883869005555"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.82023739367676e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0680871870860791"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00718215508152799"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.89883869005555"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.82023739367676e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0680871870860791"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00718215508152799"}
     },
     {
-      "@id": "niiri:aba5327d5af4da14a38514380253613f",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4efa70bd6a3304ba75992adf5bb64efd",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0032",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-46,-66,-6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-46,-66,-6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9ddb05b4772809d6c8a6fa21104b3ce4",
-      "entity": "niiri:f79d6102313cb9c1b58014d0d7523705"
+      "entity_derived": "niiri:1a0ea80e15936593cdd19a72a1195f48",
+      "entity": "niiri:16274414c81621b268626b188f47a6c7"
     },
     {
-      "@id": "niiri:8d58afd557e02ead7f00aee5185d8a62",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0569ccf24fdb31c7eaca9ab9fa246e95",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0033",
-      "prov:atLocation": {"@id": "niiri:dcfee15d7c5af57953f540a6cfe78315"},
+      "prov:atLocation": {"@id": "niiri:d7c5ae76657ceee4fe0930d8038110c3"},
       "prov:value": {"@type": "xsd:float", "@value": "4.40907335281372"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.19667377576541"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.35431823886645e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.698809001225567"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0687991026397412"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.19667377576541"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.35431823886645e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.698809001225567"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0687991026397412"}
     },
     {
-      "@id": "niiri:dcfee15d7c5af57953f540a6cfe78315",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d7c5ae76657ceee4fe0930d8038110c3",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0033",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-54,-64,-8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-54,-64,-8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8d58afd557e02ead7f00aee5185d8a62",
-      "entity": "niiri:f79d6102313cb9c1b58014d0d7523705"
+      "entity_derived": "niiri:0569ccf24fdb31c7eaca9ab9fa246e95",
+      "entity": "niiri:16274414c81621b268626b188f47a6c7"
     },
     {
-      "@id": "niiri:e1c1830378bf63fec3482cfd19fe2e8d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:2a23f426a8d1ce8819ab2ddb003a1fca",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0034",
-      "prov:atLocation": {"@id": "niiri:43b11b0b6cd9a3503e94b42496a7b062"},
+      "prov:atLocation": {"@id": "niiri:f576cf1614b186ed87892b67215577f8"},
       "prov:value": {"@type": "xsd:float", "@value": "5.04332971572876"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.73795333032992"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.07943756555429e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.131940099784902"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0134243353138188"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.73795333032992"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.07943756555429e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.131940099784902"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0134243353138188"}
     },
     {
-      "@id": "niiri:43b11b0b6cd9a3503e94b42496a7b062",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f576cf1614b186ed87892b67215577f8",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0034",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-60,-16,28]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-60,-16,28]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e1c1830378bf63fec3482cfd19fe2e8d",
-      "entity": "niiri:5c0356c4e08b4f78355f5f21c8c539f6"
+      "entity_derived": "niiri:2a23f426a8d1ce8819ab2ddb003a1fca",
+      "entity": "niiri:fb5ba293db82840b5cc150cc15515c24"
     },
     {
-      "@id": "niiri:c8f3169f2253aa77f13d1ad37adc2605",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:375f7b40758a242274e5d254e754d2ea",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0035",
-      "prov:atLocation": {"@id": "niiri:3e6a325415a49fc9471d3fbcccf71d24"},
+      "prov:atLocation": {"@id": "niiri:f4854b1ae4228726a13a570242046d52"},
       "prov:value": {"@type": "xsd:float", "@value": "4.99945306777954"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.70116602240923"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.29340041166159e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.152338396794269"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.014675241706815"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.70116602240923"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.29340041166159e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.152338396794269"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.014675241706815"}
     },
     {
-      "@id": "niiri:3e6a325415a49fc9471d3fbcccf71d24",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f4854b1ae4228726a13a570242046d52",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0035",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-36,-40,-36]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-36,-40,-36]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c8f3169f2253aa77f13d1ad37adc2605",
-      "entity": "niiri:5118b94ba0e2ab04227b9b6665cca04e"
+      "entity_derived": "niiri:375f7b40758a242274e5d254e754d2ea",
+      "entity": "niiri:aee52ad89a76ef41b6e67f9bca85ad62"
     },
     {
-      "@id": "niiri:36a7f9a2c42d2ca794a9e3522f8d1928",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:2bfeae4bd1acb4a2e2656604b5cb7718",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0036",
-      "prov:atLocation": {"@id": "niiri:a6411ba2cb861e9af1987013bf2957b1"},
+      "prov:atLocation": {"@id": "niiri:1f3ebb15787863a4d572b20cc801c020"},
       "prov:value": {"@type": "xsd:float", "@value": "4.65380764007568"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.40793303387591"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.21808997933082e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.417896183733559"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0374764670608795"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.40793303387591"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.21808997933082e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.417896183733559"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0374764670608795"}
     },
     {
-      "@id": "niiri:a6411ba2cb861e9af1987013bf2957b1",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:1f3ebb15787863a4d572b20cc801c020",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0036",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-50,-46,-32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-50,-46,-32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:36a7f9a2c42d2ca794a9e3522f8d1928",
-      "entity": "niiri:5118b94ba0e2ab04227b9b6665cca04e"
+      "entity_derived": "niiri:2bfeae4bd1acb4a2e2656604b5cb7718",
+      "entity": "niiri:aee52ad89a76ef41b6e67f9bca85ad62"
     },
     {
-      "@id": "niiri:37e2a7e20f76fc9bcbadf0f44aa25172",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0e8711e2fd8d14446a6962527ef6df3a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0037",
-      "prov:atLocation": {"@id": "niiri:d5fed0d62dac319d5e63e396d28cb9c2"},
+      "prov:atLocation": {"@id": "niiri:bc7434b50faea15d0f3428e0dacb67d6"},
       "prov:value": {"@type": "xsd:float", "@value": "4.85420560836792"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.57868324924493"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.33956067374752e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.239914320959961"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0223522363243732"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.57868324924493"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.33956067374752e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.239914320959961"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0223522363243732"}
     },
     {
-      "@id": "niiri:d5fed0d62dac319d5e63e396d28cb9c2",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:bc7434b50faea15d0f3428e0dacb67d6",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0037",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-26,-92,30]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-26,-92,30]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:37e2a7e20f76fc9bcbadf0f44aa25172",
-      "entity": "niiri:0d31cfbdb7c4e7ca55a57b1a21ab5433"
+      "entity_derived": "niiri:0e8711e2fd8d14446a6962527ef6df3a",
+      "entity": "niiri:594db02a9d179d5f91a6ed68ca678d59"
     },
     {
-      "@id": "niiri:a12a5737db849b63c6713b52e6643c97",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3891a8ece23ee8ae327ba5315f1c8fbe",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0038",
-      "prov:atLocation": {"@id": "niiri:2d0e29cec11584021e2c1254e0f7f0f4"},
+      "prov:atLocation": {"@id": "niiri:0f81dc717fe65942805f5d193ea9fc3d"},
       "prov:value": {"@type": "xsd:float", "@value": "4.61261701583862"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.37258550039614"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.1391853225512e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.462242958151503"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0413121935538803"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.37258550039614"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.1391853225512e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.462242958151503"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0413121935538803"}
     },
     {
-      "@id": "niiri:2d0e29cec11584021e2c1254e0f7f0f4",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0f81dc717fe65942805f5d193ea9fc3d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0038",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-20,-98,22]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-20,-98,22]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a12a5737db849b63c6713b52e6643c97",
-      "entity": "niiri:0d31cfbdb7c4e7ca55a57b1a21ab5433"
+      "entity_derived": "niiri:3891a8ece23ee8ae327ba5315f1c8fbe",
+      "entity": "niiri:594db02a9d179d5f91a6ed68ca678d59"
     },
     {
-      "@id": "niiri:98435de98cb92135e1395fc98c4e42ea",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ea7488d0b50894dd4de66796e80748b7",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0039",
-      "prov:atLocation": {"@id": "niiri:c98cf93e5324c36b7ecdadecb43a57ba"},
+      "prov:atLocation": {"@id": "niiri:7a7d15cade7651c7745d9e603461b155"},
       "prov:value": {"@type": "xsd:float", "@value": "4.8499321937561"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.57506330130209"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.38038009880981e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.24300196499404"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0224201392740291"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.57506330130209"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.38038009880981e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.24300196499404"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0224201392740291"}
     },
     {
-      "@id": "niiri:c98cf93e5324c36b7ecdadecb43a57ba",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7a7d15cade7651c7745d9e603461b155",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0039",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[34,-54,-16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[34,-54,-16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:98435de98cb92135e1395fc98c4e42ea",
-      "entity": "niiri:dc4429e2fc1e2581ade7dee26c4a3192"
+      "entity_derived": "niiri:ea7488d0b50894dd4de66796e80748b7",
+      "entity": "niiri:6dd3d0166eed8b2fa885aeca84711d27"
     },
     {
-      "@id": "niiri:07b523e4122fe41175a47c7df60bb532",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:4331fbbba36aaea44c7a85c25098ab20",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0040",
-      "prov:atLocation": {"@id": "niiri:1d9b62cf26c539d32ccf4b664c13d80c"},
+      "prov:atLocation": {"@id": "niiri:682cd9521a1b69e766ac8efe8ede5da3"},
       "prov:value": {"@type": "xsd:float", "@value": "4.83638429641724"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.56358093042646"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.51442057541684e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.252994517911213"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.023220278156989"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.56358093042646"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.51442057541684e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.252994517911213"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.023220278156989"}
     },
     {
-      "@id": "niiri:1d9b62cf26c539d32ccf4b664c13d80c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:682cd9521a1b69e766ac8efe8ede5da3",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0040",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-18,-60,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-18,-60,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:07b523e4122fe41175a47c7df60bb532",
-      "entity": "niiri:63325afca9aca401a92169c0b82ecc64"
+      "entity_derived": "niiri:4331fbbba36aaea44c7a85c25098ab20",
+      "entity": "niiri:17120da53c5050105b9a8ee0e996c32d"
     },
     {
-      "@id": "niiri:661dcfb5c748c84f14f1e71317c8e9bd",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ab0ca88496f4fad69a12f72d809de0f9",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0041",
-      "prov:atLocation": {"@id": "niiri:708d21d2b6912d4c968b36cc2111475f"},
+      "prov:atLocation": {"@id": "niiri:de2a4a77e9c99754a28b73a5b8437f70"},
       "prov:value": {"@type": "xsd:float", "@value": "4.82152557373047"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.55097685331641"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.66987113994865e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.264312575763193"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0238865523925716"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.55097685331641"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.66987113994865e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.264312575763193"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0238865523925716"}
     },
     {
-      "@id": "niiri:708d21d2b6912d4c968b36cc2111475f",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:de2a4a77e9c99754a28b73a5b8437f70",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0041",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[16,-98,6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[16,-98,6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:661dcfb5c748c84f14f1e71317c8e9bd",
-      "entity": "niiri:8b5b90b720b0adec672c0f46135febcd"
+      "entity_derived": "niiri:ab0ca88496f4fad69a12f72d809de0f9",
+      "entity": "niiri:a533e0119aa33105f1f6664ba02c4fcf"
     },
     {
-      "@id": "niiri:fe4e7bc5932bd8388b247e5fff5e94ec",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:217c4b04d55535db719b6c29ed1ff920",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0042",
-      "prov:atLocation": {"@id": "niiri:97ee939496de2a28a732944cdce87004"},
+      "prov:atLocation": {"@id": "niiri:1eb03fa5a0b00d4cdae57571d3ef05b1"},
       "prov:value": {"@type": "xsd:float", "@value": "4.73149728775024"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.47436989109174"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.83184874719333e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.340973924582382"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0306600822692826"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.47436989109174"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.83184874719333e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.340973924582382"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0306600822692826"}
     },
     {
-      "@id": "niiri:97ee939496de2a28a732944cdce87004",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:1eb03fa5a0b00d4cdae57571d3ef05b1",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0042",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-22,-74,60]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-22,-74,60]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:fe4e7bc5932bd8388b247e5fff5e94ec",
-      "entity": "niiri:e37885e426d196d0484be86dc5869e7e"
+      "entity_derived": "niiri:217c4b04d55535db719b6c29ed1ff920",
+      "entity": "niiri:b5ea5e54d015aa2a8403364ed7da486d"
     },
     {
-      "@id": "niiri:35974aa649462ecc668ba9c8972a01d5",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:7a9ada485db0a1f6554f9ab114f1a05e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0043",
-      "prov:atLocation": {"@id": "niiri:7f0e444835e1d3ff62c42a54aef5a3de"},
+      "prov:atLocation": {"@id": "niiri:c3c5fa1f2191acb1c8d708293a305572"},
       "prov:value": {"@type": "xsd:float", "@value": "4.21357154846191"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.0257920609862"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.83919260934962e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.889725031810111"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.110652635086932"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.0257920609862"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.83919260934962e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.889725031810111"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.110652635086932"}
     },
     {
-      "@id": "niiri:7f0e444835e1d3ff62c42a54aef5a3de",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c3c5fa1f2191acb1c8d708293a305572",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0043",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-30,-72,60]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-30,-72,60]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:35974aa649462ecc668ba9c8972a01d5",
-      "entity": "niiri:e37885e426d196d0484be86dc5869e7e"
+      "entity_derived": "niiri:7a9ada485db0a1f6554f9ab114f1a05e",
+      "entity": "niiri:b5ea5e54d015aa2a8403364ed7da486d"
     },
     {
-      "@id": "niiri:b96598f322b442287e94f7963a5ef7be",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:8fed5f4ed36ab7a842539b15f966adc0",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0044",
-      "prov:atLocation": {"@id": "niiri:227085f9eb278530bc05c8d8434a7b57"},
+      "prov:atLocation": {"@id": "niiri:80ae6d5477f69a5848ae8d004bebcce2"},
       "prov:value": {"@type": "xsd:float", "@value": "4.64556264877319"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.40086444790859"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.39102339658371e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.426592793295939"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0381376242551822"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.40086444790859"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.39102339658371e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.426592793295939"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0381376242551822"}
     },
     {
-      "@id": "niiri:227085f9eb278530bc05c8d8434a7b57",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:80ae6d5477f69a5848ae8d004bebcce2",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0044",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-40,-40,44]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-40,-40,44]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b96598f322b442287e94f7963a5ef7be",
-      "entity": "niiri:b98e5a23cb840529bde8f8f04eb60352"
+      "entity_derived": "niiri:8fed5f4ed36ab7a842539b15f966adc0",
+      "entity": "niiri:16c2a7e89d0686e69f57bbeea9dc74a5"
     },
     {
-      "@id": "niiri:c610d6e1581a13855c65cbf2e5a331db",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a3ad563a699cc4326f49719045069cc7",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0045",
-      "prov:atLocation": {"@id": "niiri:7c52fbc2c3475dd9b4cde89011654125"},
+      "prov:atLocation": {"@id": "niiri:4fd23de23846ef30d2daff0b25a2d2d3"},
       "prov:value": {"@type": "xsd:float", "@value": "4.63093709945679"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.38831729610845"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.71155195205897e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.442246950226133"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0396432116271416"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.38831729610845"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.71155195205897e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.442246950226133"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0396432116271416"}
     },
     {
-      "@id": "niiri:7c52fbc2c3475dd9b4cde89011654125",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4fd23de23846ef30d2daff0b25a2d2d3",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0045",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-46,-56,14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-46,-56,14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c610d6e1581a13855c65cbf2e5a331db",
-      "entity": "niiri:08f981dcb0b605dc38e14328cd560d6b"
+      "entity_derived": "niiri:a3ad563a699cc4326f49719045069cc7",
+      "entity": "niiri:325d5f27465210c036cd8d865e80251d"
     },
     {
-      "@id": "niiri:4686902807199f04fb73d08d03ae21b5",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f46c43948a24d962d4b5ed9559dbdf9e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0046",
-      "prov:atLocation": {"@id": "niiri:a317f4f10b064fd4ba620cc89c011dee"},
+      "prov:atLocation": {"@id": "niiri:348fb68fe1e81a7d2e8118131777d3f5"},
       "prov:value": {"@type": "xsd:float", "@value": "4.48052835464478"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.25866261513588"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.02826793976218e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.615092838959958"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0606653213752077"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.25866261513588"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.02826793976218e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.615092838959958"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0606653213752077"}
     },
     {
-      "@id": "niiri:a317f4f10b064fd4ba620cc89c011dee",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:348fb68fe1e81a7d2e8118131777d3f5",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0046",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-50,-50,20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-50,-50,20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4686902807199f04fb73d08d03ae21b5",
-      "entity": "niiri:08f981dcb0b605dc38e14328cd560d6b"
+      "entity_derived": "niiri:f46c43948a24d962d4b5ed9559dbdf9e",
+      "entity": "niiri:325d5f27465210c036cd8d865e80251d"
     },
     {
-      "@id": "niiri:646e57d59fbd19fa3d0dfaf644650137",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:32ab5b28df46c33eedc2644958600327",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0047",
-      "prov:atLocation": {"@id": "niiri:d4939a061c7c02573a9d3a436a2a078e"},
+      "prov:atLocation": {"@id": "niiri:7cf03031cc3525780bb00e6d00dbb1ed"},
       "prov:value": {"@type": "xsd:float", "@value": "4.62564182281494"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.38377187185421"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.83209600213408e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.447983703874853"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0399535201049753"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.38377187185421"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.83209600213408e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.447983703874853"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0399535201049753"}
     },
     {
-      "@id": "niiri:d4939a061c7c02573a9d3a436a2a078e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7cf03031cc3525780bb00e6d00dbb1ed",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0047",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-54,-48,-16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-54,-48,-16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:646e57d59fbd19fa3d0dfaf644650137",
-      "entity": "niiri:d757dae4ee0e2ef151ed77b98cda2382"
+      "entity_derived": "niiri:32ab5b28df46c33eedc2644958600327",
+      "entity": "niiri:a77994161041027f0cf04defd7345c50"
     },
     {
-      "@id": "niiri:0d5f97bc29f0ce07bce15596e53fc18e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d100c51eef378500eb4feffaffb6838f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0048",
-      "prov:atLocation": {"@id": "niiri:898343045ef37f06d4b7c6e32adced9c"},
+      "prov:atLocation": {"@id": "niiri:3b11bab9e0b69b19971b373a7f1603ee"},
       "prov:value": {"@type": "xsd:float", "@value": "4.39731121063232"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.1864457158313"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.41678330879413e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.712242817080673"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0701395133156884"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.1864457158313"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.41678330879413e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.712242817080673"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0701395133156884"}
     },
     {
-      "@id": "niiri:898343045ef37f06d4b7c6e32adced9c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:3b11bab9e0b69b19971b373a7f1603ee",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0048",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-36,-46,-18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-36,-46,-18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0d5f97bc29f0ce07bce15596e53fc18e",
-      "entity": "niiri:d757dae4ee0e2ef151ed77b98cda2382"
+      "entity_derived": "niiri:d100c51eef378500eb4feffaffb6838f",
+      "entity": "niiri:a77994161041027f0cf04defd7345c50"
     },
     {
-      "@id": "niiri:719f3073ced10d662956b4ec37d4eb46",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:18a234ca0f5ed1ecc2090e7679e74552",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0049",
-      "prov:atLocation": {"@id": "niiri:4b4180a632f4272c9c87a6a4e225809d"},
+      "prov:atLocation": {"@id": "niiri:1c7aecbd92310ea0de4913e7e7d71499"},
       "prov:value": {"@type": "xsd:float", "@value": "4.53011417388916"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.30153087828584"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.48110654050327e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.556525968503526"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0536338708992394"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.30153087828584"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.48110654050327e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.556525968503526"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0536338708992394"}
     },
     {
-      "@id": "niiri:4b4180a632f4272c9c87a6a4e225809d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:1c7aecbd92310ea0de4913e7e7d71499",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0049",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[12,-100,20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[12,-100,20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:719f3073ced10d662956b4ec37d4eb46",
-      "entity": "niiri:660ef8a46b7c1f0d47e1dbb95e0879b4"
+      "entity_derived": "niiri:18a234ca0f5ed1ecc2090e7679e74552",
+      "entity": "niiri:78d6f29ff8a7c1f0a21810728ade20ce"
     },
     {
-      "@id": "niiri:89b2932e09b8bb2437d3f5dfb657c381",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:9f7600af4f7127e3e35e8956824b24cd",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0050",
-      "prov:atLocation": {"@id": "niiri:fedf5f20b57a4edec1241ce009390256"},
+      "prov:atLocation": {"@id": "niiri:589510f1d277d70bd38e8b41f5208f6d"},
       "prov:value": {"@type": "xsd:float", "@value": "4.43985033035278"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.22340441164883"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.20319728781348e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.663080040726423"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0655195642105904"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.22340441164883"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.20319728781348e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.663080040726423"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0655195642105904"}
     },
     {
-      "@id": "niiri:fedf5f20b57a4edec1241ce009390256",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:589510f1d277d70bd38e8b41f5208f6d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0050",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-48,2,50]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-48,2,50]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:89b2932e09b8bb2437d3f5dfb657c381",
-      "entity": "niiri:376742ba10824087fba971d247dc6783"
+      "entity_derived": "niiri:9f7600af4f7127e3e35e8956824b24cd",
+      "entity": "niiri:ef6fca405f462fa8c50ca4b0f7e48ca2"
     },
     {
-      "@id": "niiri:49ae21bfe675fa8b9db9ef01f21c8038",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:8603599eaf15b47cfc1747721a7cc043",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0051",
-      "prov:atLocation": {"@id": "niiri:ce304c4adfe4941f409f65439c15570c"},
+      "prov:atLocation": {"@id": "niiri:3808a783cb30debaf04ca96ba0dbfe0b"},
       "prov:value": {"@type": "xsd:float", "@value": "4.42902088165283"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.21400406802287"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.25441381573221e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.675732426251063"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0666653677861119"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.21400406802287"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.25441381573221e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.675732426251063"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0666653677861119"}
     },
     {
-      "@id": "niiri:ce304c4adfe4941f409f65439c15570c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:3808a783cb30debaf04ca96ba0dbfe0b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0051",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[20,-66,34]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[20,-66,34]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:49ae21bfe675fa8b9db9ef01f21c8038",
-      "entity": "niiri:8bb3c55367529f573f350336b59c6b8b"
+      "entity_derived": "niiri:8603599eaf15b47cfc1747721a7cc043",
+      "entity": "niiri:6578b8b9d153de72a9648c8488a6ac3f"
     },
     {
-      "@id": "niiri:a74a7f5b172dd1bc08ef2dec3a109f2b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:975035177d9f223d416eac85677dd73e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0052",
-      "prov:atLocation": {"@id": "niiri:6abd9bc5c4f38523e809b1b44a7e99c7"},
+      "prov:atLocation": {"@id": "niiri:e2acd36a46999c63dbedb34bdf074c27"},
       "prov:value": {"@type": "xsd:float", "@value": "4.34153509140015"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.13785173162383"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.75286391850271e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.773482364050178"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0797247033163797"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.13785173162383"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.75286391850271e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.773482364050178"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0797247033163797"}
     },
     {
-      "@id": "niiri:6abd9bc5c4f38523e809b1b44a7e99c7",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e2acd36a46999c63dbedb34bdf074c27",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0052",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[22,-80,54]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[22,-80,54]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a74a7f5b172dd1bc08ef2dec3a109f2b",
-      "entity": "niiri:ecc219c77c0dd1cbef88e6f794b57b51"
+      "entity_derived": "niiri:975035177d9f223d416eac85677dd73e",
+      "entity": "niiri:aa346a17d504ccda6e8f3483bc7567b5"
     },
     {
-      "@id": "niiri:c8cec8ce3cce361e7b04223a9a2f20db",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d8e002f5cf7541fe9f68b39c0d8728f6",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0053",
-      "prov:atLocation": {"@id": "niiri:cd9524eda65364a8a8405fe492ce646b"},
+      "prov:atLocation": {"@id": "niiri:49a3b54ceb9b87ab4cf4da4698244a80"},
       "prov:value": {"@type": "xsd:float", "@value": "4.31018495559692"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.11047161264349"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.97425911666604e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.805553175655503"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0852768580529791"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.11047161264349"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.97425911666604e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.805553175655503"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0852768580529791"}
     },
     {
-      "@id": "niiri:cd9524eda65364a8a8405fe492ce646b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:49a3b54ceb9b87ab4cf4da4698244a80",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0053",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[4,8,32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[4,8,32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c8cec8ce3cce361e7b04223a9a2f20db",
-      "entity": "niiri:a1fc6b7fb08f44460fa83f1e82f3fd55"
+      "entity_derived": "niiri:d8e002f5cf7541fe9f68b39c0d8728f6",
+      "entity": "niiri:edeaef5183ad24011f37f4883d8f953f"
     },
     {
-      "@id": "niiri:6caf772783f0738d4f58c46fb421d510",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:2159f676fe87211c3a34c5173f62ef52",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0054",
-      "prov:atLocation": {"@id": "niiri:173fb0d61a88e2483da7d0266666f1a1"},
+      "prov:atLocation": {"@id": "niiri:66764c6a7d0744dbfb27c4acb10e5096"},
       "prov:value": {"@type": "xsd:float", "@value": "4.27076530456543"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.07597586124442"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.29108861893312e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.842807876097015"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0956335108049698"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.07597586124442"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.29108861893312e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.842807876097015"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0956335108049698"}
     },
     {
-      "@id": "niiri:173fb0d61a88e2483da7d0266666f1a1",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:66764c6a7d0744dbfb27c4acb10e5096",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0054",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[44,-48,-26]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[44,-48,-26]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6caf772783f0738d4f58c46fb421d510",
-      "entity": "niiri:6e25dc1a7cdabbe6238b8c8ba92a299b"
+      "entity_derived": "niiri:2159f676fe87211c3a34c5173f62ef52",
+      "entity": "niiri:82b6d07ebf78a88f41741c7c0b4d138a"
     },
     {
-      "@id": "niiri:3e0bd7638cd27fee067494ec2e4e07d4",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d20759428478e6a2ecc5a6ac0336248b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0055",
-      "prov:atLocation": {"@id": "niiri:19bd910171088a8550259102076d90a9"},
+      "prov:atLocation": {"@id": "niiri:92ee6df0fc18e5cad532440d06b401d5"},
       "prov:value": {"@type": "xsd:float", "@value": "4.24014186859131"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.04912548760248"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.57046875662414e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.869047635745501"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.103527958580522"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.04912548760248"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.57046875662414e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.869047635745501"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.103527958580522"}
     },
     {
-      "@id": "niiri:19bd910171088a8550259102076d90a9",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:92ee6df0fc18e5cad532440d06b401d5",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0055",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[12,52,-12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[12,52,-12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3e0bd7638cd27fee067494ec2e4e07d4",
-      "entity": "niiri:b6d54c10be27fe7c4485995dd9f9debb"
+      "entity_derived": "niiri:d20759428478e6a2ecc5a6ac0336248b",
+      "entity": "niiri:23d958b69d91f95e528ceb5e2197a63a"
     },
     {
-      "@id": "niiri:3276fdd6ddac14ff6d0a7f8503e92620",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:93dad7155ab8df6434cf30dc96e0fec7",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0056",
-      "prov:atLocation": {"@id": "niiri:89f5ddbbe89a675a72593041a3ca09c3"},
+      "prov:atLocation": {"@id": "niiri:b31a74eef450f2def5dc49026d2b9709"},
       "prov:value": {"@type": "xsd:float", "@value": "4.16103744506836"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.97955763826227"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.45218098449784e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.924586885045607"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.124121852318798"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.97955763826227"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.45218098449784e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.924586885045607"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.124121852318798"}
     },
     {
-      "@id": "niiri:89f5ddbbe89a675a72593041a3ca09c3",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b31a74eef450f2def5dc49026d2b9709",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0056",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-14,-98,-4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-14,-98,-4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3276fdd6ddac14ff6d0a7f8503e92620",
-      "entity": "niiri:ef72e4c2ccfe576af6dd9f5327bf55b9"
+      "entity_derived": "niiri:93dad7155ab8df6434cf30dc96e0fec7",
+      "entity": "niiri:cd749510acee370dec9860a5407637f5"
     },
     {
-      "@id": "niiri:c3cf99e426979369b4cc70ab2cae8447",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:609028d01e5972e824b32d95ae48bf7d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0057",
-      "prov:atLocation": {"@id": "niiri:6bc0a88ccb9d151b3ac0defe4208c807"},
+      "prov:atLocation": {"@id": "niiri:594a7521ca57e63a87ec7cde2e7d4ff4"},
       "prov:value": {"@type": "xsd:float", "@value": "4.15926313400269"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.97799377863742"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.47495948790355e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.925622766117185"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.124121852318798"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.97799377863742"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.47495948790355e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.925622766117185"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.124121852318798"}
     },
     {
-      "@id": "niiri:6bc0a88ccb9d151b3ac0defe4208c807",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:594a7521ca57e63a87ec7cde2e7d4ff4",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0057",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-66,-36,22]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-66,-36,22]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c3cf99e426979369b4cc70ab2cae8447",
-      "entity": "niiri:13d8b78f07281f4256fd3c0ec01dd4c4"
+      "entity_derived": "niiri:609028d01e5972e824b32d95ae48bf7d",
+      "entity": "niiri:13d9d29fd974d6893c1726d57a98a10f"
     },
     {
-      "@id": "niiri:2db15528ae3236f993ac8beb03c4de36",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b4946cfd559a49dd59da4eb959fcc3ff",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0058",
-      "prov:atLocation": {"@id": "niiri:380a61017b4fcac325a0d7b0d9817a82"},
+      "prov:atLocation": {"@id": "niiri:329b7745f4e1247cdc3009fe502edade"},
       "prov:value": {"@type": "xsd:float", "@value": "4.15127944946289"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.9709551719526"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.57925246584623e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.930169830491485"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.125812633483204"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.9709551719526"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.57925246584623e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.930169830491485"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.125812633483204"}
     },
     {
-      "@id": "niiri:380a61017b4fcac325a0d7b0d9817a82",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:329b7745f4e1247cdc3009fe502edade",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0058",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[64,-30,-22]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[64,-30,-22]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2db15528ae3236f993ac8beb03c4de36",
-      "entity": "niiri:ba735e41f5c81e821d5431a5f33299b3"
+      "entity_derived": "niiri:b4946cfd559a49dd59da4eb959fcc3ff",
+      "entity": "niiri:0d04d9bc9dd104e43dd556533a5b2159"
     },
     {
-      "@id": "niiri:5844041981df16af64c11ea3ca033105",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:90fe65bd993a69b371b497dd0b82c3c9",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0059",
-      "prov:atLocation": {"@id": "niiri:e921ad0529a987659faf7f7d41190fa8"},
+      "prov:atLocation": {"@id": "niiri:9152c663953a89724e0ad9d96a65b31b"},
       "prov:value": {"@type": "xsd:float", "@value": "3.68732213973999"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.55676980326808"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000187721434294241"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999949562856829"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.36844208672846"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.55676980326808"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000187721434294241"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999949562856829"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.36844208672846"}
     },
     {
-      "@id": "niiri:e921ad0529a987659faf7f7d41190fa8",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:9152c663953a89724e0ad9d96a65b31b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0059",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[56,-22,-26]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[56,-22,-26]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5844041981df16af64c11ea3ca033105",
-      "entity": "niiri:ba735e41f5c81e821d5431a5f33299b3"
+      "entity_derived": "niiri:90fe65bd993a69b371b497dd0b82c3c9",
+      "entity": "niiri:0d04d9bc9dd104e43dd556533a5b2159"
     },
     {
-      "@id": "niiri:4b10c5aa444bfcc5979b02cc6a8de1ee",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:829760ac18f565fb23d2dd89751a104f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0060",
-      "prov:atLocation": {"@id": "niiri:8a6738ef74783ec9f92765754adb881c"},
+      "prov:atLocation": {"@id": "niiri:1b86c75e5e0acab33754c3d010276da8"},
       "prov:value": {"@type": "xsd:float", "@value": "4.1501989364624"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.97000233107989"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.59359643187229e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.930770937360285"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.125812633483204"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.97000233107989"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.59359643187229e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.930770937360285"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.125812633483204"}
     },
     {
-      "@id": "niiri:8a6738ef74783ec9f92765754adb881c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:1b86c75e5e0acab33754c3d010276da8",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0060",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-64,-34,8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-64,-34,8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4b10c5aa444bfcc5979b02cc6a8de1ee",
-      "entity": "niiri:9d954ccdd2f76e6021425a58f7079443"
+      "entity_derived": "niiri:829760ac18f565fb23d2dd89751a104f",
+      "entity": "niiri:7d13eda0d79684f0d63dac1332405064"
     },
     {
-      "@id": "niiri:6cf25f5b7542b6357ca8f008bf7ee40c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:11c5084b4dd50bda5192de6afa001779",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0061",
-      "prov:atLocation": {"@id": "niiri:e0aa1b34fca06e04917572c4bd840215"},
+      "prov:atLocation": {"@id": "niiri:f34f6b3556c1161d085528b512b8676a"},
       "prov:value": {"@type": "xsd:float", "@value": "4.11570262908936"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.93955268733486"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.08168366777817e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.948197934370974"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.135780811447955"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.93955268733486"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.08168366777817e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.948197934370974"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.135780811447955"}
     },
     {
-      "@id": "niiri:e0aa1b34fca06e04917572c4bd840215",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f34f6b3556c1161d085528b512b8676a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0061",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[50,46,-12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[50,46,-12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6cf25f5b7542b6357ca8f008bf7ee40c",
-      "entity": "niiri:3964078dd1cffc5e5036d7bec9ce573c"
+      "entity_derived": "niiri:11c5084b4dd50bda5192de6afa001779",
+      "entity": "niiri:9cc2d1c11d4e3b5aec5735ee91c1aca3"
     },
     {
-      "@id": "niiri:f69685daf2174c4ae82dd0bbf18c1815",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3c355638d7475943124ba9c226bfa69e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0062",
-      "prov:atLocation": {"@id": "niiri:991fe3f754094eaafd88889c8d5216bc"},
+      "prov:atLocation": {"@id": "niiri:277c0c1b8a9d2a7136d6fb53100f4535"},
       "prov:value": {"@type": "xsd:float", "@value": "4.06387186050415"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.89369529283678"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.93643251464615e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.968279346551793"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.154561047969304"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.89369529283678"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.93643251464615e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.968279346551793"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.154561047969304"}
     },
     {
-      "@id": "niiri:991fe3f754094eaafd88889c8d5216bc",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:277c0c1b8a9d2a7136d6fb53100f4535",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0062",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-38,-54,-42]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-38,-54,-42]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f69685daf2174c4ae82dd0bbf18c1815",
-      "entity": "niiri:53d1ede95ea7c0b47d5a32d1a51fe6f6"
+      "entity_derived": "niiri:3c355638d7475943124ba9c226bfa69e",
+      "entity": "niiri:5b5b201251a2cc570135bacff1a480b1"
     },
     {
-      "@id": "niiri:5a579d94d1d6355560b569d363350e71",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:73c33f38c5fedbbd36089605d2e2bed2",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0063",
-      "prov:atLocation": {"@id": "niiri:cbc27995bdd6690158ded00c24f95c43"},
+      "prov:atLocation": {"@id": "niiri:4fa8c02bb9d4119aac7ac8a420647cc3"},
       "prov:value": {"@type": "xsd:float", "@value": "3.63390350341797"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.50844773659595"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000225364892119218"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999988653013371"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.410740156420602"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.50844773659595"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000225364892119218"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999988653013371"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.410740156420602"}
     },
     {
-      "@id": "niiri:cbc27995bdd6690158ded00c24f95c43",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4fa8c02bb9d4119aac7ac8a420647cc3",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0063",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-30,-64,-40]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-30,-64,-40]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5a579d94d1d6355560b569d363350e71",
-      "entity": "niiri:53d1ede95ea7c0b47d5a32d1a51fe6f6"
+      "entity_derived": "niiri:73c33f38c5fedbbd36089605d2e2bed2",
+      "entity": "niiri:5b5b201251a2cc570135bacff1a480b1"
     },
     {
-      "@id": "niiri:0c9ed16566b9a044c58f9a53ebcfa5ae",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:dabeaf7666f754dfe37065b88c4f4b4a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0064",
-      "prov:atLocation": {"@id": "niiri:552e53c37b7f2030b7eb1cdc79b997f9"},
+      "prov:atLocation": {"@id": "niiri:dc22bbd3df567f1be35fd703ae919813"},
       "prov:value": {"@type": "xsd:float", "@value": "4.04323768615723"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.87540363822468"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.32240496489145e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.974420729710188"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.16275733943943"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.87540363822468"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.32240496489145e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.974420729710188"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.16275733943943"}
     },
     {
-      "@id": "niiri:552e53c37b7f2030b7eb1cdc79b997f9",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:dc22bbd3df567f1be35fd703ae919813",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0064",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-14,58,10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-14,58,10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0c9ed16566b9a044c58f9a53ebcfa5ae",
-      "entity": "niiri:c603845c76b83d0aac64a7584957c8fb"
+      "entity_derived": "niiri:dabeaf7666f754dfe37065b88c4f4b4a",
+      "entity": "niiri:bbf4ce7e2e67235f45331b2b87133bd7"
     },
     {
-      "@id": "niiri:d0bd5daab811539f6aa16803b1f69e0d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a62d0b592d043fda22e569f6cdb71fff",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0065",
-      "prov:atLocation": {"@id": "niiri:950ebf76d82ec218bb221dea05e45b68"},
+      "prov:atLocation": {"@id": "niiri:b487eb50f6635294ac4f3e02f1fd9c9d"},
       "prov:value": {"@type": "xsd:float", "@value": "4.03806781768799"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.87081752636553"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.4235483319065e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.975809063970924"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.164182416202422"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.87081752636553"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.4235483319065e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.975809063970924"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.164182416202422"}
     },
     {
-      "@id": "niiri:950ebf76d82ec218bb221dea05e45b68",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b487eb50f6635294ac4f3e02f1fd9c9d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0065",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-68,-34,-8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-68,-34,-8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d0bd5daab811539f6aa16803b1f69e0d",
-      "entity": "niiri:a2777ad5b03729d935f9c97ada730fc3"
+      "entity_derived": "niiri:a62d0b592d043fda22e569f6cdb71fff",
+      "entity": "niiri:6a09c31a2cb2399d4dfaa1e9734b3056"
     },
     {
-      "@id": "niiri:0c8cf9f791296db553228e784b948a60",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:4ac0f9aefed1176b14b9abe74250cbdc",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0066",
-      "prov:atLocation": {"@id": "niiri:5a2845a510ed56c8245862414385ae2d"},
+      "prov:atLocation": {"@id": "niiri:a0b34589df34a16d82775f29cdb325a5"},
       "prov:value": {"@type": "xsd:float", "@value": "4.004225730896"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.84076553938526"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.13256092123482e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.983537497151825"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.17776479000337"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.84076553938526"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.13256092123482e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.983537497151825"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.17776479000337"}
     },
     {
-      "@id": "niiri:5a2845a510ed56c8245862414385ae2d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a0b34589df34a16d82775f29cdb325a5",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0066",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[16,60,12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[16,60,12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0c8cf9f791296db553228e784b948a60",
-      "entity": "niiri:6be135d40f33855edbacae1ce12b09f5"
+      "entity_derived": "niiri:4ac0f9aefed1176b14b9abe74250cbdc",
+      "entity": "niiri:19eff7c42f4c5b43b8936b6bb77abf9e"
     },
     {
-      "@id": "niiri:ae4d80f7faf7c00b6317be8fab64a0ae",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e022009b24cfb049ed10bbfee681d92a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0067",
-      "prov:atLocation": {"@id": "niiri:a6f430823385cf68ac955fbcde5ccf0d"},
+      "prov:atLocation": {"@id": "niiri:2f7b36f5f675f649d99cf764343de5c7"},
       "prov:value": {"@type": "xsd:float", "@value": "3.97911667823792"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.81843367367204"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.71508406763222e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.987909478842303"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.188766279331586"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.81843367367204"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.71508406763222e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.987909478842303"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.188766279331586"}
     },
     {
-      "@id": "niiri:a6f430823385cf68ac955fbcde5ccf0d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:2f7b36f5f675f649d99cf764343de5c7",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0067",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[64,-32,16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[64,-32,16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ae4d80f7faf7c00b6317be8fab64a0ae",
-      "entity": "niiri:28624557fd946e461b8d82ec16375193"
+      "entity_derived": "niiri:e022009b24cfb049ed10bbfee681d92a",
+      "entity": "niiri:3a53732749467fad732fc1b126252b83"
     },
     {
-      "@id": "niiri:8f3bd36f94307a5043af1375afb8bcf9",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:abbe5bd49d9338f66a3af445c1e2372c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0068",
-      "prov:atLocation": {"@id": "niiri:8e8c43bd6056d92334167a8eba37616a"},
+      "prov:atLocation": {"@id": "niiri:7cce260bd801b5e637a5ae78e7cc6a21"},
       "prov:value": {"@type": "xsd:float", "@value": "3.96304869651794"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.80412735630895"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.11524784513529e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99018444524646"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.196465422200293"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.80412735630895"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.11524784513529e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99018444524646"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.196465422200293"}
     },
     {
-      "@id": "niiri:8e8c43bd6056d92334167a8eba37616a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7cce260bd801b5e637a5ae78e7cc6a21",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0068",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-58,-32,22]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-58,-32,22]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8f3bd36f94307a5043af1375afb8bcf9",
-      "entity": "niiri:553d9ccd8301231daa8b7127b7d9fb7f"
+      "entity_derived": "niiri:abbe5bd49d9338f66a3af445c1e2372c",
+      "entity": "niiri:4489ae9a89d81f59b4a316f0bc2ca8b8"
     },
     {
-      "@id": "niiri:67420928e9c0b8ce182108cae0641e1d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:578bcf6846bd5b49337bc46c4d7b1c7f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0069",
-      "prov:atLocation": {"@id": "niiri:fdca36f535ff1520cacb92c9bc046bab"},
+      "prov:atLocation": {"@id": "niiri:23bd153efdafbf140cfa0b6666fc959e"},
       "prov:value": {"@type": "xsd:float", "@value": "3.92521071434021"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.77039013890334"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.14962714239531e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.994203174123576"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.214086162162037"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.77039013890334"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.14962714239531e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.994203174123576"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.214086162162037"}
     },
     {
-      "@id": "niiri:fdca36f535ff1520cacb92c9bc046bab",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:23bd153efdafbf140cfa0b6666fc959e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0069",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[42,-42,14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[42,-42,14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:67420928e9c0b8ce182108cae0641e1d",
-      "entity": "niiri:2a7b2aeea7dc6c0e5169cde436a25f98"
+      "entity_derived": "niiri:578bcf6846bd5b49337bc46c4d7b1c7f",
+      "entity": "niiri:20b3e078d59196a48bbdcfae8b039f3e"
     },
     {
-      "@id": "niiri:4e18f177ec225d4f2f71271e556f529a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:da03712278abfc01eebac38b33e1cf9d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0070",
-      "prov:atLocation": {"@id": "niiri:9834348723b41a10d95bbd43f6884849"},
+      "prov:atLocation": {"@id": "niiri:e876166ff2dceea5230e5d76fbf9f15f"},
       "prov:value": {"@type": "xsd:float", "@value": "3.92441153526306"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.76967685174471"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.17295246882122e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.994270531661465"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.214086162162037"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.76967685174471"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.17295246882122e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.994270531661465"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.214086162162037"}
     },
     {
-      "@id": "niiri:9834348723b41a10d95bbd43f6884849",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e876166ff2dceea5230e5d76fbf9f15f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0070",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[54,8,-36]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[54,8,-36]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4e18f177ec225d4f2f71271e556f529a",
-      "entity": "niiri:e5ed0876efa8e7867992a3e7519d125a"
+      "entity_derived": "niiri:da03712278abfc01eebac38b33e1cf9d",
+      "entity": "niiri:87692b796865090154e70657cb33f3fa"
     },
     {
-      "@id": "niiri:ebf72ed7e3308fbf5bcd3bf6f01cc0a1",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:4776d4c0541b2407f509fe6b2b1c2853",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0071",
-      "prov:atLocation": {"@id": "niiri:6bb494ba3b4b53e4ba1a1a04f3bbb08d"},
+      "prov:atLocation": {"@id": "niiri:8e80b4015fe341dd35e4a04ffb7bd269"},
       "prov:value": {"@type": "xsd:float", "@value": "3.83119082450867"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.68627175710081"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000113781673432678"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.998771596988439"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.271448122890309"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.68627175710081"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000113781673432678"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.998771596988439"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.271448122890309"}
     },
     {
-      "@id": "niiri:6bb494ba3b4b53e4ba1a1a04f3bbb08d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:8e80b4015fe341dd35e4a04ffb7bd269",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0071",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-66,-46,8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-66,-46,8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ebf72ed7e3308fbf5bcd3bf6f01cc0a1",
-      "entity": "niiri:cc4442623b113667ed11179bf378fa55"
+      "entity_derived": "niiri:4776d4c0541b2407f509fe6b2b1c2853",
+      "entity": "niiri:f6aab0b38147783304dd12682b7a862f"
     },
     {
-      "@id": "niiri:7682e0b9d09cfa3f649fc4ab197d51c5",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a0b516d4caa56831926e6d21c58b5dad",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0072",
-      "prov:atLocation": {"@id": "niiri:242c2913f7e6868af10a0d1e4d23a118"},
+      "prov:atLocation": {"@id": "niiri:4543c36bb3fcf5b8005d17cc742876cc"},
       "prov:value": {"@type": "xsd:float", "@value": "3.80303430557251"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.66100116005044"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000125615810592783"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999284372850148"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.284998670660322"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.66100116005044"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000125615810592783"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999284372850148"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.284998670660322"}
     },
     {
-      "@id": "niiri:242c2913f7e6868af10a0d1e4d23a118",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4543c36bb3fcf5b8005d17cc742876cc",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0072",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-54,-32,42]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-54,-32,42]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7682e0b9d09cfa3f649fc4ab197d51c5",
-      "entity": "niiri:3bcdad331508ef0bb8c4160e76f8a8dc"
+      "entity_derived": "niiri:a0b516d4caa56831926e6d21c58b5dad",
+      "entity": "niiri:8cfffabbc7e33bc2c585eb4a81ebc159"
     },
     {
-      "@id": "niiri:cbe94ec4a4835e64186ebbeb09aacca1",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:6aa0a5cf04dbb3c86c7b7e42153c561d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0073",
-      "prov:atLocation": {"@id": "niiri:4e7e066e6142cbd1af0c8c0cbfde6a3f"},
+      "prov:atLocation": {"@id": "niiri:b3a94b46b45cb4c4f16342948448b2b1"},
       "prov:value": {"@type": "xsd:float", "@value": "3.80056810379028"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.65878600275762"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000126706415147559"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999318686068297"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.285311172590102"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.65878600275762"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000126706415147559"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999318686068297"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.285311172590102"}
     },
     {
-      "@id": "niiri:4e7e066e6142cbd1af0c8c0cbfde6a3f",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b3a94b46b45cb4c4f16342948448b2b1",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0073",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[14,-14,72]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[14,-14,72]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cbe94ec4a4835e64186ebbeb09aacca1",
-      "entity": "niiri:4f16f2a965f5b74e4ed5dd4273ae236f"
+      "entity_derived": "niiri:6aa0a5cf04dbb3c86c7b7e42153c561d",
+      "entity": "niiri:d93e1967e2b464317bc445a37c7560a2"
     },
     {
-      "@id": "niiri:203679be7d5444fd4f4cfa318298bdd0",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:cd7d7fa3c3a1f73e1c6e18eec54bf367",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0074",
-      "prov:atLocation": {"@id": "niiri:e4ff8b38fac4a34a30bbf71112253f56"},
+      "prov:atLocation": {"@id": "niiri:8e116c5bfb82033d215acceb7790ae6e"},
       "prov:value": {"@type": "xsd:float", "@value": "3.43387007713318"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.32638243729709"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000439905622966141"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999993561311"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.61426970601407"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.32638243729709"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000439905622966141"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999993561311"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.61426970601407"}
     },
     {
-      "@id": "niiri:e4ff8b38fac4a34a30bbf71112253f56",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:8e116c5bfb82033d215acceb7790ae6e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0074",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[12,-16,64]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[12,-16,64]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:203679be7d5444fd4f4cfa318298bdd0",
-      "entity": "niiri:4f16f2a965f5b74e4ed5dd4273ae236f"
+      "entity_derived": "niiri:cd7d7fa3c3a1f73e1c6e18eec54bf367",
+      "entity": "niiri:d93e1967e2b464317bc445a37c7560a2"
     },
     {
-      "@id": "niiri:8779f2524bd2210d4a51e10ab15bacf1",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b77f9f4ee4f5feb949a261a2483aa303",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0075",
-      "prov:atLocation": {"@id": "niiri:f9ebc740a044a4c18fc19643a7a0a51e"},
+      "prov:atLocation": {"@id": "niiri:32d8cdce54f1bc815e16b577a65b42f9"},
       "prov:value": {"@type": "xsd:float", "@value": "3.7976541519165"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.65616831501084"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000128006646334056"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999357362048204"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.285982238829825"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.65616831501084"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000128006646334056"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999357362048204"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.285982238829825"}
     },
     {
-      "@id": "niiri:f9ebc740a044a4c18fc19643a7a0a51e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:32d8cdce54f1bc815e16b577a65b42f9",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0075",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-22,-82,0]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-22,-82,0]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8779f2524bd2210d4a51e10ab15bacf1",
-      "entity": "niiri:d10cc69571498e5ccb865e70f789b959"
+      "entity_derived": "niiri:b77f9f4ee4f5feb949a261a2483aa303",
+      "entity": "niiri:80f2f6c335075aedb795e079a5688f2b"
     },
     {
-      "@id": "niiri:f09a8d192665b37e8d96030e7579dce8",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d00c21a3d5785cd0c3ace030b952b31e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0076",
-      "prov:atLocation": {"@id": "niiri:7bfc7ee92b1ed7eff6cb78456c115540"},
+      "prov:atLocation": {"@id": "niiri:0fcf7ece24e31946c54d35e8b1f83339"},
       "prov:value": {"@type": "xsd:float", "@value": "3.79047918319702"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.64972117706788"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000131262556208656"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999444488129241"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.290021691384508"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.64972117706788"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000131262556208656"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999444488129241"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.290021691384508"}
     },
     {
-      "@id": "niiri:7bfc7ee92b1ed7eff6cb78456c115540",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0fcf7ece24e31946c54d35e8b1f83339",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0076",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[52,-42,18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[52,-42,18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f09a8d192665b37e8d96030e7579dce8",
-      "entity": "niiri:eca18148c6df2bf25a3fb4224b299658"
+      "entity_derived": "niiri:d00c21a3d5785cd0c3ace030b952b31e",
+      "entity": "niiri:ef7d0561535e5e02620497afd1e27f3d"
     },
     {
-      "@id": "niiri:2da92f631c41ceb7d9d4873508d6aa07",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:81b14a242118884af4716d1386a49968",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0077",
-      "prov:atLocation": {"@id": "niiri:8165f976cf661160c4b54b6ecc8233f7"},
+      "prov:atLocation": {"@id": "niiri:796162ee36fddd7fe04fdb52f196a437"},
       "prov:value": {"@type": "xsd:float", "@value": "3.73172569274902"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.59683942997016"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000161053590001625"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999847623960611"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.333516771702899"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.59683942997016"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000161053590001625"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999847623960611"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.333516771702899"}
     },
     {
-      "@id": "niiri:8165f976cf661160c4b54b6ecc8233f7",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:796162ee36fddd7fe04fdb52f196a437",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0077",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-46,14,2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-46,14,2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2da92f631c41ceb7d9d4873508d6aa07",
-      "entity": "niiri:d01136698ec67fb4e47df44c2e197103"
+      "entity_derived": "niiri:81b14a242118884af4716d1386a49968",
+      "entity": "niiri:29289a4455046f74558f3c81d39ba67b"
     },
     {
-      "@id": "niiri:376aa18e94e3ca907cc34e047b014f85",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:1b496fdde624ffb7718731dcb5969f61",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0078",
-      "prov:atLocation": {"@id": "niiri:91c99f9a40f2bac3243e28e56f5a46f1"},
+      "prov:atLocation": {"@id": "niiri:430af058ffb53b1c5f36dba7ce187964"},
       "prov:value": {"@type": "xsd:float", "@value": "3.7307436466217"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.59595419684865"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0001616023346106"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999851120393834"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.333516771702899"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.59595419684865"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0001616023346106"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999851120393834"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.333516771702899"}
     },
     {
-      "@id": "niiri:91c99f9a40f2bac3243e28e56f5a46f1",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:430af058ffb53b1c5f36dba7ce187964",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0078",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-16,4,62]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-16,4,62]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:376aa18e94e3ca907cc34e047b014f85",
-      "entity": "niiri:b1d116fb7eeb859d3c14dbed857c171a"
+      "entity_derived": "niiri:1b496fdde624ffb7718731dcb5969f61",
+      "entity": "niiri:2821bde2f68ccf372a5e6ea09d4eada7"
     },
     {
-      "@id": "niiri:d26b2ca1de8da439299e41de5125f97a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:1949681f598de9abc79f75c80aefff35",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0079",
-      "prov:atLocation": {"@id": "niiri:3a6fff5356ac4f4e9fe9ef6bc9775a40"},
+      "prov:atLocation": {"@id": "niiri:5a39b6d66bb64abc65a91ff2a298ca0b"},
       "prov:value": {"@type": "xsd:float", "@value": "3.71718406677246"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.58372690354832"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00016936312213478"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999892552580384"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.343980192781709"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.58372690354832"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00016936312213478"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999892552580384"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.343980192781709"}
     },
     {
-      "@id": "niiri:3a6fff5356ac4f4e9fe9ef6bc9775a40",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:5a39b6d66bb64abc65a91ff2a298ca0b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0079",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[42,-86,12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[42,-86,12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d26b2ca1de8da439299e41de5125f97a",
-      "entity": "niiri:80ebd2b365389e66f0063546e25d7a7f"
+      "entity_derived": "niiri:1949681f598de9abc79f75c80aefff35",
+      "entity": "niiri:5514e5220803aad2c04bbd033aa76695"
     },
     {
-      "@id": "niiri:1b2dc1d364364e5722fb82ef93077258",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:156c0ed1194df2305d443c2e19909212",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0080",
-      "prov:atLocation": {"@id": "niiri:5b80ad657ece5096fc46befe4ce9d5fd"},
+      "prov:atLocation": {"@id": "niiri:ed2e59615ba0052e7aaa0fa34f891006"},
       "prov:value": {"@type": "xsd:float", "@value": "3.6839451789856"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.55371881325781"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000189912540090265"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999953853986457"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.369765026721735"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.55371881325781"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000189912540090265"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999953853986457"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.369765026721735"}
     },
     {
-      "@id": "niiri:5b80ad657ece5096fc46befe4ce9d5fd",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ed2e59615ba0052e7aaa0fa34f891006",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0080",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[56,-66,4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[56,-66,4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1b2dc1d364364e5722fb82ef93077258",
-      "entity": "niiri:f28ff86627fd1b6b8dff8eeb57dda0bf"
+      "entity_derived": "niiri:156c0ed1194df2305d443c2e19909212",
+      "entity": "niiri:315fcb9a135fe01c557c732f7f103e94"
     },
     {
-      "@id": "niiri:f14a65dc73e3f6c9fd9322882fd5f384",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e1346785ea40b70db27ae60f7bdd98cc",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0081",
-      "prov:atLocation": {"@id": "niiri:6c6b97923f8cb52a02f70ced73311746"},
+      "prov:atLocation": {"@id": "niiri:96891dbc0a30ebca766e502619edafda"},
       "prov:value": {"@type": "xsd:float", "@value": "3.65720558166504"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.52954228664317"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000208139586526879"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999977747731185"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.394667961040657"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.52954228664317"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000208139586526879"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999977747731185"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.394667961040657"}
     },
     {
-      "@id": "niiri:6c6b97923f8cb52a02f70ced73311746",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:96891dbc0a30ebca766e502619edafda",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0081",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-60,-46,0]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-60,-46,0]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f14a65dc73e3f6c9fd9322882fd5f384",
-      "entity": "niiri:7410e6e29d61d77d50faa3f92b630f60"
+      "entity_derived": "niiri:e1346785ea40b70db27ae60f7bdd98cc",
+      "entity": "niiri:fe8e19f11e2bcbf510735d94d7db4251"
     },
     {
-      "@id": "niiri:02849dfd89ad746265a47837c1a92364",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f9510499752a4d4a62444e63c5613551",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0082",
-      "prov:atLocation": {"@id": "niiri:2cd63410e009138f47473496c0643554"},
+      "prov:atLocation": {"@id": "niiri:a097f126e0b7b865a50e6fbd1ff0446c"},
       "prov:value": {"@type": "xsd:float", "@value": "3.6346263885498"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.50910250251801"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000224810793142627"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999988407105485"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.410740156420602"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.50910250251801"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000224810793142627"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999988407105485"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.410740156420602"}
     },
     {
-      "@id": "niiri:2cd63410e009138f47473496c0643554",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a097f126e0b7b865a50e6fbd1ff0446c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0082",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[48,34,-8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[48,34,-8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:02849dfd89ad746265a47837c1a92364",
-      "entity": "niiri:1f58e1cc42099395a446086ee96b8a42"
+      "entity_derived": "niiri:f9510499752a4d4a62444e63c5613551",
+      "entity": "niiri:fec8619ae00ff17ab9a3d3ceb9046f4e"
     },
     {
-      "@id": "niiri:db5f3893682e77a3b7decb7d8434d1e6",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:8bbd37614dea9f192710357a074c63f1",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0083",
-      "prov:atLocation": {"@id": "niiri:bec41f76953fce12a7133751b1992ba4"},
+      "prov:atLocation": {"@id": "niiri:3ca45b6a52ae0c898f083934ee671939"},
       "prov:value": {"@type": "xsd:float", "@value": "3.62398386001587"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.49946049887545"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000233100337095449"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999991575586166"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.419299318507116"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.49946049887545"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000233100337095449"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999991575586166"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.419299318507116"}
     },
     {
-      "@id": "niiri:bec41f76953fce12a7133751b1992ba4",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:3ca45b6a52ae0c898f083934ee671939",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0083",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[32,-80,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[32,-80,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:db5f3893682e77a3b7decb7d8434d1e6",
-      "entity": "niiri:873d10b94cdd2f9974ccfd2cdbfaaefa"
+      "entity_derived": "niiri:8bbd37614dea9f192710357a074c63f1",
+      "entity": "niiri:0b442ae9d99b24f7707cb51260201d38"
     },
     {
-      "@id": "niiri:67e85ffd644982c040e868ccb3dbdced",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:51e60ac16faa51fdca273f7e51c66c23",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0084",
-      "prov:atLocation": {"@id": "niiri:e027d6ed1c58202c2a254b02f4702718"},
+      "prov:atLocation": {"@id": "niiri:f15c5edf089117c22fd1387c5c6afdd5"},
       "prov:value": {"@type": "xsd:float", "@value": "3.58678197860718"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.46571659793177"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000264410189540709"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999997407846311"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.449939086167831"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.46571659793177"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000264410189540709"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999997407846311"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.449939086167831"}
     },
     {
-      "@id": "niiri:e027d6ed1c58202c2a254b02f4702718",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f15c5edf089117c22fd1387c5c6afdd5",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0084",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-28,-64,-4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-28,-64,-4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:67e85ffd644982c040e868ccb3dbdced",
-      "entity": "niiri:b90b028a3ab9996de06b07fefc72f518"
+      "entity_derived": "niiri:51e60ac16faa51fdca273f7e51c66c23",
+      "entity": "niiri:5b35b6fc65311a490ca686dedf246257"
     },
     {
-      "@id": "niiri:62dceb645c6aecf022beb10c3fb519ef",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f868633206589461de78ed5f44c3088b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0085",
-      "prov:atLocation": {"@id": "niiri:48a24e99c33a7f0ec19a0b77bd2c62d7"},
+      "prov:atLocation": {"@id": "niiri:99443289e22800a7b794d7aa4f24f6a7"},
       "prov:value": {"@type": "xsd:float", "@value": "3.53609657287598"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.41964440308829"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000313515213706594"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999559435381"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.4996866807862"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.41964440308829"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000313515213706594"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999559435381"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.4996866807862"}
     },
     {
-      "@id": "niiri:48a24e99c33a7f0ec19a0b77bd2c62d7",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:99443289e22800a7b794d7aa4f24f6a7",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0085",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-50,-40,32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-50,-40,32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:62dceb645c6aecf022beb10c3fb519ef",
-      "entity": "niiri:568f5936427903f7944d3adca7a176de"
+      "entity_derived": "niiri:f868633206589461de78ed5f44c3088b",
+      "entity": "niiri:8105ee9b0d3cbff0afc4f8e6f6cbaaaa"
     },
     {
-      "@id": "niiri:f53e7658ae9f4482134b940539b7ab67",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ae37176f4228fdcd9909a5c9d8991945",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0086",
-      "prov:atLocation": {"@id": "niiri:64a5417ebde0db9a7b44f6c34d65bc18"},
+      "prov:atLocation": {"@id": "niiri:b26986f014facbd25376c493db54de06"},
       "prov:value": {"@type": "xsd:float", "@value": "3.53580570220947"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.41937968187583"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000313820412307875"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999564147392"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.4996866807862"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.41937968187583"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000313820412307875"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999564147392"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.4996866807862"}
     },
     {
-      "@id": "niiri:64a5417ebde0db9a7b44f6c34d65bc18",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b26986f014facbd25376c493db54de06",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0086",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-60,-14,10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-60,-14,10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f53e7658ae9f4482134b940539b7ab67",
-      "entity": "niiri:8d982136130ad2ce21a159a7d9c1edaa"
+      "entity_derived": "niiri:ae37176f4228fdcd9909a5c9d8991945",
+      "entity": "niiri:b133a4090af3a2b167687334a106d130"
     },
     {
-      "@id": "niiri:35cb8e83d1dd5a9e6d193b00a170e2c8",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:dd232f665acbacec710283b33a7ffc6b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0087",
-      "prov:atLocation": {"@id": "niiri:38e2f77e5fa29335d46c00f0cf519d93"},
+      "prov:atLocation": {"@id": "niiri:d2cba17eb975b3349a089cd9a6c33464"},
       "prov:value": {"@type": "xsd:float", "@value": "3.51950573921204"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.40453920275412"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000331378932285298"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999764036674"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.515543012752167"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.40453920275412"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000331378932285298"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999764036674"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.515543012752167"}
     },
     {
-      "@id": "niiri:38e2f77e5fa29335d46c00f0cf519d93",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d2cba17eb975b3349a089cd9a6c33464",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0087",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-18,-92,8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-18,-92,8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:35cb8e83d1dd5a9e6d193b00a170e2c8",
-      "entity": "niiri:3aa90bc8976de4ac1c73e9b43c959876"
+      "entity_derived": "niiri:dd232f665acbacec710283b33a7ffc6b",
+      "entity": "niiri:4c38fc3cc2a35b74b2036daf823f1c35"
     },
     {
-      "@id": "niiri:6f371572a83f199ed55039e0561c5d8c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:52c43bf1c9ff74a8799c3b7e6d3a1981",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0088",
-      "prov:atLocation": {"@id": "niiri:ccbef341fabc72345dca7ea6ffd2a490"},
+      "prov:atLocation": {"@id": "niiri:5a482bce8aa9db2111282847cc17f383"},
       "prov:value": {"@type": "xsd:float", "@value": "3.49318885803223"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.38055434488284"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000361698840550817"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999916401603"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.545280130510157"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.38055434488284"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000361698840550817"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999916401603"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.545280130510157"}
     },
     {
-      "@id": "niiri:ccbef341fabc72345dca7ea6ffd2a490",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:5a482bce8aa9db2111282847cc17f383",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0088",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[12,-86,50]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[12,-86,50]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6f371572a83f199ed55039e0561c5d8c",
-      "entity": "niiri:9905f70b4755853ccd1de257abc32ef8"
+      "entity_derived": "niiri:52c43bf1c9ff74a8799c3b7e6d3a1981",
+      "entity": "niiri:9476947ad907c2f9d5c061ead3c8ca5c"
     },
     {
-      "@id": "niiri:5892f4bed03e7f292fcea67aad88e004",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b5befcd1e1859623d7854488fa7de979",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0089",
-      "prov:atLocation": {"@id": "niiri:3e13970ba727bfd74bd2b9690149eea1"},
+      "prov:atLocation": {"@id": "niiri:8c0885885f7d3e6a0c5d4d78d7581155"},
       "prov:value": {"@type": "xsd:float", "@value": "3.47051548957825"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.35986611616874"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000389901261900971"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999967415099"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.574030743367995"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.35986611616874"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000389901261900971"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999967415099"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.574030743367995"}
     },
     {
-      "@id": "niiri:3e13970ba727bfd74bd2b9690149eea1",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:8c0885885f7d3e6a0c5d4d78d7581155",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0089",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-28,-32,-40]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-28,-32,-40]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5892f4bed03e7f292fcea67aad88e004",
-      "entity": "niiri:cfcc37be279ca1493d8aeab64d0f7eb0"
+      "entity_derived": "niiri:b5befcd1e1859623d7854488fa7de979",
+      "entity": "niiri:eaf5abe818e88775744fc4bc734500da"
     },
     {
-      "@id": "niiri:2203f0456422e9ff6eae4640a0868058",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:fa63e0fc9565564fb8d045ce95dc3fb0",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0090",
-      "prov:atLocation": {"@id": "niiri:aede1bf93651a6aecaab4b74293687c7"},
+      "prov:atLocation": {"@id": "niiri:7fa3faad18f93a839559601b4d609c22"},
       "prov:value": {"@type": "xsd:float", "@value": "3.45754051208496"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.34801719030758"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000406959813051277"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999981385599"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.587029984895018"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.34801719030758"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000406959813051277"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999981385599"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.587029984895018"}
     },
     {
-      "@id": "niiri:aede1bf93651a6aecaab4b74293687c7",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7fa3faad18f93a839559601b4d609c22",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0090",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[8,-72,42]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[8,-72,42]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2203f0456422e9ff6eae4640a0868058",
-      "entity": "niiri:0725b220f47ead33a4ba9ecc13ada7ae"
+      "entity_derived": "niiri:fa63e0fc9565564fb8d045ce95dc3fb0",
+      "entity": "niiri:d327e883ddebc9532dc10d806d05ceea"
     },
     {
-      "@id": "niiri:39dc6fda033d5339925079c0fa3459d0",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b3ffdc96c6bca62445438ff33b6dab0b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0091",
-      "prov:atLocation": {"@id": "niiri:d73832987b8cc51a8d7cca6f48f2dfb9"},
+      "prov:atLocation": {"@id": "niiri:6953a6cf7591ac6178b3e252d77b304c"},
       "prov:value": {"@type": "xsd:float", "@value": "3.43320918083191"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.32577803511444"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000440860566175205"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999993754102"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.61426970601407"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.32577803511444"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000440860566175205"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999993754102"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.61426970601407"}
     },
     {
-      "@id": "niiri:d73832987b8cc51a8d7cca6f48f2dfb9",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6953a6cf7591ac6178b3e252d77b304c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0091",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-38,-78,8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-38,-78,8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:39dc6fda033d5339925079c0fa3459d0",
-      "entity": "niiri:c8f5cfe91a5e1c0eb3a8ce4272e74dc1"
+      "entity_derived": "niiri:b3ffdc96c6bca62445438ff33b6dab0b",
+      "entity": "niiri:b56a8e6eef495278939c1f07e4b2ec46"
     },
     {
-      "@id": "niiri:071e50bf38f644f293cc9bb4dd422042",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:63ddfa8767c13e0bf648a86357c0616c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0092",
-      "prov:atLocation": {"@id": "niiri:f1e51cf49fda710bf19cc50a4f00e96d"},
+      "prov:atLocation": {"@id": "niiri:d2bc2d6192acb2df1303a750a5ea9259"},
       "prov:value": {"@type": "xsd:float", "@value": "3.43009805679321"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.32293260301119"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000445382166252561"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999994589954"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.616048939476298"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.32293260301119"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000445382166252561"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999994589954"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.616048939476298"}
     },
     {
-      "@id": "niiri:f1e51cf49fda710bf19cc50a4f00e96d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d2bc2d6192acb2df1303a750a5ea9259",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0092",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-56,34,-20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-56,34,-20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:071e50bf38f644f293cc9bb4dd422042",
-      "entity": "niiri:76eeefc962a00f410ca4b176def01aa5"
+      "entity_derived": "niiri:63ddfa8767c13e0bf648a86357c0616c",
+      "entity": "niiri:ed00692e64206abf7a48d003e49a172c"
     },
     {
-      "@id": "niiri:49315754baf12ffcab022c7ede1aeee4",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:70cfc0282d991ec2d4a5b55d1fd54d12",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0093",
-      "prov:atLocation": {"@id": "niiri:d1408c47ea56ba0b69beb8a7482ce84a"},
+      "prov:atLocation": {"@id": "niiri:5d8529c4069514ea40bb8b8fa6993638"},
       "prov:value": {"@type": "xsd:float", "@value": "3.424649477005"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.31794834148679"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000453406269446011"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999995802847"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.621361020904295"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.31794834148679"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000453406269446011"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999995802847"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.621361020904295"}
     },
     {
-      "@id": "niiri:d1408c47ea56ba0b69beb8a7482ce84a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:5d8529c4069514ea40bb8b8fa6993638",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0093",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[18,-58,32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[18,-58,32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:49315754baf12ffcab022c7ede1aeee4",
-      "entity": "niiri:62c2a8527db43def7b959349980d6c02"
+      "entity_derived": "niiri:70cfc0282d991ec2d4a5b55d1fd54d12",
+      "entity": "niiri:33f78596b63613a9bb773b49e610c339"
     },
     {
-      "@id": "niiri:82a212cd3fd0bef3348e0d09daeef389",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:9b72288ab7c77e827d9f1f781adf3151",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0094",
-      "prov:atLocation": {"@id": "niiri:3b6a30446fcffbed845c4b0552821d9c"},
+      "prov:atLocation": {"@id": "niiri:592fa6eb01f3638945c2086fe68908ae"},
       "prov:value": {"@type": "xsd:float", "@value": "3.40277910232544"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.29792901961918"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000487003764363392"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999998528515"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.64908702869037"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.29792901961918"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000487003764363392"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999998528515"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.64908702869037"}
     },
     {
-      "@id": "niiri:3b6a30446fcffbed845c4b0552821d9c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:592fa6eb01f3638945c2086fe68908ae",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0094",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-32,-76,-2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-32,-76,-2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:82a212cd3fd0bef3348e0d09daeef389",
-      "entity": "niiri:890df2ef7ecc6eafa711940fe2c85892"
+      "entity_derived": "niiri:9b72288ab7c77e827d9f1f781adf3151",
+      "entity": "niiri:fd773d75cfefece3ae58e4b268b97593"
     },
     {
-      "@id": "niiri:9a86504d386a2f4182f1142003d96c33",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:88a8cadf94cd28dcac01eb9dbc030af6",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0095",
-      "prov:atLocation": {"@id": "niiri:7324ebe46ae61c59a2d1db2715144e2d"},
+      "prov:atLocation": {"@id": "niiri:089cb2a4ffc88484de7776f0fdffe221"},
       "prov:value": {"@type": "xsd:float", "@value": "3.3940372467041"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.28992137977698"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000501076897352348"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999044949"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.659842637673888"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.28992137977698"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000501076897352348"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999044949"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.659842637673888"}
     },
     {
-      "@id": "niiri:7324ebe46ae61c59a2d1db2715144e2d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:089cb2a4ffc88484de7776f0fdffe221",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0095",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[24,-64,-18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[24,-64,-18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9a86504d386a2f4182f1142003d96c33",
-      "entity": "niiri:1fc695464136ac390f15258db075c307"
+      "entity_derived": "niiri:88a8cadf94cd28dcac01eb9dbc030af6",
+      "entity": "niiri:b1682618b3d8ba951d4fba69d43ace19"
     },
     {
-      "@id": "niiri:53a4b0f2f41f9401d7f6dcb86b6237e1",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d72cc582c4a89de3d8d56216d7584f90",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0096",
-      "prov:atLocation": {"@id": "niiri:b099474100f78b9c0d228a1869faeadb"},
+      "prov:atLocation": {"@id": "niiri:dc0311045709c90687bf5718110350ae"},
       "prov:value": {"@type": "xsd:float", "@value": "3.38822054862976"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.28459142797104"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00051065177940457"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999286734"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.663972520258905"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.28459142797104"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00051065177940457"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999286734"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.663972520258905"}
     },
     {
-      "@id": "niiri:b099474100f78b9c0d228a1869faeadb",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:dc0311045709c90687bf5718110350ae",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0096",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[14,52,24]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[14,52,24]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:53a4b0f2f41f9401d7f6dcb86b6237e1",
-      "entity": "niiri:a63c8949e4a3fc9f1f4411a09a294513"
+      "entity_derived": "niiri:d72cc582c4a89de3d8d56216d7584f90",
+      "entity": "niiri:4aff58ce7014532950c85678251d820b"
     },
     {
-      "@id": "niiri:9e0947c09704adef13f3b70ec9dddd3f",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e16c4d3e320d40e426df93aee2ca6add",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0097",
-      "prov:atLocation": {"@id": "niiri:3e028f3bfc0f70c1effeb63290a7354b"},
+      "prov:atLocation": {"@id": "niiri:dc54ccf09ba5eabcbeedfec4a1babb63"},
       "prov:value": {"@type": "xsd:float", "@value": "3.34795022010803"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.24765190787991"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000581807655324229"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999914172"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.723121887342887"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.24765190787991"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000581807655324229"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999914172"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.723121887342887"}
     },
     {
-      "@id": "niiri:3e028f3bfc0f70c1effeb63290a7354b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:dc54ccf09ba5eabcbeedfec4a1babb63",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0097",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-64,-24,46]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-64,-24,46]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9e0947c09704adef13f3b70ec9dddd3f",
-      "entity": "niiri:df25ac5a53adfde0956454127605d4b6"
+      "entity_derived": "niiri:e16c4d3e320d40e426df93aee2ca6add",
+      "entity": "niiri:d98d8e8d25b59a9503f694b966d532d9"
     },
     {
-      "@id": "niiri:6ec431a571f4735696dc4984399d308e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d70ef29aa1808eec49d1cf3e0a54e0ff",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0098",
-      "prov:atLocation": {"@id": "niiri:b8bc78b3e981b7fcc913bfc909ccf788"},
+      "prov:atLocation": {"@id": "niiri:08d1e3f57a3aaac82503778457e03a57"},
       "prov:value": {"@type": "xsd:float", "@value": "3.33032703399658"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.23146500785458"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000615787011640778"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999967832"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.750358478642178"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.23146500785458"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000615787011640778"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999967832"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.750358478642178"}
     },
     {
-      "@id": "niiri:b8bc78b3e981b7fcc913bfc909ccf788",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:08d1e3f57a3aaac82503778457e03a57",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0098",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-56,24,22]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-56,24,22]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6ec431a571f4735696dc4984399d308e",
-      "entity": "niiri:430b756d7a021f005bd015a459e3abf2"
+      "entity_derived": "niiri:d70ef29aa1808eec49d1cf3e0a54e0ff",
+      "entity": "niiri:5b8cc71e1c4a9af4a428ecbfd59af0c3"
     },
     {
-      "@id": "niiri:99b6e759c8b0eb20ae8aaa87fbde6737",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:2188b2e49f6e63679bc313f1b84db925",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0099",
-      "prov:atLocation": {"@id": "niiri:7d6da070b4f6e591e3085e6e571a1966"},
+      "prov:atLocation": {"@id": "niiri:d487a995ae698c5bffe6a334eff5c7c1"},
       "prov:value": {"@type": "xsd:float", "@value": "3.30043077468872"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.20397578866589"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000677719372958352"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999994377"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.800935685960822"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.20397578866589"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000677719372958352"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999994377"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.800935685960822"}
     },
     {
-      "@id": "niiri:7d6da070b4f6e591e3085e6e571a1966",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d487a995ae698c5bffe6a334eff5c7c1",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0099",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-14,4,16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-14,4,16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:99b6e759c8b0eb20ae8aaa87fbde6737",
-      "entity": "niiri:080141eb52f83c2bae53c858e92b0d56"
+      "entity_derived": "niiri:2188b2e49f6e63679bc313f1b84db925",
+      "entity": "niiri:9399cc4d9102dea2381bab7e4de270e7"
     },
     {
-      "@id": "niiri:b91f6c305dd11f910e73ed60f2a249f3",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ee6edaf11ccf62cbd5f1fae3293222dd",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0100",
-      "prov:atLocation": {"@id": "niiri:488d58948f0d059927a9d730b2cdf37e"},
+      "prov:atLocation": {"@id": "niiri:db7766986aa39069f0e3fb4da12f89d8"},
       "prov:value": {"@type": "xsd:float", "@value": "3.2954432964325"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.19938627223673"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000688602556676021"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999995838"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.80659749253585"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.19938627223673"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000688602556676021"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999995838"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.80659749253585"}
     },
     {
-      "@id": "niiri:488d58948f0d059927a9d730b2cdf37e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:db7766986aa39069f0e3fb4da12f89d8",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0100",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[12,-18,52]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[12,-18,52]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b91f6c305dd11f910e73ed60f2a249f3",
-      "entity": "niiri:455661055a3ab874933b9807b54adec0"
+      "entity_derived": "niiri:ee6edaf11ccf62cbd5f1fae3293222dd",
+      "entity": "niiri:25449e2c897446ebd8a31026fdd28119"
     },
     {
-      "@id": "niiri:5c1608357abe96da883fe35465665204",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:15350a82e9c3fc01fd72c2bc7362c921",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0101",
-      "prov:atLocation": {"@id": "niiri:056dd170589b438d65a7d98296054229"},
+      "prov:atLocation": {"@id": "niiri:0b730f42d0287a0e641497fcb4468ec4"},
       "prov:value": {"@type": "xsd:float", "@value": "3.29354763031006"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.19764159673963"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000692781844264911"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999996291"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.80659749253585"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.19764159673963"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000692781844264911"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999996291"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.80659749253585"}
     },
     {
-      "@id": "niiri:056dd170589b438d65a7d98296054229",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0b730f42d0287a0e641497fcb4468ec4",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0101",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[10,-8,6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[10,-8,6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5c1608357abe96da883fe35465665204",
-      "entity": "niiri:a4e79b29ae579ef25088671c40dcd4aa"
+      "entity_derived": "niiri:15350a82e9c3fc01fd72c2bc7362c921",
+      "entity": "niiri:0e21ee277152eb058ea4661ca48674d9"
     },
     {
-      "@id": "niiri:0a77f567539e320675a7cd2692e26d57",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:06e844c8b746ab33069a3ac489ba1d42",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0102",
-      "prov:atLocation": {"@id": "niiri:7190fbc7d8cfd6eae79ac5d55e6d0895"},
+      "prov:atLocation": {"@id": "niiri:62c24f999648e906a27d9930430b903e"},
       "prov:value": {"@type": "xsd:float", "@value": "3.27130317687988"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.17715789461409"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000743630203309364"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999069"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.839869575034518"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.17715789461409"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000743630203309364"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999069"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.839869575034518"}
     },
     {
-      "@id": "niiri:7190fbc7d8cfd6eae79ac5d55e6d0895",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:62c24f999648e906a27d9930430b903e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0102",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-32,14,60]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-32,14,60]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0a77f567539e320675a7cd2692e26d57",
-      "entity": "niiri:cf1fb2a622b7b69b2867e5cf7760fe38"
+      "entity_derived": "niiri:06e844c8b746ab33069a3ac489ba1d42",
+      "entity": "niiri:0e8a97e94bdd4af70efd21917168b43e"
     },
     {
-      "@id": "niiri:2db82a8953dc9ed6a3caf065a03aa8a8",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0dcdfb141f26fdfb1b6f3ff37ca276eb",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0103",
-      "prov:atLocation": {"@id": "niiri:bd9299d468954298ce4be1ae75b041c1"},
+      "prov:atLocation": {"@id": "niiri:aa4caf2f8978443c3ecd0274bb9ae0e1"},
       "prov:value": {"@type": "xsd:float", "@value": "3.27024936676025"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.17618699537964"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000746123636619966"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999129"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.839869575034518"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.17618699537964"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000746123636619966"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999129"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.839869575034518"}
     },
     {
-      "@id": "niiri:bd9299d468954298ce4be1ae75b041c1",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:aa4caf2f8978443c3ecd0274bb9ae0e1",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0103",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-34,-84,6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-34,-84,6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2db82a8953dc9ed6a3caf065a03aa8a8",
-      "entity": "niiri:d2c0709213ef56652ef36c9d207acf04"
+      "entity_derived": "niiri:0dcdfb141f26fdfb1b6f3ff37ca276eb",
+      "entity": "niiri:5b01f2070bd1d0178ffb33f1582d88a3"
     },
     {
-      "@id": "niiri:80952fc1321d7065adc990156b3c8d67",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:837e6614e3814f2aedc901891549d812",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0104",
-      "prov:atLocation": {"@id": "niiri:81b9f5928c32c4134424b70fa2d84481"},
+      "prov:atLocation": {"@id": "niiri:5cb2949541c80c967fcb899f69618232"},
       "prov:value": {"@type": "xsd:float", "@value": "3.2392430305481"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.1475998920821"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000823084243901762"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999886"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.897361297935526"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.1475998920821"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000823084243901762"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999886"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.897361297935526"}
     },
     {
-      "@id": "niiri:81b9f5928c32c4134424b70fa2d84481",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:5cb2949541c80c967fcb899f69618232",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0104",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[36,-58,38]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[36,-58,38]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:80952fc1321d7065adc990156b3c8d67",
-      "entity": "niiri:2945ea3e25037efb18cb1b0c0a9604f5"
+      "entity_derived": "niiri:837e6614e3814f2aedc901891549d812",
+      "entity": "niiri:329bc820e22a3a07c45bd811037a5b92"
     },
     {
-      "@id": "niiri:539ad8882d8d701cec75ccf8ee58ff0f",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:db893cc3d08eff94a18a2ded424c27da",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0105",
-      "prov:atLocation": {"@id": "niiri:70e18bc08102e21b9c7a37263e571537"},
+      "prov:atLocation": {"@id": "niiri:1644dc14a37498514a08b1d016af0de4"},
       "prov:value": {"@type": "xsd:float", "@value": "3.22486090660095"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.13432667345374"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0008612448992944"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999957"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.922927255586177"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.13432667345374"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0008612448992944"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999957"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.922927255586177"}
     },
     {
-      "@id": "niiri:70e18bc08102e21b9c7a37263e571537",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:1644dc14a37498514a08b1d016af0de4",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0105",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[50,-42,-44]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[50,-42,-44]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:539ad8882d8d701cec75ccf8ee58ff0f",
-      "entity": "niiri:81211325ca547298daf652760e8bad87"
+      "entity_derived": "niiri:db893cc3d08eff94a18a2ded424c27da",
+      "entity": "niiri:4121c76a27252e2b2396a4e6040a0baf"
     },
     {
-      "@id": "niiri:49a04475044520da784c779056673f49",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0d719d9c0dda162347b33fc762ee9dba",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0106",
-      "prov:atLocation": {"@id": "niiri:63f2f5cabdc99373f9dafa0ed9c90280"},
+      "prov:atLocation": {"@id": "niiri:c1de986c07ccf82f9e7eec004acec01f"},
       "prov:value": {"@type": "xsd:float", "@value": "3.21566033363342"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.12583111524387"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000886516713776597"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999977"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.938118112536103"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.12583111524387"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000886516713776597"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999977"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.938118112536103"}
     },
     {
-      "@id": "niiri:63f2f5cabdc99373f9dafa0ed9c90280",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c1de986c07ccf82f9e7eec004acec01f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0106",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-52,-64,-24]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-52,-64,-24]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:49a04475044520da784c779056673f49",
-      "entity": "niiri:4b62f251a83aafef65b16eccc82e668e"
+      "entity_derived": "niiri:0d719d9c0dda162347b33fc762ee9dba",
+      "entity": "niiri:419bb28f6b465c3e5015a6d14e56b223"
     },
     {
-      "@id": "niiri:82a6ed12e5a8da474abbc5dea4df5359",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e0efd8540741b57d022a32fe600f4a60",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0107",
-      "prov:atLocation": {"@id": "niiri:b66d142b1bdb334b9cbe0dc4a6639fed"},
+      "prov:atLocation": {"@id": "niiri:05aa9aebd8dad58a0f2d1603e21cf930"},
       "prov:value": {"@type": "xsd:float", "@value": "3.21121668815613"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.12172675458225"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000898968641653619"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999984"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.943425557898272"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.12172675458225"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000898968641653619"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999984"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.943425557898272"}
     },
     {
-      "@id": "niiri:b66d142b1bdb334b9cbe0dc4a6639fed",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:05aa9aebd8dad58a0f2d1603e21cf930",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0107",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-42,-24,70]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-42,-24,70]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:82a6ed12e5a8da474abbc5dea4df5359",
-      "entity": "niiri:773351148f166f1064c72ad4e1f11422"
+      "entity_derived": "niiri:e0efd8540741b57d022a32fe600f4a60",
+      "entity": "niiri:e64d676ce70ddc69f3b8a79a997afc14"
     },
     {
-      "@id": "niiri:da5c8b2733a583126d729dd943d5c284",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:984314d1e545f3779d40732df43ac486",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0108",
-      "prov:atLocation": {"@id": "niiri:c651c5d7f1e0ccabc5f0759dacd92040"},
+      "prov:atLocation": {"@id": "niiri:f32ffd76360ec205c4000b22913ce264"},
       "prov:value": {"@type": "xsd:float", "@value": "3.19088125228882"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.10293388694787"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00095806220289707"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999996"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.978708956745583"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.10293388694787"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00095806220289707"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999996"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.978708956745583"}
     },
     {
-      "@id": "niiri:c651c5d7f1e0ccabc5f0759dacd92040",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f32ffd76360ec205c4000b22913ce264",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0108",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-42,-86,16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-42,-86,16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:da5c8b2733a583126d729dd943d5c284",
-      "entity": "niiri:eaca7a045a95a69292520d89e15df899"
+      "entity_derived": "niiri:984314d1e545f3779d40732df43ac486",
+      "entity": "niiri:b2fe473551b0d5958d6a1fafaa7495aa"
     },
     {
-      "@id": "niiri:4898b2fdd61b6ce95f680cb82b31d491",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:441ee164b95e1dde37ae482e9d9d5e83",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0109",
-      "prov:atLocation": {"@id": "niiri:269ee2db40ed82a81c8b5dda4153466a"},
+      "prov:atLocation": {"@id": "niiri:a7ba281dfef3a6043ffbd77f05f7c9c0"},
       "prov:value": {"@type": "xsd:float", "@value": "3.18322372436523"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.0958529484655"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000981238298823239"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999998"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.987875729427955"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.0958529484655"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000981238298823239"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999998"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.987875729427955"}
     },
     {
-      "@id": "niiri:269ee2db40ed82a81c8b5dda4153466a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a7ba281dfef3a6043ffbd77f05f7c9c0",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0109",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[8,-2,28]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[8,-2,28]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4898b2fdd61b6ce95f680cb82b31d491",
-      "entity": "niiri:147f8e061f74d3386fbcc5d348522c64"
+      "entity_derived": "niiri:441ee164b95e1dde37ae482e9d9d5e83",
+      "entity": "niiri:8fc15b04ecd3232fd23805615acbe960"
     },
     {
-      "@id": "niiri:5275cd3865d61bea1f6d6330f476434d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:2319fac2b0bcd7224a1b3319200a5ae7",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0110",
-      "prov:atLocation": {"@id": "niiri:a560de35b7d1376b165e5db6f489d1ee"},
+      "prov:atLocation": {"@id": "niiri:c92676a64fcf679097acf689ece5636c"},
       "prov:value": {"@type": "xsd:float", "@value": "3.18283724784851"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.09549551060057"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000982421736617112"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999998"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.987875729427955"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.09549551060057"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000982421736617112"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999998"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.987875729427955"}
     },
     {
-      "@id": "niiri:a560de35b7d1376b165e5db6f489d1ee",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c92676a64fcf679097acf689ece5636c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0110",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[14,-22,76]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[14,-22,76]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5275cd3865d61bea1f6d6330f476434d",
-      "entity": "niiri:b140e937ac96257d15f410e255ead183"
+      "entity_derived": "niiri:2319fac2b0bcd7224a1b3319200a5ae7",
+      "entity": "niiri:3ba4f4eceb22f4823f915b7f2ea31b71"
     }
   ]
 }

--- a/spmexport/ex_spm_temporal_derivative/nidm.ttl
+++ b/spmexport/ex_spm_temporal_derivative/nidm.ttl
@@ -4,7 +4,7 @@
 @prefix niiri: <http://iri.nidash.org/> .
 @prefix spm: <http://purl.org/nidash/spm#> .
 @prefix neurolex: <http://neurolex.org/wiki/> .
-@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#> .
+@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
@@ -17,27 +17,27 @@
 @prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-niiri:d68280cb6822bab913dcba96aa39a76c
+niiri:e80fdd02e6c9b8a432f69b8cd870cc7e
   a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
   rdfs:label "NIDM-Results" ;
   nidm_version: "1.3.0"^^xsd:string .
 
-niiri:89ead2eed1218544375f650b92753466
+niiri:1987d1dc27e5d0c86458fed59bf44fa8
   a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
   rdfs:label "spm_results_nidm" ;
-  nidm_softwareVersion: "12.6903"^^xsd:string .
+  nidm_softwareVersion: "12.7057"^^xsd:string .
 
-niiri:03410e5507843b5dc1ff1430fc291929
+niiri:ce8ee76d421d7195cb9a3077c3f493ea
   a prov:Activity, nidm_NIDMResultsExport: ; 
   rdfs:label "NIDM-Results export" .
 
-niiri:03410e5507843b5dc1ff1430fc291929 prov:wasAssociatedWith niiri:89ead2eed1218544375f650b92753466 .
+niiri:ce8ee76d421d7195cb9a3077c3f493ea prov:wasAssociatedWith niiri:1987d1dc27e5d0c86458fed59bf44fa8 .
 
 _:blank5 a prov:Generation .
 
-niiri:d68280cb6822bab913dcba96aa39a76c prov:qualifiedGeneration _:blank5 .
+niiri:e80fdd02e6c9b8a432f69b8cd870cc7e prov:qualifiedGeneration _:blank5 .
 
-_:blank5 prov:atTime "2016-12-07T16:09:27"^^xsd:dateTime .
+_:blank5 prov:atTime "2017-04-19T12:18:53"^^xsd:dateTime .
 
 @prefix nidm_Ixi549CoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000050> .
 @prefix src_SPM: <http://scicrunch.org/resolver/SCR_007037> .
@@ -143,12 +143,12 @@ _:blank5 prov:atTime "2016-12-07T16:09:27"^^xsd:dateTime .
 @prefix nidm_Coordinate: <http://purl.org/nidash/nidm#NIDM_0000015> .
 @prefix nidm_coordinateVector: <http://purl.org/nidash/nidm#NIDM_0000086> .
 
-niiri:490e5ab2436b12162f59fedeb9e1e9d8
+niiri:65bbe1871e61c631eb812e3b6150407c
     a prov:Agent, src_SPM:, prov:SoftwareAgent ; 
     rdfs:label "SPM" ;
-    nidm_softwareVersion: "12.12.2"^^xsd:string .
+    nidm_softwareVersion: "12.6906"^^xsd:string .
 
-niiri:2ada174836b28044a9513f1a34eef87f
+niiri:b410708237a32a427489f32ca35c4711
     a prov:Entity, nidm_CoordinateSpace: ; 
     rdfs:label "Coordinate space 1" ;
     nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
@@ -158,49 +158,49 @@ niiri:2ada174836b28044a9513f1a34eef87f
     nidm_numberOfDimensions: "3"^^xsd:int ;
     nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
 
-niiri:bdbd8606798b7fde558fcb563c2e6588
+niiri:181adcf33bc1c55ebfad49dc712d7cd6
     a prov:Agent, nlx_Imaginginstrument:, nlx_Magneticresonanceimagingscanner: ; 
     rdfs:label "MRI Scanner" .
 
-niiri:d001e9075e8cc82b7c6a9c041152e765
+niiri:fd83cd08b03cd16aa7c54c67699b8c14
     a prov:Agent, prov:Person ; 
     rdfs:label "Person" .
 
-niiri:41eae4e7c79ff13a7860fdb5e15df324
+niiri:ef76ace3c4054ff67be710e42fb82df5
     a prov:Entity, prov:Collection, nidm_Data: ; 
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "true"^^xsd:boolean ;
     nidm_targetIntensity: "100"^^xsd:float ;
     nidm_hasMRIProtocol: nlx_FunctionalMRIprotocol: .
 
-niiri:41eae4e7c79ff13a7860fdb5e15df324 prov:wasAttributedTo niiri:bdbd8606798b7fde558fcb563c2e6588 .
+niiri:ef76ace3c4054ff67be710e42fb82df5 prov:wasAttributedTo niiri:181adcf33bc1c55ebfad49dc712d7cd6 .
 
-niiri:41eae4e7c79ff13a7860fdb5e15df324 prov:wasAttributedTo niiri:d001e9075e8cc82b7c6a9c041152e765 .
+niiri:ef76ace3c4054ff67be710e42fb82df5 prov:wasAttributedTo niiri:fd83cd08b03cd16aa7c54c67699b8c14 .
 
-niiri:3dd8e44dd2339c934a0f169b3c59b948
+niiri:1ba26f6e6e02762b1231f47d7d0c5385
     a prov:Entity, spm_DCTDriftModel: ; 
     rdfs:label "SPM's DCT Drift Model" ;
     spm_SPMsDriftCutoffPeriod: "128"^^xsd:float .
 
-niiri:ded035420e24d45acc47137ac0d3c65c
+niiri:e68475df9e5152b04c95bde006aa28c2
     a prov:Entity, nidm_DesignMatrix: ; 
     prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.csv"^^xsd:string ;
     dct:format "text/csv"^^xsd:string ;
-    dc:description niiri:61cd29e1dac6242111457491dae53b6a ;
+    dc:description niiri:1addda2a0d4d8015583267922f5f8509 ;
     rdfs:label "Design Matrix" ;
     nidm_regressorNames: "[\"Sn(1) to*bf(1)\", \"Sn(1) to*bf(2)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) \ntask001 co*bf(2)\", \"Sn(1) constant\"]"^^xsd:string ;
-    nidm_hasDriftModel: niiri:3dd8e44dd2339c934a0f169b3c59b948 ;
+    nidm_hasDriftModel: niiri:1ba26f6e6e02762b1231f47d7d0c5385 ;
     nidm_hasHRFBasis: spm_SPMsCanonicalHRF: ;
     nidm_hasHRFBasis: spm_SPMsTemporalDerivative: .
 
-niiri:61cd29e1dac6242111457491dae53b6a
+niiri:1addda2a0d4d8015583267922f5f8509
     a prov:Entity, dctype:Image ; 
     prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:889f7c969cdf527a22ca3b3c0ce47c70
+niiri:fe3aee97e82c6b81a5edb0430f731daf
     a prov:Entity, nidm_ErrorModel: ; 
     nidm_hasErrorDistribution: obo_normaldistribution: ;
     nidm_hasErrorDependence: obo_Toeplitzcovariancestructure: ;
@@ -208,216 +208,216 @@ niiri:889f7c969cdf527a22ca3b3c0ce47c70
     nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
     nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
 
-niiri:dab7ede7835ef6993526fce9c3b60438
+niiri:690e3f484f6e5f7a6eec1242e70053c5
     a prov:Activity, nidm_ModelParametersEstimation: ; 
     rdfs:label "Model parameters estimation" ;
     nidm_withEstimationMethod: obo_generalizedleastsquaresestimation: .
 
-niiri:dab7ede7835ef6993526fce9c3b60438 prov:wasAssociatedWith niiri:490e5ab2436b12162f59fedeb9e1e9d8 .
+niiri:690e3f484f6e5f7a6eec1242e70053c5 prov:wasAssociatedWith niiri:65bbe1871e61c631eb812e3b6150407c .
 
-niiri:dab7ede7835ef6993526fce9c3b60438 prov:used niiri:ded035420e24d45acc47137ac0d3c65c .
+niiri:690e3f484f6e5f7a6eec1242e70053c5 prov:used niiri:e68475df9e5152b04c95bde006aa28c2 .
 
-niiri:dab7ede7835ef6993526fce9c3b60438 prov:used niiri:41eae4e7c79ff13a7860fdb5e15df324 .
+niiri:690e3f484f6e5f7a6eec1242e70053c5 prov:used niiri:ef76ace3c4054ff67be710e42fb82df5 .
 
-niiri:dab7ede7835ef6993526fce9c3b60438 prov:used niiri:889f7c969cdf527a22ca3b3c0ce47c70 .
+niiri:690e3f484f6e5f7a6eec1242e70053c5 prov:used niiri:fe3aee97e82c6b81a5edb0430f731daf .
 
-niiri:391bfa5f6d92b504b7bbd76dc18b1db4
+niiri:07485f81ffa874bdd72e7579bb4e934b
     a prov:Entity, nidm_MaskMap: ; 
     prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
     nidm_isUserDefined: "false"^^xsd:boolean ;
     nfo:fileName "Mask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Mask" ;
-    nidm_inCoordinateSpace: niiri:2ada174836b28044a9513f1a34eef87f ;
+    nidm_inCoordinateSpace: niiri:b410708237a32a427489f32ca35c4711 ;
     crypto:sha512 "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876"^^xsd:string .
 
-niiri:844ff796879373fbd4abd17641a0b795
+niiri:9588fe052df37634cce35de2c4c0e782
     a prov:Entity, nidm_MaskMap: ; 
     nfo:fileName "mask.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "36929e1f5f4143bd9cc818cd896a25f129961fab208c3a4438555f40444c08347b359142ee8c53ece6e8cca1627f49db0788a1fd3b9e2ecaef61999c6c6c67ac"^^xsd:string .
 
-niiri:391bfa5f6d92b504b7bbd76dc18b1db4 prov:wasDerivedFrom niiri:844ff796879373fbd4abd17641a0b795 .
+niiri:07485f81ffa874bdd72e7579bb4e934b prov:wasDerivedFrom niiri:9588fe052df37634cce35de2c4c0e782 .
 
-niiri:391bfa5f6d92b504b7bbd76dc18b1db4 prov:wasGeneratedBy niiri:dab7ede7835ef6993526fce9c3b60438 .
+niiri:07485f81ffa874bdd72e7579bb4e934b prov:wasGeneratedBy niiri:690e3f484f6e5f7a6eec1242e70053c5 .
 
-niiri:2279f304aeeb3c6a736b1270cf7418f1
+niiri:b365bb411ced2017b69b3dbafa0e85f3
     a prov:Entity, nidm_GrandMeanMap: ; 
     prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
     nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Grand Mean Map" ;
     nidm_maskedMedian: "116.092018127441"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:2ada174836b28044a9513f1a34eef87f ;
+    nidm_inCoordinateSpace: niiri:b410708237a32a427489f32ca35c4711 ;
     crypto:sha512 "7bcbd0dbf511033ee5ce279852f073e8a82d6254329e78285b8e4948a17585a46457d5a65704e08e0524b91f02aec7c3c012f4222da246177f172afbc7eb65d5"^^xsd:string .
 
-niiri:2279f304aeeb3c6a736b1270cf7418f1 prov:wasGeneratedBy niiri:dab7ede7835ef6993526fce9c3b60438 .
+niiri:b365bb411ced2017b69b3dbafa0e85f3 prov:wasGeneratedBy niiri:690e3f484f6e5f7a6eec1242e70053c5 .
 
-niiri:abb5e4bf5790aaf850ac3e1cadc1130c
+niiri:3cc1a4d9e0dbae0ea522ae6e6bee7809
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0001.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0001.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 1" ;
-    nidm_inCoordinateSpace: niiri:2ada174836b28044a9513f1a34eef87f ;
+    nidm_inCoordinateSpace: niiri:b410708237a32a427489f32ca35c4711 ;
     crypto:sha512 "41593a1a82624e6c05f8214f64595e596b33c664304743792797665b1b36762a46e7e883d9aaaa3324fc62bf7a43261c8ed39f0ee575a4b451533dfe3eed89d7"^^xsd:string .
 
-niiri:51a39e56bffb8a149eadd63c7045b5cb
+niiri:e44f0f19f822ee7f804728a0a9835c26
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "41593a1a82624e6c05f8214f64595e596b33c664304743792797665b1b36762a46e7e883d9aaaa3324fc62bf7a43261c8ed39f0ee575a4b451533dfe3eed89d7"^^xsd:string .
 
-niiri:abb5e4bf5790aaf850ac3e1cadc1130c prov:wasDerivedFrom niiri:51a39e56bffb8a149eadd63c7045b5cb .
+niiri:3cc1a4d9e0dbae0ea522ae6e6bee7809 prov:wasDerivedFrom niiri:e44f0f19f822ee7f804728a0a9835c26 .
 
-niiri:abb5e4bf5790aaf850ac3e1cadc1130c prov:wasGeneratedBy niiri:dab7ede7835ef6993526fce9c3b60438 .
+niiri:3cc1a4d9e0dbae0ea522ae6e6bee7809 prov:wasGeneratedBy niiri:690e3f484f6e5f7a6eec1242e70053c5 .
 
-niiri:cba3c18e10f4767a196f92c51cfb376b
+niiri:8de1184852768964088718dab52c75f6
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0002.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0002.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 2" ;
-    nidm_inCoordinateSpace: niiri:2ada174836b28044a9513f1a34eef87f ;
+    nidm_inCoordinateSpace: niiri:b410708237a32a427489f32ca35c4711 ;
     crypto:sha512 "7a0d86a340516306df21786c1cbe22427b70ba2cfdea9ec8f384718104f8a3d5221ec0164e884662a96dec28f194814dabb605f0c8f8b37ef7828f7ecf45701f"^^xsd:string .
 
-niiri:d16f41a161b165456881d29024c519d5
+niiri:954f92fad652775f12537d62ef353a73
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0002.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "7a0d86a340516306df21786c1cbe22427b70ba2cfdea9ec8f384718104f8a3d5221ec0164e884662a96dec28f194814dabb605f0c8f8b37ef7828f7ecf45701f"^^xsd:string .
 
-niiri:cba3c18e10f4767a196f92c51cfb376b prov:wasDerivedFrom niiri:d16f41a161b165456881d29024c519d5 .
+niiri:8de1184852768964088718dab52c75f6 prov:wasDerivedFrom niiri:954f92fad652775f12537d62ef353a73 .
 
-niiri:cba3c18e10f4767a196f92c51cfb376b prov:wasGeneratedBy niiri:dab7ede7835ef6993526fce9c3b60438 .
+niiri:8de1184852768964088718dab52c75f6 prov:wasGeneratedBy niiri:690e3f484f6e5f7a6eec1242e70053c5 .
 
-niiri:43180ee92a7c8b91ce052068207fffeb
+niiri:814e7ed06d738c9f3a585f4228558207
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0003.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0003.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 3" ;
-    nidm_inCoordinateSpace: niiri:2ada174836b28044a9513f1a34eef87f ;
+    nidm_inCoordinateSpace: niiri:b410708237a32a427489f32ca35c4711 ;
     crypto:sha512 "683d243642dd44e2be739b6da7c49cfdb8fb66a8a58d8f12be426a80ba5f27f4d786217804c8f3b88a8f0e123111d57886b1f6f977b082d84bf55d4289f652a8"^^xsd:string .
 
-niiri:ca7d16e56b6829b233487d24e58f1c7f
+niiri:103821464851111f6bca4c68fe70a82a
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0003.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "683d243642dd44e2be739b6da7c49cfdb8fb66a8a58d8f12be426a80ba5f27f4d786217804c8f3b88a8f0e123111d57886b1f6f977b082d84bf55d4289f652a8"^^xsd:string .
 
-niiri:43180ee92a7c8b91ce052068207fffeb prov:wasDerivedFrom niiri:ca7d16e56b6829b233487d24e58f1c7f .
+niiri:814e7ed06d738c9f3a585f4228558207 prov:wasDerivedFrom niiri:103821464851111f6bca4c68fe70a82a .
 
-niiri:43180ee92a7c8b91ce052068207fffeb prov:wasGeneratedBy niiri:dab7ede7835ef6993526fce9c3b60438 .
+niiri:814e7ed06d738c9f3a585f4228558207 prov:wasGeneratedBy niiri:690e3f484f6e5f7a6eec1242e70053c5 .
 
-niiri:462859b57f29cc9dc62453fdd40a75ac
+niiri:055713a7baa36cc6f47d02b18892edab
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0004.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0004.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 4" ;
-    nidm_inCoordinateSpace: niiri:2ada174836b28044a9513f1a34eef87f ;
+    nidm_inCoordinateSpace: niiri:b410708237a32a427489f32ca35c4711 ;
     crypto:sha512 "dba26c065cb5d6ae4f7597010da0ea7329adf2177d3b8019871beb79506a47e902c8f23f4e4beb69f3a8cfa2067e28add1ff90054bab0d1ebf39c556e58a1c60"^^xsd:string .
 
-niiri:10a31df8b6ad7b2fae856ace98f252d6
+niiri:4ec71cdc1dd74a4d7e5dbf9c950e3969
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0004.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "dba26c065cb5d6ae4f7597010da0ea7329adf2177d3b8019871beb79506a47e902c8f23f4e4beb69f3a8cfa2067e28add1ff90054bab0d1ebf39c556e58a1c60"^^xsd:string .
 
-niiri:462859b57f29cc9dc62453fdd40a75ac prov:wasDerivedFrom niiri:10a31df8b6ad7b2fae856ace98f252d6 .
+niiri:055713a7baa36cc6f47d02b18892edab prov:wasDerivedFrom niiri:4ec71cdc1dd74a4d7e5dbf9c950e3969 .
 
-niiri:462859b57f29cc9dc62453fdd40a75ac prov:wasGeneratedBy niiri:dab7ede7835ef6993526fce9c3b60438 .
+niiri:055713a7baa36cc6f47d02b18892edab prov:wasGeneratedBy niiri:690e3f484f6e5f7a6eec1242e70053c5 .
 
-niiri:ea0a4d3ea65789f29653126c02f37df2
+niiri:9e2b1e2183fda70e5c8eaa09275db3b7
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0005.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0005.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 5" ;
-    nidm_inCoordinateSpace: niiri:2ada174836b28044a9513f1a34eef87f ;
+    nidm_inCoordinateSpace: niiri:b410708237a32a427489f32ca35c4711 ;
     crypto:sha512 "9760c5863f41702fba7b69b0eccde533fdb276d89380f514b5bf01691639531f18dfda8348c4e1f37fb030b0b81b3c348697e5e920b450e99796f8a22652bfb3"^^xsd:string .
 
-niiri:460a1955876793cd9ac5fab1a251202b
+niiri:5ee11adfe4ab413ef5516242c7951078
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0005.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "9760c5863f41702fba7b69b0eccde533fdb276d89380f514b5bf01691639531f18dfda8348c4e1f37fb030b0b81b3c348697e5e920b450e99796f8a22652bfb3"^^xsd:string .
 
-niiri:ea0a4d3ea65789f29653126c02f37df2 prov:wasDerivedFrom niiri:460a1955876793cd9ac5fab1a251202b .
+niiri:9e2b1e2183fda70e5c8eaa09275db3b7 prov:wasDerivedFrom niiri:5ee11adfe4ab413ef5516242c7951078 .
 
-niiri:ea0a4d3ea65789f29653126c02f37df2 prov:wasGeneratedBy niiri:dab7ede7835ef6993526fce9c3b60438 .
+niiri:9e2b1e2183fda70e5c8eaa09275db3b7 prov:wasGeneratedBy niiri:690e3f484f6e5f7a6eec1242e70053c5 .
 
-niiri:9fc2b1fdcc3756035f503401455ad416
+niiri:43a89bc0051da8157a5bff983ba89bc5
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Residual Mean Squares Map" ;
-    nidm_inCoordinateSpace: niiri:2ada174836b28044a9513f1a34eef87f ;
+    nidm_inCoordinateSpace: niiri:b410708237a32a427489f32ca35c4711 ;
     crypto:sha512 "77eca9b40d48cdbed5705dcfa828c6ff7693ecb43c305cfb0ef28660d8c7d60df8819bfcfaf0be6d223b0aa760c0114165d48afb8338fae9929f2700ae3eba82"^^xsd:string .
 
-niiri:46d987ee96393a2e2395c32b2e6f22f8
+niiri:60f4af728d95c8bc6e63352f6e049770
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     nfo:fileName "ResMS.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "cd5c1a79918d35ce4774b90a7801056e74cfb5cf68f49240a51d713c455d63895d394dd8a8f15d2b73eee86c0828b6cbc862d038d5a4d1cc299171d25ad8d4dc"^^xsd:string .
 
-niiri:9fc2b1fdcc3756035f503401455ad416 prov:wasDerivedFrom niiri:46d987ee96393a2e2395c32b2e6f22f8 .
+niiri:43a89bc0051da8157a5bff983ba89bc5 prov:wasDerivedFrom niiri:60f4af728d95c8bc6e63352f6e049770 .
 
-niiri:9fc2b1fdcc3756035f503401455ad416 prov:wasGeneratedBy niiri:dab7ede7835ef6993526fce9c3b60438 .
+niiri:43a89bc0051da8157a5bff983ba89bc5 prov:wasGeneratedBy niiri:690e3f484f6e5f7a6eec1242e70053c5 .
 
-niiri:618d3be01362df0705449588778a62f5
+niiri:08f53b8611d5bdec5c8de0c449a1db6f
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Resels per Voxel Map" ;
-    nidm_inCoordinateSpace: niiri:2ada174836b28044a9513f1a34eef87f ;
+    nidm_inCoordinateSpace: niiri:b410708237a32a427489f32ca35c4711 ;
     crypto:sha512 "e34e4eeb83555ac00c097e516f70bf3aa83f22b775b1eaa1034c5de67c3703afa41546b0dea1a061178282b842559420d773d1c8817e44adec7ed4cc01b195f4"^^xsd:string .
 
-niiri:b9e91f6719864b3367404406fc450d7b
+niiri:f9e38aef778cfa4bf78b01f51a10f4eb
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     nfo:fileName "RPV.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "1b9e3df7665e35441c1e98ddfa9aa90576563c0f976179e331a78cb43a3a52d7252e97899b6ba800b68a5eed479a81d3c29ac5a75e27aaaec451c69b48c29faf"^^xsd:string .
 
-niiri:618d3be01362df0705449588778a62f5 prov:wasDerivedFrom niiri:b9e91f6719864b3367404406fc450d7b .
+niiri:08f53b8611d5bdec5c8de0c449a1db6f prov:wasDerivedFrom niiri:f9e38aef778cfa4bf78b01f51a10f4eb .
 
-niiri:618d3be01362df0705449588778a62f5 prov:wasGeneratedBy niiri:dab7ede7835ef6993526fce9c3b60438 .
+niiri:08f53b8611d5bdec5c8de0c449a1db6f prov:wasGeneratedBy niiri:690e3f484f6e5f7a6eec1242e70053c5 .
 
-niiri:0e3570df900ab584e89c9d8ac7a6c4f2
+niiri:f0323f01131105dbd3d84869ff50e9ae
     a prov:Entity, obo_contrastweightmatrix: ; 
     nidm_statisticType: obo_tstatistic: ;
     nidm_contrastName: "tone counting vs baseline"^^xsd:string ;
     rdfs:label "Contrast: tone counting vs baseline" ;
     prov:value "[1, 0, 0, 0, 0]"^^xsd:string .
 
-niiri:73d96604016859b026bef5404df2dc57
+niiri:8cff757e6900adeab2b9b8a66b5a61ea
     a prov:Activity, nidm_ContrastEstimation: ; 
     rdfs:label "Contrast estimation" .
 
-niiri:73d96604016859b026bef5404df2dc57 prov:wasAssociatedWith niiri:490e5ab2436b12162f59fedeb9e1e9d8 .
+niiri:8cff757e6900adeab2b9b8a66b5a61ea prov:wasAssociatedWith niiri:65bbe1871e61c631eb812e3b6150407c .
 
-niiri:73d96604016859b026bef5404df2dc57 prov:used niiri:391bfa5f6d92b504b7bbd76dc18b1db4 .
+niiri:8cff757e6900adeab2b9b8a66b5a61ea prov:used niiri:07485f81ffa874bdd72e7579bb4e934b .
 
-niiri:73d96604016859b026bef5404df2dc57 prov:used niiri:9fc2b1fdcc3756035f503401455ad416 .
+niiri:8cff757e6900adeab2b9b8a66b5a61ea prov:used niiri:43a89bc0051da8157a5bff983ba89bc5 .
 
-niiri:73d96604016859b026bef5404df2dc57 prov:used niiri:ded035420e24d45acc47137ac0d3c65c .
+niiri:8cff757e6900adeab2b9b8a66b5a61ea prov:used niiri:e68475df9e5152b04c95bde006aa28c2 .
 
-niiri:73d96604016859b026bef5404df2dc57 prov:used niiri:0e3570df900ab584e89c9d8ac7a6c4f2 .
+niiri:8cff757e6900adeab2b9b8a66b5a61ea prov:used niiri:f0323f01131105dbd3d84869ff50e9ae .
 
-niiri:73d96604016859b026bef5404df2dc57 prov:used niiri:abb5e4bf5790aaf850ac3e1cadc1130c .
+niiri:8cff757e6900adeab2b9b8a66b5a61ea prov:used niiri:3cc1a4d9e0dbae0ea522ae6e6bee7809 .
 
-niiri:73d96604016859b026bef5404df2dc57 prov:used niiri:cba3c18e10f4767a196f92c51cfb376b .
+niiri:8cff757e6900adeab2b9b8a66b5a61ea prov:used niiri:8de1184852768964088718dab52c75f6 .
 
-niiri:73d96604016859b026bef5404df2dc57 prov:used niiri:43180ee92a7c8b91ce052068207fffeb .
+niiri:8cff757e6900adeab2b9b8a66b5a61ea prov:used niiri:814e7ed06d738c9f3a585f4228558207 .
 
-niiri:73d96604016859b026bef5404df2dc57 prov:used niiri:462859b57f29cc9dc62453fdd40a75ac .
+niiri:8cff757e6900adeab2b9b8a66b5a61ea prov:used niiri:055713a7baa36cc6f47d02b18892edab .
 
-niiri:73d96604016859b026bef5404df2dc57 prov:used niiri:ea0a4d3ea65789f29653126c02f37df2 .
+niiri:8cff757e6900adeab2b9b8a66b5a61ea prov:used niiri:9e2b1e2183fda70e5c8eaa09275db3b7 .
 
-niiri:f68e579c103081f8fc95d5851132f6ab
+niiri:aa1effb702cc7db6a16eac195236db09
     a prov:Entity, nidm_StatisticMap: ; 
     prov:atLocation "TStatistic.nii.gz"^^xsd:anyURI ;
     nfo:fileName "TStatistic.nii.gz"^^xsd:string ;
@@ -427,124 +427,124 @@ niiri:f68e579c103081f8fc95d5851132f6ab
     nidm_contrastName: "tone counting vs baseline"^^xsd:string ;
     nidm_errorDegreesOfFreedom: "95.9999999999612"^^xsd:float ;
     nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:2ada174836b28044a9513f1a34eef87f ;
+    nidm_inCoordinateSpace: niiri:b410708237a32a427489f32ca35c4711 ;
     crypto:sha512 "559b9991a86bb27d60af713860b88249f0a74bb9a7be767d1bc0ab2af4c8c206308434fd6f0549578121151d43d71ebc4e4d72cf6e825b3f82f095fd308832c5"^^xsd:string .
 
-niiri:f130df501f82aa4d00c50f8ef3d69e06
+niiri:612caf1dd2e842956fc81ba14de59582
     a prov:Entity, nidm_StatisticMap: ; 
     nfo:fileName "spmT_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "4d4f039b6b55f49d46991f6fffd3e0e7f933b3708d1a955f3c949863480dba89dd5fb4466b8e0f711eff753fbeb3c16c52cef9d24e13c9f494f6607dd379f64e"^^xsd:string .
 
-niiri:f68e579c103081f8fc95d5851132f6ab prov:wasDerivedFrom niiri:f130df501f82aa4d00c50f8ef3d69e06 .
+niiri:aa1effb702cc7db6a16eac195236db09 prov:wasDerivedFrom niiri:612caf1dd2e842956fc81ba14de59582 .
 
-niiri:f68e579c103081f8fc95d5851132f6ab prov:wasGeneratedBy niiri:73d96604016859b026bef5404df2dc57 .
+niiri:aa1effb702cc7db6a16eac195236db09 prov:wasGeneratedBy niiri:8cff757e6900adeab2b9b8a66b5a61ea .
 
-niiri:5d9e2f8c3ab10dbf5ee342f229e15758
+niiri:243b7b4df25be507aa622f4c9754d427
     a prov:Entity, nidm_ContrastMap: ; 
     prov:atLocation "Contrast.nii.gz"^^xsd:anyURI ;
     nfo:fileName "Contrast.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Map: tone counting vs baseline" ;
     nidm_contrastName: "tone counting vs baseline"^^xsd:string ;
-    nidm_inCoordinateSpace: niiri:2ada174836b28044a9513f1a34eef87f ;
+    nidm_inCoordinateSpace: niiri:b410708237a32a427489f32ca35c4711 ;
     crypto:sha512 "e9762825614822a23109b51b645e4397695352f3bd0fa37407e2ad0998f9acb23becd4f15698cd622b50687e083d6b94e71c696959b1175560e3ac0e50056f61"^^xsd:string .
 
-niiri:d09cfb20d2217f6d9d7b3e4e2f607e15
+niiri:08a567ac0816c0a0aceb2ed59aeea49b
     a prov:Entity, nidm_ContrastMap: ; 
     nfo:fileName "con_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "f4f1aed8094bcdf691de6bccc404a792e4cef66bb2eed29472a7b663276509857a23bfd24e7d92e4a0aaf513da4980f632094021b2ca048cf9b6ad21f481b20f"^^xsd:string .
 
-niiri:5d9e2f8c3ab10dbf5ee342f229e15758 prov:wasDerivedFrom niiri:d09cfb20d2217f6d9d7b3e4e2f607e15 .
+niiri:243b7b4df25be507aa622f4c9754d427 prov:wasDerivedFrom niiri:08a567ac0816c0a0aceb2ed59aeea49b .
 
-niiri:5d9e2f8c3ab10dbf5ee342f229e15758 prov:wasGeneratedBy niiri:73d96604016859b026bef5404df2dc57 .
+niiri:243b7b4df25be507aa622f4c9754d427 prov:wasGeneratedBy niiri:8cff757e6900adeab2b9b8a66b5a61ea .
 
-niiri:6114eaf8f264daf5c67bf0cac93aee24
+niiri:57e63fdc854e959fb8423a4f086ce703
     a prov:Entity, nidm_ContrastStandardErrorMap: ; 
     prov:atLocation "ContrastStandardError.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ContrastStandardError.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Standard Error Map" ;
-    nidm_inCoordinateSpace: niiri:2ada174836b28044a9513f1a34eef87f ;
+    nidm_inCoordinateSpace: niiri:b410708237a32a427489f32ca35c4711 ;
     crypto:sha512 "403792ebe042c165a2310a4ffac22fb225f87abecb96d927bb5b582d00ead23c9bb13ca9423963c5100a171f36d9ec7a4c0c04d20818088613d61d250ef45dd6"^^xsd:string .
 
-niiri:6114eaf8f264daf5c67bf0cac93aee24 prov:wasGeneratedBy niiri:73d96604016859b026bef5404df2dc57 .
+niiri:57e63fdc854e959fb8423a4f086ce703 prov:wasGeneratedBy niiri:8cff757e6900adeab2b9b8a66b5a61ea .
 
-niiri:8c0ca80e074a908ed461be6200aa0c16
+niiri:3dc9d42cdfae6ad474927bdb0e9bdc21
     a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
-    rdfs:label "Height Threshold: p<0.000999 (unc.)" ;
+    rdfs:label "Height Threshold: p<0.001 (unc.)" ;
     prov:value "0.000999499965079309"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:13746686410a8d72161a200356d7336a ;
-    nidm_equivalentThreshold: niiri:77660e0999804061c51dab5ad64fcfe1 .
+    nidm_equivalentThreshold: niiri:c48ee5e9869243c5ee3ef5d8de4d9211 ;
+    nidm_equivalentThreshold: niiri:5c238cdd746fbc26bd9ddecfb9e7fc15 .
 
-niiri:13746686410a8d72161a200356d7336a
+niiri:c48ee5e9869243c5ee3ef5d8de4d9211
     a prov:Entity, nidm_HeightThreshold:, obo_statistic: ; 
-    rdfs:label "Height Threshold" ;
+    rdfs:label "Height Threshold: T=3.177308)" ;
     prov:value "3.17730776622277"^^xsd:float .
 
-niiri:77660e0999804061c51dab5ad64fcfe1
+niiri:5c238cdd746fbc26bd9ddecfb9e7fc15
     a prov:Entity, nidm_HeightThreshold:, obo_FWERadjustedpvalue: ; 
-    rdfs:label "Height Threshold" ;
+    rdfs:label "Height Threshold: p<1.000000 (FWE)" ;
     prov:value "0.999999999999999"^^xsd:float .
 
-niiri:21fa5bd48e4e88c9a9121e1e236cbb5c
+niiri:102fecaa14caf589304b204290d2ae40
     a prov:Entity, nidm_ExtentThreshold:, obo_statistic: ; 
     rdfs:label "Extent Threshold: k>=0" ;
     nidm_clusterSizeInVoxels: "0"^^xsd:int ;
     nidm_clusterSizeInResels: "0"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:f20db2e5c02f93b90e7eae0807e3e491 ;
-    nidm_equivalentThreshold: niiri:3bffd8f80a4b7186e621386536c18763 .
+    nidm_equivalentThreshold: niiri:6995399cabf336da2a6296280269642f ;
+    nidm_equivalentThreshold: niiri:c6aa5eb71f55d9e8b0ed842961179eb0 .
 
-niiri:f20db2e5c02f93b90e7eae0807e3e491
+niiri:6995399cabf336da2a6296280269642f
     a prov:Entity, nidm_ExtentThreshold:, obo_FWERadjustedpvalue: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:3bffd8f80a4b7186e621386536c18763
+niiri:c6aa5eb71f55d9e8b0ed842961179eb0
     a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:24e9f0b05542386f7ba14394c762f9ac
+niiri:161fb640ca5be8910668e6da2f030000
     a prov:Entity, nidm_PeakDefinitionCriteria: ; 
     rdfs:label "Peak Definition Criteria" ;
     nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
     nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
 
-niiri:b658c7bd807d7547789ddf46a3dd33dd
+niiri:95a4466fd86f8eb162d7c71ec577da13
     a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
     rdfs:label "Cluster Connectivity Criterion: 18" ;
     nidm_hasConnectivityCriterion: nidm_voxel18connected: .
 
-niiri:4b8c75bb59b3e9de0482c23e91e61c11
+niiri:975d5305cd6d906f0149068326afc106
     a prov:Activity, nidm_Inference: ; 
     nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
     rdfs:label "Inference" .
 
-niiri:4b8c75bb59b3e9de0482c23e91e61c11 prov:wasAssociatedWith niiri:490e5ab2436b12162f59fedeb9e1e9d8 .
+niiri:975d5305cd6d906f0149068326afc106 prov:wasAssociatedWith niiri:65bbe1871e61c631eb812e3b6150407c .
 
-niiri:4b8c75bb59b3e9de0482c23e91e61c11 prov:used niiri:8c0ca80e074a908ed461be6200aa0c16 .
+niiri:975d5305cd6d906f0149068326afc106 prov:used niiri:3dc9d42cdfae6ad474927bdb0e9bdc21 .
 
-niiri:4b8c75bb59b3e9de0482c23e91e61c11 prov:used niiri:21fa5bd48e4e88c9a9121e1e236cbb5c .
+niiri:975d5305cd6d906f0149068326afc106 prov:used niiri:102fecaa14caf589304b204290d2ae40 .
 
-niiri:4b8c75bb59b3e9de0482c23e91e61c11 prov:used niiri:f68e579c103081f8fc95d5851132f6ab .
+niiri:975d5305cd6d906f0149068326afc106 prov:used niiri:aa1effb702cc7db6a16eac195236db09 .
 
-niiri:4b8c75bb59b3e9de0482c23e91e61c11 prov:used niiri:618d3be01362df0705449588778a62f5 .
+niiri:975d5305cd6d906f0149068326afc106 prov:used niiri:08f53b8611d5bdec5c8de0c449a1db6f .
 
-niiri:4b8c75bb59b3e9de0482c23e91e61c11 prov:used niiri:391bfa5f6d92b504b7bbd76dc18b1db4 .
+niiri:975d5305cd6d906f0149068326afc106 prov:used niiri:07485f81ffa874bdd72e7579bb4e934b .
 
-niiri:4b8c75bb59b3e9de0482c23e91e61c11 prov:used niiri:24e9f0b05542386f7ba14394c762f9ac .
+niiri:975d5305cd6d906f0149068326afc106 prov:used niiri:161fb640ca5be8910668e6da2f030000 .
 
-niiri:4b8c75bb59b3e9de0482c23e91e61c11 prov:used niiri:b658c7bd807d7547789ddf46a3dd33dd .
+niiri:975d5305cd6d906f0149068326afc106 prov:used niiri:95a4466fd86f8eb162d7c71ec577da13 .
 
-niiri:ba2ed8f06a0d316ea23f5b365ccce2aa
+niiri:1ade20198bb3c55969610ae99f5a7dcb
     a prov:Entity, nidm_SearchSpaceMaskMap: ; 
     prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
     nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Search Space Mask Map" ;
-    nidm_inCoordinateSpace: niiri:2ada174836b28044a9513f1a34eef87f ;
+    nidm_inCoordinateSpace: niiri:b410708237a32a427489f32ca35c4711 ;
     nidm_searchVolumeInVoxels: "223057"^^xsd:int ;
     nidm_searchVolumeInUnits: "1784456"^^xsd:float ;
     nidm_reselSizeInVoxels: "64.3564266652164"^^xsd:float ;
@@ -561,9 +561,9 @@ niiri:ba2ed8f06a0d316ea23f5b365ccce2aa
     spm_smallestSignificantClusterSizeInVoxelsFWE05: "97"^^xsd:int ;
     spm_smallestSignificantClusterSizeInVoxelsFDR05: "58"^^xsd:int .
 
-niiri:ba2ed8f06a0d316ea23f5b365ccce2aa prov:wasGeneratedBy niiri:4b8c75bb59b3e9de0482c23e91e61c11 .
+niiri:1ade20198bb3c55969610ae99f5a7dcb prov:wasGeneratedBy niiri:975d5305cd6d906f0149068326afc106 .
 
-niiri:c818225e9c6f166518804d3ab91c1a34
+niiri:32d0bf812c17b0e83c10c6b9e47a20d3
     a prov:Entity, nidm_ExcursionSetMap: ; 
     prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
@@ -571,29 +571,29 @@ niiri:c818225e9c6f166518804d3ab91c1a34
     rdfs:label "Excursion Set Map" ;
     nidm_numberOfSupraThresholdClusters: "84"^^xsd:int ;
     nidm_pValue: "5.23248111505836e-13"^^xsd:float ;
-    nidm_hasClusterLabelsMap: niiri:6e46e9a4c912d8769ff0718be16640c3 ;
-    nidm_hasMaximumIntensityProjection: niiri:b90dac405ab103450ed0afca54b1339e ;
-    nidm_inCoordinateSpace: niiri:2ada174836b28044a9513f1a34eef87f ;
+    nidm_hasClusterLabelsMap: niiri:1a46842083eecd60bf7b67f9b6b68ccb ;
+    nidm_hasMaximumIntensityProjection: niiri:da6cd8a8a31c5aadfdb433e08d00228b ;
+    nidm_inCoordinateSpace: niiri:b410708237a32a427489f32ca35c4711 ;
     crypto:sha512 "e3de08e691d68d649233bdce2639a4bbea750162fdb8ba7e29ddfbfd23760faba59f34e347d136b9a0fd9971f48200cb7c30294d1960bd27bd40661b39fe82a5"^^xsd:string .
 
-niiri:6e46e9a4c912d8769ff0718be16640c3
+niiri:1a46842083eecd60bf7b67f9b6b68ccb
     a prov:Entity, nidm_ClusterLabelsMap: ; 
     prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Cluster Labels Map" ;
-    nidm_inCoordinateSpace: niiri:2ada174836b28044a9513f1a34eef87f ;
+    nidm_inCoordinateSpace: niiri:b410708237a32a427489f32ca35c4711 ;
     crypto:sha512 "192b1d648a385a172f839b0c03aab878274f1288c0ae8c12589f2ab0657756cc57b1691a072ba8fbd8c974dee181779696289703ac99d963860bea112a19017e"^^xsd:string .
 
-niiri:b90dac405ab103450ed0afca54b1339e
+niiri:da6cd8a8a31c5aadfdb433e08d00228b
     a prov:Entity, dctype:Image ; 
     prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
     nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:c818225e9c6f166518804d3ab91c1a34 prov:wasGeneratedBy niiri:4b8c75bb59b3e9de0482c23e91e61c11 .
+niiri:32d0bf812c17b0e83c10c6b9e47a20d3 prov:wasGeneratedBy niiri:975d5305cd6d906f0149068326afc106 .
 
-niiri:8f36a85f042f8cc7fc3bd83b628271f2
+niiri:d4b353636b454d9def0cc10eaa71d2b8
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0001" ;
     nidm_clusterSizeInVoxels: "10733"^^xsd:int ;
@@ -603,9 +603,9 @@ niiri:8f36a85f042f8cc7fc3bd83b628271f2
     nidm_qValueFDR: "3.82071147380491e-68"^^xsd:float ;
     nidm_clusterLabelId: "1"^^xsd:int .
 
-niiri:8f36a85f042f8cc7fc3bd83b628271f2 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:d4b353636b454d9def0cc10eaa71d2b8 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:0571c455c5021749fc8693f5d5c53029
+niiri:dabc6f32070848fa7096bac116f4a0d0
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0002" ;
     nidm_clusterSizeInVoxels: "433"^^xsd:int ;
@@ -615,9 +615,9 @@ niiri:0571c455c5021749fc8693f5d5c53029
     nidm_qValueFDR: "1.31532949289466e-07"^^xsd:float ;
     nidm_clusterLabelId: "2"^^xsd:int .
 
-niiri:0571c455c5021749fc8693f5d5c53029 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:dabc6f32070848fa7096bac116f4a0d0 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:8976f2283c83032c1e6578e393bc1c08
+niiri:4e8b9634c8b43c73966139ed11b75ec8
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0003" ;
     nidm_clusterSizeInVoxels: "429"^^xsd:int ;
@@ -627,9 +627,9 @@ niiri:8976f2283c83032c1e6578e393bc1c08
     nidm_qValueFDR: "1.31532949289466e-07"^^xsd:float ;
     nidm_clusterLabelId: "3"^^xsd:int .
 
-niiri:8976f2283c83032c1e6578e393bc1c08 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:4e8b9634c8b43c73966139ed11b75ec8 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:f1f77d0ce1cc3ba5587c7ec07f2eac8d
+niiri:a731c83f0edffc39ddaeae57a80dc5ba
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0004" ;
     nidm_clusterSizeInVoxels: "1024"^^xsd:int ;
@@ -639,9 +639,9 @@ niiri:f1f77d0ce1cc3ba5587c7ec07f2eac8d
     nidm_qValueFDR: "1.39632790040503e-13"^^xsd:float ;
     nidm_clusterLabelId: "4"^^xsd:int .
 
-niiri:f1f77d0ce1cc3ba5587c7ec07f2eac8d prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:a731c83f0edffc39ddaeae57a80dc5ba prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:efa240525eee79c28032f1f8e966fad3
+niiri:5299ea7c2ff48f8ccb9e3da606289f28
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0005" ;
     nidm_clusterSizeInVoxels: "153"^^xsd:int ;
@@ -651,9 +651,9 @@ niiri:efa240525eee79c28032f1f8e966fad3
     nidm_qValueFDR: "0.000879975569889356"^^xsd:float ;
     nidm_clusterLabelId: "5"^^xsd:int .
 
-niiri:efa240525eee79c28032f1f8e966fad3 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:5299ea7c2ff48f8ccb9e3da606289f28 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:7e9b1ebb227a2ee5938d0545b30aca96
+niiri:2152e06e3cb49b34d19eb6146b5817f7
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0006" ;
     nidm_clusterSizeInVoxels: "108"^^xsd:int ;
@@ -663,9 +663,9 @@ niiri:7e9b1ebb227a2ee5938d0545b30aca96
     nidm_qValueFDR: "0.0049240436339622"^^xsd:float ;
     nidm_clusterLabelId: "6"^^xsd:int .
 
-niiri:7e9b1ebb227a2ee5938d0545b30aca96 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:2152e06e3cb49b34d19eb6146b5817f7 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:1c354e7e3ff502199baf755636f12453
+niiri:c205169674df01953a0df15ba2cb5f08
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0007" ;
     nidm_clusterSizeInVoxels: "513"^^xsd:int ;
@@ -675,9 +675,9 @@ niiri:1c354e7e3ff502199baf755636f12453
     nidm_qValueFDR: "2.06325301323367e-08"^^xsd:float ;
     nidm_clusterLabelId: "7"^^xsd:int .
 
-niiri:1c354e7e3ff502199baf755636f12453 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:c205169674df01953a0df15ba2cb5f08 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:7b36354f0687338fb029a58183e4b870
+niiri:f7a0ae64373c9fadcbae5c1ee69af3e7
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0008" ;
     nidm_clusterSizeInVoxels: "44"^^xsd:int ;
@@ -687,9 +687,9 @@ niiri:7b36354f0687338fb029a58183e4b870
     nidm_qValueFDR: "0.0740208627761461"^^xsd:float ;
     nidm_clusterLabelId: "8"^^xsd:int .
 
-niiri:7b36354f0687338fb029a58183e4b870 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:f7a0ae64373c9fadcbae5c1ee69af3e7 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:f1318eaae736dc28b717174be4e8be03
+niiri:f78c9c52eb8c41c81b7108fc768afea1
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0009" ;
     nidm_clusterSizeInVoxels: "25"^^xsd:int ;
@@ -699,9 +699,9 @@ niiri:f1318eaae736dc28b717174be4e8be03
     nidm_qValueFDR: "0.181411748684856"^^xsd:float ;
     nidm_clusterLabelId: "9"^^xsd:int .
 
-niiri:f1318eaae736dc28b717174be4e8be03 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:f78c9c52eb8c41c81b7108fc768afea1 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:565e2f7e2e5bde3342f5c45d37979a75
+niiri:defff4241093fb74f3bb72454faeb0c8
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0010" ;
     nidm_clusterSizeInVoxels: "65"^^xsd:int ;
@@ -711,9 +711,9 @@ niiri:565e2f7e2e5bde3342f5c45d37979a75
     nidm_qValueFDR: "0.0298041956673574"^^xsd:float ;
     nidm_clusterLabelId: "10"^^xsd:int .
 
-niiri:565e2f7e2e5bde3342f5c45d37979a75 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:defff4241093fb74f3bb72454faeb0c8 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:8447e2fc880db809a273004483217edc
+niiri:a32e7c63a62151c6c42d8b86e0a4c19e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0011" ;
     nidm_clusterSizeInVoxels: "159"^^xsd:int ;
@@ -723,9 +723,9 @@ niiri:8447e2fc880db809a273004483217edc
     nidm_qValueFDR: "0.000788072944892913"^^xsd:float ;
     nidm_clusterLabelId: "11"^^xsd:int .
 
-niiri:8447e2fc880db809a273004483217edc prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:a32e7c63a62151c6c42d8b86e0a4c19e prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:94238ef8670737705b8341502f2746a2
+niiri:f9c64f2f13c1018c1b0c90db5e455972
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0012" ;
     nidm_clusterSizeInVoxels: "127"^^xsd:int ;
@@ -735,9 +735,9 @@ niiri:94238ef8670737705b8341502f2746a2
     nidm_qValueFDR: "0.00234071125745476"^^xsd:float ;
     nidm_clusterLabelId: "12"^^xsd:int .
 
-niiri:94238ef8670737705b8341502f2746a2 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:f9c64f2f13c1018c1b0c90db5e455972 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:56882afdece5437620adade43b7e28ed
+niiri:2e1d13240b9a458b380045313214b3ba
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0013" ;
     nidm_clusterSizeInVoxels: "399"^^xsd:int ;
@@ -747,9 +747,9 @@ niiri:56882afdece5437620adade43b7e28ed
     nidm_qValueFDR: "2.64432952434356e-07"^^xsd:float ;
     nidm_clusterLabelId: "13"^^xsd:int .
 
-niiri:56882afdece5437620adade43b7e28ed prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:2e1d13240b9a458b380045313214b3ba prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:80acc2ec15379dd56dd3a4d3c0d4db28
+niiri:76bd6a834aaa05e8f24aef110c831619
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0014" ;
     nidm_clusterSizeInVoxels: "50"^^xsd:int ;
@@ -759,9 +759,9 @@ niiri:80acc2ec15379dd56dd3a4d3c0d4db28
     nidm_qValueFDR: "0.0574979385567823"^^xsd:float ;
     nidm_clusterLabelId: "14"^^xsd:int .
 
-niiri:80acc2ec15379dd56dd3a4d3c0d4db28 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:76bd6a834aaa05e8f24aef110c831619 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:f79d6102313cb9c1b58014d0d7523705
+niiri:16274414c81621b268626b188f47a6c7
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0015" ;
     nidm_clusterSizeInVoxels: "58"^^xsd:int ;
@@ -771,9 +771,9 @@ niiri:f79d6102313cb9c1b58014d0d7523705
     nidm_qValueFDR: "0.0410054007958169"^^xsd:float ;
     nidm_clusterLabelId: "15"^^xsd:int .
 
-niiri:f79d6102313cb9c1b58014d0d7523705 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:16274414c81621b268626b188f47a6c7 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:5c0356c4e08b4f78355f5f21c8c539f6
+niiri:fb5ba293db82840b5cc150cc15515c24
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0016" ;
     nidm_clusterSizeInVoxels: "35"^^xsd:int ;
@@ -783,9 +783,9 @@ niiri:5c0356c4e08b4f78355f5f21c8c539f6
     nidm_qValueFDR: "0.10906782882323"^^xsd:float ;
     nidm_clusterLabelId: "16"^^xsd:int .
 
-niiri:5c0356c4e08b4f78355f5f21c8c539f6 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:fb5ba293db82840b5cc150cc15515c24 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:5118b94ba0e2ab04227b9b6665cca04e
+niiri:aee52ad89a76ef41b6e67f9bca85ad62
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0017" ;
     nidm_clusterSizeInVoxels: "87"^^xsd:int ;
@@ -795,9 +795,9 @@ niiri:5118b94ba0e2ab04227b9b6665cca04e
     nidm_qValueFDR: "0.010285841826243"^^xsd:float ;
     nidm_clusterLabelId: "17"^^xsd:int .
 
-niiri:5118b94ba0e2ab04227b9b6665cca04e prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:aee52ad89a76ef41b6e67f9bca85ad62 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:0d31cfbdb7c4e7ca55a57b1a21ab5433
+niiri:594db02a9d179d5f91a6ed68ca678d59
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0018" ;
     nidm_clusterSizeInVoxels: "24"^^xsd:int ;
@@ -807,9 +807,9 @@ niiri:0d31cfbdb7c4e7ca55a57b1a21ab5433
     nidm_qValueFDR: "0.188859204729427"^^xsd:float ;
     nidm_clusterLabelId: "18"^^xsd:int .
 
-niiri:0d31cfbdb7c4e7ca55a57b1a21ab5433 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:594db02a9d179d5f91a6ed68ca678d59 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:dc4429e2fc1e2581ade7dee26c4a3192
+niiri:6dd3d0166eed8b2fa885aeca84711d27
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0019" ;
     nidm_clusterSizeInVoxels: "35"^^xsd:int ;
@@ -819,9 +819,9 @@ niiri:dc4429e2fc1e2581ade7dee26c4a3192
     nidm_qValueFDR: "0.10906782882323"^^xsd:float ;
     nidm_clusterLabelId: "19"^^xsd:int .
 
-niiri:dc4429e2fc1e2581ade7dee26c4a3192 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:6dd3d0166eed8b2fa885aeca84711d27 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:63325afca9aca401a92169c0b82ecc64
+niiri:17120da53c5050105b9a8ee0e996c32d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0020" ;
     nidm_clusterSizeInVoxels: "30"^^xsd:int ;
@@ -831,9 +831,9 @@ niiri:63325afca9aca401a92169c0b82ecc64
     nidm_qValueFDR: "0.147277032375543"^^xsd:float ;
     nidm_clusterLabelId: "20"^^xsd:int .
 
-niiri:63325afca9aca401a92169c0b82ecc64 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:17120da53c5050105b9a8ee0e996c32d prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:8b5b90b720b0adec672c0f46135febcd
+niiri:a533e0119aa33105f1f6664ba02c4fcf
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0021" ;
     nidm_clusterSizeInVoxels: "19"^^xsd:int ;
@@ -843,9 +843,9 @@ niiri:8b5b90b720b0adec672c0f46135febcd
     nidm_qValueFDR: "0.246054548063466"^^xsd:float ;
     nidm_clusterLabelId: "21"^^xsd:int .
 
-niiri:8b5b90b720b0adec672c0f46135febcd prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:a533e0119aa33105f1f6664ba02c4fcf prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:e37885e426d196d0484be86dc5869e7e
+niiri:b5ea5e54d015aa2a8403364ed7da486d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0022" ;
     nidm_clusterSizeInVoxels: "18"^^xsd:int ;
@@ -855,9 +855,9 @@ niiri:e37885e426d196d0484be86dc5869e7e
     nidm_qValueFDR: "0.259412548289672"^^xsd:float ;
     nidm_clusterLabelId: "22"^^xsd:int .
 
-niiri:e37885e426d196d0484be86dc5869e7e prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:b5ea5e54d015aa2a8403364ed7da486d prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:b98e5a23cb840529bde8f8f04eb60352
+niiri:16c2a7e89d0686e69f57bbeea9dc74a5
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0023" ;
     nidm_clusterSizeInVoxels: "44"^^xsd:int ;
@@ -867,9 +867,9 @@ niiri:b98e5a23cb840529bde8f8f04eb60352
     nidm_qValueFDR: "0.0740208627761461"^^xsd:float ;
     nidm_clusterLabelId: "23"^^xsd:int .
 
-niiri:b98e5a23cb840529bde8f8f04eb60352 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:16c2a7e89d0686e69f57bbeea9dc74a5 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:08f981dcb0b605dc38e14328cd560d6b
+niiri:325d5f27465210c036cd8d865e80251d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0024" ;
     nidm_clusterSizeInVoxels: "97"^^xsd:int ;
@@ -879,9 +879,9 @@ niiri:08f981dcb0b605dc38e14328cd560d6b
     nidm_qValueFDR: "0.00686276661745747"^^xsd:float ;
     nidm_clusterLabelId: "24"^^xsd:int .
 
-niiri:08f981dcb0b605dc38e14328cd560d6b prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:325d5f27465210c036cd8d865e80251d prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:d757dae4ee0e2ef151ed77b98cda2382
+niiri:a77994161041027f0cf04defd7345c50
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0025" ;
     nidm_clusterSizeInVoxels: "104"^^xsd:int ;
@@ -891,9 +891,9 @@ niiri:d757dae4ee0e2ef151ed77b98cda2382
     nidm_qValueFDR: "0.0053855680065022"^^xsd:float ;
     nidm_clusterLabelId: "25"^^xsd:int .
 
-niiri:d757dae4ee0e2ef151ed77b98cda2382 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:a77994161041027f0cf04defd7345c50 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:660ef8a46b7c1f0d47e1dbb95e0879b4
+niiri:78d6f29ff8a7c1f0a21810728ade20ce
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0026" ;
     nidm_clusterSizeInVoxels: "10"^^xsd:int ;
@@ -903,9 +903,9 @@ niiri:660ef8a46b7c1f0d47e1dbb95e0879b4
     nidm_qValueFDR: "0.436064159892175"^^xsd:float ;
     nidm_clusterLabelId: "26"^^xsd:int .
 
-niiri:660ef8a46b7c1f0d47e1dbb95e0879b4 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:78d6f29ff8a7c1f0a21810728ade20ce prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:376742ba10824087fba971d247dc6783
+niiri:ef6fca405f462fa8c50ca4b0f7e48ca2
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0027" ;
     nidm_clusterSizeInVoxels: "28"^^xsd:int ;
@@ -915,9 +915,9 @@ niiri:376742ba10824087fba971d247dc6783
     nidm_qValueFDR: "0.156756631364725"^^xsd:float ;
     nidm_clusterLabelId: "27"^^xsd:int .
 
-niiri:376742ba10824087fba971d247dc6783 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:ef6fca405f462fa8c50ca4b0f7e48ca2 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:8bb3c55367529f573f350336b59c6b8b
+niiri:6578b8b9d153de72a9648c8488a6ac3f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0028" ;
     nidm_clusterSizeInVoxels: "15"^^xsd:int ;
@@ -927,9 +927,9 @@ niiri:8bb3c55367529f573f350336b59c6b8b
     nidm_qValueFDR: "0.308527638155876"^^xsd:float ;
     nidm_clusterLabelId: "28"^^xsd:int .
 
-niiri:8bb3c55367529f573f350336b59c6b8b prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:6578b8b9d153de72a9648c8488a6ac3f prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:ecc219c77c0dd1cbef88e6f794b57b51
+niiri:aa346a17d504ccda6e8f3483bc7567b5
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0029" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -939,9 +939,9 @@ niiri:ecc219c77c0dd1cbef88e6f794b57b51
     nidm_qValueFDR: "0.622760268743341"^^xsd:float ;
     nidm_clusterLabelId: "29"^^xsd:int .
 
-niiri:ecc219c77c0dd1cbef88e6f794b57b51 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:aa346a17d504ccda6e8f3483bc7567b5 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:a1fc6b7fb08f44460fa83f1e82f3fd55
+niiri:edeaef5183ad24011f37f4883d8f953f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0030" ;
     nidm_clusterSizeInVoxels: "38"^^xsd:int ;
@@ -951,9 +951,9 @@ niiri:a1fc6b7fb08f44460fa83f1e82f3fd55
     nidm_qValueFDR: "0.102910467682425"^^xsd:float ;
     nidm_clusterLabelId: "30"^^xsd:int .
 
-niiri:a1fc6b7fb08f44460fa83f1e82f3fd55 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:edeaef5183ad24011f37f4883d8f953f prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:6e25dc1a7cdabbe6238b8c8ba92a299b
+niiri:82b6d07ebf78a88f41741c7c0b4d138a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0031" ;
     nidm_clusterSizeInVoxels: "53"^^xsd:int ;
@@ -963,9 +963,9 @@ niiri:6e25dc1a7cdabbe6238b8c8ba92a299b
     nidm_qValueFDR: "0.0512115385978591"^^xsd:float ;
     nidm_clusterLabelId: "31"^^xsd:int .
 
-niiri:6e25dc1a7cdabbe6238b8c8ba92a299b prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:82b6d07ebf78a88f41741c7c0b4d138a prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:b6d54c10be27fe7c4485995dd9f9debb
+niiri:23d958b69d91f95e528ceb5e2197a63a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0032" ;
     nidm_clusterSizeInVoxels: "29"^^xsd:int ;
@@ -975,9 +975,9 @@ niiri:b6d54c10be27fe7c4485995dd9f9debb
     nidm_qValueFDR: "0.151759183691829"^^xsd:float ;
     nidm_clusterLabelId: "32"^^xsd:int .
 
-niiri:b6d54c10be27fe7c4485995dd9f9debb prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:23d958b69d91f95e528ceb5e2197a63a prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:ef72e4c2ccfe576af6dd9f5327bf55b9
+niiri:cd749510acee370dec9860a5407637f5
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0033" ;
     nidm_clusterSizeInVoxels: "11"^^xsd:int ;
@@ -987,9 +987,9 @@ niiri:ef72e4c2ccfe576af6dd9f5327bf55b9
     nidm_qValueFDR: "0.404223246421551"^^xsd:float ;
     nidm_clusterLabelId: "33"^^xsd:int .
 
-niiri:ef72e4c2ccfe576af6dd9f5327bf55b9 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:cd749510acee370dec9860a5407637f5 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:13d8b78f07281f4256fd3c0ec01dd4c4
+niiri:13d9d29fd974d6893c1726d57a98a10f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0034" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -999,9 +999,9 @@ niiri:13d8b78f07281f4256fd3c0ec01dd4c4
     nidm_qValueFDR: "0.515929316180906"^^xsd:float ;
     nidm_clusterLabelId: "34"^^xsd:int .
 
-niiri:13d8b78f07281f4256fd3c0ec01dd4c4 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:13d9d29fd974d6893c1726d57a98a10f prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:ba735e41f5c81e821d5431a5f33299b3
+niiri:0d04d9bc9dd104e43dd556533a5b2159
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0035" ;
     nidm_clusterSizeInVoxels: "25"^^xsd:int ;
@@ -1011,9 +1011,9 @@ niiri:ba735e41f5c81e821d5431a5f33299b3
     nidm_qValueFDR: "0.181411748684856"^^xsd:float ;
     nidm_clusterLabelId: "35"^^xsd:int .
 
-niiri:ba735e41f5c81e821d5431a5f33299b3 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:0d04d9bc9dd104e43dd556533a5b2159 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:9d954ccdd2f76e6021425a58f7079443
+niiri:7d13eda0d79684f0d63dac1332405064
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0036" ;
     nidm_clusterSizeInVoxels: "20"^^xsd:int ;
@@ -1023,9 +1023,9 @@ niiri:9d954ccdd2f76e6021425a58f7079443
     nidm_qValueFDR: "0.241481672920932"^^xsd:float ;
     nidm_clusterLabelId: "36"^^xsd:int .
 
-niiri:9d954ccdd2f76e6021425a58f7079443 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:7d13eda0d79684f0d63dac1332405064 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:3964078dd1cffc5e5036d7bec9ce573c
+niiri:9cc2d1c11d4e3b5aec5735ee91c1aca3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0037" ;
     nidm_clusterSizeInVoxels: "11"^^xsd:int ;
@@ -1035,9 +1035,9 @@ niiri:3964078dd1cffc5e5036d7bec9ce573c
     nidm_qValueFDR: "0.404223246421551"^^xsd:float ;
     nidm_clusterLabelId: "37"^^xsd:int .
 
-niiri:3964078dd1cffc5e5036d7bec9ce573c prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:9cc2d1c11d4e3b5aec5735ee91c1aca3 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:53d1ede95ea7c0b47d5a32d1a51fe6f6
+niiri:5b5b201251a2cc570135bacff1a480b1
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0038" ;
     nidm_clusterSizeInVoxels: "22"^^xsd:int ;
@@ -1047,9 +1047,9 @@ niiri:53d1ede95ea7c0b47d5a32d1a51fe6f6
     nidm_qValueFDR: "0.212931578784742"^^xsd:float ;
     nidm_clusterLabelId: "38"^^xsd:int .
 
-niiri:53d1ede95ea7c0b47d5a32d1a51fe6f6 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:5b5b201251a2cc570135bacff1a480b1 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:c603845c76b83d0aac64a7584957c8fb
+niiri:bbf4ce7e2e67235f45331b2b87133bd7
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0039" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -1059,9 +1059,9 @@ niiri:c603845c76b83d0aac64a7584957c8fb
     nidm_qValueFDR: "0.515929316180906"^^xsd:float ;
     nidm_clusterLabelId: "39"^^xsd:int .
 
-niiri:c603845c76b83d0aac64a7584957c8fb prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:bbf4ce7e2e67235f45331b2b87133bd7 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:a2777ad5b03729d935f9c97ada730fc3
+niiri:6a09c31a2cb2399d4dfaa1e9734b3056
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0040" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -1071,9 +1071,9 @@ niiri:a2777ad5b03729d935f9c97ada730fc3
     nidm_qValueFDR: "0.515929316180906"^^xsd:float ;
     nidm_clusterLabelId: "40"^^xsd:int .
 
-niiri:a2777ad5b03729d935f9c97ada730fc3 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:6a09c31a2cb2399d4dfaa1e9734b3056 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:6be135d40f33855edbacae1ce12b09f5
+niiri:19eff7c42f4c5b43b8936b6bb77abf9e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0041" ;
     nidm_clusterSizeInVoxels: "14"^^xsd:int ;
@@ -1083,9 +1083,9 @@ niiri:6be135d40f33855edbacae1ce12b09f5
     nidm_qValueFDR: "0.328607258916625"^^xsd:float ;
     nidm_clusterLabelId: "41"^^xsd:int .
 
-niiri:6be135d40f33855edbacae1ce12b09f5 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:19eff7c42f4c5b43b8936b6bb77abf9e prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:28624557fd946e461b8d82ec16375193
+niiri:3a53732749467fad732fc1b126252b83
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0042" ;
     nidm_clusterSizeInVoxels: "36"^^xsd:int ;
@@ -1095,9 +1095,9 @@ niiri:28624557fd946e461b8d82ec16375193
     nidm_qValueFDR: "0.10906782882323"^^xsd:float ;
     nidm_clusterLabelId: "42"^^xsd:int .
 
-niiri:28624557fd946e461b8d82ec16375193 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:3a53732749467fad732fc1b126252b83 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:553d9ccd8301231daa8b7127b7d9fb7f
+niiri:4489ae9a89d81f59b4a316f0bc2ca8b8
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0043" ;
     nidm_clusterSizeInVoxels: "13"^^xsd:int ;
@@ -1107,9 +1107,9 @@ niiri:553d9ccd8301231daa8b7127b7d9fb7f
     nidm_qValueFDR: "0.350994981817484"^^xsd:float ;
     nidm_clusterLabelId: "43"^^xsd:int .
 
-niiri:553d9ccd8301231daa8b7127b7d9fb7f prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:4489ae9a89d81f59b4a316f0bc2ca8b8 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:2a7b2aeea7dc6c0e5169cde436a25f98
+niiri:20b3e078d59196a48bbdcfae8b039f3e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0044" ;
     nidm_clusterSizeInVoxels: "17"^^xsd:int ;
@@ -1119,9 +1119,9 @@ niiri:2a7b2aeea7dc6c0e5169cde436a25f98
     nidm_qValueFDR: "0.266540882546409"^^xsd:float ;
     nidm_clusterLabelId: "44"^^xsd:int .
 
-niiri:2a7b2aeea7dc6c0e5169cde436a25f98 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:20b3e078d59196a48bbdcfae8b039f3e prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:e5ed0876efa8e7867992a3e7519d125a
+niiri:87692b796865090154e70657cb33f3fa
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0045" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -1131,9 +1131,9 @@ niiri:e5ed0876efa8e7867992a3e7519d125a
     nidm_qValueFDR: "0.536340932634632"^^xsd:float ;
     nidm_clusterLabelId: "45"^^xsd:int .
 
-niiri:e5ed0876efa8e7867992a3e7519d125a prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:87692b796865090154e70657cb33f3fa prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:cc4442623b113667ed11179bf378fa55
+niiri:f6aab0b38147783304dd12682b7a862f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0046" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1143,9 +1143,9 @@ niiri:cc4442623b113667ed11179bf378fa55
     nidm_qValueFDR: "0.69298518133747"^^xsd:float ;
     nidm_clusterLabelId: "46"^^xsd:int .
 
-niiri:cc4442623b113667ed11179bf378fa55 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:f6aab0b38147783304dd12682b7a862f prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:3bcdad331508ef0bb8c4160e76f8a8dc
+niiri:8cfffabbc7e33bc2c585eb4a81ebc159
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0047" ;
     nidm_clusterSizeInVoxels: "9"^^xsd:int ;
@@ -1155,9 +1155,9 @@ niiri:3bcdad331508ef0bb8c4160e76f8a8dc
     nidm_qValueFDR: "0.472279999279227"^^xsd:float ;
     nidm_clusterLabelId: "47"^^xsd:int .
 
-niiri:3bcdad331508ef0bb8c4160e76f8a8dc prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:8cfffabbc7e33bc2c585eb4a81ebc159 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:4f16f2a965f5b74e4ed5dd4273ae236f
+niiri:d93e1967e2b464317bc445a37c7560a2
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0048" ;
     nidm_clusterSizeInVoxels: "17"^^xsd:int ;
@@ -1167,9 +1167,9 @@ niiri:4f16f2a965f5b74e4ed5dd4273ae236f
     nidm_qValueFDR: "0.266540882546409"^^xsd:float ;
     nidm_clusterLabelId: "48"^^xsd:int .
 
-niiri:4f16f2a965f5b74e4ed5dd4273ae236f prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:d93e1967e2b464317bc445a37c7560a2 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:d10cc69571498e5ccb865e70f789b959
+niiri:80f2f6c335075aedb795e079a5688f2b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0049" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -1179,9 +1179,9 @@ niiri:d10cc69571498e5ccb865e70f789b959
     nidm_qValueFDR: "0.574625932623638"^^xsd:float ;
     nidm_clusterLabelId: "49"^^xsd:int .
 
-niiri:d10cc69571498e5ccb865e70f789b959 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:80f2f6c335075aedb795e079a5688f2b prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:eca18148c6df2bf25a3fb4224b299658
+niiri:ef7d0561535e5e02620497afd1e27f3d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0050" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -1191,9 +1191,9 @@ niiri:eca18148c6df2bf25a3fb4224b299658
     nidm_qValueFDR: "0.536340932634632"^^xsd:float ;
     nidm_clusterLabelId: "50"^^xsd:int .
 
-niiri:eca18148c6df2bf25a3fb4224b299658 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:ef7d0561535e5e02620497afd1e27f3d prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:d01136698ec67fb4e47df44c2e197103
+niiri:29289a4455046f74558f3c81d39ba67b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0051" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -1203,9 +1203,9 @@ niiri:d01136698ec67fb4e47df44c2e197103
     nidm_qValueFDR: "0.574625932623638"^^xsd:float ;
     nidm_clusterLabelId: "51"^^xsd:int .
 
-niiri:d01136698ec67fb4e47df44c2e197103 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:29289a4455046f74558f3c81d39ba67b prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:b1d116fb7eeb859d3c14dbed857c171a
+niiri:2821bde2f68ccf372a5e6ea09d4eada7
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0052" ;
     nidm_clusterSizeInVoxels: "19"^^xsd:int ;
@@ -1215,9 +1215,9 @@ niiri:b1d116fb7eeb859d3c14dbed857c171a
     nidm_qValueFDR: "0.246054548063466"^^xsd:float ;
     nidm_clusterLabelId: "52"^^xsd:int .
 
-niiri:b1d116fb7eeb859d3c14dbed857c171a prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:2821bde2f68ccf372a5e6ea09d4eada7 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:80ebd2b365389e66f0063546e25d7a7f
+niiri:5514e5220803aad2c04bbd033aa76695
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0053" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1227,9 +1227,9 @@ niiri:80ebd2b365389e66f0063546e25d7a7f
     nidm_qValueFDR: "0.720258744789692"^^xsd:float ;
     nidm_clusterLabelId: "53"^^xsd:int .
 
-niiri:80ebd2b365389e66f0063546e25d7a7f prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:5514e5220803aad2c04bbd033aa76695 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:f28ff86627fd1b6b8dff8eeb57dda0bf
+niiri:315fcb9a135fe01c557c732f7f103e94
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0054" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1239,9 +1239,9 @@ niiri:f28ff86627fd1b6b8dff8eeb57dda0bf
     nidm_qValueFDR: "0.69298518133747"^^xsd:float ;
     nidm_clusterLabelId: "54"^^xsd:int .
 
-niiri:f28ff86627fd1b6b8dff8eeb57dda0bf prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:315fcb9a135fe01c557c732f7f103e94 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:7410e6e29d61d77d50faa3f92b630f60
+niiri:fe8e19f11e2bcbf510735d94d7db4251
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0055" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -1251,9 +1251,9 @@ niiri:7410e6e29d61d77d50faa3f92b630f60
     nidm_qValueFDR: "0.515929316180906"^^xsd:float ;
     nidm_clusterLabelId: "55"^^xsd:int .
 
-niiri:7410e6e29d61d77d50faa3f92b630f60 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:fe8e19f11e2bcbf510735d94d7db4251 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:1f58e1cc42099395a446086ee96b8a42
+niiri:fec8619ae00ff17ab9a3d3ceb9046f4e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0056" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -1263,9 +1263,9 @@ niiri:1f58e1cc42099395a446086ee96b8a42
     nidm_qValueFDR: "0.574625932623638"^^xsd:float ;
     nidm_clusterLabelId: "56"^^xsd:int .
 
-niiri:1f58e1cc42099395a446086ee96b8a42 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:fec8619ae00ff17ab9a3d3ceb9046f4e prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:873d10b94cdd2f9974ccfd2cdbfaaefa
+niiri:0b442ae9d99b24f7707cb51260201d38
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0057" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1275,9 +1275,9 @@ niiri:873d10b94cdd2f9974ccfd2cdbfaaefa
     nidm_qValueFDR: "0.720258744789692"^^xsd:float ;
     nidm_clusterLabelId: "57"^^xsd:int .
 
-niiri:873d10b94cdd2f9974ccfd2cdbfaaefa prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:0b442ae9d99b24f7707cb51260201d38 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:b90b028a3ab9996de06b07fefc72f518
+niiri:5b35b6fc65311a490ca686dedf246257
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0058" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -1287,9 +1287,9 @@ niiri:b90b028a3ab9996de06b07fefc72f518
     nidm_qValueFDR: "0.515929316180906"^^xsd:float ;
     nidm_clusterLabelId: "58"^^xsd:int .
 
-niiri:b90b028a3ab9996de06b07fefc72f518 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:5b35b6fc65311a490ca686dedf246257 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:568f5936427903f7944d3adca7a176de
+niiri:8105ee9b0d3cbff0afc4f8e6f6cbaaaa
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0059" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1299,9 +1299,9 @@ niiri:568f5936427903f7944d3adca7a176de
     nidm_qValueFDR: "0.720258744789692"^^xsd:float ;
     nidm_clusterLabelId: "59"^^xsd:int .
 
-niiri:568f5936427903f7944d3adca7a176de prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:8105ee9b0d3cbff0afc4f8e6f6cbaaaa prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:8d982136130ad2ce21a159a7d9c1edaa
+niiri:b133a4090af3a2b167687334a106d130
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0060" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1311,9 +1311,9 @@ niiri:8d982136130ad2ce21a159a7d9c1edaa
     nidm_qValueFDR: "0.622760268743341"^^xsd:float ;
     nidm_clusterLabelId: "60"^^xsd:int .
 
-niiri:8d982136130ad2ce21a159a7d9c1edaa prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:b133a4090af3a2b167687334a106d130 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:3aa90bc8976de4ac1c73e9b43c959876
+niiri:4c38fc3cc2a35b74b2036daf823f1c35
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0061" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -1323,9 +1323,9 @@ niiri:3aa90bc8976de4ac1c73e9b43c959876
     nidm_qValueFDR: "0.515929316180906"^^xsd:float ;
     nidm_clusterLabelId: "61"^^xsd:int .
 
-niiri:3aa90bc8976de4ac1c73e9b43c959876 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:4c38fc3cc2a35b74b2036daf823f1c35 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:9905f70b4755853ccd1de257abc32ef8
+niiri:9476947ad907c2f9d5c061ead3c8ca5c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0062" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1335,9 +1335,9 @@ niiri:9905f70b4755853ccd1de257abc32ef8
     nidm_qValueFDR: "0.69298518133747"^^xsd:float ;
     nidm_clusterLabelId: "62"^^xsd:int .
 
-niiri:9905f70b4755853ccd1de257abc32ef8 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:9476947ad907c2f9d5c061ead3c8ca5c prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:cfcc37be279ca1493d8aeab64d0f7eb0
+niiri:eaf5abe818e88775744fc4bc734500da
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0063" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -1347,9 +1347,9 @@ niiri:cfcc37be279ca1493d8aeab64d0f7eb0
     nidm_qValueFDR: "0.536340932634632"^^xsd:float ;
     nidm_clusterLabelId: "63"^^xsd:int .
 
-niiri:cfcc37be279ca1493d8aeab64d0f7eb0 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:eaf5abe818e88775744fc4bc734500da prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:0725b220f47ead33a4ba9ecc13ada7ae
+niiri:d327e883ddebc9532dc10d806d05ceea
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0064" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1359,9 +1359,9 @@ niiri:0725b220f47ead33a4ba9ecc13ada7ae
     nidm_qValueFDR: "0.720258744789692"^^xsd:float ;
     nidm_clusterLabelId: "64"^^xsd:int .
 
-niiri:0725b220f47ead33a4ba9ecc13ada7ae prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:d327e883ddebc9532dc10d806d05ceea prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:c8f5cfe91a5e1c0eb3a8ce4272e74dc1
+niiri:b56a8e6eef495278939c1f07e4b2ec46
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0065" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1371,9 +1371,9 @@ niiri:c8f5cfe91a5e1c0eb3a8ce4272e74dc1
     nidm_qValueFDR: "0.69298518133747"^^xsd:float ;
     nidm_clusterLabelId: "65"^^xsd:int .
 
-niiri:c8f5cfe91a5e1c0eb3a8ce4272e74dc1 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:b56a8e6eef495278939c1f07e4b2ec46 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:76eeefc962a00f410ca4b176def01aa5
+niiri:ed00692e64206abf7a48d003e49a172c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0066" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1383,9 +1383,9 @@ niiri:76eeefc962a00f410ca4b176def01aa5
     nidm_qValueFDR: "0.720258744789692"^^xsd:float ;
     nidm_clusterLabelId: "66"^^xsd:int .
 
-niiri:76eeefc962a00f410ca4b176def01aa5 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:ed00692e64206abf7a48d003e49a172c prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:62c2a8527db43def7b959349980d6c02
+niiri:33f78596b63613a9bb773b49e610c339
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0067" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1395,9 +1395,9 @@ niiri:62c2a8527db43def7b959349980d6c02
     nidm_qValueFDR: "0.69298518133747"^^xsd:float ;
     nidm_clusterLabelId: "67"^^xsd:int .
 
-niiri:62c2a8527db43def7b959349980d6c02 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:33f78596b63613a9bb773b49e610c339 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:890df2ef7ecc6eafa711940fe2c85892
+niiri:fd773d75cfefece3ae58e4b268b97593
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0068" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1407,9 +1407,9 @@ niiri:890df2ef7ecc6eafa711940fe2c85892
     nidm_qValueFDR: "0.684623517753047"^^xsd:float ;
     nidm_clusterLabelId: "68"^^xsd:int .
 
-niiri:890df2ef7ecc6eafa711940fe2c85892 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:fd773d75cfefece3ae58e4b268b97593 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:1fc695464136ac390f15258db075c307
+niiri:b1682618b3d8ba951d4fba69d43ace19
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0069" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1419,9 +1419,9 @@ niiri:1fc695464136ac390f15258db075c307
     nidm_qValueFDR: "0.720258744789692"^^xsd:float ;
     nidm_clusterLabelId: "69"^^xsd:int .
 
-niiri:1fc695464136ac390f15258db075c307 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:b1682618b3d8ba951d4fba69d43ace19 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:a63c8949e4a3fc9f1f4411a09a294513
+niiri:4aff58ce7014532950c85678251d820b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0070" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1431,9 +1431,9 @@ niiri:a63c8949e4a3fc9f1f4411a09a294513
     nidm_qValueFDR: "0.69298518133747"^^xsd:float ;
     nidm_clusterLabelId: "70"^^xsd:int .
 
-niiri:a63c8949e4a3fc9f1f4411a09a294513 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:4aff58ce7014532950c85678251d820b prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:df25ac5a53adfde0956454127605d4b6
+niiri:d98d8e8d25b59a9503f694b966d532d9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0071" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1443,9 +1443,9 @@ niiri:df25ac5a53adfde0956454127605d4b6
     nidm_qValueFDR: "0.69298518133747"^^xsd:float ;
     nidm_clusterLabelId: "71"^^xsd:int .
 
-niiri:df25ac5a53adfde0956454127605d4b6 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:d98d8e8d25b59a9503f694b966d532d9 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:430b756d7a021f005bd015a459e3abf2
+niiri:5b8cc71e1c4a9af4a428ecbfd59af0c3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0072" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1455,9 +1455,9 @@ niiri:430b756d7a021f005bd015a459e3abf2
     nidm_qValueFDR: "0.622760268743341"^^xsd:float ;
     nidm_clusterLabelId: "72"^^xsd:int .
 
-niiri:430b756d7a021f005bd015a459e3abf2 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:5b8cc71e1c4a9af4a428ecbfd59af0c3 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:080141eb52f83c2bae53c858e92b0d56
+niiri:9399cc4d9102dea2381bab7e4de270e7
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0073" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -1467,9 +1467,9 @@ niiri:080141eb52f83c2bae53c858e92b0d56
     nidm_qValueFDR: "0.536340932634632"^^xsd:float ;
     nidm_clusterLabelId: "73"^^xsd:int .
 
-niiri:080141eb52f83c2bae53c858e92b0d56 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:9399cc4d9102dea2381bab7e4de270e7 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:455661055a3ab874933b9807b54adec0
+niiri:25449e2c897446ebd8a31026fdd28119
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0074" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1479,9 +1479,9 @@ niiri:455661055a3ab874933b9807b54adec0
     nidm_qValueFDR: "0.720258744789692"^^xsd:float ;
     nidm_clusterLabelId: "74"^^xsd:int .
 
-niiri:455661055a3ab874933b9807b54adec0 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:25449e2c897446ebd8a31026fdd28119 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:a4e79b29ae579ef25088671c40dcd4aa
+niiri:0e21ee277152eb058ea4661ca48674d9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0075" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1491,9 +1491,9 @@ niiri:a4e79b29ae579ef25088671c40dcd4aa
     nidm_qValueFDR: "0.684623517753047"^^xsd:float ;
     nidm_clusterLabelId: "75"^^xsd:int .
 
-niiri:a4e79b29ae579ef25088671c40dcd4aa prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:0e21ee277152eb058ea4661ca48674d9 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:cf1fb2a622b7b69b2867e5cf7760fe38
+niiri:0e8a97e94bdd4af70efd21917168b43e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0076" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1503,9 +1503,9 @@ niiri:cf1fb2a622b7b69b2867e5cf7760fe38
     nidm_qValueFDR: "0.69298518133747"^^xsd:float ;
     nidm_clusterLabelId: "76"^^xsd:int .
 
-niiri:cf1fb2a622b7b69b2867e5cf7760fe38 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:0e8a97e94bdd4af70efd21917168b43e prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:d2c0709213ef56652ef36c9d207acf04
+niiri:5b01f2070bd1d0178ffb33f1582d88a3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0077" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1515,9 +1515,9 @@ niiri:d2c0709213ef56652ef36c9d207acf04
     nidm_qValueFDR: "0.69298518133747"^^xsd:float ;
     nidm_clusterLabelId: "77"^^xsd:int .
 
-niiri:d2c0709213ef56652ef36c9d207acf04 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:5b01f2070bd1d0178ffb33f1582d88a3 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:2945ea3e25037efb18cb1b0c0a9604f5
+niiri:329bc820e22a3a07c45bd811037a5b92
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0078" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1527,9 +1527,9 @@ niiri:2945ea3e25037efb18cb1b0c0a9604f5
     nidm_qValueFDR: "0.69298518133747"^^xsd:float ;
     nidm_clusterLabelId: "78"^^xsd:int .
 
-niiri:2945ea3e25037efb18cb1b0c0a9604f5 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:329bc820e22a3a07c45bd811037a5b92 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:81211325ca547298daf652760e8bad87
+niiri:4121c76a27252e2b2396a4e6040a0baf
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0079" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1539,9 +1539,9 @@ niiri:81211325ca547298daf652760e8bad87
     nidm_qValueFDR: "0.684623517753047"^^xsd:float ;
     nidm_clusterLabelId: "79"^^xsd:int .
 
-niiri:81211325ca547298daf652760e8bad87 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:4121c76a27252e2b2396a4e6040a0baf prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:4b62f251a83aafef65b16eccc82e668e
+niiri:419bb28f6b465c3e5015a6d14e56b223
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0080" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1551,9 +1551,9 @@ niiri:4b62f251a83aafef65b16eccc82e668e
     nidm_qValueFDR: "0.720258744789692"^^xsd:float ;
     nidm_clusterLabelId: "80"^^xsd:int .
 
-niiri:4b62f251a83aafef65b16eccc82e668e prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:419bb28f6b465c3e5015a6d14e56b223 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:773351148f166f1064c72ad4e1f11422
+niiri:e64d676ce70ddc69f3b8a79a997afc14
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0081" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1563,9 +1563,9 @@ niiri:773351148f166f1064c72ad4e1f11422
     nidm_qValueFDR: "0.720258744789692"^^xsd:float ;
     nidm_clusterLabelId: "81"^^xsd:int .
 
-niiri:773351148f166f1064c72ad4e1f11422 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:e64d676ce70ddc69f3b8a79a997afc14 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:eaca7a045a95a69292520d89e15df899
+niiri:b2fe473551b0d5958d6a1fafaa7495aa
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0082" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1575,9 +1575,9 @@ niiri:eaca7a045a95a69292520d89e15df899
     nidm_qValueFDR: "0.720258744789692"^^xsd:float ;
     nidm_clusterLabelId: "82"^^xsd:int .
 
-niiri:eaca7a045a95a69292520d89e15df899 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:b2fe473551b0d5958d6a1fafaa7495aa prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:147f8e061f74d3386fbcc5d348522c64
+niiri:8fc15b04ecd3232fd23805615acbe960
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0083" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1587,9 +1587,9 @@ niiri:147f8e061f74d3386fbcc5d348522c64
     nidm_qValueFDR: "0.720258744789692"^^xsd:float ;
     nidm_clusterLabelId: "83"^^xsd:int .
 
-niiri:147f8e061f74d3386fbcc5d348522c64 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:8fc15b04ecd3232fd23805615acbe960 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:b140e937ac96257d15f410e255ead183
+niiri:3ba4f4eceb22f4823f915b7f2ea31b71
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0084" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1599,1875 +1599,1875 @@ niiri:b140e937ac96257d15f410e255ead183
     nidm_qValueFDR: "0.720258744789692"^^xsd:float ;
     nidm_clusterLabelId: "84"^^xsd:int .
 
-niiri:b140e937ac96257d15f410e255ead183 prov:wasDerivedFrom niiri:c818225e9c6f166518804d3ab91c1a34 .
+niiri:3ba4f4eceb22f4823f915b7f2ea31b71 prov:wasDerivedFrom niiri:32d0bf812c17b0e83c10c6b9e47a20d3 .
 
-niiri:cbd10319b485230bd42be33c69190e0b
+niiri:61bd43e2cb11ead4b85522ae0ab9c70f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0001" ;
-    prov:atLocation niiri:19c1127e56da22effc8ec6831ccd53c7 ;
+    prov:atLocation niiri:19fd8a73f42418dd2674d3fea35437a4 ;
     prov:value "9.2086353302002"^^xsd:float ;
     nidm_equivalentZStatistic: "7.76768101511643"^^xsd:float ;
     nidm_pValueUncorrected: "3.99680288865056e-15"^^xsd:float ;
     nidm_pValueFWER: "8.41986258492966e-10"^^xsd:float ;
     nidm_qValueFDR: "1.98279886818782e-08"^^xsd:float .
 
-niiri:19c1127e56da22effc8ec6831ccd53c7
+niiri:19fd8a73f42418dd2674d3fea35437a4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0001" ;
     nidm_coordinateVector: "[46,14,22]"^^xsd:string .
 
-niiri:cbd10319b485230bd42be33c69190e0b prov:wasDerivedFrom niiri:8f36a85f042f8cc7fc3bd83b628271f2 .
+niiri:61bd43e2cb11ead4b85522ae0ab9c70f prov:wasDerivedFrom niiri:d4b353636b454d9def0cc10eaa71d2b8 .
 
-niiri:f6627370100a3b64d18799c1d6bee92b
+niiri:aaefd41c0d243a75bbaf8975589a5d52
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0002" ;
-    prov:atLocation niiri:bb6e96dff73f6f682be2a93c3f8037b0 ;
+    prov:atLocation niiri:76939a99f5c8dab773bec0d17d3e3287 ;
     prov:value "7.77265024185181"^^xsd:float ;
     nidm_equivalentZStatistic: "6.82858568121235"^^xsd:float ;
     nidm_pValueUncorrected: "4.28779234340482e-12"^^xsd:float ;
     nidm_pValueFWER: "9.56372568139408e-07"^^xsd:float ;
     nidm_qValueFDR: "5.15073725636882e-06"^^xsd:float .
 
-niiri:bb6e96dff73f6f682be2a93c3f8037b0
+niiri:76939a99f5c8dab773bec0d17d3e3287
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0002" ;
     nidm_coordinateVector: "[32,24,-6]"^^xsd:string .
 
-niiri:f6627370100a3b64d18799c1d6bee92b prov:wasDerivedFrom niiri:8f36a85f042f8cc7fc3bd83b628271f2 .
+niiri:aaefd41c0d243a75bbaf8975589a5d52 prov:wasDerivedFrom niiri:d4b353636b454d9def0cc10eaa71d2b8 .
 
-niiri:7b9e42461bd57488c28ce61f04157a16
+niiri:9c6062c0b908383a480b076e8fb62317
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0003" ;
-    prov:atLocation niiri:fa44ca794f0d12d4d915c2886a5e614d ;
+    prov:atLocation niiri:3cb0eeaad7f509be77fbbb3c734b17c8 ;
     prov:value "7.7477593421936"^^xsd:float ;
     nidm_equivalentZStatistic: "6.81126740568942"^^xsd:float ;
     nidm_pValueUncorrected: "4.83713069598934e-12"^^xsd:float ;
     nidm_pValueFWER: "1.07890633305185e-06"^^xsd:float ;
     nidm_qValueFDR: "5.15073725636882e-06"^^xsd:float .
 
-niiri:fa44ca794f0d12d4d915c2886a5e614d
+niiri:3cb0eeaad7f509be77fbbb3c734b17c8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0003" ;
     nidm_coordinateVector: "[8,18,50]"^^xsd:string .
 
-niiri:7b9e42461bd57488c28ce61f04157a16 prov:wasDerivedFrom niiri:8f36a85f042f8cc7fc3bd83b628271f2 .
+niiri:9c6062c0b908383a480b076e8fb62317 prov:wasDerivedFrom niiri:d4b353636b454d9def0cc10eaa71d2b8 .
 
-niiri:41817b9e9d02e04a62572b281bd1703c
+niiri:f05f6aec7d624e6197dbd9ac07aef88b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0004" ;
-    prov:atLocation niiri:61201c57599cb8e89dd26d9aeb8cbf0b ;
+    prov:atLocation niiri:e4554759a85d8e68a90cbf39443103fe ;
     prov:value "7.59118175506592"^^xsd:float ;
     nidm_equivalentZStatistic: "6.70158988664555"^^xsd:float ;
     nidm_pValueUncorrected: "1.03081987390397e-11"^^xsd:float ;
     nidm_pValueFWER: "2.29926635753053e-06"^^xsd:float ;
     nidm_qValueFDR: "7.75261359723548e-06"^^xsd:float .
 
-niiri:61201c57599cb8e89dd26d9aeb8cbf0b
+niiri:e4554759a85d8e68a90cbf39443103fe
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0004" ;
     nidm_coordinateVector: "[34,-88,-2]"^^xsd:string .
 
-niiri:41817b9e9d02e04a62572b281bd1703c prov:wasDerivedFrom niiri:0571c455c5021749fc8693f5d5c53029 .
+niiri:f05f6aec7d624e6197dbd9ac07aef88b prov:wasDerivedFrom niiri:dabc6f32070848fa7096bac116f4a0d0 .
 
-niiri:1642fc731ff715f5797db051685ef81a
+niiri:c11d713034b63a168bdd812994537584
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0005" ;
-    prov:atLocation niiri:e840a0198f27f08ba380a14487eed616 ;
+    prov:atLocation niiri:d844d02b36a9dc3a0e8ff3270dd100e1 ;
     prov:value "7.03135824203491"^^xsd:float ;
     nidm_equivalentZStatistic: "6.29919779546036"^^xsd:float ;
     nidm_pValueUncorrected: "1.49595003051672e-10"^^xsd:float ;
     nidm_pValueFWER: "3.33681630670934e-05"^^xsd:float ;
     nidm_qValueFDR: "3.5929708651339e-05"^^xsd:float .
 
-niiri:e840a0198f27f08ba380a14487eed616
+niiri:d844d02b36a9dc3a0e8ff3270dd100e1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0005" ;
     nidm_coordinateVector: "[42,-72,-10]"^^xsd:string .
 
-niiri:1642fc731ff715f5797db051685ef81a prov:wasDerivedFrom niiri:0571c455c5021749fc8693f5d5c53029 .
+niiri:c11d713034b63a168bdd812994537584 prov:wasDerivedFrom niiri:dabc6f32070848fa7096bac116f4a0d0 .
 
-niiri:f4fcfa92a45e24ac8ac208b54357bbdf
+niiri:db60aac6428eac8ac3baeeff8d9d9a89
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0006" ;
-    prov:atLocation niiri:e8c6929875c2e296ea59e2df4226246a ;
+    prov:atLocation niiri:6db693a2950e3c3898b2016d47b0c085 ;
     prov:value "5.73506736755371"^^xsd:float ;
     nidm_equivalentZStatistic: "5.30472446220131"^^xsd:float ;
     nidm_pValueUncorrected: "5.64216566800724e-08"^^xsd:float ;
     nidm_pValueFWER: "0.0107086846025504"^^xsd:float ;
     nidm_qValueFDR: "0.00182363082319185"^^xsd:float .
 
-niiri:e8c6929875c2e296ea59e2df4226246a
+niiri:6db693a2950e3c3898b2016d47b0c085
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0006" ;
     nidm_coordinateVector: "[34,-86,12]"^^xsd:string .
 
-niiri:f4fcfa92a45e24ac8ac208b54357bbdf prov:wasDerivedFrom niiri:0571c455c5021749fc8693f5d5c53029 .
+niiri:db60aac6428eac8ac3baeeff8d9d9a89 prov:wasDerivedFrom niiri:dabc6f32070848fa7096bac116f4a0d0 .
 
-niiri:44f9881a215a120bf4b329dce020683b
+niiri:da07c9cffdb89f061f471c62455179f6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0007" ;
-    prov:atLocation niiri:397db41518ebd19c94d28370f46f0779 ;
+    prov:atLocation niiri:7cbc707f01d3236308dd2e2563f62b70 ;
     prov:value "6.97286987304688"^^xsd:float ;
     nidm_equivalentZStatistic: "6.25622394584082"^^xsd:float ;
     nidm_pValueUncorrected: "1.97205141105883e-10"^^xsd:float ;
     nidm_pValueFWER: "4.39879376310515e-05"^^xsd:float ;
     nidm_qValueFDR: "4.20152926830756e-05"^^xsd:float .
 
-niiri:397db41518ebd19c94d28370f46f0779
+niiri:7cbc707f01d3236308dd2e2563f62b70
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0007" ;
     nidm_coordinateVector: "[32,2,46]"^^xsd:string .
 
-niiri:44f9881a215a120bf4b329dce020683b prov:wasDerivedFrom niiri:8976f2283c83032c1e6578e393bc1c08 .
+niiri:da07c9cffdb89f061f471c62455179f6 prov:wasDerivedFrom niiri:4e8b9634c8b43c73966139ed11b75ec8 .
 
-niiri:1a453f37de3a7137cc1c2c7d1adec306
+niiri:f030a501c14ec9c10fe484ff04b4868f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0008" ;
-    prov:atLocation niiri:315b72d58d02d44f0736dd094bebfa16 ;
+    prov:atLocation niiri:069d0ce94e80aac1d9ad38251824f8eb ;
     prov:value "5.64730930328369"^^xsd:float ;
     nidm_equivalentZStatistic: "5.23420507732884"^^xsd:float ;
     nidm_pValueUncorrected: "8.28482022985355e-08"^^xsd:float ;
     nidm_pValueFWER: "0.0149983527932318"^^xsd:float ;
     nidm_qValueFDR: "0.00232586421758464"^^xsd:float .
 
-niiri:315b72d58d02d44f0736dd094bebfa16
+niiri:069d0ce94e80aac1d9ad38251824f8eb
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0008" ;
     nidm_coordinateVector: "[30,4,58]"^^xsd:string .
 
-niiri:1a453f37de3a7137cc1c2c7d1adec306 prov:wasDerivedFrom niiri:8976f2283c83032c1e6578e393bc1c08 .
+niiri:f030a501c14ec9c10fe484ff04b4868f prov:wasDerivedFrom niiri:4e8b9634c8b43c73966139ed11b75ec8 .
 
-niiri:ad8abfc758206e227b5e8ec29ca97227
+niiri:32366a46bbf0f9fae450db4ea84aff6d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0009" ;
-    prov:atLocation niiri:c820d1f4b777306bd48bffa479b9049b ;
+    prov:atLocation niiri:d0279504420cdd8ef5cbb33ef8bc17e3 ;
     prov:value "4.40563726425171"^^xsd:float ;
     nidm_equivalentZStatistic: "4.19368654428063"^^xsd:float ;
     nidm_pValueUncorrected: "1.37228586966076e-05"^^xsd:float ;
     nidm_pValueFWER: "0.702748192357301"^^xsd:float ;
     nidm_qValueFDR: "0.0688715370678382"^^xsd:float .
 
-niiri:c820d1f4b777306bd48bffa479b9049b
+niiri:d0279504420cdd8ef5cbb33ef8bc17e3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0009" ;
     nidm_coordinateVector: "[42,4,48]"^^xsd:string .
 
-niiri:ad8abfc758206e227b5e8ec29ca97227 prov:wasDerivedFrom niiri:8976f2283c83032c1e6578e393bc1c08 .
+niiri:32366a46bbf0f9fae450db4ea84aff6d prov:wasDerivedFrom niiri:4e8b9634c8b43c73966139ed11b75ec8 .
 
-niiri:49b125058259e4eff03e45f034b27386
+niiri:8fc9a86e848c24dae11f15925f03b510
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0010" ;
-    prov:atLocation niiri:c58f1801199f38300b69084468129a10 ;
+    prov:atLocation niiri:1891de7048560b92cd5e00c827fd79cd ;
     prov:value "6.86515712738037"^^xsd:float ;
     nidm_equivalentZStatistic: "6.17661732625786"^^xsd:float ;
     nidm_pValueUncorrected: "3.27447735593012e-10"^^xsd:float ;
     nidm_pValueFWER: "7.3039460029567e-05"^^xsd:float ;
     nidm_qValueFDR: "5.79507633018939e-05"^^xsd:float .
 
-niiri:c58f1801199f38300b69084468129a10
+niiri:1891de7048560b92cd5e00c827fd79cd
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0010" ;
     nidm_coordinateVector: "[40,-62,50]"^^xsd:string .
 
-niiri:49b125058259e4eff03e45f034b27386 prov:wasDerivedFrom niiri:f1f77d0ce1cc3ba5587c7ec07f2eac8d .
+niiri:8fc9a86e848c24dae11f15925f03b510 prov:wasDerivedFrom niiri:a731c83f0edffc39ddaeae57a80dc5ba .
 
-niiri:7a28a0868310495da2f8c91ed5ce0f98
+niiri:661f534ccc7bdcb595c223d462813fb2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0011" ;
-    prov:atLocation niiri:94dfc5baba99c12f7c59e872a5759a60 ;
+    prov:atLocation niiri:45d6dbe200ad3545589d96cbcb3e79ed ;
     prov:value "6.85877418518066"^^xsd:float ;
     nidm_equivalentZStatistic: "6.17188094462764"^^xsd:float ;
     nidm_pValueUncorrected: "3.37411543149813e-10"^^xsd:float ;
     nidm_pValueFWER: "7.52619570517643e-05"^^xsd:float ;
     nidm_qValueFDR: "5.79507633018939e-05"^^xsd:float .
 
-niiri:94dfc5baba99c12f7c59e872a5759a60
+niiri:45d6dbe200ad3545589d96cbcb3e79ed
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0011" ;
     nidm_coordinateVector: "[52,-32,42]"^^xsd:string .
 
-niiri:7a28a0868310495da2f8c91ed5ce0f98 prov:wasDerivedFrom niiri:f1f77d0ce1cc3ba5587c7ec07f2eac8d .
+niiri:661f534ccc7bdcb595c223d462813fb2 prov:wasDerivedFrom niiri:a731c83f0edffc39ddaeae57a80dc5ba .
 
-niiri:a29ed698fe7ba052097f16e1858a3283
+niiri:0439c89a311e9fd92d450045320abef9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0012" ;
-    prov:atLocation niiri:5161bb42084a38ee9f38d527b05d3ad8 ;
+    prov:atLocation niiri:c68b3dc10dcd6c086fe4ae651da53586 ;
     prov:value "6.75158262252808"^^xsd:float ;
     nidm_equivalentZStatistic: "6.0920231289905"^^xsd:float ;
     nidm_pValueUncorrected: "5.57462853656432e-10"^^xsd:float ;
     nidm_pValueFWER: "0.000124345942219439"^^xsd:float ;
     nidm_qValueFDR: "7.74014448313719e-05"^^xsd:float .
 
-niiri:5161bb42084a38ee9f38d527b05d3ad8
+niiri:c68b3dc10dcd6c086fe4ae651da53586
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0012" ;
     nidm_coordinateVector: "[44,-70,50]"^^xsd:string .
 
-niiri:a29ed698fe7ba052097f16e1858a3283 prov:wasDerivedFrom niiri:f1f77d0ce1cc3ba5587c7ec07f2eac8d .
+niiri:0439c89a311e9fd92d450045320abef9 prov:wasDerivedFrom niiri:a731c83f0edffc39ddaeae57a80dc5ba .
 
-niiri:7fe871a90ba5d65f8651badf91747c71
+niiri:f3634f34416055e1f89021e72074c0b8
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0013" ;
-    prov:atLocation niiri:0de60fa9f6849a6f9aaa47c12161ba51 ;
+    prov:atLocation niiri:25d042185f02c49a8254ea541b284e66 ;
     prov:value "6.74185800552368"^^xsd:float ;
     nidm_equivalentZStatistic: "6.08474855499121"^^xsd:float ;
     nidm_pValueUncorrected: "5.83371351225992e-10"^^xsd:float ;
     nidm_pValueFWER: "0.000130125013961813"^^xsd:float ;
     nidm_qValueFDR: "7.74014448313719e-05"^^xsd:float .
 
-niiri:0de60fa9f6849a6f9aaa47c12161ba51
+niiri:25d042185f02c49a8254ea541b284e66
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0013" ;
     nidm_coordinateVector: "[-34,-2,52]"^^xsd:string .
 
-niiri:7fe871a90ba5d65f8651badf91747c71 prov:wasDerivedFrom niiri:efa240525eee79c28032f1f8e966fad3 .
+niiri:f3634f34416055e1f89021e72074c0b8 prov:wasDerivedFrom niiri:5299ea7c2ff48f8ccb9e3da606289f28 .
 
-niiri:fa40140dbb79851494c1ddddd5a98188
+niiri:349a28a9b41a96a17877fc37d66ae69a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0014" ;
-    prov:atLocation niiri:3bd6e8b5270e98f2d4237f8bf0c57f6d ;
+    prov:atLocation niiri:3d53b41dc35ce105f59d533871035a1b ;
     prov:value "6.66947507858276"^^xsd:float ;
     nidm_equivalentZStatistic: "6.03044660761629"^^xsd:float ;
     nidm_pValueUncorrected: "8.17535927843949e-10"^^xsd:float ;
     nidm_pValueFWER: "0.000182357061928484"^^xsd:float ;
     nidm_qValueFDR: "9.89064171074034e-05"^^xsd:float .
 
-niiri:3bd6e8b5270e98f2d4237f8bf0c57f6d
+niiri:3d53b41dc35ce105f59d533871035a1b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0014" ;
     nidm_coordinateVector: "[-28,-94,4]"^^xsd:string .
 
-niiri:fa40140dbb79851494c1ddddd5a98188 prov:wasDerivedFrom niiri:7e9b1ebb227a2ee5938d0545b30aca96 .
+niiri:349a28a9b41a96a17877fc37d66ae69a prov:wasDerivedFrom niiri:2152e06e3cb49b34d19eb6146b5817f7 .
 
-niiri:26c8c36656a588e4969a7cc42bbacae5
+niiri:3e1ef8a3ca25ac8b59d80bd43c358ed4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0015" ;
-    prov:atLocation niiri:4f15ec04ef2895aa2492b01cd33e5be6 ;
+    prov:atLocation niiri:8d2cea471932539cb762241eca542d48 ;
     prov:value "4.72731781005859"^^xsd:float ;
     nidm_equivalentZStatistic: "4.47080352419215"^^xsd:float ;
     nidm_pValueUncorrected: "3.89631317532224e-06"^^xsd:float ;
     nidm_pValueFWER: "0.344866937398066"^^xsd:float ;
     nidm_qValueFDR: "0.0306600822692826"^^xsd:float .
 
-niiri:4f15ec04ef2895aa2492b01cd33e5be6
+niiri:8d2cea471932539cb762241eca542d48
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0015" ;
     nidm_coordinateVector: "[-50,-72,2]"^^xsd:string .
 
-niiri:26c8c36656a588e4969a7cc42bbacae5 prov:wasDerivedFrom niiri:7e9b1ebb227a2ee5938d0545b30aca96 .
+niiri:3e1ef8a3ca25ac8b59d80bd43c358ed4 prov:wasDerivedFrom niiri:2152e06e3cb49b34d19eb6146b5817f7 .
 
-niiri:fae924d67a74986d22e106df3a835732
+niiri:cd8ff33c2ca2918b0a27282345d1bda0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0016" ;
-    prov:atLocation niiri:dadb92913ade3f3d43aaf8fbc814f8d3 ;
+    prov:atLocation niiri:4fa4b02b261b8765f2b1916297e8d0ef ;
     prov:value "6.61547613143921"^^xsd:float ;
     nidm_equivalentZStatistic: "5.98975768195926"^^xsd:float ;
     nidm_pValueUncorrected: "1.05076958245576e-09"^^xsd:float ;
     nidm_pValueFWER: "0.00023438146122523"^^xsd:float ;
     nidm_qValueFDR: "0.000109520618634045"^^xsd:float .
 
-niiri:dadb92913ade3f3d43aaf8fbc814f8d3
+niiri:4fa4b02b261b8765f2b1916297e8d0ef
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0016" ;
     nidm_coordinateVector: "[-52,0,38]"^^xsd:string .
 
-niiri:fae924d67a74986d22e106df3a835732 prov:wasDerivedFrom niiri:1c354e7e3ff502199baf755636f12453 .
+niiri:cd8ff33c2ca2918b0a27282345d1bda0 prov:wasDerivedFrom niiri:c205169674df01953a0df15ba2cb5f08 .
 
-niiri:93b914ea539309faa02f24f4cf1cd643
+niiri:dfbab0b4541c5aa0d17a7fc20cc92006
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0017" ;
-    prov:atLocation niiri:fc112f66da4bc7c44412af4817475dca ;
+    prov:atLocation niiri:efbb40cf819ae486eb77486299b67a9e ;
     prov:value "5.67108535766602"^^xsd:float ;
     nidm_equivalentZStatistic: "5.25335064729294"^^xsd:float ;
     nidm_pValueUncorrected: "7.46783984650889e-08"^^xsd:float ;
     nidm_pValueFWER: "0.013695505906366"^^xsd:float ;
     nidm_qValueFDR: "0.00217066284688228"^^xsd:float .
 
-niiri:fc112f66da4bc7c44412af4817475dca
+niiri:efbb40cf819ae486eb77486299b67a9e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0017" ;
     nidm_coordinateVector: "[-46,6,28]"^^xsd:string .
 
-niiri:93b914ea539309faa02f24f4cf1cd643 prov:wasDerivedFrom niiri:1c354e7e3ff502199baf755636f12453 .
+niiri:dfbab0b4541c5aa0d17a7fc20cc92006 prov:wasDerivedFrom niiri:c205169674df01953a0df15ba2cb5f08 .
 
-niiri:ad07d5767cad0f3c964799f5d96ec3bc
+niiri:ef8223f420455816c0e95ee6e024db6c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0018" ;
-    prov:atLocation niiri:17c2cf0f509d7d287303d46e9d956542 ;
+    prov:atLocation niiri:561d5625f54e1b5697536c0413529bc8 ;
     prov:value "5.49257516860962"^^xsd:float ;
     nidm_equivalentZStatistic: "5.10888189288487"^^xsd:float ;
     nidm_pValueUncorrected: "1.62035419970508e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0268824268377835"^^xsd:float ;
     nidm_qValueFDR: "0.00349505918676715"^^xsd:float .
 
-niiri:17c2cf0f509d7d287303d46e9d956542
+niiri:561d5625f54e1b5697536c0413529bc8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0018" ;
     nidm_coordinateVector: "[-60,8,20]"^^xsd:string .
 
-niiri:ad07d5767cad0f3c964799f5d96ec3bc prov:wasDerivedFrom niiri:1c354e7e3ff502199baf755636f12453 .
+niiri:ef8223f420455816c0e95ee6e024db6c prov:wasDerivedFrom niiri:c205169674df01953a0df15ba2cb5f08 .
 
-niiri:1f02a31c29e4c3f51d7e16c1b63edf46
+niiri:35bbf8c9030a11e48d1b2dee7e09dc11
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0019" ;
-    prov:atLocation niiri:023c0b9dc1d125d8056f022800b7a076 ;
+    prov:atLocation niiri:5a3e8745d343d64c09a7291cc9599412 ;
     prov:value "6.17608976364136"^^xsd:float ;
     nidm_equivalentZStatistic: "5.65297947754486"^^xsd:float ;
     nidm_pValueUncorrected: "7.88450704725108e-09"^^xsd:float ;
     nidm_pValueFWER: "0.00175869443891008"^^xsd:float ;
     nidm_qValueFDR: "0.000479412815824312"^^xsd:float .
 
-niiri:023c0b9dc1d125d8056f022800b7a076
+niiri:5a3e8745d343d64c09a7291cc9599412
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0019" ;
     nidm_coordinateVector: "[-58,-30,-18]"^^xsd:string .
 
-niiri:1f02a31c29e4c3f51d7e16c1b63edf46 prov:wasDerivedFrom niiri:7b36354f0687338fb029a58183e4b870 .
+niiri:35bbf8c9030a11e48d1b2dee7e09dc11 prov:wasDerivedFrom niiri:f7a0ae64373c9fadcbae5c1ee69af3e7 .
 
-niiri:e16a4cb3173debde9f393e0c367f7fae
+niiri:27f7bd95d47b079be25c832329669ee6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0020" ;
-    prov:atLocation niiri:ba115bb746c8b44ec654e368f832f0fe ;
+    prov:atLocation niiri:2152150ffc3b9877675f544c6e8d05b5 ;
     prov:value "6.00111627578735"^^xsd:float ;
     nidm_equivalentZStatistic: "5.51603694557944"^^xsd:float ;
     nidm_pValueUncorrected: "1.7336469926299e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00377055438802265"^^xsd:float ;
     nidm_qValueFDR: "0.000889054456506852"^^xsd:float .
 
-niiri:ba115bb746c8b44ec654e368f832f0fe
+niiri:2152150ffc3b9877675f544c6e8d05b5
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0020" ;
     nidm_coordinateVector: "[-54,-46,58]"^^xsd:string .
 
-niiri:e16a4cb3173debde9f393e0c367f7fae prov:wasDerivedFrom niiri:f1318eaae736dc28b717174be4e8be03 .
+niiri:27f7bd95d47b079be25c832329669ee6 prov:wasDerivedFrom niiri:f78c9c52eb8c41c81b7108fc768afea1 .
 
-niiri:5a5ef5d63e6684d4d2a5e3b8dedb76ed
+niiri:c27894706882af29cb375ead129ef8cb
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0021" ;
-    prov:atLocation niiri:35a4593f1741359cfb89e1740463cb80 ;
+    prov:atLocation niiri:90f9c2bd488287a611152e190f59541c ;
     prov:value "5.88819122314453"^^xsd:float ;
     nidm_equivalentZStatistic: "5.42680001669675"^^xsd:float ;
     nidm_pValueUncorrected: "2.86866747023495e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00589533759301752"^^xsd:float ;
     nidm_qValueFDR: "0.00119802154665121"^^xsd:float .
 
-niiri:35a4593f1741359cfb89e1740463cb80
+niiri:90f9c2bd488287a611152e190f59541c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0021" ;
     nidm_coordinateVector: "[-62,-38,48]"^^xsd:string .
 
-niiri:5a5ef5d63e6684d4d2a5e3b8dedb76ed prov:wasDerivedFrom niiri:565e2f7e2e5bde3342f5c45d37979a75 .
+niiri:c27894706882af29cb375ead129ef8cb prov:wasDerivedFrom niiri:defff4241093fb74f3bb72454faeb0c8 .
 
-niiri:4c895f0e6b277ed749ed6cdcaebf571a
+niiri:c9d1046585f7728d08cc54165c11ff59
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0022" ;
-    prov:atLocation niiri:6eb49ee48f662f4c29411db54cb9d61c ;
+    prov:atLocation niiri:c169b7364207ba5710701c5015add790 ;
     prov:value "5.44929027557373"^^xsd:float ;
     nidm_equivalentZStatistic: "5.07359999694323"^^xsd:float ;
     nidm_pValueUncorrected: "1.95179594375539e-07"^^xsd:float ;
     nidm_pValueFWER: "0.031565196414938"^^xsd:float ;
     nidm_qValueFDR: "0.00384073346935762"^^xsd:float .
 
-niiri:6eb49ee48f662f4c29411db54cb9d61c
+niiri:c169b7364207ba5710701c5015add790
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0022" ;
     nidm_coordinateVector: "[-60,-50,48]"^^xsd:string .
 
-niiri:4c895f0e6b277ed749ed6cdcaebf571a prov:wasDerivedFrom niiri:565e2f7e2e5bde3342f5c45d37979a75 .
+niiri:c9d1046585f7728d08cc54165c11ff59 prov:wasDerivedFrom niiri:defff4241093fb74f3bb72454faeb0c8 .
 
-niiri:ab8a36df15e3c8b64fda443435e347ef
+niiri:03c13f292babfb2b1d3290faffb9e334
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0023" ;
-    prov:atLocation niiri:483eff7df6af0712e20facb890a46299 ;
+    prov:atLocation niiri:c1c09ce48f662e61c3ae3b80bce02189 ;
     prov:value "5.43339920043945"^^xsd:float ;
     nidm_equivalentZStatistic: "5.060622473607"^^xsd:float ;
     nidm_pValueUncorrected: "2.08944963109303e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0334714202830716"^^xsd:float ;
     nidm_qValueFDR: "0.0039964071128327"^^xsd:float .
 
-niiri:483eff7df6af0712e20facb890a46299
+niiri:c1c09ce48f662e61c3ae3b80bce02189
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0023" ;
     nidm_coordinateVector: "[-36,-74,-14]"^^xsd:string .
 
-niiri:ab8a36df15e3c8b64fda443435e347ef prov:wasDerivedFrom niiri:8447e2fc880db809a273004483217edc .
+niiri:03c13f292babfb2b1d3290faffb9e334 prov:wasDerivedFrom niiri:a32e7c63a62151c6c42d8b86e0a4c19e .
 
-niiri:c8181d0f3dc243173287af823030f8a6
+niiri:4cc88fa1c2d357c36750e5a6a684d7c5
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0024" ;
-    prov:atLocation niiri:05396e3c44a36ced65e0057ce86ff36b ;
+    prov:atLocation niiri:0a07fa954d8bab227c98c3596c82c06e ;
     prov:value "5.05177354812622"^^xsd:float ;
     nidm_equivalentZStatistic: "4.74502150166861"^^xsd:float ;
     nidm_pValueUncorrected: "1.04242094267626e-06"^^xsd:float ;
     nidm_pValueFWER: "0.128300853408892"^^xsd:float ;
     nidm_qValueFDR: "0.0133943818856599"^^xsd:float .
 
-niiri:05396e3c44a36ced65e0057ce86ff36b
+niiri:0a07fa954d8bab227c98c3596c82c06e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0024" ;
     nidm_coordinateVector: "[-36,-68,-20]"^^xsd:string .
 
-niiri:c8181d0f3dc243173287af823030f8a6 prov:wasDerivedFrom niiri:8447e2fc880db809a273004483217edc .
+niiri:4cc88fa1c2d357c36750e5a6a684d7c5 prov:wasDerivedFrom niiri:a32e7c63a62151c6c42d8b86e0a4c19e .
 
-niiri:afbf96e3587255c2500918ed9b4aa838
+niiri:3cf98988c38bad72a5c4221177532d4d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0025" ;
-    prov:atLocation niiri:0d5b8cdd3918252b4418dda16c6f570b ;
+    prov:atLocation niiri:212b43414a4117095f4147d02a241fbc ;
     prov:value "4.12923574447632"^^xsd:float ;
     nidm_equivalentZStatistic: "3.95150505699521"^^xsd:float ;
     nidm_pValueUncorrected: "3.88306154154305e-05"^^xsd:float ;
     nidm_pValueFWER: "0.94176507916668"^^xsd:float ;
     nidm_qValueFDR: "0.131281271533869"^^xsd:float .
 
-niiri:0d5b8cdd3918252b4418dda16c6f570b
+niiri:212b43414a4117095f4147d02a241fbc
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0025" ;
     nidm_coordinateVector: "[-30,-58,-16]"^^xsd:string .
 
-niiri:afbf96e3587255c2500918ed9b4aa838 prov:wasDerivedFrom niiri:8447e2fc880db809a273004483217edc .
+niiri:3cf98988c38bad72a5c4221177532d4d prov:wasDerivedFrom niiri:a32e7c63a62151c6c42d8b86e0a4c19e .
 
-niiri:06f1be12bfa871726124f544f21c7b69
+niiri:a8c8296f49eb09a8f5f2bc2e7fe30473
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0026" ;
-    prov:atLocation niiri:e6b02a724ce3fd161f792f712268561e ;
+    prov:atLocation niiri:5e6ebb25f5bd7a0d3ffd55fc5a8c6ee8 ;
     prov:value "5.30700492858887"^^xsd:float ;
     nidm_equivalentZStatistic: "4.95693297367533"^^xsd:float ;
     nidm_pValueUncorrected: "3.58073340978038e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0530089422098637"^^xsd:float ;
     nidm_qValueFDR: "0.00589411306675136"^^xsd:float .
 
-niiri:e6b02a724ce3fd161f792f712268561e
+niiri:5e6ebb25f5bd7a0d3ffd55fc5a8c6ee8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0026" ;
     nidm_coordinateVector: "[-36,-74,-34]"^^xsd:string .
 
-niiri:06f1be12bfa871726124f544f21c7b69 prov:wasDerivedFrom niiri:94238ef8670737705b8341502f2746a2 .
+niiri:a8c8296f49eb09a8f5f2bc2e7fe30473 prov:wasDerivedFrom niiri:f9c64f2f13c1018c1b0c90db5e455972 .
 
-niiri:47f29222b154f5e5dad9d55f53b4c689
+niiri:5f7d79a55e6736946606e61cf06d0fef
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0027" ;
-    prov:atLocation niiri:e8196de7fed425575ae41f959e296985 ;
+    prov:atLocation niiri:e3bf7803b46511439f4ae96a9a7dca98 ;
     prov:value "3.51177191734314"^^xsd:float ;
     nidm_equivalentZStatistic: "3.39749381675455"^^xsd:float ;
     nidm_pValueUncorrected: "0.000340030624079946"^^xsd:float ;
     nidm_pValueFWER: "0.999999824991842"^^xsd:float ;
     nidm_qValueFDR: "0.523087759562521"^^xsd:float .
 
-niiri:e8196de7fed425575ae41f959e296985
+niiri:e3bf7803b46511439f4ae96a9a7dca98
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0027" ;
     nidm_coordinateVector: "[-44,-62,-32]"^^xsd:string .
 
-niiri:47f29222b154f5e5dad9d55f53b4c689 prov:wasDerivedFrom niiri:94238ef8670737705b8341502f2746a2 .
+niiri:5f7d79a55e6736946606e61cf06d0fef prov:wasDerivedFrom niiri:f9c64f2f13c1018c1b0c90db5e455972 .
 
-niiri:a7b836daecc245c7cc52bbf5c95f8bae
+niiri:9325884a6c8f484b70d3de818aebf275
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0028" ;
-    prov:atLocation niiri:475ce32a7e381b3b19ba8dbc8078488b ;
+    prov:atLocation niiri:a7d68510d6f28e3c6be8d50b297c9719 ;
     prov:value "5.28576564788818"^^xsd:float ;
     nidm_equivalentZStatistic: "4.93942736847709"^^xsd:float ;
     nidm_pValueUncorrected: "3.91761603713014e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0571951960553233"^^xsd:float ;
     nidm_qValueFDR: "0.00627550171974501"^^xsd:float .
 
-niiri:475ce32a7e381b3b19ba8dbc8078488b
+niiri:a7d68510d6f28e3c6be8d50b297c9719
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0028" ;
     nidm_coordinateVector: "[58,-38,6]"^^xsd:string .
 
-niiri:a7b836daecc245c7cc52bbf5c95f8bae prov:wasDerivedFrom niiri:56882afdece5437620adade43b7e28ed .
+niiri:9325884a6c8f484b70d3de818aebf275 prov:wasDerivedFrom niiri:2e1d13240b9a458b380045313214b3ba .
 
-niiri:eb4db314cf8b3b6a98528630e857d5bd
+niiri:60a921fcb727986aa30984a19c231f18
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0029" ;
-    prov:atLocation niiri:96bac1748016c54d2f342b97ac9a054d ;
+    prov:atLocation niiri:71e187cc3dbc6e62f7d1ac6db011de77 ;
     prov:value "4.67409086227417"^^xsd:float ;
     nidm_equivalentZStatistic: "4.42530768589333"^^xsd:float ;
     nidm_pValueUncorrected: "4.81524595430383e-06"^^xsd:float ;
     nidm_pValueFWER: "0.396915869709553"^^xsd:float ;
     nidm_qValueFDR: "0.0353779325915568"^^xsd:float .
 
-niiri:96bac1748016c54d2f342b97ac9a054d
+niiri:71e187cc3dbc6e62f7d1ac6db011de77
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0029" ;
     nidm_coordinateVector: "[62,-32,-6]"^^xsd:string .
 
-niiri:eb4db314cf8b3b6a98528630e857d5bd prov:wasDerivedFrom niiri:56882afdece5437620adade43b7e28ed .
+niiri:60a921fcb727986aa30984a19c231f18 prov:wasDerivedFrom niiri:2e1d13240b9a458b380045313214b3ba .
 
-niiri:ccbc96ca1c1e19849232d29d0f7852fc
+niiri:b3d0ce5827aa453674fe13aef68e7d16
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0030" ;
-    prov:atLocation niiri:7af0e6e0e1f7dda0083c39e417eaa5ee ;
+    prov:atLocation niiri:dbbee4c7d179888417ce4d2b85538f44 ;
     prov:value "4.45858383178711"^^xsd:float ;
     nidm_equivalentZStatistic: "4.23965208014699"^^xsd:float ;
     nidm_pValueUncorrected: "1.11933243143181e-05"^^xsd:float ;
     nidm_pValueFWER: "0.641045560649102"^^xsd:float ;
     nidm_qValueFDR: "0.0627964060338669"^^xsd:float .
 
-niiri:7af0e6e0e1f7dda0083c39e417eaa5ee
+niiri:dbbee4c7d179888417ce4d2b85538f44
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0030" ;
     nidm_coordinateVector: "[54,-24,-2]"^^xsd:string .
 
-niiri:ccbc96ca1c1e19849232d29d0f7852fc prov:wasDerivedFrom niiri:56882afdece5437620adade43b7e28ed .
+niiri:b3d0ce5827aa453674fe13aef68e7d16 prov:wasDerivedFrom niiri:2e1d13240b9a458b380045313214b3ba .
 
-niiri:5177a621d25aa2f0e2c93d7c7232dee5
+niiri:794d4453dd2ad3bd3730dd91ae6b30e9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0031" ;
-    prov:atLocation niiri:d5a31ec7b2cc7ef38380bc074667a747 ;
+    prov:atLocation niiri:af634bd5ad9bbec585044c47707b7f32 ;
     prov:value "5.24946975708008"^^xsd:float ;
     nidm_equivalentZStatistic: "4.9094577193641"^^xsd:float ;
     nidm_pValueUncorrected: "4.56642935686702e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0650689222727684"^^xsd:float ;
     nidm_qValueFDR: "0.00706047439822435"^^xsd:float .
 
-niiri:d5a31ec7b2cc7ef38380bc074667a747
+niiri:af634bd5ad9bbec585044c47707b7f32
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0031" ;
     nidm_coordinateVector: "[-50,-60,54]"^^xsd:string .
 
-niiri:5177a621d25aa2f0e2c93d7c7232dee5 prov:wasDerivedFrom niiri:80acc2ec15379dd56dd3a4d3c0d4db28 .
+niiri:794d4453dd2ad3bd3730dd91ae6b30e9 prov:wasDerivedFrom niiri:76bd6a834aaa05e8f24aef110c831619 .
 
-niiri:9ddb05b4772809d6c8a6fa21104b3ce4
+niiri:1a0ea80e15936593cdd19a72a1195f48
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0032" ;
-    prov:atLocation niiri:aba5327d5af4da14a38514380253613f ;
+    prov:atLocation niiri:4efa70bd6a3304ba75992adf5bb64efd ;
     prov:value "5.23662900924683"^^xsd:float ;
     nidm_equivalentZStatistic: "4.89883869005555"^^xsd:float ;
     nidm_pValueUncorrected: "4.82023739367676e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0680871870860791"^^xsd:float ;
     nidm_qValueFDR: "0.00718215508152799"^^xsd:float .
 
-niiri:aba5327d5af4da14a38514380253613f
+niiri:4efa70bd6a3304ba75992adf5bb64efd
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0032" ;
     nidm_coordinateVector: "[-46,-66,-6]"^^xsd:string .
 
-niiri:9ddb05b4772809d6c8a6fa21104b3ce4 prov:wasDerivedFrom niiri:f79d6102313cb9c1b58014d0d7523705 .
+niiri:1a0ea80e15936593cdd19a72a1195f48 prov:wasDerivedFrom niiri:16274414c81621b268626b188f47a6c7 .
 
-niiri:8d58afd557e02ead7f00aee5185d8a62
+niiri:0569ccf24fdb31c7eaca9ab9fa246e95
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0033" ;
-    prov:atLocation niiri:dcfee15d7c5af57953f540a6cfe78315 ;
+    prov:atLocation niiri:d7c5ae76657ceee4fe0930d8038110c3 ;
     prov:value "4.40907335281372"^^xsd:float ;
     nidm_equivalentZStatistic: "4.19667377576541"^^xsd:float ;
     nidm_pValueUncorrected: "1.35431823886645e-05"^^xsd:float ;
     nidm_pValueFWER: "0.698809001225567"^^xsd:float ;
     nidm_qValueFDR: "0.0687991026397412"^^xsd:float .
 
-niiri:dcfee15d7c5af57953f540a6cfe78315
+niiri:d7c5ae76657ceee4fe0930d8038110c3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0033" ;
     nidm_coordinateVector: "[-54,-64,-8]"^^xsd:string .
 
-niiri:8d58afd557e02ead7f00aee5185d8a62 prov:wasDerivedFrom niiri:f79d6102313cb9c1b58014d0d7523705 .
+niiri:0569ccf24fdb31c7eaca9ab9fa246e95 prov:wasDerivedFrom niiri:16274414c81621b268626b188f47a6c7 .
 
-niiri:e1c1830378bf63fec3482cfd19fe2e8d
+niiri:2a23f426a8d1ce8819ab2ddb003a1fca
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0034" ;
-    prov:atLocation niiri:43b11b0b6cd9a3503e94b42496a7b062 ;
+    prov:atLocation niiri:f576cf1614b186ed87892b67215577f8 ;
     prov:value "5.04332971572876"^^xsd:float ;
     nidm_equivalentZStatistic: "4.73795333032992"^^xsd:float ;
     nidm_pValueUncorrected: "1.07943756555429e-06"^^xsd:float ;
     nidm_pValueFWER: "0.131940099784902"^^xsd:float ;
     nidm_qValueFDR: "0.0134243353138188"^^xsd:float .
 
-niiri:43b11b0b6cd9a3503e94b42496a7b062
+niiri:f576cf1614b186ed87892b67215577f8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0034" ;
     nidm_coordinateVector: "[-60,-16,28]"^^xsd:string .
 
-niiri:e1c1830378bf63fec3482cfd19fe2e8d prov:wasDerivedFrom niiri:5c0356c4e08b4f78355f5f21c8c539f6 .
+niiri:2a23f426a8d1ce8819ab2ddb003a1fca prov:wasDerivedFrom niiri:fb5ba293db82840b5cc150cc15515c24 .
 
-niiri:c8f3169f2253aa77f13d1ad37adc2605
+niiri:375f7b40758a242274e5d254e754d2ea
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0035" ;
-    prov:atLocation niiri:3e6a325415a49fc9471d3fbcccf71d24 ;
+    prov:atLocation niiri:f4854b1ae4228726a13a570242046d52 ;
     prov:value "4.99945306777954"^^xsd:float ;
     nidm_equivalentZStatistic: "4.70116602240923"^^xsd:float ;
     nidm_pValueUncorrected: "1.29340041166159e-06"^^xsd:float ;
     nidm_pValueFWER: "0.152338396794269"^^xsd:float ;
     nidm_qValueFDR: "0.014675241706815"^^xsd:float .
 
-niiri:3e6a325415a49fc9471d3fbcccf71d24
+niiri:f4854b1ae4228726a13a570242046d52
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0035" ;
     nidm_coordinateVector: "[-36,-40,-36]"^^xsd:string .
 
-niiri:c8f3169f2253aa77f13d1ad37adc2605 prov:wasDerivedFrom niiri:5118b94ba0e2ab04227b9b6665cca04e .
+niiri:375f7b40758a242274e5d254e754d2ea prov:wasDerivedFrom niiri:aee52ad89a76ef41b6e67f9bca85ad62 .
 
-niiri:36a7f9a2c42d2ca794a9e3522f8d1928
+niiri:2bfeae4bd1acb4a2e2656604b5cb7718
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0036" ;
-    prov:atLocation niiri:a6411ba2cb861e9af1987013bf2957b1 ;
+    prov:atLocation niiri:1f3ebb15787863a4d572b20cc801c020 ;
     prov:value "4.65380764007568"^^xsd:float ;
     nidm_equivalentZStatistic: "4.40793303387591"^^xsd:float ;
     nidm_pValueUncorrected: "5.21808997933082e-06"^^xsd:float ;
     nidm_pValueFWER: "0.417896183733559"^^xsd:float ;
     nidm_qValueFDR: "0.0374764670608795"^^xsd:float .
 
-niiri:a6411ba2cb861e9af1987013bf2957b1
+niiri:1f3ebb15787863a4d572b20cc801c020
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0036" ;
     nidm_coordinateVector: "[-50,-46,-32]"^^xsd:string .
 
-niiri:36a7f9a2c42d2ca794a9e3522f8d1928 prov:wasDerivedFrom niiri:5118b94ba0e2ab04227b9b6665cca04e .
+niiri:2bfeae4bd1acb4a2e2656604b5cb7718 prov:wasDerivedFrom niiri:aee52ad89a76ef41b6e67f9bca85ad62 .
 
-niiri:37e2a7e20f76fc9bcbadf0f44aa25172
+niiri:0e8711e2fd8d14446a6962527ef6df3a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0037" ;
-    prov:atLocation niiri:d5fed0d62dac319d5e63e396d28cb9c2 ;
+    prov:atLocation niiri:bc7434b50faea15d0f3428e0dacb67d6 ;
     prov:value "4.85420560836792"^^xsd:float ;
     nidm_equivalentZStatistic: "4.57868324924493"^^xsd:float ;
     nidm_pValueUncorrected: "2.33956067374752e-06"^^xsd:float ;
     nidm_pValueFWER: "0.239914320959961"^^xsd:float ;
     nidm_qValueFDR: "0.0223522363243732"^^xsd:float .
 
-niiri:d5fed0d62dac319d5e63e396d28cb9c2
+niiri:bc7434b50faea15d0f3428e0dacb67d6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0037" ;
     nidm_coordinateVector: "[-26,-92,30]"^^xsd:string .
 
-niiri:37e2a7e20f76fc9bcbadf0f44aa25172 prov:wasDerivedFrom niiri:0d31cfbdb7c4e7ca55a57b1a21ab5433 .
+niiri:0e8711e2fd8d14446a6962527ef6df3a prov:wasDerivedFrom niiri:594db02a9d179d5f91a6ed68ca678d59 .
 
-niiri:a12a5737db849b63c6713b52e6643c97
+niiri:3891a8ece23ee8ae327ba5315f1c8fbe
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0038" ;
-    prov:atLocation niiri:2d0e29cec11584021e2c1254e0f7f0f4 ;
+    prov:atLocation niiri:0f81dc717fe65942805f5d193ea9fc3d ;
     prov:value "4.61261701583862"^^xsd:float ;
     nidm_equivalentZStatistic: "4.37258550039614"^^xsd:float ;
     nidm_pValueUncorrected: "6.1391853225512e-06"^^xsd:float ;
     nidm_pValueFWER: "0.462242958151503"^^xsd:float ;
     nidm_qValueFDR: "0.0413121935538803"^^xsd:float .
 
-niiri:2d0e29cec11584021e2c1254e0f7f0f4
+niiri:0f81dc717fe65942805f5d193ea9fc3d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0038" ;
     nidm_coordinateVector: "[-20,-98,22]"^^xsd:string .
 
-niiri:a12a5737db849b63c6713b52e6643c97 prov:wasDerivedFrom niiri:0d31cfbdb7c4e7ca55a57b1a21ab5433 .
+niiri:3891a8ece23ee8ae327ba5315f1c8fbe prov:wasDerivedFrom niiri:594db02a9d179d5f91a6ed68ca678d59 .
 
-niiri:98435de98cb92135e1395fc98c4e42ea
+niiri:ea7488d0b50894dd4de66796e80748b7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0039" ;
-    prov:atLocation niiri:c98cf93e5324c36b7ecdadecb43a57ba ;
+    prov:atLocation niiri:7a7d15cade7651c7745d9e603461b155 ;
     prov:value "4.8499321937561"^^xsd:float ;
     nidm_equivalentZStatistic: "4.57506330130209"^^xsd:float ;
     nidm_pValueUncorrected: "2.38038009880981e-06"^^xsd:float ;
     nidm_pValueFWER: "0.24300196499404"^^xsd:float ;
     nidm_qValueFDR: "0.0224201392740291"^^xsd:float .
 
-niiri:c98cf93e5324c36b7ecdadecb43a57ba
+niiri:7a7d15cade7651c7745d9e603461b155
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0039" ;
     nidm_coordinateVector: "[34,-54,-16]"^^xsd:string .
 
-niiri:98435de98cb92135e1395fc98c4e42ea prov:wasDerivedFrom niiri:dc4429e2fc1e2581ade7dee26c4a3192 .
+niiri:ea7488d0b50894dd4de66796e80748b7 prov:wasDerivedFrom niiri:6dd3d0166eed8b2fa885aeca84711d27 .
 
-niiri:07b523e4122fe41175a47c7df60bb532
+niiri:4331fbbba36aaea44c7a85c25098ab20
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0040" ;
-    prov:atLocation niiri:1d9b62cf26c539d32ccf4b664c13d80c ;
+    prov:atLocation niiri:682cd9521a1b69e766ac8efe8ede5da3 ;
     prov:value "4.83638429641724"^^xsd:float ;
     nidm_equivalentZStatistic: "4.56358093042646"^^xsd:float ;
     nidm_pValueUncorrected: "2.51442057541684e-06"^^xsd:float ;
     nidm_pValueFWER: "0.252994517911213"^^xsd:float ;
     nidm_qValueFDR: "0.023220278156989"^^xsd:float .
 
-niiri:1d9b62cf26c539d32ccf4b664c13d80c
+niiri:682cd9521a1b69e766ac8efe8ede5da3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0040" ;
     nidm_coordinateVector: "[-18,-60,48]"^^xsd:string .
 
-niiri:07b523e4122fe41175a47c7df60bb532 prov:wasDerivedFrom niiri:63325afca9aca401a92169c0b82ecc64 .
+niiri:4331fbbba36aaea44c7a85c25098ab20 prov:wasDerivedFrom niiri:17120da53c5050105b9a8ee0e996c32d .
 
-niiri:661dcfb5c748c84f14f1e71317c8e9bd
+niiri:ab0ca88496f4fad69a12f72d809de0f9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0041" ;
-    prov:atLocation niiri:708d21d2b6912d4c968b36cc2111475f ;
+    prov:atLocation niiri:de2a4a77e9c99754a28b73a5b8437f70 ;
     prov:value "4.82152557373047"^^xsd:float ;
     nidm_equivalentZStatistic: "4.55097685331641"^^xsd:float ;
     nidm_pValueUncorrected: "2.66987113994865e-06"^^xsd:float ;
     nidm_pValueFWER: "0.264312575763193"^^xsd:float ;
     nidm_qValueFDR: "0.0238865523925716"^^xsd:float .
 
-niiri:708d21d2b6912d4c968b36cc2111475f
+niiri:de2a4a77e9c99754a28b73a5b8437f70
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0041" ;
     nidm_coordinateVector: "[16,-98,6]"^^xsd:string .
 
-niiri:661dcfb5c748c84f14f1e71317c8e9bd prov:wasDerivedFrom niiri:8b5b90b720b0adec672c0f46135febcd .
+niiri:ab0ca88496f4fad69a12f72d809de0f9 prov:wasDerivedFrom niiri:a533e0119aa33105f1f6664ba02c4fcf .
 
-niiri:fe4e7bc5932bd8388b247e5fff5e94ec
+niiri:217c4b04d55535db719b6c29ed1ff920
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0042" ;
-    prov:atLocation niiri:97ee939496de2a28a732944cdce87004 ;
+    prov:atLocation niiri:1eb03fa5a0b00d4cdae57571d3ef05b1 ;
     prov:value "4.73149728775024"^^xsd:float ;
     nidm_equivalentZStatistic: "4.47436989109174"^^xsd:float ;
     nidm_pValueUncorrected: "3.83184874719333e-06"^^xsd:float ;
     nidm_pValueFWER: "0.340973924582382"^^xsd:float ;
     nidm_qValueFDR: "0.0306600822692826"^^xsd:float .
 
-niiri:97ee939496de2a28a732944cdce87004
+niiri:1eb03fa5a0b00d4cdae57571d3ef05b1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0042" ;
     nidm_coordinateVector: "[-22,-74,60]"^^xsd:string .
 
-niiri:fe4e7bc5932bd8388b247e5fff5e94ec prov:wasDerivedFrom niiri:e37885e426d196d0484be86dc5869e7e .
+niiri:217c4b04d55535db719b6c29ed1ff920 prov:wasDerivedFrom niiri:b5ea5e54d015aa2a8403364ed7da486d .
 
-niiri:35974aa649462ecc668ba9c8972a01d5
+niiri:7a9ada485db0a1f6554f9ab114f1a05e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0043" ;
-    prov:atLocation niiri:7f0e444835e1d3ff62c42a54aef5a3de ;
+    prov:atLocation niiri:c3c5fa1f2191acb1c8d708293a305572 ;
     prov:value "4.21357154846191"^^xsd:float ;
     nidm_equivalentZStatistic: "4.0257920609862"^^xsd:float ;
     nidm_pValueUncorrected: "2.83919260934962e-05"^^xsd:float ;
     nidm_pValueFWER: "0.889725031810111"^^xsd:float ;
     nidm_qValueFDR: "0.110652635086932"^^xsd:float .
 
-niiri:7f0e444835e1d3ff62c42a54aef5a3de
+niiri:c3c5fa1f2191acb1c8d708293a305572
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0043" ;
     nidm_coordinateVector: "[-30,-72,60]"^^xsd:string .
 
-niiri:35974aa649462ecc668ba9c8972a01d5 prov:wasDerivedFrom niiri:e37885e426d196d0484be86dc5869e7e .
+niiri:7a9ada485db0a1f6554f9ab114f1a05e prov:wasDerivedFrom niiri:b5ea5e54d015aa2a8403364ed7da486d .
 
-niiri:b96598f322b442287e94f7963a5ef7be
+niiri:8fed5f4ed36ab7a842539b15f966adc0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0044" ;
-    prov:atLocation niiri:227085f9eb278530bc05c8d8434a7b57 ;
+    prov:atLocation niiri:80ae6d5477f69a5848ae8d004bebcce2 ;
     prov:value "4.64556264877319"^^xsd:float ;
     nidm_equivalentZStatistic: "4.40086444790859"^^xsd:float ;
     nidm_pValueUncorrected: "5.39102339658371e-06"^^xsd:float ;
     nidm_pValueFWER: "0.426592793295939"^^xsd:float ;
     nidm_qValueFDR: "0.0381376242551822"^^xsd:float .
 
-niiri:227085f9eb278530bc05c8d8434a7b57
+niiri:80ae6d5477f69a5848ae8d004bebcce2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0044" ;
     nidm_coordinateVector: "[-40,-40,44]"^^xsd:string .
 
-niiri:b96598f322b442287e94f7963a5ef7be prov:wasDerivedFrom niiri:b98e5a23cb840529bde8f8f04eb60352 .
+niiri:8fed5f4ed36ab7a842539b15f966adc0 prov:wasDerivedFrom niiri:16c2a7e89d0686e69f57bbeea9dc74a5 .
 
-niiri:c610d6e1581a13855c65cbf2e5a331db
+niiri:a3ad563a699cc4326f49719045069cc7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0045" ;
-    prov:atLocation niiri:7c52fbc2c3475dd9b4cde89011654125 ;
+    prov:atLocation niiri:4fd23de23846ef30d2daff0b25a2d2d3 ;
     prov:value "4.63093709945679"^^xsd:float ;
     nidm_equivalentZStatistic: "4.38831729610845"^^xsd:float ;
     nidm_pValueUncorrected: "5.71155195205897e-06"^^xsd:float ;
     nidm_pValueFWER: "0.442246950226133"^^xsd:float ;
     nidm_qValueFDR: "0.0396432116271416"^^xsd:float .
 
-niiri:7c52fbc2c3475dd9b4cde89011654125
+niiri:4fd23de23846ef30d2daff0b25a2d2d3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0045" ;
     nidm_coordinateVector: "[-46,-56,14]"^^xsd:string .
 
-niiri:c610d6e1581a13855c65cbf2e5a331db prov:wasDerivedFrom niiri:08f981dcb0b605dc38e14328cd560d6b .
+niiri:a3ad563a699cc4326f49719045069cc7 prov:wasDerivedFrom niiri:325d5f27465210c036cd8d865e80251d .
 
-niiri:4686902807199f04fb73d08d03ae21b5
+niiri:f46c43948a24d962d4b5ed9559dbdf9e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0046" ;
-    prov:atLocation niiri:a317f4f10b064fd4ba620cc89c011dee ;
+    prov:atLocation niiri:348fb68fe1e81a7d2e8118131777d3f5 ;
     prov:value "4.48052835464478"^^xsd:float ;
     nidm_equivalentZStatistic: "4.25866261513588"^^xsd:float ;
     nidm_pValueUncorrected: "1.02826793976218e-05"^^xsd:float ;
     nidm_pValueFWER: "0.615092838959958"^^xsd:float ;
     nidm_qValueFDR: "0.0606653213752077"^^xsd:float .
 
-niiri:a317f4f10b064fd4ba620cc89c011dee
+niiri:348fb68fe1e81a7d2e8118131777d3f5
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0046" ;
     nidm_coordinateVector: "[-50,-50,20]"^^xsd:string .
 
-niiri:4686902807199f04fb73d08d03ae21b5 prov:wasDerivedFrom niiri:08f981dcb0b605dc38e14328cd560d6b .
+niiri:f46c43948a24d962d4b5ed9559dbdf9e prov:wasDerivedFrom niiri:325d5f27465210c036cd8d865e80251d .
 
-niiri:646e57d59fbd19fa3d0dfaf644650137
+niiri:32ab5b28df46c33eedc2644958600327
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0047" ;
-    prov:atLocation niiri:d4939a061c7c02573a9d3a436a2a078e ;
+    prov:atLocation niiri:7cf03031cc3525780bb00e6d00dbb1ed ;
     prov:value "4.62564182281494"^^xsd:float ;
     nidm_equivalentZStatistic: "4.38377187185421"^^xsd:float ;
     nidm_pValueUncorrected: "5.83209600213408e-06"^^xsd:float ;
     nidm_pValueFWER: "0.447983703874853"^^xsd:float ;
     nidm_qValueFDR: "0.0399535201049753"^^xsd:float .
 
-niiri:d4939a061c7c02573a9d3a436a2a078e
+niiri:7cf03031cc3525780bb00e6d00dbb1ed
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0047" ;
     nidm_coordinateVector: "[-54,-48,-16]"^^xsd:string .
 
-niiri:646e57d59fbd19fa3d0dfaf644650137 prov:wasDerivedFrom niiri:d757dae4ee0e2ef151ed77b98cda2382 .
+niiri:32ab5b28df46c33eedc2644958600327 prov:wasDerivedFrom niiri:a77994161041027f0cf04defd7345c50 .
 
-niiri:0d5f97bc29f0ce07bce15596e53fc18e
+niiri:d100c51eef378500eb4feffaffb6838f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0048" ;
-    prov:atLocation niiri:898343045ef37f06d4b7c6e32adced9c ;
+    prov:atLocation niiri:3b11bab9e0b69b19971b373a7f1603ee ;
     prov:value "4.39731121063232"^^xsd:float ;
     nidm_equivalentZStatistic: "4.1864457158313"^^xsd:float ;
     nidm_pValueUncorrected: "1.41678330879413e-05"^^xsd:float ;
     nidm_pValueFWER: "0.712242817080673"^^xsd:float ;
     nidm_qValueFDR: "0.0701395133156884"^^xsd:float .
 
-niiri:898343045ef37f06d4b7c6e32adced9c
+niiri:3b11bab9e0b69b19971b373a7f1603ee
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0048" ;
     nidm_coordinateVector: "[-36,-46,-18]"^^xsd:string .
 
-niiri:0d5f97bc29f0ce07bce15596e53fc18e prov:wasDerivedFrom niiri:d757dae4ee0e2ef151ed77b98cda2382 .
+niiri:d100c51eef378500eb4feffaffb6838f prov:wasDerivedFrom niiri:a77994161041027f0cf04defd7345c50 .
 
-niiri:719f3073ced10d662956b4ec37d4eb46
+niiri:18a234ca0f5ed1ecc2090e7679e74552
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0049" ;
-    prov:atLocation niiri:4b4180a632f4272c9c87a6a4e225809d ;
+    prov:atLocation niiri:1c7aecbd92310ea0de4913e7e7d71499 ;
     prov:value "4.53011417388916"^^xsd:float ;
     nidm_equivalentZStatistic: "4.30153087828584"^^xsd:float ;
     nidm_pValueUncorrected: "8.48110654050327e-06"^^xsd:float ;
     nidm_pValueFWER: "0.556525968503526"^^xsd:float ;
     nidm_qValueFDR: "0.0536338708992394"^^xsd:float .
 
-niiri:4b4180a632f4272c9c87a6a4e225809d
+niiri:1c7aecbd92310ea0de4913e7e7d71499
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0049" ;
     nidm_coordinateVector: "[12,-100,20]"^^xsd:string .
 
-niiri:719f3073ced10d662956b4ec37d4eb46 prov:wasDerivedFrom niiri:660ef8a46b7c1f0d47e1dbb95e0879b4 .
+niiri:18a234ca0f5ed1ecc2090e7679e74552 prov:wasDerivedFrom niiri:78d6f29ff8a7c1f0a21810728ade20ce .
 
-niiri:89b2932e09b8bb2437d3f5dfb657c381
+niiri:9f7600af4f7127e3e35e8956824b24cd
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0050" ;
-    prov:atLocation niiri:fedf5f20b57a4edec1241ce009390256 ;
+    prov:atLocation niiri:589510f1d277d70bd38e8b41f5208f6d ;
     prov:value "4.43985033035278"^^xsd:float ;
     nidm_equivalentZStatistic: "4.22340441164883"^^xsd:float ;
     nidm_pValueUncorrected: "1.20319728781348e-05"^^xsd:float ;
     nidm_pValueFWER: "0.663080040726423"^^xsd:float ;
     nidm_qValueFDR: "0.0655195642105904"^^xsd:float .
 
-niiri:fedf5f20b57a4edec1241ce009390256
+niiri:589510f1d277d70bd38e8b41f5208f6d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0050" ;
     nidm_coordinateVector: "[-48,2,50]"^^xsd:string .
 
-niiri:89b2932e09b8bb2437d3f5dfb657c381 prov:wasDerivedFrom niiri:376742ba10824087fba971d247dc6783 .
+niiri:9f7600af4f7127e3e35e8956824b24cd prov:wasDerivedFrom niiri:ef6fca405f462fa8c50ca4b0f7e48ca2 .
 
-niiri:49ae21bfe675fa8b9db9ef01f21c8038
+niiri:8603599eaf15b47cfc1747721a7cc043
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0051" ;
-    prov:atLocation niiri:ce304c4adfe4941f409f65439c15570c ;
+    prov:atLocation niiri:3808a783cb30debaf04ca96ba0dbfe0b ;
     prov:value "4.42902088165283"^^xsd:float ;
     nidm_equivalentZStatistic: "4.21400406802287"^^xsd:float ;
     nidm_pValueUncorrected: "1.25441381573221e-05"^^xsd:float ;
     nidm_pValueFWER: "0.675732426251063"^^xsd:float ;
     nidm_qValueFDR: "0.0666653677861119"^^xsd:float .
 
-niiri:ce304c4adfe4941f409f65439c15570c
+niiri:3808a783cb30debaf04ca96ba0dbfe0b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0051" ;
     nidm_coordinateVector: "[20,-66,34]"^^xsd:string .
 
-niiri:49ae21bfe675fa8b9db9ef01f21c8038 prov:wasDerivedFrom niiri:8bb3c55367529f573f350336b59c6b8b .
+niiri:8603599eaf15b47cfc1747721a7cc043 prov:wasDerivedFrom niiri:6578b8b9d153de72a9648c8488a6ac3f .
 
-niiri:a74a7f5b172dd1bc08ef2dec3a109f2b
+niiri:975035177d9f223d416eac85677dd73e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0052" ;
-    prov:atLocation niiri:6abd9bc5c4f38523e809b1b44a7e99c7 ;
+    prov:atLocation niiri:e2acd36a46999c63dbedb34bdf074c27 ;
     prov:value "4.34153509140015"^^xsd:float ;
     nidm_equivalentZStatistic: "4.13785173162383"^^xsd:float ;
     nidm_pValueUncorrected: "1.75286391850271e-05"^^xsd:float ;
     nidm_pValueFWER: "0.773482364050178"^^xsd:float ;
     nidm_qValueFDR: "0.0797247033163797"^^xsd:float .
 
-niiri:6abd9bc5c4f38523e809b1b44a7e99c7
+niiri:e2acd36a46999c63dbedb34bdf074c27
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0052" ;
     nidm_coordinateVector: "[22,-80,54]"^^xsd:string .
 
-niiri:a74a7f5b172dd1bc08ef2dec3a109f2b prov:wasDerivedFrom niiri:ecc219c77c0dd1cbef88e6f794b57b51 .
+niiri:975035177d9f223d416eac85677dd73e prov:wasDerivedFrom niiri:aa346a17d504ccda6e8f3483bc7567b5 .
 
-niiri:c8cec8ce3cce361e7b04223a9a2f20db
+niiri:d8e002f5cf7541fe9f68b39c0d8728f6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0053" ;
-    prov:atLocation niiri:cd9524eda65364a8a8405fe492ce646b ;
+    prov:atLocation niiri:49a3b54ceb9b87ab4cf4da4698244a80 ;
     prov:value "4.31018495559692"^^xsd:float ;
     nidm_equivalentZStatistic: "4.11047161264349"^^xsd:float ;
     nidm_pValueUncorrected: "1.97425911666604e-05"^^xsd:float ;
     nidm_pValueFWER: "0.805553175655503"^^xsd:float ;
     nidm_qValueFDR: "0.0852768580529791"^^xsd:float .
 
-niiri:cd9524eda65364a8a8405fe492ce646b
+niiri:49a3b54ceb9b87ab4cf4da4698244a80
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0053" ;
     nidm_coordinateVector: "[4,8,32]"^^xsd:string .
 
-niiri:c8cec8ce3cce361e7b04223a9a2f20db prov:wasDerivedFrom niiri:a1fc6b7fb08f44460fa83f1e82f3fd55 .
+niiri:d8e002f5cf7541fe9f68b39c0d8728f6 prov:wasDerivedFrom niiri:edeaef5183ad24011f37f4883d8f953f .
 
-niiri:6caf772783f0738d4f58c46fb421d510
+niiri:2159f676fe87211c3a34c5173f62ef52
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0054" ;
-    prov:atLocation niiri:173fb0d61a88e2483da7d0266666f1a1 ;
+    prov:atLocation niiri:66764c6a7d0744dbfb27c4acb10e5096 ;
     prov:value "4.27076530456543"^^xsd:float ;
     nidm_equivalentZStatistic: "4.07597586124442"^^xsd:float ;
     nidm_pValueUncorrected: "2.29108861893312e-05"^^xsd:float ;
     nidm_pValueFWER: "0.842807876097015"^^xsd:float ;
     nidm_qValueFDR: "0.0956335108049698"^^xsd:float .
 
-niiri:173fb0d61a88e2483da7d0266666f1a1
+niiri:66764c6a7d0744dbfb27c4acb10e5096
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0054" ;
     nidm_coordinateVector: "[44,-48,-26]"^^xsd:string .
 
-niiri:6caf772783f0738d4f58c46fb421d510 prov:wasDerivedFrom niiri:6e25dc1a7cdabbe6238b8c8ba92a299b .
+niiri:2159f676fe87211c3a34c5173f62ef52 prov:wasDerivedFrom niiri:82b6d07ebf78a88f41741c7c0b4d138a .
 
-niiri:3e0bd7638cd27fee067494ec2e4e07d4
+niiri:d20759428478e6a2ecc5a6ac0336248b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0055" ;
-    prov:atLocation niiri:19bd910171088a8550259102076d90a9 ;
+    prov:atLocation niiri:92ee6df0fc18e5cad532440d06b401d5 ;
     prov:value "4.24014186859131"^^xsd:float ;
     nidm_equivalentZStatistic: "4.04912548760248"^^xsd:float ;
     nidm_pValueUncorrected: "2.57046875662414e-05"^^xsd:float ;
     nidm_pValueFWER: "0.869047635745501"^^xsd:float ;
     nidm_qValueFDR: "0.103527958580522"^^xsd:float .
 
-niiri:19bd910171088a8550259102076d90a9
+niiri:92ee6df0fc18e5cad532440d06b401d5
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0055" ;
     nidm_coordinateVector: "[12,52,-12]"^^xsd:string .
 
-niiri:3e0bd7638cd27fee067494ec2e4e07d4 prov:wasDerivedFrom niiri:b6d54c10be27fe7c4485995dd9f9debb .
+niiri:d20759428478e6a2ecc5a6ac0336248b prov:wasDerivedFrom niiri:23d958b69d91f95e528ceb5e2197a63a .
 
-niiri:3276fdd6ddac14ff6d0a7f8503e92620
+niiri:93dad7155ab8df6434cf30dc96e0fec7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0056" ;
-    prov:atLocation niiri:89f5ddbbe89a675a72593041a3ca09c3 ;
+    prov:atLocation niiri:b31a74eef450f2def5dc49026d2b9709 ;
     prov:value "4.16103744506836"^^xsd:float ;
     nidm_equivalentZStatistic: "3.97955763826227"^^xsd:float ;
     nidm_pValueUncorrected: "3.45218098449784e-05"^^xsd:float ;
     nidm_pValueFWER: "0.924586885045607"^^xsd:float ;
     nidm_qValueFDR: "0.124121852318798"^^xsd:float .
 
-niiri:89f5ddbbe89a675a72593041a3ca09c3
+niiri:b31a74eef450f2def5dc49026d2b9709
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0056" ;
     nidm_coordinateVector: "[-14,-98,-4]"^^xsd:string .
 
-niiri:3276fdd6ddac14ff6d0a7f8503e92620 prov:wasDerivedFrom niiri:ef72e4c2ccfe576af6dd9f5327bf55b9 .
+niiri:93dad7155ab8df6434cf30dc96e0fec7 prov:wasDerivedFrom niiri:cd749510acee370dec9860a5407637f5 .
 
-niiri:c3cf99e426979369b4cc70ab2cae8447
+niiri:609028d01e5972e824b32d95ae48bf7d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0057" ;
-    prov:atLocation niiri:6bc0a88ccb9d151b3ac0defe4208c807 ;
+    prov:atLocation niiri:594a7521ca57e63a87ec7cde2e7d4ff4 ;
     prov:value "4.15926313400269"^^xsd:float ;
     nidm_equivalentZStatistic: "3.97799377863742"^^xsd:float ;
     nidm_pValueUncorrected: "3.47495948790355e-05"^^xsd:float ;
     nidm_pValueFWER: "0.925622766117185"^^xsd:float ;
     nidm_qValueFDR: "0.124121852318798"^^xsd:float .
 
-niiri:6bc0a88ccb9d151b3ac0defe4208c807
+niiri:594a7521ca57e63a87ec7cde2e7d4ff4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0057" ;
     nidm_coordinateVector: "[-66,-36,22]"^^xsd:string .
 
-niiri:c3cf99e426979369b4cc70ab2cae8447 prov:wasDerivedFrom niiri:13d8b78f07281f4256fd3c0ec01dd4c4 .
+niiri:609028d01e5972e824b32d95ae48bf7d prov:wasDerivedFrom niiri:13d9d29fd974d6893c1726d57a98a10f .
 
-niiri:2db15528ae3236f993ac8beb03c4de36
+niiri:b4946cfd559a49dd59da4eb959fcc3ff
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0058" ;
-    prov:atLocation niiri:380a61017b4fcac325a0d7b0d9817a82 ;
+    prov:atLocation niiri:329b7745f4e1247cdc3009fe502edade ;
     prov:value "4.15127944946289"^^xsd:float ;
     nidm_equivalentZStatistic: "3.9709551719526"^^xsd:float ;
     nidm_pValueUncorrected: "3.57925246584623e-05"^^xsd:float ;
     nidm_pValueFWER: "0.930169830491485"^^xsd:float ;
     nidm_qValueFDR: "0.125812633483204"^^xsd:float .
 
-niiri:380a61017b4fcac325a0d7b0d9817a82
+niiri:329b7745f4e1247cdc3009fe502edade
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0058" ;
     nidm_coordinateVector: "[64,-30,-22]"^^xsd:string .
 
-niiri:2db15528ae3236f993ac8beb03c4de36 prov:wasDerivedFrom niiri:ba735e41f5c81e821d5431a5f33299b3 .
+niiri:b4946cfd559a49dd59da4eb959fcc3ff prov:wasDerivedFrom niiri:0d04d9bc9dd104e43dd556533a5b2159 .
 
-niiri:5844041981df16af64c11ea3ca033105
+niiri:90fe65bd993a69b371b497dd0b82c3c9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0059" ;
-    prov:atLocation niiri:e921ad0529a987659faf7f7d41190fa8 ;
+    prov:atLocation niiri:9152c663953a89724e0ad9d96a65b31b ;
     prov:value "3.68732213973999"^^xsd:float ;
     nidm_equivalentZStatistic: "3.55676980326808"^^xsd:float ;
     nidm_pValueUncorrected: "0.000187721434294241"^^xsd:float ;
     nidm_pValueFWER: "0.999949562856829"^^xsd:float ;
     nidm_qValueFDR: "0.36844208672846"^^xsd:float .
 
-niiri:e921ad0529a987659faf7f7d41190fa8
+niiri:9152c663953a89724e0ad9d96a65b31b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0059" ;
     nidm_coordinateVector: "[56,-22,-26]"^^xsd:string .
 
-niiri:5844041981df16af64c11ea3ca033105 prov:wasDerivedFrom niiri:ba735e41f5c81e821d5431a5f33299b3 .
+niiri:90fe65bd993a69b371b497dd0b82c3c9 prov:wasDerivedFrom niiri:0d04d9bc9dd104e43dd556533a5b2159 .
 
-niiri:4b10c5aa444bfcc5979b02cc6a8de1ee
+niiri:829760ac18f565fb23d2dd89751a104f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0060" ;
-    prov:atLocation niiri:8a6738ef74783ec9f92765754adb881c ;
+    prov:atLocation niiri:1b86c75e5e0acab33754c3d010276da8 ;
     prov:value "4.1501989364624"^^xsd:float ;
     nidm_equivalentZStatistic: "3.97000233107989"^^xsd:float ;
     nidm_pValueUncorrected: "3.59359643187229e-05"^^xsd:float ;
     nidm_pValueFWER: "0.930770937360285"^^xsd:float ;
     nidm_qValueFDR: "0.125812633483204"^^xsd:float .
 
-niiri:8a6738ef74783ec9f92765754adb881c
+niiri:1b86c75e5e0acab33754c3d010276da8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0060" ;
     nidm_coordinateVector: "[-64,-34,8]"^^xsd:string .
 
-niiri:4b10c5aa444bfcc5979b02cc6a8de1ee prov:wasDerivedFrom niiri:9d954ccdd2f76e6021425a58f7079443 .
+niiri:829760ac18f565fb23d2dd89751a104f prov:wasDerivedFrom niiri:7d13eda0d79684f0d63dac1332405064 .
 
-niiri:6cf25f5b7542b6357ca8f008bf7ee40c
+niiri:11c5084b4dd50bda5192de6afa001779
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0061" ;
-    prov:atLocation niiri:e0aa1b34fca06e04917572c4bd840215 ;
+    prov:atLocation niiri:f34f6b3556c1161d085528b512b8676a ;
     prov:value "4.11570262908936"^^xsd:float ;
     nidm_equivalentZStatistic: "3.93955268733486"^^xsd:float ;
     nidm_pValueUncorrected: "4.08168366777817e-05"^^xsd:float ;
     nidm_pValueFWER: "0.948197934370974"^^xsd:float ;
     nidm_qValueFDR: "0.135780811447955"^^xsd:float .
 
-niiri:e0aa1b34fca06e04917572c4bd840215
+niiri:f34f6b3556c1161d085528b512b8676a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0061" ;
     nidm_coordinateVector: "[50,46,-12]"^^xsd:string .
 
-niiri:6cf25f5b7542b6357ca8f008bf7ee40c prov:wasDerivedFrom niiri:3964078dd1cffc5e5036d7bec9ce573c .
+niiri:11c5084b4dd50bda5192de6afa001779 prov:wasDerivedFrom niiri:9cc2d1c11d4e3b5aec5735ee91c1aca3 .
 
-niiri:f69685daf2174c4ae82dd0bbf18c1815
+niiri:3c355638d7475943124ba9c226bfa69e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0062" ;
-    prov:atLocation niiri:991fe3f754094eaafd88889c8d5216bc ;
+    prov:atLocation niiri:277c0c1b8a9d2a7136d6fb53100f4535 ;
     prov:value "4.06387186050415"^^xsd:float ;
     nidm_equivalentZStatistic: "3.89369529283678"^^xsd:float ;
     nidm_pValueUncorrected: "4.93643251464615e-05"^^xsd:float ;
     nidm_pValueFWER: "0.968279346551793"^^xsd:float ;
     nidm_qValueFDR: "0.154561047969304"^^xsd:float .
 
-niiri:991fe3f754094eaafd88889c8d5216bc
+niiri:277c0c1b8a9d2a7136d6fb53100f4535
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0062" ;
     nidm_coordinateVector: "[-38,-54,-42]"^^xsd:string .
 
-niiri:f69685daf2174c4ae82dd0bbf18c1815 prov:wasDerivedFrom niiri:53d1ede95ea7c0b47d5a32d1a51fe6f6 .
+niiri:3c355638d7475943124ba9c226bfa69e prov:wasDerivedFrom niiri:5b5b201251a2cc570135bacff1a480b1 .
 
-niiri:5a579d94d1d6355560b569d363350e71
+niiri:73c33f38c5fedbbd36089605d2e2bed2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0063" ;
-    prov:atLocation niiri:cbc27995bdd6690158ded00c24f95c43 ;
+    prov:atLocation niiri:4fa8c02bb9d4119aac7ac8a420647cc3 ;
     prov:value "3.63390350341797"^^xsd:float ;
     nidm_equivalentZStatistic: "3.50844773659595"^^xsd:float ;
     nidm_pValueUncorrected: "0.000225364892119218"^^xsd:float ;
     nidm_pValueFWER: "0.999988653013371"^^xsd:float ;
     nidm_qValueFDR: "0.410740156420602"^^xsd:float .
 
-niiri:cbc27995bdd6690158ded00c24f95c43
+niiri:4fa8c02bb9d4119aac7ac8a420647cc3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0063" ;
     nidm_coordinateVector: "[-30,-64,-40]"^^xsd:string .
 
-niiri:5a579d94d1d6355560b569d363350e71 prov:wasDerivedFrom niiri:53d1ede95ea7c0b47d5a32d1a51fe6f6 .
+niiri:73c33f38c5fedbbd36089605d2e2bed2 prov:wasDerivedFrom niiri:5b5b201251a2cc570135bacff1a480b1 .
 
-niiri:0c9ed16566b9a044c58f9a53ebcfa5ae
+niiri:dabeaf7666f754dfe37065b88c4f4b4a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0064" ;
-    prov:atLocation niiri:552e53c37b7f2030b7eb1cdc79b997f9 ;
+    prov:atLocation niiri:dc22bbd3df567f1be35fd703ae919813 ;
     prov:value "4.04323768615723"^^xsd:float ;
     nidm_equivalentZStatistic: "3.87540363822468"^^xsd:float ;
     nidm_pValueUncorrected: "5.32240496489145e-05"^^xsd:float ;
     nidm_pValueFWER: "0.974420729710188"^^xsd:float ;
     nidm_qValueFDR: "0.16275733943943"^^xsd:float .
 
-niiri:552e53c37b7f2030b7eb1cdc79b997f9
+niiri:dc22bbd3df567f1be35fd703ae919813
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0064" ;
     nidm_coordinateVector: "[-14,58,10]"^^xsd:string .
 
-niiri:0c9ed16566b9a044c58f9a53ebcfa5ae prov:wasDerivedFrom niiri:c603845c76b83d0aac64a7584957c8fb .
+niiri:dabeaf7666f754dfe37065b88c4f4b4a prov:wasDerivedFrom niiri:bbf4ce7e2e67235f45331b2b87133bd7 .
 
-niiri:d0bd5daab811539f6aa16803b1f69e0d
+niiri:a62d0b592d043fda22e569f6cdb71fff
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0065" ;
-    prov:atLocation niiri:950ebf76d82ec218bb221dea05e45b68 ;
+    prov:atLocation niiri:b487eb50f6635294ac4f3e02f1fd9c9d ;
     prov:value "4.03806781768799"^^xsd:float ;
     nidm_equivalentZStatistic: "3.87081752636553"^^xsd:float ;
     nidm_pValueUncorrected: "5.4235483319065e-05"^^xsd:float ;
     nidm_pValueFWER: "0.975809063970924"^^xsd:float ;
     nidm_qValueFDR: "0.164182416202422"^^xsd:float .
 
-niiri:950ebf76d82ec218bb221dea05e45b68
+niiri:b487eb50f6635294ac4f3e02f1fd9c9d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0065" ;
     nidm_coordinateVector: "[-68,-34,-8]"^^xsd:string .
 
-niiri:d0bd5daab811539f6aa16803b1f69e0d prov:wasDerivedFrom niiri:a2777ad5b03729d935f9c97ada730fc3 .
+niiri:a62d0b592d043fda22e569f6cdb71fff prov:wasDerivedFrom niiri:6a09c31a2cb2399d4dfaa1e9734b3056 .
 
-niiri:0c8cf9f791296db553228e784b948a60
+niiri:4ac0f9aefed1176b14b9abe74250cbdc
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0066" ;
-    prov:atLocation niiri:5a2845a510ed56c8245862414385ae2d ;
+    prov:atLocation niiri:a0b34589df34a16d82775f29cdb325a5 ;
     prov:value "4.004225730896"^^xsd:float ;
     nidm_equivalentZStatistic: "3.84076553938526"^^xsd:float ;
     nidm_pValueUncorrected: "6.13256092123482e-05"^^xsd:float ;
     nidm_pValueFWER: "0.983537497151825"^^xsd:float ;
     nidm_qValueFDR: "0.17776479000337"^^xsd:float .
 
-niiri:5a2845a510ed56c8245862414385ae2d
+niiri:a0b34589df34a16d82775f29cdb325a5
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0066" ;
     nidm_coordinateVector: "[16,60,12]"^^xsd:string .
 
-niiri:0c8cf9f791296db553228e784b948a60 prov:wasDerivedFrom niiri:6be135d40f33855edbacae1ce12b09f5 .
+niiri:4ac0f9aefed1176b14b9abe74250cbdc prov:wasDerivedFrom niiri:19eff7c42f4c5b43b8936b6bb77abf9e .
 
-niiri:ae4d80f7faf7c00b6317be8fab64a0ae
+niiri:e022009b24cfb049ed10bbfee681d92a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0067" ;
-    prov:atLocation niiri:a6f430823385cf68ac955fbcde5ccf0d ;
+    prov:atLocation niiri:2f7b36f5f675f649d99cf764343de5c7 ;
     prov:value "3.97911667823792"^^xsd:float ;
     nidm_equivalentZStatistic: "3.81843367367204"^^xsd:float ;
     nidm_pValueUncorrected: "6.71508406763222e-05"^^xsd:float ;
     nidm_pValueFWER: "0.987909478842303"^^xsd:float ;
     nidm_qValueFDR: "0.188766279331586"^^xsd:float .
 
-niiri:a6f430823385cf68ac955fbcde5ccf0d
+niiri:2f7b36f5f675f649d99cf764343de5c7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0067" ;
     nidm_coordinateVector: "[64,-32,16]"^^xsd:string .
 
-niiri:ae4d80f7faf7c00b6317be8fab64a0ae prov:wasDerivedFrom niiri:28624557fd946e461b8d82ec16375193 .
+niiri:e022009b24cfb049ed10bbfee681d92a prov:wasDerivedFrom niiri:3a53732749467fad732fc1b126252b83 .
 
-niiri:8f3bd36f94307a5043af1375afb8bcf9
+niiri:abbe5bd49d9338f66a3af445c1e2372c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0068" ;
-    prov:atLocation niiri:8e8c43bd6056d92334167a8eba37616a ;
+    prov:atLocation niiri:7cce260bd801b5e637a5ae78e7cc6a21 ;
     prov:value "3.96304869651794"^^xsd:float ;
     nidm_equivalentZStatistic: "3.80412735630895"^^xsd:float ;
     nidm_pValueUncorrected: "7.11524784513529e-05"^^xsd:float ;
     nidm_pValueFWER: "0.99018444524646"^^xsd:float ;
     nidm_qValueFDR: "0.196465422200293"^^xsd:float .
 
-niiri:8e8c43bd6056d92334167a8eba37616a
+niiri:7cce260bd801b5e637a5ae78e7cc6a21
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0068" ;
     nidm_coordinateVector: "[-58,-32,22]"^^xsd:string .
 
-niiri:8f3bd36f94307a5043af1375afb8bcf9 prov:wasDerivedFrom niiri:553d9ccd8301231daa8b7127b7d9fb7f .
+niiri:abbe5bd49d9338f66a3af445c1e2372c prov:wasDerivedFrom niiri:4489ae9a89d81f59b4a316f0bc2ca8b8 .
 
-niiri:67420928e9c0b8ce182108cae0641e1d
+niiri:578bcf6846bd5b49337bc46c4d7b1c7f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0069" ;
-    prov:atLocation niiri:fdca36f535ff1520cacb92c9bc046bab ;
+    prov:atLocation niiri:23bd153efdafbf140cfa0b6666fc959e ;
     prov:value "3.92521071434021"^^xsd:float ;
     nidm_equivalentZStatistic: "3.77039013890334"^^xsd:float ;
     nidm_pValueUncorrected: "8.14962714239531e-05"^^xsd:float ;
     nidm_pValueFWER: "0.994203174123576"^^xsd:float ;
     nidm_qValueFDR: "0.214086162162037"^^xsd:float .
 
-niiri:fdca36f535ff1520cacb92c9bc046bab
+niiri:23bd153efdafbf140cfa0b6666fc959e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0069" ;
     nidm_coordinateVector: "[42,-42,14]"^^xsd:string .
 
-niiri:67420928e9c0b8ce182108cae0641e1d prov:wasDerivedFrom niiri:2a7b2aeea7dc6c0e5169cde436a25f98 .
+niiri:578bcf6846bd5b49337bc46c4d7b1c7f prov:wasDerivedFrom niiri:20b3e078d59196a48bbdcfae8b039f3e .
 
-niiri:4e18f177ec225d4f2f71271e556f529a
+niiri:da03712278abfc01eebac38b33e1cf9d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0070" ;
-    prov:atLocation niiri:9834348723b41a10d95bbd43f6884849 ;
+    prov:atLocation niiri:e876166ff2dceea5230e5d76fbf9f15f ;
     prov:value "3.92441153526306"^^xsd:float ;
     nidm_equivalentZStatistic: "3.76967685174471"^^xsd:float ;
     nidm_pValueUncorrected: "8.17295246882122e-05"^^xsd:float ;
     nidm_pValueFWER: "0.994270531661465"^^xsd:float ;
     nidm_qValueFDR: "0.214086162162037"^^xsd:float .
 
-niiri:9834348723b41a10d95bbd43f6884849
+niiri:e876166ff2dceea5230e5d76fbf9f15f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0070" ;
     nidm_coordinateVector: "[54,8,-36]"^^xsd:string .
 
-niiri:4e18f177ec225d4f2f71271e556f529a prov:wasDerivedFrom niiri:e5ed0876efa8e7867992a3e7519d125a .
+niiri:da03712278abfc01eebac38b33e1cf9d prov:wasDerivedFrom niiri:87692b796865090154e70657cb33f3fa .
 
-niiri:ebf72ed7e3308fbf5bcd3bf6f01cc0a1
+niiri:4776d4c0541b2407f509fe6b2b1c2853
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0071" ;
-    prov:atLocation niiri:6bb494ba3b4b53e4ba1a1a04f3bbb08d ;
+    prov:atLocation niiri:8e80b4015fe341dd35e4a04ffb7bd269 ;
     prov:value "3.83119082450867"^^xsd:float ;
     nidm_equivalentZStatistic: "3.68627175710081"^^xsd:float ;
     nidm_pValueUncorrected: "0.000113781673432678"^^xsd:float ;
     nidm_pValueFWER: "0.998771596988439"^^xsd:float ;
     nidm_qValueFDR: "0.271448122890309"^^xsd:float .
 
-niiri:6bb494ba3b4b53e4ba1a1a04f3bbb08d
+niiri:8e80b4015fe341dd35e4a04ffb7bd269
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0071" ;
     nidm_coordinateVector: "[-66,-46,8]"^^xsd:string .
 
-niiri:ebf72ed7e3308fbf5bcd3bf6f01cc0a1 prov:wasDerivedFrom niiri:cc4442623b113667ed11179bf378fa55 .
+niiri:4776d4c0541b2407f509fe6b2b1c2853 prov:wasDerivedFrom niiri:f6aab0b38147783304dd12682b7a862f .
 
-niiri:7682e0b9d09cfa3f649fc4ab197d51c5
+niiri:a0b516d4caa56831926e6d21c58b5dad
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0072" ;
-    prov:atLocation niiri:242c2913f7e6868af10a0d1e4d23a118 ;
+    prov:atLocation niiri:4543c36bb3fcf5b8005d17cc742876cc ;
     prov:value "3.80303430557251"^^xsd:float ;
     nidm_equivalentZStatistic: "3.66100116005044"^^xsd:float ;
     nidm_pValueUncorrected: "0.000125615810592783"^^xsd:float ;
     nidm_pValueFWER: "0.999284372850148"^^xsd:float ;
     nidm_qValueFDR: "0.284998670660322"^^xsd:float .
 
-niiri:242c2913f7e6868af10a0d1e4d23a118
+niiri:4543c36bb3fcf5b8005d17cc742876cc
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0072" ;
     nidm_coordinateVector: "[-54,-32,42]"^^xsd:string .
 
-niiri:7682e0b9d09cfa3f649fc4ab197d51c5 prov:wasDerivedFrom niiri:3bcdad331508ef0bb8c4160e76f8a8dc .
+niiri:a0b516d4caa56831926e6d21c58b5dad prov:wasDerivedFrom niiri:8cfffabbc7e33bc2c585eb4a81ebc159 .
 
-niiri:cbe94ec4a4835e64186ebbeb09aacca1
+niiri:6aa0a5cf04dbb3c86c7b7e42153c561d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0073" ;
-    prov:atLocation niiri:4e7e066e6142cbd1af0c8c0cbfde6a3f ;
+    prov:atLocation niiri:b3a94b46b45cb4c4f16342948448b2b1 ;
     prov:value "3.80056810379028"^^xsd:float ;
     nidm_equivalentZStatistic: "3.65878600275762"^^xsd:float ;
     nidm_pValueUncorrected: "0.000126706415147559"^^xsd:float ;
     nidm_pValueFWER: "0.999318686068297"^^xsd:float ;
     nidm_qValueFDR: "0.285311172590102"^^xsd:float .
 
-niiri:4e7e066e6142cbd1af0c8c0cbfde6a3f
+niiri:b3a94b46b45cb4c4f16342948448b2b1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0073" ;
     nidm_coordinateVector: "[14,-14,72]"^^xsd:string .
 
-niiri:cbe94ec4a4835e64186ebbeb09aacca1 prov:wasDerivedFrom niiri:4f16f2a965f5b74e4ed5dd4273ae236f .
+niiri:6aa0a5cf04dbb3c86c7b7e42153c561d prov:wasDerivedFrom niiri:d93e1967e2b464317bc445a37c7560a2 .
 
-niiri:203679be7d5444fd4f4cfa318298bdd0
+niiri:cd7d7fa3c3a1f73e1c6e18eec54bf367
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0074" ;
-    prov:atLocation niiri:e4ff8b38fac4a34a30bbf71112253f56 ;
+    prov:atLocation niiri:8e116c5bfb82033d215acceb7790ae6e ;
     prov:value "3.43387007713318"^^xsd:float ;
     nidm_equivalentZStatistic: "3.32638243729709"^^xsd:float ;
     nidm_pValueUncorrected: "0.000439905622966141"^^xsd:float ;
     nidm_pValueFWER: "0.999999993561311"^^xsd:float ;
     nidm_qValueFDR: "0.61426970601407"^^xsd:float .
 
-niiri:e4ff8b38fac4a34a30bbf71112253f56
+niiri:8e116c5bfb82033d215acceb7790ae6e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0074" ;
     nidm_coordinateVector: "[12,-16,64]"^^xsd:string .
 
-niiri:203679be7d5444fd4f4cfa318298bdd0 prov:wasDerivedFrom niiri:4f16f2a965f5b74e4ed5dd4273ae236f .
+niiri:cd7d7fa3c3a1f73e1c6e18eec54bf367 prov:wasDerivedFrom niiri:d93e1967e2b464317bc445a37c7560a2 .
 
-niiri:8779f2524bd2210d4a51e10ab15bacf1
+niiri:b77f9f4ee4f5feb949a261a2483aa303
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0075" ;
-    prov:atLocation niiri:f9ebc740a044a4c18fc19643a7a0a51e ;
+    prov:atLocation niiri:32d8cdce54f1bc815e16b577a65b42f9 ;
     prov:value "3.7976541519165"^^xsd:float ;
     nidm_equivalentZStatistic: "3.65616831501084"^^xsd:float ;
     nidm_pValueUncorrected: "0.000128006646334056"^^xsd:float ;
     nidm_pValueFWER: "0.999357362048204"^^xsd:float ;
     nidm_qValueFDR: "0.285982238829825"^^xsd:float .
 
-niiri:f9ebc740a044a4c18fc19643a7a0a51e
+niiri:32d8cdce54f1bc815e16b577a65b42f9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0075" ;
     nidm_coordinateVector: "[-22,-82,0]"^^xsd:string .
 
-niiri:8779f2524bd2210d4a51e10ab15bacf1 prov:wasDerivedFrom niiri:d10cc69571498e5ccb865e70f789b959 .
+niiri:b77f9f4ee4f5feb949a261a2483aa303 prov:wasDerivedFrom niiri:80f2f6c335075aedb795e079a5688f2b .
 
-niiri:f09a8d192665b37e8d96030e7579dce8
+niiri:d00c21a3d5785cd0c3ace030b952b31e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0076" ;
-    prov:atLocation niiri:7bfc7ee92b1ed7eff6cb78456c115540 ;
+    prov:atLocation niiri:0fcf7ece24e31946c54d35e8b1f83339 ;
     prov:value "3.79047918319702"^^xsd:float ;
     nidm_equivalentZStatistic: "3.64972117706788"^^xsd:float ;
     nidm_pValueUncorrected: "0.000131262556208656"^^xsd:float ;
     nidm_pValueFWER: "0.999444488129241"^^xsd:float ;
     nidm_qValueFDR: "0.290021691384508"^^xsd:float .
 
-niiri:7bfc7ee92b1ed7eff6cb78456c115540
+niiri:0fcf7ece24e31946c54d35e8b1f83339
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0076" ;
     nidm_coordinateVector: "[52,-42,18]"^^xsd:string .
 
-niiri:f09a8d192665b37e8d96030e7579dce8 prov:wasDerivedFrom niiri:eca18148c6df2bf25a3fb4224b299658 .
+niiri:d00c21a3d5785cd0c3ace030b952b31e prov:wasDerivedFrom niiri:ef7d0561535e5e02620497afd1e27f3d .
 
-niiri:2da92f631c41ceb7d9d4873508d6aa07
+niiri:81b14a242118884af4716d1386a49968
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0077" ;
-    prov:atLocation niiri:8165f976cf661160c4b54b6ecc8233f7 ;
+    prov:atLocation niiri:796162ee36fddd7fe04fdb52f196a437 ;
     prov:value "3.73172569274902"^^xsd:float ;
     nidm_equivalentZStatistic: "3.59683942997016"^^xsd:float ;
     nidm_pValueUncorrected: "0.000161053590001625"^^xsd:float ;
     nidm_pValueFWER: "0.999847623960611"^^xsd:float ;
     nidm_qValueFDR: "0.333516771702899"^^xsd:float .
 
-niiri:8165f976cf661160c4b54b6ecc8233f7
+niiri:796162ee36fddd7fe04fdb52f196a437
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0077" ;
     nidm_coordinateVector: "[-46,14,2]"^^xsd:string .
 
-niiri:2da92f631c41ceb7d9d4873508d6aa07 prov:wasDerivedFrom niiri:d01136698ec67fb4e47df44c2e197103 .
+niiri:81b14a242118884af4716d1386a49968 prov:wasDerivedFrom niiri:29289a4455046f74558f3c81d39ba67b .
 
-niiri:376aa18e94e3ca907cc34e047b014f85
+niiri:1b496fdde624ffb7718731dcb5969f61
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0078" ;
-    prov:atLocation niiri:91c99f9a40f2bac3243e28e56f5a46f1 ;
+    prov:atLocation niiri:430af058ffb53b1c5f36dba7ce187964 ;
     prov:value "3.7307436466217"^^xsd:float ;
     nidm_equivalentZStatistic: "3.59595419684865"^^xsd:float ;
     nidm_pValueUncorrected: "0.0001616023346106"^^xsd:float ;
     nidm_pValueFWER: "0.999851120393834"^^xsd:float ;
     nidm_qValueFDR: "0.333516771702899"^^xsd:float .
 
-niiri:91c99f9a40f2bac3243e28e56f5a46f1
+niiri:430af058ffb53b1c5f36dba7ce187964
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0078" ;
     nidm_coordinateVector: "[-16,4,62]"^^xsd:string .
 
-niiri:376aa18e94e3ca907cc34e047b014f85 prov:wasDerivedFrom niiri:b1d116fb7eeb859d3c14dbed857c171a .
+niiri:1b496fdde624ffb7718731dcb5969f61 prov:wasDerivedFrom niiri:2821bde2f68ccf372a5e6ea09d4eada7 .
 
-niiri:d26b2ca1de8da439299e41de5125f97a
+niiri:1949681f598de9abc79f75c80aefff35
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0079" ;
-    prov:atLocation niiri:3a6fff5356ac4f4e9fe9ef6bc9775a40 ;
+    prov:atLocation niiri:5a39b6d66bb64abc65a91ff2a298ca0b ;
     prov:value "3.71718406677246"^^xsd:float ;
     nidm_equivalentZStatistic: "3.58372690354832"^^xsd:float ;
     nidm_pValueUncorrected: "0.00016936312213478"^^xsd:float ;
     nidm_pValueFWER: "0.999892552580384"^^xsd:float ;
     nidm_qValueFDR: "0.343980192781709"^^xsd:float .
 
-niiri:3a6fff5356ac4f4e9fe9ef6bc9775a40
+niiri:5a39b6d66bb64abc65a91ff2a298ca0b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0079" ;
     nidm_coordinateVector: "[42,-86,12]"^^xsd:string .
 
-niiri:d26b2ca1de8da439299e41de5125f97a prov:wasDerivedFrom niiri:80ebd2b365389e66f0063546e25d7a7f .
+niiri:1949681f598de9abc79f75c80aefff35 prov:wasDerivedFrom niiri:5514e5220803aad2c04bbd033aa76695 .
 
-niiri:1b2dc1d364364e5722fb82ef93077258
+niiri:156c0ed1194df2305d443c2e19909212
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0080" ;
-    prov:atLocation niiri:5b80ad657ece5096fc46befe4ce9d5fd ;
+    prov:atLocation niiri:ed2e59615ba0052e7aaa0fa34f891006 ;
     prov:value "3.6839451789856"^^xsd:float ;
     nidm_equivalentZStatistic: "3.55371881325781"^^xsd:float ;
     nidm_pValueUncorrected: "0.000189912540090265"^^xsd:float ;
     nidm_pValueFWER: "0.999953853986457"^^xsd:float ;
     nidm_qValueFDR: "0.369765026721735"^^xsd:float .
 
-niiri:5b80ad657ece5096fc46befe4ce9d5fd
+niiri:ed2e59615ba0052e7aaa0fa34f891006
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0080" ;
     nidm_coordinateVector: "[56,-66,4]"^^xsd:string .
 
-niiri:1b2dc1d364364e5722fb82ef93077258 prov:wasDerivedFrom niiri:f28ff86627fd1b6b8dff8eeb57dda0bf .
+niiri:156c0ed1194df2305d443c2e19909212 prov:wasDerivedFrom niiri:315fcb9a135fe01c557c732f7f103e94 .
 
-niiri:f14a65dc73e3f6c9fd9322882fd5f384
+niiri:e1346785ea40b70db27ae60f7bdd98cc
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0081" ;
-    prov:atLocation niiri:6c6b97923f8cb52a02f70ced73311746 ;
+    prov:atLocation niiri:96891dbc0a30ebca766e502619edafda ;
     prov:value "3.65720558166504"^^xsd:float ;
     nidm_equivalentZStatistic: "3.52954228664317"^^xsd:float ;
     nidm_pValueUncorrected: "0.000208139586526879"^^xsd:float ;
     nidm_pValueFWER: "0.999977747731185"^^xsd:float ;
     nidm_qValueFDR: "0.394667961040657"^^xsd:float .
 
-niiri:6c6b97923f8cb52a02f70ced73311746
+niiri:96891dbc0a30ebca766e502619edafda
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0081" ;
     nidm_coordinateVector: "[-60,-46,0]"^^xsd:string .
 
-niiri:f14a65dc73e3f6c9fd9322882fd5f384 prov:wasDerivedFrom niiri:7410e6e29d61d77d50faa3f92b630f60 .
+niiri:e1346785ea40b70db27ae60f7bdd98cc prov:wasDerivedFrom niiri:fe8e19f11e2bcbf510735d94d7db4251 .
 
-niiri:02849dfd89ad746265a47837c1a92364
+niiri:f9510499752a4d4a62444e63c5613551
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0082" ;
-    prov:atLocation niiri:2cd63410e009138f47473496c0643554 ;
+    prov:atLocation niiri:a097f126e0b7b865a50e6fbd1ff0446c ;
     prov:value "3.6346263885498"^^xsd:float ;
     nidm_equivalentZStatistic: "3.50910250251801"^^xsd:float ;
     nidm_pValueUncorrected: "0.000224810793142627"^^xsd:float ;
     nidm_pValueFWER: "0.999988407105485"^^xsd:float ;
     nidm_qValueFDR: "0.410740156420602"^^xsd:float .
 
-niiri:2cd63410e009138f47473496c0643554
+niiri:a097f126e0b7b865a50e6fbd1ff0446c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0082" ;
     nidm_coordinateVector: "[48,34,-8]"^^xsd:string .
 
-niiri:02849dfd89ad746265a47837c1a92364 prov:wasDerivedFrom niiri:1f58e1cc42099395a446086ee96b8a42 .
+niiri:f9510499752a4d4a62444e63c5613551 prov:wasDerivedFrom niiri:fec8619ae00ff17ab9a3d3ceb9046f4e .
 
-niiri:db5f3893682e77a3b7decb7d8434d1e6
+niiri:8bbd37614dea9f192710357a074c63f1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0083" ;
-    prov:atLocation niiri:bec41f76953fce12a7133751b1992ba4 ;
+    prov:atLocation niiri:3ca45b6a52ae0c898f083934ee671939 ;
     prov:value "3.62398386001587"^^xsd:float ;
     nidm_equivalentZStatistic: "3.49946049887545"^^xsd:float ;
     nidm_pValueUncorrected: "0.000233100337095449"^^xsd:float ;
     nidm_pValueFWER: "0.999991575586166"^^xsd:float ;
     nidm_qValueFDR: "0.419299318507116"^^xsd:float .
 
-niiri:bec41f76953fce12a7133751b1992ba4
+niiri:3ca45b6a52ae0c898f083934ee671939
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0083" ;
     nidm_coordinateVector: "[32,-80,48]"^^xsd:string .
 
-niiri:db5f3893682e77a3b7decb7d8434d1e6 prov:wasDerivedFrom niiri:873d10b94cdd2f9974ccfd2cdbfaaefa .
+niiri:8bbd37614dea9f192710357a074c63f1 prov:wasDerivedFrom niiri:0b442ae9d99b24f7707cb51260201d38 .
 
-niiri:67e85ffd644982c040e868ccb3dbdced
+niiri:51e60ac16faa51fdca273f7e51c66c23
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0084" ;
-    prov:atLocation niiri:e027d6ed1c58202c2a254b02f4702718 ;
+    prov:atLocation niiri:f15c5edf089117c22fd1387c5c6afdd5 ;
     prov:value "3.58678197860718"^^xsd:float ;
     nidm_equivalentZStatistic: "3.46571659793177"^^xsd:float ;
     nidm_pValueUncorrected: "0.000264410189540709"^^xsd:float ;
     nidm_pValueFWER: "0.999997407846311"^^xsd:float ;
     nidm_qValueFDR: "0.449939086167831"^^xsd:float .
 
-niiri:e027d6ed1c58202c2a254b02f4702718
+niiri:f15c5edf089117c22fd1387c5c6afdd5
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0084" ;
     nidm_coordinateVector: "[-28,-64,-4]"^^xsd:string .
 
-niiri:67e85ffd644982c040e868ccb3dbdced prov:wasDerivedFrom niiri:b90b028a3ab9996de06b07fefc72f518 .
+niiri:51e60ac16faa51fdca273f7e51c66c23 prov:wasDerivedFrom niiri:5b35b6fc65311a490ca686dedf246257 .
 
-niiri:62dceb645c6aecf022beb10c3fb519ef
+niiri:f868633206589461de78ed5f44c3088b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0085" ;
-    prov:atLocation niiri:48a24e99c33a7f0ec19a0b77bd2c62d7 ;
+    prov:atLocation niiri:99443289e22800a7b794d7aa4f24f6a7 ;
     prov:value "3.53609657287598"^^xsd:float ;
     nidm_equivalentZStatistic: "3.41964440308829"^^xsd:float ;
     nidm_pValueUncorrected: "0.000313515213706594"^^xsd:float ;
     nidm_pValueFWER: "0.999999559435381"^^xsd:float ;
     nidm_qValueFDR: "0.4996866807862"^^xsd:float .
 
-niiri:48a24e99c33a7f0ec19a0b77bd2c62d7
+niiri:99443289e22800a7b794d7aa4f24f6a7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0085" ;
     nidm_coordinateVector: "[-50,-40,32]"^^xsd:string .
 
-niiri:62dceb645c6aecf022beb10c3fb519ef prov:wasDerivedFrom niiri:568f5936427903f7944d3adca7a176de .
+niiri:f868633206589461de78ed5f44c3088b prov:wasDerivedFrom niiri:8105ee9b0d3cbff0afc4f8e6f6cbaaaa .
 
-niiri:f53e7658ae9f4482134b940539b7ab67
+niiri:ae37176f4228fdcd9909a5c9d8991945
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0086" ;
-    prov:atLocation niiri:64a5417ebde0db9a7b44f6c34d65bc18 ;
+    prov:atLocation niiri:b26986f014facbd25376c493db54de06 ;
     prov:value "3.53580570220947"^^xsd:float ;
     nidm_equivalentZStatistic: "3.41937968187583"^^xsd:float ;
     nidm_pValueUncorrected: "0.000313820412307875"^^xsd:float ;
     nidm_pValueFWER: "0.999999564147392"^^xsd:float ;
     nidm_qValueFDR: "0.4996866807862"^^xsd:float .
 
-niiri:64a5417ebde0db9a7b44f6c34d65bc18
+niiri:b26986f014facbd25376c493db54de06
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0086" ;
     nidm_coordinateVector: "[-60,-14,10]"^^xsd:string .
 
-niiri:f53e7658ae9f4482134b940539b7ab67 prov:wasDerivedFrom niiri:8d982136130ad2ce21a159a7d9c1edaa .
+niiri:ae37176f4228fdcd9909a5c9d8991945 prov:wasDerivedFrom niiri:b133a4090af3a2b167687334a106d130 .
 
-niiri:35cb8e83d1dd5a9e6d193b00a170e2c8
+niiri:dd232f665acbacec710283b33a7ffc6b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0087" ;
-    prov:atLocation niiri:38e2f77e5fa29335d46c00f0cf519d93 ;
+    prov:atLocation niiri:d2cba17eb975b3349a089cd9a6c33464 ;
     prov:value "3.51950573921204"^^xsd:float ;
     nidm_equivalentZStatistic: "3.40453920275412"^^xsd:float ;
     nidm_pValueUncorrected: "0.000331378932285298"^^xsd:float ;
     nidm_pValueFWER: "0.999999764036674"^^xsd:float ;
     nidm_qValueFDR: "0.515543012752167"^^xsd:float .
 
-niiri:38e2f77e5fa29335d46c00f0cf519d93
+niiri:d2cba17eb975b3349a089cd9a6c33464
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0087" ;
     nidm_coordinateVector: "[-18,-92,8]"^^xsd:string .
 
-niiri:35cb8e83d1dd5a9e6d193b00a170e2c8 prov:wasDerivedFrom niiri:3aa90bc8976de4ac1c73e9b43c959876 .
+niiri:dd232f665acbacec710283b33a7ffc6b prov:wasDerivedFrom niiri:4c38fc3cc2a35b74b2036daf823f1c35 .
 
-niiri:6f371572a83f199ed55039e0561c5d8c
+niiri:52c43bf1c9ff74a8799c3b7e6d3a1981
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0088" ;
-    prov:atLocation niiri:ccbef341fabc72345dca7ea6ffd2a490 ;
+    prov:atLocation niiri:5a482bce8aa9db2111282847cc17f383 ;
     prov:value "3.49318885803223"^^xsd:float ;
     nidm_equivalentZStatistic: "3.38055434488284"^^xsd:float ;
     nidm_pValueUncorrected: "0.000361698840550817"^^xsd:float ;
     nidm_pValueFWER: "0.999999916401603"^^xsd:float ;
     nidm_qValueFDR: "0.545280130510157"^^xsd:float .
 
-niiri:ccbef341fabc72345dca7ea6ffd2a490
+niiri:5a482bce8aa9db2111282847cc17f383
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0088" ;
     nidm_coordinateVector: "[12,-86,50]"^^xsd:string .
 
-niiri:6f371572a83f199ed55039e0561c5d8c prov:wasDerivedFrom niiri:9905f70b4755853ccd1de257abc32ef8 .
+niiri:52c43bf1c9ff74a8799c3b7e6d3a1981 prov:wasDerivedFrom niiri:9476947ad907c2f9d5c061ead3c8ca5c .
 
-niiri:5892f4bed03e7f292fcea67aad88e004
+niiri:b5befcd1e1859623d7854488fa7de979
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0089" ;
-    prov:atLocation niiri:3e13970ba727bfd74bd2b9690149eea1 ;
+    prov:atLocation niiri:8c0885885f7d3e6a0c5d4d78d7581155 ;
     prov:value "3.47051548957825"^^xsd:float ;
     nidm_equivalentZStatistic: "3.35986611616874"^^xsd:float ;
     nidm_pValueUncorrected: "0.000389901261900971"^^xsd:float ;
     nidm_pValueFWER: "0.999999967415099"^^xsd:float ;
     nidm_qValueFDR: "0.574030743367995"^^xsd:float .
 
-niiri:3e13970ba727bfd74bd2b9690149eea1
+niiri:8c0885885f7d3e6a0c5d4d78d7581155
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0089" ;
     nidm_coordinateVector: "[-28,-32,-40]"^^xsd:string .
 
-niiri:5892f4bed03e7f292fcea67aad88e004 prov:wasDerivedFrom niiri:cfcc37be279ca1493d8aeab64d0f7eb0 .
+niiri:b5befcd1e1859623d7854488fa7de979 prov:wasDerivedFrom niiri:eaf5abe818e88775744fc4bc734500da .
 
-niiri:2203f0456422e9ff6eae4640a0868058
+niiri:fa63e0fc9565564fb8d045ce95dc3fb0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0090" ;
-    prov:atLocation niiri:aede1bf93651a6aecaab4b74293687c7 ;
+    prov:atLocation niiri:7fa3faad18f93a839559601b4d609c22 ;
     prov:value "3.45754051208496"^^xsd:float ;
     nidm_equivalentZStatistic: "3.34801719030758"^^xsd:float ;
     nidm_pValueUncorrected: "0.000406959813051277"^^xsd:float ;
     nidm_pValueFWER: "0.999999981385599"^^xsd:float ;
     nidm_qValueFDR: "0.587029984895018"^^xsd:float .
 
-niiri:aede1bf93651a6aecaab4b74293687c7
+niiri:7fa3faad18f93a839559601b4d609c22
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0090" ;
     nidm_coordinateVector: "[8,-72,42]"^^xsd:string .
 
-niiri:2203f0456422e9ff6eae4640a0868058 prov:wasDerivedFrom niiri:0725b220f47ead33a4ba9ecc13ada7ae .
+niiri:fa63e0fc9565564fb8d045ce95dc3fb0 prov:wasDerivedFrom niiri:d327e883ddebc9532dc10d806d05ceea .
 
-niiri:39dc6fda033d5339925079c0fa3459d0
+niiri:b3ffdc96c6bca62445438ff33b6dab0b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0091" ;
-    prov:atLocation niiri:d73832987b8cc51a8d7cca6f48f2dfb9 ;
+    prov:atLocation niiri:6953a6cf7591ac6178b3e252d77b304c ;
     prov:value "3.43320918083191"^^xsd:float ;
     nidm_equivalentZStatistic: "3.32577803511444"^^xsd:float ;
     nidm_pValueUncorrected: "0.000440860566175205"^^xsd:float ;
     nidm_pValueFWER: "0.999999993754102"^^xsd:float ;
     nidm_qValueFDR: "0.61426970601407"^^xsd:float .
 
-niiri:d73832987b8cc51a8d7cca6f48f2dfb9
+niiri:6953a6cf7591ac6178b3e252d77b304c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0091" ;
     nidm_coordinateVector: "[-38,-78,8]"^^xsd:string .
 
-niiri:39dc6fda033d5339925079c0fa3459d0 prov:wasDerivedFrom niiri:c8f5cfe91a5e1c0eb3a8ce4272e74dc1 .
+niiri:b3ffdc96c6bca62445438ff33b6dab0b prov:wasDerivedFrom niiri:b56a8e6eef495278939c1f07e4b2ec46 .
 
-niiri:071e50bf38f644f293cc9bb4dd422042
+niiri:63ddfa8767c13e0bf648a86357c0616c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0092" ;
-    prov:atLocation niiri:f1e51cf49fda710bf19cc50a4f00e96d ;
+    prov:atLocation niiri:d2bc2d6192acb2df1303a750a5ea9259 ;
     prov:value "3.43009805679321"^^xsd:float ;
     nidm_equivalentZStatistic: "3.32293260301119"^^xsd:float ;
     nidm_pValueUncorrected: "0.000445382166252561"^^xsd:float ;
     nidm_pValueFWER: "0.999999994589954"^^xsd:float ;
     nidm_qValueFDR: "0.616048939476298"^^xsd:float .
 
-niiri:f1e51cf49fda710bf19cc50a4f00e96d
+niiri:d2bc2d6192acb2df1303a750a5ea9259
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0092" ;
     nidm_coordinateVector: "[-56,34,-20]"^^xsd:string .
 
-niiri:071e50bf38f644f293cc9bb4dd422042 prov:wasDerivedFrom niiri:76eeefc962a00f410ca4b176def01aa5 .
+niiri:63ddfa8767c13e0bf648a86357c0616c prov:wasDerivedFrom niiri:ed00692e64206abf7a48d003e49a172c .
 
-niiri:49315754baf12ffcab022c7ede1aeee4
+niiri:70cfc0282d991ec2d4a5b55d1fd54d12
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0093" ;
-    prov:atLocation niiri:d1408c47ea56ba0b69beb8a7482ce84a ;
+    prov:atLocation niiri:5d8529c4069514ea40bb8b8fa6993638 ;
     prov:value "3.424649477005"^^xsd:float ;
     nidm_equivalentZStatistic: "3.31794834148679"^^xsd:float ;
     nidm_pValueUncorrected: "0.000453406269446011"^^xsd:float ;
     nidm_pValueFWER: "0.999999995802847"^^xsd:float ;
     nidm_qValueFDR: "0.621361020904295"^^xsd:float .
 
-niiri:d1408c47ea56ba0b69beb8a7482ce84a
+niiri:5d8529c4069514ea40bb8b8fa6993638
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0093" ;
     nidm_coordinateVector: "[18,-58,32]"^^xsd:string .
 
-niiri:49315754baf12ffcab022c7ede1aeee4 prov:wasDerivedFrom niiri:62c2a8527db43def7b959349980d6c02 .
+niiri:70cfc0282d991ec2d4a5b55d1fd54d12 prov:wasDerivedFrom niiri:33f78596b63613a9bb773b49e610c339 .
 
-niiri:82a212cd3fd0bef3348e0d09daeef389
+niiri:9b72288ab7c77e827d9f1f781adf3151
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0094" ;
-    prov:atLocation niiri:3b6a30446fcffbed845c4b0552821d9c ;
+    prov:atLocation niiri:592fa6eb01f3638945c2086fe68908ae ;
     prov:value "3.40277910232544"^^xsd:float ;
     nidm_equivalentZStatistic: "3.29792901961918"^^xsd:float ;
     nidm_pValueUncorrected: "0.000487003764363392"^^xsd:float ;
     nidm_pValueFWER: "0.999999998528515"^^xsd:float ;
     nidm_qValueFDR: "0.64908702869037"^^xsd:float .
 
-niiri:3b6a30446fcffbed845c4b0552821d9c
+niiri:592fa6eb01f3638945c2086fe68908ae
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0094" ;
     nidm_coordinateVector: "[-32,-76,-2]"^^xsd:string .
 
-niiri:82a212cd3fd0bef3348e0d09daeef389 prov:wasDerivedFrom niiri:890df2ef7ecc6eafa711940fe2c85892 .
+niiri:9b72288ab7c77e827d9f1f781adf3151 prov:wasDerivedFrom niiri:fd773d75cfefece3ae58e4b268b97593 .
 
-niiri:9a86504d386a2f4182f1142003d96c33
+niiri:88a8cadf94cd28dcac01eb9dbc030af6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0095" ;
-    prov:atLocation niiri:7324ebe46ae61c59a2d1db2715144e2d ;
+    prov:atLocation niiri:089cb2a4ffc88484de7776f0fdffe221 ;
     prov:value "3.3940372467041"^^xsd:float ;
     nidm_equivalentZStatistic: "3.28992137977698"^^xsd:float ;
     nidm_pValueUncorrected: "0.000501076897352348"^^xsd:float ;
     nidm_pValueFWER: "0.999999999044949"^^xsd:float ;
     nidm_qValueFDR: "0.659842637673888"^^xsd:float .
 
-niiri:7324ebe46ae61c59a2d1db2715144e2d
+niiri:089cb2a4ffc88484de7776f0fdffe221
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0095" ;
     nidm_coordinateVector: "[24,-64,-18]"^^xsd:string .
 
-niiri:9a86504d386a2f4182f1142003d96c33 prov:wasDerivedFrom niiri:1fc695464136ac390f15258db075c307 .
+niiri:88a8cadf94cd28dcac01eb9dbc030af6 prov:wasDerivedFrom niiri:b1682618b3d8ba951d4fba69d43ace19 .
 
-niiri:53a4b0f2f41f9401d7f6dcb86b6237e1
+niiri:d72cc582c4a89de3d8d56216d7584f90
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0096" ;
-    prov:atLocation niiri:b099474100f78b9c0d228a1869faeadb ;
+    prov:atLocation niiri:dc0311045709c90687bf5718110350ae ;
     prov:value "3.38822054862976"^^xsd:float ;
     nidm_equivalentZStatistic: "3.28459142797104"^^xsd:float ;
     nidm_pValueUncorrected: "0.00051065177940457"^^xsd:float ;
     nidm_pValueFWER: "0.999999999286734"^^xsd:float ;
     nidm_qValueFDR: "0.663972520258905"^^xsd:float .
 
-niiri:b099474100f78b9c0d228a1869faeadb
+niiri:dc0311045709c90687bf5718110350ae
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0096" ;
     nidm_coordinateVector: "[14,52,24]"^^xsd:string .
 
-niiri:53a4b0f2f41f9401d7f6dcb86b6237e1 prov:wasDerivedFrom niiri:a63c8949e4a3fc9f1f4411a09a294513 .
+niiri:d72cc582c4a89de3d8d56216d7584f90 prov:wasDerivedFrom niiri:4aff58ce7014532950c85678251d820b .
 
-niiri:9e0947c09704adef13f3b70ec9dddd3f
+niiri:e16c4d3e320d40e426df93aee2ca6add
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0097" ;
-    prov:atLocation niiri:3e028f3bfc0f70c1effeb63290a7354b ;
+    prov:atLocation niiri:dc54ccf09ba5eabcbeedfec4a1babb63 ;
     prov:value "3.34795022010803"^^xsd:float ;
     nidm_equivalentZStatistic: "3.24765190787991"^^xsd:float ;
     nidm_pValueUncorrected: "0.000581807655324229"^^xsd:float ;
     nidm_pValueFWER: "0.999999999914172"^^xsd:float ;
     nidm_qValueFDR: "0.723121887342887"^^xsd:float .
 
-niiri:3e028f3bfc0f70c1effeb63290a7354b
+niiri:dc54ccf09ba5eabcbeedfec4a1babb63
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0097" ;
     nidm_coordinateVector: "[-64,-24,46]"^^xsd:string .
 
-niiri:9e0947c09704adef13f3b70ec9dddd3f prov:wasDerivedFrom niiri:df25ac5a53adfde0956454127605d4b6 .
+niiri:e16c4d3e320d40e426df93aee2ca6add prov:wasDerivedFrom niiri:d98d8e8d25b59a9503f694b966d532d9 .
 
-niiri:6ec431a571f4735696dc4984399d308e
+niiri:d70ef29aa1808eec49d1cf3e0a54e0ff
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0098" ;
-    prov:atLocation niiri:b8bc78b3e981b7fcc913bfc909ccf788 ;
+    prov:atLocation niiri:08d1e3f57a3aaac82503778457e03a57 ;
     prov:value "3.33032703399658"^^xsd:float ;
     nidm_equivalentZStatistic: "3.23146500785458"^^xsd:float ;
     nidm_pValueUncorrected: "0.000615787011640778"^^xsd:float ;
     nidm_pValueFWER: "0.999999999967832"^^xsd:float ;
     nidm_qValueFDR: "0.750358478642178"^^xsd:float .
 
-niiri:b8bc78b3e981b7fcc913bfc909ccf788
+niiri:08d1e3f57a3aaac82503778457e03a57
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0098" ;
     nidm_coordinateVector: "[-56,24,22]"^^xsd:string .
 
-niiri:6ec431a571f4735696dc4984399d308e prov:wasDerivedFrom niiri:430b756d7a021f005bd015a459e3abf2 .
+niiri:d70ef29aa1808eec49d1cf3e0a54e0ff prov:wasDerivedFrom niiri:5b8cc71e1c4a9af4a428ecbfd59af0c3 .
 
-niiri:99b6e759c8b0eb20ae8aaa87fbde6737
+niiri:2188b2e49f6e63679bc313f1b84db925
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0099" ;
-    prov:atLocation niiri:7d6da070b4f6e591e3085e6e571a1966 ;
+    prov:atLocation niiri:d487a995ae698c5bffe6a334eff5c7c1 ;
     prov:value "3.30043077468872"^^xsd:float ;
     nidm_equivalentZStatistic: "3.20397578866589"^^xsd:float ;
     nidm_pValueUncorrected: "0.000677719372958352"^^xsd:float ;
     nidm_pValueFWER: "0.999999999994377"^^xsd:float ;
     nidm_qValueFDR: "0.800935685960822"^^xsd:float .
 
-niiri:7d6da070b4f6e591e3085e6e571a1966
+niiri:d487a995ae698c5bffe6a334eff5c7c1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0099" ;
     nidm_coordinateVector: "[-14,4,16]"^^xsd:string .
 
-niiri:99b6e759c8b0eb20ae8aaa87fbde6737 prov:wasDerivedFrom niiri:080141eb52f83c2bae53c858e92b0d56 .
+niiri:2188b2e49f6e63679bc313f1b84db925 prov:wasDerivedFrom niiri:9399cc4d9102dea2381bab7e4de270e7 .
 
-niiri:b91f6c305dd11f910e73ed60f2a249f3
+niiri:ee6edaf11ccf62cbd5f1fae3293222dd
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0100" ;
-    prov:atLocation niiri:488d58948f0d059927a9d730b2cdf37e ;
+    prov:atLocation niiri:db7766986aa39069f0e3fb4da12f89d8 ;
     prov:value "3.2954432964325"^^xsd:float ;
     nidm_equivalentZStatistic: "3.19938627223673"^^xsd:float ;
     nidm_pValueUncorrected: "0.000688602556676021"^^xsd:float ;
     nidm_pValueFWER: "0.999999999995838"^^xsd:float ;
     nidm_qValueFDR: "0.80659749253585"^^xsd:float .
 
-niiri:488d58948f0d059927a9d730b2cdf37e
+niiri:db7766986aa39069f0e3fb4da12f89d8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0100" ;
     nidm_coordinateVector: "[12,-18,52]"^^xsd:string .
 
-niiri:b91f6c305dd11f910e73ed60f2a249f3 prov:wasDerivedFrom niiri:455661055a3ab874933b9807b54adec0 .
+niiri:ee6edaf11ccf62cbd5f1fae3293222dd prov:wasDerivedFrom niiri:25449e2c897446ebd8a31026fdd28119 .
 
-niiri:5c1608357abe96da883fe35465665204
+niiri:15350a82e9c3fc01fd72c2bc7362c921
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0101" ;
-    prov:atLocation niiri:056dd170589b438d65a7d98296054229 ;
+    prov:atLocation niiri:0b730f42d0287a0e641497fcb4468ec4 ;
     prov:value "3.29354763031006"^^xsd:float ;
     nidm_equivalentZStatistic: "3.19764159673963"^^xsd:float ;
     nidm_pValueUncorrected: "0.000692781844264911"^^xsd:float ;
     nidm_pValueFWER: "0.999999999996291"^^xsd:float ;
     nidm_qValueFDR: "0.80659749253585"^^xsd:float .
 
-niiri:056dd170589b438d65a7d98296054229
+niiri:0b730f42d0287a0e641497fcb4468ec4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0101" ;
     nidm_coordinateVector: "[10,-8,6]"^^xsd:string .
 
-niiri:5c1608357abe96da883fe35465665204 prov:wasDerivedFrom niiri:a4e79b29ae579ef25088671c40dcd4aa .
+niiri:15350a82e9c3fc01fd72c2bc7362c921 prov:wasDerivedFrom niiri:0e21ee277152eb058ea4661ca48674d9 .
 
-niiri:0a77f567539e320675a7cd2692e26d57
+niiri:06e844c8b746ab33069a3ac489ba1d42
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0102" ;
-    prov:atLocation niiri:7190fbc7d8cfd6eae79ac5d55e6d0895 ;
+    prov:atLocation niiri:62c24f999648e906a27d9930430b903e ;
     prov:value "3.27130317687988"^^xsd:float ;
     nidm_equivalentZStatistic: "3.17715789461409"^^xsd:float ;
     nidm_pValueUncorrected: "0.000743630203309364"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999069"^^xsd:float ;
     nidm_qValueFDR: "0.839869575034518"^^xsd:float .
 
-niiri:7190fbc7d8cfd6eae79ac5d55e6d0895
+niiri:62c24f999648e906a27d9930430b903e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0102" ;
     nidm_coordinateVector: "[-32,14,60]"^^xsd:string .
 
-niiri:0a77f567539e320675a7cd2692e26d57 prov:wasDerivedFrom niiri:cf1fb2a622b7b69b2867e5cf7760fe38 .
+niiri:06e844c8b746ab33069a3ac489ba1d42 prov:wasDerivedFrom niiri:0e8a97e94bdd4af70efd21917168b43e .
 
-niiri:2db82a8953dc9ed6a3caf065a03aa8a8
+niiri:0dcdfb141f26fdfb1b6f3ff37ca276eb
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0103" ;
-    prov:atLocation niiri:bd9299d468954298ce4be1ae75b041c1 ;
+    prov:atLocation niiri:aa4caf2f8978443c3ecd0274bb9ae0e1 ;
     prov:value "3.27024936676025"^^xsd:float ;
     nidm_equivalentZStatistic: "3.17618699537964"^^xsd:float ;
     nidm_pValueUncorrected: "0.000746123636619966"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999129"^^xsd:float ;
     nidm_qValueFDR: "0.839869575034518"^^xsd:float .
 
-niiri:bd9299d468954298ce4be1ae75b041c1
+niiri:aa4caf2f8978443c3ecd0274bb9ae0e1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0103" ;
     nidm_coordinateVector: "[-34,-84,6]"^^xsd:string .
 
-niiri:2db82a8953dc9ed6a3caf065a03aa8a8 prov:wasDerivedFrom niiri:d2c0709213ef56652ef36c9d207acf04 .
+niiri:0dcdfb141f26fdfb1b6f3ff37ca276eb prov:wasDerivedFrom niiri:5b01f2070bd1d0178ffb33f1582d88a3 .
 
-niiri:80952fc1321d7065adc990156b3c8d67
+niiri:837e6614e3814f2aedc901891549d812
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0104" ;
-    prov:atLocation niiri:81b9f5928c32c4134424b70fa2d84481 ;
+    prov:atLocation niiri:5cb2949541c80c967fcb899f69618232 ;
     prov:value "3.2392430305481"^^xsd:float ;
     nidm_equivalentZStatistic: "3.1475998920821"^^xsd:float ;
     nidm_pValueUncorrected: "0.000823084243901762"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999886"^^xsd:float ;
     nidm_qValueFDR: "0.897361297935526"^^xsd:float .
 
-niiri:81b9f5928c32c4134424b70fa2d84481
+niiri:5cb2949541c80c967fcb899f69618232
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0104" ;
     nidm_coordinateVector: "[36,-58,38]"^^xsd:string .
 
-niiri:80952fc1321d7065adc990156b3c8d67 prov:wasDerivedFrom niiri:2945ea3e25037efb18cb1b0c0a9604f5 .
+niiri:837e6614e3814f2aedc901891549d812 prov:wasDerivedFrom niiri:329bc820e22a3a07c45bd811037a5b92 .
 
-niiri:539ad8882d8d701cec75ccf8ee58ff0f
+niiri:db893cc3d08eff94a18a2ded424c27da
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0105" ;
-    prov:atLocation niiri:70e18bc08102e21b9c7a37263e571537 ;
+    prov:atLocation niiri:1644dc14a37498514a08b1d016af0de4 ;
     prov:value "3.22486090660095"^^xsd:float ;
     nidm_equivalentZStatistic: "3.13432667345374"^^xsd:float ;
     nidm_pValueUncorrected: "0.0008612448992944"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999957"^^xsd:float ;
     nidm_qValueFDR: "0.922927255586177"^^xsd:float .
 
-niiri:70e18bc08102e21b9c7a37263e571537
+niiri:1644dc14a37498514a08b1d016af0de4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0105" ;
     nidm_coordinateVector: "[50,-42,-44]"^^xsd:string .
 
-niiri:539ad8882d8d701cec75ccf8ee58ff0f prov:wasDerivedFrom niiri:81211325ca547298daf652760e8bad87 .
+niiri:db893cc3d08eff94a18a2ded424c27da prov:wasDerivedFrom niiri:4121c76a27252e2b2396a4e6040a0baf .
 
-niiri:49a04475044520da784c779056673f49
+niiri:0d719d9c0dda162347b33fc762ee9dba
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0106" ;
-    prov:atLocation niiri:63f2f5cabdc99373f9dafa0ed9c90280 ;
+    prov:atLocation niiri:c1de986c07ccf82f9e7eec004acec01f ;
     prov:value "3.21566033363342"^^xsd:float ;
     nidm_equivalentZStatistic: "3.12583111524387"^^xsd:float ;
     nidm_pValueUncorrected: "0.000886516713776597"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999977"^^xsd:float ;
     nidm_qValueFDR: "0.938118112536103"^^xsd:float .
 
-niiri:63f2f5cabdc99373f9dafa0ed9c90280
+niiri:c1de986c07ccf82f9e7eec004acec01f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0106" ;
     nidm_coordinateVector: "[-52,-64,-24]"^^xsd:string .
 
-niiri:49a04475044520da784c779056673f49 prov:wasDerivedFrom niiri:4b62f251a83aafef65b16eccc82e668e .
+niiri:0d719d9c0dda162347b33fc762ee9dba prov:wasDerivedFrom niiri:419bb28f6b465c3e5015a6d14e56b223 .
 
-niiri:82a6ed12e5a8da474abbc5dea4df5359
+niiri:e0efd8540741b57d022a32fe600f4a60
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0107" ;
-    prov:atLocation niiri:b66d142b1bdb334b9cbe0dc4a6639fed ;
+    prov:atLocation niiri:05aa9aebd8dad58a0f2d1603e21cf930 ;
     prov:value "3.21121668815613"^^xsd:float ;
     nidm_equivalentZStatistic: "3.12172675458225"^^xsd:float ;
     nidm_pValueUncorrected: "0.000898968641653619"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999984"^^xsd:float ;
     nidm_qValueFDR: "0.943425557898272"^^xsd:float .
 
-niiri:b66d142b1bdb334b9cbe0dc4a6639fed
+niiri:05aa9aebd8dad58a0f2d1603e21cf930
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0107" ;
     nidm_coordinateVector: "[-42,-24,70]"^^xsd:string .
 
-niiri:82a6ed12e5a8da474abbc5dea4df5359 prov:wasDerivedFrom niiri:773351148f166f1064c72ad4e1f11422 .
+niiri:e0efd8540741b57d022a32fe600f4a60 prov:wasDerivedFrom niiri:e64d676ce70ddc69f3b8a79a997afc14 .
 
-niiri:da5c8b2733a583126d729dd943d5c284
+niiri:984314d1e545f3779d40732df43ac486
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0108" ;
-    prov:atLocation niiri:c651c5d7f1e0ccabc5f0759dacd92040 ;
+    prov:atLocation niiri:f32ffd76360ec205c4000b22913ce264 ;
     prov:value "3.19088125228882"^^xsd:float ;
     nidm_equivalentZStatistic: "3.10293388694787"^^xsd:float ;
     nidm_pValueUncorrected: "0.00095806220289707"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999996"^^xsd:float ;
     nidm_qValueFDR: "0.978708956745583"^^xsd:float .
 
-niiri:c651c5d7f1e0ccabc5f0759dacd92040
+niiri:f32ffd76360ec205c4000b22913ce264
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0108" ;
     nidm_coordinateVector: "[-42,-86,16]"^^xsd:string .
 
-niiri:da5c8b2733a583126d729dd943d5c284 prov:wasDerivedFrom niiri:eaca7a045a95a69292520d89e15df899 .
+niiri:984314d1e545f3779d40732df43ac486 prov:wasDerivedFrom niiri:b2fe473551b0d5958d6a1fafaa7495aa .
 
-niiri:4898b2fdd61b6ce95f680cb82b31d491
+niiri:441ee164b95e1dde37ae482e9d9d5e83
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0109" ;
-    prov:atLocation niiri:269ee2db40ed82a81c8b5dda4153466a ;
+    prov:atLocation niiri:a7ba281dfef3a6043ffbd77f05f7c9c0 ;
     prov:value "3.18322372436523"^^xsd:float ;
     nidm_equivalentZStatistic: "3.0958529484655"^^xsd:float ;
     nidm_pValueUncorrected: "0.000981238298823239"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999998"^^xsd:float ;
     nidm_qValueFDR: "0.987875729427955"^^xsd:float .
 
-niiri:269ee2db40ed82a81c8b5dda4153466a
+niiri:a7ba281dfef3a6043ffbd77f05f7c9c0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0109" ;
     nidm_coordinateVector: "[8,-2,28]"^^xsd:string .
 
-niiri:4898b2fdd61b6ce95f680cb82b31d491 prov:wasDerivedFrom niiri:147f8e061f74d3386fbcc5d348522c64 .
+niiri:441ee164b95e1dde37ae482e9d9d5e83 prov:wasDerivedFrom niiri:8fc15b04ecd3232fd23805615acbe960 .
 
-niiri:5275cd3865d61bea1f6d6330f476434d
+niiri:2319fac2b0bcd7224a1b3319200a5ae7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0110" ;
-    prov:atLocation niiri:a560de35b7d1376b165e5db6f489d1ee ;
+    prov:atLocation niiri:c92676a64fcf679097acf689ece5636c ;
     prov:value "3.18283724784851"^^xsd:float ;
     nidm_equivalentZStatistic: "3.09549551060057"^^xsd:float ;
     nidm_pValueUncorrected: "0.000982421736617112"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999998"^^xsd:float ;
     nidm_qValueFDR: "0.987875729427955"^^xsd:float .
 
-niiri:a560de35b7d1376b165e5db6f489d1ee
+niiri:c92676a64fcf679097acf689ece5636c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0110" ;
     nidm_coordinateVector: "[14,-22,76]"^^xsd:string .
 
-niiri:5275cd3865d61bea1f6d6330f476434d prov:wasDerivedFrom niiri:b140e937ac96257d15f410e255ead183 .
+niiri:2319fac2b0bcd7224a1b3319200a5ae7 prov:wasDerivedFrom niiri:3ba4f4eceb22f4823f915b7f2ea31b71 .
 

--- a/spmexport/ex_spm_thr_clustfwep05/nidm.json
+++ b/spmexport/ex_spm_thr_clustfwep05/nidm.json
@@ -1,0 +1,3358 @@
+{
+  "prefix": {
+    "nidm": "http://purl.org/nidash/nidm#",
+    "niiri": "http://iri.nidash.org/",
+    "spm": "http://purl.org/nidash/spm#",
+    "neurolex": "http://neurolex.org/wiki/",
+    "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/",
+    "dct": "http://purl.org/dc/terms/",
+    "nfo": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#",
+    "dc": "http://purl.org/dc/elements/1.1/",
+    "dctype": "http://purl.org/dc/dcmitype/",
+    "obo": "http://purl.obolibrary.org/obo/",
+    "nidm_NIDMResults": "http://purl.org/nidash/nidm#NIDM_0000027",
+    "nidm_version": "http://purl.org/nidash/nidm#NIDM_0000127",
+    "nidm_spm_results_nidm": "http://purl.org/nidash/nidm#NIDM_0000168",
+    "nidm_softwareVersion": "http://purl.org/nidash/nidm#NIDM_0000122",
+    "nidm_NIDMResultsExport": "http://purl.org/nidash/nidm#NIDM_0000166"
+  },
+  "entity": {
+    "niiri:e31f56e03ff5aca2edc16a51c094a508": {
+      "prov:type": [
+        {
+        "$": "prov:Bundle",
+        "type": "xsd:QName"
+        },
+        {
+        "$": "nidm_NIDMResults:",
+        "type": "xsd:QName"
+        }
+      ],
+      "prov:label": {
+        "$": "NIDM-Results",
+        "type": "xsd:string"
+      },
+      "nidm_version:": {
+        "$": "1.3.0",
+        "type": "xsd:string"
+      }
+    }
+  },
+  "activity": {
+    "niiri:71e962f0352be27a49a0cadb61d1f6a0": {
+      "prov:type": {
+        "$": "nidm_NIDMResultsExport:",
+        "type": "xsd:QName"
+      },
+      "prov:label": {
+        "$": "NIDM-Results export",
+        "type": "xsd:string"
+      }
+    }
+  },
+  "agent": {
+    "niiri:3e9b8ab3f99b4316053190b556d70b8d": {
+      "prov:type": [
+        {
+        "$": "nidm_spm_results_nidm:",
+        "type": "xsd:QName"
+        },
+        {
+        "$": "prov:SoftwareAgent",
+        "type": "xsd:QName"
+        }
+      ],
+      "prov:label": {
+        "$": "spm_results_nidm",
+        "type": "xsd:string"
+      },
+      "nidm_softwareVersion:": {
+        "$": "12.7057",
+        "type": "xsd:string"
+      }
+    }
+  },
+  "wasGeneratedBy": {
+    "_:wGB5": {
+      "prov:entity": "niiri:e31f56e03ff5aca2edc16a51c094a508",
+      "prov:activity": "niiri:71e962f0352be27a49a0cadb61d1f6a0",
+      "prov:time": "2017-04-19T12:19:01"
+    }
+  },
+  "wasAssociatedWith": {
+    "_:wAW4": {
+      "prov:activity": "niiri:71e962f0352be27a49a0cadb61d1f6a0",
+      "prov:agent": "niiri:3e9b8ab3f99b4316053190b556d70b8d"
+    }
+  },
+  "bundle": {
+    "niiri:e31f56e03ff5aca2edc16a51c094a508": {
+    "prefix": {
+        "nidm_softwareVersion": "http://purl.org/nidash/nidm#NIDM_0000122",
+        "nidm_CoordinateSpace": "http://purl.org/nidash/nidm#NIDM_0000016",
+        "nidm_voxelToWorldMapping": "http://purl.org/nidash/nidm#NIDM_0000132",
+        "nidm_voxelUnits": "http://purl.org/nidash/nidm#NIDM_0000133",
+        "nidm_voxelSize": "http://purl.org/nidash/nidm#NIDM_0000131",
+        "nidm_inWorldCoordinateSystem": "http://purl.org/nidash/nidm#NIDM_0000105",
+        "nidm_numberOfDimensions": "http://purl.org/nidash/nidm#NIDM_0000112",
+        "nidm_dimensionsInVoxels": "http://purl.org/nidash/nidm#NIDM_0000090",
+        "nlx_Imaginginstrument": "http://uri.neuinfo.org/nif/nifstd/birnlex_2094",
+        "nlx_Magneticresonanceimagingscanner": "http://uri.neuinfo.org/nif/nifstd/birnlex_2100",
+        "nidm_grandMeanScaling": "http://purl.org/nidash/nidm#NIDM_0000096",
+        "nidm_targetIntensity": "http://purl.org/nidash/nidm#NIDM_0000124",
+        "nidm_hasMRIProtocol": "http://purl.org/nidash/nidm#NIDM_0000172",
+        "nlx_FunctionalMRIprotocol": "http://uri.neuinfo.org/nif/nifstd/birnlex_2250",
+        "nidm_Data": "http://purl.org/nidash/nidm#NIDM_0000169",
+        "spm_DCTDriftModel": "http://purl.org/nidash/spm#SPM_0000002",
+        "spm_SPMsDriftCutoffPeriod": "http://purl.org/nidash/spm#SPM_0000001",
+        "nidm_hasDriftModel": "http://purl.org/nidash/nidm#NIDM_0000088",
+        "nidm_hasHRFBasis": "http://purl.org/nidash/nidm#NIDM_0000102",
+        "spm_SPMsCanonicalHRF": "http://purl.org/nidash/spm#SPM_0000004",
+        "nidm_DesignMatrix": "http://purl.org/nidash/nidm#NIDM_0000019",
+        "nidm_regressorNames": "http://purl.org/nidash/nidm#NIDM_0000021",
+        "nidm_hasErrorDependence": "http://purl.org/nidash/nidm#NIDM_0000100",
+        "obo_Toeplitzcovariancestructure": "http://purl.obolibrary.org/obo/STATO_0000357",
+        "nidm_dependenceMapWiseDependence": "http://purl.org/nidash/nidm#NIDM_0000089",
+        "nidm_ConstantParameter": "http://purl.org/nidash/nidm#NIDM_0000072",
+        "nidm_errorVarianceHomogeneous": "http://purl.org/nidash/nidm#NIDM_0000094",
+        "nidm_varianceMapWiseDependence": "http://purl.org/nidash/nidm#NIDM_0000126",
+        "nidm_IndependentParameter": "http://purl.org/nidash/nidm#NIDM_0000073",
+        "nidm_withEstimationMethod": "http://purl.org/nidash/nidm#NIDM_0000134",
+        "obo_generalizedleastsquaresestimation": "http://purl.obolibrary.org/obo/STATO_0000372",
+        "nidm_ErrorModel": "http://purl.org/nidash/nidm#NIDM_0000023",
+        "nidm_hasErrorDistribution": "http://purl.org/nidash/nidm#NIDM_0000101",
+        "obo_normaldistribution": "http://purl.obolibrary.org/obo/STATO_0000227",
+        "nidm_ModelParametersEstimation": "http://purl.org/nidash/nidm#NIDM_0000056",
+        "nidm_MaskMap": "http://purl.org/nidash/nidm#NIDM_0000054",
+        "nidm_isUserDefined": "http://purl.org/nidash/nidm#NIDM_0000106",
+        "nidm_inCoordinateSpace": "http://purl.org/nidash/nidm#NIDM_0000104",
+        "nidm_GrandMeanMap": "http://purl.org/nidash/nidm#NIDM_0000033",
+        "nidm_maskedMedian": "http://purl.org/nidash/nidm#NIDM_0000107",
+        "nidm_ParameterEstimateMap": "http://purl.org/nidash/nidm#NIDM_0000061",
+        "nidm_ResidualMeanSquaresMap": "http://purl.org/nidash/nidm#NIDM_0000066",
+        "nidm_ReselsPerVoxelMap": "http://purl.org/nidash/nidm#NIDM_0000144",
+        "obo_contrastweightmatrix": "http://purl.obolibrary.org/obo/STATO_0000323",
+        "nidm_statisticType": "http://purl.org/nidash/nidm#NIDM_0000123",
+        "obo_tstatistic": "http://purl.obolibrary.org/obo/STATO_0000176",
+        "nidm_contrastName": "http://purl.org/nidash/nidm#NIDM_0000085",
+        "nidm_ContrastEstimation": "http://purl.org/nidash/nidm#NIDM_0000001",
+        "nidm_StatisticMap": "http://purl.org/nidash/nidm#NIDM_0000076",
+        "nidm_errorDegreesOfFreedom": "http://purl.org/nidash/nidm#NIDM_0000093",
+        "nidm_effectDegreesOfFreedom": "http://purl.org/nidash/nidm#NIDM_0000091",
+        "nidm_ContrastMap": "http://purl.org/nidash/nidm#NIDM_0000002",
+        "nidm_ContrastStandardErrorMap": "http://purl.org/nidash/nidm#NIDM_0000013",
+        "obo_statistic": "http://purl.obolibrary.org/obo/STATO_0000039",
+        "nidm_PValueUncorrected": "http://purl.org/nidash/nidm#NIDM_0000160",
+        "obo_FWERadjustedpvalue": "http://purl.obolibrary.org/obo/OBI_0001265",
+        "nidm_HeightThreshold": "http://purl.org/nidash/nidm#NIDM_0000034",
+        "nidm_equivalentThreshold": "http://purl.org/nidash/nidm#NIDM_0000161",
+        "nidm_ExtentThreshold": "http://purl.org/nidash/nidm#NIDM_0000026",
+        "nidm_clusterSizeInVoxels": "http://purl.org/nidash/nidm#NIDM_0000084",
+        "nidm_clusterSizeInResels": "http://purl.org/nidash/nidm#NIDM_0000156",
+        "nidm_PeakDefinitionCriteria": "http://purl.org/nidash/nidm#NIDM_0000063",
+        "nidm_maxNumberOfPeaksPerCluster": "http://purl.org/nidash/nidm#NIDM_0000108",
+        "nidm_minDistanceBetweenPeaks": "http://purl.org/nidash/nidm#NIDM_0000109",
+        "nidm_ClusterDefinitionCriteria": "http://purl.org/nidash/nidm#NIDM_0000007",
+        "nidm_hasConnectivityCriterion": "http://purl.org/nidash/nidm#NIDM_0000099",
+        "nidm_voxel18connected": "http://purl.org/nidash/nidm#NIDM_0000128",
+        "nidm_Inference": "http://purl.org/nidash/nidm#NIDM_0000049",
+        "nidm_hasAlternativeHypothesis": "http://purl.org/nidash/nidm#NIDM_0000097",
+        "nidm_OneTailedTest": "http://purl.org/nidash/nidm#NIDM_0000060",
+        "nidm_SearchSpaceMaskMap": "http://purl.org/nidash/nidm#NIDM_0000068",
+        "nidm_searchVolumeInVoxels": "http://purl.org/nidash/nidm#NIDM_0000121",
+        "nidm_searchVolumeInUnits": "http://purl.org/nidash/nidm#NIDM_0000136",
+        "nidm_reselSizeInVoxels": "http://purl.org/nidash/nidm#NIDM_0000148",
+        "nidm_searchVolumeInResels": "http://purl.org/nidash/nidm#NIDM_0000149",
+        "spm_searchVolumeReselsGeometry": "http://purl.org/nidash/spm#SPM_0000010",
+        "nidm_noiseFWHMInVoxels": "http://purl.org/nidash/nidm#NIDM_0000159",
+        "nidm_noiseFWHMInUnits": "http://purl.org/nidash/nidm#NIDM_0000157",
+        "nidm_randomFieldStationarity": "http://purl.org/nidash/nidm#NIDM_0000120",
+        "nidm_expectedNumberOfVoxelsPerCluster": "http://purl.org/nidash/nidm#NIDM_0000143",
+        "nidm_expectedNumberOfClusters": "http://purl.org/nidash/nidm#NIDM_0000141",
+        "nidm_heightCriticalThresholdFWE05": "http://purl.org/nidash/nidm#NIDM_0000147",
+        "nidm_heightCriticalThresholdFDR05": "http://purl.org/nidash/nidm#NIDM_0000146",
+        "spm_smallestSignificantClusterSizeInVoxelsFWE05": "http://purl.org/nidash/spm#SPM_0000014",
+        "spm_smallestSignificantClusterSizeInVoxelsFDR05": "http://purl.org/nidash/spm#SPM_0000013",
+        "nidm_ExcursionSetMap": "http://purl.org/nidash/nidm#NIDM_0000025",
+        "nidm_numberOfSupraThresholdClusters": "http://purl.org/nidash/nidm#NIDM_0000111",
+        "nidm_pValue": "http://purl.org/nidash/nidm#NIDM_0000114",
+        "nidm_hasClusterLabelsMap": "http://purl.org/nidash/nidm#NIDM_0000098",
+        "nidm_hasMaximumIntensityProjection": "http://purl.org/nidash/nidm#NIDM_0000138",
+        "nidm_ClusterLabelsMap": "http://purl.org/nidash/nidm#NIDM_0000008",
+        "nidm_SupraThresholdCluster": "http://purl.org/nidash/nidm#NIDM_0000070",
+        "nidm_pValueUncorrected": "http://purl.org/nidash/nidm#NIDM_0000116",
+        "nidm_pValueFWER": "http://purl.org/nidash/nidm#NIDM_0000115",
+        "nidm_qValueFDR": "http://purl.org/nidash/nidm#NIDM_0000119",
+        "nidm_clusterLabelId": "http://purl.org/nidash/nidm#NIDM_0000082",
+        "nidm_Peak": "http://purl.org/nidash/nidm#NIDM_0000062",
+        "nidm_equivalentZStatistic": "http://purl.org/nidash/nidm#NIDM_0000092",
+        "nidm_Coordinate": "http://purl.org/nidash/nidm#NIDM_0000015",
+        "nidm_coordinateVector": "http://purl.org/nidash/nidm#NIDM_0000086"
+    },
+    "entity": {
+        "niiri:fb077c2db1c7afee934de729a4c9618d": {
+            "prov:type": {
+                "$": "nidm_CoordinateSpace:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Coordinate space 1",
+                "type": "xsd:string"
+            },
+            "nidm_voxelToWorldMapping:": {
+                "$": "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]",
+                "type": "xsd:string"
+            },
+            "nidm_voxelUnits:": {
+                "$": "[\"mm\", \"mm\", \"mm\"]",
+                "type": "xsd:string"
+            },
+            "nidm_voxelSize:": {
+                "$": "[2, 2, 2]",
+                "type": "xsd:string"
+            },
+            "nidm_inWorldCoordinateSystem:": {
+                "$": "nidm_Ixi549CoordinateSystem:",
+                "type": "xsd:string"
+            },
+            "nidm_numberOfDimensions:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_dimensionsInVoxels:": {
+                "$": "[79,95,79]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:87f956daaa9073497b8b73a5d7227428": {
+            "prov:type": [
+                {
+                "$": "prov:Collection",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Data:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Data",
+                "type": "xsd:string"
+            },
+            "nidm_grandMeanScaling:": {
+                "$": "true",
+                "type": "xsd:boolean"
+            },
+            "nidm_targetIntensity:": {
+                "$": "100",
+                "type": "xsd:float"
+            },
+            "nidm_hasMRIProtocol:": {
+                "$": "nlx_FunctionalMRIprotocol:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7572230598f6780417a95d7b43f25cc0": {
+            "prov:type": {
+                "$": "spm_DCTDriftModel:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "SPM's DCT Drift Model",
+                "type": "xsd:string"
+            },
+            "spm_SPMsDriftCutoffPeriod:": {
+                "$": "128",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d1ec8e870ecb39337f2b3c95137664a8": {
+            "prov:type": {
+                "$": "nidm_DesignMatrix:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "DesignMatrix.csv",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "DesignMatrix.csv",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "text/csv",
+                "type": "xsd:string"
+            },
+            "dc:description": {
+                "$": "niiri:def8137d4f6f4767c2f27db070f9ab9c",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Design Matrix",
+                "type": "xsd:string"
+            },
+            "nidm_regressorNames:": {
+                "$": "[\"Sn(1) to*bf(1)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) constant\"]",
+                "type": "xsd:string"
+            },
+            "nidm_hasDriftModel:": {
+                "$": "niiri:7572230598f6780417a95d7b43f25cc0",
+                "type": "xsd:string"
+            },
+            "nidm_hasHRFBasis:": {
+                "$": "spm_SPMsCanonicalHRF:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:def8137d4f6f4767c2f27db070f9ab9c": {
+            "prov:type": {
+                "$": "dctype:Image",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "DesignMatrix.png",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "DesignMatrix.png",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/png",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:834307fe7ea4f6c3b2e4869cc5c572b5": {
+            "prov:type": {
+                "$": "nidm_ErrorModel:",
+                "type": "xsd:QName"
+            },
+            "nidm_hasErrorDistribution:": {
+                "$": "obo_normaldistribution:",
+                "type": "xsd:string"
+            },
+            "nidm_hasErrorDependence:": {
+                "$": "obo_Toeplitzcovariancestructure:",
+                "type": "xsd:string"
+            },
+            "nidm_dependenceMapWiseDependence:": {
+                "$": "nidm_ConstantParameter:",
+                "type": "xsd:string"
+            },
+            "nidm_errorVarianceHomogeneous:": {
+                "$": "true",
+                "type": "xsd:boolean"
+            },
+            "nidm_varianceMapWiseDependence:": {
+                "$": "nidm_IndependentParameter:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ece3cdb35b4a193e1c1a956e1d18a83f": {
+            "prov:type": {
+                "$": "nidm_MaskMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "Mask.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nidm_isUserDefined:": {
+                "$": "false",
+                "type": "xsd:boolean"
+            },
+            "nfo:fileName": {
+                "$": "Mask.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Mask",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:fb077c2db1c7afee934de729a4c9618d",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d47a652ea52d803eaf61a1440d4ee9a0": {
+            "prov:type": {
+                "$": "nidm_MaskMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "mask.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "36929e1f5f4143bd9cc818cd896a25f129961fab208c3a4438555f40444c08347b359142ee8c53ece6e8cca1627f49db0788a1fd3b9e2ecaef61999c6c6c67ac",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ba71907eeb2ae78e67e358350ac6e2e4": {
+            "prov:type": {
+                "$": "nidm_GrandMeanMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "GrandMean.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "GrandMean.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Grand Mean Map",
+                "type": "xsd:string"
+            },
+            "nidm_maskedMedian:": {
+                "$": "111.557487487793",
+                "type": "xsd:float"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:fb077c2db1c7afee934de729a4c9618d",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "512157cc6bff89d9343a09b4068226eb3edd64a8cbcee861f06231767fae6f8d4819921182adebee083a9bf309afd65529ab04a92f0aa6b0038c8098550f6124",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:70a8c763acea17b445f0c2df0fa7cdea": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0001.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0001.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 1",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:fb077c2db1c7afee934de729a4c9618d",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ad407352278e434503a359c1fa3e1a9d": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0001.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:60bd42c7d00085cd0c9e78ca9093dc8d": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0002.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0002.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 2",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:fb077c2db1c7afee934de729a4c9618d",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b30f76932fae67727ecae774f20f5b46": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0002.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e3deb37fe68eb835201c5af97c411ff7": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0003.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0003.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 3",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:fb077c2db1c7afee934de729a4c9618d",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ad57dd041b5129b8d2970ceebd686269": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0003.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a0e5946d7d1dd4083af55338b3c2d3c9": {
+            "prov:type": {
+                "$": "nidm_ResidualMeanSquaresMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ResidualMeanSquares.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ResidualMeanSquares.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Residual Mean Squares Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:fb077c2db1c7afee934de729a4c9618d",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "991abf563d795a43b1e2eef8643e57023f2e0b090b2031f05f839321fc0643df6f71d423486a1021519b6dc82f6b0f563e19f3fbd50cb16063bed54a0e192d3e",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1ad97186abe5157f975894f121d5e5f9": {
+            "prov:type": {
+                "$": "nidm_ResidualMeanSquaresMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "ResMS.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "40b28d03fcf9a2f60b11f10d7fb83bf3618b234fb5aedf09df644cb7cbb6aab8c9f468897c1078166d455a3d04a83f4e3bf762cfca0b4ea982d7a4e406849f18",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a0a699bc84151f3770428014d5881784": {
+            "prov:type": {
+                "$": "nidm_ReselsPerVoxelMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ReselsPerVoxel.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ReselsPerVoxel.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Resels per Voxel Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:fb077c2db1c7afee934de729a4c9618d",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "1a3f9216e145249ccc0b14b2bc337d6b38b81ad45e32768001fb22b35f0c2c0f3e2bce013b40c85f7dc0fc62723ac761ee7f7e1e6aff128a05f0ba7b8b8202a3",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:825faee5541a664e02864bcc9e5f7db6": {
+            "prov:type": {
+                "$": "nidm_ReselsPerVoxelMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "RPV.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "4f76663162857f6b38b2a45a63b15a23b2ca8b338c283b69c1e71f2ea2f43797d045a733cd14e845be9c12f8b8f84d3931c599a08e8f6d77e99fab46ad87ab8f",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:83435a694f0d3952e54da4131150dfc4": {
+            "prov:type": {
+                "$": "obo_contrastweightmatrix:",
+                "type": "xsd:QName"
+            },
+            "nidm_statisticType:": {
+                "$": "obo_tstatistic:",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast: tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "[1, 0, 0]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:db9345d4e9933a8e4b01bd306e4d1ada": {
+            "prov:type": {
+                "$": "nidm_StatisticMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "TStatistic.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "TStatistic.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "T-Statistic Map: tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "nidm_statisticType:": {
+                "$": "obo_tstatistic:",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "nidm_errorDegreesOfFreedom:": {
+                "$": "97.9999999998522",
+                "type": "xsd:float"
+            },
+            "nidm_effectDegreesOfFreedom:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:fb077c2db1c7afee934de729a4c9618d",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "9e1714c2d86a050b38b4e10a4d2d23253a24c5e1d228ae16a9c3be8872739278505ac0729ecab54265a717e3a54f9f782d0ed72eea904e0d482a6072bb817bd4",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2ae9dd843807c2964f069dac80060045": {
+            "prov:type": {
+                "$": "nidm_StatisticMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "spmT_0001.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "d288b1b0f117f64502555da13c5398dffa5bf5ff0b58951510e43d5388755bc185798802a92e98a07c7e313c6991066d2908f2a44aa5153ba23433da1335970f",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:aa2414e92da918a041265bddb4dcdf0d": {
+            "prov:type": {
+                "$": "nidm_ContrastMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "Contrast.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "Contrast.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast Map: tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:fb077c2db1c7afee934de729a4c9618d",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "fc5e2ad175243ee496db98f9b2e1b235c4c3bae1a8d7122ce461c897b537e40c49dfee5d6cf20f71c6a2bb9b5f0760fcb4ecd8fe2e9428910ef3d60d8f3c56a9",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:896ddf9a768ce97fe2d39d3682cde4f2": {
+            "prov:type": {
+                "$": "nidm_ContrastMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "con_0001.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "d4aa46b3603ba508578e39751262d528cf6d1ed2e722ec46f1cd8194c50591e46b229deb8cb4f72d1b7e0e2640f3e6604be7a335301c5c8357f453e5d0d4daf2",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1f712c8148d8d15ace4a81b516943032": {
+            "prov:type": {
+                "$": "nidm_ContrastStandardErrorMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ContrastStandardError.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ContrastStandardError.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast Standard Error Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:fb077c2db1c7afee934de729a4c9618d",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "791d48f5d1adb15079a5289271ce0c4b95c56d69bfdb3e5d41b0d24eb538d3075e1cdd15502494b5a5a18c16eaa2153cb4847a996043fa48cdaf26e938a2576d",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0913319d344f1fdba3d922a2dfae4612": {
+            "prov:type": [
+                {
+                "$": "nidm_HeightThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_PValueUncorrected:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Height Threshold: p<0.001 (unc.)",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "0.000999500158000544",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentThreshold:": [
+                {
+                "$": "niiri:013b7be5dd7ca8fbb3d35355e8b4f3aa",
+                "type": "xsd:string"
+                },
+                {
+                "$": "niiri:4e8b898c9c0affa831a9bdb84c970721",
+                "type": "xsd:string"
+                }
+            ]
+        },
+        "niiri:013b7be5dd7ca8fbb3d35355e8b4f3aa": {
+            "prov:type": [
+                {
+                "$": "nidm_HeightThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_statistic:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Height Threshold: T=3.175486)",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.17548628637284",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4e8b898c9c0affa831a9bdb84c970721": {
+            "prov:type": [
+                {
+                "$": "nidm_HeightThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_FWERadjustedpvalue:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Height Threshold: p<1.000000 (FWE)",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "0.999999999999997",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:38c63862d3fa4aeb37b16674898b17d0": {
+            "prov:type": [
+                {
+                "$": "nidm_ExtentThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_statistic:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Extent Threshold: k>=116",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "116",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.7688671224263",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentThreshold:": [
+                {
+                "$": "niiri:2722fd44f9e7d6b1c6f50c721ba5e19b",
+                "type": "xsd:string"
+                },
+                {
+                "$": "niiri:0b8fed5ea39b873139620e7b43513466",
+                "type": "xsd:string"
+                }
+            ]
+        },
+        "niiri:2722fd44f9e7d6b1c6f50c721ba5e19b": {
+            "prov:type": [
+                {
+                "$": "nidm_ExtentThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_FWERadjustedpvalue:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Extent Threshold",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "0.0150888416289883",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0b8fed5ea39b873139620e7b43513466": {
+            "prov:type": [
+                {
+                "$": "nidm_ExtentThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_PValueUncorrected:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Extent Threshold",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "0.000452977534465859",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ded58d3d760e7c562c993612ce5bdbb0": {
+            "prov:type": {
+                "$": "nidm_PeakDefinitionCriteria:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak Definition Criteria",
+                "type": "xsd:string"
+            },
+            "nidm_maxNumberOfPeaksPerCluster:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_minDistanceBetweenPeaks:": {
+                "$": "8",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c3a4c242421f98d32ff2ef9357eb073e": {
+            "prov:type": {
+                "$": "nidm_ClusterDefinitionCriteria:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Cluster Connectivity Criterion: 18",
+                "type": "xsd:string"
+            },
+            "nidm_hasConnectivityCriterion:": {
+                "$": "nidm_voxel18connected:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b5be02643f367e1e1ed18da1e913b142": {
+            "prov:type": {
+                "$": "nidm_SearchSpaceMaskMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "SearchSpaceMask.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "SearchSpaceMask.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Search Space Mask Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:fb077c2db1c7afee934de729a4c9618d",
+                "type": "xsd:string"
+            },
+            "nidm_searchVolumeInVoxels:": {
+                "$": "223057",
+                "type": "xsd:int"
+            },
+            "nidm_searchVolumeInUnits:": {
+                "$": "1784456",
+                "type": "xsd:float"
+            },
+            "nidm_reselSizeInVoxels:": {
+                "$": "65.5786964036542",
+                "type": "xsd:float"
+            },
+            "nidm_searchVolumeInResels:": {
+                "$": "3155.84193266257",
+                "type": "xsd:float"
+            },
+            "spm_searchVolumeReselsGeometry:": {
+                "$": "[6, 97.8140592306853, 965.938819261507, 3155.84193266257]",
+                "type": "xsd:string"
+            },
+            "nidm_noiseFWHMInVoxels:": {
+                "$": "[4.09118640605185, 4.0346308705955, 3.97291894351243]",
+                "type": "xsd:string"
+            },
+            "nidm_noiseFWHMInUnits:": {
+                "$": "[8.18237281210369, 8.069261741191, 7.94583788702486]",
+                "type": "xsd:string"
+            },
+            "nidm_randomFieldStationarity:": {
+                "$": "true",
+                "type": "xsd:boolean"
+            },
+            "nidm_expectedNumberOfVoxelsPerCluster:": {
+                "$": "7.21748994812991",
+                "type": "xsd:float"
+            },
+            "nidm_expectedNumberOfClusters:": {
+                "$": "0.0152038364250172",
+                "type": "xsd:float"
+            },
+            "nidm_heightCriticalThresholdFWE05:": {
+                "$": "5.30963135104407",
+                "type": "xsd:float"
+            },
+            "nidm_heightCriticalThresholdFDR05:": {
+                "$": "4.69981384277344",
+                "type": "xsd:float"
+            },
+            "crypto:sha512": {
+                "$": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876",
+                "type": "xsd:string"
+            },
+            "spm_smallestSignificantClusterSizeInVoxelsFWE05:": {
+                "$": "116",
+                "type": "xsd:int"
+            },
+            "spm_smallestSignificantClusterSizeInVoxelsFDR05:": {
+                "$": "61",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:e1e17399f999e1f91dc21c7b68dbdf0b": {
+            "prov:type": {
+                "$": "nidm_ExcursionSetMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ExcursionSet.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ExcursionSet.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Excursion Set Map",
+                "type": "xsd:string"
+            },
+            "nidm_numberOfSupraThresholdClusters:": {
+                "$": "10",
+                "type": "xsd:int"
+            },
+            "nidm_pValue:": {
+                "$": "0",
+                "type": "xsd:float"
+            },
+            "nidm_hasClusterLabelsMap:": {
+                "$": "niiri:914772f2d1711625ae963abf3b3ae8b4",
+                "type": "xsd:string"
+            },
+            "nidm_hasMaximumIntensityProjection:": {
+                "$": "niiri:475e9458d2df603def75554bb36f93a9",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:fb077c2db1c7afee934de729a4c9618d",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "ba4f79758d41b7104bbd0f688aaa433cf258e1254cfd9e6de5e6c2c4bacacc9be392e9d7a3954c1f9db7a7a5fd6ecc6e3336fcec30eddc434de3c0c86dfe8562",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:914772f2d1711625ae963abf3b3ae8b4": {
+            "prov:type": {
+                "$": "nidm_ClusterLabelsMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ClusterLabels.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ClusterLabels.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Cluster Labels Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:fb077c2db1c7afee934de729a4c9618d",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "db5a86bea3707aaf8380866c8431e2ebc0c1c822c57ceaf420a53b3311ec38101478c53bac8ecc4c1915427e495415c63cd023fc663e89a7387b705998afdf00",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:475e9458d2df603def75554bb36f93a9": {
+            "prov:type": {
+                "$": "dctype:Image",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "MaximumIntensityProjection.png",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "MaximumIntensityProjection.png",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/png",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9dd5e0cba75bc4a093eb61cbd76e36a6": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0001",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1804",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "27.5089335246298",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.46511379022666e-21",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "5.93371085041799e-20",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "1",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:29f39b3a7ffc8526221cbb764dc91ed6": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0002",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "356",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "5.42859220330831",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.6728855149243e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "2.91098190852157e-06",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1.17083954451478e-06",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "2",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:9119b99e73e7caf27ccbc46b71a20fe2": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0003",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "5090",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "77.6166694237059",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.51031151932561e-42",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "2.03335233065374e-40",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "3",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:5a140c712e9e00e14ac695343ed92c6a": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0004",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "766",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "11.6806225498151",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.69891112070838e-12",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "5.70226088569825e-11",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "4.58706002591263e-11",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "4",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:1b0ec2e914c1e26ce0156061bea8ec55": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0005",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "285",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "4.34592353354738",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.15539697056139e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "2.73725770201239e-05",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "9.4369593516496e-06",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "5",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f6128a48e628339748454f9195fb4b90": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0006",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "395",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "6.02329752895164",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.70020762554596e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "9.06303145864484e-07",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "4.37433635338446e-07",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "6",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:16996fcb45118225812852d29f9f9a73": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0007",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "116",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.7688671224263",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000452977534465859",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0150888416289883",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00366911802917346",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "7",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:b374b0b364537d85069da6781ed3bce7": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0008",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "447",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "6.81623796314274",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.03851586308171e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "2.02678038352389e-07",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1.22279946227405e-07",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "8",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:47eda65cfe1f349741bbd56fa3361233": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0009",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "162",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "2.47031442959535",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.63852466674842e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00222568832297587",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000672150622508277",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "9",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:8235aa92a4300c6c7e12d8fb288e2e09": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0010",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "134",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "2.04334650349245",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000208225307159483",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00696455376757865",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00187402776443535",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "10",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:219af4d66e697f49e07199776077e216": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0001",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:2aab79258a69f0db7f63751d429ec6e0",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "7.92007970809937",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "6.94608360738412",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.87783122385099e-12",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "4.18813870695089e-07",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "5.21674435923017e-06",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:2aab79258a69f0db7f63751d429ec6e0": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0001",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[46,16,24]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ea59d816b162d773d020ce2c78fe6579": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0002",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:3a14839f82a10251f5ca1ac1e6ab0a84",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.31603479385376",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.77079466112137",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.94492849498107e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.000879943865776389",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000830722551601523",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3a14839f82a10251f5ca1ac1e6ab0a84": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0002",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[32,24,-4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9f9284ea2fb3b52c1c958913ea07adc6": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0003",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a3ff3ba6e003adbe983a538a39e41e7d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.68819808959961",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.27450168515333",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.655864770444e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0121028975026269",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00350091530962783",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a3ff3ba6e003adbe983a538a39e41e7d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0003",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[18,16,4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:944bc30a544eea31480b7ce73c7de33e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0004",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:1663962b579598837b549cce2fe973e6",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "7.11683940887451",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "6.37404871703245",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "9.20510334623259e-11",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "2.05325778424026e-05",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "9.33757664730496e-05",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:1663962b579598837b549cce2fe973e6": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0004",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[34,-88,-2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2c9d4a11c4fa1759dc1470cf7bbdc2d0": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0005",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:393bdeddfa8315a2909d86e9748639c6",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.48292255401611",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.8992593141605",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.82568493656277e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.000407231755366277",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000830722551601523",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:393bdeddfa8315a2909d86e9748639c6": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0005",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[42,-72,-10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:acc8196a4273a3c86f5676b2bc4a6016": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0006",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d0c9e40fb953987b03f13aa2c7c6b34b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.2275915145874",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.89738468004472",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.85602978606003e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0670610253017228",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0118363293065346",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d0c9e40fb953987b03f13aa2c7c6b34b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0006",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[34,-86,12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8d391d27c7d45276c852a9406623c60f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0007",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ddaec90e4d0de561cdc7f6e01e38a5d2",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.28007745742798",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.74292583422276",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.65272453897825e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00103782272796227",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000830722551601523",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ddaec90e4d0de561cdc7f6e01e38a5d2": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0007",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[8,18,50]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6725f4fbe7aeb3714270626b873a4445": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0008",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:03947289df407f4dfaee992081ab79d1",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.15222215652466",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.64328512810061",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.34178537356678e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00186069357054308",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000972721201433817",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:03947289df407f4dfaee992081ab79d1": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0008",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-6,12,52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:430a862ed862cdb51f3527d8fa8754fd": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0009",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b6f52d40cc25ee4d9e2e660bf01ffdcc",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.98517084121704",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.51181334779297",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.77577724747024e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00376326218366319",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00136419627856355",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b6f52d40cc25ee4d9e2e660bf01ffdcc": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0009",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[8,32,38]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b05bca128b30571198c9e6e1d9341331": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0010",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:9f7c92dff8010e9bb8d470367995d0e6",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.25127363204956",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.72055271981637",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.30890376104765e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0011841880966994",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000830722551601523",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:9f7c92dff8010e9bb8d470367995d0e6": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0010",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[52,-32,42]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:83f14a358618817c9a4a6a55d65d9d48": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0011",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:eccc7ce308baf5cc0394b6c8e559a22d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.24752378463745",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.71763687476157",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.40078304300806e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00120468241369565",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000830722551601523",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:eccc7ce308baf5cc0394b6c8e559a22d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0011",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[40,-62,50]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:85743f2fb9669a51df0ec45eb8d8c238": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0012",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:593fddd783d0fc554f40d4cbb2ae9fd8",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.70337772369385",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.28674301747281",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.22566831420812e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.011413186758684",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00350091530962783",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:593fddd783d0fc554f40d4cbb2ae9fd8": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0012",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[56,-44,52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:004249a446a2a2711503faa18a5be983": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0013",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4ba5a90af9efd38fd0be8658803dd352",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.10109901428223",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.60320502193174",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.05212039080982e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00234682813060005",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00104518293275697",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4ba5a90af9efd38fd0be8658803dd352": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0013",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[32,2,46]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a41084fb733e0e08cf6c8c3fb3eb5701": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0014",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:18764a45f2220339c69ef7c9bfdc47e7",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.6086859703064",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.3736141683061",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.11031435759912e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.453877178455514",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0599714495109201",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:18764a45f2220339c69ef7c9bfdc47e7": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0014",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[28,4,58]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6ff1fdc33f1b4c1ab70d3a900c678f9c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0015",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c8ad2195d487c19092289414f0abafd1",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.98793148994446",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.82932508069717",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.42475887594474e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.984644566584946",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.233149120368192",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c8ad2195d487c19092289414f0abafd1": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0015",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[42,4,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c70c9f283443901436c2946acb819132": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0016",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e05c37b5c74c14f57c7e2e30c9035861",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.98348569869995",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.51047970249337",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.78928538652201e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00378871596531738",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00136419627856355",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e05c37b5c74c14f57c7e2e30c9035861": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0016",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-52,0,38]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8cf7256afe51307616ffb11a8dcf7656": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0017",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:eb1fdad4df23df5a2b3d3c0d6a56a6d5",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.2253565788269",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.89552821543552",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.90210114501011e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0675937275056587",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0118363293065346",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:eb1fdad4df23df5a2b3d3c0d6a56a6d5": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0017",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-60,8,20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5311d6026c4d7b6211bd21394ed3cd34": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0018",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7d87737758e0654156614064a8771717",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.98950004577637",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.69817956585148",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.31245304380023e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.151048137890434",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0233609510296683",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7d87737758e0654156614064a8771717": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0018",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-44,6,28]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:932949e2a06a6b558e7f4e4fdfaef630": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0019",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:867678d8e68882ecd35ff7e4ada5602f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.78093099594116",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.34909755317379",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.41969442155354e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00844151822925698",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00286742427823329",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:867678d8e68882ecd35ff7e4ada5602f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0019",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-34,-2,52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0ff41f9a206a4f614332cd4bd0d4db48": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0020",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b2bc2fe9dcebc44d696b30462a22509b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.30699443817139",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.96317509467693",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.46750043123123e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0504786376455083",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0106752417476244",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b2bc2fe9dcebc44d696b30462a22509b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0020",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[32,40,16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b7cd492bae1a54bc9978c2c30ae62044": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0021",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:5d959d006ddff911006f677f2f35bdc0",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.5497465133667",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.32273570618355",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.7053150754347e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.520378392891944",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0649997423676262",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:5d959d006ddff911006f677f2f35bdc0": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0021",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[40,46,12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5361732ec0e4c8b9cac0fb646789c096": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0022",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b5342f9bc1453a7c01e4c7e8ea7cc962",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.31582498550415",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.11913273798974",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.90150518718513e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.788829013385429",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.116130094830597",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b5342f9bc1453a7c01e4c7e8ea7cc962": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0022",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[36,54,6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1c1efb50135a7c1bad8db7e4cf11686f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0023",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:35725a8dc35ca221915f18e8878596aa",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.27030229568481",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.93281349716267",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.05267701952816e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0575990926145485",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0110040663565173",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:35725a8dc35ca221915f18e8878596aa": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0023",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[40,26,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:142faca43b00bbe02174b97cc402bc5e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0024",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d64683a5a499945ff7594f708a0ca237",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.72232866287231",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.47122948835043",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.88855941602095e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.338512677882141",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.044836631144536",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d64683a5a499945ff7594f708a0ca237": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0024",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[58,-38,6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d3d21d9fb8f5c4e3c028dafc33492ae5": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0025",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a444192598b15b39c8f68d9d10ad798f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.98372888565063",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.8255778871433",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.52328381068878e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.985409231324461",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.233731539105478",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a444192598b15b39c8f68d9d10ad798f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0025",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[64,-30,-4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:67d65736ad13421436d72a8215e48d31": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0026",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:3c8566c59af37fa6a9390ed38a37517b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.50753784179688",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.39582098150001",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000342115474631921",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999778829603",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.564856004417035",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3c8566c59af37fa6a9390ed38a37517b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0026",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[60,-40,-12]",
+                "type": "xsd:string"
+            }
+        }
+    },
+    "activity": {
+        "niiri:77556fccd50035e27041bcd31a9c4d58": {
+            "prov:type": {
+                "$": "nidm_ModelParametersEstimation:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Model parameters estimation",
+                "type": "xsd:string"
+            },
+            "nidm_withEstimationMethod:": {
+                "$": "obo_generalizedleastsquaresestimation:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8abfa89e769aa3a3b89c1b4bc433cf48": {
+            "prov:type": {
+                "$": "nidm_ContrastEstimation:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Contrast estimation",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:22f75f4eb883a33606785984a05451e3": {
+            "prov:type": {
+                "$": "nidm_Inference:",
+                "type": "xsd:QName"
+            },
+            "nidm_hasAlternativeHypothesis:": {
+                "$": "nidm_OneTailedTest:",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Inference",
+                "type": "xsd:string"
+            }
+        }
+    },
+    "agent": {
+        "niiri:978ecfac61168b631aeb24784516a78c": {
+            "prov:type": [
+                {
+                "$": "src_SPM:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "prov:SoftwareAgent",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "SPM",
+                "type": "xsd:string"
+            },
+            "nidm_softwareVersion:": {
+                "$": "12.6906",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f260b10e486c81130f24499cfffa8499": {
+            "prov:type": [
+                {
+                "$": "nlx_Imaginginstrument:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nlx_Magneticresonanceimagingscanner:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "MRI Scanner",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:445a3d62de6b1fe45f5fbb9742c962fc": {
+            "prov:type": {
+                "$": "prov:Person",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Person",
+                "type": "xsd:string"
+            }
+        }
+    },
+    "wasGeneratedBy": {
+        "_:wGB20": {
+            "prov:entity": "niiri:ece3cdb35b4a193e1c1a956e1d18a83f",
+            "prov:activity": "niiri:77556fccd50035e27041bcd31a9c4d58"
+        },
+        "_:wGB22": {
+            "prov:entity": "niiri:ba71907eeb2ae78e67e358350ac6e2e4",
+            "prov:activity": "niiri:77556fccd50035e27041bcd31a9c4d58"
+        },
+        "_:wGB26": {
+            "prov:entity": "niiri:70a8c763acea17b445f0c2df0fa7cdea",
+            "prov:activity": "niiri:77556fccd50035e27041bcd31a9c4d58"
+        },
+        "_:wGB30": {
+            "prov:entity": "niiri:60bd42c7d00085cd0c9e78ca9093dc8d",
+            "prov:activity": "niiri:77556fccd50035e27041bcd31a9c4d58"
+        },
+        "_:wGB34": {
+            "prov:entity": "niiri:e3deb37fe68eb835201c5af97c411ff7",
+            "prov:activity": "niiri:77556fccd50035e27041bcd31a9c4d58"
+        },
+        "_:wGB38": {
+            "prov:entity": "niiri:a0e5946d7d1dd4083af55338b3c2d3c9",
+            "prov:activity": "niiri:77556fccd50035e27041bcd31a9c4d58"
+        },
+        "_:wGB42": {
+            "prov:entity": "niiri:a0a699bc84151f3770428014d5881784",
+            "prov:activity": "niiri:77556fccd50035e27041bcd31a9c4d58"
+        },
+        "_:wGB56": {
+            "prov:entity": "niiri:db9345d4e9933a8e4b01bd306e4d1ada",
+            "prov:activity": "niiri:8abfa89e769aa3a3b89c1b4bc433cf48"
+        },
+        "_:wGB60": {
+            "prov:entity": "niiri:aa2414e92da918a041265bddb4dcdf0d",
+            "prov:activity": "niiri:8abfa89e769aa3a3b89c1b4bc433cf48"
+        },
+        "_:wGB62": {
+            "prov:entity": "niiri:1f712c8148d8d15ace4a81b516943032",
+            "prov:activity": "niiri:8abfa89e769aa3a3b89c1b4bc433cf48"
+        },
+        "_:wGB81": {
+            "prov:entity": "niiri:b5be02643f367e1e1ed18da1e913b142",
+            "prov:activity": "niiri:22f75f4eb883a33606785984a05451e3"
+        },
+        "_:wGB85": {
+            "prov:entity": "niiri:e1e17399f999e1f91dc21c7b68dbdf0b",
+            "prov:activity": "niiri:22f75f4eb883a33606785984a05451e3"
+        }
+    },
+    "used": {
+        "_:u14": {
+            "prov:activity": "niiri:77556fccd50035e27041bcd31a9c4d58",
+            "prov:entity": "niiri:d1ec8e870ecb39337f2b3c95137664a8"
+        },
+        "_:u15": {
+            "prov:activity": "niiri:77556fccd50035e27041bcd31a9c4d58",
+            "prov:entity": "niiri:87f956daaa9073497b8b73a5d7227428"
+        },
+        "_:u16": {
+            "prov:activity": "niiri:77556fccd50035e27041bcd31a9c4d58",
+            "prov:entity": "niiri:834307fe7ea4f6c3b2e4869cc5c572b5"
+        },
+        "_:u46": {
+            "prov:activity": "niiri:8abfa89e769aa3a3b89c1b4bc433cf48",
+            "prov:entity": "niiri:ece3cdb35b4a193e1c1a956e1d18a83f"
+        },
+        "_:u47": {
+            "prov:activity": "niiri:8abfa89e769aa3a3b89c1b4bc433cf48",
+            "prov:entity": "niiri:a0e5946d7d1dd4083af55338b3c2d3c9"
+        },
+        "_:u48": {
+            "prov:activity": "niiri:8abfa89e769aa3a3b89c1b4bc433cf48",
+            "prov:entity": "niiri:d1ec8e870ecb39337f2b3c95137664a8"
+        },
+        "_:u49": {
+            "prov:activity": "niiri:8abfa89e769aa3a3b89c1b4bc433cf48",
+            "prov:entity": "niiri:83435a694f0d3952e54da4131150dfc4"
+        },
+        "_:u50": {
+            "prov:activity": "niiri:8abfa89e769aa3a3b89c1b4bc433cf48",
+            "prov:entity": "niiri:70a8c763acea17b445f0c2df0fa7cdea"
+        },
+        "_:u51": {
+            "prov:activity": "niiri:8abfa89e769aa3a3b89c1b4bc433cf48",
+            "prov:entity": "niiri:60bd42c7d00085cd0c9e78ca9093dc8d"
+        },
+        "_:u52": {
+            "prov:activity": "niiri:8abfa89e769aa3a3b89c1b4bc433cf48",
+            "prov:entity": "niiri:e3deb37fe68eb835201c5af97c411ff7"
+        },
+        "_:u73": {
+            "prov:activity": "niiri:22f75f4eb883a33606785984a05451e3",
+            "prov:entity": "niiri:0913319d344f1fdba3d922a2dfae4612"
+        },
+        "_:u74": {
+            "prov:activity": "niiri:22f75f4eb883a33606785984a05451e3",
+            "prov:entity": "niiri:38c63862d3fa4aeb37b16674898b17d0"
+        },
+        "_:u75": {
+            "prov:activity": "niiri:22f75f4eb883a33606785984a05451e3",
+            "prov:entity": "niiri:db9345d4e9933a8e4b01bd306e4d1ada"
+        },
+        "_:u76": {
+            "prov:activity": "niiri:22f75f4eb883a33606785984a05451e3",
+            "prov:entity": "niiri:a0a699bc84151f3770428014d5881784"
+        },
+        "_:u77": {
+            "prov:activity": "niiri:22f75f4eb883a33606785984a05451e3",
+            "prov:entity": "niiri:ece3cdb35b4a193e1c1a956e1d18a83f"
+        },
+        "_:u78": {
+            "prov:activity": "niiri:22f75f4eb883a33606785984a05451e3",
+            "prov:entity": "niiri:ded58d3d760e7c562c993612ce5bdbb0"
+        },
+        "_:u79": {
+            "prov:activity": "niiri:22f75f4eb883a33606785984a05451e3",
+            "prov:entity": "niiri:c3a4c242421f98d32ff2ef9357eb073e"
+        }
+    },
+    "wasDerivedFrom": {
+        "_:wDF19": {
+            "prov:generatedEntity": "niiri:ece3cdb35b4a193e1c1a956e1d18a83f",
+            "prov:usedEntity": "niiri:d47a652ea52d803eaf61a1440d4ee9a0"
+        },
+        "_:wDF25": {
+            "prov:generatedEntity": "niiri:70a8c763acea17b445f0c2df0fa7cdea",
+            "prov:usedEntity": "niiri:ad407352278e434503a359c1fa3e1a9d"
+        },
+        "_:wDF29": {
+            "prov:generatedEntity": "niiri:60bd42c7d00085cd0c9e78ca9093dc8d",
+            "prov:usedEntity": "niiri:b30f76932fae67727ecae774f20f5b46"
+        },
+        "_:wDF33": {
+            "prov:generatedEntity": "niiri:e3deb37fe68eb835201c5af97c411ff7",
+            "prov:usedEntity": "niiri:ad57dd041b5129b8d2970ceebd686269"
+        },
+        "_:wDF37": {
+            "prov:generatedEntity": "niiri:a0e5946d7d1dd4083af55338b3c2d3c9",
+            "prov:usedEntity": "niiri:1ad97186abe5157f975894f121d5e5f9"
+        },
+        "_:wDF41": {
+            "prov:generatedEntity": "niiri:a0a699bc84151f3770428014d5881784",
+            "prov:usedEntity": "niiri:825faee5541a664e02864bcc9e5f7db6"
+        },
+        "_:wDF55": {
+            "prov:generatedEntity": "niiri:db9345d4e9933a8e4b01bd306e4d1ada",
+            "prov:usedEntity": "niiri:2ae9dd843807c2964f069dac80060045"
+        },
+        "_:wDF59": {
+            "prov:generatedEntity": "niiri:aa2414e92da918a041265bddb4dcdf0d",
+            "prov:usedEntity": "niiri:896ddf9a768ce97fe2d39d3682cde4f2"
+        },
+        "_:wDF87": {
+            "prov:generatedEntity": "niiri:9dd5e0cba75bc4a093eb61cbd76e36a6",
+            "prov:usedEntity": "niiri:e1e17399f999e1f91dc21c7b68dbdf0b"
+        },
+        "_:wDF89": {
+            "prov:generatedEntity": "niiri:29f39b3a7ffc8526221cbb764dc91ed6",
+            "prov:usedEntity": "niiri:e1e17399f999e1f91dc21c7b68dbdf0b"
+        },
+        "_:wDF91": {
+            "prov:generatedEntity": "niiri:9119b99e73e7caf27ccbc46b71a20fe2",
+            "prov:usedEntity": "niiri:e1e17399f999e1f91dc21c7b68dbdf0b"
+        },
+        "_:wDF93": {
+            "prov:generatedEntity": "niiri:5a140c712e9e00e14ac695343ed92c6a",
+            "prov:usedEntity": "niiri:e1e17399f999e1f91dc21c7b68dbdf0b"
+        },
+        "_:wDF95": {
+            "prov:generatedEntity": "niiri:1b0ec2e914c1e26ce0156061bea8ec55",
+            "prov:usedEntity": "niiri:e1e17399f999e1f91dc21c7b68dbdf0b"
+        },
+        "_:wDF97": {
+            "prov:generatedEntity": "niiri:f6128a48e628339748454f9195fb4b90",
+            "prov:usedEntity": "niiri:e1e17399f999e1f91dc21c7b68dbdf0b"
+        },
+        "_:wDF99": {
+            "prov:generatedEntity": "niiri:16996fcb45118225812852d29f9f9a73",
+            "prov:usedEntity": "niiri:e1e17399f999e1f91dc21c7b68dbdf0b"
+        },
+        "_:wDF101": {
+            "prov:generatedEntity": "niiri:b374b0b364537d85069da6781ed3bce7",
+            "prov:usedEntity": "niiri:e1e17399f999e1f91dc21c7b68dbdf0b"
+        },
+        "_:wDF103": {
+            "prov:generatedEntity": "niiri:47eda65cfe1f349741bbd56fa3361233",
+            "prov:usedEntity": "niiri:e1e17399f999e1f91dc21c7b68dbdf0b"
+        },
+        "_:wDF105": {
+            "prov:generatedEntity": "niiri:8235aa92a4300c6c7e12d8fb288e2e09",
+            "prov:usedEntity": "niiri:e1e17399f999e1f91dc21c7b68dbdf0b"
+        },
+        "_:wDF108": {
+            "prov:generatedEntity": "niiri:219af4d66e697f49e07199776077e216",
+            "prov:usedEntity": "niiri:9dd5e0cba75bc4a093eb61cbd76e36a6"
+        },
+        "_:wDF111": {
+            "prov:generatedEntity": "niiri:ea59d816b162d773d020ce2c78fe6579",
+            "prov:usedEntity": "niiri:9dd5e0cba75bc4a093eb61cbd76e36a6"
+        },
+        "_:wDF114": {
+            "prov:generatedEntity": "niiri:9f9284ea2fb3b52c1c958913ea07adc6",
+            "prov:usedEntity": "niiri:9dd5e0cba75bc4a093eb61cbd76e36a6"
+        },
+        "_:wDF117": {
+            "prov:generatedEntity": "niiri:944bc30a544eea31480b7ce73c7de33e",
+            "prov:usedEntity": "niiri:29f39b3a7ffc8526221cbb764dc91ed6"
+        },
+        "_:wDF120": {
+            "prov:generatedEntity": "niiri:2c9d4a11c4fa1759dc1470cf7bbdc2d0",
+            "prov:usedEntity": "niiri:29f39b3a7ffc8526221cbb764dc91ed6"
+        },
+        "_:wDF123": {
+            "prov:generatedEntity": "niiri:acc8196a4273a3c86f5676b2bc4a6016",
+            "prov:usedEntity": "niiri:29f39b3a7ffc8526221cbb764dc91ed6"
+        },
+        "_:wDF126": {
+            "prov:generatedEntity": "niiri:8d391d27c7d45276c852a9406623c60f",
+            "prov:usedEntity": "niiri:9119b99e73e7caf27ccbc46b71a20fe2"
+        },
+        "_:wDF129": {
+            "prov:generatedEntity": "niiri:6725f4fbe7aeb3714270626b873a4445",
+            "prov:usedEntity": "niiri:9119b99e73e7caf27ccbc46b71a20fe2"
+        },
+        "_:wDF132": {
+            "prov:generatedEntity": "niiri:430a862ed862cdb51f3527d8fa8754fd",
+            "prov:usedEntity": "niiri:9119b99e73e7caf27ccbc46b71a20fe2"
+        },
+        "_:wDF135": {
+            "prov:generatedEntity": "niiri:b05bca128b30571198c9e6e1d9341331",
+            "prov:usedEntity": "niiri:5a140c712e9e00e14ac695343ed92c6a"
+        },
+        "_:wDF138": {
+            "prov:generatedEntity": "niiri:83f14a358618817c9a4a6a55d65d9d48",
+            "prov:usedEntity": "niiri:5a140c712e9e00e14ac695343ed92c6a"
+        },
+        "_:wDF141": {
+            "prov:generatedEntity": "niiri:85743f2fb9669a51df0ec45eb8d8c238",
+            "prov:usedEntity": "niiri:5a140c712e9e00e14ac695343ed92c6a"
+        },
+        "_:wDF144": {
+            "prov:generatedEntity": "niiri:004249a446a2a2711503faa18a5be983",
+            "prov:usedEntity": "niiri:1b0ec2e914c1e26ce0156061bea8ec55"
+        },
+        "_:wDF147": {
+            "prov:generatedEntity": "niiri:a41084fb733e0e08cf6c8c3fb3eb5701",
+            "prov:usedEntity": "niiri:1b0ec2e914c1e26ce0156061bea8ec55"
+        },
+        "_:wDF150": {
+            "prov:generatedEntity": "niiri:6ff1fdc33f1b4c1ab70d3a900c678f9c",
+            "prov:usedEntity": "niiri:1b0ec2e914c1e26ce0156061bea8ec55"
+        },
+        "_:wDF153": {
+            "prov:generatedEntity": "niiri:c70c9f283443901436c2946acb819132",
+            "prov:usedEntity": "niiri:f6128a48e628339748454f9195fb4b90"
+        },
+        "_:wDF156": {
+            "prov:generatedEntity": "niiri:8cf7256afe51307616ffb11a8dcf7656",
+            "prov:usedEntity": "niiri:f6128a48e628339748454f9195fb4b90"
+        },
+        "_:wDF159": {
+            "prov:generatedEntity": "niiri:5311d6026c4d7b6211bd21394ed3cd34",
+            "prov:usedEntity": "niiri:f6128a48e628339748454f9195fb4b90"
+        },
+        "_:wDF162": {
+            "prov:generatedEntity": "niiri:932949e2a06a6b558e7f4e4fdfaef630",
+            "prov:usedEntity": "niiri:16996fcb45118225812852d29f9f9a73"
+        },
+        "_:wDF165": {
+            "prov:generatedEntity": "niiri:0ff41f9a206a4f614332cd4bd0d4db48",
+            "prov:usedEntity": "niiri:b374b0b364537d85069da6781ed3bce7"
+        },
+        "_:wDF168": {
+            "prov:generatedEntity": "niiri:b7cd492bae1a54bc9978c2c30ae62044",
+            "prov:usedEntity": "niiri:b374b0b364537d85069da6781ed3bce7"
+        },
+        "_:wDF171": {
+            "prov:generatedEntity": "niiri:5361732ec0e4c8b9cac0fb646789c096",
+            "prov:usedEntity": "niiri:b374b0b364537d85069da6781ed3bce7"
+        },
+        "_:wDF174": {
+            "prov:generatedEntity": "niiri:1c1efb50135a7c1bad8db7e4cf11686f",
+            "prov:usedEntity": "niiri:47eda65cfe1f349741bbd56fa3361233"
+        },
+        "_:wDF177": {
+            "prov:generatedEntity": "niiri:142faca43b00bbe02174b97cc402bc5e",
+            "prov:usedEntity": "niiri:8235aa92a4300c6c7e12d8fb288e2e09"
+        },
+        "_:wDF180": {
+            "prov:generatedEntity": "niiri:d3d21d9fb8f5c4e3c028dafc33492ae5",
+            "prov:usedEntity": "niiri:8235aa92a4300c6c7e12d8fb288e2e09"
+        },
+        "_:wDF183": {
+            "prov:generatedEntity": "niiri:67d65736ad13421436d72a8215e48d31",
+            "prov:usedEntity": "niiri:8235aa92a4300c6c7e12d8fb288e2e09"
+        }
+    },
+    "wasAttributedTo": {
+        "_:wAT6": {
+            "prov:entity": "niiri:87f956daaa9073497b8b73a5d7227428",
+            "prov:agent": "niiri:f260b10e486c81130f24499cfffa8499"
+        },
+        "_:wAT7": {
+            "prov:entity": "niiri:87f956daaa9073497b8b73a5d7227428",
+            "prov:agent": "niiri:445a3d62de6b1fe45f5fbb9742c962fc"
+        }
+    },
+    "wasAssociatedWith": {
+        "_:wAW13": {
+            "prov:activity": "niiri:77556fccd50035e27041bcd31a9c4d58",
+            "prov:agent": "niiri:978ecfac61168b631aeb24784516a78c"
+        },
+        "_:wAW45": {
+            "prov:activity": "niiri:8abfa89e769aa3a3b89c1b4bc433cf48",
+            "prov:agent": "niiri:978ecfac61168b631aeb24784516a78c"
+        },
+        "_:wAW72": {
+            "prov:activity": "niiri:22f75f4eb883a33606785984a05451e3",
+            "prov:agent": "niiri:978ecfac61168b631aeb24784516a78c"
+        }
+    }
+    }
+  }
+}

--- a/spmexport/ex_spm_thr_clustfwep05/nidm.jsonld
+++ b/spmexport/ex_spm_thr_clustfwep05/nidm.jsonld
@@ -7,7 +7,7 @@
       "niiri": "http://iri.nidash.org/",
       "spm": "http://purl.org/nidash/spm#",
       "neurolex": "http://neurolex.org/wiki/",
-      "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#",
+      "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/",
       "dct": "http://purl.org/dc/terms/",
       "nfo": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#",
       "dc": "http://purl.org/dc/elements/1.1/",
@@ -22,32 +22,32 @@
   ],
   "@graph": [
     {
-      "@id": "niiri:182e1b85b8336e56fb4e133ba8563b45",
-      "@type": ["prov:Entity","prov:Bundle","nidm_NIDMResults:"],
+      "@id": "niiri:e31f56e03ff5aca2edc16a51c094a508",
+      "@type": ["prov:Entity","prov:Bundle","nidm_NIDMResults"],
       "rdfs:label": "NIDM-Results",
-      "nidm_version:": {"@type": "xsd:string", "@value": "1.3.0"}
+      "nidm_version": {"@type": "xsd:string", "@value": "1.3.0"}
     },
     {
-      "@id": "niiri:f469c2b953993b48ba75b9bf54a94c6b",
-      "@type": ["prov:Agent","nidm_spm_results_nidm:","prov:SoftwareAgent"],
+      "@id": "niiri:3e9b8ab3f99b4316053190b556d70b8d",
+      "@type": ["prov:Agent","nidm_spm_results_nidm","prov:SoftwareAgent"],
       "rdfs:label": "spm_results_nidm",
-      "nidm_softwareVersion:": {"@type": "xsd:string", "@value": "12.6903"}
+      "nidm_softwareVersion": {"@type": "xsd:string", "@value": "12.7057"}
     },
     {
-      "@id": "niiri:bb9ab37b1fccfb3fd76941f0e4a000c8",
-      "@type": ["prov:Activity","nidm_NIDMResultsExport:"],
+      "@id": "niiri:71e962f0352be27a49a0cadb61d1f6a0",
+      "@type": ["prov:Activity","nidm_NIDMResultsExport"],
       "rdfs:label": "NIDM-Results export"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:bb9ab37b1fccfb3fd76941f0e4a000c8",
-      "agent": "niiri:f469c2b953993b48ba75b9bf54a94c6b"
+      "activity_associated": "niiri:71e962f0352be27a49a0cadb61d1f6a0",
+      "agent": "niiri:3e9b8ab3f99b4316053190b556d70b8d"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:182e1b85b8336e56fb4e133ba8563b45",
-      "activity": "niiri:bb9ab37b1fccfb3fd76941f0e4a000c8",
-      "atTime": "2016-12-07T16:09:37"
+      "entity_generated": "niiri:e31f56e03ff5aca2edc16a51c094a508",
+      "activity": "niiri:71e962f0352be27a49a0cadb61d1f6a0",
+      "atTime": "2017-04-19T12:19:01"
     }
   ]
 },
@@ -158,572 +158,572 @@
       "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
     }
   ],
-  "@id": "niiri:182e1b85b8336e56fb4e133ba8563b45",
+  "@id": "niiri:e31f56e03ff5aca2edc16a51c094a508",
   "@graph": [
     {
-      "@id": "niiri:e2a1a9b317b694a52959d155d5af349f",
-      "@type": ["prov:Agent","src_SPM:","prov:SoftwareAgent"],
+      "@id": "niiri:978ecfac61168b631aeb24784516a78c",
+      "@type": ["prov:Agent","src_SPM","prov:SoftwareAgent"],
       "rdfs:label": "SPM",
-      "nidm_softwareVersion:": {"@type": "xsd:string", "@value": "12.12.2"}
+      "nidm_softwareVersion": {"@type": "xsd:string", "@value": "12.6906"}
     },
     {
-      "@id": "niiri:c2aaa0e17efdb9a83de1fa6bf4a54bc6",
-      "@type": ["prov:Entity","nidm_CoordinateSpace:"],
+      "@id": "niiri:fb077c2db1c7afee934de729a4c9618d",
+      "@type": ["prov:Entity","nidm_CoordinateSpace"],
       "rdfs:label": "Coordinate space 1",
-      "nidm_voxelToWorldMapping:": {"@type": "xsd:string", "@value": "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"},
-      "nidm_voxelUnits:": {"@type": "xsd:string", "@value": "[\"mm\", \"mm\", \"mm\"]"},
-      "nidm_voxelSize:": {"@type": "xsd:string", "@value": "[2, 2, 2]"},
-      "nidm_inWorldCoordinateSystem:": {"@id": "nidm_Ixi549CoordinateSystem:"},
-      "nidm_numberOfDimensions:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_dimensionsInVoxels:": {"@type": "xsd:string", "@value": "[79,95,79]"}
+      "nidm_voxelToWorldMapping": {"@type": "xsd:string", "@value": "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"},
+      "nidm_voxelUnits": {"@type": "xsd:string", "@value": "[\"mm\", \"mm\", \"mm\"]"},
+      "nidm_voxelSize": {"@type": "xsd:string", "@value": "[2, 2, 2]"},
+      "nidm_inWorldCoordinateSystem": {"@id": "nidm_Ixi549CoordinateSystem"},
+      "nidm_numberOfDimensions": {"@type": "xsd:int", "@value": "3"},
+      "nidm_dimensionsInVoxels": {"@type": "xsd:string", "@value": "[79,95,79]"}
     },
     {
-      "@id": "niiri:d8c388ab3dfea6a7b247c469dae1b1b8",
-      "@type": ["prov:Agent","nlx_Imaginginstrument:","nlx_Magneticresonanceimagingscanner:"],
+      "@id": "niiri:f260b10e486c81130f24499cfffa8499",
+      "@type": ["prov:Agent","nlx_Imaginginstrument","nlx_Magneticresonanceimagingscanner"],
       "rdfs:label": "MRI Scanner"
     },
     {
-      "@id": "niiri:a87734463062b87831df564586eab7fe",
+      "@id": "niiri:445a3d62de6b1fe45f5fbb9742c962fc",
       "@type": ["prov:Agent","prov:Person"],
       "rdfs:label": "Person"
     },
     {
-      "@id": "niiri:caa7ede8420d82834420135a1a9f91f9",
-      "@type": ["prov:Entity","prov:Collection","nidm_Data:"],
+      "@id": "niiri:87f956daaa9073497b8b73a5d7227428",
+      "@type": ["prov:Entity","prov:Collection","nidm_Data"],
       "rdfs:label": "Data",
-      "nidm_grandMeanScaling:": {"@type": "xsd:boolean", "@value": "true"},
-      "nidm_targetIntensity:": {"@type": "xsd:float", "@value": "100"},
-      "nidm_hasMRIProtocol:": {"@id": "nlx_FunctionalMRIprotocol:"}
+      "nidm_grandMeanScaling": {"@type": "xsd:boolean", "@value": "true"},
+      "nidm_targetIntensity": {"@type": "xsd:float", "@value": "100"},
+      "nidm_hasMRIProtocol": {"@id": "nlx_FunctionalMRIprotocol"}
     },
     {
       "@type": "prov:Attribution",
-      "entity_attributed": "niiri:caa7ede8420d82834420135a1a9f91f9",
-      "agent": "niiri:d8c388ab3dfea6a7b247c469dae1b1b8"
+      "entity_attributed": "niiri:87f956daaa9073497b8b73a5d7227428",
+      "agent": "niiri:f260b10e486c81130f24499cfffa8499"
     },
     {
       "@type": "prov:Attribution",
-      "entity_attributed": "niiri:caa7ede8420d82834420135a1a9f91f9",
-      "agent": "niiri:a87734463062b87831df564586eab7fe"
+      "entity_attributed": "niiri:87f956daaa9073497b8b73a5d7227428",
+      "agent": "niiri:445a3d62de6b1fe45f5fbb9742c962fc"
     },
     {
-      "@id": "niiri:9eb0c8cfb97ecd146406dbb1515c9b27",
-      "@type": ["prov:Entity","spm_DCTDriftModel:"],
+      "@id": "niiri:7572230598f6780417a95d7b43f25cc0",
+      "@type": ["prov:Entity","spm_DCTDriftModel"],
       "rdfs:label": "SPM's DCT Drift Model",
-      "spm_SPMsDriftCutoffPeriod:": {"@type": "xsd:float", "@value": "128"}
+      "spm_SPMsDriftCutoffPeriod": {"@type": "xsd:float", "@value": "128"}
     },
     {
-      "@id": "niiri:b4917982e1dece6d418b5ffc48c5a250",
-      "@type": ["prov:Entity","nidm_DesignMatrix:"],
+      "@id": "niiri:d1ec8e870ecb39337f2b3c95137664a8",
+      "@type": ["prov:Entity","nidm_DesignMatrix"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "DesignMatrix.csv"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "DesignMatrix.csv"},
       "dct:format": {"@type": "xsd:string", "@value": "text/csv"},
-      "dc:description": {"@id": "niiri:b363f9617399bf3cdb912b0d40669842"},
+      "dc:description": {"@id": "niiri:def8137d4f6f4767c2f27db070f9ab9c"},
       "rdfs:label": "Design Matrix",
-      "nidm_regressorNames:": {"@type": "xsd:string", "@value": "[\"Sn(1) to*bf(1)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) constant\"]"},
-      "nidm_hasDriftModel:": {"@id": "niiri:9eb0c8cfb97ecd146406dbb1515c9b27"},
-      "nidm_hasHRFBasis:": {"@id": "spm_SPMsCanonicalHRF:"}
+      "nidm_regressorNames": {"@type": "xsd:string", "@value": "[\"Sn(1) to*bf(1)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) constant\"]"},
+      "nidm_hasDriftModel": {"@id": "niiri:7572230598f6780417a95d7b43f25cc0"},
+      "nidm_hasHRFBasis": {"@id": "spm_SPMsCanonicalHRF"}
     },
     {
-      "@id": "niiri:b363f9617399bf3cdb912b0d40669842",
+      "@id": "niiri:def8137d4f6f4767c2f27db070f9ab9c",
       "@type": ["prov:Entity","dctype:Image"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "DesignMatrix.png"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "DesignMatrix.png"},
       "dct:format": {"@type": "xsd:string", "@value": "image/png"}
     },
     {
-      "@id": "niiri:0adb91d96cd65a3ed2384b92ce8f1a20",
-      "@type": ["prov:Entity","nidm_ErrorModel:"],
-      "nidm_hasErrorDistribution:": {"@id": "obo_normaldistribution:"},
-      "nidm_hasErrorDependence:": {"@id": "obo_Toeplitzcovariancestructure:"},
-      "nidm_dependenceMapWiseDependence:": {"@id": "nidm_ConstantParameter:"},
-      "nidm_errorVarianceHomogeneous:": {"@type": "xsd:boolean", "@value": "true"},
-      "nidm_varianceMapWiseDependence:": {"@id": "nidm_IndependentParameter:"}
+      "@id": "niiri:834307fe7ea4f6c3b2e4869cc5c572b5",
+      "@type": ["prov:Entity","nidm_ErrorModel"],
+      "nidm_hasErrorDistribution": {"@id": "obo_normaldistribution"},
+      "nidm_hasErrorDependence": {"@id": "obo_Toeplitzcovariancestructure"},
+      "nidm_dependenceMapWiseDependence": {"@id": "nidm_ConstantParameter"},
+      "nidm_errorVarianceHomogeneous": {"@type": "xsd:boolean", "@value": "true"},
+      "nidm_varianceMapWiseDependence": {"@id": "nidm_IndependentParameter"}
     },
     {
-      "@id": "niiri:7bd41a5b9f6aaf494399fec4584d47fa",
-      "@type": ["prov:Activity","nidm_ModelParametersEstimation:"],
+      "@id": "niiri:77556fccd50035e27041bcd31a9c4d58",
+      "@type": ["prov:Activity","nidm_ModelParametersEstimation"],
       "rdfs:label": "Model parameters estimation",
-      "nidm_withEstimationMethod:": {"@id": "obo_generalizedleastsquaresestimation:"}
+      "nidm_withEstimationMethod": {"@id": "obo_generalizedleastsquaresestimation"}
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:7bd41a5b9f6aaf494399fec4584d47fa",
-      "agent": "niiri:e2a1a9b317b694a52959d155d5af349f"
+      "activity_associated": "niiri:77556fccd50035e27041bcd31a9c4d58",
+      "agent": "niiri:978ecfac61168b631aeb24784516a78c"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:7bd41a5b9f6aaf494399fec4584d47fa",
-      "entity": "niiri:b4917982e1dece6d418b5ffc48c5a250"
+      "activity_using": "niiri:77556fccd50035e27041bcd31a9c4d58",
+      "entity": "niiri:d1ec8e870ecb39337f2b3c95137664a8"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:7bd41a5b9f6aaf494399fec4584d47fa",
-      "entity": "niiri:caa7ede8420d82834420135a1a9f91f9"
+      "activity_using": "niiri:77556fccd50035e27041bcd31a9c4d58",
+      "entity": "niiri:87f956daaa9073497b8b73a5d7227428"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:7bd41a5b9f6aaf494399fec4584d47fa",
-      "entity": "niiri:0adb91d96cd65a3ed2384b92ce8f1a20"
+      "activity_using": "niiri:77556fccd50035e27041bcd31a9c4d58",
+      "entity": "niiri:834307fe7ea4f6c3b2e4869cc5c572b5"
     },
     {
-      "@id": "niiri:65dce2099c092d41e73a7baa0d8ac97a",
-      "@type": ["prov:Entity","nidm_MaskMap:"],
+      "@id": "niiri:ece3cdb35b4a193e1c1a956e1d18a83f",
+      "@type": ["prov:Entity","nidm_MaskMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "Mask.nii.gz"},
-      "nidm_isUserDefined:": {"@type": "xsd:boolean", "@value": "false"},
+      "nidm_isUserDefined": {"@type": "xsd:boolean", "@value": "false"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "Mask.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Mask",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:c2aaa0e17efdb9a83de1fa6bf4a54bc6"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:fb077c2db1c7afee934de729a4c9618d"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876"}
     },
     {
-      "@id": "niiri:c322724a3de2840ebfa0522f3346f269",
-      "@type": ["prov:Entity","nidm_MaskMap:"],
+      "@id": "niiri:d47a652ea52d803eaf61a1440d4ee9a0",
+      "@type": ["prov:Entity","nidm_MaskMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "mask.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "36929e1f5f4143bd9cc818cd896a25f129961fab208c3a4438555f40444c08347b359142ee8c53ece6e8cca1627f49db0788a1fd3b9e2ecaef61999c6c6c67ac"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:65dce2099c092d41e73a7baa0d8ac97a",
-      "entity": "niiri:c322724a3de2840ebfa0522f3346f269"
+      "entity_derived": "niiri:ece3cdb35b4a193e1c1a956e1d18a83f",
+      "entity": "niiri:d47a652ea52d803eaf61a1440d4ee9a0"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:65dce2099c092d41e73a7baa0d8ac97a",
-      "activity": "niiri:7bd41a5b9f6aaf494399fec4584d47fa"
+      "entity_generated": "niiri:ece3cdb35b4a193e1c1a956e1d18a83f",
+      "activity": "niiri:77556fccd50035e27041bcd31a9c4d58"
     },
     {
-      "@id": "niiri:74140559724685d133c8461ff080d4e7",
-      "@type": ["prov:Entity","nidm_GrandMeanMap:"],
+      "@id": "niiri:ba71907eeb2ae78e67e358350ac6e2e4",
+      "@type": ["prov:Entity","nidm_GrandMeanMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "GrandMean.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "GrandMean.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Grand Mean Map",
-      "nidm_maskedMedian:": {"@type": "xsd:float", "@value": "111.557487487793"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:c2aaa0e17efdb9a83de1fa6bf4a54bc6"},
+      "nidm_maskedMedian": {"@type": "xsd:float", "@value": "111.557487487793"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:fb077c2db1c7afee934de729a4c9618d"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "512157cc6bff89d9343a09b4068226eb3edd64a8cbcee861f06231767fae6f8d4819921182adebee083a9bf309afd65529ab04a92f0aa6b0038c8098550f6124"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:74140559724685d133c8461ff080d4e7",
-      "activity": "niiri:7bd41a5b9f6aaf494399fec4584d47fa"
+      "entity_generated": "niiri:ba71907eeb2ae78e67e358350ac6e2e4",
+      "activity": "niiri:77556fccd50035e27041bcd31a9c4d58"
     },
     {
-      "@id": "niiri:8606838a8849d1f202c2dd6bee5673af",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:70a8c763acea17b445f0c2df0fa7cdea",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0001.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0001.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 1",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:c2aaa0e17efdb9a83de1fa6bf4a54bc6"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:fb077c2db1c7afee934de729a4c9618d"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd"}
     },
     {
-      "@id": "niiri:d9369b4849003c0e839297e38d66257c",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:ad407352278e434503a359c1fa3e1a9d",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0001.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8606838a8849d1f202c2dd6bee5673af",
-      "entity": "niiri:d9369b4849003c0e839297e38d66257c"
+      "entity_derived": "niiri:70a8c763acea17b445f0c2df0fa7cdea",
+      "entity": "niiri:ad407352278e434503a359c1fa3e1a9d"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:8606838a8849d1f202c2dd6bee5673af",
-      "activity": "niiri:7bd41a5b9f6aaf494399fec4584d47fa"
+      "entity_generated": "niiri:70a8c763acea17b445f0c2df0fa7cdea",
+      "activity": "niiri:77556fccd50035e27041bcd31a9c4d58"
     },
     {
-      "@id": "niiri:2ef5ffca78be6241588a0eae21bd876c",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:60bd42c7d00085cd0c9e78ca9093dc8d",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0002.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0002.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 2",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:c2aaa0e17efdb9a83de1fa6bf4a54bc6"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:fb077c2db1c7afee934de729a4c9618d"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c"}
     },
     {
-      "@id": "niiri:66739312dad9317758189edf3e520586",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:b30f76932fae67727ecae774f20f5b46",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0002.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2ef5ffca78be6241588a0eae21bd876c",
-      "entity": "niiri:66739312dad9317758189edf3e520586"
+      "entity_derived": "niiri:60bd42c7d00085cd0c9e78ca9093dc8d",
+      "entity": "niiri:b30f76932fae67727ecae774f20f5b46"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:2ef5ffca78be6241588a0eae21bd876c",
-      "activity": "niiri:7bd41a5b9f6aaf494399fec4584d47fa"
+      "entity_generated": "niiri:60bd42c7d00085cd0c9e78ca9093dc8d",
+      "activity": "niiri:77556fccd50035e27041bcd31a9c4d58"
     },
     {
-      "@id": "niiri:0bd2bbc2eac7681c414f17783107f296",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:e3deb37fe68eb835201c5af97c411ff7",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0003.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0003.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 3",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:c2aaa0e17efdb9a83de1fa6bf4a54bc6"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:fb077c2db1c7afee934de729a4c9618d"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373"}
     },
     {
-      "@id": "niiri:674272b909f4e3f3591842780633fdc6",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:ad57dd041b5129b8d2970ceebd686269",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0003.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0bd2bbc2eac7681c414f17783107f296",
-      "entity": "niiri:674272b909f4e3f3591842780633fdc6"
+      "entity_derived": "niiri:e3deb37fe68eb835201c5af97c411ff7",
+      "entity": "niiri:ad57dd041b5129b8d2970ceebd686269"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:0bd2bbc2eac7681c414f17783107f296",
-      "activity": "niiri:7bd41a5b9f6aaf494399fec4584d47fa"
+      "entity_generated": "niiri:e3deb37fe68eb835201c5af97c411ff7",
+      "activity": "niiri:77556fccd50035e27041bcd31a9c4d58"
     },
     {
-      "@id": "niiri:b9c3fba0ca30e15142f4fa3364c8fbd5",
-      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap:"],
+      "@id": "niiri:a0e5946d7d1dd4083af55338b3c2d3c9",
+      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ResidualMeanSquares.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ResidualMeanSquares.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Residual Mean Squares Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:c2aaa0e17efdb9a83de1fa6bf4a54bc6"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:fb077c2db1c7afee934de729a4c9618d"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "991abf563d795a43b1e2eef8643e57023f2e0b090b2031f05f839321fc0643df6f71d423486a1021519b6dc82f6b0f563e19f3fbd50cb16063bed54a0e192d3e"}
     },
     {
-      "@id": "niiri:a27662cb10db077c3577a14c26b9021f",
-      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap:"],
+      "@id": "niiri:1ad97186abe5157f975894f121d5e5f9",
+      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "ResMS.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "40b28d03fcf9a2f60b11f10d7fb83bf3618b234fb5aedf09df644cb7cbb6aab8c9f468897c1078166d455a3d04a83f4e3bf762cfca0b4ea982d7a4e406849f18"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b9c3fba0ca30e15142f4fa3364c8fbd5",
-      "entity": "niiri:a27662cb10db077c3577a14c26b9021f"
+      "entity_derived": "niiri:a0e5946d7d1dd4083af55338b3c2d3c9",
+      "entity": "niiri:1ad97186abe5157f975894f121d5e5f9"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:b9c3fba0ca30e15142f4fa3364c8fbd5",
-      "activity": "niiri:7bd41a5b9f6aaf494399fec4584d47fa"
+      "entity_generated": "niiri:a0e5946d7d1dd4083af55338b3c2d3c9",
+      "activity": "niiri:77556fccd50035e27041bcd31a9c4d58"
     },
     {
-      "@id": "niiri:e9c71f26b021b43b4cecb0f037a24625",
-      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap:"],
+      "@id": "niiri:a0a699bc84151f3770428014d5881784",
+      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ReselsPerVoxel.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ReselsPerVoxel.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Resels per Voxel Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:c2aaa0e17efdb9a83de1fa6bf4a54bc6"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:fb077c2db1c7afee934de729a4c9618d"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "1a3f9216e145249ccc0b14b2bc337d6b38b81ad45e32768001fb22b35f0c2c0f3e2bce013b40c85f7dc0fc62723ac761ee7f7e1e6aff128a05f0ba7b8b8202a3"}
     },
     {
-      "@id": "niiri:538dc6c65e511ac7b3561b0dd78593b0",
-      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap:"],
+      "@id": "niiri:825faee5541a664e02864bcc9e5f7db6",
+      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "RPV.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "4f76663162857f6b38b2a45a63b15a23b2ca8b338c283b69c1e71f2ea2f43797d045a733cd14e845be9c12f8b8f84d3931c599a08e8f6d77e99fab46ad87ab8f"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e9c71f26b021b43b4cecb0f037a24625",
-      "entity": "niiri:538dc6c65e511ac7b3561b0dd78593b0"
+      "entity_derived": "niiri:a0a699bc84151f3770428014d5881784",
+      "entity": "niiri:825faee5541a664e02864bcc9e5f7db6"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:e9c71f26b021b43b4cecb0f037a24625",
-      "activity": "niiri:7bd41a5b9f6aaf494399fec4584d47fa"
+      "entity_generated": "niiri:a0a699bc84151f3770428014d5881784",
+      "activity": "niiri:77556fccd50035e27041bcd31a9c4d58"
     },
     {
-      "@id": "niiri:d6e9d88f26bafd609ebcaeceba4d45dd",
-      "@type": ["prov:Entity","obo_contrastweightmatrix:"],
-      "nidm_statisticType:": {"@id": "obo_tstatistic:"},
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
+      "@id": "niiri:83435a694f0d3952e54da4131150dfc4",
+      "@type": ["prov:Entity","obo_contrastweightmatrix"],
+      "nidm_statisticType": {"@id": "obo_tstatistic"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
       "rdfs:label": "Contrast: tone counting vs baseline",
       "prov:value": {"@type": "xsd:string", "@value": "[1, 0, 0]"}
     },
     {
-      "@id": "niiri:07a3285e23ffce50c6323158116dd224",
-      "@type": ["prov:Activity","nidm_ContrastEstimation:"],
+      "@id": "niiri:8abfa89e769aa3a3b89c1b4bc433cf48",
+      "@type": ["prov:Activity","nidm_ContrastEstimation"],
       "rdfs:label": "Contrast estimation"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:07a3285e23ffce50c6323158116dd224",
-      "agent": "niiri:e2a1a9b317b694a52959d155d5af349f"
+      "activity_associated": "niiri:8abfa89e769aa3a3b89c1b4bc433cf48",
+      "agent": "niiri:978ecfac61168b631aeb24784516a78c"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:07a3285e23ffce50c6323158116dd224",
-      "entity": "niiri:65dce2099c092d41e73a7baa0d8ac97a"
+      "activity_using": "niiri:8abfa89e769aa3a3b89c1b4bc433cf48",
+      "entity": "niiri:ece3cdb35b4a193e1c1a956e1d18a83f"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:07a3285e23ffce50c6323158116dd224",
-      "entity": "niiri:b9c3fba0ca30e15142f4fa3364c8fbd5"
+      "activity_using": "niiri:8abfa89e769aa3a3b89c1b4bc433cf48",
+      "entity": "niiri:a0e5946d7d1dd4083af55338b3c2d3c9"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:07a3285e23ffce50c6323158116dd224",
-      "entity": "niiri:b4917982e1dece6d418b5ffc48c5a250"
+      "activity_using": "niiri:8abfa89e769aa3a3b89c1b4bc433cf48",
+      "entity": "niiri:d1ec8e870ecb39337f2b3c95137664a8"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:07a3285e23ffce50c6323158116dd224",
-      "entity": "niiri:d6e9d88f26bafd609ebcaeceba4d45dd"
+      "activity_using": "niiri:8abfa89e769aa3a3b89c1b4bc433cf48",
+      "entity": "niiri:83435a694f0d3952e54da4131150dfc4"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:07a3285e23ffce50c6323158116dd224",
-      "entity": "niiri:8606838a8849d1f202c2dd6bee5673af"
+      "activity_using": "niiri:8abfa89e769aa3a3b89c1b4bc433cf48",
+      "entity": "niiri:70a8c763acea17b445f0c2df0fa7cdea"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:07a3285e23ffce50c6323158116dd224",
-      "entity": "niiri:2ef5ffca78be6241588a0eae21bd876c"
+      "activity_using": "niiri:8abfa89e769aa3a3b89c1b4bc433cf48",
+      "entity": "niiri:60bd42c7d00085cd0c9e78ca9093dc8d"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:07a3285e23ffce50c6323158116dd224",
-      "entity": "niiri:0bd2bbc2eac7681c414f17783107f296"
+      "activity_using": "niiri:8abfa89e769aa3a3b89c1b4bc433cf48",
+      "entity": "niiri:e3deb37fe68eb835201c5af97c411ff7"
     },
     {
-      "@id": "niiri:cd2388fd62981ea59c5fc9dc434272fa",
-      "@type": ["prov:Entity","nidm_StatisticMap:"],
+      "@id": "niiri:db9345d4e9933a8e4b01bd306e4d1ada",
+      "@type": ["prov:Entity","nidm_StatisticMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "TStatistic.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "TStatistic.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "T-Statistic Map: tone counting vs baseline",
-      "nidm_statisticType:": {"@id": "obo_tstatistic:"},
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
-      "nidm_errorDegreesOfFreedom:": {"@type": "xsd:float", "@value": "97.9999999998522"},
-      "nidm_effectDegreesOfFreedom:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:c2aaa0e17efdb9a83de1fa6bf4a54bc6"},
+      "nidm_statisticType": {"@id": "obo_tstatistic"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
+      "nidm_errorDegreesOfFreedom": {"@type": "xsd:float", "@value": "97.9999999998522"},
+      "nidm_effectDegreesOfFreedom": {"@type": "xsd:float", "@value": "1"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:fb077c2db1c7afee934de729a4c9618d"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "9e1714c2d86a050b38b4e10a4d2d23253a24c5e1d228ae16a9c3be8872739278505ac0729ecab54265a717e3a54f9f782d0ed72eea904e0d482a6072bb817bd4"}
     },
     {
-      "@id": "niiri:8f83bfc8fa762b9560732c11f58cef8b",
-      "@type": ["prov:Entity","nidm_StatisticMap:"],
+      "@id": "niiri:2ae9dd843807c2964f069dac80060045",
+      "@type": ["prov:Entity","nidm_StatisticMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "spmT_0001.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "d288b1b0f117f64502555da13c5398dffa5bf5ff0b58951510e43d5388755bc185798802a92e98a07c7e313c6991066d2908f2a44aa5153ba23433da1335970f"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cd2388fd62981ea59c5fc9dc434272fa",
-      "entity": "niiri:8f83bfc8fa762b9560732c11f58cef8b"
+      "entity_derived": "niiri:db9345d4e9933a8e4b01bd306e4d1ada",
+      "entity": "niiri:2ae9dd843807c2964f069dac80060045"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:cd2388fd62981ea59c5fc9dc434272fa",
-      "activity": "niiri:07a3285e23ffce50c6323158116dd224"
+      "entity_generated": "niiri:db9345d4e9933a8e4b01bd306e4d1ada",
+      "activity": "niiri:8abfa89e769aa3a3b89c1b4bc433cf48"
     },
     {
-      "@id": "niiri:1a78c56343464be12051d5b886a37d11",
-      "@type": ["prov:Entity","nidm_ContrastMap:"],
+      "@id": "niiri:aa2414e92da918a041265bddb4dcdf0d",
+      "@type": ["prov:Entity","nidm_ContrastMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "Contrast.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "Contrast.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Contrast Map: tone counting vs baseline",
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:c2aaa0e17efdb9a83de1fa6bf4a54bc6"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:fb077c2db1c7afee934de729a4c9618d"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "fc5e2ad175243ee496db98f9b2e1b235c4c3bae1a8d7122ce461c897b537e40c49dfee5d6cf20f71c6a2bb9b5f0760fcb4ecd8fe2e9428910ef3d60d8f3c56a9"}
     },
     {
-      "@id": "niiri:4bae6a056ddaf2df7ca8d90787f8e481",
-      "@type": ["prov:Entity","nidm_ContrastMap:"],
+      "@id": "niiri:896ddf9a768ce97fe2d39d3682cde4f2",
+      "@type": ["prov:Entity","nidm_ContrastMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "con_0001.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "d4aa46b3603ba508578e39751262d528cf6d1ed2e722ec46f1cd8194c50591e46b229deb8cb4f72d1b7e0e2640f3e6604be7a335301c5c8357f453e5d0d4daf2"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1a78c56343464be12051d5b886a37d11",
-      "entity": "niiri:4bae6a056ddaf2df7ca8d90787f8e481"
+      "entity_derived": "niiri:aa2414e92da918a041265bddb4dcdf0d",
+      "entity": "niiri:896ddf9a768ce97fe2d39d3682cde4f2"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:1a78c56343464be12051d5b886a37d11",
-      "activity": "niiri:07a3285e23ffce50c6323158116dd224"
+      "entity_generated": "niiri:aa2414e92da918a041265bddb4dcdf0d",
+      "activity": "niiri:8abfa89e769aa3a3b89c1b4bc433cf48"
     },
     {
-      "@id": "niiri:e4a65e58a16c0deb0f489bd70643d3d2",
-      "@type": ["prov:Entity","nidm_ContrastStandardErrorMap:"],
+      "@id": "niiri:1f712c8148d8d15ace4a81b516943032",
+      "@type": ["prov:Entity","nidm_ContrastStandardErrorMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ContrastStandardError.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ContrastStandardError.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Contrast Standard Error Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:c2aaa0e17efdb9a83de1fa6bf4a54bc6"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:fb077c2db1c7afee934de729a4c9618d"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "791d48f5d1adb15079a5289271ce0c4b95c56d69bfdb3e5d41b0d24eb538d3075e1cdd15502494b5a5a18c16eaa2153cb4847a996043fa48cdaf26e938a2576d"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:e4a65e58a16c0deb0f489bd70643d3d2",
-      "activity": "niiri:07a3285e23ffce50c6323158116dd224"
+      "entity_generated": "niiri:1f712c8148d8d15ace4a81b516943032",
+      "activity": "niiri:8abfa89e769aa3a3b89c1b4bc433cf48"
     },
     {
-      "@id": "niiri:083b72805718136d80959aba1322a458",
-      "@type": ["prov:Entity","nidm_HeightThreshold:","nidm_PValueUncorrected:"],
-      "rdfs:label": "Height Threshold: p<0.001000 (unc.)",
+      "@id": "niiri:0913319d344f1fdba3d922a2dfae4612",
+      "@type": ["prov:Entity","nidm_HeightThreshold","nidm_PValueUncorrected"],
+      "rdfs:label": "Height Threshold: p<0.001 (unc.)",
       "prov:value": {"@type": "xsd:float", "@value": "0.000999500158000544"},
-      "nidm_equivalentThreshold:": [{"@id": "niiri:a779e6f7de8242e20b26241926456cdf"},{"@id": "niiri:f1f6c273077ac68ef3da270edc9de95d"}]
+      "nidm_equivalentThreshold": [{"@id": "niiri:013b7be5dd7ca8fbb3d35355e8b4f3aa"},{"@id": "niiri:4e8b898c9c0affa831a9bdb84c970721"}]
     },
     {
-      "@id": "niiri:a779e6f7de8242e20b26241926456cdf",
-      "@type": ["prov:Entity","nidm_HeightThreshold:","obo_statistic:"],
-      "rdfs:label": "Height Threshold",
+      "@id": "niiri:013b7be5dd7ca8fbb3d35355e8b4f3aa",
+      "@type": ["prov:Entity","nidm_HeightThreshold","obo_statistic"],
+      "rdfs:label": "Height Threshold: T=3.175486)",
       "prov:value": {"@type": "xsd:float", "@value": "3.17548628637284"}
     },
     {
-      "@id": "niiri:f1f6c273077ac68ef3da270edc9de95d",
-      "@type": ["prov:Entity","nidm_HeightThreshold:","obo_FWERadjustedpvalue:"],
-      "rdfs:label": "Height Threshold",
+      "@id": "niiri:4e8b898c9c0affa831a9bdb84c970721",
+      "@type": ["prov:Entity","nidm_HeightThreshold","obo_FWERadjustedpvalue"],
+      "rdfs:label": "Height Threshold: p<1.000000 (FWE)",
       "prov:value": {"@type": "xsd:float", "@value": "0.999999999999997"}
     },
     {
-      "@id": "niiri:b7d55931ab8bfe4177e0cf74b1e0723e",
-      "@type": ["prov:Entity","nidm_ExtentThreshold:","obo_statistic:"],
+      "@id": "niiri:38c63862d3fa4aeb37b16674898b17d0",
+      "@type": ["prov:Entity","nidm_ExtentThreshold","obo_statistic"],
       "rdfs:label": "Extent Threshold: k>=116",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "116"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.7688671224263"},
-      "nidm_equivalentThreshold:": [{"@id": "niiri:838f6eb43feddd98af244131c1f8d7d7"},{"@id": "niiri:63a864518e9ad6f0b8d693580e7697a6"}]
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "116"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.7688671224263"},
+      "nidm_equivalentThreshold": [{"@id": "niiri:2722fd44f9e7d6b1c6f50c721ba5e19b"},{"@id": "niiri:0b8fed5ea39b873139620e7b43513466"}]
     },
     {
-      "@id": "niiri:838f6eb43feddd98af244131c1f8d7d7",
-      "@type": ["prov:Entity","nidm_ExtentThreshold:","obo_FWERadjustedpvalue:"],
+      "@id": "niiri:2722fd44f9e7d6b1c6f50c721ba5e19b",
+      "@type": ["prov:Entity","nidm_ExtentThreshold","obo_FWERadjustedpvalue"],
       "rdfs:label": "Extent Threshold",
       "prov:value": {"@type": "xsd:float", "@value": "0.0150888416289883"}
     },
     {
-      "@id": "niiri:63a864518e9ad6f0b8d693580e7697a6",
-      "@type": ["prov:Entity","nidm_ExtentThreshold:","nidm_PValueUncorrected:"],
+      "@id": "niiri:0b8fed5ea39b873139620e7b43513466",
+      "@type": ["prov:Entity","nidm_ExtentThreshold","nidm_PValueUncorrected"],
       "rdfs:label": "Extent Threshold",
       "prov:value": {"@type": "xsd:float", "@value": "0.000452977534465859"}
     },
     {
-      "@id": "niiri:2e789eb634bf515dca3c74e028484eda",
-      "@type": ["prov:Entity","nidm_PeakDefinitionCriteria:"],
+      "@id": "niiri:ded58d3d760e7c562c993612ce5bdbb0",
+      "@type": ["prov:Entity","nidm_PeakDefinitionCriteria"],
       "rdfs:label": "Peak Definition Criteria",
-      "nidm_maxNumberOfPeaksPerCluster:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_minDistanceBetweenPeaks:": {"@type": "xsd:float", "@value": "8"}
+      "nidm_maxNumberOfPeaksPerCluster": {"@type": "xsd:int", "@value": "3"},
+      "nidm_minDistanceBetweenPeaks": {"@type": "xsd:float", "@value": "8"}
     },
     {
-      "@id": "niiri:0cd070cb2241c08895462ab4099a104a",
-      "@type": ["prov:Entity","nidm_ClusterDefinitionCriteria:"],
+      "@id": "niiri:c3a4c242421f98d32ff2ef9357eb073e",
+      "@type": ["prov:Entity","nidm_ClusterDefinitionCriteria"],
       "rdfs:label": "Cluster Connectivity Criterion: 18",
-      "nidm_hasConnectivityCriterion:": {"@id": "nidm_voxel18connected:"}
+      "nidm_hasConnectivityCriterion": {"@id": "nidm_voxel18connected"}
     },
     {
-      "@id": "niiri:983041cba08acd2140526edea30a630f",
-      "@type": ["prov:Activity","nidm_Inference:"],
-      "nidm_hasAlternativeHypothesis:": {"@id": "nidm_OneTailedTest:"},
+      "@id": "niiri:22f75f4eb883a33606785984a05451e3",
+      "@type": ["prov:Activity","nidm_Inference"],
+      "nidm_hasAlternativeHypothesis": {"@id": "nidm_OneTailedTest"},
       "rdfs:label": "Inference"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:983041cba08acd2140526edea30a630f",
-      "agent": "niiri:e2a1a9b317b694a52959d155d5af349f"
+      "activity_associated": "niiri:22f75f4eb883a33606785984a05451e3",
+      "agent": "niiri:978ecfac61168b631aeb24784516a78c"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:983041cba08acd2140526edea30a630f",
-      "entity": "niiri:083b72805718136d80959aba1322a458"
+      "activity_using": "niiri:22f75f4eb883a33606785984a05451e3",
+      "entity": "niiri:0913319d344f1fdba3d922a2dfae4612"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:983041cba08acd2140526edea30a630f",
-      "entity": "niiri:b7d55931ab8bfe4177e0cf74b1e0723e"
+      "activity_using": "niiri:22f75f4eb883a33606785984a05451e3",
+      "entity": "niiri:38c63862d3fa4aeb37b16674898b17d0"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:983041cba08acd2140526edea30a630f",
-      "entity": "niiri:cd2388fd62981ea59c5fc9dc434272fa"
+      "activity_using": "niiri:22f75f4eb883a33606785984a05451e3",
+      "entity": "niiri:db9345d4e9933a8e4b01bd306e4d1ada"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:983041cba08acd2140526edea30a630f",
-      "entity": "niiri:e9c71f26b021b43b4cecb0f037a24625"
+      "activity_using": "niiri:22f75f4eb883a33606785984a05451e3",
+      "entity": "niiri:a0a699bc84151f3770428014d5881784"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:983041cba08acd2140526edea30a630f",
-      "entity": "niiri:65dce2099c092d41e73a7baa0d8ac97a"
+      "activity_using": "niiri:22f75f4eb883a33606785984a05451e3",
+      "entity": "niiri:ece3cdb35b4a193e1c1a956e1d18a83f"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:983041cba08acd2140526edea30a630f",
-      "entity": "niiri:2e789eb634bf515dca3c74e028484eda"
+      "activity_using": "niiri:22f75f4eb883a33606785984a05451e3",
+      "entity": "niiri:ded58d3d760e7c562c993612ce5bdbb0"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:983041cba08acd2140526edea30a630f",
-      "entity": "niiri:0cd070cb2241c08895462ab4099a104a"
+      "activity_using": "niiri:22f75f4eb883a33606785984a05451e3",
+      "entity": "niiri:c3a4c242421f98d32ff2ef9357eb073e"
     },
     {
-      "@id": "niiri:f1112f069407bf10806649b7fc8972f6",
-      "@type": ["prov:Entity","nidm_SearchSpaceMaskMap:"],
+      "@id": "niiri:b5be02643f367e1e1ed18da1e913b142",
+      "@type": ["prov:Entity","nidm_SearchSpaceMaskMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "SearchSpaceMask.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "SearchSpaceMask.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Search Space Mask Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:c2aaa0e17efdb9a83de1fa6bf4a54bc6"},
-      "nidm_searchVolumeInVoxels:": {"@type": "xsd:int", "@value": "223057"},
-      "nidm_searchVolumeInUnits:": {"@type": "xsd:float", "@value": "1784456"},
-      "nidm_reselSizeInVoxels:": {"@type": "xsd:float", "@value": "65.5786964036542"},
-      "nidm_searchVolumeInResels:": {"@type": "xsd:float", "@value": "3155.84193266257"},
-      "spm_searchVolumeReselsGeometry:": {"@type": "xsd:string", "@value": "[6, 97.8140592306853, 965.938819261507, 3155.84193266257]"},
-      "nidm_noiseFWHMInVoxels:": {"@type": "xsd:string", "@value": "[4.09118640605185, 4.0346308705955, 3.97291894351243]"},
-      "nidm_noiseFWHMInUnits:": {"@type": "xsd:string", "@value": "[8.18237281210369, 8.069261741191, 7.94583788702486]"},
-      "nidm_randomFieldStationarity:": {"@type": "xsd:boolean", "@value": "true"},
-      "nidm_expectedNumberOfVoxelsPerCluster:": {"@type": "xsd:float", "@value": "7.21748994812991"},
-      "nidm_expectedNumberOfClusters:": {"@type": "xsd:float", "@value": "0.0152038364250172"},
-      "nidm_heightCriticalThresholdFWE05:": {"@type": "xsd:float", "@value": "5.30963135104407"},
-      "nidm_heightCriticalThresholdFDR05:": {"@type": "xsd:float", "@value": "4.69981384277344"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:fb077c2db1c7afee934de729a4c9618d"},
+      "nidm_searchVolumeInVoxels": {"@type": "xsd:int", "@value": "223057"},
+      "nidm_searchVolumeInUnits": {"@type": "xsd:float", "@value": "1784456"},
+      "nidm_reselSizeInVoxels": {"@type": "xsd:float", "@value": "65.5786964036542"},
+      "nidm_searchVolumeInResels": {"@type": "xsd:float", "@value": "3155.84193266257"},
+      "spm_searchVolumeReselsGeometry": {"@type": "xsd:string", "@value": "[6, 97.8140592306853, 965.938819261507, 3155.84193266257]"},
+      "nidm_noiseFWHMInVoxels": {"@type": "xsd:string", "@value": "[4.09118640605185, 4.0346308705955, 3.97291894351243]"},
+      "nidm_noiseFWHMInUnits": {"@type": "xsd:string", "@value": "[8.18237281210369, 8.069261741191, 7.94583788702486]"},
+      "nidm_randomFieldStationarity": {"@type": "xsd:boolean", "@value": "true"},
+      "nidm_expectedNumberOfVoxelsPerCluster": {"@type": "xsd:float", "@value": "7.21748994812991"},
+      "nidm_expectedNumberOfClusters": {"@type": "xsd:float", "@value": "0.0152038364250172"},
+      "nidm_heightCriticalThresholdFWE05": {"@type": "xsd:float", "@value": "5.30963135104407"},
+      "nidm_heightCriticalThresholdFDR05": {"@type": "xsd:float", "@value": "4.69981384277344"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876"},
-      "spm_smallestSignificantClusterSizeInVoxelsFWE05:": {"@type": "xsd:int", "@value": "116"},
-      "spm_smallestSignificantClusterSizeInVoxelsFDR05:": {"@type": "xsd:int", "@value": "61"}
+      "spm_smallestSignificantClusterSizeInVoxelsFWE05": {"@type": "xsd:int", "@value": "116"},
+      "spm_smallestSignificantClusterSizeInVoxelsFDR05": {"@type": "xsd:int", "@value": "61"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:f1112f069407bf10806649b7fc8972f6",
-      "activity": "niiri:983041cba08acd2140526edea30a630f"
+      "entity_generated": "niiri:b5be02643f367e1e1ed18da1e913b142",
+      "activity": "niiri:22f75f4eb883a33606785984a05451e3"
     },
     {
-      "@id": "niiri:35dcf56589dc3d231a39fb382f513f5c",
-      "@type": ["prov:Entity","nidm_ExcursionSetMap:"],
+      "@id": "niiri:e1e17399f999e1f91dc21c7b68dbdf0b",
+      "@type": ["prov:Entity","nidm_ExcursionSetMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ExcursionSet.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ExcursionSet.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Excursion Set Map",
-      "nidm_numberOfSupraThresholdClusters:": {"@type": "xsd:int", "@value": "10"},
-      "nidm_pValue:": {"@type": "xsd:float", "@value": "0"},
-      "nidm_hasClusterLabelsMap:": {"@id": "niiri:28823f4a150c3ca742456112f89d6b21"},
-      "nidm_hasMaximumIntensityProjection:": {"@id": "niiri:94acb04492ae25a9ab2d34ba609d3090"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:c2aaa0e17efdb9a83de1fa6bf4a54bc6"},
+      "nidm_numberOfSupraThresholdClusters": {"@type": "xsd:int", "@value": "10"},
+      "nidm_pValue": {"@type": "xsd:float", "@value": "0"},
+      "nidm_hasClusterLabelsMap": {"@id": "niiri:914772f2d1711625ae963abf3b3ae8b4"},
+      "nidm_hasMaximumIntensityProjection": {"@id": "niiri:475e9458d2df603def75554bb36f93a9"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:fb077c2db1c7afee934de729a4c9618d"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "ba4f79758d41b7104bbd0f688aaa433cf258e1254cfd9e6de5e6c2c4bacacc9be392e9d7a3954c1f9db7a7a5fd6ecc6e3336fcec30eddc434de3c0c86dfe8562"}
     },
     {
-      "@id": "niiri:28823f4a150c3ca742456112f89d6b21",
-      "@type": ["prov:Entity","nidm_ClusterLabelsMap:"],
+      "@id": "niiri:914772f2d1711625ae963abf3b3ae8b4",
+      "@type": ["prov:Entity","nidm_ClusterLabelsMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ClusterLabels.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ClusterLabels.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Cluster Labels Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:c2aaa0e17efdb9a83de1fa6bf4a54bc6"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:fb077c2db1c7afee934de729a4c9618d"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "db5a86bea3707aaf8380866c8431e2ebc0c1c822c57ceaf420a53b3311ec38101478c53bac8ecc4c1915427e495415c63cd023fc663e89a7387b705998afdf00"}
     },
     {
-      "@id": "niiri:94acb04492ae25a9ab2d34ba609d3090",
+      "@id": "niiri:475e9458d2df603def75554bb36f93a9",
       "@type": ["prov:Entity","dctype:Image"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "MaximumIntensityProjection.png"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "MaximumIntensityProjection.png"},
@@ -731,740 +731,740 @@
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:35dcf56589dc3d231a39fb382f513f5c",
-      "activity": "niiri:983041cba08acd2140526edea30a630f"
+      "entity_generated": "niiri:e1e17399f999e1f91dc21c7b68dbdf0b",
+      "activity": "niiri:22f75f4eb883a33606785984a05451e3"
     },
     {
-      "@id": "niiri:289f6a571b6c05659e38c60824b6ae97",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:9dd5e0cba75bc4a093eb61cbd76e36a6",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0001",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1804"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "27.5089335246298"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.46511379022666e-21"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "5.93371085041799e-20"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "1"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1804"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "27.5089335246298"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.46511379022666e-21"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "5.93371085041799e-20"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "1"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:289f6a571b6c05659e38c60824b6ae97",
-      "entity": "niiri:35dcf56589dc3d231a39fb382f513f5c"
+      "entity_derived": "niiri:9dd5e0cba75bc4a093eb61cbd76e36a6",
+      "entity": "niiri:e1e17399f999e1f91dc21c7b68dbdf0b"
     },
     {
-      "@id": "niiri:6eeb37a8bd0a4838f61862b04a99c5db",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:29f39b3a7ffc8526221cbb764dc91ed6",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0002",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "356"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "5.42859220330831"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.6728855149243e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "2.91098190852157e-06"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1.17083954451478e-06"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "2"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "356"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "5.42859220330831"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.6728855149243e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "2.91098190852157e-06"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1.17083954451478e-06"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "2"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6eeb37a8bd0a4838f61862b04a99c5db",
-      "entity": "niiri:35dcf56589dc3d231a39fb382f513f5c"
+      "entity_derived": "niiri:29f39b3a7ffc8526221cbb764dc91ed6",
+      "entity": "niiri:e1e17399f999e1f91dc21c7b68dbdf0b"
     },
     {
-      "@id": "niiri:2d4d8819babe3ddacdf0557e9803d3c3",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:9119b99e73e7caf27ccbc46b71a20fe2",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0003",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "5090"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "77.6166694237059"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.51031151932561e-42"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "2.03335233065374e-40"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "3"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "5090"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "77.6166694237059"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.51031151932561e-42"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "2.03335233065374e-40"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "3"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2d4d8819babe3ddacdf0557e9803d3c3",
-      "entity": "niiri:35dcf56589dc3d231a39fb382f513f5c"
+      "entity_derived": "niiri:9119b99e73e7caf27ccbc46b71a20fe2",
+      "entity": "niiri:e1e17399f999e1f91dc21c7b68dbdf0b"
     },
     {
-      "@id": "niiri:7ef5339838ce0f10390b275732bf42b1",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:5a140c712e9e00e14ac695343ed92c6a",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0004",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "766"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "11.6806225498151"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.69891112070838e-12"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "5.70226088569825e-11"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "4.58706002591263e-11"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "4"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "766"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "11.6806225498151"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.69891112070838e-12"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "5.70226088569825e-11"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "4.58706002591263e-11"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "4"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7ef5339838ce0f10390b275732bf42b1",
-      "entity": "niiri:35dcf56589dc3d231a39fb382f513f5c"
+      "entity_derived": "niiri:5a140c712e9e00e14ac695343ed92c6a",
+      "entity": "niiri:e1e17399f999e1f91dc21c7b68dbdf0b"
     },
     {
-      "@id": "niiri:b86df2eebd66ba5883ad7b57360dd393",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:1b0ec2e914c1e26ce0156061bea8ec55",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0005",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "285"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "4.34592353354738"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.15539697056139e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "2.73725770201239e-05"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "9.4369593516496e-06"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "5"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "285"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "4.34592353354738"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.15539697056139e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "2.73725770201239e-05"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "9.4369593516496e-06"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "5"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b86df2eebd66ba5883ad7b57360dd393",
-      "entity": "niiri:35dcf56589dc3d231a39fb382f513f5c"
+      "entity_derived": "niiri:1b0ec2e914c1e26ce0156061bea8ec55",
+      "entity": "niiri:e1e17399f999e1f91dc21c7b68dbdf0b"
     },
     {
-      "@id": "niiri:c61079d69888f267f17faecfe84c9ce8",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f6128a48e628339748454f9195fb4b90",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0006",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "395"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "6.02329752895164"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.70020762554596e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "9.06303145864484e-07"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "4.37433635338446e-07"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "6"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "395"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "6.02329752895164"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.70020762554596e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "9.06303145864484e-07"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "4.37433635338446e-07"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "6"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c61079d69888f267f17faecfe84c9ce8",
-      "entity": "niiri:35dcf56589dc3d231a39fb382f513f5c"
+      "entity_derived": "niiri:f6128a48e628339748454f9195fb4b90",
+      "entity": "niiri:e1e17399f999e1f91dc21c7b68dbdf0b"
     },
     {
-      "@id": "niiri:cd22280b374ae77e13e4c8e1b578cd1d",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:16996fcb45118225812852d29f9f9a73",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0007",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "116"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.7688671224263"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000452977534465859"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0150888416289883"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00366911802917346"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "7"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "116"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.7688671224263"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000452977534465859"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0150888416289883"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00366911802917346"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "7"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cd22280b374ae77e13e4c8e1b578cd1d",
-      "entity": "niiri:35dcf56589dc3d231a39fb382f513f5c"
+      "entity_derived": "niiri:16996fcb45118225812852d29f9f9a73",
+      "entity": "niiri:e1e17399f999e1f91dc21c7b68dbdf0b"
     },
     {
-      "@id": "niiri:a8c21f93ea05f237f1d5a4f475ee2545",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:b374b0b364537d85069da6781ed3bce7",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0008",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "447"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "6.81623796314274"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.03851586308171e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "2.02678038352389e-07"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1.22279946227405e-07"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "8"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "447"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "6.81623796314274"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.03851586308171e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "2.02678038352389e-07"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1.22279946227405e-07"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "8"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a8c21f93ea05f237f1d5a4f475ee2545",
-      "entity": "niiri:35dcf56589dc3d231a39fb382f513f5c"
+      "entity_derived": "niiri:b374b0b364537d85069da6781ed3bce7",
+      "entity": "niiri:e1e17399f999e1f91dc21c7b68dbdf0b"
     },
     {
-      "@id": "niiri:6f51b281dc4706f206736c798a91ba30",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:47eda65cfe1f349741bbd56fa3361233",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0009",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "162"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "2.47031442959535"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.63852466674842e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00222568832297587"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000672150622508277"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "9"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "162"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "2.47031442959535"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.63852466674842e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00222568832297587"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000672150622508277"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "9"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6f51b281dc4706f206736c798a91ba30",
-      "entity": "niiri:35dcf56589dc3d231a39fb382f513f5c"
+      "entity_derived": "niiri:47eda65cfe1f349741bbd56fa3361233",
+      "entity": "niiri:e1e17399f999e1f91dc21c7b68dbdf0b"
     },
     {
-      "@id": "niiri:c25a8cb898d061e65d3970120b76fad9",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:8235aa92a4300c6c7e12d8fb288e2e09",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0010",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "134"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "2.04334650349245"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000208225307159483"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00696455376757865"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00187402776443535"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "10"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "134"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "2.04334650349245"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000208225307159483"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00696455376757865"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00187402776443535"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "10"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c25a8cb898d061e65d3970120b76fad9",
-      "entity": "niiri:35dcf56589dc3d231a39fb382f513f5c"
+      "entity_derived": "niiri:8235aa92a4300c6c7e12d8fb288e2e09",
+      "entity": "niiri:e1e17399f999e1f91dc21c7b68dbdf0b"
     },
     {
-      "@id": "niiri:69e74743cffc3b5ec4410d25d73e3b94",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:219af4d66e697f49e07199776077e216",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0001",
-      "prov:atLocation": {"@id": "niiri:6d28bb2eee84f65b03e234c9b7495869"},
+      "prov:atLocation": {"@id": "niiri:2aab79258a69f0db7f63751d429ec6e0"},
       "prov:value": {"@type": "xsd:float", "@value": "7.92007970809937"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "6.94608360738412"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.87783122385099e-12"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "4.18813870695089e-07"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "5.21674435923017e-06"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "6.94608360738412"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.87783122385099e-12"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "4.18813870695089e-07"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "5.21674435923017e-06"}
     },
     {
-      "@id": "niiri:6d28bb2eee84f65b03e234c9b7495869",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:2aab79258a69f0db7f63751d429ec6e0",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0001",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[46,16,24]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[46,16,24]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:69e74743cffc3b5ec4410d25d73e3b94",
-      "entity": "niiri:289f6a571b6c05659e38c60824b6ae97"
+      "entity_derived": "niiri:219af4d66e697f49e07199776077e216",
+      "entity": "niiri:9dd5e0cba75bc4a093eb61cbd76e36a6"
     },
     {
-      "@id": "niiri:050068d6e5c8af1000f8c84aebda8cef",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ea59d816b162d773d020ce2c78fe6579",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0002",
-      "prov:atLocation": {"@id": "niiri:dd72798cd5d4aed5ebf240342a39bc03"},
+      "prov:atLocation": {"@id": "niiri:3a14839f82a10251f5ca1ac1e6ab0a84"},
       "prov:value": {"@type": "xsd:float", "@value": "6.31603479385376"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.77079466112137"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.94492849498107e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.000879943865776389"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000830722551601523"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.77079466112137"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.94492849498107e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.000879943865776389"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000830722551601523"}
     },
     {
-      "@id": "niiri:dd72798cd5d4aed5ebf240342a39bc03",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:3a14839f82a10251f5ca1ac1e6ab0a84",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0002",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[32,24,-4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[32,24,-4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:050068d6e5c8af1000f8c84aebda8cef",
-      "entity": "niiri:289f6a571b6c05659e38c60824b6ae97"
+      "entity_derived": "niiri:ea59d816b162d773d020ce2c78fe6579",
+      "entity": "niiri:9dd5e0cba75bc4a093eb61cbd76e36a6"
     },
     {
-      "@id": "niiri:8d6269a374249b42955a5ae090f66fa7",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:9f9284ea2fb3b52c1c958913ea07adc6",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0003",
-      "prov:atLocation": {"@id": "niiri:593aa23dd8068eb354899d7c9a4781e1"},
+      "prov:atLocation": {"@id": "niiri:a3ff3ba6e003adbe983a538a39e41e7d"},
       "prov:value": {"@type": "xsd:float", "@value": "5.68819808959961"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.27450168515333"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.655864770444e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0121028975026269"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00350091530962783"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.27450168515333"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.655864770444e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0121028975026269"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00350091530962783"}
     },
     {
-      "@id": "niiri:593aa23dd8068eb354899d7c9a4781e1",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a3ff3ba6e003adbe983a538a39e41e7d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0003",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[18,16,4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[18,16,4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8d6269a374249b42955a5ae090f66fa7",
-      "entity": "niiri:289f6a571b6c05659e38c60824b6ae97"
+      "entity_derived": "niiri:9f9284ea2fb3b52c1c958913ea07adc6",
+      "entity": "niiri:9dd5e0cba75bc4a093eb61cbd76e36a6"
     },
     {
-      "@id": "niiri:fc9d3df843cacae41ecbc8915a362442",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:944bc30a544eea31480b7ce73c7de33e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0004",
-      "prov:atLocation": {"@id": "niiri:1725b3da3aa9b2aecba33b2e6b3fb35f"},
+      "prov:atLocation": {"@id": "niiri:1663962b579598837b549cce2fe973e6"},
       "prov:value": {"@type": "xsd:float", "@value": "7.11683940887451"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "6.37404871703245"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "9.20510334623259e-11"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "2.05325778424026e-05"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "9.33757664730496e-05"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "6.37404871703245"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "9.20510334623259e-11"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "2.05325778424026e-05"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "9.33757664730496e-05"}
     },
     {
-      "@id": "niiri:1725b3da3aa9b2aecba33b2e6b3fb35f",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:1663962b579598837b549cce2fe973e6",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0004",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[34,-88,-2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[34,-88,-2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:fc9d3df843cacae41ecbc8915a362442",
-      "entity": "niiri:6eeb37a8bd0a4838f61862b04a99c5db"
+      "entity_derived": "niiri:944bc30a544eea31480b7ce73c7de33e",
+      "entity": "niiri:29f39b3a7ffc8526221cbb764dc91ed6"
     },
     {
-      "@id": "niiri:07140cdcb12d2a506ba71eee8cd03e9e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:2c9d4a11c4fa1759dc1470cf7bbdc2d0",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0005",
-      "prov:atLocation": {"@id": "niiri:bba10cf867e5830bfdd6d8799ee7d1b2"},
+      "prov:atLocation": {"@id": "niiri:393bdeddfa8315a2909d86e9748639c6"},
       "prov:value": {"@type": "xsd:float", "@value": "6.48292255401611"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.8992593141605"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.82568493656277e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.000407231755366277"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000830722551601523"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.8992593141605"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.82568493656277e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.000407231755366277"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000830722551601523"}
     },
     {
-      "@id": "niiri:bba10cf867e5830bfdd6d8799ee7d1b2",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:393bdeddfa8315a2909d86e9748639c6",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0005",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[42,-72,-10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[42,-72,-10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:07140cdcb12d2a506ba71eee8cd03e9e",
-      "entity": "niiri:6eeb37a8bd0a4838f61862b04a99c5db"
+      "entity_derived": "niiri:2c9d4a11c4fa1759dc1470cf7bbdc2d0",
+      "entity": "niiri:29f39b3a7ffc8526221cbb764dc91ed6"
     },
     {
-      "@id": "niiri:15bbc7641c21f7110c1d271381ce2ebf",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:acc8196a4273a3c86f5676b2bc4a6016",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0006",
-      "prov:atLocation": {"@id": "niiri:d88536fec80f63d44d6f51376744d754"},
+      "prov:atLocation": {"@id": "niiri:d0c9e40fb953987b03f13aa2c7c6b34b"},
       "prov:value": {"@type": "xsd:float", "@value": "5.2275915145874"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.89738468004472"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.85602978606003e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0670610253017228"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0118363293065346"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.89738468004472"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.85602978606003e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0670610253017228"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0118363293065346"}
     },
     {
-      "@id": "niiri:d88536fec80f63d44d6f51376744d754",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d0c9e40fb953987b03f13aa2c7c6b34b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0006",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[34,-86,12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[34,-86,12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:15bbc7641c21f7110c1d271381ce2ebf",
-      "entity": "niiri:6eeb37a8bd0a4838f61862b04a99c5db"
+      "entity_derived": "niiri:acc8196a4273a3c86f5676b2bc4a6016",
+      "entity": "niiri:29f39b3a7ffc8526221cbb764dc91ed6"
     },
     {
-      "@id": "niiri:7d77c66bcf5fcc2b35231d36f9453c56",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:8d391d27c7d45276c852a9406623c60f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0007",
-      "prov:atLocation": {"@id": "niiri:aa6ccaf4c49dac1b198a2a4435c40d8d"},
+      "prov:atLocation": {"@id": "niiri:ddaec90e4d0de561cdc7f6e01e38a5d2"},
       "prov:value": {"@type": "xsd:float", "@value": "6.28007745742798"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.74292583422276"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.65272453897825e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00103782272796227"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000830722551601523"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.74292583422276"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.65272453897825e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00103782272796227"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000830722551601523"}
     },
     {
-      "@id": "niiri:aa6ccaf4c49dac1b198a2a4435c40d8d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ddaec90e4d0de561cdc7f6e01e38a5d2",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0007",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[8,18,50]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[8,18,50]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7d77c66bcf5fcc2b35231d36f9453c56",
-      "entity": "niiri:2d4d8819babe3ddacdf0557e9803d3c3"
+      "entity_derived": "niiri:8d391d27c7d45276c852a9406623c60f",
+      "entity": "niiri:9119b99e73e7caf27ccbc46b71a20fe2"
     },
     {
-      "@id": "niiri:96ec5f9698442df720b453b98513381d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:6725f4fbe7aeb3714270626b873a4445",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0008",
-      "prov:atLocation": {"@id": "niiri:697006dfe9da91de0ef29f0318be3d05"},
+      "prov:atLocation": {"@id": "niiri:03947289df407f4dfaee992081ab79d1"},
       "prov:value": {"@type": "xsd:float", "@value": "6.15222215652466"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.64328512810061"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.34178537356678e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00186069357054308"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000972721201433817"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.64328512810061"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.34178537356678e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00186069357054308"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000972721201433817"}
     },
     {
-      "@id": "niiri:697006dfe9da91de0ef29f0318be3d05",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:03947289df407f4dfaee992081ab79d1",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0008",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-6,12,52]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-6,12,52]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:96ec5f9698442df720b453b98513381d",
-      "entity": "niiri:2d4d8819babe3ddacdf0557e9803d3c3"
+      "entity_derived": "niiri:6725f4fbe7aeb3714270626b873a4445",
+      "entity": "niiri:9119b99e73e7caf27ccbc46b71a20fe2"
     },
     {
-      "@id": "niiri:86835c30b47236c8759a822248ae1a7b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:430a862ed862cdb51f3527d8fa8754fd",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0009",
-      "prov:atLocation": {"@id": "niiri:42180e23ca90aa10eea3fdab9e906838"},
+      "prov:atLocation": {"@id": "niiri:b6f52d40cc25ee4d9e2e660bf01ffdcc"},
       "prov:value": {"@type": "xsd:float", "@value": "5.98517084121704"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.51181334779297"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.77577724747024e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00376326218366319"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00136419627856355"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.51181334779297"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.77577724747024e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00376326218366319"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00136419627856355"}
     },
     {
-      "@id": "niiri:42180e23ca90aa10eea3fdab9e906838",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b6f52d40cc25ee4d9e2e660bf01ffdcc",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0009",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[8,32,38]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[8,32,38]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:86835c30b47236c8759a822248ae1a7b",
-      "entity": "niiri:2d4d8819babe3ddacdf0557e9803d3c3"
+      "entity_derived": "niiri:430a862ed862cdb51f3527d8fa8754fd",
+      "entity": "niiri:9119b99e73e7caf27ccbc46b71a20fe2"
     },
     {
-      "@id": "niiri:740c29df2fbcd574a6da91c82fc0e324",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b05bca128b30571198c9e6e1d9341331",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0010",
-      "prov:atLocation": {"@id": "niiri:6bbf41234fc8a6d22a0231ea4a73e47b"},
+      "prov:atLocation": {"@id": "niiri:9f7c92dff8010e9bb8d470367995d0e6"},
       "prov:value": {"@type": "xsd:float", "@value": "6.25127363204956"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.72055271981637"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.30890376104765e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0011841880966994"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000830722551601523"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.72055271981637"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.30890376104765e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0011841880966994"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000830722551601523"}
     },
     {
-      "@id": "niiri:6bbf41234fc8a6d22a0231ea4a73e47b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:9f7c92dff8010e9bb8d470367995d0e6",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0010",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[52,-32,42]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[52,-32,42]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:740c29df2fbcd574a6da91c82fc0e324",
-      "entity": "niiri:7ef5339838ce0f10390b275732bf42b1"
+      "entity_derived": "niiri:b05bca128b30571198c9e6e1d9341331",
+      "entity": "niiri:5a140c712e9e00e14ac695343ed92c6a"
     },
     {
-      "@id": "niiri:25717939f6bc521501b6bea98f9921a0",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:83f14a358618817c9a4a6a55d65d9d48",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0011",
-      "prov:atLocation": {"@id": "niiri:83280c58f4d4a8ee4edfa739d3ac75b9"},
+      "prov:atLocation": {"@id": "niiri:eccc7ce308baf5cc0394b6c8e559a22d"},
       "prov:value": {"@type": "xsd:float", "@value": "6.24752378463745"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.71763687476157"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.40078304300806e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00120468241369565"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000830722551601523"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.71763687476157"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.40078304300806e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00120468241369565"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000830722551601523"}
     },
     {
-      "@id": "niiri:83280c58f4d4a8ee4edfa739d3ac75b9",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:eccc7ce308baf5cc0394b6c8e559a22d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0011",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[40,-62,50]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[40,-62,50]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:25717939f6bc521501b6bea98f9921a0",
-      "entity": "niiri:7ef5339838ce0f10390b275732bf42b1"
+      "entity_derived": "niiri:83f14a358618817c9a4a6a55d65d9d48",
+      "entity": "niiri:5a140c712e9e00e14ac695343ed92c6a"
     },
     {
-      "@id": "niiri:1e0e7daf15fb3458359237d457192e6e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:85743f2fb9669a51df0ec45eb8d8c238",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0012",
-      "prov:atLocation": {"@id": "niiri:d7bbaac6676d1525d0edd68a08c63d1a"},
+      "prov:atLocation": {"@id": "niiri:593fddd783d0fc554f40d4cbb2ae9fd8"},
       "prov:value": {"@type": "xsd:float", "@value": "5.70337772369385"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.28674301747281"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.22566831420812e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.011413186758684"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00350091530962783"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.28674301747281"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.22566831420812e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.011413186758684"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00350091530962783"}
     },
     {
-      "@id": "niiri:d7bbaac6676d1525d0edd68a08c63d1a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:593fddd783d0fc554f40d4cbb2ae9fd8",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0012",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[56,-44,52]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[56,-44,52]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1e0e7daf15fb3458359237d457192e6e",
-      "entity": "niiri:7ef5339838ce0f10390b275732bf42b1"
+      "entity_derived": "niiri:85743f2fb9669a51df0ec45eb8d8c238",
+      "entity": "niiri:5a140c712e9e00e14ac695343ed92c6a"
     },
     {
-      "@id": "niiri:28d9d8d8b820a935fd506cc19951cb36",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:004249a446a2a2711503faa18a5be983",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0013",
-      "prov:atLocation": {"@id": "niiri:09d2b984c867b9231df1760b08d3af39"},
+      "prov:atLocation": {"@id": "niiri:4ba5a90af9efd38fd0be8658803dd352"},
       "prov:value": {"@type": "xsd:float", "@value": "6.10109901428223"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.60320502193174"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.05212039080982e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00234682813060005"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00104518293275697"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.60320502193174"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.05212039080982e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00234682813060005"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00104518293275697"}
     },
     {
-      "@id": "niiri:09d2b984c867b9231df1760b08d3af39",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4ba5a90af9efd38fd0be8658803dd352",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0013",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[32,2,46]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[32,2,46]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:28d9d8d8b820a935fd506cc19951cb36",
-      "entity": "niiri:b86df2eebd66ba5883ad7b57360dd393"
+      "entity_derived": "niiri:004249a446a2a2711503faa18a5be983",
+      "entity": "niiri:1b0ec2e914c1e26ce0156061bea8ec55"
     },
     {
-      "@id": "niiri:aad8486e71e8fc524f27573bf88b3898",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a41084fb733e0e08cf6c8c3fb3eb5701",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0014",
-      "prov:atLocation": {"@id": "niiri:eb1bc008e7109bbb3631f97b5453bf7c"},
+      "prov:atLocation": {"@id": "niiri:18764a45f2220339c69ef7c9bfdc47e7"},
       "prov:value": {"@type": "xsd:float", "@value": "4.6086859703064"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.3736141683061"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.11031435759912e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.453877178455514"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0599714495109201"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.3736141683061"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.11031435759912e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.453877178455514"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0599714495109201"}
     },
     {
-      "@id": "niiri:eb1bc008e7109bbb3631f97b5453bf7c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:18764a45f2220339c69ef7c9bfdc47e7",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0014",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[28,4,58]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[28,4,58]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:aad8486e71e8fc524f27573bf88b3898",
-      "entity": "niiri:b86df2eebd66ba5883ad7b57360dd393"
+      "entity_derived": "niiri:a41084fb733e0e08cf6c8c3fb3eb5701",
+      "entity": "niiri:1b0ec2e914c1e26ce0156061bea8ec55"
     },
     {
-      "@id": "niiri:623246f4c2d05584cae00585a8a26390",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:6ff1fdc33f1b4c1ab70d3a900c678f9c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0015",
-      "prov:atLocation": {"@id": "niiri:a15a3af6428c84a8a7c2cca46f243ec6"},
+      "prov:atLocation": {"@id": "niiri:c8ad2195d487c19092289414f0abafd1"},
       "prov:value": {"@type": "xsd:float", "@value": "3.98793148994446"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.82932508069717"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.42475887594474e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.984644566584946"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.233149120368192"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.82932508069717"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.42475887594474e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.984644566584946"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.233149120368192"}
     },
     {
-      "@id": "niiri:a15a3af6428c84a8a7c2cca46f243ec6",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c8ad2195d487c19092289414f0abafd1",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0015",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[42,4,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[42,4,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:623246f4c2d05584cae00585a8a26390",
-      "entity": "niiri:b86df2eebd66ba5883ad7b57360dd393"
+      "entity_derived": "niiri:6ff1fdc33f1b4c1ab70d3a900c678f9c",
+      "entity": "niiri:1b0ec2e914c1e26ce0156061bea8ec55"
     },
     {
-      "@id": "niiri:bbc863a960c2c202baa922de0bbe2bda",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c70c9f283443901436c2946acb819132",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0016",
-      "prov:atLocation": {"@id": "niiri:4fe8ca4f432631f0b38d1bf5707dac6e"},
+      "prov:atLocation": {"@id": "niiri:e05c37b5c74c14f57c7e2e30c9035861"},
       "prov:value": {"@type": "xsd:float", "@value": "5.98348569869995"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.51047970249337"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.78928538652201e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00378871596531738"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00136419627856355"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.51047970249337"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.78928538652201e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00378871596531738"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00136419627856355"}
     },
     {
-      "@id": "niiri:4fe8ca4f432631f0b38d1bf5707dac6e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e05c37b5c74c14f57c7e2e30c9035861",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0016",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-52,0,38]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-52,0,38]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:bbc863a960c2c202baa922de0bbe2bda",
-      "entity": "niiri:c61079d69888f267f17faecfe84c9ce8"
+      "entity_derived": "niiri:c70c9f283443901436c2946acb819132",
+      "entity": "niiri:f6128a48e628339748454f9195fb4b90"
     },
     {
-      "@id": "niiri:6674ef85cd54cf09d270fc67f7b7377f",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:8cf7256afe51307616ffb11a8dcf7656",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0017",
-      "prov:atLocation": {"@id": "niiri:0f20e781d121f37a4bf2ab17199be0d9"},
+      "prov:atLocation": {"@id": "niiri:eb1fdad4df23df5a2b3d3c0d6a56a6d5"},
       "prov:value": {"@type": "xsd:float", "@value": "5.2253565788269"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.89552821543552"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.90210114501011e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0675937275056587"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0118363293065346"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.89552821543552"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.90210114501011e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0675937275056587"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0118363293065346"}
     },
     {
-      "@id": "niiri:0f20e781d121f37a4bf2ab17199be0d9",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:eb1fdad4df23df5a2b3d3c0d6a56a6d5",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0017",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-60,8,20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-60,8,20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6674ef85cd54cf09d270fc67f7b7377f",
-      "entity": "niiri:c61079d69888f267f17faecfe84c9ce8"
+      "entity_derived": "niiri:8cf7256afe51307616ffb11a8dcf7656",
+      "entity": "niiri:f6128a48e628339748454f9195fb4b90"
     },
     {
-      "@id": "niiri:a6c4f5fa76525074a8e0bfade60c9f27",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5311d6026c4d7b6211bd21394ed3cd34",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0018",
-      "prov:atLocation": {"@id": "niiri:e43908a0c36843ed209b0eba37e50d75"},
+      "prov:atLocation": {"@id": "niiri:7d87737758e0654156614064a8771717"},
       "prov:value": {"@type": "xsd:float", "@value": "4.98950004577637"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.69817956585148"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.31245304380023e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.151048137890434"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0233609510296683"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.69817956585148"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.31245304380023e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.151048137890434"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0233609510296683"}
     },
     {
-      "@id": "niiri:e43908a0c36843ed209b0eba37e50d75",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7d87737758e0654156614064a8771717",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0018",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-44,6,28]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-44,6,28]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a6c4f5fa76525074a8e0bfade60c9f27",
-      "entity": "niiri:c61079d69888f267f17faecfe84c9ce8"
+      "entity_derived": "niiri:5311d6026c4d7b6211bd21394ed3cd34",
+      "entity": "niiri:f6128a48e628339748454f9195fb4b90"
     },
     {
-      "@id": "niiri:645b4d78ae14c2b26b79ee898d11d012",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:932949e2a06a6b558e7f4e4fdfaef630",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0019",
-      "prov:atLocation": {"@id": "niiri:eb2722464de0f62707afbbf4d6bf8844"},
+      "prov:atLocation": {"@id": "niiri:867678d8e68882ecd35ff7e4ada5602f"},
       "prov:value": {"@type": "xsd:float", "@value": "5.78093099594116"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.34909755317379"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.41969442155354e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00844151822925698"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00286742427823329"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.34909755317379"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.41969442155354e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00844151822925698"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00286742427823329"}
     },
     {
-      "@id": "niiri:eb2722464de0f62707afbbf4d6bf8844",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:867678d8e68882ecd35ff7e4ada5602f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0019",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-34,-2,52]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-34,-2,52]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:645b4d78ae14c2b26b79ee898d11d012",
-      "entity": "niiri:cd22280b374ae77e13e4c8e1b578cd1d"
+      "entity_derived": "niiri:932949e2a06a6b558e7f4e4fdfaef630",
+      "entity": "niiri:16996fcb45118225812852d29f9f9a73"
     },
     {
-      "@id": "niiri:fdde41354522241386acfa16eac024ee",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0ff41f9a206a4f614332cd4bd0d4db48",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0020",
-      "prov:atLocation": {"@id": "niiri:a528fb74e5454d828bfcb7fb64ff5e51"},
+      "prov:atLocation": {"@id": "niiri:b2bc2fe9dcebc44d696b30462a22509b"},
       "prov:value": {"@type": "xsd:float", "@value": "5.30699443817139"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.96317509467693"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.46750043123123e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0504786376455083"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0106752417476244"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.96317509467693"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.46750043123123e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0504786376455083"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0106752417476244"}
     },
     {
-      "@id": "niiri:a528fb74e5454d828bfcb7fb64ff5e51",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b2bc2fe9dcebc44d696b30462a22509b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0020",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[32,40,16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[32,40,16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:fdde41354522241386acfa16eac024ee",
-      "entity": "niiri:a8c21f93ea05f237f1d5a4f475ee2545"
+      "entity_derived": "niiri:0ff41f9a206a4f614332cd4bd0d4db48",
+      "entity": "niiri:b374b0b364537d85069da6781ed3bce7"
     },
     {
-      "@id": "niiri:ca1201b1709fe1af43c1a16015e8300a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b7cd492bae1a54bc9978c2c30ae62044",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0021",
-      "prov:atLocation": {"@id": "niiri:059f5e1504b0b74a098f9eb38e7b8c2b"},
+      "prov:atLocation": {"@id": "niiri:5d959d006ddff911006f677f2f35bdc0"},
       "prov:value": {"@type": "xsd:float", "@value": "4.5497465133667"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.32273570618355"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.7053150754347e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.520378392891944"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0649997423676262"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.32273570618355"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.7053150754347e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.520378392891944"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0649997423676262"}
     },
     {
-      "@id": "niiri:059f5e1504b0b74a098f9eb38e7b8c2b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:5d959d006ddff911006f677f2f35bdc0",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0021",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[40,46,12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[40,46,12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ca1201b1709fe1af43c1a16015e8300a",
-      "entity": "niiri:a8c21f93ea05f237f1d5a4f475ee2545"
+      "entity_derived": "niiri:b7cd492bae1a54bc9978c2c30ae62044",
+      "entity": "niiri:b374b0b364537d85069da6781ed3bce7"
     },
     {
-      "@id": "niiri:c5a8f15e086e65859ead340a09ac4f9b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5361732ec0e4c8b9cac0fb646789c096",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0022",
-      "prov:atLocation": {"@id": "niiri:2a3dfef8697f81c9e1d52d990cc7fe25"},
+      "prov:atLocation": {"@id": "niiri:b5342f9bc1453a7c01e4c7e8ea7cc962"},
       "prov:value": {"@type": "xsd:float", "@value": "4.31582498550415"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.11913273798974"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.90150518718513e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.788829013385429"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.116130094830597"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.11913273798974"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.90150518718513e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.788829013385429"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.116130094830597"}
     },
     {
-      "@id": "niiri:2a3dfef8697f81c9e1d52d990cc7fe25",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b5342f9bc1453a7c01e4c7e8ea7cc962",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0022",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[36,54,6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[36,54,6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c5a8f15e086e65859ead340a09ac4f9b",
-      "entity": "niiri:a8c21f93ea05f237f1d5a4f475ee2545"
+      "entity_derived": "niiri:5361732ec0e4c8b9cac0fb646789c096",
+      "entity": "niiri:b374b0b364537d85069da6781ed3bce7"
     },
     {
-      "@id": "niiri:2c25aabcf5b166b064e4649fb8473ef0",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:1c1efb50135a7c1bad8db7e4cf11686f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0023",
-      "prov:atLocation": {"@id": "niiri:027a1408e9f0aa75eb2b665b1d785257"},
+      "prov:atLocation": {"@id": "niiri:35725a8dc35ca221915f18e8878596aa"},
       "prov:value": {"@type": "xsd:float", "@value": "5.27030229568481"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.93281349716267"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.05267701952816e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0575990926145485"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0110040663565173"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.93281349716267"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.05267701952816e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0575990926145485"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0110040663565173"}
     },
     {
-      "@id": "niiri:027a1408e9f0aa75eb2b665b1d785257",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:35725a8dc35ca221915f18e8878596aa",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0023",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[40,26,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[40,26,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2c25aabcf5b166b064e4649fb8473ef0",
-      "entity": "niiri:6f51b281dc4706f206736c798a91ba30"
+      "entity_derived": "niiri:1c1efb50135a7c1bad8db7e4cf11686f",
+      "entity": "niiri:47eda65cfe1f349741bbd56fa3361233"
     },
     {
-      "@id": "niiri:eb5564371ee096c26953a7911ad47fbe",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:142faca43b00bbe02174b97cc402bc5e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0024",
-      "prov:atLocation": {"@id": "niiri:da4b988e03393052039eea8b1be78259"},
+      "prov:atLocation": {"@id": "niiri:d64683a5a499945ff7594f708a0ca237"},
       "prov:value": {"@type": "xsd:float", "@value": "4.72232866287231"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.47122948835043"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.88855941602095e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.338512677882141"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.044836631144536"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.47122948835043"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.88855941602095e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.338512677882141"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.044836631144536"}
     },
     {
-      "@id": "niiri:da4b988e03393052039eea8b1be78259",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d64683a5a499945ff7594f708a0ca237",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0024",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[58,-38,6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[58,-38,6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:eb5564371ee096c26953a7911ad47fbe",
-      "entity": "niiri:c25a8cb898d061e65d3970120b76fad9"
+      "entity_derived": "niiri:142faca43b00bbe02174b97cc402bc5e",
+      "entity": "niiri:8235aa92a4300c6c7e12d8fb288e2e09"
     },
     {
-      "@id": "niiri:7fa07b417d168f7e49c28acede45488e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d3d21d9fb8f5c4e3c028dafc33492ae5",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0025",
-      "prov:atLocation": {"@id": "niiri:1a471d98e4a0738d037ddb9d69f9145c"},
+      "prov:atLocation": {"@id": "niiri:a444192598b15b39c8f68d9d10ad798f"},
       "prov:value": {"@type": "xsd:float", "@value": "3.98372888565063"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.8255778871433"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.52328381068878e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.985409231324461"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.233731539105478"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.8255778871433"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.52328381068878e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.985409231324461"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.233731539105478"}
     },
     {
-      "@id": "niiri:1a471d98e4a0738d037ddb9d69f9145c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a444192598b15b39c8f68d9d10ad798f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0025",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[64,-30,-4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[64,-30,-4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7fa07b417d168f7e49c28acede45488e",
-      "entity": "niiri:c25a8cb898d061e65d3970120b76fad9"
+      "entity_derived": "niiri:d3d21d9fb8f5c4e3c028dafc33492ae5",
+      "entity": "niiri:8235aa92a4300c6c7e12d8fb288e2e09"
     },
     {
-      "@id": "niiri:2a40cfff6e0c1e255ff9003adbe498b5",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:67d65736ad13421436d72a8215e48d31",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0026",
-      "prov:atLocation": {"@id": "niiri:d7d3268c6eed62e2fd9247e016c651f8"},
+      "prov:atLocation": {"@id": "niiri:3c8566c59af37fa6a9390ed38a37517b"},
       "prov:value": {"@type": "xsd:float", "@value": "3.50753784179688"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.39582098150001"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000342115474631921"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999778829603"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.564856004417035"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.39582098150001"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000342115474631921"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999778829603"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.564856004417035"}
     },
     {
-      "@id": "niiri:d7d3268c6eed62e2fd9247e016c651f8",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:3c8566c59af37fa6a9390ed38a37517b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0026",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[60,-40,-12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[60,-40,-12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2a40cfff6e0c1e255ff9003adbe498b5",
-      "entity": "niiri:c25a8cb898d061e65d3970120b76fad9"
+      "entity_derived": "niiri:67d65736ad13421436d72a8215e48d31",
+      "entity": "niiri:8235aa92a4300c6c7e12d8fb288e2e09"
     }
   ]
 }

--- a/spmexport/ex_spm_thr_clustfwep05/nidm.ttl
+++ b/spmexport/ex_spm_thr_clustfwep05/nidm.ttl
@@ -4,7 +4,7 @@
 @prefix niiri: <http://iri.nidash.org/> .
 @prefix spm: <http://purl.org/nidash/spm#> .
 @prefix neurolex: <http://neurolex.org/wiki/> .
-@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#> .
+@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
@@ -17,27 +17,27 @@
 @prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-niiri:182e1b85b8336e56fb4e133ba8563b45
+niiri:e31f56e03ff5aca2edc16a51c094a508
   a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
   rdfs:label "NIDM-Results" ;
   nidm_version: "1.3.0"^^xsd:string .
 
-niiri:f469c2b953993b48ba75b9bf54a94c6b
+niiri:3e9b8ab3f99b4316053190b556d70b8d
   a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
   rdfs:label "spm_results_nidm" ;
-  nidm_softwareVersion: "12.6903"^^xsd:string .
+  nidm_softwareVersion: "12.7057"^^xsd:string .
 
-niiri:bb9ab37b1fccfb3fd76941f0e4a000c8
+niiri:71e962f0352be27a49a0cadb61d1f6a0
   a prov:Activity, nidm_NIDMResultsExport: ; 
   rdfs:label "NIDM-Results export" .
 
-niiri:bb9ab37b1fccfb3fd76941f0e4a000c8 prov:wasAssociatedWith niiri:f469c2b953993b48ba75b9bf54a94c6b .
+niiri:71e962f0352be27a49a0cadb61d1f6a0 prov:wasAssociatedWith niiri:3e9b8ab3f99b4316053190b556d70b8d .
 
 _:blank5 a prov:Generation .
 
-niiri:182e1b85b8336e56fb4e133ba8563b45 prov:qualifiedGeneration _:blank5 .
+niiri:e31f56e03ff5aca2edc16a51c094a508 prov:qualifiedGeneration _:blank5 .
 
-_:blank5 prov:atTime "2016-12-07T16:09:37"^^xsd:dateTime .
+_:blank5 prov:atTime "2017-04-19T12:19:01"^^xsd:dateTime .
 
 @prefix nidm_Ixi549CoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000050> .
 @prefix src_SPM: <http://scicrunch.org/resolver/SCR_007037> .
@@ -142,12 +142,12 @@ _:blank5 prov:atTime "2016-12-07T16:09:37"^^xsd:dateTime .
 @prefix nidm_Coordinate: <http://purl.org/nidash/nidm#NIDM_0000015> .
 @prefix nidm_coordinateVector: <http://purl.org/nidash/nidm#NIDM_0000086> .
 
-niiri:e2a1a9b317b694a52959d155d5af349f
+niiri:978ecfac61168b631aeb24784516a78c
     a prov:Agent, src_SPM:, prov:SoftwareAgent ; 
     rdfs:label "SPM" ;
-    nidm_softwareVersion: "12.12.2"^^xsd:string .
+    nidm_softwareVersion: "12.6906"^^xsd:string .
 
-niiri:c2aaa0e17efdb9a83de1fa6bf4a54bc6
+niiri:fb077c2db1c7afee934de729a4c9618d
     a prov:Entity, nidm_CoordinateSpace: ; 
     rdfs:label "Coordinate space 1" ;
     nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
@@ -157,48 +157,48 @@ niiri:c2aaa0e17efdb9a83de1fa6bf4a54bc6
     nidm_numberOfDimensions: "3"^^xsd:int ;
     nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
 
-niiri:d8c388ab3dfea6a7b247c469dae1b1b8
+niiri:f260b10e486c81130f24499cfffa8499
     a prov:Agent, nlx_Imaginginstrument:, nlx_Magneticresonanceimagingscanner: ; 
     rdfs:label "MRI Scanner" .
 
-niiri:a87734463062b87831df564586eab7fe
+niiri:445a3d62de6b1fe45f5fbb9742c962fc
     a prov:Agent, prov:Person ; 
     rdfs:label "Person" .
 
-niiri:caa7ede8420d82834420135a1a9f91f9
+niiri:87f956daaa9073497b8b73a5d7227428
     a prov:Entity, prov:Collection, nidm_Data: ; 
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "true"^^xsd:boolean ;
     nidm_targetIntensity: "100"^^xsd:float ;
     nidm_hasMRIProtocol: nlx_FunctionalMRIprotocol: .
 
-niiri:caa7ede8420d82834420135a1a9f91f9 prov:wasAttributedTo niiri:d8c388ab3dfea6a7b247c469dae1b1b8 .
+niiri:87f956daaa9073497b8b73a5d7227428 prov:wasAttributedTo niiri:f260b10e486c81130f24499cfffa8499 .
 
-niiri:caa7ede8420d82834420135a1a9f91f9 prov:wasAttributedTo niiri:a87734463062b87831df564586eab7fe .
+niiri:87f956daaa9073497b8b73a5d7227428 prov:wasAttributedTo niiri:445a3d62de6b1fe45f5fbb9742c962fc .
 
-niiri:9eb0c8cfb97ecd146406dbb1515c9b27
+niiri:7572230598f6780417a95d7b43f25cc0
     a prov:Entity, spm_DCTDriftModel: ; 
     rdfs:label "SPM's DCT Drift Model" ;
     spm_SPMsDriftCutoffPeriod: "128"^^xsd:float .
 
-niiri:b4917982e1dece6d418b5ffc48c5a250
+niiri:d1ec8e870ecb39337f2b3c95137664a8
     a prov:Entity, nidm_DesignMatrix: ; 
     prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.csv"^^xsd:string ;
     dct:format "text/csv"^^xsd:string ;
-    dc:description niiri:b363f9617399bf3cdb912b0d40669842 ;
+    dc:description niiri:def8137d4f6f4767c2f27db070f9ab9c ;
     rdfs:label "Design Matrix" ;
     nidm_regressorNames: "[\"Sn(1) to*bf(1)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) constant\"]"^^xsd:string ;
-    nidm_hasDriftModel: niiri:9eb0c8cfb97ecd146406dbb1515c9b27 ;
+    nidm_hasDriftModel: niiri:7572230598f6780417a95d7b43f25cc0 ;
     nidm_hasHRFBasis: spm_SPMsCanonicalHRF: .
 
-niiri:b363f9617399bf3cdb912b0d40669842
+niiri:def8137d4f6f4767c2f27db070f9ab9c
     a prov:Entity, dctype:Image ; 
     prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:0adb91d96cd65a3ed2384b92ce8f1a20
+niiri:834307fe7ea4f6c3b2e4869cc5c572b5
     a prov:Entity, nidm_ErrorModel: ; 
     nidm_hasErrorDistribution: obo_normaldistribution: ;
     nidm_hasErrorDependence: obo_Toeplitzcovariancestructure: ;
@@ -206,174 +206,174 @@ niiri:0adb91d96cd65a3ed2384b92ce8f1a20
     nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
     nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
 
-niiri:7bd41a5b9f6aaf494399fec4584d47fa
+niiri:77556fccd50035e27041bcd31a9c4d58
     a prov:Activity, nidm_ModelParametersEstimation: ; 
     rdfs:label "Model parameters estimation" ;
     nidm_withEstimationMethod: obo_generalizedleastsquaresestimation: .
 
-niiri:7bd41a5b9f6aaf494399fec4584d47fa prov:wasAssociatedWith niiri:e2a1a9b317b694a52959d155d5af349f .
+niiri:77556fccd50035e27041bcd31a9c4d58 prov:wasAssociatedWith niiri:978ecfac61168b631aeb24784516a78c .
 
-niiri:7bd41a5b9f6aaf494399fec4584d47fa prov:used niiri:b4917982e1dece6d418b5ffc48c5a250 .
+niiri:77556fccd50035e27041bcd31a9c4d58 prov:used niiri:d1ec8e870ecb39337f2b3c95137664a8 .
 
-niiri:7bd41a5b9f6aaf494399fec4584d47fa prov:used niiri:caa7ede8420d82834420135a1a9f91f9 .
+niiri:77556fccd50035e27041bcd31a9c4d58 prov:used niiri:87f956daaa9073497b8b73a5d7227428 .
 
-niiri:7bd41a5b9f6aaf494399fec4584d47fa prov:used niiri:0adb91d96cd65a3ed2384b92ce8f1a20 .
+niiri:77556fccd50035e27041bcd31a9c4d58 prov:used niiri:834307fe7ea4f6c3b2e4869cc5c572b5 .
 
-niiri:65dce2099c092d41e73a7baa0d8ac97a
+niiri:ece3cdb35b4a193e1c1a956e1d18a83f
     a prov:Entity, nidm_MaskMap: ; 
     prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
     nidm_isUserDefined: "false"^^xsd:boolean ;
     nfo:fileName "Mask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Mask" ;
-    nidm_inCoordinateSpace: niiri:c2aaa0e17efdb9a83de1fa6bf4a54bc6 ;
+    nidm_inCoordinateSpace: niiri:fb077c2db1c7afee934de729a4c9618d ;
     crypto:sha512 "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876"^^xsd:string .
 
-niiri:c322724a3de2840ebfa0522f3346f269
+niiri:d47a652ea52d803eaf61a1440d4ee9a0
     a prov:Entity, nidm_MaskMap: ; 
     nfo:fileName "mask.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "36929e1f5f4143bd9cc818cd896a25f129961fab208c3a4438555f40444c08347b359142ee8c53ece6e8cca1627f49db0788a1fd3b9e2ecaef61999c6c6c67ac"^^xsd:string .
 
-niiri:65dce2099c092d41e73a7baa0d8ac97a prov:wasDerivedFrom niiri:c322724a3de2840ebfa0522f3346f269 .
+niiri:ece3cdb35b4a193e1c1a956e1d18a83f prov:wasDerivedFrom niiri:d47a652ea52d803eaf61a1440d4ee9a0 .
 
-niiri:65dce2099c092d41e73a7baa0d8ac97a prov:wasGeneratedBy niiri:7bd41a5b9f6aaf494399fec4584d47fa .
+niiri:ece3cdb35b4a193e1c1a956e1d18a83f prov:wasGeneratedBy niiri:77556fccd50035e27041bcd31a9c4d58 .
 
-niiri:74140559724685d133c8461ff080d4e7
+niiri:ba71907eeb2ae78e67e358350ac6e2e4
     a prov:Entity, nidm_GrandMeanMap: ; 
     prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
     nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Grand Mean Map" ;
     nidm_maskedMedian: "111.557487487793"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:c2aaa0e17efdb9a83de1fa6bf4a54bc6 ;
+    nidm_inCoordinateSpace: niiri:fb077c2db1c7afee934de729a4c9618d ;
     crypto:sha512 "512157cc6bff89d9343a09b4068226eb3edd64a8cbcee861f06231767fae6f8d4819921182adebee083a9bf309afd65529ab04a92f0aa6b0038c8098550f6124"^^xsd:string .
 
-niiri:74140559724685d133c8461ff080d4e7 prov:wasGeneratedBy niiri:7bd41a5b9f6aaf494399fec4584d47fa .
+niiri:ba71907eeb2ae78e67e358350ac6e2e4 prov:wasGeneratedBy niiri:77556fccd50035e27041bcd31a9c4d58 .
 
-niiri:8606838a8849d1f202c2dd6bee5673af
+niiri:70a8c763acea17b445f0c2df0fa7cdea
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0001.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0001.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 1" ;
-    nidm_inCoordinateSpace: niiri:c2aaa0e17efdb9a83de1fa6bf4a54bc6 ;
+    nidm_inCoordinateSpace: niiri:fb077c2db1c7afee934de729a4c9618d ;
     crypto:sha512 "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd"^^xsd:string .
 
-niiri:d9369b4849003c0e839297e38d66257c
+niiri:ad407352278e434503a359c1fa3e1a9d
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd"^^xsd:string .
 
-niiri:8606838a8849d1f202c2dd6bee5673af prov:wasDerivedFrom niiri:d9369b4849003c0e839297e38d66257c .
+niiri:70a8c763acea17b445f0c2df0fa7cdea prov:wasDerivedFrom niiri:ad407352278e434503a359c1fa3e1a9d .
 
-niiri:8606838a8849d1f202c2dd6bee5673af prov:wasGeneratedBy niiri:7bd41a5b9f6aaf494399fec4584d47fa .
+niiri:70a8c763acea17b445f0c2df0fa7cdea prov:wasGeneratedBy niiri:77556fccd50035e27041bcd31a9c4d58 .
 
-niiri:2ef5ffca78be6241588a0eae21bd876c
+niiri:60bd42c7d00085cd0c9e78ca9093dc8d
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0002.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0002.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 2" ;
-    nidm_inCoordinateSpace: niiri:c2aaa0e17efdb9a83de1fa6bf4a54bc6 ;
+    nidm_inCoordinateSpace: niiri:fb077c2db1c7afee934de729a4c9618d ;
     crypto:sha512 "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c"^^xsd:string .
 
-niiri:66739312dad9317758189edf3e520586
+niiri:b30f76932fae67727ecae774f20f5b46
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0002.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c"^^xsd:string .
 
-niiri:2ef5ffca78be6241588a0eae21bd876c prov:wasDerivedFrom niiri:66739312dad9317758189edf3e520586 .
+niiri:60bd42c7d00085cd0c9e78ca9093dc8d prov:wasDerivedFrom niiri:b30f76932fae67727ecae774f20f5b46 .
 
-niiri:2ef5ffca78be6241588a0eae21bd876c prov:wasGeneratedBy niiri:7bd41a5b9f6aaf494399fec4584d47fa .
+niiri:60bd42c7d00085cd0c9e78ca9093dc8d prov:wasGeneratedBy niiri:77556fccd50035e27041bcd31a9c4d58 .
 
-niiri:0bd2bbc2eac7681c414f17783107f296
+niiri:e3deb37fe68eb835201c5af97c411ff7
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0003.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0003.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 3" ;
-    nidm_inCoordinateSpace: niiri:c2aaa0e17efdb9a83de1fa6bf4a54bc6 ;
+    nidm_inCoordinateSpace: niiri:fb077c2db1c7afee934de729a4c9618d ;
     crypto:sha512 "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373"^^xsd:string .
 
-niiri:674272b909f4e3f3591842780633fdc6
+niiri:ad57dd041b5129b8d2970ceebd686269
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0003.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373"^^xsd:string .
 
-niiri:0bd2bbc2eac7681c414f17783107f296 prov:wasDerivedFrom niiri:674272b909f4e3f3591842780633fdc6 .
+niiri:e3deb37fe68eb835201c5af97c411ff7 prov:wasDerivedFrom niiri:ad57dd041b5129b8d2970ceebd686269 .
 
-niiri:0bd2bbc2eac7681c414f17783107f296 prov:wasGeneratedBy niiri:7bd41a5b9f6aaf494399fec4584d47fa .
+niiri:e3deb37fe68eb835201c5af97c411ff7 prov:wasGeneratedBy niiri:77556fccd50035e27041bcd31a9c4d58 .
 
-niiri:b9c3fba0ca30e15142f4fa3364c8fbd5
+niiri:a0e5946d7d1dd4083af55338b3c2d3c9
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Residual Mean Squares Map" ;
-    nidm_inCoordinateSpace: niiri:c2aaa0e17efdb9a83de1fa6bf4a54bc6 ;
+    nidm_inCoordinateSpace: niiri:fb077c2db1c7afee934de729a4c9618d ;
     crypto:sha512 "991abf563d795a43b1e2eef8643e57023f2e0b090b2031f05f839321fc0643df6f71d423486a1021519b6dc82f6b0f563e19f3fbd50cb16063bed54a0e192d3e"^^xsd:string .
 
-niiri:a27662cb10db077c3577a14c26b9021f
+niiri:1ad97186abe5157f975894f121d5e5f9
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     nfo:fileName "ResMS.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "40b28d03fcf9a2f60b11f10d7fb83bf3618b234fb5aedf09df644cb7cbb6aab8c9f468897c1078166d455a3d04a83f4e3bf762cfca0b4ea982d7a4e406849f18"^^xsd:string .
 
-niiri:b9c3fba0ca30e15142f4fa3364c8fbd5 prov:wasDerivedFrom niiri:a27662cb10db077c3577a14c26b9021f .
+niiri:a0e5946d7d1dd4083af55338b3c2d3c9 prov:wasDerivedFrom niiri:1ad97186abe5157f975894f121d5e5f9 .
 
-niiri:b9c3fba0ca30e15142f4fa3364c8fbd5 prov:wasGeneratedBy niiri:7bd41a5b9f6aaf494399fec4584d47fa .
+niiri:a0e5946d7d1dd4083af55338b3c2d3c9 prov:wasGeneratedBy niiri:77556fccd50035e27041bcd31a9c4d58 .
 
-niiri:e9c71f26b021b43b4cecb0f037a24625
+niiri:a0a699bc84151f3770428014d5881784
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Resels per Voxel Map" ;
-    nidm_inCoordinateSpace: niiri:c2aaa0e17efdb9a83de1fa6bf4a54bc6 ;
+    nidm_inCoordinateSpace: niiri:fb077c2db1c7afee934de729a4c9618d ;
     crypto:sha512 "1a3f9216e145249ccc0b14b2bc337d6b38b81ad45e32768001fb22b35f0c2c0f3e2bce013b40c85f7dc0fc62723ac761ee7f7e1e6aff128a05f0ba7b8b8202a3"^^xsd:string .
 
-niiri:538dc6c65e511ac7b3561b0dd78593b0
+niiri:825faee5541a664e02864bcc9e5f7db6
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     nfo:fileName "RPV.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "4f76663162857f6b38b2a45a63b15a23b2ca8b338c283b69c1e71f2ea2f43797d045a733cd14e845be9c12f8b8f84d3931c599a08e8f6d77e99fab46ad87ab8f"^^xsd:string .
 
-niiri:e9c71f26b021b43b4cecb0f037a24625 prov:wasDerivedFrom niiri:538dc6c65e511ac7b3561b0dd78593b0 .
+niiri:a0a699bc84151f3770428014d5881784 prov:wasDerivedFrom niiri:825faee5541a664e02864bcc9e5f7db6 .
 
-niiri:e9c71f26b021b43b4cecb0f037a24625 prov:wasGeneratedBy niiri:7bd41a5b9f6aaf494399fec4584d47fa .
+niiri:a0a699bc84151f3770428014d5881784 prov:wasGeneratedBy niiri:77556fccd50035e27041bcd31a9c4d58 .
 
-niiri:d6e9d88f26bafd609ebcaeceba4d45dd
+niiri:83435a694f0d3952e54da4131150dfc4
     a prov:Entity, obo_contrastweightmatrix: ; 
     nidm_statisticType: obo_tstatistic: ;
     nidm_contrastName: "tone counting vs baseline"^^xsd:string ;
     rdfs:label "Contrast: tone counting vs baseline" ;
     prov:value "[1, 0, 0]"^^xsd:string .
 
-niiri:07a3285e23ffce50c6323158116dd224
+niiri:8abfa89e769aa3a3b89c1b4bc433cf48
     a prov:Activity, nidm_ContrastEstimation: ; 
     rdfs:label "Contrast estimation" .
 
-niiri:07a3285e23ffce50c6323158116dd224 prov:wasAssociatedWith niiri:e2a1a9b317b694a52959d155d5af349f .
+niiri:8abfa89e769aa3a3b89c1b4bc433cf48 prov:wasAssociatedWith niiri:978ecfac61168b631aeb24784516a78c .
 
-niiri:07a3285e23ffce50c6323158116dd224 prov:used niiri:65dce2099c092d41e73a7baa0d8ac97a .
+niiri:8abfa89e769aa3a3b89c1b4bc433cf48 prov:used niiri:ece3cdb35b4a193e1c1a956e1d18a83f .
 
-niiri:07a3285e23ffce50c6323158116dd224 prov:used niiri:b9c3fba0ca30e15142f4fa3364c8fbd5 .
+niiri:8abfa89e769aa3a3b89c1b4bc433cf48 prov:used niiri:a0e5946d7d1dd4083af55338b3c2d3c9 .
 
-niiri:07a3285e23ffce50c6323158116dd224 prov:used niiri:b4917982e1dece6d418b5ffc48c5a250 .
+niiri:8abfa89e769aa3a3b89c1b4bc433cf48 prov:used niiri:d1ec8e870ecb39337f2b3c95137664a8 .
 
-niiri:07a3285e23ffce50c6323158116dd224 prov:used niiri:d6e9d88f26bafd609ebcaeceba4d45dd .
+niiri:8abfa89e769aa3a3b89c1b4bc433cf48 prov:used niiri:83435a694f0d3952e54da4131150dfc4 .
 
-niiri:07a3285e23ffce50c6323158116dd224 prov:used niiri:8606838a8849d1f202c2dd6bee5673af .
+niiri:8abfa89e769aa3a3b89c1b4bc433cf48 prov:used niiri:70a8c763acea17b445f0c2df0fa7cdea .
 
-niiri:07a3285e23ffce50c6323158116dd224 prov:used niiri:2ef5ffca78be6241588a0eae21bd876c .
+niiri:8abfa89e769aa3a3b89c1b4bc433cf48 prov:used niiri:60bd42c7d00085cd0c9e78ca9093dc8d .
 
-niiri:07a3285e23ffce50c6323158116dd224 prov:used niiri:0bd2bbc2eac7681c414f17783107f296 .
+niiri:8abfa89e769aa3a3b89c1b4bc433cf48 prov:used niiri:e3deb37fe68eb835201c5af97c411ff7 .
 
-niiri:cd2388fd62981ea59c5fc9dc434272fa
+niiri:db9345d4e9933a8e4b01bd306e4d1ada
     a prov:Entity, nidm_StatisticMap: ; 
     prov:atLocation "TStatistic.nii.gz"^^xsd:anyURI ;
     nfo:fileName "TStatistic.nii.gz"^^xsd:string ;
@@ -383,124 +383,124 @@ niiri:cd2388fd62981ea59c5fc9dc434272fa
     nidm_contrastName: "tone counting vs baseline"^^xsd:string ;
     nidm_errorDegreesOfFreedom: "97.9999999998522"^^xsd:float ;
     nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:c2aaa0e17efdb9a83de1fa6bf4a54bc6 ;
+    nidm_inCoordinateSpace: niiri:fb077c2db1c7afee934de729a4c9618d ;
     crypto:sha512 "9e1714c2d86a050b38b4e10a4d2d23253a24c5e1d228ae16a9c3be8872739278505ac0729ecab54265a717e3a54f9f782d0ed72eea904e0d482a6072bb817bd4"^^xsd:string .
 
-niiri:8f83bfc8fa762b9560732c11f58cef8b
+niiri:2ae9dd843807c2964f069dac80060045
     a prov:Entity, nidm_StatisticMap: ; 
     nfo:fileName "spmT_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "d288b1b0f117f64502555da13c5398dffa5bf5ff0b58951510e43d5388755bc185798802a92e98a07c7e313c6991066d2908f2a44aa5153ba23433da1335970f"^^xsd:string .
 
-niiri:cd2388fd62981ea59c5fc9dc434272fa prov:wasDerivedFrom niiri:8f83bfc8fa762b9560732c11f58cef8b .
+niiri:db9345d4e9933a8e4b01bd306e4d1ada prov:wasDerivedFrom niiri:2ae9dd843807c2964f069dac80060045 .
 
-niiri:cd2388fd62981ea59c5fc9dc434272fa prov:wasGeneratedBy niiri:07a3285e23ffce50c6323158116dd224 .
+niiri:db9345d4e9933a8e4b01bd306e4d1ada prov:wasGeneratedBy niiri:8abfa89e769aa3a3b89c1b4bc433cf48 .
 
-niiri:1a78c56343464be12051d5b886a37d11
+niiri:aa2414e92da918a041265bddb4dcdf0d
     a prov:Entity, nidm_ContrastMap: ; 
     prov:atLocation "Contrast.nii.gz"^^xsd:anyURI ;
     nfo:fileName "Contrast.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Map: tone counting vs baseline" ;
     nidm_contrastName: "tone counting vs baseline"^^xsd:string ;
-    nidm_inCoordinateSpace: niiri:c2aaa0e17efdb9a83de1fa6bf4a54bc6 ;
+    nidm_inCoordinateSpace: niiri:fb077c2db1c7afee934de729a4c9618d ;
     crypto:sha512 "fc5e2ad175243ee496db98f9b2e1b235c4c3bae1a8d7122ce461c897b537e40c49dfee5d6cf20f71c6a2bb9b5f0760fcb4ecd8fe2e9428910ef3d60d8f3c56a9"^^xsd:string .
 
-niiri:4bae6a056ddaf2df7ca8d90787f8e481
+niiri:896ddf9a768ce97fe2d39d3682cde4f2
     a prov:Entity, nidm_ContrastMap: ; 
     nfo:fileName "con_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "d4aa46b3603ba508578e39751262d528cf6d1ed2e722ec46f1cd8194c50591e46b229deb8cb4f72d1b7e0e2640f3e6604be7a335301c5c8357f453e5d0d4daf2"^^xsd:string .
 
-niiri:1a78c56343464be12051d5b886a37d11 prov:wasDerivedFrom niiri:4bae6a056ddaf2df7ca8d90787f8e481 .
+niiri:aa2414e92da918a041265bddb4dcdf0d prov:wasDerivedFrom niiri:896ddf9a768ce97fe2d39d3682cde4f2 .
 
-niiri:1a78c56343464be12051d5b886a37d11 prov:wasGeneratedBy niiri:07a3285e23ffce50c6323158116dd224 .
+niiri:aa2414e92da918a041265bddb4dcdf0d prov:wasGeneratedBy niiri:8abfa89e769aa3a3b89c1b4bc433cf48 .
 
-niiri:e4a65e58a16c0deb0f489bd70643d3d2
+niiri:1f712c8148d8d15ace4a81b516943032
     a prov:Entity, nidm_ContrastStandardErrorMap: ; 
     prov:atLocation "ContrastStandardError.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ContrastStandardError.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Standard Error Map" ;
-    nidm_inCoordinateSpace: niiri:c2aaa0e17efdb9a83de1fa6bf4a54bc6 ;
+    nidm_inCoordinateSpace: niiri:fb077c2db1c7afee934de729a4c9618d ;
     crypto:sha512 "791d48f5d1adb15079a5289271ce0c4b95c56d69bfdb3e5d41b0d24eb538d3075e1cdd15502494b5a5a18c16eaa2153cb4847a996043fa48cdaf26e938a2576d"^^xsd:string .
 
-niiri:e4a65e58a16c0deb0f489bd70643d3d2 prov:wasGeneratedBy niiri:07a3285e23ffce50c6323158116dd224 .
+niiri:1f712c8148d8d15ace4a81b516943032 prov:wasGeneratedBy niiri:8abfa89e769aa3a3b89c1b4bc433cf48 .
 
-niiri:083b72805718136d80959aba1322a458
+niiri:0913319d344f1fdba3d922a2dfae4612
     a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
-    rdfs:label "Height Threshold: p<0.001000 (unc.)" ;
+    rdfs:label "Height Threshold: p<0.001 (unc.)" ;
     prov:value "0.000999500158000544"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:a779e6f7de8242e20b26241926456cdf ;
-    nidm_equivalentThreshold: niiri:f1f6c273077ac68ef3da270edc9de95d .
+    nidm_equivalentThreshold: niiri:013b7be5dd7ca8fbb3d35355e8b4f3aa ;
+    nidm_equivalentThreshold: niiri:4e8b898c9c0affa831a9bdb84c970721 .
 
-niiri:a779e6f7de8242e20b26241926456cdf
+niiri:013b7be5dd7ca8fbb3d35355e8b4f3aa
     a prov:Entity, nidm_HeightThreshold:, obo_statistic: ; 
-    rdfs:label "Height Threshold" ;
+    rdfs:label "Height Threshold: T=3.175486)" ;
     prov:value "3.17548628637284"^^xsd:float .
 
-niiri:f1f6c273077ac68ef3da270edc9de95d
+niiri:4e8b898c9c0affa831a9bdb84c970721
     a prov:Entity, nidm_HeightThreshold:, obo_FWERadjustedpvalue: ; 
-    rdfs:label "Height Threshold" ;
+    rdfs:label "Height Threshold: p<1.000000 (FWE)" ;
     prov:value "0.999999999999997"^^xsd:float .
 
-niiri:b7d55931ab8bfe4177e0cf74b1e0723e
+niiri:38c63862d3fa4aeb37b16674898b17d0
     a prov:Entity, nidm_ExtentThreshold:, obo_statistic: ; 
     rdfs:label "Extent Threshold: k>=116" ;
     nidm_clusterSizeInVoxels: "116"^^xsd:int ;
     nidm_clusterSizeInResels: "1.7688671224263"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:838f6eb43feddd98af244131c1f8d7d7 ;
-    nidm_equivalentThreshold: niiri:63a864518e9ad6f0b8d693580e7697a6 .
+    nidm_equivalentThreshold: niiri:2722fd44f9e7d6b1c6f50c721ba5e19b ;
+    nidm_equivalentThreshold: niiri:0b8fed5ea39b873139620e7b43513466 .
 
-niiri:838f6eb43feddd98af244131c1f8d7d7
+niiri:2722fd44f9e7d6b1c6f50c721ba5e19b
     a prov:Entity, nidm_ExtentThreshold:, obo_FWERadjustedpvalue: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "0.0150888416289883"^^xsd:float .
 
-niiri:63a864518e9ad6f0b8d693580e7697a6
+niiri:0b8fed5ea39b873139620e7b43513466
     a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "0.000452977534465859"^^xsd:float .
 
-niiri:2e789eb634bf515dca3c74e028484eda
+niiri:ded58d3d760e7c562c993612ce5bdbb0
     a prov:Entity, nidm_PeakDefinitionCriteria: ; 
     rdfs:label "Peak Definition Criteria" ;
     nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
     nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
 
-niiri:0cd070cb2241c08895462ab4099a104a
+niiri:c3a4c242421f98d32ff2ef9357eb073e
     a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
     rdfs:label "Cluster Connectivity Criterion: 18" ;
     nidm_hasConnectivityCriterion: nidm_voxel18connected: .
 
-niiri:983041cba08acd2140526edea30a630f
+niiri:22f75f4eb883a33606785984a05451e3
     a prov:Activity, nidm_Inference: ; 
     nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
     rdfs:label "Inference" .
 
-niiri:983041cba08acd2140526edea30a630f prov:wasAssociatedWith niiri:e2a1a9b317b694a52959d155d5af349f .
+niiri:22f75f4eb883a33606785984a05451e3 prov:wasAssociatedWith niiri:978ecfac61168b631aeb24784516a78c .
 
-niiri:983041cba08acd2140526edea30a630f prov:used niiri:083b72805718136d80959aba1322a458 .
+niiri:22f75f4eb883a33606785984a05451e3 prov:used niiri:0913319d344f1fdba3d922a2dfae4612 .
 
-niiri:983041cba08acd2140526edea30a630f prov:used niiri:b7d55931ab8bfe4177e0cf74b1e0723e .
+niiri:22f75f4eb883a33606785984a05451e3 prov:used niiri:38c63862d3fa4aeb37b16674898b17d0 .
 
-niiri:983041cba08acd2140526edea30a630f prov:used niiri:cd2388fd62981ea59c5fc9dc434272fa .
+niiri:22f75f4eb883a33606785984a05451e3 prov:used niiri:db9345d4e9933a8e4b01bd306e4d1ada .
 
-niiri:983041cba08acd2140526edea30a630f prov:used niiri:e9c71f26b021b43b4cecb0f037a24625 .
+niiri:22f75f4eb883a33606785984a05451e3 prov:used niiri:a0a699bc84151f3770428014d5881784 .
 
-niiri:983041cba08acd2140526edea30a630f prov:used niiri:65dce2099c092d41e73a7baa0d8ac97a .
+niiri:22f75f4eb883a33606785984a05451e3 prov:used niiri:ece3cdb35b4a193e1c1a956e1d18a83f .
 
-niiri:983041cba08acd2140526edea30a630f prov:used niiri:2e789eb634bf515dca3c74e028484eda .
+niiri:22f75f4eb883a33606785984a05451e3 prov:used niiri:ded58d3d760e7c562c993612ce5bdbb0 .
 
-niiri:983041cba08acd2140526edea30a630f prov:used niiri:0cd070cb2241c08895462ab4099a104a .
+niiri:22f75f4eb883a33606785984a05451e3 prov:used niiri:c3a4c242421f98d32ff2ef9357eb073e .
 
-niiri:f1112f069407bf10806649b7fc8972f6
+niiri:b5be02643f367e1e1ed18da1e913b142
     a prov:Entity, nidm_SearchSpaceMaskMap: ; 
     prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
     nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Search Space Mask Map" ;
-    nidm_inCoordinateSpace: niiri:c2aaa0e17efdb9a83de1fa6bf4a54bc6 ;
+    nidm_inCoordinateSpace: niiri:fb077c2db1c7afee934de729a4c9618d ;
     nidm_searchVolumeInVoxels: "223057"^^xsd:int ;
     nidm_searchVolumeInUnits: "1784456"^^xsd:float ;
     nidm_reselSizeInVoxels: "65.5786964036542"^^xsd:float ;
@@ -517,9 +517,9 @@ niiri:f1112f069407bf10806649b7fc8972f6
     spm_smallestSignificantClusterSizeInVoxelsFWE05: "116"^^xsd:int ;
     spm_smallestSignificantClusterSizeInVoxelsFDR05: "61"^^xsd:int .
 
-niiri:f1112f069407bf10806649b7fc8972f6 prov:wasGeneratedBy niiri:983041cba08acd2140526edea30a630f .
+niiri:b5be02643f367e1e1ed18da1e913b142 prov:wasGeneratedBy niiri:22f75f4eb883a33606785984a05451e3 .
 
-niiri:35dcf56589dc3d231a39fb382f513f5c
+niiri:e1e17399f999e1f91dc21c7b68dbdf0b
     a prov:Entity, nidm_ExcursionSetMap: ; 
     prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
@@ -527,29 +527,29 @@ niiri:35dcf56589dc3d231a39fb382f513f5c
     rdfs:label "Excursion Set Map" ;
     nidm_numberOfSupraThresholdClusters: "10"^^xsd:int ;
     nidm_pValue: "0"^^xsd:float ;
-    nidm_hasClusterLabelsMap: niiri:28823f4a150c3ca742456112f89d6b21 ;
-    nidm_hasMaximumIntensityProjection: niiri:94acb04492ae25a9ab2d34ba609d3090 ;
-    nidm_inCoordinateSpace: niiri:c2aaa0e17efdb9a83de1fa6bf4a54bc6 ;
+    nidm_hasClusterLabelsMap: niiri:914772f2d1711625ae963abf3b3ae8b4 ;
+    nidm_hasMaximumIntensityProjection: niiri:475e9458d2df603def75554bb36f93a9 ;
+    nidm_inCoordinateSpace: niiri:fb077c2db1c7afee934de729a4c9618d ;
     crypto:sha512 "ba4f79758d41b7104bbd0f688aaa433cf258e1254cfd9e6de5e6c2c4bacacc9be392e9d7a3954c1f9db7a7a5fd6ecc6e3336fcec30eddc434de3c0c86dfe8562"^^xsd:string .
 
-niiri:28823f4a150c3ca742456112f89d6b21
+niiri:914772f2d1711625ae963abf3b3ae8b4
     a prov:Entity, nidm_ClusterLabelsMap: ; 
     prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Cluster Labels Map" ;
-    nidm_inCoordinateSpace: niiri:c2aaa0e17efdb9a83de1fa6bf4a54bc6 ;
+    nidm_inCoordinateSpace: niiri:fb077c2db1c7afee934de729a4c9618d ;
     crypto:sha512 "db5a86bea3707aaf8380866c8431e2ebc0c1c822c57ceaf420a53b3311ec38101478c53bac8ecc4c1915427e495415c63cd023fc663e89a7387b705998afdf00"^^xsd:string .
 
-niiri:94acb04492ae25a9ab2d34ba609d3090
+niiri:475e9458d2df603def75554bb36f93a9
     a prov:Entity, dctype:Image ; 
     prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
     nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:35dcf56589dc3d231a39fb382f513f5c prov:wasGeneratedBy niiri:983041cba08acd2140526edea30a630f .
+niiri:e1e17399f999e1f91dc21c7b68dbdf0b prov:wasGeneratedBy niiri:22f75f4eb883a33606785984a05451e3 .
 
-niiri:289f6a571b6c05659e38c60824b6ae97
+niiri:9dd5e0cba75bc4a093eb61cbd76e36a6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0001" ;
     nidm_clusterSizeInVoxels: "1804"^^xsd:int ;
@@ -559,9 +559,9 @@ niiri:289f6a571b6c05659e38c60824b6ae97
     nidm_qValueFDR: "5.93371085041799e-20"^^xsd:float ;
     nidm_clusterLabelId: "1"^^xsd:int .
 
-niiri:289f6a571b6c05659e38c60824b6ae97 prov:wasDerivedFrom niiri:35dcf56589dc3d231a39fb382f513f5c .
+niiri:9dd5e0cba75bc4a093eb61cbd76e36a6 prov:wasDerivedFrom niiri:e1e17399f999e1f91dc21c7b68dbdf0b .
 
-niiri:6eeb37a8bd0a4838f61862b04a99c5db
+niiri:29f39b3a7ffc8526221cbb764dc91ed6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0002" ;
     nidm_clusterSizeInVoxels: "356"^^xsd:int ;
@@ -571,9 +571,9 @@ niiri:6eeb37a8bd0a4838f61862b04a99c5db
     nidm_qValueFDR: "1.17083954451478e-06"^^xsd:float ;
     nidm_clusterLabelId: "2"^^xsd:int .
 
-niiri:6eeb37a8bd0a4838f61862b04a99c5db prov:wasDerivedFrom niiri:35dcf56589dc3d231a39fb382f513f5c .
+niiri:29f39b3a7ffc8526221cbb764dc91ed6 prov:wasDerivedFrom niiri:e1e17399f999e1f91dc21c7b68dbdf0b .
 
-niiri:2d4d8819babe3ddacdf0557e9803d3c3
+niiri:9119b99e73e7caf27ccbc46b71a20fe2
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0003" ;
     nidm_clusterSizeInVoxels: "5090"^^xsd:int ;
@@ -583,9 +583,9 @@ niiri:2d4d8819babe3ddacdf0557e9803d3c3
     nidm_qValueFDR: "2.03335233065374e-40"^^xsd:float ;
     nidm_clusterLabelId: "3"^^xsd:int .
 
-niiri:2d4d8819babe3ddacdf0557e9803d3c3 prov:wasDerivedFrom niiri:35dcf56589dc3d231a39fb382f513f5c .
+niiri:9119b99e73e7caf27ccbc46b71a20fe2 prov:wasDerivedFrom niiri:e1e17399f999e1f91dc21c7b68dbdf0b .
 
-niiri:7ef5339838ce0f10390b275732bf42b1
+niiri:5a140c712e9e00e14ac695343ed92c6a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0004" ;
     nidm_clusterSizeInVoxels: "766"^^xsd:int ;
@@ -595,9 +595,9 @@ niiri:7ef5339838ce0f10390b275732bf42b1
     nidm_qValueFDR: "4.58706002591263e-11"^^xsd:float ;
     nidm_clusterLabelId: "4"^^xsd:int .
 
-niiri:7ef5339838ce0f10390b275732bf42b1 prov:wasDerivedFrom niiri:35dcf56589dc3d231a39fb382f513f5c .
+niiri:5a140c712e9e00e14ac695343ed92c6a prov:wasDerivedFrom niiri:e1e17399f999e1f91dc21c7b68dbdf0b .
 
-niiri:b86df2eebd66ba5883ad7b57360dd393
+niiri:1b0ec2e914c1e26ce0156061bea8ec55
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0005" ;
     nidm_clusterSizeInVoxels: "285"^^xsd:int ;
@@ -607,9 +607,9 @@ niiri:b86df2eebd66ba5883ad7b57360dd393
     nidm_qValueFDR: "9.4369593516496e-06"^^xsd:float ;
     nidm_clusterLabelId: "5"^^xsd:int .
 
-niiri:b86df2eebd66ba5883ad7b57360dd393 prov:wasDerivedFrom niiri:35dcf56589dc3d231a39fb382f513f5c .
+niiri:1b0ec2e914c1e26ce0156061bea8ec55 prov:wasDerivedFrom niiri:e1e17399f999e1f91dc21c7b68dbdf0b .
 
-niiri:c61079d69888f267f17faecfe84c9ce8
+niiri:f6128a48e628339748454f9195fb4b90
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0006" ;
     nidm_clusterSizeInVoxels: "395"^^xsd:int ;
@@ -619,9 +619,9 @@ niiri:c61079d69888f267f17faecfe84c9ce8
     nidm_qValueFDR: "4.37433635338446e-07"^^xsd:float ;
     nidm_clusterLabelId: "6"^^xsd:int .
 
-niiri:c61079d69888f267f17faecfe84c9ce8 prov:wasDerivedFrom niiri:35dcf56589dc3d231a39fb382f513f5c .
+niiri:f6128a48e628339748454f9195fb4b90 prov:wasDerivedFrom niiri:e1e17399f999e1f91dc21c7b68dbdf0b .
 
-niiri:cd22280b374ae77e13e4c8e1b578cd1d
+niiri:16996fcb45118225812852d29f9f9a73
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0007" ;
     nidm_clusterSizeInVoxels: "116"^^xsd:int ;
@@ -631,9 +631,9 @@ niiri:cd22280b374ae77e13e4c8e1b578cd1d
     nidm_qValueFDR: "0.00366911802917346"^^xsd:float ;
     nidm_clusterLabelId: "7"^^xsd:int .
 
-niiri:cd22280b374ae77e13e4c8e1b578cd1d prov:wasDerivedFrom niiri:35dcf56589dc3d231a39fb382f513f5c .
+niiri:16996fcb45118225812852d29f9f9a73 prov:wasDerivedFrom niiri:e1e17399f999e1f91dc21c7b68dbdf0b .
 
-niiri:a8c21f93ea05f237f1d5a4f475ee2545
+niiri:b374b0b364537d85069da6781ed3bce7
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0008" ;
     nidm_clusterSizeInVoxels: "447"^^xsd:int ;
@@ -643,9 +643,9 @@ niiri:a8c21f93ea05f237f1d5a4f475ee2545
     nidm_qValueFDR: "1.22279946227405e-07"^^xsd:float ;
     nidm_clusterLabelId: "8"^^xsd:int .
 
-niiri:a8c21f93ea05f237f1d5a4f475ee2545 prov:wasDerivedFrom niiri:35dcf56589dc3d231a39fb382f513f5c .
+niiri:b374b0b364537d85069da6781ed3bce7 prov:wasDerivedFrom niiri:e1e17399f999e1f91dc21c7b68dbdf0b .
 
-niiri:6f51b281dc4706f206736c798a91ba30
+niiri:47eda65cfe1f349741bbd56fa3361233
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0009" ;
     nidm_clusterSizeInVoxels: "162"^^xsd:int ;
@@ -655,9 +655,9 @@ niiri:6f51b281dc4706f206736c798a91ba30
     nidm_qValueFDR: "0.000672150622508277"^^xsd:float ;
     nidm_clusterLabelId: "9"^^xsd:int .
 
-niiri:6f51b281dc4706f206736c798a91ba30 prov:wasDerivedFrom niiri:35dcf56589dc3d231a39fb382f513f5c .
+niiri:47eda65cfe1f349741bbd56fa3361233 prov:wasDerivedFrom niiri:e1e17399f999e1f91dc21c7b68dbdf0b .
 
-niiri:c25a8cb898d061e65d3970120b76fad9
+niiri:8235aa92a4300c6c7e12d8fb288e2e09
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0010" ;
     nidm_clusterSizeInVoxels: "134"^^xsd:int ;
@@ -667,447 +667,447 @@ niiri:c25a8cb898d061e65d3970120b76fad9
     nidm_qValueFDR: "0.00187402776443535"^^xsd:float ;
     nidm_clusterLabelId: "10"^^xsd:int .
 
-niiri:c25a8cb898d061e65d3970120b76fad9 prov:wasDerivedFrom niiri:35dcf56589dc3d231a39fb382f513f5c .
+niiri:8235aa92a4300c6c7e12d8fb288e2e09 prov:wasDerivedFrom niiri:e1e17399f999e1f91dc21c7b68dbdf0b .
 
-niiri:69e74743cffc3b5ec4410d25d73e3b94
+niiri:219af4d66e697f49e07199776077e216
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0001" ;
-    prov:atLocation niiri:6d28bb2eee84f65b03e234c9b7495869 ;
+    prov:atLocation niiri:2aab79258a69f0db7f63751d429ec6e0 ;
     prov:value "7.92007970809937"^^xsd:float ;
     nidm_equivalentZStatistic: "6.94608360738412"^^xsd:float ;
     nidm_pValueUncorrected: "1.87783122385099e-12"^^xsd:float ;
     nidm_pValueFWER: "4.18813870695089e-07"^^xsd:float ;
     nidm_qValueFDR: "5.21674435923017e-06"^^xsd:float .
 
-niiri:6d28bb2eee84f65b03e234c9b7495869
+niiri:2aab79258a69f0db7f63751d429ec6e0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0001" ;
     nidm_coordinateVector: "[46,16,24]"^^xsd:string .
 
-niiri:69e74743cffc3b5ec4410d25d73e3b94 prov:wasDerivedFrom niiri:289f6a571b6c05659e38c60824b6ae97 .
+niiri:219af4d66e697f49e07199776077e216 prov:wasDerivedFrom niiri:9dd5e0cba75bc4a093eb61cbd76e36a6 .
 
-niiri:050068d6e5c8af1000f8c84aebda8cef
+niiri:ea59d816b162d773d020ce2c78fe6579
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0002" ;
-    prov:atLocation niiri:dd72798cd5d4aed5ebf240342a39bc03 ;
+    prov:atLocation niiri:3a14839f82a10251f5ca1ac1e6ab0a84 ;
     prov:value "6.31603479385376"^^xsd:float ;
     nidm_equivalentZStatistic: "5.77079466112137"^^xsd:float ;
     nidm_pValueUncorrected: "3.94492849498107e-09"^^xsd:float ;
     nidm_pValueFWER: "0.000879943865776389"^^xsd:float ;
     nidm_qValueFDR: "0.000830722551601523"^^xsd:float .
 
-niiri:dd72798cd5d4aed5ebf240342a39bc03
+niiri:3a14839f82a10251f5ca1ac1e6ab0a84
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0002" ;
     nidm_coordinateVector: "[32,24,-4]"^^xsd:string .
 
-niiri:050068d6e5c8af1000f8c84aebda8cef prov:wasDerivedFrom niiri:289f6a571b6c05659e38c60824b6ae97 .
+niiri:ea59d816b162d773d020ce2c78fe6579 prov:wasDerivedFrom niiri:9dd5e0cba75bc4a093eb61cbd76e36a6 .
 
-niiri:8d6269a374249b42955a5ae090f66fa7
+niiri:9f9284ea2fb3b52c1c958913ea07adc6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0003" ;
-    prov:atLocation niiri:593aa23dd8068eb354899d7c9a4781e1 ;
+    prov:atLocation niiri:a3ff3ba6e003adbe983a538a39e41e7d ;
     prov:value "5.68819808959961"^^xsd:float ;
     nidm_equivalentZStatistic: "5.27450168515333"^^xsd:float ;
     nidm_pValueUncorrected: "6.655864770444e-08"^^xsd:float ;
     nidm_pValueFWER: "0.0121028975026269"^^xsd:float ;
     nidm_qValueFDR: "0.00350091530962783"^^xsd:float .
 
-niiri:593aa23dd8068eb354899d7c9a4781e1
+niiri:a3ff3ba6e003adbe983a538a39e41e7d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0003" ;
     nidm_coordinateVector: "[18,16,4]"^^xsd:string .
 
-niiri:8d6269a374249b42955a5ae090f66fa7 prov:wasDerivedFrom niiri:289f6a571b6c05659e38c60824b6ae97 .
+niiri:9f9284ea2fb3b52c1c958913ea07adc6 prov:wasDerivedFrom niiri:9dd5e0cba75bc4a093eb61cbd76e36a6 .
 
-niiri:fc9d3df843cacae41ecbc8915a362442
+niiri:944bc30a544eea31480b7ce73c7de33e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0004" ;
-    prov:atLocation niiri:1725b3da3aa9b2aecba33b2e6b3fb35f ;
+    prov:atLocation niiri:1663962b579598837b549cce2fe973e6 ;
     prov:value "7.11683940887451"^^xsd:float ;
     nidm_equivalentZStatistic: "6.37404871703245"^^xsd:float ;
     nidm_pValueUncorrected: "9.20510334623259e-11"^^xsd:float ;
     nidm_pValueFWER: "2.05325778424026e-05"^^xsd:float ;
     nidm_qValueFDR: "9.33757664730496e-05"^^xsd:float .
 
-niiri:1725b3da3aa9b2aecba33b2e6b3fb35f
+niiri:1663962b579598837b549cce2fe973e6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0004" ;
     nidm_coordinateVector: "[34,-88,-2]"^^xsd:string .
 
-niiri:fc9d3df843cacae41ecbc8915a362442 prov:wasDerivedFrom niiri:6eeb37a8bd0a4838f61862b04a99c5db .
+niiri:944bc30a544eea31480b7ce73c7de33e prov:wasDerivedFrom niiri:29f39b3a7ffc8526221cbb764dc91ed6 .
 
-niiri:07140cdcb12d2a506ba71eee8cd03e9e
+niiri:2c9d4a11c4fa1759dc1470cf7bbdc2d0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0005" ;
-    prov:atLocation niiri:bba10cf867e5830bfdd6d8799ee7d1b2 ;
+    prov:atLocation niiri:393bdeddfa8315a2909d86e9748639c6 ;
     prov:value "6.48292255401611"^^xsd:float ;
     nidm_equivalentZStatistic: "5.8992593141605"^^xsd:float ;
     nidm_pValueUncorrected: "1.82568493656277e-09"^^xsd:float ;
     nidm_pValueFWER: "0.000407231755366277"^^xsd:float ;
     nidm_qValueFDR: "0.000830722551601523"^^xsd:float .
 
-niiri:bba10cf867e5830bfdd6d8799ee7d1b2
+niiri:393bdeddfa8315a2909d86e9748639c6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0005" ;
     nidm_coordinateVector: "[42,-72,-10]"^^xsd:string .
 
-niiri:07140cdcb12d2a506ba71eee8cd03e9e prov:wasDerivedFrom niiri:6eeb37a8bd0a4838f61862b04a99c5db .
+niiri:2c9d4a11c4fa1759dc1470cf7bbdc2d0 prov:wasDerivedFrom niiri:29f39b3a7ffc8526221cbb764dc91ed6 .
 
-niiri:15bbc7641c21f7110c1d271381ce2ebf
+niiri:acc8196a4273a3c86f5676b2bc4a6016
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0006" ;
-    prov:atLocation niiri:d88536fec80f63d44d6f51376744d754 ;
+    prov:atLocation niiri:d0c9e40fb953987b03f13aa2c7c6b34b ;
     prov:value "5.2275915145874"^^xsd:float ;
     nidm_equivalentZStatistic: "4.89738468004472"^^xsd:float ;
     nidm_pValueUncorrected: "4.85602978606003e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0670610253017228"^^xsd:float ;
     nidm_qValueFDR: "0.0118363293065346"^^xsd:float .
 
-niiri:d88536fec80f63d44d6f51376744d754
+niiri:d0c9e40fb953987b03f13aa2c7c6b34b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0006" ;
     nidm_coordinateVector: "[34,-86,12]"^^xsd:string .
 
-niiri:15bbc7641c21f7110c1d271381ce2ebf prov:wasDerivedFrom niiri:6eeb37a8bd0a4838f61862b04a99c5db .
+niiri:acc8196a4273a3c86f5676b2bc4a6016 prov:wasDerivedFrom niiri:29f39b3a7ffc8526221cbb764dc91ed6 .
 
-niiri:7d77c66bcf5fcc2b35231d36f9453c56
+niiri:8d391d27c7d45276c852a9406623c60f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0007" ;
-    prov:atLocation niiri:aa6ccaf4c49dac1b198a2a4435c40d8d ;
+    prov:atLocation niiri:ddaec90e4d0de561cdc7f6e01e38a5d2 ;
     prov:value "6.28007745742798"^^xsd:float ;
     nidm_equivalentZStatistic: "5.74292583422276"^^xsd:float ;
     nidm_pValueUncorrected: "4.65272453897825e-09"^^xsd:float ;
     nidm_pValueFWER: "0.00103782272796227"^^xsd:float ;
     nidm_qValueFDR: "0.000830722551601523"^^xsd:float .
 
-niiri:aa6ccaf4c49dac1b198a2a4435c40d8d
+niiri:ddaec90e4d0de561cdc7f6e01e38a5d2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0007" ;
     nidm_coordinateVector: "[8,18,50]"^^xsd:string .
 
-niiri:7d77c66bcf5fcc2b35231d36f9453c56 prov:wasDerivedFrom niiri:2d4d8819babe3ddacdf0557e9803d3c3 .
+niiri:8d391d27c7d45276c852a9406623c60f prov:wasDerivedFrom niiri:9119b99e73e7caf27ccbc46b71a20fe2 .
 
-niiri:96ec5f9698442df720b453b98513381d
+niiri:6725f4fbe7aeb3714270626b873a4445
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0008" ;
-    prov:atLocation niiri:697006dfe9da91de0ef29f0318be3d05 ;
+    prov:atLocation niiri:03947289df407f4dfaee992081ab79d1 ;
     prov:value "6.15222215652466"^^xsd:float ;
     nidm_equivalentZStatistic: "5.64328512810061"^^xsd:float ;
     nidm_pValueUncorrected: "8.34178537356678e-09"^^xsd:float ;
     nidm_pValueFWER: "0.00186069357054308"^^xsd:float ;
     nidm_qValueFDR: "0.000972721201433817"^^xsd:float .
 
-niiri:697006dfe9da91de0ef29f0318be3d05
+niiri:03947289df407f4dfaee992081ab79d1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0008" ;
     nidm_coordinateVector: "[-6,12,52]"^^xsd:string .
 
-niiri:96ec5f9698442df720b453b98513381d prov:wasDerivedFrom niiri:2d4d8819babe3ddacdf0557e9803d3c3 .
+niiri:6725f4fbe7aeb3714270626b873a4445 prov:wasDerivedFrom niiri:9119b99e73e7caf27ccbc46b71a20fe2 .
 
-niiri:86835c30b47236c8759a822248ae1a7b
+niiri:430a862ed862cdb51f3527d8fa8754fd
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0009" ;
-    prov:atLocation niiri:42180e23ca90aa10eea3fdab9e906838 ;
+    prov:atLocation niiri:b6f52d40cc25ee4d9e2e660bf01ffdcc ;
     prov:value "5.98517084121704"^^xsd:float ;
     nidm_equivalentZStatistic: "5.51181334779297"^^xsd:float ;
     nidm_pValueUncorrected: "1.77577724747024e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00376326218366319"^^xsd:float ;
     nidm_qValueFDR: "0.00136419627856355"^^xsd:float .
 
-niiri:42180e23ca90aa10eea3fdab9e906838
+niiri:b6f52d40cc25ee4d9e2e660bf01ffdcc
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0009" ;
     nidm_coordinateVector: "[8,32,38]"^^xsd:string .
 
-niiri:86835c30b47236c8759a822248ae1a7b prov:wasDerivedFrom niiri:2d4d8819babe3ddacdf0557e9803d3c3 .
+niiri:430a862ed862cdb51f3527d8fa8754fd prov:wasDerivedFrom niiri:9119b99e73e7caf27ccbc46b71a20fe2 .
 
-niiri:740c29df2fbcd574a6da91c82fc0e324
+niiri:b05bca128b30571198c9e6e1d9341331
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0010" ;
-    prov:atLocation niiri:6bbf41234fc8a6d22a0231ea4a73e47b ;
+    prov:atLocation niiri:9f7c92dff8010e9bb8d470367995d0e6 ;
     prov:value "6.25127363204956"^^xsd:float ;
     nidm_equivalentZStatistic: "5.72055271981637"^^xsd:float ;
     nidm_pValueUncorrected: "5.30890376104765e-09"^^xsd:float ;
     nidm_pValueFWER: "0.0011841880966994"^^xsd:float ;
     nidm_qValueFDR: "0.000830722551601523"^^xsd:float .
 
-niiri:6bbf41234fc8a6d22a0231ea4a73e47b
+niiri:9f7c92dff8010e9bb8d470367995d0e6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0010" ;
     nidm_coordinateVector: "[52,-32,42]"^^xsd:string .
 
-niiri:740c29df2fbcd574a6da91c82fc0e324 prov:wasDerivedFrom niiri:7ef5339838ce0f10390b275732bf42b1 .
+niiri:b05bca128b30571198c9e6e1d9341331 prov:wasDerivedFrom niiri:5a140c712e9e00e14ac695343ed92c6a .
 
-niiri:25717939f6bc521501b6bea98f9921a0
+niiri:83f14a358618817c9a4a6a55d65d9d48
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0011" ;
-    prov:atLocation niiri:83280c58f4d4a8ee4edfa739d3ac75b9 ;
+    prov:atLocation niiri:eccc7ce308baf5cc0394b6c8e559a22d ;
     prov:value "6.24752378463745"^^xsd:float ;
     nidm_equivalentZStatistic: "5.71763687476157"^^xsd:float ;
     nidm_pValueUncorrected: "5.40078304300806e-09"^^xsd:float ;
     nidm_pValueFWER: "0.00120468241369565"^^xsd:float ;
     nidm_qValueFDR: "0.000830722551601523"^^xsd:float .
 
-niiri:83280c58f4d4a8ee4edfa739d3ac75b9
+niiri:eccc7ce308baf5cc0394b6c8e559a22d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0011" ;
     nidm_coordinateVector: "[40,-62,50]"^^xsd:string .
 
-niiri:25717939f6bc521501b6bea98f9921a0 prov:wasDerivedFrom niiri:7ef5339838ce0f10390b275732bf42b1 .
+niiri:83f14a358618817c9a4a6a55d65d9d48 prov:wasDerivedFrom niiri:5a140c712e9e00e14ac695343ed92c6a .
 
-niiri:1e0e7daf15fb3458359237d457192e6e
+niiri:85743f2fb9669a51df0ec45eb8d8c238
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0012" ;
-    prov:atLocation niiri:d7bbaac6676d1525d0edd68a08c63d1a ;
+    prov:atLocation niiri:593fddd783d0fc554f40d4cbb2ae9fd8 ;
     prov:value "5.70337772369385"^^xsd:float ;
     nidm_equivalentZStatistic: "5.28674301747281"^^xsd:float ;
     nidm_pValueUncorrected: "6.22566831420812e-08"^^xsd:float ;
     nidm_pValueFWER: "0.011413186758684"^^xsd:float ;
     nidm_qValueFDR: "0.00350091530962783"^^xsd:float .
 
-niiri:d7bbaac6676d1525d0edd68a08c63d1a
+niiri:593fddd783d0fc554f40d4cbb2ae9fd8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0012" ;
     nidm_coordinateVector: "[56,-44,52]"^^xsd:string .
 
-niiri:1e0e7daf15fb3458359237d457192e6e prov:wasDerivedFrom niiri:7ef5339838ce0f10390b275732bf42b1 .
+niiri:85743f2fb9669a51df0ec45eb8d8c238 prov:wasDerivedFrom niiri:5a140c712e9e00e14ac695343ed92c6a .
 
-niiri:28d9d8d8b820a935fd506cc19951cb36
+niiri:004249a446a2a2711503faa18a5be983
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0013" ;
-    prov:atLocation niiri:09d2b984c867b9231df1760b08d3af39 ;
+    prov:atLocation niiri:4ba5a90af9efd38fd0be8658803dd352 ;
     prov:value "6.10109901428223"^^xsd:float ;
     nidm_equivalentZStatistic: "5.60320502193174"^^xsd:float ;
     nidm_pValueUncorrected: "1.05212039080982e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00234682813060005"^^xsd:float ;
     nidm_qValueFDR: "0.00104518293275697"^^xsd:float .
 
-niiri:09d2b984c867b9231df1760b08d3af39
+niiri:4ba5a90af9efd38fd0be8658803dd352
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0013" ;
     nidm_coordinateVector: "[32,2,46]"^^xsd:string .
 
-niiri:28d9d8d8b820a935fd506cc19951cb36 prov:wasDerivedFrom niiri:b86df2eebd66ba5883ad7b57360dd393 .
+niiri:004249a446a2a2711503faa18a5be983 prov:wasDerivedFrom niiri:1b0ec2e914c1e26ce0156061bea8ec55 .
 
-niiri:aad8486e71e8fc524f27573bf88b3898
+niiri:a41084fb733e0e08cf6c8c3fb3eb5701
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0014" ;
-    prov:atLocation niiri:eb1bc008e7109bbb3631f97b5453bf7c ;
+    prov:atLocation niiri:18764a45f2220339c69ef7c9bfdc47e7 ;
     prov:value "4.6086859703064"^^xsd:float ;
     nidm_equivalentZStatistic: "4.3736141683061"^^xsd:float ;
     nidm_pValueUncorrected: "6.11031435759912e-06"^^xsd:float ;
     nidm_pValueFWER: "0.453877178455514"^^xsd:float ;
     nidm_qValueFDR: "0.0599714495109201"^^xsd:float .
 
-niiri:eb1bc008e7109bbb3631f97b5453bf7c
+niiri:18764a45f2220339c69ef7c9bfdc47e7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0014" ;
     nidm_coordinateVector: "[28,4,58]"^^xsd:string .
 
-niiri:aad8486e71e8fc524f27573bf88b3898 prov:wasDerivedFrom niiri:b86df2eebd66ba5883ad7b57360dd393 .
+niiri:a41084fb733e0e08cf6c8c3fb3eb5701 prov:wasDerivedFrom niiri:1b0ec2e914c1e26ce0156061bea8ec55 .
 
-niiri:623246f4c2d05584cae00585a8a26390
+niiri:6ff1fdc33f1b4c1ab70d3a900c678f9c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0015" ;
-    prov:atLocation niiri:a15a3af6428c84a8a7c2cca46f243ec6 ;
+    prov:atLocation niiri:c8ad2195d487c19092289414f0abafd1 ;
     prov:value "3.98793148994446"^^xsd:float ;
     nidm_equivalentZStatistic: "3.82932508069717"^^xsd:float ;
     nidm_pValueUncorrected: "6.42475887594474e-05"^^xsd:float ;
     nidm_pValueFWER: "0.984644566584946"^^xsd:float ;
     nidm_qValueFDR: "0.233149120368192"^^xsd:float .
 
-niiri:a15a3af6428c84a8a7c2cca46f243ec6
+niiri:c8ad2195d487c19092289414f0abafd1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0015" ;
     nidm_coordinateVector: "[42,4,48]"^^xsd:string .
 
-niiri:623246f4c2d05584cae00585a8a26390 prov:wasDerivedFrom niiri:b86df2eebd66ba5883ad7b57360dd393 .
+niiri:6ff1fdc33f1b4c1ab70d3a900c678f9c prov:wasDerivedFrom niiri:1b0ec2e914c1e26ce0156061bea8ec55 .
 
-niiri:bbc863a960c2c202baa922de0bbe2bda
+niiri:c70c9f283443901436c2946acb819132
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0016" ;
-    prov:atLocation niiri:4fe8ca4f432631f0b38d1bf5707dac6e ;
+    prov:atLocation niiri:e05c37b5c74c14f57c7e2e30c9035861 ;
     prov:value "5.98348569869995"^^xsd:float ;
     nidm_equivalentZStatistic: "5.51047970249337"^^xsd:float ;
     nidm_pValueUncorrected: "1.78928538652201e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00378871596531738"^^xsd:float ;
     nidm_qValueFDR: "0.00136419627856355"^^xsd:float .
 
-niiri:4fe8ca4f432631f0b38d1bf5707dac6e
+niiri:e05c37b5c74c14f57c7e2e30c9035861
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0016" ;
     nidm_coordinateVector: "[-52,0,38]"^^xsd:string .
 
-niiri:bbc863a960c2c202baa922de0bbe2bda prov:wasDerivedFrom niiri:c61079d69888f267f17faecfe84c9ce8 .
+niiri:c70c9f283443901436c2946acb819132 prov:wasDerivedFrom niiri:f6128a48e628339748454f9195fb4b90 .
 
-niiri:6674ef85cd54cf09d270fc67f7b7377f
+niiri:8cf7256afe51307616ffb11a8dcf7656
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0017" ;
-    prov:atLocation niiri:0f20e781d121f37a4bf2ab17199be0d9 ;
+    prov:atLocation niiri:eb1fdad4df23df5a2b3d3c0d6a56a6d5 ;
     prov:value "5.2253565788269"^^xsd:float ;
     nidm_equivalentZStatistic: "4.89552821543552"^^xsd:float ;
     nidm_pValueUncorrected: "4.90210114501011e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0675937275056587"^^xsd:float ;
     nidm_qValueFDR: "0.0118363293065346"^^xsd:float .
 
-niiri:0f20e781d121f37a4bf2ab17199be0d9
+niiri:eb1fdad4df23df5a2b3d3c0d6a56a6d5
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0017" ;
     nidm_coordinateVector: "[-60,8,20]"^^xsd:string .
 
-niiri:6674ef85cd54cf09d270fc67f7b7377f prov:wasDerivedFrom niiri:c61079d69888f267f17faecfe84c9ce8 .
+niiri:8cf7256afe51307616ffb11a8dcf7656 prov:wasDerivedFrom niiri:f6128a48e628339748454f9195fb4b90 .
 
-niiri:a6c4f5fa76525074a8e0bfade60c9f27
+niiri:5311d6026c4d7b6211bd21394ed3cd34
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0018" ;
-    prov:atLocation niiri:e43908a0c36843ed209b0eba37e50d75 ;
+    prov:atLocation niiri:7d87737758e0654156614064a8771717 ;
     prov:value "4.98950004577637"^^xsd:float ;
     nidm_equivalentZStatistic: "4.69817956585148"^^xsd:float ;
     nidm_pValueUncorrected: "1.31245304380023e-06"^^xsd:float ;
     nidm_pValueFWER: "0.151048137890434"^^xsd:float ;
     nidm_qValueFDR: "0.0233609510296683"^^xsd:float .
 
-niiri:e43908a0c36843ed209b0eba37e50d75
+niiri:7d87737758e0654156614064a8771717
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0018" ;
     nidm_coordinateVector: "[-44,6,28]"^^xsd:string .
 
-niiri:a6c4f5fa76525074a8e0bfade60c9f27 prov:wasDerivedFrom niiri:c61079d69888f267f17faecfe84c9ce8 .
+niiri:5311d6026c4d7b6211bd21394ed3cd34 prov:wasDerivedFrom niiri:f6128a48e628339748454f9195fb4b90 .
 
-niiri:645b4d78ae14c2b26b79ee898d11d012
+niiri:932949e2a06a6b558e7f4e4fdfaef630
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0019" ;
-    prov:atLocation niiri:eb2722464de0f62707afbbf4d6bf8844 ;
+    prov:atLocation niiri:867678d8e68882ecd35ff7e4ada5602f ;
     prov:value "5.78093099594116"^^xsd:float ;
     nidm_equivalentZStatistic: "5.34909755317379"^^xsd:float ;
     nidm_pValueUncorrected: "4.41969442155354e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00844151822925698"^^xsd:float ;
     nidm_qValueFDR: "0.00286742427823329"^^xsd:float .
 
-niiri:eb2722464de0f62707afbbf4d6bf8844
+niiri:867678d8e68882ecd35ff7e4ada5602f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0019" ;
     nidm_coordinateVector: "[-34,-2,52]"^^xsd:string .
 
-niiri:645b4d78ae14c2b26b79ee898d11d012 prov:wasDerivedFrom niiri:cd22280b374ae77e13e4c8e1b578cd1d .
+niiri:932949e2a06a6b558e7f4e4fdfaef630 prov:wasDerivedFrom niiri:16996fcb45118225812852d29f9f9a73 .
 
-niiri:fdde41354522241386acfa16eac024ee
+niiri:0ff41f9a206a4f614332cd4bd0d4db48
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0020" ;
-    prov:atLocation niiri:a528fb74e5454d828bfcb7fb64ff5e51 ;
+    prov:atLocation niiri:b2bc2fe9dcebc44d696b30462a22509b ;
     prov:value "5.30699443817139"^^xsd:float ;
     nidm_equivalentZStatistic: "4.96317509467693"^^xsd:float ;
     nidm_pValueUncorrected: "3.46750043123123e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0504786376455083"^^xsd:float ;
     nidm_qValueFDR: "0.0106752417476244"^^xsd:float .
 
-niiri:a528fb74e5454d828bfcb7fb64ff5e51
+niiri:b2bc2fe9dcebc44d696b30462a22509b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0020" ;
     nidm_coordinateVector: "[32,40,16]"^^xsd:string .
 
-niiri:fdde41354522241386acfa16eac024ee prov:wasDerivedFrom niiri:a8c21f93ea05f237f1d5a4f475ee2545 .
+niiri:0ff41f9a206a4f614332cd4bd0d4db48 prov:wasDerivedFrom niiri:b374b0b364537d85069da6781ed3bce7 .
 
-niiri:ca1201b1709fe1af43c1a16015e8300a
+niiri:b7cd492bae1a54bc9978c2c30ae62044
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0021" ;
-    prov:atLocation niiri:059f5e1504b0b74a098f9eb38e7b8c2b ;
+    prov:atLocation niiri:5d959d006ddff911006f677f2f35bdc0 ;
     prov:value "4.5497465133667"^^xsd:float ;
     nidm_equivalentZStatistic: "4.32273570618355"^^xsd:float ;
     nidm_pValueUncorrected: "7.7053150754347e-06"^^xsd:float ;
     nidm_pValueFWER: "0.520378392891944"^^xsd:float ;
     nidm_qValueFDR: "0.0649997423676262"^^xsd:float .
 
-niiri:059f5e1504b0b74a098f9eb38e7b8c2b
+niiri:5d959d006ddff911006f677f2f35bdc0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0021" ;
     nidm_coordinateVector: "[40,46,12]"^^xsd:string .
 
-niiri:ca1201b1709fe1af43c1a16015e8300a prov:wasDerivedFrom niiri:a8c21f93ea05f237f1d5a4f475ee2545 .
+niiri:b7cd492bae1a54bc9978c2c30ae62044 prov:wasDerivedFrom niiri:b374b0b364537d85069da6781ed3bce7 .
 
-niiri:c5a8f15e086e65859ead340a09ac4f9b
+niiri:5361732ec0e4c8b9cac0fb646789c096
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0022" ;
-    prov:atLocation niiri:2a3dfef8697f81c9e1d52d990cc7fe25 ;
+    prov:atLocation niiri:b5342f9bc1453a7c01e4c7e8ea7cc962 ;
     prov:value "4.31582498550415"^^xsd:float ;
     nidm_equivalentZStatistic: "4.11913273798974"^^xsd:float ;
     nidm_pValueUncorrected: "1.90150518718513e-05"^^xsd:float ;
     nidm_pValueFWER: "0.788829013385429"^^xsd:float ;
     nidm_qValueFDR: "0.116130094830597"^^xsd:float .
 
-niiri:2a3dfef8697f81c9e1d52d990cc7fe25
+niiri:b5342f9bc1453a7c01e4c7e8ea7cc962
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0022" ;
     nidm_coordinateVector: "[36,54,6]"^^xsd:string .
 
-niiri:c5a8f15e086e65859ead340a09ac4f9b prov:wasDerivedFrom niiri:a8c21f93ea05f237f1d5a4f475ee2545 .
+niiri:5361732ec0e4c8b9cac0fb646789c096 prov:wasDerivedFrom niiri:b374b0b364537d85069da6781ed3bce7 .
 
-niiri:2c25aabcf5b166b064e4649fb8473ef0
+niiri:1c1efb50135a7c1bad8db7e4cf11686f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0023" ;
-    prov:atLocation niiri:027a1408e9f0aa75eb2b665b1d785257 ;
+    prov:atLocation niiri:35725a8dc35ca221915f18e8878596aa ;
     prov:value "5.27030229568481"^^xsd:float ;
     nidm_equivalentZStatistic: "4.93281349716267"^^xsd:float ;
     nidm_pValueUncorrected: "4.05267701952816e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0575990926145485"^^xsd:float ;
     nidm_qValueFDR: "0.0110040663565173"^^xsd:float .
 
-niiri:027a1408e9f0aa75eb2b665b1d785257
+niiri:35725a8dc35ca221915f18e8878596aa
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0023" ;
     nidm_coordinateVector: "[40,26,48]"^^xsd:string .
 
-niiri:2c25aabcf5b166b064e4649fb8473ef0 prov:wasDerivedFrom niiri:6f51b281dc4706f206736c798a91ba30 .
+niiri:1c1efb50135a7c1bad8db7e4cf11686f prov:wasDerivedFrom niiri:47eda65cfe1f349741bbd56fa3361233 .
 
-niiri:eb5564371ee096c26953a7911ad47fbe
+niiri:142faca43b00bbe02174b97cc402bc5e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0024" ;
-    prov:atLocation niiri:da4b988e03393052039eea8b1be78259 ;
+    prov:atLocation niiri:d64683a5a499945ff7594f708a0ca237 ;
     prov:value "4.72232866287231"^^xsd:float ;
     nidm_equivalentZStatistic: "4.47122948835043"^^xsd:float ;
     nidm_pValueUncorrected: "3.88855941602095e-06"^^xsd:float ;
     nidm_pValueFWER: "0.338512677882141"^^xsd:float ;
     nidm_qValueFDR: "0.044836631144536"^^xsd:float .
 
-niiri:da4b988e03393052039eea8b1be78259
+niiri:d64683a5a499945ff7594f708a0ca237
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0024" ;
     nidm_coordinateVector: "[58,-38,6]"^^xsd:string .
 
-niiri:eb5564371ee096c26953a7911ad47fbe prov:wasDerivedFrom niiri:c25a8cb898d061e65d3970120b76fad9 .
+niiri:142faca43b00bbe02174b97cc402bc5e prov:wasDerivedFrom niiri:8235aa92a4300c6c7e12d8fb288e2e09 .
 
-niiri:7fa07b417d168f7e49c28acede45488e
+niiri:d3d21d9fb8f5c4e3c028dafc33492ae5
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0025" ;
-    prov:atLocation niiri:1a471d98e4a0738d037ddb9d69f9145c ;
+    prov:atLocation niiri:a444192598b15b39c8f68d9d10ad798f ;
     prov:value "3.98372888565063"^^xsd:float ;
     nidm_equivalentZStatistic: "3.8255778871433"^^xsd:float ;
     nidm_pValueUncorrected: "6.52328381068878e-05"^^xsd:float ;
     nidm_pValueFWER: "0.985409231324461"^^xsd:float ;
     nidm_qValueFDR: "0.233731539105478"^^xsd:float .
 
-niiri:1a471d98e4a0738d037ddb9d69f9145c
+niiri:a444192598b15b39c8f68d9d10ad798f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0025" ;
     nidm_coordinateVector: "[64,-30,-4]"^^xsd:string .
 
-niiri:7fa07b417d168f7e49c28acede45488e prov:wasDerivedFrom niiri:c25a8cb898d061e65d3970120b76fad9 .
+niiri:d3d21d9fb8f5c4e3c028dafc33492ae5 prov:wasDerivedFrom niiri:8235aa92a4300c6c7e12d8fb288e2e09 .
 
-niiri:2a40cfff6e0c1e255ff9003adbe498b5
+niiri:67d65736ad13421436d72a8215e48d31
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0026" ;
-    prov:atLocation niiri:d7d3268c6eed62e2fd9247e016c651f8 ;
+    prov:atLocation niiri:3c8566c59af37fa6a9390ed38a37517b ;
     prov:value "3.50753784179688"^^xsd:float ;
     nidm_equivalentZStatistic: "3.39582098150001"^^xsd:float ;
     nidm_pValueUncorrected: "0.000342115474631921"^^xsd:float ;
     nidm_pValueFWER: "0.999999778829603"^^xsd:float ;
     nidm_qValueFDR: "0.564856004417035"^^xsd:float .
 
-niiri:d7d3268c6eed62e2fd9247e016c651f8
+niiri:3c8566c59af37fa6a9390ed38a37517b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0026" ;
     nidm_coordinateVector: "[60,-40,-12]"^^xsd:string .
 
-niiri:2a40cfff6e0c1e255ff9003adbe498b5 prov:wasDerivedFrom niiri:c25a8cb898d061e65d3970120b76fad9 .
+niiri:67d65736ad13421436d72a8215e48d31 prov:wasDerivedFrom niiri:8235aa92a4300c6c7e12d8fb288e2e09 .
 

--- a/spmexport/ex_spm_thr_clustunck10/nidm.json
+++ b/spmexport/ex_spm_thr_clustunck10/nidm.json
@@ -1,0 +1,6298 @@
+{
+  "prefix": {
+    "nidm": "http://purl.org/nidash/nidm#",
+    "niiri": "http://iri.nidash.org/",
+    "spm": "http://purl.org/nidash/spm#",
+    "neurolex": "http://neurolex.org/wiki/",
+    "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/",
+    "dct": "http://purl.org/dc/terms/",
+    "nfo": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#",
+    "dc": "http://purl.org/dc/elements/1.1/",
+    "dctype": "http://purl.org/dc/dcmitype/",
+    "obo": "http://purl.obolibrary.org/obo/",
+    "nidm_NIDMResults": "http://purl.org/nidash/nidm#NIDM_0000027",
+    "nidm_version": "http://purl.org/nidash/nidm#NIDM_0000127",
+    "nidm_spm_results_nidm": "http://purl.org/nidash/nidm#NIDM_0000168",
+    "nidm_softwareVersion": "http://purl.org/nidash/nidm#NIDM_0000122",
+    "nidm_NIDMResultsExport": "http://purl.org/nidash/nidm#NIDM_0000166"
+  },
+  "entity": {
+    "niiri:05f8e697eec5ffc5aace5c1f4c105fda": {
+      "prov:type": [
+        {
+        "$": "prov:Bundle",
+        "type": "xsd:QName"
+        },
+        {
+        "$": "nidm_NIDMResults:",
+        "type": "xsd:QName"
+        }
+      ],
+      "prov:label": {
+        "$": "NIDM-Results",
+        "type": "xsd:string"
+      },
+      "nidm_version:": {
+        "$": "1.3.0",
+        "type": "xsd:string"
+      }
+    }
+  },
+  "activity": {
+    "niiri:09e1635174afe5c856ec0e948fac8237": {
+      "prov:type": {
+        "$": "nidm_NIDMResultsExport:",
+        "type": "xsd:QName"
+      },
+      "prov:label": {
+        "$": "NIDM-Results export",
+        "type": "xsd:string"
+      }
+    }
+  },
+  "agent": {
+    "niiri:4f37bcd80c8dd68304abbe610cb6c460": {
+      "prov:type": [
+        {
+        "$": "nidm_spm_results_nidm:",
+        "type": "xsd:QName"
+        },
+        {
+        "$": "prov:SoftwareAgent",
+        "type": "xsd:QName"
+        }
+      ],
+      "prov:label": {
+        "$": "spm_results_nidm",
+        "type": "xsd:string"
+      },
+      "nidm_softwareVersion:": {
+        "$": "12.7057",
+        "type": "xsd:string"
+      }
+    }
+  },
+  "wasGeneratedBy": {
+    "_:wGB5": {
+      "prov:entity": "niiri:05f8e697eec5ffc5aace5c1f4c105fda",
+      "prov:activity": "niiri:09e1635174afe5c856ec0e948fac8237",
+      "prov:time": "2017-04-19T12:19:06"
+    }
+  },
+  "wasAssociatedWith": {
+    "_:wAW4": {
+      "prov:activity": "niiri:09e1635174afe5c856ec0e948fac8237",
+      "prov:agent": "niiri:4f37bcd80c8dd68304abbe610cb6c460"
+    }
+  },
+  "bundle": {
+    "niiri:05f8e697eec5ffc5aace5c1f4c105fda": {
+    "prefix": {
+        "nidm_softwareVersion": "http://purl.org/nidash/nidm#NIDM_0000122",
+        "nidm_CoordinateSpace": "http://purl.org/nidash/nidm#NIDM_0000016",
+        "nidm_voxelToWorldMapping": "http://purl.org/nidash/nidm#NIDM_0000132",
+        "nidm_voxelUnits": "http://purl.org/nidash/nidm#NIDM_0000133",
+        "nidm_voxelSize": "http://purl.org/nidash/nidm#NIDM_0000131",
+        "nidm_inWorldCoordinateSystem": "http://purl.org/nidash/nidm#NIDM_0000105",
+        "nidm_numberOfDimensions": "http://purl.org/nidash/nidm#NIDM_0000112",
+        "nidm_dimensionsInVoxels": "http://purl.org/nidash/nidm#NIDM_0000090",
+        "nlx_Imaginginstrument": "http://uri.neuinfo.org/nif/nifstd/birnlex_2094",
+        "nlx_Magneticresonanceimagingscanner": "http://uri.neuinfo.org/nif/nifstd/birnlex_2100",
+        "nidm_grandMeanScaling": "http://purl.org/nidash/nidm#NIDM_0000096",
+        "nidm_targetIntensity": "http://purl.org/nidash/nidm#NIDM_0000124",
+        "nidm_hasMRIProtocol": "http://purl.org/nidash/nidm#NIDM_0000172",
+        "nlx_FunctionalMRIprotocol": "http://uri.neuinfo.org/nif/nifstd/birnlex_2250",
+        "nidm_Data": "http://purl.org/nidash/nidm#NIDM_0000169",
+        "spm_DCTDriftModel": "http://purl.org/nidash/spm#SPM_0000002",
+        "spm_SPMsDriftCutoffPeriod": "http://purl.org/nidash/spm#SPM_0000001",
+        "nidm_hasDriftModel": "http://purl.org/nidash/nidm#NIDM_0000088",
+        "nidm_hasHRFBasis": "http://purl.org/nidash/nidm#NIDM_0000102",
+        "spm_SPMsCanonicalHRF": "http://purl.org/nidash/spm#SPM_0000004",
+        "nidm_DesignMatrix": "http://purl.org/nidash/nidm#NIDM_0000019",
+        "nidm_regressorNames": "http://purl.org/nidash/nidm#NIDM_0000021",
+        "nidm_hasErrorDependence": "http://purl.org/nidash/nidm#NIDM_0000100",
+        "obo_Toeplitzcovariancestructure": "http://purl.obolibrary.org/obo/STATO_0000357",
+        "nidm_dependenceMapWiseDependence": "http://purl.org/nidash/nidm#NIDM_0000089",
+        "nidm_ConstantParameter": "http://purl.org/nidash/nidm#NIDM_0000072",
+        "nidm_errorVarianceHomogeneous": "http://purl.org/nidash/nidm#NIDM_0000094",
+        "nidm_varianceMapWiseDependence": "http://purl.org/nidash/nidm#NIDM_0000126",
+        "nidm_IndependentParameter": "http://purl.org/nidash/nidm#NIDM_0000073",
+        "nidm_withEstimationMethod": "http://purl.org/nidash/nidm#NIDM_0000134",
+        "obo_generalizedleastsquaresestimation": "http://purl.obolibrary.org/obo/STATO_0000372",
+        "nidm_ErrorModel": "http://purl.org/nidash/nidm#NIDM_0000023",
+        "nidm_hasErrorDistribution": "http://purl.org/nidash/nidm#NIDM_0000101",
+        "obo_normaldistribution": "http://purl.obolibrary.org/obo/STATO_0000227",
+        "nidm_ModelParametersEstimation": "http://purl.org/nidash/nidm#NIDM_0000056",
+        "nidm_MaskMap": "http://purl.org/nidash/nidm#NIDM_0000054",
+        "nidm_isUserDefined": "http://purl.org/nidash/nidm#NIDM_0000106",
+        "nidm_inCoordinateSpace": "http://purl.org/nidash/nidm#NIDM_0000104",
+        "nidm_GrandMeanMap": "http://purl.org/nidash/nidm#NIDM_0000033",
+        "nidm_maskedMedian": "http://purl.org/nidash/nidm#NIDM_0000107",
+        "nidm_ParameterEstimateMap": "http://purl.org/nidash/nidm#NIDM_0000061",
+        "nidm_ResidualMeanSquaresMap": "http://purl.org/nidash/nidm#NIDM_0000066",
+        "nidm_ReselsPerVoxelMap": "http://purl.org/nidash/nidm#NIDM_0000144",
+        "obo_contrastweightmatrix": "http://purl.obolibrary.org/obo/STATO_0000323",
+        "nidm_statisticType": "http://purl.org/nidash/nidm#NIDM_0000123",
+        "obo_tstatistic": "http://purl.obolibrary.org/obo/STATO_0000176",
+        "nidm_contrastName": "http://purl.org/nidash/nidm#NIDM_0000085",
+        "nidm_ContrastEstimation": "http://purl.org/nidash/nidm#NIDM_0000001",
+        "nidm_StatisticMap": "http://purl.org/nidash/nidm#NIDM_0000076",
+        "nidm_errorDegreesOfFreedom": "http://purl.org/nidash/nidm#NIDM_0000093",
+        "nidm_effectDegreesOfFreedom": "http://purl.org/nidash/nidm#NIDM_0000091",
+        "nidm_ContrastMap": "http://purl.org/nidash/nidm#NIDM_0000002",
+        "nidm_ContrastStandardErrorMap": "http://purl.org/nidash/nidm#NIDM_0000013",
+        "obo_statistic": "http://purl.obolibrary.org/obo/STATO_0000039",
+        "nidm_PValueUncorrected": "http://purl.org/nidash/nidm#NIDM_0000160",
+        "obo_FWERadjustedpvalue": "http://purl.obolibrary.org/obo/OBI_0001265",
+        "nidm_HeightThreshold": "http://purl.org/nidash/nidm#NIDM_0000034",
+        "nidm_equivalentThreshold": "http://purl.org/nidash/nidm#NIDM_0000161",
+        "nidm_ExtentThreshold": "http://purl.org/nidash/nidm#NIDM_0000026",
+        "nidm_clusterSizeInVoxels": "http://purl.org/nidash/nidm#NIDM_0000084",
+        "nidm_clusterSizeInResels": "http://purl.org/nidash/nidm#NIDM_0000156",
+        "nidm_PeakDefinitionCriteria": "http://purl.org/nidash/nidm#NIDM_0000063",
+        "nidm_maxNumberOfPeaksPerCluster": "http://purl.org/nidash/nidm#NIDM_0000108",
+        "nidm_minDistanceBetweenPeaks": "http://purl.org/nidash/nidm#NIDM_0000109",
+        "nidm_ClusterDefinitionCriteria": "http://purl.org/nidash/nidm#NIDM_0000007",
+        "nidm_hasConnectivityCriterion": "http://purl.org/nidash/nidm#NIDM_0000099",
+        "nidm_voxel18connected": "http://purl.org/nidash/nidm#NIDM_0000128",
+        "nidm_Inference": "http://purl.org/nidash/nidm#NIDM_0000049",
+        "nidm_hasAlternativeHypothesis": "http://purl.org/nidash/nidm#NIDM_0000097",
+        "nidm_OneTailedTest": "http://purl.org/nidash/nidm#NIDM_0000060",
+        "nidm_SearchSpaceMaskMap": "http://purl.org/nidash/nidm#NIDM_0000068",
+        "nidm_searchVolumeInVoxels": "http://purl.org/nidash/nidm#NIDM_0000121",
+        "nidm_searchVolumeInUnits": "http://purl.org/nidash/nidm#NIDM_0000136",
+        "nidm_reselSizeInVoxels": "http://purl.org/nidash/nidm#NIDM_0000148",
+        "nidm_searchVolumeInResels": "http://purl.org/nidash/nidm#NIDM_0000149",
+        "spm_searchVolumeReselsGeometry": "http://purl.org/nidash/spm#SPM_0000010",
+        "nidm_noiseFWHMInVoxels": "http://purl.org/nidash/nidm#NIDM_0000159",
+        "nidm_noiseFWHMInUnits": "http://purl.org/nidash/nidm#NIDM_0000157",
+        "nidm_randomFieldStationarity": "http://purl.org/nidash/nidm#NIDM_0000120",
+        "nidm_expectedNumberOfVoxelsPerCluster": "http://purl.org/nidash/nidm#NIDM_0000143",
+        "nidm_expectedNumberOfClusters": "http://purl.org/nidash/nidm#NIDM_0000141",
+        "nidm_heightCriticalThresholdFWE05": "http://purl.org/nidash/nidm#NIDM_0000147",
+        "nidm_heightCriticalThresholdFDR05": "http://purl.org/nidash/nidm#NIDM_0000146",
+        "spm_smallestSignificantClusterSizeInVoxelsFWE05": "http://purl.org/nidash/spm#SPM_0000014",
+        "spm_smallestSignificantClusterSizeInVoxelsFDR05": "http://purl.org/nidash/spm#SPM_0000013",
+        "nidm_ExcursionSetMap": "http://purl.org/nidash/nidm#NIDM_0000025",
+        "nidm_numberOfSupraThresholdClusters": "http://purl.org/nidash/nidm#NIDM_0000111",
+        "nidm_pValue": "http://purl.org/nidash/nidm#NIDM_0000114",
+        "nidm_hasClusterLabelsMap": "http://purl.org/nidash/nidm#NIDM_0000098",
+        "nidm_hasMaximumIntensityProjection": "http://purl.org/nidash/nidm#NIDM_0000138",
+        "nidm_ClusterLabelsMap": "http://purl.org/nidash/nidm#NIDM_0000008",
+        "nidm_SupraThresholdCluster": "http://purl.org/nidash/nidm#NIDM_0000070",
+        "nidm_pValueUncorrected": "http://purl.org/nidash/nidm#NIDM_0000116",
+        "nidm_pValueFWER": "http://purl.org/nidash/nidm#NIDM_0000115",
+        "nidm_qValueFDR": "http://purl.org/nidash/nidm#NIDM_0000119",
+        "nidm_clusterLabelId": "http://purl.org/nidash/nidm#NIDM_0000082",
+        "nidm_Peak": "http://purl.org/nidash/nidm#NIDM_0000062",
+        "nidm_equivalentZStatistic": "http://purl.org/nidash/nidm#NIDM_0000092",
+        "nidm_Coordinate": "http://purl.org/nidash/nidm#NIDM_0000015",
+        "nidm_coordinateVector": "http://purl.org/nidash/nidm#NIDM_0000086"
+    },
+    "entity": {
+        "niiri:c8b0140b68018da6f9905cc4b8fd05ad": {
+            "prov:type": {
+                "$": "nidm_CoordinateSpace:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Coordinate space 1",
+                "type": "xsd:string"
+            },
+            "nidm_voxelToWorldMapping:": {
+                "$": "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]",
+                "type": "xsd:string"
+            },
+            "nidm_voxelUnits:": {
+                "$": "[\"mm\", \"mm\", \"mm\"]",
+                "type": "xsd:string"
+            },
+            "nidm_voxelSize:": {
+                "$": "[2, 2, 2]",
+                "type": "xsd:string"
+            },
+            "nidm_inWorldCoordinateSystem:": {
+                "$": "nidm_Ixi549CoordinateSystem:",
+                "type": "xsd:string"
+            },
+            "nidm_numberOfDimensions:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_dimensionsInVoxels:": {
+                "$": "[79,95,79]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:43ad2ab273c1e85fdc66627cd3ea961c": {
+            "prov:type": [
+                {
+                "$": "prov:Collection",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Data:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Data",
+                "type": "xsd:string"
+            },
+            "nidm_grandMeanScaling:": {
+                "$": "true",
+                "type": "xsd:boolean"
+            },
+            "nidm_targetIntensity:": {
+                "$": "100",
+                "type": "xsd:float"
+            },
+            "nidm_hasMRIProtocol:": {
+                "$": "nlx_FunctionalMRIprotocol:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:235a75292ec305bec2bfb9e1f1f26e2e": {
+            "prov:type": {
+                "$": "spm_DCTDriftModel:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "SPM's DCT Drift Model",
+                "type": "xsd:string"
+            },
+            "spm_SPMsDriftCutoffPeriod:": {
+                "$": "128",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a260d6b771a7d3d82e1d9830dcf02423": {
+            "prov:type": {
+                "$": "nidm_DesignMatrix:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "DesignMatrix.csv",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "DesignMatrix.csv",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "text/csv",
+                "type": "xsd:string"
+            },
+            "dc:description": {
+                "$": "niiri:9ba45fb0e707add8e7f710c709a22a63",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Design Matrix",
+                "type": "xsd:string"
+            },
+            "nidm_regressorNames:": {
+                "$": "[\"Sn(1) to*bf(1)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) constant\"]",
+                "type": "xsd:string"
+            },
+            "nidm_hasDriftModel:": {
+                "$": "niiri:235a75292ec305bec2bfb9e1f1f26e2e",
+                "type": "xsd:string"
+            },
+            "nidm_hasHRFBasis:": {
+                "$": "spm_SPMsCanonicalHRF:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9ba45fb0e707add8e7f710c709a22a63": {
+            "prov:type": {
+                "$": "dctype:Image",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "DesignMatrix.png",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "DesignMatrix.png",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/png",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:983f87f6bef9f3ca6917e33e21de8141": {
+            "prov:type": {
+                "$": "nidm_ErrorModel:",
+                "type": "xsd:QName"
+            },
+            "nidm_hasErrorDistribution:": {
+                "$": "obo_normaldistribution:",
+                "type": "xsd:string"
+            },
+            "nidm_hasErrorDependence:": {
+                "$": "obo_Toeplitzcovariancestructure:",
+                "type": "xsd:string"
+            },
+            "nidm_dependenceMapWiseDependence:": {
+                "$": "nidm_ConstantParameter:",
+                "type": "xsd:string"
+            },
+            "nidm_errorVarianceHomogeneous:": {
+                "$": "true",
+                "type": "xsd:boolean"
+            },
+            "nidm_varianceMapWiseDependence:": {
+                "$": "nidm_IndependentParameter:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:670ea0bcbdf9cc6f21ab6a8f5eef7e10": {
+            "prov:type": {
+                "$": "nidm_MaskMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "Mask.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nidm_isUserDefined:": {
+                "$": "false",
+                "type": "xsd:boolean"
+            },
+            "nfo:fileName": {
+                "$": "Mask.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Mask",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:c8b0140b68018da6f9905cc4b8fd05ad",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b4c604265d7449416900828c600fa004": {
+            "prov:type": {
+                "$": "nidm_MaskMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "mask.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "36929e1f5f4143bd9cc818cd896a25f129961fab208c3a4438555f40444c08347b359142ee8c53ece6e8cca1627f49db0788a1fd3b9e2ecaef61999c6c6c67ac",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d0e2322759b4a23ea6686e5c5874d635": {
+            "prov:type": {
+                "$": "nidm_GrandMeanMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "GrandMean.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "GrandMean.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Grand Mean Map",
+                "type": "xsd:string"
+            },
+            "nidm_maskedMedian:": {
+                "$": "111.557487487793",
+                "type": "xsd:float"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:c8b0140b68018da6f9905cc4b8fd05ad",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "512157cc6bff89d9343a09b4068226eb3edd64a8cbcee861f06231767fae6f8d4819921182adebee083a9bf309afd65529ab04a92f0aa6b0038c8098550f6124",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5b992ad55d4d262b7a58b0b4c761ff0d": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0001.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0001.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 1",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:c8b0140b68018da6f9905cc4b8fd05ad",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d1f669439d72f1805a497adb6df799cb": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0001.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e3f451cbbb64a9ffb1ea71bcaf5d3553": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0002.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0002.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 2",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:c8b0140b68018da6f9905cc4b8fd05ad",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:32ab03f45c3ae4ed0c58b56c5d3e699a": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0002.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:94fec9121a605a700be78134f859b81d": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0003.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0003.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 3",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:c8b0140b68018da6f9905cc4b8fd05ad",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ae331890935ac6c1c632c8ba6b1390db": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0003.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:49c48883a4e6af1935a92b5f42299adf": {
+            "prov:type": {
+                "$": "nidm_ResidualMeanSquaresMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ResidualMeanSquares.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ResidualMeanSquares.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Residual Mean Squares Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:c8b0140b68018da6f9905cc4b8fd05ad",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "991abf563d795a43b1e2eef8643e57023f2e0b090b2031f05f839321fc0643df6f71d423486a1021519b6dc82f6b0f563e19f3fbd50cb16063bed54a0e192d3e",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:425a977be056b0392b27ebe2ebf0d5b0": {
+            "prov:type": {
+                "$": "nidm_ResidualMeanSquaresMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "ResMS.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "40b28d03fcf9a2f60b11f10d7fb83bf3618b234fb5aedf09df644cb7cbb6aab8c9f468897c1078166d455a3d04a83f4e3bf762cfca0b4ea982d7a4e406849f18",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f5afca80c28adf7d02a12d1328e18dc4": {
+            "prov:type": {
+                "$": "nidm_ReselsPerVoxelMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ReselsPerVoxel.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ReselsPerVoxel.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Resels per Voxel Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:c8b0140b68018da6f9905cc4b8fd05ad",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "1a3f9216e145249ccc0b14b2bc337d6b38b81ad45e32768001fb22b35f0c2c0f3e2bce013b40c85f7dc0fc62723ac761ee7f7e1e6aff128a05f0ba7b8b8202a3",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c29df4d87431481482987ba8e96377c4": {
+            "prov:type": {
+                "$": "nidm_ReselsPerVoxelMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "RPV.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "4f76663162857f6b38b2a45a63b15a23b2ca8b338c283b69c1e71f2ea2f43797d045a733cd14e845be9c12f8b8f84d3931c599a08e8f6d77e99fab46ad87ab8f",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6c5005a7bc069d11fc4a87c6369a3038": {
+            "prov:type": {
+                "$": "obo_contrastweightmatrix:",
+                "type": "xsd:QName"
+            },
+            "nidm_statisticType:": {
+                "$": "obo_tstatistic:",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast: tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "[1, 0, 0]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:113d8c92a0971f69fc045ea25e0ac452": {
+            "prov:type": {
+                "$": "nidm_StatisticMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "TStatistic.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "TStatistic.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "T-Statistic Map: tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "nidm_statisticType:": {
+                "$": "obo_tstatistic:",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "nidm_errorDegreesOfFreedom:": {
+                "$": "97.9999999998522",
+                "type": "xsd:float"
+            },
+            "nidm_effectDegreesOfFreedom:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:c8b0140b68018da6f9905cc4b8fd05ad",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "9e1714c2d86a050b38b4e10a4d2d23253a24c5e1d228ae16a9c3be8872739278505ac0729ecab54265a717e3a54f9f782d0ed72eea904e0d482a6072bb817bd4",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c9be9db6b926ab9d722466a7953ca805": {
+            "prov:type": {
+                "$": "nidm_StatisticMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "spmT_0001.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "d288b1b0f117f64502555da13c5398dffa5bf5ff0b58951510e43d5388755bc185798802a92e98a07c7e313c6991066d2908f2a44aa5153ba23433da1335970f",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0472234a561a04222e0d544d0654b7ab": {
+            "prov:type": {
+                "$": "nidm_ContrastMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "Contrast.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "Contrast.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast Map: tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:c8b0140b68018da6f9905cc4b8fd05ad",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "fc5e2ad175243ee496db98f9b2e1b235c4c3bae1a8d7122ce461c897b537e40c49dfee5d6cf20f71c6a2bb9b5f0760fcb4ecd8fe2e9428910ef3d60d8f3c56a9",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b2fec2ed7f2b195ecbc862d12bd13e4d": {
+            "prov:type": {
+                "$": "nidm_ContrastMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "con_0001.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "d4aa46b3603ba508578e39751262d528cf6d1ed2e722ec46f1cd8194c50591e46b229deb8cb4f72d1b7e0e2640f3e6604be7a335301c5c8357f453e5d0d4daf2",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:fa01d09024a9f2eb7c842f11f9e05d7c": {
+            "prov:type": {
+                "$": "nidm_ContrastStandardErrorMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ContrastStandardError.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ContrastStandardError.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast Standard Error Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:c8b0140b68018da6f9905cc4b8fd05ad",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "791d48f5d1adb15079a5289271ce0c4b95c56d69bfdb3e5d41b0d24eb538d3075e1cdd15502494b5a5a18c16eaa2153cb4847a996043fa48cdaf26e938a2576d",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:311f473b94b906ba6c5a22011f2bf44d": {
+            "prov:type": [
+                {
+                "$": "nidm_HeightThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_PValueUncorrected:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Height Threshold: p<0.001 (unc.)",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "0.000999500158000544",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentThreshold:": [
+                {
+                "$": "niiri:2bfc4bebfe1177a3004cbd378dafd2c1",
+                "type": "xsd:string"
+                },
+                {
+                "$": "niiri:496cd88b6fd812b8f219563fa7c3bf08",
+                "type": "xsd:string"
+                }
+            ]
+        },
+        "niiri:2bfc4bebfe1177a3004cbd378dafd2c1": {
+            "prov:type": [
+                {
+                "$": "nidm_HeightThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_statistic:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Height Threshold: T=3.175486)",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.17548628637284",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:496cd88b6fd812b8f219563fa7c3bf08": {
+            "prov:type": [
+                {
+                "$": "nidm_HeightThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_FWERadjustedpvalue:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Height Threshold: p<1.000000 (FWE)",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "0.999999999999997",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7f7b05e69f02276d0d0544852cbc5b7a": {
+            "prov:type": [
+                {
+                "$": "nidm_ExtentThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_statistic:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Extent Threshold: k>=10",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "10",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.15248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentThreshold:": [
+                {
+                "$": "niiri:097bd44b0c58cfa5bc7be0a0de9c38f9",
+                "type": "xsd:string"
+                },
+                {
+                "$": "niiri:03f77b40ea055cd340662c393ea55c0b",
+                "type": "xsd:string"
+                }
+            ]
+        },
+        "niiri:097bd44b0c58cfa5bc7be0a0de9c38f9": {
+            "prov:type": [
+                {
+                "$": "nidm_ExtentThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_FWERadjustedpvalue:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Extent Threshold",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "0.999430072930499",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:03f77b40ea055cd340662c393ea55c0b": {
+            "prov:type": [
+                {
+                "$": "nidm_ExtentThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_PValueUncorrected:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Extent Threshold",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "0.22255850848336",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f9a61a4056f36732add4b9b80a53bc8d": {
+            "prov:type": {
+                "$": "nidm_PeakDefinitionCriteria:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak Definition Criteria",
+                "type": "xsd:string"
+            },
+            "nidm_maxNumberOfPeaksPerCluster:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_minDistanceBetweenPeaks:": {
+                "$": "8",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:2c9fd0f62c916461f5d00571f467366e": {
+            "prov:type": {
+                "$": "nidm_ClusterDefinitionCriteria:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Cluster Connectivity Criterion: 18",
+                "type": "xsd:string"
+            },
+            "nidm_hasConnectivityCriterion:": {
+                "$": "nidm_voxel18connected:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e7fa1fe72bad934822d8ef41842387f5": {
+            "prov:type": {
+                "$": "nidm_SearchSpaceMaskMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "SearchSpaceMask.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "SearchSpaceMask.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Search Space Mask Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:c8b0140b68018da6f9905cc4b8fd05ad",
+                "type": "xsd:string"
+            },
+            "nidm_searchVolumeInVoxels:": {
+                "$": "223057",
+                "type": "xsd:int"
+            },
+            "nidm_searchVolumeInUnits:": {
+                "$": "1784456",
+                "type": "xsd:float"
+            },
+            "nidm_reselSizeInVoxels:": {
+                "$": "65.5786964036542",
+                "type": "xsd:float"
+            },
+            "nidm_searchVolumeInResels:": {
+                "$": "3155.84193266257",
+                "type": "xsd:float"
+            },
+            "spm_searchVolumeReselsGeometry:": {
+                "$": "[6, 97.8140592306853, 965.938819261507, 3155.84193266257]",
+                "type": "xsd:string"
+            },
+            "nidm_noiseFWHMInVoxels:": {
+                "$": "[4.09118640605185, 4.0346308705955, 3.97291894351243]",
+                "type": "xsd:string"
+            },
+            "nidm_noiseFWHMInUnits:": {
+                "$": "[8.18237281210369, 8.069261741191, 7.94583788702486]",
+                "type": "xsd:string"
+            },
+            "nidm_randomFieldStationarity:": {
+                "$": "true",
+                "type": "xsd:boolean"
+            },
+            "nidm_expectedNumberOfVoxelsPerCluster:": {
+                "$": "7.21748994812991",
+                "type": "xsd:float"
+            },
+            "nidm_expectedNumberOfClusters:": {
+                "$": "7.47000215356561",
+                "type": "xsd:float"
+            },
+            "nidm_heightCriticalThresholdFWE05:": {
+                "$": "5.30963135104407",
+                "type": "xsd:float"
+            },
+            "nidm_heightCriticalThresholdFDR05:": {
+                "$": "4.69981384277344",
+                "type": "xsd:float"
+            },
+            "crypto:sha512": {
+                "$": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876",
+                "type": "xsd:string"
+            },
+            "spm_smallestSignificantClusterSizeInVoxelsFWE05:": {
+                "$": "116",
+                "type": "xsd:int"
+            },
+            "spm_smallestSignificantClusterSizeInVoxelsFDR05:": {
+                "$": "61",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:74ccd8c140ada8dc4af99773bc09dcbc": {
+            "prov:type": {
+                "$": "nidm_ExcursionSetMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ExcursionSet.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ExcursionSet.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Excursion Set Map",
+                "type": "xsd:string"
+            },
+            "nidm_numberOfSupraThresholdClusters:": {
+                "$": "37",
+                "type": "xsd:int"
+            },
+            "nidm_pValue:": {
+                "$": "1.0547118733939e-14",
+                "type": "xsd:float"
+            },
+            "nidm_hasClusterLabelsMap:": {
+                "$": "niiri:31512b9ad741a32434f9e9a179b05e24",
+                "type": "xsd:string"
+            },
+            "nidm_hasMaximumIntensityProjection:": {
+                "$": "niiri:ab16dbc3e4925d392c891ea1edd16188",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:c8b0140b68018da6f9905cc4b8fd05ad",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "7c47836783829c9d104b853bdb9b46a988960ed9386e3d6bd1ffd9a0ef8fe115b75a0f91560fe1b8dfd21679c4406374db0824a65e5fdb4a98cd5c9f6d384cc9",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:31512b9ad741a32434f9e9a179b05e24": {
+            "prov:type": {
+                "$": "nidm_ClusterLabelsMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ClusterLabels.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ClusterLabels.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Cluster Labels Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:c8b0140b68018da6f9905cc4b8fd05ad",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "2201a146e5e5a8bbbea7a3cb8ba3326744133bb484069e09afde0d678c99f2b8306b0519abcf59452234736b359abd058a93af565ddc0dd8831a7c5b94893c4d",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ab16dbc3e4925d392c891ea1edd16188": {
+            "prov:type": {
+                "$": "dctype:Image",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "MaximumIntensityProjection.png",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "MaximumIntensityProjection.png",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/png",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f3b96c552779d9374a531718147427d0": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0001",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1804",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "27.5089335246298",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.46511379022666e-21",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "5.93371085041799e-20",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "1",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:31281ad36fc49da248ac587f4076c953": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0002",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "356",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "5.42859220330831",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.6728855149243e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "2.91098190852157e-06",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1.17083954451478e-06",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "2",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:1bc8b121d587eb836f9b3b7858047889": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0003",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "5090",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "77.6166694237059",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.51031151932561e-42",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "2.03335233065374e-40",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "3",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c131d22e9155057f870d66e758ece437": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0004",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "766",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "11.6806225498151",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.69891112070838e-12",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "5.70226088569825e-11",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "4.58706002591263e-11",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "4",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c0d0506786bef63ddf2f635fb7755534": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0005",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "54",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.823438143198452",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00980531403246826",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.280434478478115",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.061094648971533",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "5",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:dccd359642442c550b8e126ef0768318": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0006",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "285",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "4.34592353354738",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.15539697056139e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "2.73725770201239e-05",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "9.4369593516496e-06",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "6",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:4c25e0ccdac5828019bc6ab24105a598": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0007",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "395",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "6.02329752895164",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.70020762554596e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "9.06303145864484e-07",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "4.37433635338446e-07",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "7",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:439c3d37a059fc0c9fe663876cd44696": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0008",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "116",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.7688671224263",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000452977534465859",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0150888416289883",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00366911802917346",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "8",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:e4902bb46a21f477eb5d9e386fc19878": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0009",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "19",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.289728235569826",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0997597824989178",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.964858026030202",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.278639392496977",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "9",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:392b01269887f7941cf41e331de9925c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0010",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "50",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.762442725183751",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0123570633152281",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.339498021136914",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0707678054255747",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "10",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:7e231620402d8b69f99aa21ba8f6b058": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0011",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "447",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "6.81623796314274",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.03851586308171e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "2.02678038352389e-07",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1.22279946227405e-07",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "11",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c6a240b5ad789d06fb0190076dcbb863": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0012",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "162",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "2.47031442959535",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.63852466674842e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00222568832297587",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000672150622508277",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "12",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:1b71ce972cf56fb139ab88975f4640c9": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0013",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "29",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.442216780606576",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0470937359607303",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.79416170413585",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.190729630640958",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "13",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:ca0dd10dbf94ba5d07f8de45f011307c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0014",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "38",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.579456471139651",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0257597057294564",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.578781830495109",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.130408510255373",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "14",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:cae6fd96eea7e9972a3dd49f5837e19f": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0015",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "134",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "2.04334650349245",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000208225307159483",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00696455376757865",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00187402776443535",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "15",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:a5ea3c101aaf1b98c7ee58fcc76dff1b": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0016",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "76",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.1589129422793",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00300279655548563",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0958739715182708",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.022111501908576",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "16",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:6f05166f31ef45c33808420434a13f55": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0017",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "16",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.2439816720588",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.128031320700056",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.986394362860718",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.324079280522016",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "17",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f686250b6fb996d621aa21cdf5cf6717": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0018",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "26",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.396470217095551",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0583630672052552",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.858988054642613",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.205539497548942",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "18",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:36a0a86f1b5fa4bc787a9c7b7eba11a2": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0019",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "29",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.442216780606576",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0470937359607303",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.79416170413585",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.190729630640958",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "19",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:ee27ca4fbf4487cbf6ede6f498d03b89": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0020",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "10",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.15248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.22255850848336",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999430072930499",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.487222680733842",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "20",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f6df377f07bd1d85bb45726e6330c017": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0021",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "49",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.747193870680076",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0131051491528842",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.355876032106543",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0707678054255747",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "21",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:0f57c541cf04642c5618cb3c8c754be3": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0022",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "21",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.320225944577176",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0850912379420168",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.942502902202007",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.255273713826051",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "22",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:10dca7f82f910606e689ba8e2b5af3ff": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0023",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "30",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.457465635110251",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.043916653732793",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.770998817460931",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.190729630640958",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "23",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:34abbea5b5b7e9caec8749719282f69d": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0024",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "27",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.411719071599226",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0542875242970965",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.83831709934398",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.199876794002946",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "24",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f97396b2a54d55285f02d93b58dbe2b6": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0025",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "10",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.15248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.22255850848336",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999430072930499",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.487222680733842",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "25",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:a4357c1b32f8a28c66891660675a8ceb": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0026",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "61",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.930180124724177",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00662877418964967",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.199476682033478",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0447442257801353",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "26",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:9e1f64e5a9ff6cda9c7c7070f1f8c2b9": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0027",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "19",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.289728235569826",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0997597824989178",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.964858026030202",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.278639392496977",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "27",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:e13313ba9b9b954243d9c9332f3caf96": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0028",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "14",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.21348396305145",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.152527900243506",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.994020866354823",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.374386664234061",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "28",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:63e1799e700f05ae3736bff33a2b65f4": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0029",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "18",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.27447938106615",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.108241900089372",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.973564689982443",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.292253130241304",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "29",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:5dfbf6ab6301360ce96203aca13f8257": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0030",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "28",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.426967926102901",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.050541462694511",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.81665481379022",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.194945641821685",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "30",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:82c6c5dde224f3815e887f0f89a10062": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0031",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "21",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.320225944577176",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0850912379420168",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.942502902202007",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.255273713826051",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "31",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f9cd18224526a4801de142048b64a357": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0032",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "29",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.442216780606576",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0470937359607303",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.79416170413585",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.190729630640958",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "32",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:b2129866f39d8d89964577f80028f418": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0033",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "24",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.365972508088201",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0676477474681771",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.896743975460065",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.228311147705098",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "33",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:1d15a2f17b8507a037170dff62d0df0f": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0034",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "12",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.1829862540441",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.183276076907294",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.997869754572677",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.42415320655688",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "34",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:92cdcaac8dc15abca00aaf2035c3d353": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0035",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "21",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.320225944577176",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0850912379420168",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.942502902202007",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.255273713826051",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "35",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:a766e15fcf31e1d6ce69e989e67adf78": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0036",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "16",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.2439816720588",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.128031320700056",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.986394362860718",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.324079280522016",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "36",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f364696f65c95b091099ba5aa2f33e2b": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0037",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "13",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.198235108547775",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.166999709083906",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.996321368733297",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.39785224811166",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "37",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:60751fd1c75909c8f22f3188decc0b24": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0001",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f857ed5b37db9d516826e1fe049e298e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "7.92007970809937",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "6.94608360738412",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.87783122385099e-12",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "4.18813870695089e-07",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "5.21674435923017e-06",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f857ed5b37db9d516826e1fe049e298e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0001",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[46,16,24]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b5e1aa9b45d83dea2221d28bd37262f2": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0002",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ed2331a7cf87add50918be5bd659afc1",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.31603479385376",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.77079466112137",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.94492849498107e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.000879943865776389",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000830722551601523",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ed2331a7cf87add50918be5bd659afc1": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0002",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[32,24,-4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:32b931355eb48f34a576c74d8531d572": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0003",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:280385c283fdc62462e4706eab377298",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.68819808959961",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.27450168515333",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.655864770444e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0121028975026269",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00350091530962783",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:280385c283fdc62462e4706eab377298": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0003",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[18,16,4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f5951e733e9591d4ba75b0258296ccca": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0004",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:3efbdfe72d5b5db5c0a2617705ba8152",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "7.11683940887451",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "6.37404871703245",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "9.20510334623259e-11",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "2.05325778424026e-05",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "9.33757664730496e-05",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3efbdfe72d5b5db5c0a2617705ba8152": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0004",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[34,-88,-2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b2dfa583b093fac4721ad0ee8e3b22b6": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0005",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a828e9a512b1b18b628b6352b9841b81",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.48292255401611",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.8992593141605",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.82568493656277e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.000407231755366277",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000830722551601523",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a828e9a512b1b18b628b6352b9841b81": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0005",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[42,-72,-10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4d03394faeeb99576cb7d36401fb8e9e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0006",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a3ad78691cb88bc080a2ad24b7f4624b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.2275915145874",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.89738468004472",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.85602978606003e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0670610253017228",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0118363293065346",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a3ad78691cb88bc080a2ad24b7f4624b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0006",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[34,-86,12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ec9d4f0e234313738c8b9f2aa3bf749f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0007",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a8570442309c47fdfec5293c10c727c3",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.28007745742798",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.74292583422276",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.65272453897825e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00103782272796227",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000830722551601523",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a8570442309c47fdfec5293c10c727c3": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0007",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[8,18,50]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:15dd1c92e83f1e367cd3e9341f2376b1": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0008",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:65533b720f685277b5ffaabaea192278",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.15222215652466",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.64328512810061",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.34178537356678e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00186069357054308",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000972721201433817",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:65533b720f685277b5ffaabaea192278": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0008",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-6,12,52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:adae04095680f26a1da7f5413ac6928c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0009",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ba57c8cb8e6498910435395572d4059b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.98517084121704",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.51181334779297",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.77577724747024e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00376326218366319",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00136419627856355",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ba57c8cb8e6498910435395572d4059b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0009",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[8,32,38]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:81e12a87ecad9a224f78f5ba0436d093": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0010",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4e8fd18340a3d30598d15370242d6def",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.25127363204956",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.72055271981637",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.30890376104765e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0011841880966994",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000830722551601523",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4e8fd18340a3d30598d15370242d6def": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0010",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[52,-32,42]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:91ba3878269ac05538257d7f8ed10f1c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0011",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c83ef98d4875cea36cc2197877333dd8",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.24752378463745",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.71763687476157",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.40078304300806e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00120468241369565",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000830722551601523",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c83ef98d4875cea36cc2197877333dd8": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0011",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[40,-62,50]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:30283203f0fdcfdedb7c6446c63aa51e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0012",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:732ed2e2fa65230309fc1469c052099e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.70337772369385",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.28674301747281",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.22566831420812e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.011413186758684",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00350091530962783",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:732ed2e2fa65230309fc1469c052099e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0012",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[56,-44,52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:10d8dde0e7451af1a2cb3417fa3976a7": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0013",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:793d5a5dcc585871596598e1989a5a00",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.15371799468994",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.64445580026639",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.285227171001e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00184807786755337",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000972721201433817",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:793d5a5dcc585871596598e1989a5a00": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0013",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-28,-94,4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d6edab9aa6b5ef4f0c295f9803943d19": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0014",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:61351f75ee1916faadae7b2aadea0ff2",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.71480798721313",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.58412084932714",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000169107736440521",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999869855188705",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.383925327139989",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:61351f75ee1916faadae7b2aadea0ff2": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0014",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-34,-84,-2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6f4c3201b3b10591156730aeb058f98d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0015",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:1dd8f041cfdaf90d4500f0c9d0f92698",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.10109901428223",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.60320502193174",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.05212039080982e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00234682813060005",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00104518293275697",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:1dd8f041cfdaf90d4500f0c9d0f92698": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0015",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[32,2,46]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e09718d2ea585b971df91ec9ab3ce111": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0016",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:31217090dc47a01657c91b5135f4774a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.6086859703064",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.3736141683061",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.11031435759912e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.453877178455514",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0599714495109201",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:31217090dc47a01657c91b5135f4774a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0016",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[28,4,58]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:bf8d2fa297b31faa11d9a75da96a1ecd": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0017",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:1405899c5a02bcf163ebb333d48c9695",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.98793148994446",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.82932508069717",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.42475887594474e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.984644566584946",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.233149120368192",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:1405899c5a02bcf163ebb333d48c9695": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0017",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[42,4,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b1491cceb4af6aa6b3bf2ca1bf80d7ed": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0018",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a5f8fb798258fe5ff8b0d433dc52e3d4",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.98348569869995",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.51047970249337",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.78928538652201e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00378871596531738",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00136419627856355",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a5f8fb798258fe5ff8b0d433dc52e3d4": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0018",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-52,0,38]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4728f15a30a3478ad47a3573b31291a2": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0019",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7cb43e92d04918591f6c8f33a35fd1a4",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.2253565788269",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.89552821543552",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.90210114501011e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0675937275056587",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0118363293065346",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7cb43e92d04918591f6c8f33a35fd1a4": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0019",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-60,8,20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2846f983f4248ecf39eb3d072230034f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0020",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f11c725020f0b62e517ee9feeaa492b4",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.98950004577637",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.69817956585148",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.31245304380023e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.151048137890434",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0233609510296683",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f11c725020f0b62e517ee9feeaa492b4": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0020",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-44,6,28]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c839fd693cb9f15e4f75ff285bd20825": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0021",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0d681cd86b3782448e46f423694c73cd",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.78093099594116",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.34909755317379",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.41969442155354e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00844151822925698",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00286742427823329",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0d681cd86b3782448e46f423694c73cd": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0021",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-34,-2,52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2fe2b34ab4c1433aecafed937c37e601": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0022",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:1368b3660adcb57e09b9a1f1f88185f4",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.40964078903198",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.04774404642803",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.23528758724889e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0346958937061391",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00846044059259994",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:1368b3660adcb57e09b9a1f1f88185f4": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0022",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-54,-46,58]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:072b9ac5eb756bc6330b5dadc2697fbd": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0023",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:37e4188c492c5a4165b3dac3071e5850",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.31841945648193",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.97261482231588",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.30279114724163e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0484353441449864",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0106752417476244",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:37e4188c492c5a4165b3dac3071e5850": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0023",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-62,-38,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8267f3c7f7dd3ca73f48fdd78c883180": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0024",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:2f52144540b5809f055058dec6116471",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.57099342346191",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.34109644800954",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.08867353027554e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.496004086968197",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0635474729952592",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:2f52144540b5809f055058dec6116471": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0024",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-60,-50,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:febe52264f5e54a6a5b0f5444ac1b68c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0025",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:bb31516c2b7139961eca38d0f885ab41",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.30699443817139",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.96317509467693",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.46750043123123e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0504786376455083",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0106752417476244",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:bb31516c2b7139961eca38d0f885ab41": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0025",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[32,40,16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7a9aad9b667e6ea2734b6e8dfe04acd7": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0026",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:45969fab01b5727b00223bf465f615c0",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.5497465133667",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.32273570618355",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.7053150754347e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.520378392891944",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0649997423676262",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:45969fab01b5727b00223bf465f615c0": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0026",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[40,46,12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:685d9eb36c33716b1c7e61d0a5ffb870": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0027",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b5e6f22c3e4ceb8f75b6756624dc984f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.31582498550415",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.11913273798974",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.90150518718513e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.788829013385429",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.116130094830597",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b5e6f22c3e4ceb8f75b6756624dc984f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0027",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[36,54,6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4c95fa10598ea9fed0a1913a9efd2fec": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0028",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:44c91cfa2af752860c64b94ae533e716",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.27030229568481",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.93281349716267",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.05267701952816e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0575990926145485",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0110040663565173",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:44c91cfa2af752860c64b94ae533e716": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0028",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[40,26,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a3e7b604bb117fab93742f1fd5e8f473": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0029",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:1d6bbd703ff2243ac599b69731c47544",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.93343877792358",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.65085575575197",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.6528024058271e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.180887232162623",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0254967087736733",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:1d6bbd703ff2243ac599b69731c47544": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0029",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-58,-30,-18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:58ec7f33f37bb7ef67d8acccf7b40081": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0030",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4c332c72810f59b3208483ae780441ef",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.76414346694946",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.50698548813516",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.287756441539e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.301278778226174",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0396433885053995",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4c332c72810f59b3208483ae780441ef": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0030",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-46,-66,-6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:78bd497bb5dc90d3f2b4e3ced5e4fe7a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0031",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c699689651173fd2a45ae693a27b8ce4",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.7637345790863",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.62829384243901",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000142650218672435",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999605970761399",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.34409224637793",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c699689651173fd2a45ae693a27b8ce4": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0031",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-54,-64,-8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0635a977111ede7fa6bc63091cd0e675": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0032",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b5dbb05246499ae43a44b9697932ef7d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.72232866287231",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.47122948835043",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.88855941602095e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.338512677882141",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.044836631144536",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b5dbb05246499ae43a44b9697932ef7d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0032",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[58,-38,6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ff64de7e90ef291344583e6b3ac31db1": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0033",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:cddf881c6e42c41e1712c3dcfd7cc65d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.98372888565063",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.8255778871433",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.52328381068878e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.985409231324461",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.233731539105478",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:cddf881c6e42c41e1712c3dcfd7cc65d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0033",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[64,-30,-4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ea99a82e713304e75f5d834789fc3609": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0034",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c72302c49efa40a4578b8e26bdabfb7b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.50753784179688",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.39582098150001",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000342115474631921",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999778829603",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.564856004417035",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c72302c49efa40a4578b8e26bdabfb7b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0034",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[60,-40,-12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f229e485b8e3ee7f5cd9e3690d44e1dc": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0035",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:35c5569d0795499fb727a1041cef0d38",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.70483255386353",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.45624265093732",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.17043099876224e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.354967306449537",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0466228196503302",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:35c5569d0795499fb727a1041cef0d38": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0035",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-36,-74,-14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:47c14511d37e558a3fb5b4c44e333292": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0036",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e421002626e0d3b2155132ea5f9909af",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.08770418167114",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.91804495668",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.46350297789166e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.955724279224547",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.186719971332974",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e421002626e0d3b2155132ea5f9909af": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0036",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-36,-68,-20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e5ced5655aca3ab6d63936e6dbc4d14e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0037",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:dcc9a77d6e6075391c18a887c0b9c878",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.71012616157532",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.57988831343959",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000171870546999631",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999883757236262",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.385893135248467",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:dcc9a77d6e6075391c18a887c0b9c878": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0037",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-30,-58,-16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c84076330649c427ef2696347c4054ae": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0038",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0aa3d7e4b295c6343a575906df312730",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.59621620178223",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.36286413267216",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.41853365035416e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.467637998233248",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0604181585485856",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0aa3d7e4b295c6343a575906df312730": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0038",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[16,-98,6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e2506b44ed692dcde07aecfe65313995": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0039",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:1b80736cff1f2516ac52233b65e1d43d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.57891654968262",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.34793761600864",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.87118388575936e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.487021764768749",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0629240173925056",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:1b80736cff1f2516ac52233b65e1d43d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0039",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-60,-16,28]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a711ec92a5095b7cc31e6073cba60aeb": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0040",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:bbea81c0dc1081250ce2a110d7d6270d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.37013816833496",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.16664310578498",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.54558935169247e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.730405153245217",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.101858458171742",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:bbea81c0dc1081250ce2a110d7d6270d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0040",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-52,-62,52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4babfa934e3c293ae57513a1dbf42b27": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0041",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:eb0e468fad0731dc048069a34964eba0",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.24533367156982",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.05725918601008",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.4825985211363e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.855631833511506",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.135717263652471",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:eb0e468fad0731dc048069a34964eba0": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0041",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-18,-60,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2c50f18e7e3b4acc2a572ba2fbdb7169": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0042",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f37e4ddd039f0786c97ddd37a174dedd",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.22599840164185",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.04024618213588",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.66975618669063e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.871760516202526",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.138603763901635",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f37e4ddd039f0786c97ddd37a174dedd": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0042",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-36,-74,-34]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1ef0626fbe7b6528eb64d1fc1902fdff": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0043",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:fa8d5f5a9b143e007389f2fdcb17fb3a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.20391035079956",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.02078923241408",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.900174224163e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.888907080881232",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.143583628261646",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:fa8d5f5a9b143e007389f2fdcb17fb3a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0043",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[34,-54,-16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:be786d3fdaa6a6946a7e31cca13afc20": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0044",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:fd3442b98529d2f70ead87b5000c6342",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.17404651641846",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.99444589181498",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.24228638075574e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.909844421846994",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.153735203854581",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:fd3442b98529d2f70ead87b5000c6342": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0044",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-40,-38,44]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d5463f9ce8c3e863106d9a205e4c2c3a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0045",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:bf85679e3d6743985d98d3df6f63ab50",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.12145137786865",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.94794832362008",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.94119065879606e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.940339218142555",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.172448885449819",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:bf85679e3d6743985d98d3df6f63ab50": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0045",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-48,-72,2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:23d3e4257473feb39f485dec221abb31": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0046",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c3b3402429d4a8377c7a30cb88abe2dd",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.07333517074585",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.9052963692066",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.70549882543025e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.961337330645756",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.192831151077206",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c3b3402429d4a8377c7a30cb88abe2dd": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0046",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[20,-66,34]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7e76e2da1f22ce6b895d3014a33d1739": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0047",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e04fc808b05489b451f47249a93ec634",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.05762767791748",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.89134919103145",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.98441713834286e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.966867400896655",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.199920408224698",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e04fc808b05489b451f47249a93ec634": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0047",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-46,-56,14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a76fe1af0c08762eb9239007a5f9dc2c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0048",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6e79740bd3660186f4fdf7f38fec1b3c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.97341108322144",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.81637469850314",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.7713399346081e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.987160063394768",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.237117251115433",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6e79740bd3660186f4fdf7f38fec1b3c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0048",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-50,-50,20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:30853859b00c0b5c92d53d8e023cba9d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0049",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4799db48ff3ae922b73cc32f5cc0cd23",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.03719234466553",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.87318677164159",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.37107204765519e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.973166168280088",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.210147957128937",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4799db48ff3ae922b73cc32f5cc0cd23": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0049",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-48,2,50]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:356f79ecf79738d01b5b4b7026b7e188": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0050",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e472df3ca776655c319913d4e08d6e9b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.0217924118042",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.85948683644491",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.68126885931441e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.977286609355005",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.217632520436791",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e472df3ca776655c319913d4e08d6e9b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0050",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-36,-40,-36]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4265e2cdabcc64eab47a5d072484d937": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0051",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d80ff4fffd0d4464945b79660c578dad",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.9634416103363",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.80747753892992",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.01957428701494e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.988689669381963",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.237117251115433",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d80ff4fffd0d4464945b79660c578dad": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0051",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[4,6,32]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b6e09f6b679ea623d2841ff4bcf6291e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0052",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a59f8dea4edffbdd72892882c133b0e9",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.96245408058167",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.80659597790245",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.04463150378309e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.988832912076595",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.237117251115433",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a59f8dea4edffbdd72892882c133b0e9": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0052",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-50,-48,-16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:df0b4499eab340f0f5ffcf69ea26e94e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0053",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0f2c7e9dfacf69ad400623d015e16bf8",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.9098813533783",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.75959988615137",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.50926599039736e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.994607633788328",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.264100967145263",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0f2c7e9dfacf69ad400623d015e16bf8": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0053",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[54,-24,-2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d0bc7891180bf59606c1dd42f7521b58": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0054",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:fbd4fdf05f1b858456b20418252ad82e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.90285301208496",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.75330746420074",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.72582920719012e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99514521861122",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.264100967145263",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:fbd4fdf05f1b858456b20418252ad82e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0054",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-36,-46,-18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:048c50de4960b48aa105d96778779061": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0055",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:fede7e0698f56da3b9f59e90e65c68a5",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.8867518901825",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.73888373627584",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "9.24195907030523e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.996210852184447",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.271701156704036",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:fede7e0698f56da3b9f59e90e65c68a5": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0055",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-50,-46,-32]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f6f60a34610b49cc5b443ce199ca79c0": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0056",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:18668f3157ce13938d310aebc49ef7b9",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.82178378105164",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.68056404693028",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000116359297336222",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.998750111206092",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.307505393775956",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:18668f3157ce13938d310aebc49ef7b9": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0056",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[12,52,-12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6bd4ba02e7d4f4207d829a2c8b49bb4e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0057",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ab3768ac2a57998c1f00e6093a6cdaf9",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.7885959148407",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.65069869844077",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000130763947768786",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999340802437346",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.325675502417125",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ab3768ac2a57998c1f00e6093a6cdaf9": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0057",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[22,40,26]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:bae89a3df5e8c7b953547ae7d7534e95": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0058",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:646c22a0ec339e5b474a3aaa23751b4d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.65790581703186",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.53261354467296",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000205736742878826",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999969815552823",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.430567192397012",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:646c22a0ec339e5b474a3aaa23751b4d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0058",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[52,-46,-12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f2e5294144fb56653d91e924583c3e1b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0059",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:1330f955b402cf21c726b658b67095cd",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.55148839950562",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.43590473729199",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000295289297083445",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999889206113",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.518882279088377",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:1330f955b402cf21c726b658b67095cd": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0059",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[64,-34,16]",
+                "type": "xsd:string"
+            }
+        }
+    },
+    "activity": {
+        "niiri:c2c197b0fad8993c6cc7208559f40202": {
+            "prov:type": {
+                "$": "nidm_ModelParametersEstimation:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Model parameters estimation",
+                "type": "xsd:string"
+            },
+            "nidm_withEstimationMethod:": {
+                "$": "obo_generalizedleastsquaresestimation:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:660a6a4292f04758ec1d3b9e0aa1c672": {
+            "prov:type": {
+                "$": "nidm_ContrastEstimation:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Contrast estimation",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:75cbb0b1a11a78d87cbc93882cc0e892": {
+            "prov:type": {
+                "$": "nidm_Inference:",
+                "type": "xsd:QName"
+            },
+            "nidm_hasAlternativeHypothesis:": {
+                "$": "nidm_OneTailedTest:",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Inference",
+                "type": "xsd:string"
+            }
+        }
+    },
+    "agent": {
+        "niiri:c2ec86ce73c8b9ab4324393fc2d80b63": {
+            "prov:type": [
+                {
+                "$": "src_SPM:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "prov:SoftwareAgent",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "SPM",
+                "type": "xsd:string"
+            },
+            "nidm_softwareVersion:": {
+                "$": "12.6906",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:748b469bb5be2daf21097ad82e962dbc": {
+            "prov:type": [
+                {
+                "$": "nlx_Imaginginstrument:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nlx_Magneticresonanceimagingscanner:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "MRI Scanner",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6727c965ace54e00c464f50309d28201": {
+            "prov:type": {
+                "$": "prov:Person",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Person",
+                "type": "xsd:string"
+            }
+        }
+    },
+    "wasGeneratedBy": {
+        "_:wGB20": {
+            "prov:entity": "niiri:670ea0bcbdf9cc6f21ab6a8f5eef7e10",
+            "prov:activity": "niiri:c2c197b0fad8993c6cc7208559f40202"
+        },
+        "_:wGB22": {
+            "prov:entity": "niiri:d0e2322759b4a23ea6686e5c5874d635",
+            "prov:activity": "niiri:c2c197b0fad8993c6cc7208559f40202"
+        },
+        "_:wGB26": {
+            "prov:entity": "niiri:5b992ad55d4d262b7a58b0b4c761ff0d",
+            "prov:activity": "niiri:c2c197b0fad8993c6cc7208559f40202"
+        },
+        "_:wGB30": {
+            "prov:entity": "niiri:e3f451cbbb64a9ffb1ea71bcaf5d3553",
+            "prov:activity": "niiri:c2c197b0fad8993c6cc7208559f40202"
+        },
+        "_:wGB34": {
+            "prov:entity": "niiri:94fec9121a605a700be78134f859b81d",
+            "prov:activity": "niiri:c2c197b0fad8993c6cc7208559f40202"
+        },
+        "_:wGB38": {
+            "prov:entity": "niiri:49c48883a4e6af1935a92b5f42299adf",
+            "prov:activity": "niiri:c2c197b0fad8993c6cc7208559f40202"
+        },
+        "_:wGB42": {
+            "prov:entity": "niiri:f5afca80c28adf7d02a12d1328e18dc4",
+            "prov:activity": "niiri:c2c197b0fad8993c6cc7208559f40202"
+        },
+        "_:wGB56": {
+            "prov:entity": "niiri:113d8c92a0971f69fc045ea25e0ac452",
+            "prov:activity": "niiri:660a6a4292f04758ec1d3b9e0aa1c672"
+        },
+        "_:wGB60": {
+            "prov:entity": "niiri:0472234a561a04222e0d544d0654b7ab",
+            "prov:activity": "niiri:660a6a4292f04758ec1d3b9e0aa1c672"
+        },
+        "_:wGB62": {
+            "prov:entity": "niiri:fa01d09024a9f2eb7c842f11f9e05d7c",
+            "prov:activity": "niiri:660a6a4292f04758ec1d3b9e0aa1c672"
+        },
+        "_:wGB81": {
+            "prov:entity": "niiri:e7fa1fe72bad934822d8ef41842387f5",
+            "prov:activity": "niiri:75cbb0b1a11a78d87cbc93882cc0e892"
+        },
+        "_:wGB85": {
+            "prov:entity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc",
+            "prov:activity": "niiri:75cbb0b1a11a78d87cbc93882cc0e892"
+        }
+    },
+    "used": {
+        "_:u14": {
+            "prov:activity": "niiri:c2c197b0fad8993c6cc7208559f40202",
+            "prov:entity": "niiri:a260d6b771a7d3d82e1d9830dcf02423"
+        },
+        "_:u15": {
+            "prov:activity": "niiri:c2c197b0fad8993c6cc7208559f40202",
+            "prov:entity": "niiri:43ad2ab273c1e85fdc66627cd3ea961c"
+        },
+        "_:u16": {
+            "prov:activity": "niiri:c2c197b0fad8993c6cc7208559f40202",
+            "prov:entity": "niiri:983f87f6bef9f3ca6917e33e21de8141"
+        },
+        "_:u46": {
+            "prov:activity": "niiri:660a6a4292f04758ec1d3b9e0aa1c672",
+            "prov:entity": "niiri:670ea0bcbdf9cc6f21ab6a8f5eef7e10"
+        },
+        "_:u47": {
+            "prov:activity": "niiri:660a6a4292f04758ec1d3b9e0aa1c672",
+            "prov:entity": "niiri:49c48883a4e6af1935a92b5f42299adf"
+        },
+        "_:u48": {
+            "prov:activity": "niiri:660a6a4292f04758ec1d3b9e0aa1c672",
+            "prov:entity": "niiri:a260d6b771a7d3d82e1d9830dcf02423"
+        },
+        "_:u49": {
+            "prov:activity": "niiri:660a6a4292f04758ec1d3b9e0aa1c672",
+            "prov:entity": "niiri:6c5005a7bc069d11fc4a87c6369a3038"
+        },
+        "_:u50": {
+            "prov:activity": "niiri:660a6a4292f04758ec1d3b9e0aa1c672",
+            "prov:entity": "niiri:5b992ad55d4d262b7a58b0b4c761ff0d"
+        },
+        "_:u51": {
+            "prov:activity": "niiri:660a6a4292f04758ec1d3b9e0aa1c672",
+            "prov:entity": "niiri:e3f451cbbb64a9ffb1ea71bcaf5d3553"
+        },
+        "_:u52": {
+            "prov:activity": "niiri:660a6a4292f04758ec1d3b9e0aa1c672",
+            "prov:entity": "niiri:94fec9121a605a700be78134f859b81d"
+        },
+        "_:u73": {
+            "prov:activity": "niiri:75cbb0b1a11a78d87cbc93882cc0e892",
+            "prov:entity": "niiri:311f473b94b906ba6c5a22011f2bf44d"
+        },
+        "_:u74": {
+            "prov:activity": "niiri:75cbb0b1a11a78d87cbc93882cc0e892",
+            "prov:entity": "niiri:7f7b05e69f02276d0d0544852cbc5b7a"
+        },
+        "_:u75": {
+            "prov:activity": "niiri:75cbb0b1a11a78d87cbc93882cc0e892",
+            "prov:entity": "niiri:113d8c92a0971f69fc045ea25e0ac452"
+        },
+        "_:u76": {
+            "prov:activity": "niiri:75cbb0b1a11a78d87cbc93882cc0e892",
+            "prov:entity": "niiri:f5afca80c28adf7d02a12d1328e18dc4"
+        },
+        "_:u77": {
+            "prov:activity": "niiri:75cbb0b1a11a78d87cbc93882cc0e892",
+            "prov:entity": "niiri:670ea0bcbdf9cc6f21ab6a8f5eef7e10"
+        },
+        "_:u78": {
+            "prov:activity": "niiri:75cbb0b1a11a78d87cbc93882cc0e892",
+            "prov:entity": "niiri:f9a61a4056f36732add4b9b80a53bc8d"
+        },
+        "_:u79": {
+            "prov:activity": "niiri:75cbb0b1a11a78d87cbc93882cc0e892",
+            "prov:entity": "niiri:2c9fd0f62c916461f5d00571f467366e"
+        }
+    },
+    "wasDerivedFrom": {
+        "_:wDF19": {
+            "prov:generatedEntity": "niiri:670ea0bcbdf9cc6f21ab6a8f5eef7e10",
+            "prov:usedEntity": "niiri:b4c604265d7449416900828c600fa004"
+        },
+        "_:wDF25": {
+            "prov:generatedEntity": "niiri:5b992ad55d4d262b7a58b0b4c761ff0d",
+            "prov:usedEntity": "niiri:d1f669439d72f1805a497adb6df799cb"
+        },
+        "_:wDF29": {
+            "prov:generatedEntity": "niiri:e3f451cbbb64a9ffb1ea71bcaf5d3553",
+            "prov:usedEntity": "niiri:32ab03f45c3ae4ed0c58b56c5d3e699a"
+        },
+        "_:wDF33": {
+            "prov:generatedEntity": "niiri:94fec9121a605a700be78134f859b81d",
+            "prov:usedEntity": "niiri:ae331890935ac6c1c632c8ba6b1390db"
+        },
+        "_:wDF37": {
+            "prov:generatedEntity": "niiri:49c48883a4e6af1935a92b5f42299adf",
+            "prov:usedEntity": "niiri:425a977be056b0392b27ebe2ebf0d5b0"
+        },
+        "_:wDF41": {
+            "prov:generatedEntity": "niiri:f5afca80c28adf7d02a12d1328e18dc4",
+            "prov:usedEntity": "niiri:c29df4d87431481482987ba8e96377c4"
+        },
+        "_:wDF55": {
+            "prov:generatedEntity": "niiri:113d8c92a0971f69fc045ea25e0ac452",
+            "prov:usedEntity": "niiri:c9be9db6b926ab9d722466a7953ca805"
+        },
+        "_:wDF59": {
+            "prov:generatedEntity": "niiri:0472234a561a04222e0d544d0654b7ab",
+            "prov:usedEntity": "niiri:b2fec2ed7f2b195ecbc862d12bd13e4d"
+        },
+        "_:wDF87": {
+            "prov:generatedEntity": "niiri:f3b96c552779d9374a531718147427d0",
+            "prov:usedEntity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
+        },
+        "_:wDF89": {
+            "prov:generatedEntity": "niiri:31281ad36fc49da248ac587f4076c953",
+            "prov:usedEntity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
+        },
+        "_:wDF91": {
+            "prov:generatedEntity": "niiri:1bc8b121d587eb836f9b3b7858047889",
+            "prov:usedEntity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
+        },
+        "_:wDF93": {
+            "prov:generatedEntity": "niiri:c131d22e9155057f870d66e758ece437",
+            "prov:usedEntity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
+        },
+        "_:wDF95": {
+            "prov:generatedEntity": "niiri:c0d0506786bef63ddf2f635fb7755534",
+            "prov:usedEntity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
+        },
+        "_:wDF97": {
+            "prov:generatedEntity": "niiri:dccd359642442c550b8e126ef0768318",
+            "prov:usedEntity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
+        },
+        "_:wDF99": {
+            "prov:generatedEntity": "niiri:4c25e0ccdac5828019bc6ab24105a598",
+            "prov:usedEntity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
+        },
+        "_:wDF101": {
+            "prov:generatedEntity": "niiri:439c3d37a059fc0c9fe663876cd44696",
+            "prov:usedEntity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
+        },
+        "_:wDF103": {
+            "prov:generatedEntity": "niiri:e4902bb46a21f477eb5d9e386fc19878",
+            "prov:usedEntity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
+        },
+        "_:wDF105": {
+            "prov:generatedEntity": "niiri:392b01269887f7941cf41e331de9925c",
+            "prov:usedEntity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
+        },
+        "_:wDF107": {
+            "prov:generatedEntity": "niiri:7e231620402d8b69f99aa21ba8f6b058",
+            "prov:usedEntity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
+        },
+        "_:wDF109": {
+            "prov:generatedEntity": "niiri:c6a240b5ad789d06fb0190076dcbb863",
+            "prov:usedEntity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
+        },
+        "_:wDF111": {
+            "prov:generatedEntity": "niiri:1b71ce972cf56fb139ab88975f4640c9",
+            "prov:usedEntity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
+        },
+        "_:wDF113": {
+            "prov:generatedEntity": "niiri:ca0dd10dbf94ba5d07f8de45f011307c",
+            "prov:usedEntity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
+        },
+        "_:wDF115": {
+            "prov:generatedEntity": "niiri:cae6fd96eea7e9972a3dd49f5837e19f",
+            "prov:usedEntity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
+        },
+        "_:wDF117": {
+            "prov:generatedEntity": "niiri:a5ea3c101aaf1b98c7ee58fcc76dff1b",
+            "prov:usedEntity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
+        },
+        "_:wDF119": {
+            "prov:generatedEntity": "niiri:6f05166f31ef45c33808420434a13f55",
+            "prov:usedEntity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
+        },
+        "_:wDF121": {
+            "prov:generatedEntity": "niiri:f686250b6fb996d621aa21cdf5cf6717",
+            "prov:usedEntity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
+        },
+        "_:wDF123": {
+            "prov:generatedEntity": "niiri:36a0a86f1b5fa4bc787a9c7b7eba11a2",
+            "prov:usedEntity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
+        },
+        "_:wDF125": {
+            "prov:generatedEntity": "niiri:ee27ca4fbf4487cbf6ede6f498d03b89",
+            "prov:usedEntity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
+        },
+        "_:wDF127": {
+            "prov:generatedEntity": "niiri:f6df377f07bd1d85bb45726e6330c017",
+            "prov:usedEntity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
+        },
+        "_:wDF129": {
+            "prov:generatedEntity": "niiri:0f57c541cf04642c5618cb3c8c754be3",
+            "prov:usedEntity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
+        },
+        "_:wDF131": {
+            "prov:generatedEntity": "niiri:10dca7f82f910606e689ba8e2b5af3ff",
+            "prov:usedEntity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
+        },
+        "_:wDF133": {
+            "prov:generatedEntity": "niiri:34abbea5b5b7e9caec8749719282f69d",
+            "prov:usedEntity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
+        },
+        "_:wDF135": {
+            "prov:generatedEntity": "niiri:f97396b2a54d55285f02d93b58dbe2b6",
+            "prov:usedEntity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
+        },
+        "_:wDF137": {
+            "prov:generatedEntity": "niiri:a4357c1b32f8a28c66891660675a8ceb",
+            "prov:usedEntity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
+        },
+        "_:wDF139": {
+            "prov:generatedEntity": "niiri:9e1f64e5a9ff6cda9c7c7070f1f8c2b9",
+            "prov:usedEntity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
+        },
+        "_:wDF141": {
+            "prov:generatedEntity": "niiri:e13313ba9b9b954243d9c9332f3caf96",
+            "prov:usedEntity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
+        },
+        "_:wDF143": {
+            "prov:generatedEntity": "niiri:63e1799e700f05ae3736bff33a2b65f4",
+            "prov:usedEntity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
+        },
+        "_:wDF145": {
+            "prov:generatedEntity": "niiri:5dfbf6ab6301360ce96203aca13f8257",
+            "prov:usedEntity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
+        },
+        "_:wDF147": {
+            "prov:generatedEntity": "niiri:82c6c5dde224f3815e887f0f89a10062",
+            "prov:usedEntity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
+        },
+        "_:wDF149": {
+            "prov:generatedEntity": "niiri:f9cd18224526a4801de142048b64a357",
+            "prov:usedEntity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
+        },
+        "_:wDF151": {
+            "prov:generatedEntity": "niiri:b2129866f39d8d89964577f80028f418",
+            "prov:usedEntity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
+        },
+        "_:wDF153": {
+            "prov:generatedEntity": "niiri:1d15a2f17b8507a037170dff62d0df0f",
+            "prov:usedEntity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
+        },
+        "_:wDF155": {
+            "prov:generatedEntity": "niiri:92cdcaac8dc15abca00aaf2035c3d353",
+            "prov:usedEntity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
+        },
+        "_:wDF157": {
+            "prov:generatedEntity": "niiri:a766e15fcf31e1d6ce69e989e67adf78",
+            "prov:usedEntity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
+        },
+        "_:wDF159": {
+            "prov:generatedEntity": "niiri:f364696f65c95b091099ba5aa2f33e2b",
+            "prov:usedEntity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
+        },
+        "_:wDF162": {
+            "prov:generatedEntity": "niiri:60751fd1c75909c8f22f3188decc0b24",
+            "prov:usedEntity": "niiri:f3b96c552779d9374a531718147427d0"
+        },
+        "_:wDF165": {
+            "prov:generatedEntity": "niiri:b5e1aa9b45d83dea2221d28bd37262f2",
+            "prov:usedEntity": "niiri:f3b96c552779d9374a531718147427d0"
+        },
+        "_:wDF168": {
+            "prov:generatedEntity": "niiri:32b931355eb48f34a576c74d8531d572",
+            "prov:usedEntity": "niiri:f3b96c552779d9374a531718147427d0"
+        },
+        "_:wDF171": {
+            "prov:generatedEntity": "niiri:f5951e733e9591d4ba75b0258296ccca",
+            "prov:usedEntity": "niiri:31281ad36fc49da248ac587f4076c953"
+        },
+        "_:wDF174": {
+            "prov:generatedEntity": "niiri:b2dfa583b093fac4721ad0ee8e3b22b6",
+            "prov:usedEntity": "niiri:31281ad36fc49da248ac587f4076c953"
+        },
+        "_:wDF177": {
+            "prov:generatedEntity": "niiri:4d03394faeeb99576cb7d36401fb8e9e",
+            "prov:usedEntity": "niiri:31281ad36fc49da248ac587f4076c953"
+        },
+        "_:wDF180": {
+            "prov:generatedEntity": "niiri:ec9d4f0e234313738c8b9f2aa3bf749f",
+            "prov:usedEntity": "niiri:1bc8b121d587eb836f9b3b7858047889"
+        },
+        "_:wDF183": {
+            "prov:generatedEntity": "niiri:15dd1c92e83f1e367cd3e9341f2376b1",
+            "prov:usedEntity": "niiri:1bc8b121d587eb836f9b3b7858047889"
+        },
+        "_:wDF186": {
+            "prov:generatedEntity": "niiri:adae04095680f26a1da7f5413ac6928c",
+            "prov:usedEntity": "niiri:1bc8b121d587eb836f9b3b7858047889"
+        },
+        "_:wDF189": {
+            "prov:generatedEntity": "niiri:81e12a87ecad9a224f78f5ba0436d093",
+            "prov:usedEntity": "niiri:c131d22e9155057f870d66e758ece437"
+        },
+        "_:wDF192": {
+            "prov:generatedEntity": "niiri:91ba3878269ac05538257d7f8ed10f1c",
+            "prov:usedEntity": "niiri:c131d22e9155057f870d66e758ece437"
+        },
+        "_:wDF195": {
+            "prov:generatedEntity": "niiri:30283203f0fdcfdedb7c6446c63aa51e",
+            "prov:usedEntity": "niiri:c131d22e9155057f870d66e758ece437"
+        },
+        "_:wDF198": {
+            "prov:generatedEntity": "niiri:10d8dde0e7451af1a2cb3417fa3976a7",
+            "prov:usedEntity": "niiri:c0d0506786bef63ddf2f635fb7755534"
+        },
+        "_:wDF201": {
+            "prov:generatedEntity": "niiri:d6edab9aa6b5ef4f0c295f9803943d19",
+            "prov:usedEntity": "niiri:c0d0506786bef63ddf2f635fb7755534"
+        },
+        "_:wDF204": {
+            "prov:generatedEntity": "niiri:6f4c3201b3b10591156730aeb058f98d",
+            "prov:usedEntity": "niiri:dccd359642442c550b8e126ef0768318"
+        },
+        "_:wDF207": {
+            "prov:generatedEntity": "niiri:e09718d2ea585b971df91ec9ab3ce111",
+            "prov:usedEntity": "niiri:dccd359642442c550b8e126ef0768318"
+        },
+        "_:wDF210": {
+            "prov:generatedEntity": "niiri:bf8d2fa297b31faa11d9a75da96a1ecd",
+            "prov:usedEntity": "niiri:dccd359642442c550b8e126ef0768318"
+        },
+        "_:wDF213": {
+            "prov:generatedEntity": "niiri:b1491cceb4af6aa6b3bf2ca1bf80d7ed",
+            "prov:usedEntity": "niiri:4c25e0ccdac5828019bc6ab24105a598"
+        },
+        "_:wDF216": {
+            "prov:generatedEntity": "niiri:4728f15a30a3478ad47a3573b31291a2",
+            "prov:usedEntity": "niiri:4c25e0ccdac5828019bc6ab24105a598"
+        },
+        "_:wDF219": {
+            "prov:generatedEntity": "niiri:2846f983f4248ecf39eb3d072230034f",
+            "prov:usedEntity": "niiri:4c25e0ccdac5828019bc6ab24105a598"
+        },
+        "_:wDF222": {
+            "prov:generatedEntity": "niiri:c839fd693cb9f15e4f75ff285bd20825",
+            "prov:usedEntity": "niiri:439c3d37a059fc0c9fe663876cd44696"
+        },
+        "_:wDF225": {
+            "prov:generatedEntity": "niiri:2fe2b34ab4c1433aecafed937c37e601",
+            "prov:usedEntity": "niiri:e4902bb46a21f477eb5d9e386fc19878"
+        },
+        "_:wDF228": {
+            "prov:generatedEntity": "niiri:072b9ac5eb756bc6330b5dadc2697fbd",
+            "prov:usedEntity": "niiri:392b01269887f7941cf41e331de9925c"
+        },
+        "_:wDF231": {
+            "prov:generatedEntity": "niiri:8267f3c7f7dd3ca73f48fdd78c883180",
+            "prov:usedEntity": "niiri:392b01269887f7941cf41e331de9925c"
+        },
+        "_:wDF234": {
+            "prov:generatedEntity": "niiri:febe52264f5e54a6a5b0f5444ac1b68c",
+            "prov:usedEntity": "niiri:7e231620402d8b69f99aa21ba8f6b058"
+        },
+        "_:wDF237": {
+            "prov:generatedEntity": "niiri:7a9aad9b667e6ea2734b6e8dfe04acd7",
+            "prov:usedEntity": "niiri:7e231620402d8b69f99aa21ba8f6b058"
+        },
+        "_:wDF240": {
+            "prov:generatedEntity": "niiri:685d9eb36c33716b1c7e61d0a5ffb870",
+            "prov:usedEntity": "niiri:7e231620402d8b69f99aa21ba8f6b058"
+        },
+        "_:wDF243": {
+            "prov:generatedEntity": "niiri:4c95fa10598ea9fed0a1913a9efd2fec",
+            "prov:usedEntity": "niiri:c6a240b5ad789d06fb0190076dcbb863"
+        },
+        "_:wDF246": {
+            "prov:generatedEntity": "niiri:a3e7b604bb117fab93742f1fd5e8f473",
+            "prov:usedEntity": "niiri:1b71ce972cf56fb139ab88975f4640c9"
+        },
+        "_:wDF249": {
+            "prov:generatedEntity": "niiri:58ec7f33f37bb7ef67d8acccf7b40081",
+            "prov:usedEntity": "niiri:ca0dd10dbf94ba5d07f8de45f011307c"
+        },
+        "_:wDF252": {
+            "prov:generatedEntity": "niiri:78bd497bb5dc90d3f2b4e3ced5e4fe7a",
+            "prov:usedEntity": "niiri:ca0dd10dbf94ba5d07f8de45f011307c"
+        },
+        "_:wDF255": {
+            "prov:generatedEntity": "niiri:0635a977111ede7fa6bc63091cd0e675",
+            "prov:usedEntity": "niiri:cae6fd96eea7e9972a3dd49f5837e19f"
+        },
+        "_:wDF258": {
+            "prov:generatedEntity": "niiri:ff64de7e90ef291344583e6b3ac31db1",
+            "prov:usedEntity": "niiri:cae6fd96eea7e9972a3dd49f5837e19f"
+        },
+        "_:wDF261": {
+            "prov:generatedEntity": "niiri:ea99a82e713304e75f5d834789fc3609",
+            "prov:usedEntity": "niiri:cae6fd96eea7e9972a3dd49f5837e19f"
+        },
+        "_:wDF264": {
+            "prov:generatedEntity": "niiri:f229e485b8e3ee7f5cd9e3690d44e1dc",
+            "prov:usedEntity": "niiri:a5ea3c101aaf1b98c7ee58fcc76dff1b"
+        },
+        "_:wDF267": {
+            "prov:generatedEntity": "niiri:47c14511d37e558a3fb5b4c44e333292",
+            "prov:usedEntity": "niiri:a5ea3c101aaf1b98c7ee58fcc76dff1b"
+        },
+        "_:wDF270": {
+            "prov:generatedEntity": "niiri:e5ced5655aca3ab6d63936e6dbc4d14e",
+            "prov:usedEntity": "niiri:a5ea3c101aaf1b98c7ee58fcc76dff1b"
+        },
+        "_:wDF273": {
+            "prov:generatedEntity": "niiri:c84076330649c427ef2696347c4054ae",
+            "prov:usedEntity": "niiri:6f05166f31ef45c33808420434a13f55"
+        },
+        "_:wDF276": {
+            "prov:generatedEntity": "niiri:e2506b44ed692dcde07aecfe65313995",
+            "prov:usedEntity": "niiri:f686250b6fb996d621aa21cdf5cf6717"
+        },
+        "_:wDF279": {
+            "prov:generatedEntity": "niiri:a711ec92a5095b7cc31e6073cba60aeb",
+            "prov:usedEntity": "niiri:36a0a86f1b5fa4bc787a9c7b7eba11a2"
+        },
+        "_:wDF282": {
+            "prov:generatedEntity": "niiri:4babfa934e3c293ae57513a1dbf42b27",
+            "prov:usedEntity": "niiri:ee27ca4fbf4487cbf6ede6f498d03b89"
+        },
+        "_:wDF285": {
+            "prov:generatedEntity": "niiri:2c50f18e7e3b4acc2a572ba2fbdb7169",
+            "prov:usedEntity": "niiri:f6df377f07bd1d85bb45726e6330c017"
+        },
+        "_:wDF288": {
+            "prov:generatedEntity": "niiri:1ef0626fbe7b6528eb64d1fc1902fdff",
+            "prov:usedEntity": "niiri:0f57c541cf04642c5618cb3c8c754be3"
+        },
+        "_:wDF291": {
+            "prov:generatedEntity": "niiri:be786d3fdaa6a6946a7e31cca13afc20",
+            "prov:usedEntity": "niiri:10dca7f82f910606e689ba8e2b5af3ff"
+        },
+        "_:wDF294": {
+            "prov:generatedEntity": "niiri:d5463f9ce8c3e863106d9a205e4c2c3a",
+            "prov:usedEntity": "niiri:34abbea5b5b7e9caec8749719282f69d"
+        },
+        "_:wDF297": {
+            "prov:generatedEntity": "niiri:23d3e4257473feb39f485dec221abb31",
+            "prov:usedEntity": "niiri:f97396b2a54d55285f02d93b58dbe2b6"
+        },
+        "_:wDF300": {
+            "prov:generatedEntity": "niiri:7e76e2da1f22ce6b895d3014a33d1739",
+            "prov:usedEntity": "niiri:a4357c1b32f8a28c66891660675a8ceb"
+        },
+        "_:wDF303": {
+            "prov:generatedEntity": "niiri:a76fe1af0c08762eb9239007a5f9dc2c",
+            "prov:usedEntity": "niiri:a4357c1b32f8a28c66891660675a8ceb"
+        },
+        "_:wDF306": {
+            "prov:generatedEntity": "niiri:30853859b00c0b5c92d53d8e023cba9d",
+            "prov:usedEntity": "niiri:9e1f64e5a9ff6cda9c7c7070f1f8c2b9"
+        },
+        "_:wDF309": {
+            "prov:generatedEntity": "niiri:356f79ecf79738d01b5b4b7026b7e188",
+            "prov:usedEntity": "niiri:e13313ba9b9b954243d9c9332f3caf96"
+        },
+        "_:wDF312": {
+            "prov:generatedEntity": "niiri:4265e2cdabcc64eab47a5d072484d937",
+            "prov:usedEntity": "niiri:63e1799e700f05ae3736bff33a2b65f4"
+        },
+        "_:wDF315": {
+            "prov:generatedEntity": "niiri:b6e09f6b679ea623d2841ff4bcf6291e",
+            "prov:usedEntity": "niiri:5dfbf6ab6301360ce96203aca13f8257"
+        },
+        "_:wDF318": {
+            "prov:generatedEntity": "niiri:df0b4499eab340f0f5ffcf69ea26e94e",
+            "prov:usedEntity": "niiri:82c6c5dde224f3815e887f0f89a10062"
+        },
+        "_:wDF321": {
+            "prov:generatedEntity": "niiri:d0bc7891180bf59606c1dd42f7521b58",
+            "prov:usedEntity": "niiri:f9cd18224526a4801de142048b64a357"
+        },
+        "_:wDF324": {
+            "prov:generatedEntity": "niiri:048c50de4960b48aa105d96778779061",
+            "prov:usedEntity": "niiri:b2129866f39d8d89964577f80028f418"
+        },
+        "_:wDF327": {
+            "prov:generatedEntity": "niiri:f6f60a34610b49cc5b443ce199ca79c0",
+            "prov:usedEntity": "niiri:1d15a2f17b8507a037170dff62d0df0f"
+        },
+        "_:wDF330": {
+            "prov:generatedEntity": "niiri:6bd4ba02e7d4f4207d829a2c8b49bb4e",
+            "prov:usedEntity": "niiri:92cdcaac8dc15abca00aaf2035c3d353"
+        },
+        "_:wDF333": {
+            "prov:generatedEntity": "niiri:bae89a3df5e8c7b953547ae7d7534e95",
+            "prov:usedEntity": "niiri:a766e15fcf31e1d6ce69e989e67adf78"
+        },
+        "_:wDF336": {
+            "prov:generatedEntity": "niiri:f2e5294144fb56653d91e924583c3e1b",
+            "prov:usedEntity": "niiri:f364696f65c95b091099ba5aa2f33e2b"
+        }
+    },
+    "wasAttributedTo": {
+        "_:wAT6": {
+            "prov:entity": "niiri:43ad2ab273c1e85fdc66627cd3ea961c",
+            "prov:agent": "niiri:748b469bb5be2daf21097ad82e962dbc"
+        },
+        "_:wAT7": {
+            "prov:entity": "niiri:43ad2ab273c1e85fdc66627cd3ea961c",
+            "prov:agent": "niiri:6727c965ace54e00c464f50309d28201"
+        }
+    },
+    "wasAssociatedWith": {
+        "_:wAW13": {
+            "prov:activity": "niiri:c2c197b0fad8993c6cc7208559f40202",
+            "prov:agent": "niiri:c2ec86ce73c8b9ab4324393fc2d80b63"
+        },
+        "_:wAW45": {
+            "prov:activity": "niiri:660a6a4292f04758ec1d3b9e0aa1c672",
+            "prov:agent": "niiri:c2ec86ce73c8b9ab4324393fc2d80b63"
+        },
+        "_:wAW72": {
+            "prov:activity": "niiri:75cbb0b1a11a78d87cbc93882cc0e892",
+            "prov:agent": "niiri:c2ec86ce73c8b9ab4324393fc2d80b63"
+        }
+    }
+    }
+  }
+}

--- a/spmexport/ex_spm_thr_clustunck10/nidm.jsonld
+++ b/spmexport/ex_spm_thr_clustunck10/nidm.jsonld
@@ -7,7 +7,7 @@
       "niiri": "http://iri.nidash.org/",
       "spm": "http://purl.org/nidash/spm#",
       "neurolex": "http://neurolex.org/wiki/",
-      "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#",
+      "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/",
       "dct": "http://purl.org/dc/terms/",
       "nfo": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#",
       "dc": "http://purl.org/dc/elements/1.1/",
@@ -22,32 +22,32 @@
   ],
   "@graph": [
     {
-      "@id": "niiri:a63b539faedf59712e4b345bd22a4d2f",
-      "@type": ["prov:Entity","prov:Bundle","nidm_NIDMResults:"],
+      "@id": "niiri:05f8e697eec5ffc5aace5c1f4c105fda",
+      "@type": ["prov:Entity","prov:Bundle","nidm_NIDMResults"],
       "rdfs:label": "NIDM-Results",
-      "nidm_version:": {"@type": "xsd:string", "@value": "1.3.0"}
+      "nidm_version": {"@type": "xsd:string", "@value": "1.3.0"}
     },
     {
-      "@id": "niiri:a1ead588d29d1f2aab15e31634325b92",
-      "@type": ["prov:Agent","nidm_spm_results_nidm:","prov:SoftwareAgent"],
+      "@id": "niiri:4f37bcd80c8dd68304abbe610cb6c460",
+      "@type": ["prov:Agent","nidm_spm_results_nidm","prov:SoftwareAgent"],
       "rdfs:label": "spm_results_nidm",
-      "nidm_softwareVersion:": {"@type": "xsd:string", "@value": "12.6903"}
+      "nidm_softwareVersion": {"@type": "xsd:string", "@value": "12.7057"}
     },
     {
-      "@id": "niiri:758cb3b4047ff4106c5e20908223452e",
-      "@type": ["prov:Activity","nidm_NIDMResultsExport:"],
+      "@id": "niiri:09e1635174afe5c856ec0e948fac8237",
+      "@type": ["prov:Activity","nidm_NIDMResultsExport"],
       "rdfs:label": "NIDM-Results export"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:758cb3b4047ff4106c5e20908223452e",
-      "agent": "niiri:a1ead588d29d1f2aab15e31634325b92"
+      "activity_associated": "niiri:09e1635174afe5c856ec0e948fac8237",
+      "agent": "niiri:4f37bcd80c8dd68304abbe610cb6c460"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:a63b539faedf59712e4b345bd22a4d2f",
-      "activity": "niiri:758cb3b4047ff4106c5e20908223452e",
-      "atTime": "2016-12-07T16:09:44"
+      "entity_generated": "niiri:05f8e697eec5ffc5aace5c1f4c105fda",
+      "activity": "niiri:09e1635174afe5c856ec0e948fac8237",
+      "atTime": "2017-04-19T12:19:06"
     }
   ]
 },
@@ -158,572 +158,572 @@
       "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
     }
   ],
-  "@id": "niiri:a63b539faedf59712e4b345bd22a4d2f",
+  "@id": "niiri:05f8e697eec5ffc5aace5c1f4c105fda",
   "@graph": [
     {
-      "@id": "niiri:e195d58cb4a7afb511b291abe9c58673",
-      "@type": ["prov:Agent","src_SPM:","prov:SoftwareAgent"],
+      "@id": "niiri:c2ec86ce73c8b9ab4324393fc2d80b63",
+      "@type": ["prov:Agent","src_SPM","prov:SoftwareAgent"],
       "rdfs:label": "SPM",
-      "nidm_softwareVersion:": {"@type": "xsd:string", "@value": "12.12.2"}
+      "nidm_softwareVersion": {"@type": "xsd:string", "@value": "12.6906"}
     },
     {
-      "@id": "niiri:bd502eec9fb9df4c578a25b6ac824a14",
-      "@type": ["prov:Entity","nidm_CoordinateSpace:"],
+      "@id": "niiri:c8b0140b68018da6f9905cc4b8fd05ad",
+      "@type": ["prov:Entity","nidm_CoordinateSpace"],
       "rdfs:label": "Coordinate space 1",
-      "nidm_voxelToWorldMapping:": {"@type": "xsd:string", "@value": "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"},
-      "nidm_voxelUnits:": {"@type": "xsd:string", "@value": "[\"mm\", \"mm\", \"mm\"]"},
-      "nidm_voxelSize:": {"@type": "xsd:string", "@value": "[2, 2, 2]"},
-      "nidm_inWorldCoordinateSystem:": {"@id": "nidm_Ixi549CoordinateSystem:"},
-      "nidm_numberOfDimensions:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_dimensionsInVoxels:": {"@type": "xsd:string", "@value": "[79,95,79]"}
+      "nidm_voxelToWorldMapping": {"@type": "xsd:string", "@value": "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"},
+      "nidm_voxelUnits": {"@type": "xsd:string", "@value": "[\"mm\", \"mm\", \"mm\"]"},
+      "nidm_voxelSize": {"@type": "xsd:string", "@value": "[2, 2, 2]"},
+      "nidm_inWorldCoordinateSystem": {"@id": "nidm_Ixi549CoordinateSystem"},
+      "nidm_numberOfDimensions": {"@type": "xsd:int", "@value": "3"},
+      "nidm_dimensionsInVoxels": {"@type": "xsd:string", "@value": "[79,95,79]"}
     },
     {
-      "@id": "niiri:d7d8108b33b61c0ddd2ea5c7e0f6b30d",
-      "@type": ["prov:Agent","nlx_Imaginginstrument:","nlx_Magneticresonanceimagingscanner:"],
+      "@id": "niiri:748b469bb5be2daf21097ad82e962dbc",
+      "@type": ["prov:Agent","nlx_Imaginginstrument","nlx_Magneticresonanceimagingscanner"],
       "rdfs:label": "MRI Scanner"
     },
     {
-      "@id": "niiri:f01830debc918d2d2a8ac43c6169bec8",
+      "@id": "niiri:6727c965ace54e00c464f50309d28201",
       "@type": ["prov:Agent","prov:Person"],
       "rdfs:label": "Person"
     },
     {
-      "@id": "niiri:ecf786f09c31c2fd1f8fff3c4b1c8499",
-      "@type": ["prov:Entity","prov:Collection","nidm_Data:"],
+      "@id": "niiri:43ad2ab273c1e85fdc66627cd3ea961c",
+      "@type": ["prov:Entity","prov:Collection","nidm_Data"],
       "rdfs:label": "Data",
-      "nidm_grandMeanScaling:": {"@type": "xsd:boolean", "@value": "true"},
-      "nidm_targetIntensity:": {"@type": "xsd:float", "@value": "100"},
-      "nidm_hasMRIProtocol:": {"@id": "nlx_FunctionalMRIprotocol:"}
+      "nidm_grandMeanScaling": {"@type": "xsd:boolean", "@value": "true"},
+      "nidm_targetIntensity": {"@type": "xsd:float", "@value": "100"},
+      "nidm_hasMRIProtocol": {"@id": "nlx_FunctionalMRIprotocol"}
     },
     {
       "@type": "prov:Attribution",
-      "entity_attributed": "niiri:ecf786f09c31c2fd1f8fff3c4b1c8499",
-      "agent": "niiri:d7d8108b33b61c0ddd2ea5c7e0f6b30d"
+      "entity_attributed": "niiri:43ad2ab273c1e85fdc66627cd3ea961c",
+      "agent": "niiri:748b469bb5be2daf21097ad82e962dbc"
     },
     {
       "@type": "prov:Attribution",
-      "entity_attributed": "niiri:ecf786f09c31c2fd1f8fff3c4b1c8499",
-      "agent": "niiri:f01830debc918d2d2a8ac43c6169bec8"
+      "entity_attributed": "niiri:43ad2ab273c1e85fdc66627cd3ea961c",
+      "agent": "niiri:6727c965ace54e00c464f50309d28201"
     },
     {
-      "@id": "niiri:734c3323450668db8eea94b45e90b6e1",
-      "@type": ["prov:Entity","spm_DCTDriftModel:"],
+      "@id": "niiri:235a75292ec305bec2bfb9e1f1f26e2e",
+      "@type": ["prov:Entity","spm_DCTDriftModel"],
       "rdfs:label": "SPM's DCT Drift Model",
-      "spm_SPMsDriftCutoffPeriod:": {"@type": "xsd:float", "@value": "128"}
+      "spm_SPMsDriftCutoffPeriod": {"@type": "xsd:float", "@value": "128"}
     },
     {
-      "@id": "niiri:d7b500305477a954c7d6a2f04c1e44d5",
-      "@type": ["prov:Entity","nidm_DesignMatrix:"],
+      "@id": "niiri:a260d6b771a7d3d82e1d9830dcf02423",
+      "@type": ["prov:Entity","nidm_DesignMatrix"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "DesignMatrix.csv"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "DesignMatrix.csv"},
       "dct:format": {"@type": "xsd:string", "@value": "text/csv"},
-      "dc:description": {"@id": "niiri:46026a0dad4f63f1c7c7d151bcd45f48"},
+      "dc:description": {"@id": "niiri:9ba45fb0e707add8e7f710c709a22a63"},
       "rdfs:label": "Design Matrix",
-      "nidm_regressorNames:": {"@type": "xsd:string", "@value": "[\"Sn(1) to*bf(1)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) constant\"]"},
-      "nidm_hasDriftModel:": {"@id": "niiri:734c3323450668db8eea94b45e90b6e1"},
-      "nidm_hasHRFBasis:": {"@id": "spm_SPMsCanonicalHRF:"}
+      "nidm_regressorNames": {"@type": "xsd:string", "@value": "[\"Sn(1) to*bf(1)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) constant\"]"},
+      "nidm_hasDriftModel": {"@id": "niiri:235a75292ec305bec2bfb9e1f1f26e2e"},
+      "nidm_hasHRFBasis": {"@id": "spm_SPMsCanonicalHRF"}
     },
     {
-      "@id": "niiri:46026a0dad4f63f1c7c7d151bcd45f48",
+      "@id": "niiri:9ba45fb0e707add8e7f710c709a22a63",
       "@type": ["prov:Entity","dctype:Image"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "DesignMatrix.png"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "DesignMatrix.png"},
       "dct:format": {"@type": "xsd:string", "@value": "image/png"}
     },
     {
-      "@id": "niiri:a7f52c7e7e4d16e13f49d294bf67df3e",
-      "@type": ["prov:Entity","nidm_ErrorModel:"],
-      "nidm_hasErrorDistribution:": {"@id": "obo_normaldistribution:"},
-      "nidm_hasErrorDependence:": {"@id": "obo_Toeplitzcovariancestructure:"},
-      "nidm_dependenceMapWiseDependence:": {"@id": "nidm_ConstantParameter:"},
-      "nidm_errorVarianceHomogeneous:": {"@type": "xsd:boolean", "@value": "true"},
-      "nidm_varianceMapWiseDependence:": {"@id": "nidm_IndependentParameter:"}
+      "@id": "niiri:983f87f6bef9f3ca6917e33e21de8141",
+      "@type": ["prov:Entity","nidm_ErrorModel"],
+      "nidm_hasErrorDistribution": {"@id": "obo_normaldistribution"},
+      "nidm_hasErrorDependence": {"@id": "obo_Toeplitzcovariancestructure"},
+      "nidm_dependenceMapWiseDependence": {"@id": "nidm_ConstantParameter"},
+      "nidm_errorVarianceHomogeneous": {"@type": "xsd:boolean", "@value": "true"},
+      "nidm_varianceMapWiseDependence": {"@id": "nidm_IndependentParameter"}
     },
     {
-      "@id": "niiri:9373eea9b5c80c5420a14ed31174239a",
-      "@type": ["prov:Activity","nidm_ModelParametersEstimation:"],
+      "@id": "niiri:c2c197b0fad8993c6cc7208559f40202",
+      "@type": ["prov:Activity","nidm_ModelParametersEstimation"],
       "rdfs:label": "Model parameters estimation",
-      "nidm_withEstimationMethod:": {"@id": "obo_generalizedleastsquaresestimation:"}
+      "nidm_withEstimationMethod": {"@id": "obo_generalizedleastsquaresestimation"}
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:9373eea9b5c80c5420a14ed31174239a",
-      "agent": "niiri:e195d58cb4a7afb511b291abe9c58673"
+      "activity_associated": "niiri:c2c197b0fad8993c6cc7208559f40202",
+      "agent": "niiri:c2ec86ce73c8b9ab4324393fc2d80b63"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:9373eea9b5c80c5420a14ed31174239a",
-      "entity": "niiri:d7b500305477a954c7d6a2f04c1e44d5"
+      "activity_using": "niiri:c2c197b0fad8993c6cc7208559f40202",
+      "entity": "niiri:a260d6b771a7d3d82e1d9830dcf02423"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:9373eea9b5c80c5420a14ed31174239a",
-      "entity": "niiri:ecf786f09c31c2fd1f8fff3c4b1c8499"
+      "activity_using": "niiri:c2c197b0fad8993c6cc7208559f40202",
+      "entity": "niiri:43ad2ab273c1e85fdc66627cd3ea961c"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:9373eea9b5c80c5420a14ed31174239a",
-      "entity": "niiri:a7f52c7e7e4d16e13f49d294bf67df3e"
+      "activity_using": "niiri:c2c197b0fad8993c6cc7208559f40202",
+      "entity": "niiri:983f87f6bef9f3ca6917e33e21de8141"
     },
     {
-      "@id": "niiri:97a5f4038f996763845e252476bfddbc",
-      "@type": ["prov:Entity","nidm_MaskMap:"],
+      "@id": "niiri:670ea0bcbdf9cc6f21ab6a8f5eef7e10",
+      "@type": ["prov:Entity","nidm_MaskMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "Mask.nii.gz"},
-      "nidm_isUserDefined:": {"@type": "xsd:boolean", "@value": "false"},
+      "nidm_isUserDefined": {"@type": "xsd:boolean", "@value": "false"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "Mask.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Mask",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:bd502eec9fb9df4c578a25b6ac824a14"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:c8b0140b68018da6f9905cc4b8fd05ad"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876"}
     },
     {
-      "@id": "niiri:6f519cf414ce7f7481fe6fd707ed44cd",
-      "@type": ["prov:Entity","nidm_MaskMap:"],
+      "@id": "niiri:b4c604265d7449416900828c600fa004",
+      "@type": ["prov:Entity","nidm_MaskMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "mask.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "36929e1f5f4143bd9cc818cd896a25f129961fab208c3a4438555f40444c08347b359142ee8c53ece6e8cca1627f49db0788a1fd3b9e2ecaef61999c6c6c67ac"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:97a5f4038f996763845e252476bfddbc",
-      "entity": "niiri:6f519cf414ce7f7481fe6fd707ed44cd"
+      "entity_derived": "niiri:670ea0bcbdf9cc6f21ab6a8f5eef7e10",
+      "entity": "niiri:b4c604265d7449416900828c600fa004"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:97a5f4038f996763845e252476bfddbc",
-      "activity": "niiri:9373eea9b5c80c5420a14ed31174239a"
+      "entity_generated": "niiri:670ea0bcbdf9cc6f21ab6a8f5eef7e10",
+      "activity": "niiri:c2c197b0fad8993c6cc7208559f40202"
     },
     {
-      "@id": "niiri:c990ff47051297ce4c04f2d314082ae9",
-      "@type": ["prov:Entity","nidm_GrandMeanMap:"],
+      "@id": "niiri:d0e2322759b4a23ea6686e5c5874d635",
+      "@type": ["prov:Entity","nidm_GrandMeanMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "GrandMean.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "GrandMean.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Grand Mean Map",
-      "nidm_maskedMedian:": {"@type": "xsd:float", "@value": "111.557487487793"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:bd502eec9fb9df4c578a25b6ac824a14"},
+      "nidm_maskedMedian": {"@type": "xsd:float", "@value": "111.557487487793"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:c8b0140b68018da6f9905cc4b8fd05ad"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "512157cc6bff89d9343a09b4068226eb3edd64a8cbcee861f06231767fae6f8d4819921182adebee083a9bf309afd65529ab04a92f0aa6b0038c8098550f6124"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:c990ff47051297ce4c04f2d314082ae9",
-      "activity": "niiri:9373eea9b5c80c5420a14ed31174239a"
+      "entity_generated": "niiri:d0e2322759b4a23ea6686e5c5874d635",
+      "activity": "niiri:c2c197b0fad8993c6cc7208559f40202"
     },
     {
-      "@id": "niiri:0c78edca8a5d13f9f471c5c699fa4128",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:5b992ad55d4d262b7a58b0b4c761ff0d",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0001.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0001.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 1",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:bd502eec9fb9df4c578a25b6ac824a14"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:c8b0140b68018da6f9905cc4b8fd05ad"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd"}
     },
     {
-      "@id": "niiri:2004ce9eaa27477ebbab60db4568790a",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:d1f669439d72f1805a497adb6df799cb",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0001.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0c78edca8a5d13f9f471c5c699fa4128",
-      "entity": "niiri:2004ce9eaa27477ebbab60db4568790a"
+      "entity_derived": "niiri:5b992ad55d4d262b7a58b0b4c761ff0d",
+      "entity": "niiri:d1f669439d72f1805a497adb6df799cb"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:0c78edca8a5d13f9f471c5c699fa4128",
-      "activity": "niiri:9373eea9b5c80c5420a14ed31174239a"
+      "entity_generated": "niiri:5b992ad55d4d262b7a58b0b4c761ff0d",
+      "activity": "niiri:c2c197b0fad8993c6cc7208559f40202"
     },
     {
-      "@id": "niiri:e1aaedc9a7738f383e7360fbef306e63",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:e3f451cbbb64a9ffb1ea71bcaf5d3553",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0002.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0002.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 2",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:bd502eec9fb9df4c578a25b6ac824a14"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:c8b0140b68018da6f9905cc4b8fd05ad"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c"}
     },
     {
-      "@id": "niiri:64ee9cb7b3ce09b0e03ec060b6fd6771",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:32ab03f45c3ae4ed0c58b56c5d3e699a",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0002.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e1aaedc9a7738f383e7360fbef306e63",
-      "entity": "niiri:64ee9cb7b3ce09b0e03ec060b6fd6771"
+      "entity_derived": "niiri:e3f451cbbb64a9ffb1ea71bcaf5d3553",
+      "entity": "niiri:32ab03f45c3ae4ed0c58b56c5d3e699a"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:e1aaedc9a7738f383e7360fbef306e63",
-      "activity": "niiri:9373eea9b5c80c5420a14ed31174239a"
+      "entity_generated": "niiri:e3f451cbbb64a9ffb1ea71bcaf5d3553",
+      "activity": "niiri:c2c197b0fad8993c6cc7208559f40202"
     },
     {
-      "@id": "niiri:39edcc292ff235e7c9d940c9aedc2840",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:94fec9121a605a700be78134f859b81d",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0003.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0003.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 3",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:bd502eec9fb9df4c578a25b6ac824a14"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:c8b0140b68018da6f9905cc4b8fd05ad"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373"}
     },
     {
-      "@id": "niiri:828b9a8153dc1c947f8350192c7b785a",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:ae331890935ac6c1c632c8ba6b1390db",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0003.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:39edcc292ff235e7c9d940c9aedc2840",
-      "entity": "niiri:828b9a8153dc1c947f8350192c7b785a"
+      "entity_derived": "niiri:94fec9121a605a700be78134f859b81d",
+      "entity": "niiri:ae331890935ac6c1c632c8ba6b1390db"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:39edcc292ff235e7c9d940c9aedc2840",
-      "activity": "niiri:9373eea9b5c80c5420a14ed31174239a"
+      "entity_generated": "niiri:94fec9121a605a700be78134f859b81d",
+      "activity": "niiri:c2c197b0fad8993c6cc7208559f40202"
     },
     {
-      "@id": "niiri:46e980de8a2cae8243cca0529b26dcfb",
-      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap:"],
+      "@id": "niiri:49c48883a4e6af1935a92b5f42299adf",
+      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ResidualMeanSquares.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ResidualMeanSquares.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Residual Mean Squares Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:bd502eec9fb9df4c578a25b6ac824a14"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:c8b0140b68018da6f9905cc4b8fd05ad"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "991abf563d795a43b1e2eef8643e57023f2e0b090b2031f05f839321fc0643df6f71d423486a1021519b6dc82f6b0f563e19f3fbd50cb16063bed54a0e192d3e"}
     },
     {
-      "@id": "niiri:870099995b04bdfa4402559ec43ee291",
-      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap:"],
+      "@id": "niiri:425a977be056b0392b27ebe2ebf0d5b0",
+      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "ResMS.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "40b28d03fcf9a2f60b11f10d7fb83bf3618b234fb5aedf09df644cb7cbb6aab8c9f468897c1078166d455a3d04a83f4e3bf762cfca0b4ea982d7a4e406849f18"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:46e980de8a2cae8243cca0529b26dcfb",
-      "entity": "niiri:870099995b04bdfa4402559ec43ee291"
+      "entity_derived": "niiri:49c48883a4e6af1935a92b5f42299adf",
+      "entity": "niiri:425a977be056b0392b27ebe2ebf0d5b0"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:46e980de8a2cae8243cca0529b26dcfb",
-      "activity": "niiri:9373eea9b5c80c5420a14ed31174239a"
+      "entity_generated": "niiri:49c48883a4e6af1935a92b5f42299adf",
+      "activity": "niiri:c2c197b0fad8993c6cc7208559f40202"
     },
     {
-      "@id": "niiri:c51db7231d6ff0819bce879b142d84d9",
-      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap:"],
+      "@id": "niiri:f5afca80c28adf7d02a12d1328e18dc4",
+      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ReselsPerVoxel.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ReselsPerVoxel.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Resels per Voxel Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:bd502eec9fb9df4c578a25b6ac824a14"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:c8b0140b68018da6f9905cc4b8fd05ad"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "1a3f9216e145249ccc0b14b2bc337d6b38b81ad45e32768001fb22b35f0c2c0f3e2bce013b40c85f7dc0fc62723ac761ee7f7e1e6aff128a05f0ba7b8b8202a3"}
     },
     {
-      "@id": "niiri:0e5b8b589ee5eb2bcf4f50c3d2eee41b",
-      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap:"],
+      "@id": "niiri:c29df4d87431481482987ba8e96377c4",
+      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "RPV.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "4f76663162857f6b38b2a45a63b15a23b2ca8b338c283b69c1e71f2ea2f43797d045a733cd14e845be9c12f8b8f84d3931c599a08e8f6d77e99fab46ad87ab8f"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c51db7231d6ff0819bce879b142d84d9",
-      "entity": "niiri:0e5b8b589ee5eb2bcf4f50c3d2eee41b"
+      "entity_derived": "niiri:f5afca80c28adf7d02a12d1328e18dc4",
+      "entity": "niiri:c29df4d87431481482987ba8e96377c4"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:c51db7231d6ff0819bce879b142d84d9",
-      "activity": "niiri:9373eea9b5c80c5420a14ed31174239a"
+      "entity_generated": "niiri:f5afca80c28adf7d02a12d1328e18dc4",
+      "activity": "niiri:c2c197b0fad8993c6cc7208559f40202"
     },
     {
-      "@id": "niiri:9393c9b82a852cdb5a33a3bdedb81eba",
-      "@type": ["prov:Entity","obo_contrastweightmatrix:"],
-      "nidm_statisticType:": {"@id": "obo_tstatistic:"},
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
+      "@id": "niiri:6c5005a7bc069d11fc4a87c6369a3038",
+      "@type": ["prov:Entity","obo_contrastweightmatrix"],
+      "nidm_statisticType": {"@id": "obo_tstatistic"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
       "rdfs:label": "Contrast: tone counting vs baseline",
       "prov:value": {"@type": "xsd:string", "@value": "[1, 0, 0]"}
     },
     {
-      "@id": "niiri:5cd4d30379cc213d9034d537a9d9473f",
-      "@type": ["prov:Activity","nidm_ContrastEstimation:"],
+      "@id": "niiri:660a6a4292f04758ec1d3b9e0aa1c672",
+      "@type": ["prov:Activity","nidm_ContrastEstimation"],
       "rdfs:label": "Contrast estimation"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:5cd4d30379cc213d9034d537a9d9473f",
-      "agent": "niiri:e195d58cb4a7afb511b291abe9c58673"
+      "activity_associated": "niiri:660a6a4292f04758ec1d3b9e0aa1c672",
+      "agent": "niiri:c2ec86ce73c8b9ab4324393fc2d80b63"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:5cd4d30379cc213d9034d537a9d9473f",
-      "entity": "niiri:97a5f4038f996763845e252476bfddbc"
+      "activity_using": "niiri:660a6a4292f04758ec1d3b9e0aa1c672",
+      "entity": "niiri:670ea0bcbdf9cc6f21ab6a8f5eef7e10"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:5cd4d30379cc213d9034d537a9d9473f",
-      "entity": "niiri:46e980de8a2cae8243cca0529b26dcfb"
+      "activity_using": "niiri:660a6a4292f04758ec1d3b9e0aa1c672",
+      "entity": "niiri:49c48883a4e6af1935a92b5f42299adf"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:5cd4d30379cc213d9034d537a9d9473f",
-      "entity": "niiri:d7b500305477a954c7d6a2f04c1e44d5"
+      "activity_using": "niiri:660a6a4292f04758ec1d3b9e0aa1c672",
+      "entity": "niiri:a260d6b771a7d3d82e1d9830dcf02423"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:5cd4d30379cc213d9034d537a9d9473f",
-      "entity": "niiri:9393c9b82a852cdb5a33a3bdedb81eba"
+      "activity_using": "niiri:660a6a4292f04758ec1d3b9e0aa1c672",
+      "entity": "niiri:6c5005a7bc069d11fc4a87c6369a3038"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:5cd4d30379cc213d9034d537a9d9473f",
-      "entity": "niiri:0c78edca8a5d13f9f471c5c699fa4128"
+      "activity_using": "niiri:660a6a4292f04758ec1d3b9e0aa1c672",
+      "entity": "niiri:5b992ad55d4d262b7a58b0b4c761ff0d"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:5cd4d30379cc213d9034d537a9d9473f",
-      "entity": "niiri:e1aaedc9a7738f383e7360fbef306e63"
+      "activity_using": "niiri:660a6a4292f04758ec1d3b9e0aa1c672",
+      "entity": "niiri:e3f451cbbb64a9ffb1ea71bcaf5d3553"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:5cd4d30379cc213d9034d537a9d9473f",
-      "entity": "niiri:39edcc292ff235e7c9d940c9aedc2840"
+      "activity_using": "niiri:660a6a4292f04758ec1d3b9e0aa1c672",
+      "entity": "niiri:94fec9121a605a700be78134f859b81d"
     },
     {
-      "@id": "niiri:8234fc4c714d1aa8f3a12ecea0ded16e",
-      "@type": ["prov:Entity","nidm_StatisticMap:"],
+      "@id": "niiri:113d8c92a0971f69fc045ea25e0ac452",
+      "@type": ["prov:Entity","nidm_StatisticMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "TStatistic.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "TStatistic.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "T-Statistic Map: tone counting vs baseline",
-      "nidm_statisticType:": {"@id": "obo_tstatistic:"},
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
-      "nidm_errorDegreesOfFreedom:": {"@type": "xsd:float", "@value": "97.9999999998522"},
-      "nidm_effectDegreesOfFreedom:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:bd502eec9fb9df4c578a25b6ac824a14"},
+      "nidm_statisticType": {"@id": "obo_tstatistic"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
+      "nidm_errorDegreesOfFreedom": {"@type": "xsd:float", "@value": "97.9999999998522"},
+      "nidm_effectDegreesOfFreedom": {"@type": "xsd:float", "@value": "1"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:c8b0140b68018da6f9905cc4b8fd05ad"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "9e1714c2d86a050b38b4e10a4d2d23253a24c5e1d228ae16a9c3be8872739278505ac0729ecab54265a717e3a54f9f782d0ed72eea904e0d482a6072bb817bd4"}
     },
     {
-      "@id": "niiri:a84cbdb68584ed314539628acf43ba8c",
-      "@type": ["prov:Entity","nidm_StatisticMap:"],
+      "@id": "niiri:c9be9db6b926ab9d722466a7953ca805",
+      "@type": ["prov:Entity","nidm_StatisticMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "spmT_0001.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "d288b1b0f117f64502555da13c5398dffa5bf5ff0b58951510e43d5388755bc185798802a92e98a07c7e313c6991066d2908f2a44aa5153ba23433da1335970f"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8234fc4c714d1aa8f3a12ecea0ded16e",
-      "entity": "niiri:a84cbdb68584ed314539628acf43ba8c"
+      "entity_derived": "niiri:113d8c92a0971f69fc045ea25e0ac452",
+      "entity": "niiri:c9be9db6b926ab9d722466a7953ca805"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:8234fc4c714d1aa8f3a12ecea0ded16e",
-      "activity": "niiri:5cd4d30379cc213d9034d537a9d9473f"
+      "entity_generated": "niiri:113d8c92a0971f69fc045ea25e0ac452",
+      "activity": "niiri:660a6a4292f04758ec1d3b9e0aa1c672"
     },
     {
-      "@id": "niiri:55c7fb97d1e38a3382fcfdca89da7635",
-      "@type": ["prov:Entity","nidm_ContrastMap:"],
+      "@id": "niiri:0472234a561a04222e0d544d0654b7ab",
+      "@type": ["prov:Entity","nidm_ContrastMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "Contrast.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "Contrast.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Contrast Map: tone counting vs baseline",
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:bd502eec9fb9df4c578a25b6ac824a14"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:c8b0140b68018da6f9905cc4b8fd05ad"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "fc5e2ad175243ee496db98f9b2e1b235c4c3bae1a8d7122ce461c897b537e40c49dfee5d6cf20f71c6a2bb9b5f0760fcb4ecd8fe2e9428910ef3d60d8f3c56a9"}
     },
     {
-      "@id": "niiri:ae821101a7c2e3fd4bfaa97d6e58bd78",
-      "@type": ["prov:Entity","nidm_ContrastMap:"],
+      "@id": "niiri:b2fec2ed7f2b195ecbc862d12bd13e4d",
+      "@type": ["prov:Entity","nidm_ContrastMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "con_0001.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "d4aa46b3603ba508578e39751262d528cf6d1ed2e722ec46f1cd8194c50591e46b229deb8cb4f72d1b7e0e2640f3e6604be7a335301c5c8357f453e5d0d4daf2"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:55c7fb97d1e38a3382fcfdca89da7635",
-      "entity": "niiri:ae821101a7c2e3fd4bfaa97d6e58bd78"
+      "entity_derived": "niiri:0472234a561a04222e0d544d0654b7ab",
+      "entity": "niiri:b2fec2ed7f2b195ecbc862d12bd13e4d"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:55c7fb97d1e38a3382fcfdca89da7635",
-      "activity": "niiri:5cd4d30379cc213d9034d537a9d9473f"
+      "entity_generated": "niiri:0472234a561a04222e0d544d0654b7ab",
+      "activity": "niiri:660a6a4292f04758ec1d3b9e0aa1c672"
     },
     {
-      "@id": "niiri:adf108a020a1d2bac94b02874ce48bda",
-      "@type": ["prov:Entity","nidm_ContrastStandardErrorMap:"],
+      "@id": "niiri:fa01d09024a9f2eb7c842f11f9e05d7c",
+      "@type": ["prov:Entity","nidm_ContrastStandardErrorMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ContrastStandardError.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ContrastStandardError.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Contrast Standard Error Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:bd502eec9fb9df4c578a25b6ac824a14"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:c8b0140b68018da6f9905cc4b8fd05ad"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "791d48f5d1adb15079a5289271ce0c4b95c56d69bfdb3e5d41b0d24eb538d3075e1cdd15502494b5a5a18c16eaa2153cb4847a996043fa48cdaf26e938a2576d"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:adf108a020a1d2bac94b02874ce48bda",
-      "activity": "niiri:5cd4d30379cc213d9034d537a9d9473f"
+      "entity_generated": "niiri:fa01d09024a9f2eb7c842f11f9e05d7c",
+      "activity": "niiri:660a6a4292f04758ec1d3b9e0aa1c672"
     },
     {
-      "@id": "niiri:5d2fabf109275e7e70695b5e5c8414ca",
-      "@type": ["prov:Entity","nidm_HeightThreshold:","nidm_PValueUncorrected:"],
-      "rdfs:label": "Height Threshold: p<0.001000 (unc.)",
+      "@id": "niiri:311f473b94b906ba6c5a22011f2bf44d",
+      "@type": ["prov:Entity","nidm_HeightThreshold","nidm_PValueUncorrected"],
+      "rdfs:label": "Height Threshold: p<0.001 (unc.)",
       "prov:value": {"@type": "xsd:float", "@value": "0.000999500158000544"},
-      "nidm_equivalentThreshold:": [{"@id": "niiri:b0ff4c49e2c5ffa9b6b376ebb171033b"},{"@id": "niiri:91f44211c250f503f422c234d36de5f6"}]
+      "nidm_equivalentThreshold": [{"@id": "niiri:2bfc4bebfe1177a3004cbd378dafd2c1"},{"@id": "niiri:496cd88b6fd812b8f219563fa7c3bf08"}]
     },
     {
-      "@id": "niiri:b0ff4c49e2c5ffa9b6b376ebb171033b",
-      "@type": ["prov:Entity","nidm_HeightThreshold:","obo_statistic:"],
-      "rdfs:label": "Height Threshold",
+      "@id": "niiri:2bfc4bebfe1177a3004cbd378dafd2c1",
+      "@type": ["prov:Entity","nidm_HeightThreshold","obo_statistic"],
+      "rdfs:label": "Height Threshold: T=3.175486)",
       "prov:value": {"@type": "xsd:float", "@value": "3.17548628637284"}
     },
     {
-      "@id": "niiri:91f44211c250f503f422c234d36de5f6",
-      "@type": ["prov:Entity","nidm_HeightThreshold:","obo_FWERadjustedpvalue:"],
-      "rdfs:label": "Height Threshold",
+      "@id": "niiri:496cd88b6fd812b8f219563fa7c3bf08",
+      "@type": ["prov:Entity","nidm_HeightThreshold","obo_FWERadjustedpvalue"],
+      "rdfs:label": "Height Threshold: p<1.000000 (FWE)",
       "prov:value": {"@type": "xsd:float", "@value": "0.999999999999997"}
     },
     {
-      "@id": "niiri:6b786352e2e95a84069166615ebaf059",
-      "@type": ["prov:Entity","nidm_ExtentThreshold:","obo_statistic:"],
+      "@id": "niiri:7f7b05e69f02276d0d0544852cbc5b7a",
+      "@type": ["prov:Entity","nidm_ExtentThreshold","obo_statistic"],
       "rdfs:label": "Extent Threshold: k>=10",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "10"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.15248854503675"},
-      "nidm_equivalentThreshold:": [{"@id": "niiri:60507569cc4c5aa46ef1a7d1e378c0ab"},{"@id": "niiri:7f7b12d78c21bc83dd0a94bace67afbf"}]
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "10"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.15248854503675"},
+      "nidm_equivalentThreshold": [{"@id": "niiri:097bd44b0c58cfa5bc7be0a0de9c38f9"},{"@id": "niiri:03f77b40ea055cd340662c393ea55c0b"}]
     },
     {
-      "@id": "niiri:60507569cc4c5aa46ef1a7d1e378c0ab",
-      "@type": ["prov:Entity","nidm_ExtentThreshold:","obo_FWERadjustedpvalue:"],
+      "@id": "niiri:097bd44b0c58cfa5bc7be0a0de9c38f9",
+      "@type": ["prov:Entity","nidm_ExtentThreshold","obo_FWERadjustedpvalue"],
       "rdfs:label": "Extent Threshold",
       "prov:value": {"@type": "xsd:float", "@value": "0.999430072930499"}
     },
     {
-      "@id": "niiri:7f7b12d78c21bc83dd0a94bace67afbf",
-      "@type": ["prov:Entity","nidm_ExtentThreshold:","nidm_PValueUncorrected:"],
+      "@id": "niiri:03f77b40ea055cd340662c393ea55c0b",
+      "@type": ["prov:Entity","nidm_ExtentThreshold","nidm_PValueUncorrected"],
       "rdfs:label": "Extent Threshold",
       "prov:value": {"@type": "xsd:float", "@value": "0.22255850848336"}
     },
     {
-      "@id": "niiri:4b7778d439610759224e40ce12ba98c0",
-      "@type": ["prov:Entity","nidm_PeakDefinitionCriteria:"],
+      "@id": "niiri:f9a61a4056f36732add4b9b80a53bc8d",
+      "@type": ["prov:Entity","nidm_PeakDefinitionCriteria"],
       "rdfs:label": "Peak Definition Criteria",
-      "nidm_maxNumberOfPeaksPerCluster:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_minDistanceBetweenPeaks:": {"@type": "xsd:float", "@value": "8"}
+      "nidm_maxNumberOfPeaksPerCluster": {"@type": "xsd:int", "@value": "3"},
+      "nidm_minDistanceBetweenPeaks": {"@type": "xsd:float", "@value": "8"}
     },
     {
-      "@id": "niiri:a5f7401956f7b7fa48f794abab7e5b78",
-      "@type": ["prov:Entity","nidm_ClusterDefinitionCriteria:"],
+      "@id": "niiri:2c9fd0f62c916461f5d00571f467366e",
+      "@type": ["prov:Entity","nidm_ClusterDefinitionCriteria"],
       "rdfs:label": "Cluster Connectivity Criterion: 18",
-      "nidm_hasConnectivityCriterion:": {"@id": "nidm_voxel18connected:"}
+      "nidm_hasConnectivityCriterion": {"@id": "nidm_voxel18connected"}
     },
     {
-      "@id": "niiri:4315bbeaef18cdda72910aa44f514089",
-      "@type": ["prov:Activity","nidm_Inference:"],
-      "nidm_hasAlternativeHypothesis:": {"@id": "nidm_OneTailedTest:"},
+      "@id": "niiri:75cbb0b1a11a78d87cbc93882cc0e892",
+      "@type": ["prov:Activity","nidm_Inference"],
+      "nidm_hasAlternativeHypothesis": {"@id": "nidm_OneTailedTest"},
       "rdfs:label": "Inference"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:4315bbeaef18cdda72910aa44f514089",
-      "agent": "niiri:e195d58cb4a7afb511b291abe9c58673"
+      "activity_associated": "niiri:75cbb0b1a11a78d87cbc93882cc0e892",
+      "agent": "niiri:c2ec86ce73c8b9ab4324393fc2d80b63"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:4315bbeaef18cdda72910aa44f514089",
-      "entity": "niiri:5d2fabf109275e7e70695b5e5c8414ca"
+      "activity_using": "niiri:75cbb0b1a11a78d87cbc93882cc0e892",
+      "entity": "niiri:311f473b94b906ba6c5a22011f2bf44d"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:4315bbeaef18cdda72910aa44f514089",
-      "entity": "niiri:6b786352e2e95a84069166615ebaf059"
+      "activity_using": "niiri:75cbb0b1a11a78d87cbc93882cc0e892",
+      "entity": "niiri:7f7b05e69f02276d0d0544852cbc5b7a"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:4315bbeaef18cdda72910aa44f514089",
-      "entity": "niiri:8234fc4c714d1aa8f3a12ecea0ded16e"
+      "activity_using": "niiri:75cbb0b1a11a78d87cbc93882cc0e892",
+      "entity": "niiri:113d8c92a0971f69fc045ea25e0ac452"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:4315bbeaef18cdda72910aa44f514089",
-      "entity": "niiri:c51db7231d6ff0819bce879b142d84d9"
+      "activity_using": "niiri:75cbb0b1a11a78d87cbc93882cc0e892",
+      "entity": "niiri:f5afca80c28adf7d02a12d1328e18dc4"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:4315bbeaef18cdda72910aa44f514089",
-      "entity": "niiri:97a5f4038f996763845e252476bfddbc"
+      "activity_using": "niiri:75cbb0b1a11a78d87cbc93882cc0e892",
+      "entity": "niiri:670ea0bcbdf9cc6f21ab6a8f5eef7e10"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:4315bbeaef18cdda72910aa44f514089",
-      "entity": "niiri:4b7778d439610759224e40ce12ba98c0"
+      "activity_using": "niiri:75cbb0b1a11a78d87cbc93882cc0e892",
+      "entity": "niiri:f9a61a4056f36732add4b9b80a53bc8d"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:4315bbeaef18cdda72910aa44f514089",
-      "entity": "niiri:a5f7401956f7b7fa48f794abab7e5b78"
+      "activity_using": "niiri:75cbb0b1a11a78d87cbc93882cc0e892",
+      "entity": "niiri:2c9fd0f62c916461f5d00571f467366e"
     },
     {
-      "@id": "niiri:6b4eb214f0c393ce958c52a2b0d15ad3",
-      "@type": ["prov:Entity","nidm_SearchSpaceMaskMap:"],
+      "@id": "niiri:e7fa1fe72bad934822d8ef41842387f5",
+      "@type": ["prov:Entity","nidm_SearchSpaceMaskMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "SearchSpaceMask.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "SearchSpaceMask.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Search Space Mask Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:bd502eec9fb9df4c578a25b6ac824a14"},
-      "nidm_searchVolumeInVoxels:": {"@type": "xsd:int", "@value": "223057"},
-      "nidm_searchVolumeInUnits:": {"@type": "xsd:float", "@value": "1784456"},
-      "nidm_reselSizeInVoxels:": {"@type": "xsd:float", "@value": "65.5786964036542"},
-      "nidm_searchVolumeInResels:": {"@type": "xsd:float", "@value": "3155.84193266257"},
-      "spm_searchVolumeReselsGeometry:": {"@type": "xsd:string", "@value": "[6, 97.8140592306853, 965.938819261507, 3155.84193266257]"},
-      "nidm_noiseFWHMInVoxels:": {"@type": "xsd:string", "@value": "[4.09118640605185, 4.0346308705955, 3.97291894351243]"},
-      "nidm_noiseFWHMInUnits:": {"@type": "xsd:string", "@value": "[8.18237281210369, 8.069261741191, 7.94583788702486]"},
-      "nidm_randomFieldStationarity:": {"@type": "xsd:boolean", "@value": "true"},
-      "nidm_expectedNumberOfVoxelsPerCluster:": {"@type": "xsd:float", "@value": "7.21748994812991"},
-      "nidm_expectedNumberOfClusters:": {"@type": "xsd:float", "@value": "7.47000215356561"},
-      "nidm_heightCriticalThresholdFWE05:": {"@type": "xsd:float", "@value": "5.30963135104407"},
-      "nidm_heightCriticalThresholdFDR05:": {"@type": "xsd:float", "@value": "4.69981384277344"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:c8b0140b68018da6f9905cc4b8fd05ad"},
+      "nidm_searchVolumeInVoxels": {"@type": "xsd:int", "@value": "223057"},
+      "nidm_searchVolumeInUnits": {"@type": "xsd:float", "@value": "1784456"},
+      "nidm_reselSizeInVoxels": {"@type": "xsd:float", "@value": "65.5786964036542"},
+      "nidm_searchVolumeInResels": {"@type": "xsd:float", "@value": "3155.84193266257"},
+      "spm_searchVolumeReselsGeometry": {"@type": "xsd:string", "@value": "[6, 97.8140592306853, 965.938819261507, 3155.84193266257]"},
+      "nidm_noiseFWHMInVoxels": {"@type": "xsd:string", "@value": "[4.09118640605185, 4.0346308705955, 3.97291894351243]"},
+      "nidm_noiseFWHMInUnits": {"@type": "xsd:string", "@value": "[8.18237281210369, 8.069261741191, 7.94583788702486]"},
+      "nidm_randomFieldStationarity": {"@type": "xsd:boolean", "@value": "true"},
+      "nidm_expectedNumberOfVoxelsPerCluster": {"@type": "xsd:float", "@value": "7.21748994812991"},
+      "nidm_expectedNumberOfClusters": {"@type": "xsd:float", "@value": "7.47000215356561"},
+      "nidm_heightCriticalThresholdFWE05": {"@type": "xsd:float", "@value": "5.30963135104407"},
+      "nidm_heightCriticalThresholdFDR05": {"@type": "xsd:float", "@value": "4.69981384277344"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876"},
-      "spm_smallestSignificantClusterSizeInVoxelsFWE05:": {"@type": "xsd:int", "@value": "116"},
-      "spm_smallestSignificantClusterSizeInVoxelsFDR05:": {"@type": "xsd:int", "@value": "61"}
+      "spm_smallestSignificantClusterSizeInVoxelsFWE05": {"@type": "xsd:int", "@value": "116"},
+      "spm_smallestSignificantClusterSizeInVoxelsFDR05": {"@type": "xsd:int", "@value": "61"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:6b4eb214f0c393ce958c52a2b0d15ad3",
-      "activity": "niiri:4315bbeaef18cdda72910aa44f514089"
+      "entity_generated": "niiri:e7fa1fe72bad934822d8ef41842387f5",
+      "activity": "niiri:75cbb0b1a11a78d87cbc93882cc0e892"
     },
     {
-      "@id": "niiri:562d7f3f6f07bb6a2109c364a6267497",
-      "@type": ["prov:Entity","nidm_ExcursionSetMap:"],
+      "@id": "niiri:74ccd8c140ada8dc4af99773bc09dcbc",
+      "@type": ["prov:Entity","nidm_ExcursionSetMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ExcursionSet.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ExcursionSet.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Excursion Set Map",
-      "nidm_numberOfSupraThresholdClusters:": {"@type": "xsd:int", "@value": "37"},
-      "nidm_pValue:": {"@type": "xsd:float", "@value": "1.0547118733939e-14"},
-      "nidm_hasClusterLabelsMap:": {"@id": "niiri:bce923faf7a20ecf913804332596c5f6"},
-      "nidm_hasMaximumIntensityProjection:": {"@id": "niiri:25f8726eaf1348f0ba8e4da0eb6899ed"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:bd502eec9fb9df4c578a25b6ac824a14"},
+      "nidm_numberOfSupraThresholdClusters": {"@type": "xsd:int", "@value": "37"},
+      "nidm_pValue": {"@type": "xsd:float", "@value": "1.0547118733939e-14"},
+      "nidm_hasClusterLabelsMap": {"@id": "niiri:31512b9ad741a32434f9e9a179b05e24"},
+      "nidm_hasMaximumIntensityProjection": {"@id": "niiri:ab16dbc3e4925d392c891ea1edd16188"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:c8b0140b68018da6f9905cc4b8fd05ad"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "7c47836783829c9d104b853bdb9b46a988960ed9386e3d6bd1ffd9a0ef8fe115b75a0f91560fe1b8dfd21679c4406374db0824a65e5fdb4a98cd5c9f6d384cc9"}
     },
     {
-      "@id": "niiri:bce923faf7a20ecf913804332596c5f6",
-      "@type": ["prov:Entity","nidm_ClusterLabelsMap:"],
+      "@id": "niiri:31512b9ad741a32434f9e9a179b05e24",
+      "@type": ["prov:Entity","nidm_ClusterLabelsMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ClusterLabels.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ClusterLabels.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Cluster Labels Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:bd502eec9fb9df4c578a25b6ac824a14"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:c8b0140b68018da6f9905cc4b8fd05ad"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "2201a146e5e5a8bbbea7a3cb8ba3326744133bb484069e09afde0d678c99f2b8306b0519abcf59452234736b359abd058a93af565ddc0dd8831a7c5b94893c4d"}
     },
     {
-      "@id": "niiri:25f8726eaf1348f0ba8e4da0eb6899ed",
+      "@id": "niiri:ab16dbc3e4925d392c891ea1edd16188",
       "@type": ["prov:Entity","dctype:Image"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "MaximumIntensityProjection.png"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "MaximumIntensityProjection.png"},
@@ -731,1898 +731,1898 @@
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:562d7f3f6f07bb6a2109c364a6267497",
-      "activity": "niiri:4315bbeaef18cdda72910aa44f514089"
+      "entity_generated": "niiri:74ccd8c140ada8dc4af99773bc09dcbc",
+      "activity": "niiri:75cbb0b1a11a78d87cbc93882cc0e892"
     },
     {
-      "@id": "niiri:4bcbccd66dbc3e748dc049ea28e790ec",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f3b96c552779d9374a531718147427d0",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0001",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1804"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "27.5089335246298"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.46511379022666e-21"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "5.93371085041799e-20"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "1"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1804"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "27.5089335246298"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.46511379022666e-21"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "5.93371085041799e-20"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "1"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4bcbccd66dbc3e748dc049ea28e790ec",
-      "entity": "niiri:562d7f3f6f07bb6a2109c364a6267497"
+      "entity_derived": "niiri:f3b96c552779d9374a531718147427d0",
+      "entity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
     },
     {
-      "@id": "niiri:ede195e83c61c437e885525e08d7a512",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:31281ad36fc49da248ac587f4076c953",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0002",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "356"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "5.42859220330831"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.6728855149243e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "2.91098190852157e-06"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1.17083954451478e-06"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "2"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "356"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "5.42859220330831"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.6728855149243e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "2.91098190852157e-06"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1.17083954451478e-06"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "2"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ede195e83c61c437e885525e08d7a512",
-      "entity": "niiri:562d7f3f6f07bb6a2109c364a6267497"
+      "entity_derived": "niiri:31281ad36fc49da248ac587f4076c953",
+      "entity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
     },
     {
-      "@id": "niiri:fa5698ad69d25731ec095f4a19e6b769",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:1bc8b121d587eb836f9b3b7858047889",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0003",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "5090"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "77.6166694237059"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.51031151932561e-42"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "2.03335233065374e-40"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "3"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "5090"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "77.6166694237059"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.51031151932561e-42"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "2.03335233065374e-40"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "3"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:fa5698ad69d25731ec095f4a19e6b769",
-      "entity": "niiri:562d7f3f6f07bb6a2109c364a6267497"
+      "entity_derived": "niiri:1bc8b121d587eb836f9b3b7858047889",
+      "entity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
     },
     {
-      "@id": "niiri:887b2ca8650505f0a02eb266ef164521",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c131d22e9155057f870d66e758ece437",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0004",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "766"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "11.6806225498151"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.69891112070838e-12"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "5.70226088569825e-11"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "4.58706002591263e-11"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "4"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "766"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "11.6806225498151"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.69891112070838e-12"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "5.70226088569825e-11"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "4.58706002591263e-11"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "4"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:887b2ca8650505f0a02eb266ef164521",
-      "entity": "niiri:562d7f3f6f07bb6a2109c364a6267497"
+      "entity_derived": "niiri:c131d22e9155057f870d66e758ece437",
+      "entity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
     },
     {
-      "@id": "niiri:6cda51ac561cc297977a65efb9fbcef6",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c0d0506786bef63ddf2f635fb7755534",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0005",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "54"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.823438143198452"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00980531403246826"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.280434478478115"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.061094648971533"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "5"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "54"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.823438143198452"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00980531403246826"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.280434478478115"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.061094648971533"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "5"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6cda51ac561cc297977a65efb9fbcef6",
-      "entity": "niiri:562d7f3f6f07bb6a2109c364a6267497"
+      "entity_derived": "niiri:c0d0506786bef63ddf2f635fb7755534",
+      "entity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
     },
     {
-      "@id": "niiri:1ca66ce425b243c3c0035c8186d99a15",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:dccd359642442c550b8e126ef0768318",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0006",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "285"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "4.34592353354738"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.15539697056139e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "2.73725770201239e-05"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "9.4369593516496e-06"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "6"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "285"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "4.34592353354738"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.15539697056139e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "2.73725770201239e-05"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "9.4369593516496e-06"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "6"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1ca66ce425b243c3c0035c8186d99a15",
-      "entity": "niiri:562d7f3f6f07bb6a2109c364a6267497"
+      "entity_derived": "niiri:dccd359642442c550b8e126ef0768318",
+      "entity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
     },
     {
-      "@id": "niiri:c69f007bda67f5e2a0a40c91717f128b",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:4c25e0ccdac5828019bc6ab24105a598",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0007",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "395"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "6.02329752895164"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.70020762554596e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "9.06303145864484e-07"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "4.37433635338446e-07"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "7"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "395"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "6.02329752895164"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.70020762554596e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "9.06303145864484e-07"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "4.37433635338446e-07"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "7"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c69f007bda67f5e2a0a40c91717f128b",
-      "entity": "niiri:562d7f3f6f07bb6a2109c364a6267497"
+      "entity_derived": "niiri:4c25e0ccdac5828019bc6ab24105a598",
+      "entity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
     },
     {
-      "@id": "niiri:8009c6c2577ffab297b9446c56ac691e",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:439c3d37a059fc0c9fe663876cd44696",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0008",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "116"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.7688671224263"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000452977534465859"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0150888416289883"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00366911802917346"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "8"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "116"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.7688671224263"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000452977534465859"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0150888416289883"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00366911802917346"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "8"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8009c6c2577ffab297b9446c56ac691e",
-      "entity": "niiri:562d7f3f6f07bb6a2109c364a6267497"
+      "entity_derived": "niiri:439c3d37a059fc0c9fe663876cd44696",
+      "entity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
     },
     {
-      "@id": "niiri:ccbb2dcff74d28dda3be2c8bc2f59ef2",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:e4902bb46a21f477eb5d9e386fc19878",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0009",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "19"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.289728235569826"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0997597824989178"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.964858026030202"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.278639392496977"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "9"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "19"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.289728235569826"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0997597824989178"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.964858026030202"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.278639392496977"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "9"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ccbb2dcff74d28dda3be2c8bc2f59ef2",
-      "entity": "niiri:562d7f3f6f07bb6a2109c364a6267497"
+      "entity_derived": "niiri:e4902bb46a21f477eb5d9e386fc19878",
+      "entity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
     },
     {
-      "@id": "niiri:86578a06fc311c81acbc580eb1d83642",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:392b01269887f7941cf41e331de9925c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0010",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "50"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.762442725183751"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0123570633152281"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.339498021136914"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0707678054255747"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "10"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "50"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.762442725183751"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0123570633152281"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.339498021136914"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0707678054255747"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "10"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:86578a06fc311c81acbc580eb1d83642",
-      "entity": "niiri:562d7f3f6f07bb6a2109c364a6267497"
+      "entity_derived": "niiri:392b01269887f7941cf41e331de9925c",
+      "entity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
     },
     {
-      "@id": "niiri:9c4395321a8582f0da12ba759320292c",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:7e231620402d8b69f99aa21ba8f6b058",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0011",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "447"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "6.81623796314274"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.03851586308171e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "2.02678038352389e-07"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1.22279946227405e-07"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "11"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "447"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "6.81623796314274"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.03851586308171e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "2.02678038352389e-07"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1.22279946227405e-07"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "11"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9c4395321a8582f0da12ba759320292c",
-      "entity": "niiri:562d7f3f6f07bb6a2109c364a6267497"
+      "entity_derived": "niiri:7e231620402d8b69f99aa21ba8f6b058",
+      "entity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
     },
     {
-      "@id": "niiri:e84befdceca7e9fb020e4e603e6d2441",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c6a240b5ad789d06fb0190076dcbb863",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0012",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "162"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "2.47031442959535"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.63852466674842e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00222568832297587"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000672150622508277"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "12"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "162"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "2.47031442959535"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.63852466674842e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00222568832297587"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000672150622508277"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "12"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e84befdceca7e9fb020e4e603e6d2441",
-      "entity": "niiri:562d7f3f6f07bb6a2109c364a6267497"
+      "entity_derived": "niiri:c6a240b5ad789d06fb0190076dcbb863",
+      "entity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
     },
     {
-      "@id": "niiri:3921a44ffb5cf54649ee43045d6cc96a",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:1b71ce972cf56fb139ab88975f4640c9",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0013",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "29"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.442216780606576"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0470937359607303"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.79416170413585"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.190729630640958"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "13"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "29"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.442216780606576"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0470937359607303"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.79416170413585"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.190729630640958"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "13"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3921a44ffb5cf54649ee43045d6cc96a",
-      "entity": "niiri:562d7f3f6f07bb6a2109c364a6267497"
+      "entity_derived": "niiri:1b71ce972cf56fb139ab88975f4640c9",
+      "entity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
     },
     {
-      "@id": "niiri:d195c6d760a60eb9860a72f0fa5d33b6",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:ca0dd10dbf94ba5d07f8de45f011307c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0014",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "38"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.579456471139651"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0257597057294564"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.578781830495109"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.130408510255373"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "14"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "38"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.579456471139651"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0257597057294564"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.578781830495109"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.130408510255373"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "14"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d195c6d760a60eb9860a72f0fa5d33b6",
-      "entity": "niiri:562d7f3f6f07bb6a2109c364a6267497"
+      "entity_derived": "niiri:ca0dd10dbf94ba5d07f8de45f011307c",
+      "entity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
     },
     {
-      "@id": "niiri:eb6f2c1f9fab3eef26fb05dad9eee378",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:cae6fd96eea7e9972a3dd49f5837e19f",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0015",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "134"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "2.04334650349245"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000208225307159483"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00696455376757865"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00187402776443535"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "15"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "134"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "2.04334650349245"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000208225307159483"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00696455376757865"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00187402776443535"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "15"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:eb6f2c1f9fab3eef26fb05dad9eee378",
-      "entity": "niiri:562d7f3f6f07bb6a2109c364a6267497"
+      "entity_derived": "niiri:cae6fd96eea7e9972a3dd49f5837e19f",
+      "entity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
     },
     {
-      "@id": "niiri:3efe9387862f59b37bf90987a3a01074",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:a5ea3c101aaf1b98c7ee58fcc76dff1b",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0016",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "76"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.1589129422793"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00300279655548563"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0958739715182708"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.022111501908576"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "16"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "76"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.1589129422793"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00300279655548563"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0958739715182708"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.022111501908576"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "16"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3efe9387862f59b37bf90987a3a01074",
-      "entity": "niiri:562d7f3f6f07bb6a2109c364a6267497"
+      "entity_derived": "niiri:a5ea3c101aaf1b98c7ee58fcc76dff1b",
+      "entity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
     },
     {
-      "@id": "niiri:4fec4e3138e166ee2892b0d3d91bb41e",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:6f05166f31ef45c33808420434a13f55",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0017",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "16"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.2439816720588"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.128031320700056"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.986394362860718"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.324079280522016"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "17"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "16"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.2439816720588"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.128031320700056"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.986394362860718"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.324079280522016"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "17"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4fec4e3138e166ee2892b0d3d91bb41e",
-      "entity": "niiri:562d7f3f6f07bb6a2109c364a6267497"
+      "entity_derived": "niiri:6f05166f31ef45c33808420434a13f55",
+      "entity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
     },
     {
-      "@id": "niiri:0b5064760982e8c270bd98284ecb06d3",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f686250b6fb996d621aa21cdf5cf6717",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0018",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "26"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.396470217095551"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0583630672052552"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.858988054642613"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.205539497548942"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "18"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "26"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.396470217095551"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0583630672052552"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.858988054642613"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.205539497548942"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "18"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0b5064760982e8c270bd98284ecb06d3",
-      "entity": "niiri:562d7f3f6f07bb6a2109c364a6267497"
+      "entity_derived": "niiri:f686250b6fb996d621aa21cdf5cf6717",
+      "entity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
     },
     {
-      "@id": "niiri:71ab02bff3b085bb7b9a91d459a832f0",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:36a0a86f1b5fa4bc787a9c7b7eba11a2",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0019",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "29"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.442216780606576"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0470937359607303"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.79416170413585"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.190729630640958"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "19"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "29"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.442216780606576"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0470937359607303"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.79416170413585"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.190729630640958"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "19"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:71ab02bff3b085bb7b9a91d459a832f0",
-      "entity": "niiri:562d7f3f6f07bb6a2109c364a6267497"
+      "entity_derived": "niiri:36a0a86f1b5fa4bc787a9c7b7eba11a2",
+      "entity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
     },
     {
-      "@id": "niiri:5e8275841ed71a0e7a9cc2f07fba7508",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:ee27ca4fbf4487cbf6ede6f498d03b89",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0020",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "10"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.15248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.22255850848336"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999430072930499"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.487222680733842"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "20"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "10"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.15248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.22255850848336"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999430072930499"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.487222680733842"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "20"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5e8275841ed71a0e7a9cc2f07fba7508",
-      "entity": "niiri:562d7f3f6f07bb6a2109c364a6267497"
+      "entity_derived": "niiri:ee27ca4fbf4487cbf6ede6f498d03b89",
+      "entity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
     },
     {
-      "@id": "niiri:7d836a379d88c30e45968812bcbaec09",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f6df377f07bd1d85bb45726e6330c017",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0021",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "49"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.747193870680076"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0131051491528842"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.355876032106543"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0707678054255747"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "21"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "49"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.747193870680076"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0131051491528842"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.355876032106543"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0707678054255747"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "21"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7d836a379d88c30e45968812bcbaec09",
-      "entity": "niiri:562d7f3f6f07bb6a2109c364a6267497"
+      "entity_derived": "niiri:f6df377f07bd1d85bb45726e6330c017",
+      "entity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
     },
     {
-      "@id": "niiri:6d9719aa34ea98f8ee1e2190f57a38c2",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:0f57c541cf04642c5618cb3c8c754be3",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0022",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "21"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.320225944577176"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0850912379420168"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.942502902202007"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.255273713826051"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "22"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "21"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.320225944577176"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0850912379420168"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.942502902202007"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.255273713826051"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "22"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6d9719aa34ea98f8ee1e2190f57a38c2",
-      "entity": "niiri:562d7f3f6f07bb6a2109c364a6267497"
+      "entity_derived": "niiri:0f57c541cf04642c5618cb3c8c754be3",
+      "entity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
     },
     {
-      "@id": "niiri:7a9b91d6cb78bfe1263ffc584d3b69d2",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:10dca7f82f910606e689ba8e2b5af3ff",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0023",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "30"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.457465635110251"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.043916653732793"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.770998817460931"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.190729630640958"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "23"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "30"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.457465635110251"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.043916653732793"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.770998817460931"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.190729630640958"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "23"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7a9b91d6cb78bfe1263ffc584d3b69d2",
-      "entity": "niiri:562d7f3f6f07bb6a2109c364a6267497"
+      "entity_derived": "niiri:10dca7f82f910606e689ba8e2b5af3ff",
+      "entity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
     },
     {
-      "@id": "niiri:9dae134cd7326c7dd74b40d61a138556",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:34abbea5b5b7e9caec8749719282f69d",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0024",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "27"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.411719071599226"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0542875242970965"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.83831709934398"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.199876794002946"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "24"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "27"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.411719071599226"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0542875242970965"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.83831709934398"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.199876794002946"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "24"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9dae134cd7326c7dd74b40d61a138556",
-      "entity": "niiri:562d7f3f6f07bb6a2109c364a6267497"
+      "entity_derived": "niiri:34abbea5b5b7e9caec8749719282f69d",
+      "entity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
     },
     {
-      "@id": "niiri:a48e52ce82ef21945b533008203890a9",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f97396b2a54d55285f02d93b58dbe2b6",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0025",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "10"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.15248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.22255850848336"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999430072930499"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.487222680733842"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "25"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "10"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.15248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.22255850848336"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999430072930499"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.487222680733842"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "25"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a48e52ce82ef21945b533008203890a9",
-      "entity": "niiri:562d7f3f6f07bb6a2109c364a6267497"
+      "entity_derived": "niiri:f97396b2a54d55285f02d93b58dbe2b6",
+      "entity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
     },
     {
-      "@id": "niiri:33d2fed4b2c8785ed20bc8727adca85e",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:a4357c1b32f8a28c66891660675a8ceb",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0026",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "61"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.930180124724177"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00662877418964967"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.199476682033478"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0447442257801353"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "26"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "61"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.930180124724177"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00662877418964967"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.199476682033478"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0447442257801353"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "26"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:33d2fed4b2c8785ed20bc8727adca85e",
-      "entity": "niiri:562d7f3f6f07bb6a2109c364a6267497"
+      "entity_derived": "niiri:a4357c1b32f8a28c66891660675a8ceb",
+      "entity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
     },
     {
-      "@id": "niiri:32b9f8da6e89284036f980cbd853e723",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:9e1f64e5a9ff6cda9c7c7070f1f8c2b9",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0027",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "19"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.289728235569826"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0997597824989178"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.964858026030202"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.278639392496977"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "27"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "19"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.289728235569826"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0997597824989178"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.964858026030202"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.278639392496977"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "27"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:32b9f8da6e89284036f980cbd853e723",
-      "entity": "niiri:562d7f3f6f07bb6a2109c364a6267497"
+      "entity_derived": "niiri:9e1f64e5a9ff6cda9c7c7070f1f8c2b9",
+      "entity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
     },
     {
-      "@id": "niiri:a4fb311adc8de77c87cd3e5be5ccc62b",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:e13313ba9b9b954243d9c9332f3caf96",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0028",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "14"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.21348396305145"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.152527900243506"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.994020866354823"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.374386664234061"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "28"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "14"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.21348396305145"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.152527900243506"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.994020866354823"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.374386664234061"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "28"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a4fb311adc8de77c87cd3e5be5ccc62b",
-      "entity": "niiri:562d7f3f6f07bb6a2109c364a6267497"
+      "entity_derived": "niiri:e13313ba9b9b954243d9c9332f3caf96",
+      "entity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
     },
     {
-      "@id": "niiri:f5be0f8d59441b28ce308dfb011e10df",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:63e1799e700f05ae3736bff33a2b65f4",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0029",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "18"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.27447938106615"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.108241900089372"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.973564689982443"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.292253130241304"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "29"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "18"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.27447938106615"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.108241900089372"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.973564689982443"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.292253130241304"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "29"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f5be0f8d59441b28ce308dfb011e10df",
-      "entity": "niiri:562d7f3f6f07bb6a2109c364a6267497"
+      "entity_derived": "niiri:63e1799e700f05ae3736bff33a2b65f4",
+      "entity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
     },
     {
-      "@id": "niiri:9771726b7a7da2b81302c08e984d21aa",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:5dfbf6ab6301360ce96203aca13f8257",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0030",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "28"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.426967926102901"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.050541462694511"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.81665481379022"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.194945641821685"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "30"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "28"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.426967926102901"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.050541462694511"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.81665481379022"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.194945641821685"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "30"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9771726b7a7da2b81302c08e984d21aa",
-      "entity": "niiri:562d7f3f6f07bb6a2109c364a6267497"
+      "entity_derived": "niiri:5dfbf6ab6301360ce96203aca13f8257",
+      "entity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
     },
     {
-      "@id": "niiri:1081daf0e707c5e5ae15af9f18adc9a9",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:82c6c5dde224f3815e887f0f89a10062",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0031",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "21"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.320225944577176"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0850912379420168"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.942502902202007"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.255273713826051"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "31"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "21"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.320225944577176"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0850912379420168"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.942502902202007"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.255273713826051"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "31"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1081daf0e707c5e5ae15af9f18adc9a9",
-      "entity": "niiri:562d7f3f6f07bb6a2109c364a6267497"
+      "entity_derived": "niiri:82c6c5dde224f3815e887f0f89a10062",
+      "entity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
     },
     {
-      "@id": "niiri:9294aac4eea8be1704ba4b297809e66d",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f9cd18224526a4801de142048b64a357",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0032",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "29"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.442216780606576"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0470937359607303"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.79416170413585"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.190729630640958"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "32"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "29"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.442216780606576"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0470937359607303"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.79416170413585"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.190729630640958"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "32"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9294aac4eea8be1704ba4b297809e66d",
-      "entity": "niiri:562d7f3f6f07bb6a2109c364a6267497"
+      "entity_derived": "niiri:f9cd18224526a4801de142048b64a357",
+      "entity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
     },
     {
-      "@id": "niiri:9c2b57d941c750a81bae56005ccc8439",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:b2129866f39d8d89964577f80028f418",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0033",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "24"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.365972508088201"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0676477474681771"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.896743975460065"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.228311147705098"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "33"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "24"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.365972508088201"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0676477474681771"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.896743975460065"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.228311147705098"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "33"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9c2b57d941c750a81bae56005ccc8439",
-      "entity": "niiri:562d7f3f6f07bb6a2109c364a6267497"
+      "entity_derived": "niiri:b2129866f39d8d89964577f80028f418",
+      "entity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
     },
     {
-      "@id": "niiri:8e5c49eb54e50609e5ba92b2b8409882",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:1d15a2f17b8507a037170dff62d0df0f",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0034",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "12"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.1829862540441"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.183276076907294"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.997869754572677"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.42415320655688"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "34"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "12"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.1829862540441"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.183276076907294"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.997869754572677"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.42415320655688"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "34"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8e5c49eb54e50609e5ba92b2b8409882",
-      "entity": "niiri:562d7f3f6f07bb6a2109c364a6267497"
+      "entity_derived": "niiri:1d15a2f17b8507a037170dff62d0df0f",
+      "entity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
     },
     {
-      "@id": "niiri:a03ba6625b79992ed07f93b8c01a2bae",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:92cdcaac8dc15abca00aaf2035c3d353",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0035",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "21"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.320225944577176"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0850912379420168"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.942502902202007"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.255273713826051"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "35"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "21"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.320225944577176"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0850912379420168"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.942502902202007"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.255273713826051"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "35"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a03ba6625b79992ed07f93b8c01a2bae",
-      "entity": "niiri:562d7f3f6f07bb6a2109c364a6267497"
+      "entity_derived": "niiri:92cdcaac8dc15abca00aaf2035c3d353",
+      "entity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
     },
     {
-      "@id": "niiri:4ccc33b588ed17374f2c6edcb6528c8c",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:a766e15fcf31e1d6ce69e989e67adf78",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0036",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "16"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.2439816720588"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.128031320700056"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.986394362860718"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.324079280522016"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "36"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "16"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.2439816720588"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.128031320700056"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.986394362860718"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.324079280522016"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "36"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4ccc33b588ed17374f2c6edcb6528c8c",
-      "entity": "niiri:562d7f3f6f07bb6a2109c364a6267497"
+      "entity_derived": "niiri:a766e15fcf31e1d6ce69e989e67adf78",
+      "entity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
     },
     {
-      "@id": "niiri:9a0e43f3959fa34d67e65e823d6736df",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f364696f65c95b091099ba5aa2f33e2b",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0037",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "13"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.198235108547775"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.166999709083906"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.996321368733297"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.39785224811166"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "37"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "13"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.198235108547775"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.166999709083906"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.996321368733297"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.39785224811166"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "37"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9a0e43f3959fa34d67e65e823d6736df",
-      "entity": "niiri:562d7f3f6f07bb6a2109c364a6267497"
+      "entity_derived": "niiri:f364696f65c95b091099ba5aa2f33e2b",
+      "entity": "niiri:74ccd8c140ada8dc4af99773bc09dcbc"
     },
     {
-      "@id": "niiri:2ba80d8ffed5342d50948196439f6527",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:60751fd1c75909c8f22f3188decc0b24",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0001",
-      "prov:atLocation": {"@id": "niiri:e416a98cd9f9a86a1e11956e784e23ab"},
+      "prov:atLocation": {"@id": "niiri:f857ed5b37db9d516826e1fe049e298e"},
       "prov:value": {"@type": "xsd:float", "@value": "7.92007970809937"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "6.94608360738412"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.87783122385099e-12"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "4.18813870695089e-07"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "5.21674435923017e-06"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "6.94608360738412"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.87783122385099e-12"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "4.18813870695089e-07"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "5.21674435923017e-06"}
     },
     {
-      "@id": "niiri:e416a98cd9f9a86a1e11956e784e23ab",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f857ed5b37db9d516826e1fe049e298e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0001",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[46,16,24]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[46,16,24]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2ba80d8ffed5342d50948196439f6527",
-      "entity": "niiri:4bcbccd66dbc3e748dc049ea28e790ec"
+      "entity_derived": "niiri:60751fd1c75909c8f22f3188decc0b24",
+      "entity": "niiri:f3b96c552779d9374a531718147427d0"
     },
     {
-      "@id": "niiri:20de7c3806a32f85e015eb70cefa029f",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b5e1aa9b45d83dea2221d28bd37262f2",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0002",
-      "prov:atLocation": {"@id": "niiri:8c2d92b0d9e74f8ec893f2bf700309ad"},
+      "prov:atLocation": {"@id": "niiri:ed2331a7cf87add50918be5bd659afc1"},
       "prov:value": {"@type": "xsd:float", "@value": "6.31603479385376"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.77079466112137"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.94492849498107e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.000879943865776389"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000830722551601523"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.77079466112137"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.94492849498107e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.000879943865776389"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000830722551601523"}
     },
     {
-      "@id": "niiri:8c2d92b0d9e74f8ec893f2bf700309ad",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ed2331a7cf87add50918be5bd659afc1",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0002",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[32,24,-4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[32,24,-4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:20de7c3806a32f85e015eb70cefa029f",
-      "entity": "niiri:4bcbccd66dbc3e748dc049ea28e790ec"
+      "entity_derived": "niiri:b5e1aa9b45d83dea2221d28bd37262f2",
+      "entity": "niiri:f3b96c552779d9374a531718147427d0"
     },
     {
-      "@id": "niiri:70dc65955934a45a8cf93fc4a9a8b52f",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:32b931355eb48f34a576c74d8531d572",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0003",
-      "prov:atLocation": {"@id": "niiri:e7b89a98f83baac8975b9a70dc582435"},
+      "prov:atLocation": {"@id": "niiri:280385c283fdc62462e4706eab377298"},
       "prov:value": {"@type": "xsd:float", "@value": "5.68819808959961"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.27450168515333"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.655864770444e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0121028975026269"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00350091530962783"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.27450168515333"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.655864770444e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0121028975026269"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00350091530962783"}
     },
     {
-      "@id": "niiri:e7b89a98f83baac8975b9a70dc582435",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:280385c283fdc62462e4706eab377298",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0003",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[18,16,4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[18,16,4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:70dc65955934a45a8cf93fc4a9a8b52f",
-      "entity": "niiri:4bcbccd66dbc3e748dc049ea28e790ec"
+      "entity_derived": "niiri:32b931355eb48f34a576c74d8531d572",
+      "entity": "niiri:f3b96c552779d9374a531718147427d0"
     },
     {
-      "@id": "niiri:9b7a2eaa3e50c8c2eb1d223e98c25459",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f5951e733e9591d4ba75b0258296ccca",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0004",
-      "prov:atLocation": {"@id": "niiri:ce62716ad27ce3bd64069dc0e9d261d1"},
+      "prov:atLocation": {"@id": "niiri:3efbdfe72d5b5db5c0a2617705ba8152"},
       "prov:value": {"@type": "xsd:float", "@value": "7.11683940887451"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "6.37404871703245"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "9.20510334623259e-11"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "2.05325778424026e-05"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "9.33757664730496e-05"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "6.37404871703245"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "9.20510334623259e-11"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "2.05325778424026e-05"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "9.33757664730496e-05"}
     },
     {
-      "@id": "niiri:ce62716ad27ce3bd64069dc0e9d261d1",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:3efbdfe72d5b5db5c0a2617705ba8152",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0004",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[34,-88,-2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[34,-88,-2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9b7a2eaa3e50c8c2eb1d223e98c25459",
-      "entity": "niiri:ede195e83c61c437e885525e08d7a512"
+      "entity_derived": "niiri:f5951e733e9591d4ba75b0258296ccca",
+      "entity": "niiri:31281ad36fc49da248ac587f4076c953"
     },
     {
-      "@id": "niiri:c280de68d27d9261d076492449efb758",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b2dfa583b093fac4721ad0ee8e3b22b6",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0005",
-      "prov:atLocation": {"@id": "niiri:a2f3773d146316fec09ce151b201310b"},
+      "prov:atLocation": {"@id": "niiri:a828e9a512b1b18b628b6352b9841b81"},
       "prov:value": {"@type": "xsd:float", "@value": "6.48292255401611"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.8992593141605"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.82568493656277e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.000407231755366277"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000830722551601523"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.8992593141605"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.82568493656277e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.000407231755366277"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000830722551601523"}
     },
     {
-      "@id": "niiri:a2f3773d146316fec09ce151b201310b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a828e9a512b1b18b628b6352b9841b81",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0005",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[42,-72,-10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[42,-72,-10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c280de68d27d9261d076492449efb758",
-      "entity": "niiri:ede195e83c61c437e885525e08d7a512"
+      "entity_derived": "niiri:b2dfa583b093fac4721ad0ee8e3b22b6",
+      "entity": "niiri:31281ad36fc49da248ac587f4076c953"
     },
     {
-      "@id": "niiri:7b2fa5ed8383543bfaab4a1eec24cade",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:4d03394faeeb99576cb7d36401fb8e9e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0006",
-      "prov:atLocation": {"@id": "niiri:a74572cce81479e7589c91f54edfefb0"},
+      "prov:atLocation": {"@id": "niiri:a3ad78691cb88bc080a2ad24b7f4624b"},
       "prov:value": {"@type": "xsd:float", "@value": "5.2275915145874"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.89738468004472"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.85602978606003e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0670610253017228"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0118363293065346"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.89738468004472"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.85602978606003e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0670610253017228"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0118363293065346"}
     },
     {
-      "@id": "niiri:a74572cce81479e7589c91f54edfefb0",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a3ad78691cb88bc080a2ad24b7f4624b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0006",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[34,-86,12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[34,-86,12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7b2fa5ed8383543bfaab4a1eec24cade",
-      "entity": "niiri:ede195e83c61c437e885525e08d7a512"
+      "entity_derived": "niiri:4d03394faeeb99576cb7d36401fb8e9e",
+      "entity": "niiri:31281ad36fc49da248ac587f4076c953"
     },
     {
-      "@id": "niiri:9f386b0dea4861ac2a0e04e0b9a392a4",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ec9d4f0e234313738c8b9f2aa3bf749f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0007",
-      "prov:atLocation": {"@id": "niiri:0e869382af56c384af273063523cd969"},
+      "prov:atLocation": {"@id": "niiri:a8570442309c47fdfec5293c10c727c3"},
       "prov:value": {"@type": "xsd:float", "@value": "6.28007745742798"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.74292583422276"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.65272453897825e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00103782272796227"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000830722551601523"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.74292583422276"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.65272453897825e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00103782272796227"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000830722551601523"}
     },
     {
-      "@id": "niiri:0e869382af56c384af273063523cd969",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a8570442309c47fdfec5293c10c727c3",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0007",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[8,18,50]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[8,18,50]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9f386b0dea4861ac2a0e04e0b9a392a4",
-      "entity": "niiri:fa5698ad69d25731ec095f4a19e6b769"
+      "entity_derived": "niiri:ec9d4f0e234313738c8b9f2aa3bf749f",
+      "entity": "niiri:1bc8b121d587eb836f9b3b7858047889"
     },
     {
-      "@id": "niiri:3629d6e2bdaa9ac9ea88966c4d3a93b3",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:15dd1c92e83f1e367cd3e9341f2376b1",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0008",
-      "prov:atLocation": {"@id": "niiri:06c5ec7e5ce2bc219ee52004d24e43e3"},
+      "prov:atLocation": {"@id": "niiri:65533b720f685277b5ffaabaea192278"},
       "prov:value": {"@type": "xsd:float", "@value": "6.15222215652466"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.64328512810061"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.34178537356678e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00186069357054308"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000972721201433817"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.64328512810061"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.34178537356678e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00186069357054308"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000972721201433817"}
     },
     {
-      "@id": "niiri:06c5ec7e5ce2bc219ee52004d24e43e3",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:65533b720f685277b5ffaabaea192278",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0008",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-6,12,52]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-6,12,52]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3629d6e2bdaa9ac9ea88966c4d3a93b3",
-      "entity": "niiri:fa5698ad69d25731ec095f4a19e6b769"
+      "entity_derived": "niiri:15dd1c92e83f1e367cd3e9341f2376b1",
+      "entity": "niiri:1bc8b121d587eb836f9b3b7858047889"
     },
     {
-      "@id": "niiri:7c4d53aa4f995ab4fc1749a3bab2c536",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:adae04095680f26a1da7f5413ac6928c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0009",
-      "prov:atLocation": {"@id": "niiri:e7dd4788aee3000f6f38f577ceac6361"},
+      "prov:atLocation": {"@id": "niiri:ba57c8cb8e6498910435395572d4059b"},
       "prov:value": {"@type": "xsd:float", "@value": "5.98517084121704"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.51181334779297"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.77577724747024e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00376326218366319"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00136419627856355"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.51181334779297"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.77577724747024e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00376326218366319"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00136419627856355"}
     },
     {
-      "@id": "niiri:e7dd4788aee3000f6f38f577ceac6361",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ba57c8cb8e6498910435395572d4059b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0009",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[8,32,38]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[8,32,38]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7c4d53aa4f995ab4fc1749a3bab2c536",
-      "entity": "niiri:fa5698ad69d25731ec095f4a19e6b769"
+      "entity_derived": "niiri:adae04095680f26a1da7f5413ac6928c",
+      "entity": "niiri:1bc8b121d587eb836f9b3b7858047889"
     },
     {
-      "@id": "niiri:c1e2029a13352a22de56a02c2cce423d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:81e12a87ecad9a224f78f5ba0436d093",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0010",
-      "prov:atLocation": {"@id": "niiri:c38bcefa6c9d8814a02ca72f46bc0ff2"},
+      "prov:atLocation": {"@id": "niiri:4e8fd18340a3d30598d15370242d6def"},
       "prov:value": {"@type": "xsd:float", "@value": "6.25127363204956"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.72055271981637"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.30890376104765e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0011841880966994"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000830722551601523"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.72055271981637"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.30890376104765e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0011841880966994"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000830722551601523"}
     },
     {
-      "@id": "niiri:c38bcefa6c9d8814a02ca72f46bc0ff2",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4e8fd18340a3d30598d15370242d6def",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0010",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[52,-32,42]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[52,-32,42]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c1e2029a13352a22de56a02c2cce423d",
-      "entity": "niiri:887b2ca8650505f0a02eb266ef164521"
+      "entity_derived": "niiri:81e12a87ecad9a224f78f5ba0436d093",
+      "entity": "niiri:c131d22e9155057f870d66e758ece437"
     },
     {
-      "@id": "niiri:50751fae275003a5f41afd4f8700c77d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:91ba3878269ac05538257d7f8ed10f1c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0011",
-      "prov:atLocation": {"@id": "niiri:ef692da1ebca004473eb6e5cad511d25"},
+      "prov:atLocation": {"@id": "niiri:c83ef98d4875cea36cc2197877333dd8"},
       "prov:value": {"@type": "xsd:float", "@value": "6.24752378463745"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.71763687476157"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.40078304300806e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00120468241369565"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000830722551601523"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.71763687476157"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.40078304300806e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00120468241369565"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000830722551601523"}
     },
     {
-      "@id": "niiri:ef692da1ebca004473eb6e5cad511d25",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c83ef98d4875cea36cc2197877333dd8",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0011",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[40,-62,50]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[40,-62,50]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:50751fae275003a5f41afd4f8700c77d",
-      "entity": "niiri:887b2ca8650505f0a02eb266ef164521"
+      "entity_derived": "niiri:91ba3878269ac05538257d7f8ed10f1c",
+      "entity": "niiri:c131d22e9155057f870d66e758ece437"
     },
     {
-      "@id": "niiri:6d6cd0efd4ce1458bdcd4da4659667d6",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:30283203f0fdcfdedb7c6446c63aa51e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0012",
-      "prov:atLocation": {"@id": "niiri:bc4e0c1814e42357b7e77e4cf2e601bb"},
+      "prov:atLocation": {"@id": "niiri:732ed2e2fa65230309fc1469c052099e"},
       "prov:value": {"@type": "xsd:float", "@value": "5.70337772369385"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.28674301747281"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.22566831420812e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.011413186758684"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00350091530962783"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.28674301747281"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.22566831420812e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.011413186758684"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00350091530962783"}
     },
     {
-      "@id": "niiri:bc4e0c1814e42357b7e77e4cf2e601bb",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:732ed2e2fa65230309fc1469c052099e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0012",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[56,-44,52]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[56,-44,52]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6d6cd0efd4ce1458bdcd4da4659667d6",
-      "entity": "niiri:887b2ca8650505f0a02eb266ef164521"
+      "entity_derived": "niiri:30283203f0fdcfdedb7c6446c63aa51e",
+      "entity": "niiri:c131d22e9155057f870d66e758ece437"
     },
     {
-      "@id": "niiri:c4ecc93c2106ef923943525cd0c59df7",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:10d8dde0e7451af1a2cb3417fa3976a7",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0013",
-      "prov:atLocation": {"@id": "niiri:62de976fac06b4198c82fe0cb8daa0ae"},
+      "prov:atLocation": {"@id": "niiri:793d5a5dcc585871596598e1989a5a00"},
       "prov:value": {"@type": "xsd:float", "@value": "6.15371799468994"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.64445580026639"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.285227171001e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00184807786755337"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000972721201433817"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.64445580026639"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.285227171001e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00184807786755337"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000972721201433817"}
     },
     {
-      "@id": "niiri:62de976fac06b4198c82fe0cb8daa0ae",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:793d5a5dcc585871596598e1989a5a00",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0013",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-28,-94,4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-28,-94,4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c4ecc93c2106ef923943525cd0c59df7",
-      "entity": "niiri:6cda51ac561cc297977a65efb9fbcef6"
+      "entity_derived": "niiri:10d8dde0e7451af1a2cb3417fa3976a7",
+      "entity": "niiri:c0d0506786bef63ddf2f635fb7755534"
     },
     {
-      "@id": "niiri:55129f7d132823acf97b88da1d788729",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d6edab9aa6b5ef4f0c295f9803943d19",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0014",
-      "prov:atLocation": {"@id": "niiri:65a37cf86891551eaa067326591b9b82"},
+      "prov:atLocation": {"@id": "niiri:61351f75ee1916faadae7b2aadea0ff2"},
       "prov:value": {"@type": "xsd:float", "@value": "3.71480798721313"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.58412084932714"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000169107736440521"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999869855188705"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.383925327139989"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.58412084932714"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000169107736440521"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999869855188705"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.383925327139989"}
     },
     {
-      "@id": "niiri:65a37cf86891551eaa067326591b9b82",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:61351f75ee1916faadae7b2aadea0ff2",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0014",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-34,-84,-2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-34,-84,-2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:55129f7d132823acf97b88da1d788729",
-      "entity": "niiri:6cda51ac561cc297977a65efb9fbcef6"
+      "entity_derived": "niiri:d6edab9aa6b5ef4f0c295f9803943d19",
+      "entity": "niiri:c0d0506786bef63ddf2f635fb7755534"
     },
     {
-      "@id": "niiri:5377b5c42bb9a0949b27dee94ed9378d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:6f4c3201b3b10591156730aeb058f98d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0015",
-      "prov:atLocation": {"@id": "niiri:57d58b1ca384477433dbc1d8864e7fb5"},
+      "prov:atLocation": {"@id": "niiri:1dd8f041cfdaf90d4500f0c9d0f92698"},
       "prov:value": {"@type": "xsd:float", "@value": "6.10109901428223"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.60320502193174"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.05212039080982e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00234682813060005"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00104518293275697"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.60320502193174"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.05212039080982e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00234682813060005"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00104518293275697"}
     },
     {
-      "@id": "niiri:57d58b1ca384477433dbc1d8864e7fb5",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:1dd8f041cfdaf90d4500f0c9d0f92698",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0015",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[32,2,46]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[32,2,46]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5377b5c42bb9a0949b27dee94ed9378d",
-      "entity": "niiri:1ca66ce425b243c3c0035c8186d99a15"
+      "entity_derived": "niiri:6f4c3201b3b10591156730aeb058f98d",
+      "entity": "niiri:dccd359642442c550b8e126ef0768318"
     },
     {
-      "@id": "niiri:672552bfeda4059be2453699b205003e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e09718d2ea585b971df91ec9ab3ce111",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0016",
-      "prov:atLocation": {"@id": "niiri:c47dc48e25fd38babcfac75df201db12"},
+      "prov:atLocation": {"@id": "niiri:31217090dc47a01657c91b5135f4774a"},
       "prov:value": {"@type": "xsd:float", "@value": "4.6086859703064"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.3736141683061"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.11031435759912e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.453877178455514"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0599714495109201"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.3736141683061"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.11031435759912e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.453877178455514"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0599714495109201"}
     },
     {
-      "@id": "niiri:c47dc48e25fd38babcfac75df201db12",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:31217090dc47a01657c91b5135f4774a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0016",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[28,4,58]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[28,4,58]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:672552bfeda4059be2453699b205003e",
-      "entity": "niiri:1ca66ce425b243c3c0035c8186d99a15"
+      "entity_derived": "niiri:e09718d2ea585b971df91ec9ab3ce111",
+      "entity": "niiri:dccd359642442c550b8e126ef0768318"
     },
     {
-      "@id": "niiri:a5d5428ae77d82af81fd8ec72340a3b9",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:bf8d2fa297b31faa11d9a75da96a1ecd",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0017",
-      "prov:atLocation": {"@id": "niiri:641e3d2651d7e53387c533f146750b49"},
+      "prov:atLocation": {"@id": "niiri:1405899c5a02bcf163ebb333d48c9695"},
       "prov:value": {"@type": "xsd:float", "@value": "3.98793148994446"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.82932508069717"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.42475887594474e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.984644566584946"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.233149120368192"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.82932508069717"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.42475887594474e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.984644566584946"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.233149120368192"}
     },
     {
-      "@id": "niiri:641e3d2651d7e53387c533f146750b49",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:1405899c5a02bcf163ebb333d48c9695",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0017",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[42,4,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[42,4,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a5d5428ae77d82af81fd8ec72340a3b9",
-      "entity": "niiri:1ca66ce425b243c3c0035c8186d99a15"
+      "entity_derived": "niiri:bf8d2fa297b31faa11d9a75da96a1ecd",
+      "entity": "niiri:dccd359642442c550b8e126ef0768318"
     },
     {
-      "@id": "niiri:abff4adeaf3d10ac8b1eff4e23445323",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b1491cceb4af6aa6b3bf2ca1bf80d7ed",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0018",
-      "prov:atLocation": {"@id": "niiri:5909ae01ba922389005e6322fd2284a1"},
+      "prov:atLocation": {"@id": "niiri:a5f8fb798258fe5ff8b0d433dc52e3d4"},
       "prov:value": {"@type": "xsd:float", "@value": "5.98348569869995"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.51047970249337"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.78928538652201e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00378871596531738"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00136419627856355"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.51047970249337"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.78928538652201e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00378871596531738"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00136419627856355"}
     },
     {
-      "@id": "niiri:5909ae01ba922389005e6322fd2284a1",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a5f8fb798258fe5ff8b0d433dc52e3d4",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0018",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-52,0,38]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-52,0,38]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:abff4adeaf3d10ac8b1eff4e23445323",
-      "entity": "niiri:c69f007bda67f5e2a0a40c91717f128b"
+      "entity_derived": "niiri:b1491cceb4af6aa6b3bf2ca1bf80d7ed",
+      "entity": "niiri:4c25e0ccdac5828019bc6ab24105a598"
     },
     {
-      "@id": "niiri:3670c9d957ad21491f858b62b748b05b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:4728f15a30a3478ad47a3573b31291a2",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0019",
-      "prov:atLocation": {"@id": "niiri:bb4a0c3f5a62bc346e6319dbdb6605f7"},
+      "prov:atLocation": {"@id": "niiri:7cb43e92d04918591f6c8f33a35fd1a4"},
       "prov:value": {"@type": "xsd:float", "@value": "5.2253565788269"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.89552821543552"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.90210114501011e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0675937275056587"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0118363293065346"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.89552821543552"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.90210114501011e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0675937275056587"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0118363293065346"}
     },
     {
-      "@id": "niiri:bb4a0c3f5a62bc346e6319dbdb6605f7",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7cb43e92d04918591f6c8f33a35fd1a4",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0019",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-60,8,20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-60,8,20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3670c9d957ad21491f858b62b748b05b",
-      "entity": "niiri:c69f007bda67f5e2a0a40c91717f128b"
+      "entity_derived": "niiri:4728f15a30a3478ad47a3573b31291a2",
+      "entity": "niiri:4c25e0ccdac5828019bc6ab24105a598"
     },
     {
-      "@id": "niiri:39d19667145286e3ad7182d0806bfaa9",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:2846f983f4248ecf39eb3d072230034f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0020",
-      "prov:atLocation": {"@id": "niiri:a0470afe66823c0a4aaa368fbb26ed16"},
+      "prov:atLocation": {"@id": "niiri:f11c725020f0b62e517ee9feeaa492b4"},
       "prov:value": {"@type": "xsd:float", "@value": "4.98950004577637"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.69817956585148"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.31245304380023e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.151048137890434"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0233609510296683"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.69817956585148"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.31245304380023e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.151048137890434"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0233609510296683"}
     },
     {
-      "@id": "niiri:a0470afe66823c0a4aaa368fbb26ed16",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f11c725020f0b62e517ee9feeaa492b4",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0020",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-44,6,28]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-44,6,28]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:39d19667145286e3ad7182d0806bfaa9",
-      "entity": "niiri:c69f007bda67f5e2a0a40c91717f128b"
+      "entity_derived": "niiri:2846f983f4248ecf39eb3d072230034f",
+      "entity": "niiri:4c25e0ccdac5828019bc6ab24105a598"
     },
     {
-      "@id": "niiri:287c6a76f4bab73956e8836a41a3d561",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c839fd693cb9f15e4f75ff285bd20825",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0021",
-      "prov:atLocation": {"@id": "niiri:954b7c65ad1e956e482159d509289ea3"},
+      "prov:atLocation": {"@id": "niiri:0d681cd86b3782448e46f423694c73cd"},
       "prov:value": {"@type": "xsd:float", "@value": "5.78093099594116"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.34909755317379"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.41969442155354e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00844151822925698"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00286742427823329"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.34909755317379"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.41969442155354e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00844151822925698"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00286742427823329"}
     },
     {
-      "@id": "niiri:954b7c65ad1e956e482159d509289ea3",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0d681cd86b3782448e46f423694c73cd",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0021",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-34,-2,52]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-34,-2,52]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:287c6a76f4bab73956e8836a41a3d561",
-      "entity": "niiri:8009c6c2577ffab297b9446c56ac691e"
+      "entity_derived": "niiri:c839fd693cb9f15e4f75ff285bd20825",
+      "entity": "niiri:439c3d37a059fc0c9fe663876cd44696"
     },
     {
-      "@id": "niiri:b88ea08754ef7ca35d6cc3a42c0b1ae9",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:2fe2b34ab4c1433aecafed937c37e601",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0022",
-      "prov:atLocation": {"@id": "niiri:db2e556f7e44e2aa5d3ab23e5842cea4"},
+      "prov:atLocation": {"@id": "niiri:1368b3660adcb57e09b9a1f1f88185f4"},
       "prov:value": {"@type": "xsd:float", "@value": "5.40964078903198"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.04774404642803"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.23528758724889e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0346958937061391"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00846044059259994"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.04774404642803"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.23528758724889e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0346958937061391"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00846044059259994"}
     },
     {
-      "@id": "niiri:db2e556f7e44e2aa5d3ab23e5842cea4",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:1368b3660adcb57e09b9a1f1f88185f4",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0022",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-54,-46,58]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-54,-46,58]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b88ea08754ef7ca35d6cc3a42c0b1ae9",
-      "entity": "niiri:ccbb2dcff74d28dda3be2c8bc2f59ef2"
+      "entity_derived": "niiri:2fe2b34ab4c1433aecafed937c37e601",
+      "entity": "niiri:e4902bb46a21f477eb5d9e386fc19878"
     },
     {
-      "@id": "niiri:e4c0f5a5eb4b4c6266927153c72f5e73",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:072b9ac5eb756bc6330b5dadc2697fbd",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0023",
-      "prov:atLocation": {"@id": "niiri:ccd488f99ad859d43858b5ff8551964a"},
+      "prov:atLocation": {"@id": "niiri:37e4188c492c5a4165b3dac3071e5850"},
       "prov:value": {"@type": "xsd:float", "@value": "5.31841945648193"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.97261482231588"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.30279114724163e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0484353441449864"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0106752417476244"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.97261482231588"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.30279114724163e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0484353441449864"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0106752417476244"}
     },
     {
-      "@id": "niiri:ccd488f99ad859d43858b5ff8551964a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:37e4188c492c5a4165b3dac3071e5850",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0023",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-62,-38,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-62,-38,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e4c0f5a5eb4b4c6266927153c72f5e73",
-      "entity": "niiri:86578a06fc311c81acbc580eb1d83642"
+      "entity_derived": "niiri:072b9ac5eb756bc6330b5dadc2697fbd",
+      "entity": "niiri:392b01269887f7941cf41e331de9925c"
     },
     {
-      "@id": "niiri:7c7465214b57551e71b55c2a8308ed5c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:8267f3c7f7dd3ca73f48fdd78c883180",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0024",
-      "prov:atLocation": {"@id": "niiri:cc537fe44acdaad46beaaa820fcd1c22"},
+      "prov:atLocation": {"@id": "niiri:2f52144540b5809f055058dec6116471"},
       "prov:value": {"@type": "xsd:float", "@value": "4.57099342346191"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.34109644800954"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.08867353027554e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.496004086968197"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0635474729952592"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.34109644800954"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.08867353027554e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.496004086968197"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0635474729952592"}
     },
     {
-      "@id": "niiri:cc537fe44acdaad46beaaa820fcd1c22",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:2f52144540b5809f055058dec6116471",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0024",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-60,-50,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-60,-50,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7c7465214b57551e71b55c2a8308ed5c",
-      "entity": "niiri:86578a06fc311c81acbc580eb1d83642"
+      "entity_derived": "niiri:8267f3c7f7dd3ca73f48fdd78c883180",
+      "entity": "niiri:392b01269887f7941cf41e331de9925c"
     },
     {
-      "@id": "niiri:769669dfd8c20fd64aa8f42df6cf71ae",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:febe52264f5e54a6a5b0f5444ac1b68c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0025",
-      "prov:atLocation": {"@id": "niiri:039a4bc21a49d35121505ab11dfc0f15"},
+      "prov:atLocation": {"@id": "niiri:bb31516c2b7139961eca38d0f885ab41"},
       "prov:value": {"@type": "xsd:float", "@value": "5.30699443817139"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.96317509467693"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.46750043123123e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0504786376455083"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0106752417476244"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.96317509467693"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.46750043123123e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0504786376455083"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0106752417476244"}
     },
     {
-      "@id": "niiri:039a4bc21a49d35121505ab11dfc0f15",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:bb31516c2b7139961eca38d0f885ab41",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0025",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[32,40,16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[32,40,16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:769669dfd8c20fd64aa8f42df6cf71ae",
-      "entity": "niiri:9c4395321a8582f0da12ba759320292c"
+      "entity_derived": "niiri:febe52264f5e54a6a5b0f5444ac1b68c",
+      "entity": "niiri:7e231620402d8b69f99aa21ba8f6b058"
     },
     {
-      "@id": "niiri:591a8417c1edc6a1145bc440c259e8b9",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:7a9aad9b667e6ea2734b6e8dfe04acd7",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0026",
-      "prov:atLocation": {"@id": "niiri:fe24dec61e5bd028e9862bb8234d07db"},
+      "prov:atLocation": {"@id": "niiri:45969fab01b5727b00223bf465f615c0"},
       "prov:value": {"@type": "xsd:float", "@value": "4.5497465133667"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.32273570618355"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.7053150754347e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.520378392891944"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0649997423676262"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.32273570618355"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.7053150754347e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.520378392891944"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0649997423676262"}
     },
     {
-      "@id": "niiri:fe24dec61e5bd028e9862bb8234d07db",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:45969fab01b5727b00223bf465f615c0",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0026",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[40,46,12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[40,46,12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:591a8417c1edc6a1145bc440c259e8b9",
-      "entity": "niiri:9c4395321a8582f0da12ba759320292c"
+      "entity_derived": "niiri:7a9aad9b667e6ea2734b6e8dfe04acd7",
+      "entity": "niiri:7e231620402d8b69f99aa21ba8f6b058"
     },
     {
-      "@id": "niiri:0f02589e55ad49fadec50d378d54d41e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:685d9eb36c33716b1c7e61d0a5ffb870",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0027",
-      "prov:atLocation": {"@id": "niiri:ca18854e03c492e5b991337e774d0dc7"},
+      "prov:atLocation": {"@id": "niiri:b5e6f22c3e4ceb8f75b6756624dc984f"},
       "prov:value": {"@type": "xsd:float", "@value": "4.31582498550415"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.11913273798974"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.90150518718513e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.788829013385429"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.116130094830597"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.11913273798974"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.90150518718513e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.788829013385429"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.116130094830597"}
     },
     {
-      "@id": "niiri:ca18854e03c492e5b991337e774d0dc7",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b5e6f22c3e4ceb8f75b6756624dc984f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0027",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[36,54,6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[36,54,6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0f02589e55ad49fadec50d378d54d41e",
-      "entity": "niiri:9c4395321a8582f0da12ba759320292c"
+      "entity_derived": "niiri:685d9eb36c33716b1c7e61d0a5ffb870",
+      "entity": "niiri:7e231620402d8b69f99aa21ba8f6b058"
     },
     {
-      "@id": "niiri:3df5f1dea689940a961c1a59e79fb78e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:4c95fa10598ea9fed0a1913a9efd2fec",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0028",
-      "prov:atLocation": {"@id": "niiri:ae299c071e205411af94f37baf78ce3f"},
+      "prov:atLocation": {"@id": "niiri:44c91cfa2af752860c64b94ae533e716"},
       "prov:value": {"@type": "xsd:float", "@value": "5.27030229568481"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.93281349716267"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.05267701952816e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0575990926145485"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0110040663565173"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.93281349716267"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.05267701952816e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0575990926145485"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0110040663565173"}
     },
     {
-      "@id": "niiri:ae299c071e205411af94f37baf78ce3f",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:44c91cfa2af752860c64b94ae533e716",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0028",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[40,26,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[40,26,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3df5f1dea689940a961c1a59e79fb78e",
-      "entity": "niiri:e84befdceca7e9fb020e4e603e6d2441"
+      "entity_derived": "niiri:4c95fa10598ea9fed0a1913a9efd2fec",
+      "entity": "niiri:c6a240b5ad789d06fb0190076dcbb863"
     },
     {
-      "@id": "niiri:b10cf84edc33f058847a2c97a7caae0a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a3e7b604bb117fab93742f1fd5e8f473",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0029",
-      "prov:atLocation": {"@id": "niiri:8e3afe311c73cc788f118e5f53e9ca7a"},
+      "prov:atLocation": {"@id": "niiri:1d6bbd703ff2243ac599b69731c47544"},
       "prov:value": {"@type": "xsd:float", "@value": "4.93343877792358"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.65085575575197"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.6528024058271e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.180887232162623"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0254967087736733"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.65085575575197"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.6528024058271e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.180887232162623"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0254967087736733"}
     },
     {
-      "@id": "niiri:8e3afe311c73cc788f118e5f53e9ca7a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:1d6bbd703ff2243ac599b69731c47544",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0029",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-58,-30,-18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-58,-30,-18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b10cf84edc33f058847a2c97a7caae0a",
-      "entity": "niiri:3921a44ffb5cf54649ee43045d6cc96a"
+      "entity_derived": "niiri:a3e7b604bb117fab93742f1fd5e8f473",
+      "entity": "niiri:1b71ce972cf56fb139ab88975f4640c9"
     },
     {
-      "@id": "niiri:31df4d204ab31be89ea5dd24f01fd78d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:58ec7f33f37bb7ef67d8acccf7b40081",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0030",
-      "prov:atLocation": {"@id": "niiri:a99d807ab49efc17f5a4f12e6bcb0853"},
+      "prov:atLocation": {"@id": "niiri:4c332c72810f59b3208483ae780441ef"},
       "prov:value": {"@type": "xsd:float", "@value": "4.76414346694946"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.50698548813516"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.287756441539e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.301278778226174"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0396433885053995"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.50698548813516"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.287756441539e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.301278778226174"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0396433885053995"}
     },
     {
-      "@id": "niiri:a99d807ab49efc17f5a4f12e6bcb0853",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4c332c72810f59b3208483ae780441ef",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0030",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-46,-66,-6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-46,-66,-6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:31df4d204ab31be89ea5dd24f01fd78d",
-      "entity": "niiri:d195c6d760a60eb9860a72f0fa5d33b6"
+      "entity_derived": "niiri:58ec7f33f37bb7ef67d8acccf7b40081",
+      "entity": "niiri:ca0dd10dbf94ba5d07f8de45f011307c"
     },
     {
-      "@id": "niiri:d5cc3fc341bf072546957897c7f0d343",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:78bd497bb5dc90d3f2b4e3ced5e4fe7a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0031",
-      "prov:atLocation": {"@id": "niiri:ce9115dd9684d2946ac94d95e96a151d"},
+      "prov:atLocation": {"@id": "niiri:c699689651173fd2a45ae693a27b8ce4"},
       "prov:value": {"@type": "xsd:float", "@value": "3.7637345790863"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.62829384243901"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000142650218672435"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999605970761399"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.34409224637793"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.62829384243901"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000142650218672435"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999605970761399"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.34409224637793"}
     },
     {
-      "@id": "niiri:ce9115dd9684d2946ac94d95e96a151d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c699689651173fd2a45ae693a27b8ce4",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0031",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-54,-64,-8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-54,-64,-8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d5cc3fc341bf072546957897c7f0d343",
-      "entity": "niiri:d195c6d760a60eb9860a72f0fa5d33b6"
+      "entity_derived": "niiri:78bd497bb5dc90d3f2b4e3ced5e4fe7a",
+      "entity": "niiri:ca0dd10dbf94ba5d07f8de45f011307c"
     },
     {
-      "@id": "niiri:83636273b177146ce249a14043f3bd81",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0635a977111ede7fa6bc63091cd0e675",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0032",
-      "prov:atLocation": {"@id": "niiri:f5ddd1fd9758595b3b0dd5266dc4a82f"},
+      "prov:atLocation": {"@id": "niiri:b5dbb05246499ae43a44b9697932ef7d"},
       "prov:value": {"@type": "xsd:float", "@value": "4.72232866287231"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.47122948835043"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.88855941602095e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.338512677882141"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.044836631144536"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.47122948835043"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.88855941602095e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.338512677882141"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.044836631144536"}
     },
     {
-      "@id": "niiri:f5ddd1fd9758595b3b0dd5266dc4a82f",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b5dbb05246499ae43a44b9697932ef7d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0032",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[58,-38,6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[58,-38,6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:83636273b177146ce249a14043f3bd81",
-      "entity": "niiri:eb6f2c1f9fab3eef26fb05dad9eee378"
+      "entity_derived": "niiri:0635a977111ede7fa6bc63091cd0e675",
+      "entity": "niiri:cae6fd96eea7e9972a3dd49f5837e19f"
     },
     {
-      "@id": "niiri:dfc942b6182952e994d59f93fa7cffc3",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ff64de7e90ef291344583e6b3ac31db1",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0033",
-      "prov:atLocation": {"@id": "niiri:271055043356196b1fe09d2452976bcb"},
+      "prov:atLocation": {"@id": "niiri:cddf881c6e42c41e1712c3dcfd7cc65d"},
       "prov:value": {"@type": "xsd:float", "@value": "3.98372888565063"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.8255778871433"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.52328381068878e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.985409231324461"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.233731539105478"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.8255778871433"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.52328381068878e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.985409231324461"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.233731539105478"}
     },
     {
-      "@id": "niiri:271055043356196b1fe09d2452976bcb",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:cddf881c6e42c41e1712c3dcfd7cc65d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0033",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[64,-30,-4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[64,-30,-4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:dfc942b6182952e994d59f93fa7cffc3",
-      "entity": "niiri:eb6f2c1f9fab3eef26fb05dad9eee378"
+      "entity_derived": "niiri:ff64de7e90ef291344583e6b3ac31db1",
+      "entity": "niiri:cae6fd96eea7e9972a3dd49f5837e19f"
     },
     {
-      "@id": "niiri:549a1e66bb4d6d1a6980fc15ec7c687a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ea99a82e713304e75f5d834789fc3609",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0034",
-      "prov:atLocation": {"@id": "niiri:2baa8daf20af089a3632fab6b3bd2f9b"},
+      "prov:atLocation": {"@id": "niiri:c72302c49efa40a4578b8e26bdabfb7b"},
       "prov:value": {"@type": "xsd:float", "@value": "3.50753784179688"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.39582098150001"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000342115474631921"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999778829603"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.564856004417035"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.39582098150001"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000342115474631921"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999778829603"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.564856004417035"}
     },
     {
-      "@id": "niiri:2baa8daf20af089a3632fab6b3bd2f9b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c72302c49efa40a4578b8e26bdabfb7b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0034",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[60,-40,-12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[60,-40,-12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:549a1e66bb4d6d1a6980fc15ec7c687a",
-      "entity": "niiri:eb6f2c1f9fab3eef26fb05dad9eee378"
+      "entity_derived": "niiri:ea99a82e713304e75f5d834789fc3609",
+      "entity": "niiri:cae6fd96eea7e9972a3dd49f5837e19f"
     },
     {
-      "@id": "niiri:7371044958cc47404fd82f339ebb008b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f229e485b8e3ee7f5cd9e3690d44e1dc",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0035",
-      "prov:atLocation": {"@id": "niiri:4c4a59d2ea3cd308f28682c6c74dacc2"},
+      "prov:atLocation": {"@id": "niiri:35c5569d0795499fb727a1041cef0d38"},
       "prov:value": {"@type": "xsd:float", "@value": "4.70483255386353"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.45624265093732"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.17043099876224e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.354967306449537"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0466228196503302"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.45624265093732"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.17043099876224e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.354967306449537"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0466228196503302"}
     },
     {
-      "@id": "niiri:4c4a59d2ea3cd308f28682c6c74dacc2",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:35c5569d0795499fb727a1041cef0d38",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0035",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-36,-74,-14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-36,-74,-14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7371044958cc47404fd82f339ebb008b",
-      "entity": "niiri:3efe9387862f59b37bf90987a3a01074"
+      "entity_derived": "niiri:f229e485b8e3ee7f5cd9e3690d44e1dc",
+      "entity": "niiri:a5ea3c101aaf1b98c7ee58fcc76dff1b"
     },
     {
-      "@id": "niiri:d7b71fa497e0f8780396e93232c93a4e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:47c14511d37e558a3fb5b4c44e333292",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0036",
-      "prov:atLocation": {"@id": "niiri:5d39e0678df9edef83d5f57dab0be0bd"},
+      "prov:atLocation": {"@id": "niiri:e421002626e0d3b2155132ea5f9909af"},
       "prov:value": {"@type": "xsd:float", "@value": "4.08770418167114"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.91804495668"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.46350297789166e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.955724279224547"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.186719971332974"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.91804495668"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.46350297789166e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.955724279224547"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.186719971332974"}
     },
     {
-      "@id": "niiri:5d39e0678df9edef83d5f57dab0be0bd",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e421002626e0d3b2155132ea5f9909af",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0036",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-36,-68,-20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-36,-68,-20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d7b71fa497e0f8780396e93232c93a4e",
-      "entity": "niiri:3efe9387862f59b37bf90987a3a01074"
+      "entity_derived": "niiri:47c14511d37e558a3fb5b4c44e333292",
+      "entity": "niiri:a5ea3c101aaf1b98c7ee58fcc76dff1b"
     },
     {
-      "@id": "niiri:d3498a22c3f387bce3184bd9d945a4b0",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e5ced5655aca3ab6d63936e6dbc4d14e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0037",
-      "prov:atLocation": {"@id": "niiri:470de650a3b555c25105787679347005"},
+      "prov:atLocation": {"@id": "niiri:dcc9a77d6e6075391c18a887c0b9c878"},
       "prov:value": {"@type": "xsd:float", "@value": "3.71012616157532"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.57988831343959"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000171870546999631"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999883757236262"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.385893135248467"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.57988831343959"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000171870546999631"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999883757236262"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.385893135248467"}
     },
     {
-      "@id": "niiri:470de650a3b555c25105787679347005",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:dcc9a77d6e6075391c18a887c0b9c878",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0037",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-30,-58,-16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-30,-58,-16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d3498a22c3f387bce3184bd9d945a4b0",
-      "entity": "niiri:3efe9387862f59b37bf90987a3a01074"
+      "entity_derived": "niiri:e5ced5655aca3ab6d63936e6dbc4d14e",
+      "entity": "niiri:a5ea3c101aaf1b98c7ee58fcc76dff1b"
     },
     {
-      "@id": "niiri:4c2e1d5de4bf5e134f969677c839dcb0",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c84076330649c427ef2696347c4054ae",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0038",
-      "prov:atLocation": {"@id": "niiri:88ebd3fd625a43cc687be7c3b4700dc7"},
+      "prov:atLocation": {"@id": "niiri:0aa3d7e4b295c6343a575906df312730"},
       "prov:value": {"@type": "xsd:float", "@value": "4.59621620178223"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.36286413267216"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.41853365035416e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.467637998233248"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0604181585485856"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.36286413267216"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.41853365035416e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.467637998233248"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0604181585485856"}
     },
     {
-      "@id": "niiri:88ebd3fd625a43cc687be7c3b4700dc7",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0aa3d7e4b295c6343a575906df312730",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0038",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[16,-98,6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[16,-98,6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4c2e1d5de4bf5e134f969677c839dcb0",
-      "entity": "niiri:4fec4e3138e166ee2892b0d3d91bb41e"
+      "entity_derived": "niiri:c84076330649c427ef2696347c4054ae",
+      "entity": "niiri:6f05166f31ef45c33808420434a13f55"
     },
     {
-      "@id": "niiri:a96ffbcdd2cd1748a4acbfbee1c8e854",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e2506b44ed692dcde07aecfe65313995",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0039",
-      "prov:atLocation": {"@id": "niiri:f0bed83aaf9d16bfbd628901bf04c3e1"},
+      "prov:atLocation": {"@id": "niiri:1b80736cff1f2516ac52233b65e1d43d"},
       "prov:value": {"@type": "xsd:float", "@value": "4.57891654968262"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.34793761600864"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.87118388575936e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.487021764768749"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0629240173925056"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.34793761600864"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.87118388575936e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.487021764768749"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0629240173925056"}
     },
     {
-      "@id": "niiri:f0bed83aaf9d16bfbd628901bf04c3e1",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:1b80736cff1f2516ac52233b65e1d43d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0039",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-60,-16,28]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-60,-16,28]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a96ffbcdd2cd1748a4acbfbee1c8e854",
-      "entity": "niiri:0b5064760982e8c270bd98284ecb06d3"
+      "entity_derived": "niiri:e2506b44ed692dcde07aecfe65313995",
+      "entity": "niiri:f686250b6fb996d621aa21cdf5cf6717"
     },
     {
-      "@id": "niiri:d0e988a4e21373a9557ce8b133dc489e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a711ec92a5095b7cc31e6073cba60aeb",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0040",
-      "prov:atLocation": {"@id": "niiri:18cd91ecc562fcddb7007b0671e8606a"},
+      "prov:atLocation": {"@id": "niiri:bbea81c0dc1081250ce2a110d7d6270d"},
       "prov:value": {"@type": "xsd:float", "@value": "4.37013816833496"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.16664310578498"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.54558935169247e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.730405153245217"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.101858458171742"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.16664310578498"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.54558935169247e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.730405153245217"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.101858458171742"}
     },
     {
-      "@id": "niiri:18cd91ecc562fcddb7007b0671e8606a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:bbea81c0dc1081250ce2a110d7d6270d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0040",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-52,-62,52]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-52,-62,52]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d0e988a4e21373a9557ce8b133dc489e",
-      "entity": "niiri:71ab02bff3b085bb7b9a91d459a832f0"
+      "entity_derived": "niiri:a711ec92a5095b7cc31e6073cba60aeb",
+      "entity": "niiri:36a0a86f1b5fa4bc787a9c7b7eba11a2"
     },
     {
-      "@id": "niiri:3b31a99a7423016e7748f2f4a6b35b55",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:4babfa934e3c293ae57513a1dbf42b27",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0041",
-      "prov:atLocation": {"@id": "niiri:2097c555a217b1ea96a300093759a750"},
+      "prov:atLocation": {"@id": "niiri:eb0e468fad0731dc048069a34964eba0"},
       "prov:value": {"@type": "xsd:float", "@value": "4.24533367156982"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.05725918601008"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.4825985211363e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.855631833511506"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.135717263652471"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.05725918601008"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.4825985211363e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.855631833511506"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.135717263652471"}
     },
     {
-      "@id": "niiri:2097c555a217b1ea96a300093759a750",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:eb0e468fad0731dc048069a34964eba0",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0041",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-18,-60,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-18,-60,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3b31a99a7423016e7748f2f4a6b35b55",
-      "entity": "niiri:5e8275841ed71a0e7a9cc2f07fba7508"
+      "entity_derived": "niiri:4babfa934e3c293ae57513a1dbf42b27",
+      "entity": "niiri:ee27ca4fbf4487cbf6ede6f498d03b89"
     },
     {
-      "@id": "niiri:5c80b51a06991a61ebc72500b74c3a33",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:2c50f18e7e3b4acc2a572ba2fbdb7169",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0042",
-      "prov:atLocation": {"@id": "niiri:b1d91ba88a5a6a57c638fd74892d5b0c"},
+      "prov:atLocation": {"@id": "niiri:f37e4ddd039f0786c97ddd37a174dedd"},
       "prov:value": {"@type": "xsd:float", "@value": "4.22599840164185"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.04024618213588"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.66975618669063e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.871760516202526"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.138603763901635"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.04024618213588"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.66975618669063e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.871760516202526"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.138603763901635"}
     },
     {
-      "@id": "niiri:b1d91ba88a5a6a57c638fd74892d5b0c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f37e4ddd039f0786c97ddd37a174dedd",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0042",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-36,-74,-34]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-36,-74,-34]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5c80b51a06991a61ebc72500b74c3a33",
-      "entity": "niiri:7d836a379d88c30e45968812bcbaec09"
+      "entity_derived": "niiri:2c50f18e7e3b4acc2a572ba2fbdb7169",
+      "entity": "niiri:f6df377f07bd1d85bb45726e6330c017"
     },
     {
-      "@id": "niiri:1644ed1eb30398c5afe76833898dfc59",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:1ef0626fbe7b6528eb64d1fc1902fdff",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0043",
-      "prov:atLocation": {"@id": "niiri:e16b365b8144685b1efcdf60c337ea5b"},
+      "prov:atLocation": {"@id": "niiri:fa8d5f5a9b143e007389f2fdcb17fb3a"},
       "prov:value": {"@type": "xsd:float", "@value": "4.20391035079956"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.02078923241408"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.900174224163e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.888907080881232"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.143583628261646"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.02078923241408"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.900174224163e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.888907080881232"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.143583628261646"}
     },
     {
-      "@id": "niiri:e16b365b8144685b1efcdf60c337ea5b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:fa8d5f5a9b143e007389f2fdcb17fb3a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0043",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[34,-54,-16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[34,-54,-16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1644ed1eb30398c5afe76833898dfc59",
-      "entity": "niiri:6d9719aa34ea98f8ee1e2190f57a38c2"
+      "entity_derived": "niiri:1ef0626fbe7b6528eb64d1fc1902fdff",
+      "entity": "niiri:0f57c541cf04642c5618cb3c8c754be3"
     },
     {
-      "@id": "niiri:3e7a43420e86cacea16dd57ac398f26c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:be786d3fdaa6a6946a7e31cca13afc20",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0044",
-      "prov:atLocation": {"@id": "niiri:16630efaff9edb2b8b01f9b07b105396"},
+      "prov:atLocation": {"@id": "niiri:fd3442b98529d2f70ead87b5000c6342"},
       "prov:value": {"@type": "xsd:float", "@value": "4.17404651641846"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.99444589181498"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.24228638075574e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.909844421846994"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.153735203854581"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.99444589181498"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.24228638075574e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.909844421846994"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.153735203854581"}
     },
     {
-      "@id": "niiri:16630efaff9edb2b8b01f9b07b105396",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:fd3442b98529d2f70ead87b5000c6342",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0044",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-40,-38,44]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-40,-38,44]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3e7a43420e86cacea16dd57ac398f26c",
-      "entity": "niiri:7a9b91d6cb78bfe1263ffc584d3b69d2"
+      "entity_derived": "niiri:be786d3fdaa6a6946a7e31cca13afc20",
+      "entity": "niiri:10dca7f82f910606e689ba8e2b5af3ff"
     },
     {
-      "@id": "niiri:f7ff1f673967cba21b75d59b4f4441aa",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d5463f9ce8c3e863106d9a205e4c2c3a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0045",
-      "prov:atLocation": {"@id": "niiri:eed02f4efb26f5a9fcb1510bc214de78"},
+      "prov:atLocation": {"@id": "niiri:bf85679e3d6743985d98d3df6f63ab50"},
       "prov:value": {"@type": "xsd:float", "@value": "4.12145137786865"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.94794832362008"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.94119065879606e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.940339218142555"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.172448885449819"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.94794832362008"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.94119065879606e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.940339218142555"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.172448885449819"}
     },
     {
-      "@id": "niiri:eed02f4efb26f5a9fcb1510bc214de78",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:bf85679e3d6743985d98d3df6f63ab50",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0045",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-48,-72,2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-48,-72,2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f7ff1f673967cba21b75d59b4f4441aa",
-      "entity": "niiri:9dae134cd7326c7dd74b40d61a138556"
+      "entity_derived": "niiri:d5463f9ce8c3e863106d9a205e4c2c3a",
+      "entity": "niiri:34abbea5b5b7e9caec8749719282f69d"
     },
     {
-      "@id": "niiri:626924a6d4337fea901f4f8dfe33e2f7",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:23d3e4257473feb39f485dec221abb31",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0046",
-      "prov:atLocation": {"@id": "niiri:a33af7316a855042e55451e73a000ab6"},
+      "prov:atLocation": {"@id": "niiri:c3b3402429d4a8377c7a30cb88abe2dd"},
       "prov:value": {"@type": "xsd:float", "@value": "4.07333517074585"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.9052963692066"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.70549882543025e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.961337330645756"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.192831151077206"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.9052963692066"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.70549882543025e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.961337330645756"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.192831151077206"}
     },
     {
-      "@id": "niiri:a33af7316a855042e55451e73a000ab6",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c3b3402429d4a8377c7a30cb88abe2dd",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0046",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[20,-66,34]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[20,-66,34]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:626924a6d4337fea901f4f8dfe33e2f7",
-      "entity": "niiri:a48e52ce82ef21945b533008203890a9"
+      "entity_derived": "niiri:23d3e4257473feb39f485dec221abb31",
+      "entity": "niiri:f97396b2a54d55285f02d93b58dbe2b6"
     },
     {
-      "@id": "niiri:b5f6132daca093e0f4ec3958d256c096",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:7e76e2da1f22ce6b895d3014a33d1739",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0047",
-      "prov:atLocation": {"@id": "niiri:8ed08035bb65579ab8797d970606002d"},
+      "prov:atLocation": {"@id": "niiri:e04fc808b05489b451f47249a93ec634"},
       "prov:value": {"@type": "xsd:float", "@value": "4.05762767791748"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.89134919103145"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.98441713834286e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.966867400896655"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.199920408224698"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.89134919103145"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.98441713834286e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.966867400896655"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.199920408224698"}
     },
     {
-      "@id": "niiri:8ed08035bb65579ab8797d970606002d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e04fc808b05489b451f47249a93ec634",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0047",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-46,-56,14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-46,-56,14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b5f6132daca093e0f4ec3958d256c096",
-      "entity": "niiri:33d2fed4b2c8785ed20bc8727adca85e"
+      "entity_derived": "niiri:7e76e2da1f22ce6b895d3014a33d1739",
+      "entity": "niiri:a4357c1b32f8a28c66891660675a8ceb"
     },
     {
-      "@id": "niiri:307dd4fcb4d0ba761f6d483e260a4dca",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a76fe1af0c08762eb9239007a5f9dc2c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0048",
-      "prov:atLocation": {"@id": "niiri:dd81e902b3add9d15a1e383709d09161"},
+      "prov:atLocation": {"@id": "niiri:6e79740bd3660186f4fdf7f38fec1b3c"},
       "prov:value": {"@type": "xsd:float", "@value": "3.97341108322144"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.81637469850314"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.7713399346081e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.987160063394768"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.237117251115433"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.81637469850314"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.7713399346081e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.987160063394768"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.237117251115433"}
     },
     {
-      "@id": "niiri:dd81e902b3add9d15a1e383709d09161",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6e79740bd3660186f4fdf7f38fec1b3c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0048",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-50,-50,20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-50,-50,20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:307dd4fcb4d0ba761f6d483e260a4dca",
-      "entity": "niiri:33d2fed4b2c8785ed20bc8727adca85e"
+      "entity_derived": "niiri:a76fe1af0c08762eb9239007a5f9dc2c",
+      "entity": "niiri:a4357c1b32f8a28c66891660675a8ceb"
     },
     {
-      "@id": "niiri:053d94e39a8343d1f3d37f32c37e498d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:30853859b00c0b5c92d53d8e023cba9d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0049",
-      "prov:atLocation": {"@id": "niiri:a649b2531f6af9cadfdbd902b6239ce1"},
+      "prov:atLocation": {"@id": "niiri:4799db48ff3ae922b73cc32f5cc0cd23"},
       "prov:value": {"@type": "xsd:float", "@value": "4.03719234466553"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.87318677164159"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.37107204765519e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.973166168280088"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.210147957128937"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.87318677164159"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.37107204765519e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.973166168280088"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.210147957128937"}
     },
     {
-      "@id": "niiri:a649b2531f6af9cadfdbd902b6239ce1",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4799db48ff3ae922b73cc32f5cc0cd23",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0049",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-48,2,50]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-48,2,50]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:053d94e39a8343d1f3d37f32c37e498d",
-      "entity": "niiri:32b9f8da6e89284036f980cbd853e723"
+      "entity_derived": "niiri:30853859b00c0b5c92d53d8e023cba9d",
+      "entity": "niiri:9e1f64e5a9ff6cda9c7c7070f1f8c2b9"
     },
     {
-      "@id": "niiri:130a50f3e4f7c1ba157f08f847c3080c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:356f79ecf79738d01b5b4b7026b7e188",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0050",
-      "prov:atLocation": {"@id": "niiri:009a265ff4488eb9a438b0d6ddbb84ea"},
+      "prov:atLocation": {"@id": "niiri:e472df3ca776655c319913d4e08d6e9b"},
       "prov:value": {"@type": "xsd:float", "@value": "4.0217924118042"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.85948683644491"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.68126885931441e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.977286609355005"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.217632520436791"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.85948683644491"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.68126885931441e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.977286609355005"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.217632520436791"}
     },
     {
-      "@id": "niiri:009a265ff4488eb9a438b0d6ddbb84ea",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e472df3ca776655c319913d4e08d6e9b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0050",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-36,-40,-36]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-36,-40,-36]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:130a50f3e4f7c1ba157f08f847c3080c",
-      "entity": "niiri:a4fb311adc8de77c87cd3e5be5ccc62b"
+      "entity_derived": "niiri:356f79ecf79738d01b5b4b7026b7e188",
+      "entity": "niiri:e13313ba9b9b954243d9c9332f3caf96"
     },
     {
-      "@id": "niiri:19d5f914ae688cfe389fcf0a4f617fe0",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:4265e2cdabcc64eab47a5d072484d937",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0051",
-      "prov:atLocation": {"@id": "niiri:44ee2fd2f419642665f597a6465e8c0e"},
+      "prov:atLocation": {"@id": "niiri:d80ff4fffd0d4464945b79660c578dad"},
       "prov:value": {"@type": "xsd:float", "@value": "3.9634416103363"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.80747753892992"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.01957428701494e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.988689669381963"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.237117251115433"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.80747753892992"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.01957428701494e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.988689669381963"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.237117251115433"}
     },
     {
-      "@id": "niiri:44ee2fd2f419642665f597a6465e8c0e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d80ff4fffd0d4464945b79660c578dad",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0051",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[4,6,32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[4,6,32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:19d5f914ae688cfe389fcf0a4f617fe0",
-      "entity": "niiri:f5be0f8d59441b28ce308dfb011e10df"
+      "entity_derived": "niiri:4265e2cdabcc64eab47a5d072484d937",
+      "entity": "niiri:63e1799e700f05ae3736bff33a2b65f4"
     },
     {
-      "@id": "niiri:266b7abb3e5d3b87d3a4e58d9921a054",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b6e09f6b679ea623d2841ff4bcf6291e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0052",
-      "prov:atLocation": {"@id": "niiri:0ed4387af330a4afa36d809baed370ef"},
+      "prov:atLocation": {"@id": "niiri:a59f8dea4edffbdd72892882c133b0e9"},
       "prov:value": {"@type": "xsd:float", "@value": "3.96245408058167"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.80659597790245"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.04463150378309e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.988832912076595"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.237117251115433"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.80659597790245"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.04463150378309e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.988832912076595"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.237117251115433"}
     },
     {
-      "@id": "niiri:0ed4387af330a4afa36d809baed370ef",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a59f8dea4edffbdd72892882c133b0e9",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0052",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-50,-48,-16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-50,-48,-16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:266b7abb3e5d3b87d3a4e58d9921a054",
-      "entity": "niiri:9771726b7a7da2b81302c08e984d21aa"
+      "entity_derived": "niiri:b6e09f6b679ea623d2841ff4bcf6291e",
+      "entity": "niiri:5dfbf6ab6301360ce96203aca13f8257"
     },
     {
-      "@id": "niiri:0d35f7ec7f83e2f14c74fd13990016e3",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:df0b4499eab340f0f5ffcf69ea26e94e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0053",
-      "prov:atLocation": {"@id": "niiri:67e777c1dbdb7316faaa66904161debf"},
+      "prov:atLocation": {"@id": "niiri:0f2c7e9dfacf69ad400623d015e16bf8"},
       "prov:value": {"@type": "xsd:float", "@value": "3.9098813533783"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.75959988615137"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.50926599039736e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.994607633788328"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.264100967145263"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.75959988615137"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.50926599039736e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.994607633788328"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.264100967145263"}
     },
     {
-      "@id": "niiri:67e777c1dbdb7316faaa66904161debf",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0f2c7e9dfacf69ad400623d015e16bf8",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0053",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[54,-24,-2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[54,-24,-2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0d35f7ec7f83e2f14c74fd13990016e3",
-      "entity": "niiri:1081daf0e707c5e5ae15af9f18adc9a9"
+      "entity_derived": "niiri:df0b4499eab340f0f5ffcf69ea26e94e",
+      "entity": "niiri:82c6c5dde224f3815e887f0f89a10062"
     },
     {
-      "@id": "niiri:f68f1b953350c246fef9a85a9bf855fb",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d0bc7891180bf59606c1dd42f7521b58",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0054",
-      "prov:atLocation": {"@id": "niiri:2e2b26028ce092cfea140bb304e19f4c"},
+      "prov:atLocation": {"@id": "niiri:fbd4fdf05f1b858456b20418252ad82e"},
       "prov:value": {"@type": "xsd:float", "@value": "3.90285301208496"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.75330746420074"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.72582920719012e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99514521861122"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.264100967145263"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.75330746420074"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.72582920719012e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99514521861122"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.264100967145263"}
     },
     {
-      "@id": "niiri:2e2b26028ce092cfea140bb304e19f4c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:fbd4fdf05f1b858456b20418252ad82e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0054",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-36,-46,-18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-36,-46,-18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f68f1b953350c246fef9a85a9bf855fb",
-      "entity": "niiri:9294aac4eea8be1704ba4b297809e66d"
+      "entity_derived": "niiri:d0bc7891180bf59606c1dd42f7521b58",
+      "entity": "niiri:f9cd18224526a4801de142048b64a357"
     },
     {
-      "@id": "niiri:b9275d20f8a295c49994d5edd49258f8",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:048c50de4960b48aa105d96778779061",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0055",
-      "prov:atLocation": {"@id": "niiri:efed591f3e5ab7fbed32ccc0ef3bec8c"},
+      "prov:atLocation": {"@id": "niiri:fede7e0698f56da3b9f59e90e65c68a5"},
       "prov:value": {"@type": "xsd:float", "@value": "3.8867518901825"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.73888373627584"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "9.24195907030523e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.996210852184447"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.271701156704036"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.73888373627584"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "9.24195907030523e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.996210852184447"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.271701156704036"}
     },
     {
-      "@id": "niiri:efed591f3e5ab7fbed32ccc0ef3bec8c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:fede7e0698f56da3b9f59e90e65c68a5",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0055",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-50,-46,-32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-50,-46,-32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b9275d20f8a295c49994d5edd49258f8",
-      "entity": "niiri:9c2b57d941c750a81bae56005ccc8439"
+      "entity_derived": "niiri:048c50de4960b48aa105d96778779061",
+      "entity": "niiri:b2129866f39d8d89964577f80028f418"
     },
     {
-      "@id": "niiri:b976b106d2604175d9d8fabebe71738c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f6f60a34610b49cc5b443ce199ca79c0",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0056",
-      "prov:atLocation": {"@id": "niiri:4287ceee774f285ae67d36f37051b681"},
+      "prov:atLocation": {"@id": "niiri:18668f3157ce13938d310aebc49ef7b9"},
       "prov:value": {"@type": "xsd:float", "@value": "3.82178378105164"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.68056404693028"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000116359297336222"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.998750111206092"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.307505393775956"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.68056404693028"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000116359297336222"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.998750111206092"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.307505393775956"}
     },
     {
-      "@id": "niiri:4287ceee774f285ae67d36f37051b681",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:18668f3157ce13938d310aebc49ef7b9",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0056",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[12,52,-12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[12,52,-12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b976b106d2604175d9d8fabebe71738c",
-      "entity": "niiri:8e5c49eb54e50609e5ba92b2b8409882"
+      "entity_derived": "niiri:f6f60a34610b49cc5b443ce199ca79c0",
+      "entity": "niiri:1d15a2f17b8507a037170dff62d0df0f"
     },
     {
-      "@id": "niiri:b336bf04be7eca644b00209bac65fea7",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:6bd4ba02e7d4f4207d829a2c8b49bb4e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0057",
-      "prov:atLocation": {"@id": "niiri:59005f07096d9afe851f48ec3d9037cc"},
+      "prov:atLocation": {"@id": "niiri:ab3768ac2a57998c1f00e6093a6cdaf9"},
       "prov:value": {"@type": "xsd:float", "@value": "3.7885959148407"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.65069869844077"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000130763947768786"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999340802437346"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.325675502417125"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.65069869844077"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000130763947768786"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999340802437346"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.325675502417125"}
     },
     {
-      "@id": "niiri:59005f07096d9afe851f48ec3d9037cc",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ab3768ac2a57998c1f00e6093a6cdaf9",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0057",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[22,40,26]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[22,40,26]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b336bf04be7eca644b00209bac65fea7",
-      "entity": "niiri:a03ba6625b79992ed07f93b8c01a2bae"
+      "entity_derived": "niiri:6bd4ba02e7d4f4207d829a2c8b49bb4e",
+      "entity": "niiri:92cdcaac8dc15abca00aaf2035c3d353"
     },
     {
-      "@id": "niiri:ea7af39876f2c2729bdc445fa0545560",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:bae89a3df5e8c7b953547ae7d7534e95",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0058",
-      "prov:atLocation": {"@id": "niiri:729bff40deee62846b0525d048a7654a"},
+      "prov:atLocation": {"@id": "niiri:646c22a0ec339e5b474a3aaa23751b4d"},
       "prov:value": {"@type": "xsd:float", "@value": "3.65790581703186"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.53261354467296"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000205736742878826"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999969815552823"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.430567192397012"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.53261354467296"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000205736742878826"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999969815552823"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.430567192397012"}
     },
     {
-      "@id": "niiri:729bff40deee62846b0525d048a7654a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:646c22a0ec339e5b474a3aaa23751b4d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0058",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[52,-46,-12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[52,-46,-12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ea7af39876f2c2729bdc445fa0545560",
-      "entity": "niiri:4ccc33b588ed17374f2c6edcb6528c8c"
+      "entity_derived": "niiri:bae89a3df5e8c7b953547ae7d7534e95",
+      "entity": "niiri:a766e15fcf31e1d6ce69e989e67adf78"
     },
     {
-      "@id": "niiri:a55a0360fd92fc20c1300a071dfb10eb",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f2e5294144fb56653d91e924583c3e1b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0059",
-      "prov:atLocation": {"@id": "niiri:df3ba85030b17fc4596288509db3fc78"},
+      "prov:atLocation": {"@id": "niiri:1330f955b402cf21c726b658b67095cd"},
       "prov:value": {"@type": "xsd:float", "@value": "3.55148839950562"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.43590473729199"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000295289297083445"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999889206113"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.518882279088377"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.43590473729199"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000295289297083445"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999889206113"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.518882279088377"}
     },
     {
-      "@id": "niiri:df3ba85030b17fc4596288509db3fc78",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:1330f955b402cf21c726b658b67095cd",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0059",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[64,-34,16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[64,-34,16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a55a0360fd92fc20c1300a071dfb10eb",
-      "entity": "niiri:9a0e43f3959fa34d67e65e823d6736df"
+      "entity_derived": "niiri:f2e5294144fb56653d91e924583c3e1b",
+      "entity": "niiri:f364696f65c95b091099ba5aa2f33e2b"
     }
   ]
 }

--- a/spmexport/ex_spm_thr_clustunck10/nidm.ttl
+++ b/spmexport/ex_spm_thr_clustunck10/nidm.ttl
@@ -4,7 +4,7 @@
 @prefix niiri: <http://iri.nidash.org/> .
 @prefix spm: <http://purl.org/nidash/spm#> .
 @prefix neurolex: <http://neurolex.org/wiki/> .
-@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#> .
+@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
@@ -17,27 +17,27 @@
 @prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-niiri:a63b539faedf59712e4b345bd22a4d2f
+niiri:05f8e697eec5ffc5aace5c1f4c105fda
   a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
   rdfs:label "NIDM-Results" ;
   nidm_version: "1.3.0"^^xsd:string .
 
-niiri:a1ead588d29d1f2aab15e31634325b92
+niiri:4f37bcd80c8dd68304abbe610cb6c460
   a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
   rdfs:label "spm_results_nidm" ;
-  nidm_softwareVersion: "12.6903"^^xsd:string .
+  nidm_softwareVersion: "12.7057"^^xsd:string .
 
-niiri:758cb3b4047ff4106c5e20908223452e
+niiri:09e1635174afe5c856ec0e948fac8237
   a prov:Activity, nidm_NIDMResultsExport: ; 
   rdfs:label "NIDM-Results export" .
 
-niiri:758cb3b4047ff4106c5e20908223452e prov:wasAssociatedWith niiri:a1ead588d29d1f2aab15e31634325b92 .
+niiri:09e1635174afe5c856ec0e948fac8237 prov:wasAssociatedWith niiri:4f37bcd80c8dd68304abbe610cb6c460 .
 
 _:blank5 a prov:Generation .
 
-niiri:a63b539faedf59712e4b345bd22a4d2f prov:qualifiedGeneration _:blank5 .
+niiri:05f8e697eec5ffc5aace5c1f4c105fda prov:qualifiedGeneration _:blank5 .
 
-_:blank5 prov:atTime "2016-12-07T16:09:44"^^xsd:dateTime .
+_:blank5 prov:atTime "2017-04-19T12:19:06"^^xsd:dateTime .
 
 @prefix nidm_Ixi549CoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000050> .
 @prefix src_SPM: <http://scicrunch.org/resolver/SCR_007037> .
@@ -142,12 +142,12 @@ _:blank5 prov:atTime "2016-12-07T16:09:44"^^xsd:dateTime .
 @prefix nidm_Coordinate: <http://purl.org/nidash/nidm#NIDM_0000015> .
 @prefix nidm_coordinateVector: <http://purl.org/nidash/nidm#NIDM_0000086> .
 
-niiri:e195d58cb4a7afb511b291abe9c58673
+niiri:c2ec86ce73c8b9ab4324393fc2d80b63
     a prov:Agent, src_SPM:, prov:SoftwareAgent ; 
     rdfs:label "SPM" ;
-    nidm_softwareVersion: "12.12.2"^^xsd:string .
+    nidm_softwareVersion: "12.6906"^^xsd:string .
 
-niiri:bd502eec9fb9df4c578a25b6ac824a14
+niiri:c8b0140b68018da6f9905cc4b8fd05ad
     a prov:Entity, nidm_CoordinateSpace: ; 
     rdfs:label "Coordinate space 1" ;
     nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
@@ -157,48 +157,48 @@ niiri:bd502eec9fb9df4c578a25b6ac824a14
     nidm_numberOfDimensions: "3"^^xsd:int ;
     nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
 
-niiri:d7d8108b33b61c0ddd2ea5c7e0f6b30d
+niiri:748b469bb5be2daf21097ad82e962dbc
     a prov:Agent, nlx_Imaginginstrument:, nlx_Magneticresonanceimagingscanner: ; 
     rdfs:label "MRI Scanner" .
 
-niiri:f01830debc918d2d2a8ac43c6169bec8
+niiri:6727c965ace54e00c464f50309d28201
     a prov:Agent, prov:Person ; 
     rdfs:label "Person" .
 
-niiri:ecf786f09c31c2fd1f8fff3c4b1c8499
+niiri:43ad2ab273c1e85fdc66627cd3ea961c
     a prov:Entity, prov:Collection, nidm_Data: ; 
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "true"^^xsd:boolean ;
     nidm_targetIntensity: "100"^^xsd:float ;
     nidm_hasMRIProtocol: nlx_FunctionalMRIprotocol: .
 
-niiri:ecf786f09c31c2fd1f8fff3c4b1c8499 prov:wasAttributedTo niiri:d7d8108b33b61c0ddd2ea5c7e0f6b30d .
+niiri:43ad2ab273c1e85fdc66627cd3ea961c prov:wasAttributedTo niiri:748b469bb5be2daf21097ad82e962dbc .
 
-niiri:ecf786f09c31c2fd1f8fff3c4b1c8499 prov:wasAttributedTo niiri:f01830debc918d2d2a8ac43c6169bec8 .
+niiri:43ad2ab273c1e85fdc66627cd3ea961c prov:wasAttributedTo niiri:6727c965ace54e00c464f50309d28201 .
 
-niiri:734c3323450668db8eea94b45e90b6e1
+niiri:235a75292ec305bec2bfb9e1f1f26e2e
     a prov:Entity, spm_DCTDriftModel: ; 
     rdfs:label "SPM's DCT Drift Model" ;
     spm_SPMsDriftCutoffPeriod: "128"^^xsd:float .
 
-niiri:d7b500305477a954c7d6a2f04c1e44d5
+niiri:a260d6b771a7d3d82e1d9830dcf02423
     a prov:Entity, nidm_DesignMatrix: ; 
     prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.csv"^^xsd:string ;
     dct:format "text/csv"^^xsd:string ;
-    dc:description niiri:46026a0dad4f63f1c7c7d151bcd45f48 ;
+    dc:description niiri:9ba45fb0e707add8e7f710c709a22a63 ;
     rdfs:label "Design Matrix" ;
     nidm_regressorNames: "[\"Sn(1) to*bf(1)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) constant\"]"^^xsd:string ;
-    nidm_hasDriftModel: niiri:734c3323450668db8eea94b45e90b6e1 ;
+    nidm_hasDriftModel: niiri:235a75292ec305bec2bfb9e1f1f26e2e ;
     nidm_hasHRFBasis: spm_SPMsCanonicalHRF: .
 
-niiri:46026a0dad4f63f1c7c7d151bcd45f48
+niiri:9ba45fb0e707add8e7f710c709a22a63
     a prov:Entity, dctype:Image ; 
     prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:a7f52c7e7e4d16e13f49d294bf67df3e
+niiri:983f87f6bef9f3ca6917e33e21de8141
     a prov:Entity, nidm_ErrorModel: ; 
     nidm_hasErrorDistribution: obo_normaldistribution: ;
     nidm_hasErrorDependence: obo_Toeplitzcovariancestructure: ;
@@ -206,174 +206,174 @@ niiri:a7f52c7e7e4d16e13f49d294bf67df3e
     nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
     nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
 
-niiri:9373eea9b5c80c5420a14ed31174239a
+niiri:c2c197b0fad8993c6cc7208559f40202
     a prov:Activity, nidm_ModelParametersEstimation: ; 
     rdfs:label "Model parameters estimation" ;
     nidm_withEstimationMethod: obo_generalizedleastsquaresestimation: .
 
-niiri:9373eea9b5c80c5420a14ed31174239a prov:wasAssociatedWith niiri:e195d58cb4a7afb511b291abe9c58673 .
+niiri:c2c197b0fad8993c6cc7208559f40202 prov:wasAssociatedWith niiri:c2ec86ce73c8b9ab4324393fc2d80b63 .
 
-niiri:9373eea9b5c80c5420a14ed31174239a prov:used niiri:d7b500305477a954c7d6a2f04c1e44d5 .
+niiri:c2c197b0fad8993c6cc7208559f40202 prov:used niiri:a260d6b771a7d3d82e1d9830dcf02423 .
 
-niiri:9373eea9b5c80c5420a14ed31174239a prov:used niiri:ecf786f09c31c2fd1f8fff3c4b1c8499 .
+niiri:c2c197b0fad8993c6cc7208559f40202 prov:used niiri:43ad2ab273c1e85fdc66627cd3ea961c .
 
-niiri:9373eea9b5c80c5420a14ed31174239a prov:used niiri:a7f52c7e7e4d16e13f49d294bf67df3e .
+niiri:c2c197b0fad8993c6cc7208559f40202 prov:used niiri:983f87f6bef9f3ca6917e33e21de8141 .
 
-niiri:97a5f4038f996763845e252476bfddbc
+niiri:670ea0bcbdf9cc6f21ab6a8f5eef7e10
     a prov:Entity, nidm_MaskMap: ; 
     prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
     nidm_isUserDefined: "false"^^xsd:boolean ;
     nfo:fileName "Mask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Mask" ;
-    nidm_inCoordinateSpace: niiri:bd502eec9fb9df4c578a25b6ac824a14 ;
+    nidm_inCoordinateSpace: niiri:c8b0140b68018da6f9905cc4b8fd05ad ;
     crypto:sha512 "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876"^^xsd:string .
 
-niiri:6f519cf414ce7f7481fe6fd707ed44cd
+niiri:b4c604265d7449416900828c600fa004
     a prov:Entity, nidm_MaskMap: ; 
     nfo:fileName "mask.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "36929e1f5f4143bd9cc818cd896a25f129961fab208c3a4438555f40444c08347b359142ee8c53ece6e8cca1627f49db0788a1fd3b9e2ecaef61999c6c6c67ac"^^xsd:string .
 
-niiri:97a5f4038f996763845e252476bfddbc prov:wasDerivedFrom niiri:6f519cf414ce7f7481fe6fd707ed44cd .
+niiri:670ea0bcbdf9cc6f21ab6a8f5eef7e10 prov:wasDerivedFrom niiri:b4c604265d7449416900828c600fa004 .
 
-niiri:97a5f4038f996763845e252476bfddbc prov:wasGeneratedBy niiri:9373eea9b5c80c5420a14ed31174239a .
+niiri:670ea0bcbdf9cc6f21ab6a8f5eef7e10 prov:wasGeneratedBy niiri:c2c197b0fad8993c6cc7208559f40202 .
 
-niiri:c990ff47051297ce4c04f2d314082ae9
+niiri:d0e2322759b4a23ea6686e5c5874d635
     a prov:Entity, nidm_GrandMeanMap: ; 
     prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
     nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Grand Mean Map" ;
     nidm_maskedMedian: "111.557487487793"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:bd502eec9fb9df4c578a25b6ac824a14 ;
+    nidm_inCoordinateSpace: niiri:c8b0140b68018da6f9905cc4b8fd05ad ;
     crypto:sha512 "512157cc6bff89d9343a09b4068226eb3edd64a8cbcee861f06231767fae6f8d4819921182adebee083a9bf309afd65529ab04a92f0aa6b0038c8098550f6124"^^xsd:string .
 
-niiri:c990ff47051297ce4c04f2d314082ae9 prov:wasGeneratedBy niiri:9373eea9b5c80c5420a14ed31174239a .
+niiri:d0e2322759b4a23ea6686e5c5874d635 prov:wasGeneratedBy niiri:c2c197b0fad8993c6cc7208559f40202 .
 
-niiri:0c78edca8a5d13f9f471c5c699fa4128
+niiri:5b992ad55d4d262b7a58b0b4c761ff0d
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0001.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0001.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 1" ;
-    nidm_inCoordinateSpace: niiri:bd502eec9fb9df4c578a25b6ac824a14 ;
+    nidm_inCoordinateSpace: niiri:c8b0140b68018da6f9905cc4b8fd05ad ;
     crypto:sha512 "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd"^^xsd:string .
 
-niiri:2004ce9eaa27477ebbab60db4568790a
+niiri:d1f669439d72f1805a497adb6df799cb
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd"^^xsd:string .
 
-niiri:0c78edca8a5d13f9f471c5c699fa4128 prov:wasDerivedFrom niiri:2004ce9eaa27477ebbab60db4568790a .
+niiri:5b992ad55d4d262b7a58b0b4c761ff0d prov:wasDerivedFrom niiri:d1f669439d72f1805a497adb6df799cb .
 
-niiri:0c78edca8a5d13f9f471c5c699fa4128 prov:wasGeneratedBy niiri:9373eea9b5c80c5420a14ed31174239a .
+niiri:5b992ad55d4d262b7a58b0b4c761ff0d prov:wasGeneratedBy niiri:c2c197b0fad8993c6cc7208559f40202 .
 
-niiri:e1aaedc9a7738f383e7360fbef306e63
+niiri:e3f451cbbb64a9ffb1ea71bcaf5d3553
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0002.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0002.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 2" ;
-    nidm_inCoordinateSpace: niiri:bd502eec9fb9df4c578a25b6ac824a14 ;
+    nidm_inCoordinateSpace: niiri:c8b0140b68018da6f9905cc4b8fd05ad ;
     crypto:sha512 "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c"^^xsd:string .
 
-niiri:64ee9cb7b3ce09b0e03ec060b6fd6771
+niiri:32ab03f45c3ae4ed0c58b56c5d3e699a
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0002.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c"^^xsd:string .
 
-niiri:e1aaedc9a7738f383e7360fbef306e63 prov:wasDerivedFrom niiri:64ee9cb7b3ce09b0e03ec060b6fd6771 .
+niiri:e3f451cbbb64a9ffb1ea71bcaf5d3553 prov:wasDerivedFrom niiri:32ab03f45c3ae4ed0c58b56c5d3e699a .
 
-niiri:e1aaedc9a7738f383e7360fbef306e63 prov:wasGeneratedBy niiri:9373eea9b5c80c5420a14ed31174239a .
+niiri:e3f451cbbb64a9ffb1ea71bcaf5d3553 prov:wasGeneratedBy niiri:c2c197b0fad8993c6cc7208559f40202 .
 
-niiri:39edcc292ff235e7c9d940c9aedc2840
+niiri:94fec9121a605a700be78134f859b81d
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0003.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0003.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 3" ;
-    nidm_inCoordinateSpace: niiri:bd502eec9fb9df4c578a25b6ac824a14 ;
+    nidm_inCoordinateSpace: niiri:c8b0140b68018da6f9905cc4b8fd05ad ;
     crypto:sha512 "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373"^^xsd:string .
 
-niiri:828b9a8153dc1c947f8350192c7b785a
+niiri:ae331890935ac6c1c632c8ba6b1390db
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0003.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373"^^xsd:string .
 
-niiri:39edcc292ff235e7c9d940c9aedc2840 prov:wasDerivedFrom niiri:828b9a8153dc1c947f8350192c7b785a .
+niiri:94fec9121a605a700be78134f859b81d prov:wasDerivedFrom niiri:ae331890935ac6c1c632c8ba6b1390db .
 
-niiri:39edcc292ff235e7c9d940c9aedc2840 prov:wasGeneratedBy niiri:9373eea9b5c80c5420a14ed31174239a .
+niiri:94fec9121a605a700be78134f859b81d prov:wasGeneratedBy niiri:c2c197b0fad8993c6cc7208559f40202 .
 
-niiri:46e980de8a2cae8243cca0529b26dcfb
+niiri:49c48883a4e6af1935a92b5f42299adf
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Residual Mean Squares Map" ;
-    nidm_inCoordinateSpace: niiri:bd502eec9fb9df4c578a25b6ac824a14 ;
+    nidm_inCoordinateSpace: niiri:c8b0140b68018da6f9905cc4b8fd05ad ;
     crypto:sha512 "991abf563d795a43b1e2eef8643e57023f2e0b090b2031f05f839321fc0643df6f71d423486a1021519b6dc82f6b0f563e19f3fbd50cb16063bed54a0e192d3e"^^xsd:string .
 
-niiri:870099995b04bdfa4402559ec43ee291
+niiri:425a977be056b0392b27ebe2ebf0d5b0
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     nfo:fileName "ResMS.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "40b28d03fcf9a2f60b11f10d7fb83bf3618b234fb5aedf09df644cb7cbb6aab8c9f468897c1078166d455a3d04a83f4e3bf762cfca0b4ea982d7a4e406849f18"^^xsd:string .
 
-niiri:46e980de8a2cae8243cca0529b26dcfb prov:wasDerivedFrom niiri:870099995b04bdfa4402559ec43ee291 .
+niiri:49c48883a4e6af1935a92b5f42299adf prov:wasDerivedFrom niiri:425a977be056b0392b27ebe2ebf0d5b0 .
 
-niiri:46e980de8a2cae8243cca0529b26dcfb prov:wasGeneratedBy niiri:9373eea9b5c80c5420a14ed31174239a .
+niiri:49c48883a4e6af1935a92b5f42299adf prov:wasGeneratedBy niiri:c2c197b0fad8993c6cc7208559f40202 .
 
-niiri:c51db7231d6ff0819bce879b142d84d9
+niiri:f5afca80c28adf7d02a12d1328e18dc4
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Resels per Voxel Map" ;
-    nidm_inCoordinateSpace: niiri:bd502eec9fb9df4c578a25b6ac824a14 ;
+    nidm_inCoordinateSpace: niiri:c8b0140b68018da6f9905cc4b8fd05ad ;
     crypto:sha512 "1a3f9216e145249ccc0b14b2bc337d6b38b81ad45e32768001fb22b35f0c2c0f3e2bce013b40c85f7dc0fc62723ac761ee7f7e1e6aff128a05f0ba7b8b8202a3"^^xsd:string .
 
-niiri:0e5b8b589ee5eb2bcf4f50c3d2eee41b
+niiri:c29df4d87431481482987ba8e96377c4
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     nfo:fileName "RPV.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "4f76663162857f6b38b2a45a63b15a23b2ca8b338c283b69c1e71f2ea2f43797d045a733cd14e845be9c12f8b8f84d3931c599a08e8f6d77e99fab46ad87ab8f"^^xsd:string .
 
-niiri:c51db7231d6ff0819bce879b142d84d9 prov:wasDerivedFrom niiri:0e5b8b589ee5eb2bcf4f50c3d2eee41b .
+niiri:f5afca80c28adf7d02a12d1328e18dc4 prov:wasDerivedFrom niiri:c29df4d87431481482987ba8e96377c4 .
 
-niiri:c51db7231d6ff0819bce879b142d84d9 prov:wasGeneratedBy niiri:9373eea9b5c80c5420a14ed31174239a .
+niiri:f5afca80c28adf7d02a12d1328e18dc4 prov:wasGeneratedBy niiri:c2c197b0fad8993c6cc7208559f40202 .
 
-niiri:9393c9b82a852cdb5a33a3bdedb81eba
+niiri:6c5005a7bc069d11fc4a87c6369a3038
     a prov:Entity, obo_contrastweightmatrix: ; 
     nidm_statisticType: obo_tstatistic: ;
     nidm_contrastName: "tone counting vs baseline"^^xsd:string ;
     rdfs:label "Contrast: tone counting vs baseline" ;
     prov:value "[1, 0, 0]"^^xsd:string .
 
-niiri:5cd4d30379cc213d9034d537a9d9473f
+niiri:660a6a4292f04758ec1d3b9e0aa1c672
     a prov:Activity, nidm_ContrastEstimation: ; 
     rdfs:label "Contrast estimation" .
 
-niiri:5cd4d30379cc213d9034d537a9d9473f prov:wasAssociatedWith niiri:e195d58cb4a7afb511b291abe9c58673 .
+niiri:660a6a4292f04758ec1d3b9e0aa1c672 prov:wasAssociatedWith niiri:c2ec86ce73c8b9ab4324393fc2d80b63 .
 
-niiri:5cd4d30379cc213d9034d537a9d9473f prov:used niiri:97a5f4038f996763845e252476bfddbc .
+niiri:660a6a4292f04758ec1d3b9e0aa1c672 prov:used niiri:670ea0bcbdf9cc6f21ab6a8f5eef7e10 .
 
-niiri:5cd4d30379cc213d9034d537a9d9473f prov:used niiri:46e980de8a2cae8243cca0529b26dcfb .
+niiri:660a6a4292f04758ec1d3b9e0aa1c672 prov:used niiri:49c48883a4e6af1935a92b5f42299adf .
 
-niiri:5cd4d30379cc213d9034d537a9d9473f prov:used niiri:d7b500305477a954c7d6a2f04c1e44d5 .
+niiri:660a6a4292f04758ec1d3b9e0aa1c672 prov:used niiri:a260d6b771a7d3d82e1d9830dcf02423 .
 
-niiri:5cd4d30379cc213d9034d537a9d9473f prov:used niiri:9393c9b82a852cdb5a33a3bdedb81eba .
+niiri:660a6a4292f04758ec1d3b9e0aa1c672 prov:used niiri:6c5005a7bc069d11fc4a87c6369a3038 .
 
-niiri:5cd4d30379cc213d9034d537a9d9473f prov:used niiri:0c78edca8a5d13f9f471c5c699fa4128 .
+niiri:660a6a4292f04758ec1d3b9e0aa1c672 prov:used niiri:5b992ad55d4d262b7a58b0b4c761ff0d .
 
-niiri:5cd4d30379cc213d9034d537a9d9473f prov:used niiri:e1aaedc9a7738f383e7360fbef306e63 .
+niiri:660a6a4292f04758ec1d3b9e0aa1c672 prov:used niiri:e3f451cbbb64a9ffb1ea71bcaf5d3553 .
 
-niiri:5cd4d30379cc213d9034d537a9d9473f prov:used niiri:39edcc292ff235e7c9d940c9aedc2840 .
+niiri:660a6a4292f04758ec1d3b9e0aa1c672 prov:used niiri:94fec9121a605a700be78134f859b81d .
 
-niiri:8234fc4c714d1aa8f3a12ecea0ded16e
+niiri:113d8c92a0971f69fc045ea25e0ac452
     a prov:Entity, nidm_StatisticMap: ; 
     prov:atLocation "TStatistic.nii.gz"^^xsd:anyURI ;
     nfo:fileName "TStatistic.nii.gz"^^xsd:string ;
@@ -383,124 +383,124 @@ niiri:8234fc4c714d1aa8f3a12ecea0ded16e
     nidm_contrastName: "tone counting vs baseline"^^xsd:string ;
     nidm_errorDegreesOfFreedom: "97.9999999998522"^^xsd:float ;
     nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:bd502eec9fb9df4c578a25b6ac824a14 ;
+    nidm_inCoordinateSpace: niiri:c8b0140b68018da6f9905cc4b8fd05ad ;
     crypto:sha512 "9e1714c2d86a050b38b4e10a4d2d23253a24c5e1d228ae16a9c3be8872739278505ac0729ecab54265a717e3a54f9f782d0ed72eea904e0d482a6072bb817bd4"^^xsd:string .
 
-niiri:a84cbdb68584ed314539628acf43ba8c
+niiri:c9be9db6b926ab9d722466a7953ca805
     a prov:Entity, nidm_StatisticMap: ; 
     nfo:fileName "spmT_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "d288b1b0f117f64502555da13c5398dffa5bf5ff0b58951510e43d5388755bc185798802a92e98a07c7e313c6991066d2908f2a44aa5153ba23433da1335970f"^^xsd:string .
 
-niiri:8234fc4c714d1aa8f3a12ecea0ded16e prov:wasDerivedFrom niiri:a84cbdb68584ed314539628acf43ba8c .
+niiri:113d8c92a0971f69fc045ea25e0ac452 prov:wasDerivedFrom niiri:c9be9db6b926ab9d722466a7953ca805 .
 
-niiri:8234fc4c714d1aa8f3a12ecea0ded16e prov:wasGeneratedBy niiri:5cd4d30379cc213d9034d537a9d9473f .
+niiri:113d8c92a0971f69fc045ea25e0ac452 prov:wasGeneratedBy niiri:660a6a4292f04758ec1d3b9e0aa1c672 .
 
-niiri:55c7fb97d1e38a3382fcfdca89da7635
+niiri:0472234a561a04222e0d544d0654b7ab
     a prov:Entity, nidm_ContrastMap: ; 
     prov:atLocation "Contrast.nii.gz"^^xsd:anyURI ;
     nfo:fileName "Contrast.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Map: tone counting vs baseline" ;
     nidm_contrastName: "tone counting vs baseline"^^xsd:string ;
-    nidm_inCoordinateSpace: niiri:bd502eec9fb9df4c578a25b6ac824a14 ;
+    nidm_inCoordinateSpace: niiri:c8b0140b68018da6f9905cc4b8fd05ad ;
     crypto:sha512 "fc5e2ad175243ee496db98f9b2e1b235c4c3bae1a8d7122ce461c897b537e40c49dfee5d6cf20f71c6a2bb9b5f0760fcb4ecd8fe2e9428910ef3d60d8f3c56a9"^^xsd:string .
 
-niiri:ae821101a7c2e3fd4bfaa97d6e58bd78
+niiri:b2fec2ed7f2b195ecbc862d12bd13e4d
     a prov:Entity, nidm_ContrastMap: ; 
     nfo:fileName "con_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "d4aa46b3603ba508578e39751262d528cf6d1ed2e722ec46f1cd8194c50591e46b229deb8cb4f72d1b7e0e2640f3e6604be7a335301c5c8357f453e5d0d4daf2"^^xsd:string .
 
-niiri:55c7fb97d1e38a3382fcfdca89da7635 prov:wasDerivedFrom niiri:ae821101a7c2e3fd4bfaa97d6e58bd78 .
+niiri:0472234a561a04222e0d544d0654b7ab prov:wasDerivedFrom niiri:b2fec2ed7f2b195ecbc862d12bd13e4d .
 
-niiri:55c7fb97d1e38a3382fcfdca89da7635 prov:wasGeneratedBy niiri:5cd4d30379cc213d9034d537a9d9473f .
+niiri:0472234a561a04222e0d544d0654b7ab prov:wasGeneratedBy niiri:660a6a4292f04758ec1d3b9e0aa1c672 .
 
-niiri:adf108a020a1d2bac94b02874ce48bda
+niiri:fa01d09024a9f2eb7c842f11f9e05d7c
     a prov:Entity, nidm_ContrastStandardErrorMap: ; 
     prov:atLocation "ContrastStandardError.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ContrastStandardError.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Standard Error Map" ;
-    nidm_inCoordinateSpace: niiri:bd502eec9fb9df4c578a25b6ac824a14 ;
+    nidm_inCoordinateSpace: niiri:c8b0140b68018da6f9905cc4b8fd05ad ;
     crypto:sha512 "791d48f5d1adb15079a5289271ce0c4b95c56d69bfdb3e5d41b0d24eb538d3075e1cdd15502494b5a5a18c16eaa2153cb4847a996043fa48cdaf26e938a2576d"^^xsd:string .
 
-niiri:adf108a020a1d2bac94b02874ce48bda prov:wasGeneratedBy niiri:5cd4d30379cc213d9034d537a9d9473f .
+niiri:fa01d09024a9f2eb7c842f11f9e05d7c prov:wasGeneratedBy niiri:660a6a4292f04758ec1d3b9e0aa1c672 .
 
-niiri:5d2fabf109275e7e70695b5e5c8414ca
+niiri:311f473b94b906ba6c5a22011f2bf44d
     a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
-    rdfs:label "Height Threshold: p<0.001000 (unc.)" ;
+    rdfs:label "Height Threshold: p<0.001 (unc.)" ;
     prov:value "0.000999500158000544"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:b0ff4c49e2c5ffa9b6b376ebb171033b ;
-    nidm_equivalentThreshold: niiri:91f44211c250f503f422c234d36de5f6 .
+    nidm_equivalentThreshold: niiri:2bfc4bebfe1177a3004cbd378dafd2c1 ;
+    nidm_equivalentThreshold: niiri:496cd88b6fd812b8f219563fa7c3bf08 .
 
-niiri:b0ff4c49e2c5ffa9b6b376ebb171033b
+niiri:2bfc4bebfe1177a3004cbd378dafd2c1
     a prov:Entity, nidm_HeightThreshold:, obo_statistic: ; 
-    rdfs:label "Height Threshold" ;
+    rdfs:label "Height Threshold: T=3.175486)" ;
     prov:value "3.17548628637284"^^xsd:float .
 
-niiri:91f44211c250f503f422c234d36de5f6
+niiri:496cd88b6fd812b8f219563fa7c3bf08
     a prov:Entity, nidm_HeightThreshold:, obo_FWERadjustedpvalue: ; 
-    rdfs:label "Height Threshold" ;
+    rdfs:label "Height Threshold: p<1.000000 (FWE)" ;
     prov:value "0.999999999999997"^^xsd:float .
 
-niiri:6b786352e2e95a84069166615ebaf059
+niiri:7f7b05e69f02276d0d0544852cbc5b7a
     a prov:Entity, nidm_ExtentThreshold:, obo_statistic: ; 
     rdfs:label "Extent Threshold: k>=10" ;
     nidm_clusterSizeInVoxels: "10"^^xsd:int ;
     nidm_clusterSizeInResels: "0.15248854503675"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:60507569cc4c5aa46ef1a7d1e378c0ab ;
-    nidm_equivalentThreshold: niiri:7f7b12d78c21bc83dd0a94bace67afbf .
+    nidm_equivalentThreshold: niiri:097bd44b0c58cfa5bc7be0a0de9c38f9 ;
+    nidm_equivalentThreshold: niiri:03f77b40ea055cd340662c393ea55c0b .
 
-niiri:60507569cc4c5aa46ef1a7d1e378c0ab
+niiri:097bd44b0c58cfa5bc7be0a0de9c38f9
     a prov:Entity, nidm_ExtentThreshold:, obo_FWERadjustedpvalue: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "0.999430072930499"^^xsd:float .
 
-niiri:7f7b12d78c21bc83dd0a94bace67afbf
+niiri:03f77b40ea055cd340662c393ea55c0b
     a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "0.22255850848336"^^xsd:float .
 
-niiri:4b7778d439610759224e40ce12ba98c0
+niiri:f9a61a4056f36732add4b9b80a53bc8d
     a prov:Entity, nidm_PeakDefinitionCriteria: ; 
     rdfs:label "Peak Definition Criteria" ;
     nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
     nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
 
-niiri:a5f7401956f7b7fa48f794abab7e5b78
+niiri:2c9fd0f62c916461f5d00571f467366e
     a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
     rdfs:label "Cluster Connectivity Criterion: 18" ;
     nidm_hasConnectivityCriterion: nidm_voxel18connected: .
 
-niiri:4315bbeaef18cdda72910aa44f514089
+niiri:75cbb0b1a11a78d87cbc93882cc0e892
     a prov:Activity, nidm_Inference: ; 
     nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
     rdfs:label "Inference" .
 
-niiri:4315bbeaef18cdda72910aa44f514089 prov:wasAssociatedWith niiri:e195d58cb4a7afb511b291abe9c58673 .
+niiri:75cbb0b1a11a78d87cbc93882cc0e892 prov:wasAssociatedWith niiri:c2ec86ce73c8b9ab4324393fc2d80b63 .
 
-niiri:4315bbeaef18cdda72910aa44f514089 prov:used niiri:5d2fabf109275e7e70695b5e5c8414ca .
+niiri:75cbb0b1a11a78d87cbc93882cc0e892 prov:used niiri:311f473b94b906ba6c5a22011f2bf44d .
 
-niiri:4315bbeaef18cdda72910aa44f514089 prov:used niiri:6b786352e2e95a84069166615ebaf059 .
+niiri:75cbb0b1a11a78d87cbc93882cc0e892 prov:used niiri:7f7b05e69f02276d0d0544852cbc5b7a .
 
-niiri:4315bbeaef18cdda72910aa44f514089 prov:used niiri:8234fc4c714d1aa8f3a12ecea0ded16e .
+niiri:75cbb0b1a11a78d87cbc93882cc0e892 prov:used niiri:113d8c92a0971f69fc045ea25e0ac452 .
 
-niiri:4315bbeaef18cdda72910aa44f514089 prov:used niiri:c51db7231d6ff0819bce879b142d84d9 .
+niiri:75cbb0b1a11a78d87cbc93882cc0e892 prov:used niiri:f5afca80c28adf7d02a12d1328e18dc4 .
 
-niiri:4315bbeaef18cdda72910aa44f514089 prov:used niiri:97a5f4038f996763845e252476bfddbc .
+niiri:75cbb0b1a11a78d87cbc93882cc0e892 prov:used niiri:670ea0bcbdf9cc6f21ab6a8f5eef7e10 .
 
-niiri:4315bbeaef18cdda72910aa44f514089 prov:used niiri:4b7778d439610759224e40ce12ba98c0 .
+niiri:75cbb0b1a11a78d87cbc93882cc0e892 prov:used niiri:f9a61a4056f36732add4b9b80a53bc8d .
 
-niiri:4315bbeaef18cdda72910aa44f514089 prov:used niiri:a5f7401956f7b7fa48f794abab7e5b78 .
+niiri:75cbb0b1a11a78d87cbc93882cc0e892 prov:used niiri:2c9fd0f62c916461f5d00571f467366e .
 
-niiri:6b4eb214f0c393ce958c52a2b0d15ad3
+niiri:e7fa1fe72bad934822d8ef41842387f5
     a prov:Entity, nidm_SearchSpaceMaskMap: ; 
     prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
     nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Search Space Mask Map" ;
-    nidm_inCoordinateSpace: niiri:bd502eec9fb9df4c578a25b6ac824a14 ;
+    nidm_inCoordinateSpace: niiri:c8b0140b68018da6f9905cc4b8fd05ad ;
     nidm_searchVolumeInVoxels: "223057"^^xsd:int ;
     nidm_searchVolumeInUnits: "1784456"^^xsd:float ;
     nidm_reselSizeInVoxels: "65.5786964036542"^^xsd:float ;
@@ -517,9 +517,9 @@ niiri:6b4eb214f0c393ce958c52a2b0d15ad3
     spm_smallestSignificantClusterSizeInVoxelsFWE05: "116"^^xsd:int ;
     spm_smallestSignificantClusterSizeInVoxelsFDR05: "61"^^xsd:int .
 
-niiri:6b4eb214f0c393ce958c52a2b0d15ad3 prov:wasGeneratedBy niiri:4315bbeaef18cdda72910aa44f514089 .
+niiri:e7fa1fe72bad934822d8ef41842387f5 prov:wasGeneratedBy niiri:75cbb0b1a11a78d87cbc93882cc0e892 .
 
-niiri:562d7f3f6f07bb6a2109c364a6267497
+niiri:74ccd8c140ada8dc4af99773bc09dcbc
     a prov:Entity, nidm_ExcursionSetMap: ; 
     prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
@@ -527,29 +527,29 @@ niiri:562d7f3f6f07bb6a2109c364a6267497
     rdfs:label "Excursion Set Map" ;
     nidm_numberOfSupraThresholdClusters: "37"^^xsd:int ;
     nidm_pValue: "1.0547118733939e-14"^^xsd:float ;
-    nidm_hasClusterLabelsMap: niiri:bce923faf7a20ecf913804332596c5f6 ;
-    nidm_hasMaximumIntensityProjection: niiri:25f8726eaf1348f0ba8e4da0eb6899ed ;
-    nidm_inCoordinateSpace: niiri:bd502eec9fb9df4c578a25b6ac824a14 ;
+    nidm_hasClusterLabelsMap: niiri:31512b9ad741a32434f9e9a179b05e24 ;
+    nidm_hasMaximumIntensityProjection: niiri:ab16dbc3e4925d392c891ea1edd16188 ;
+    nidm_inCoordinateSpace: niiri:c8b0140b68018da6f9905cc4b8fd05ad ;
     crypto:sha512 "7c47836783829c9d104b853bdb9b46a988960ed9386e3d6bd1ffd9a0ef8fe115b75a0f91560fe1b8dfd21679c4406374db0824a65e5fdb4a98cd5c9f6d384cc9"^^xsd:string .
 
-niiri:bce923faf7a20ecf913804332596c5f6
+niiri:31512b9ad741a32434f9e9a179b05e24
     a prov:Entity, nidm_ClusterLabelsMap: ; 
     prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Cluster Labels Map" ;
-    nidm_inCoordinateSpace: niiri:bd502eec9fb9df4c578a25b6ac824a14 ;
+    nidm_inCoordinateSpace: niiri:c8b0140b68018da6f9905cc4b8fd05ad ;
     crypto:sha512 "2201a146e5e5a8bbbea7a3cb8ba3326744133bb484069e09afde0d678c99f2b8306b0519abcf59452234736b359abd058a93af565ddc0dd8831a7c5b94893c4d"^^xsd:string .
 
-niiri:25f8726eaf1348f0ba8e4da0eb6899ed
+niiri:ab16dbc3e4925d392c891ea1edd16188
     a prov:Entity, dctype:Image ; 
     prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
     nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:562d7f3f6f07bb6a2109c364a6267497 prov:wasGeneratedBy niiri:4315bbeaef18cdda72910aa44f514089 .
+niiri:74ccd8c140ada8dc4af99773bc09dcbc prov:wasGeneratedBy niiri:75cbb0b1a11a78d87cbc93882cc0e892 .
 
-niiri:4bcbccd66dbc3e748dc049ea28e790ec
+niiri:f3b96c552779d9374a531718147427d0
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0001" ;
     nidm_clusterSizeInVoxels: "1804"^^xsd:int ;
@@ -559,9 +559,9 @@ niiri:4bcbccd66dbc3e748dc049ea28e790ec
     nidm_qValueFDR: "5.93371085041799e-20"^^xsd:float ;
     nidm_clusterLabelId: "1"^^xsd:int .
 
-niiri:4bcbccd66dbc3e748dc049ea28e790ec prov:wasDerivedFrom niiri:562d7f3f6f07bb6a2109c364a6267497 .
+niiri:f3b96c552779d9374a531718147427d0 prov:wasDerivedFrom niiri:74ccd8c140ada8dc4af99773bc09dcbc .
 
-niiri:ede195e83c61c437e885525e08d7a512
+niiri:31281ad36fc49da248ac587f4076c953
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0002" ;
     nidm_clusterSizeInVoxels: "356"^^xsd:int ;
@@ -571,9 +571,9 @@ niiri:ede195e83c61c437e885525e08d7a512
     nidm_qValueFDR: "1.17083954451478e-06"^^xsd:float ;
     nidm_clusterLabelId: "2"^^xsd:int .
 
-niiri:ede195e83c61c437e885525e08d7a512 prov:wasDerivedFrom niiri:562d7f3f6f07bb6a2109c364a6267497 .
+niiri:31281ad36fc49da248ac587f4076c953 prov:wasDerivedFrom niiri:74ccd8c140ada8dc4af99773bc09dcbc .
 
-niiri:fa5698ad69d25731ec095f4a19e6b769
+niiri:1bc8b121d587eb836f9b3b7858047889
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0003" ;
     nidm_clusterSizeInVoxels: "5090"^^xsd:int ;
@@ -583,9 +583,9 @@ niiri:fa5698ad69d25731ec095f4a19e6b769
     nidm_qValueFDR: "2.03335233065374e-40"^^xsd:float ;
     nidm_clusterLabelId: "3"^^xsd:int .
 
-niiri:fa5698ad69d25731ec095f4a19e6b769 prov:wasDerivedFrom niiri:562d7f3f6f07bb6a2109c364a6267497 .
+niiri:1bc8b121d587eb836f9b3b7858047889 prov:wasDerivedFrom niiri:74ccd8c140ada8dc4af99773bc09dcbc .
 
-niiri:887b2ca8650505f0a02eb266ef164521
+niiri:c131d22e9155057f870d66e758ece437
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0004" ;
     nidm_clusterSizeInVoxels: "766"^^xsd:int ;
@@ -595,9 +595,9 @@ niiri:887b2ca8650505f0a02eb266ef164521
     nidm_qValueFDR: "4.58706002591263e-11"^^xsd:float ;
     nidm_clusterLabelId: "4"^^xsd:int .
 
-niiri:887b2ca8650505f0a02eb266ef164521 prov:wasDerivedFrom niiri:562d7f3f6f07bb6a2109c364a6267497 .
+niiri:c131d22e9155057f870d66e758ece437 prov:wasDerivedFrom niiri:74ccd8c140ada8dc4af99773bc09dcbc .
 
-niiri:6cda51ac561cc297977a65efb9fbcef6
+niiri:c0d0506786bef63ddf2f635fb7755534
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0005" ;
     nidm_clusterSizeInVoxels: "54"^^xsd:int ;
@@ -607,9 +607,9 @@ niiri:6cda51ac561cc297977a65efb9fbcef6
     nidm_qValueFDR: "0.061094648971533"^^xsd:float ;
     nidm_clusterLabelId: "5"^^xsd:int .
 
-niiri:6cda51ac561cc297977a65efb9fbcef6 prov:wasDerivedFrom niiri:562d7f3f6f07bb6a2109c364a6267497 .
+niiri:c0d0506786bef63ddf2f635fb7755534 prov:wasDerivedFrom niiri:74ccd8c140ada8dc4af99773bc09dcbc .
 
-niiri:1ca66ce425b243c3c0035c8186d99a15
+niiri:dccd359642442c550b8e126ef0768318
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0006" ;
     nidm_clusterSizeInVoxels: "285"^^xsd:int ;
@@ -619,9 +619,9 @@ niiri:1ca66ce425b243c3c0035c8186d99a15
     nidm_qValueFDR: "9.4369593516496e-06"^^xsd:float ;
     nidm_clusterLabelId: "6"^^xsd:int .
 
-niiri:1ca66ce425b243c3c0035c8186d99a15 prov:wasDerivedFrom niiri:562d7f3f6f07bb6a2109c364a6267497 .
+niiri:dccd359642442c550b8e126ef0768318 prov:wasDerivedFrom niiri:74ccd8c140ada8dc4af99773bc09dcbc .
 
-niiri:c69f007bda67f5e2a0a40c91717f128b
+niiri:4c25e0ccdac5828019bc6ab24105a598
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0007" ;
     nidm_clusterSizeInVoxels: "395"^^xsd:int ;
@@ -631,9 +631,9 @@ niiri:c69f007bda67f5e2a0a40c91717f128b
     nidm_qValueFDR: "4.37433635338446e-07"^^xsd:float ;
     nidm_clusterLabelId: "7"^^xsd:int .
 
-niiri:c69f007bda67f5e2a0a40c91717f128b prov:wasDerivedFrom niiri:562d7f3f6f07bb6a2109c364a6267497 .
+niiri:4c25e0ccdac5828019bc6ab24105a598 prov:wasDerivedFrom niiri:74ccd8c140ada8dc4af99773bc09dcbc .
 
-niiri:8009c6c2577ffab297b9446c56ac691e
+niiri:439c3d37a059fc0c9fe663876cd44696
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0008" ;
     nidm_clusterSizeInVoxels: "116"^^xsd:int ;
@@ -643,9 +643,9 @@ niiri:8009c6c2577ffab297b9446c56ac691e
     nidm_qValueFDR: "0.00366911802917346"^^xsd:float ;
     nidm_clusterLabelId: "8"^^xsd:int .
 
-niiri:8009c6c2577ffab297b9446c56ac691e prov:wasDerivedFrom niiri:562d7f3f6f07bb6a2109c364a6267497 .
+niiri:439c3d37a059fc0c9fe663876cd44696 prov:wasDerivedFrom niiri:74ccd8c140ada8dc4af99773bc09dcbc .
 
-niiri:ccbb2dcff74d28dda3be2c8bc2f59ef2
+niiri:e4902bb46a21f477eb5d9e386fc19878
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0009" ;
     nidm_clusterSizeInVoxels: "19"^^xsd:int ;
@@ -655,9 +655,9 @@ niiri:ccbb2dcff74d28dda3be2c8bc2f59ef2
     nidm_qValueFDR: "0.278639392496977"^^xsd:float ;
     nidm_clusterLabelId: "9"^^xsd:int .
 
-niiri:ccbb2dcff74d28dda3be2c8bc2f59ef2 prov:wasDerivedFrom niiri:562d7f3f6f07bb6a2109c364a6267497 .
+niiri:e4902bb46a21f477eb5d9e386fc19878 prov:wasDerivedFrom niiri:74ccd8c140ada8dc4af99773bc09dcbc .
 
-niiri:86578a06fc311c81acbc580eb1d83642
+niiri:392b01269887f7941cf41e331de9925c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0010" ;
     nidm_clusterSizeInVoxels: "50"^^xsd:int ;
@@ -667,9 +667,9 @@ niiri:86578a06fc311c81acbc580eb1d83642
     nidm_qValueFDR: "0.0707678054255747"^^xsd:float ;
     nidm_clusterLabelId: "10"^^xsd:int .
 
-niiri:86578a06fc311c81acbc580eb1d83642 prov:wasDerivedFrom niiri:562d7f3f6f07bb6a2109c364a6267497 .
+niiri:392b01269887f7941cf41e331de9925c prov:wasDerivedFrom niiri:74ccd8c140ada8dc4af99773bc09dcbc .
 
-niiri:9c4395321a8582f0da12ba759320292c
+niiri:7e231620402d8b69f99aa21ba8f6b058
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0011" ;
     nidm_clusterSizeInVoxels: "447"^^xsd:int ;
@@ -679,9 +679,9 @@ niiri:9c4395321a8582f0da12ba759320292c
     nidm_qValueFDR: "1.22279946227405e-07"^^xsd:float ;
     nidm_clusterLabelId: "11"^^xsd:int .
 
-niiri:9c4395321a8582f0da12ba759320292c prov:wasDerivedFrom niiri:562d7f3f6f07bb6a2109c364a6267497 .
+niiri:7e231620402d8b69f99aa21ba8f6b058 prov:wasDerivedFrom niiri:74ccd8c140ada8dc4af99773bc09dcbc .
 
-niiri:e84befdceca7e9fb020e4e603e6d2441
+niiri:c6a240b5ad789d06fb0190076dcbb863
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0012" ;
     nidm_clusterSizeInVoxels: "162"^^xsd:int ;
@@ -691,9 +691,9 @@ niiri:e84befdceca7e9fb020e4e603e6d2441
     nidm_qValueFDR: "0.000672150622508277"^^xsd:float ;
     nidm_clusterLabelId: "12"^^xsd:int .
 
-niiri:e84befdceca7e9fb020e4e603e6d2441 prov:wasDerivedFrom niiri:562d7f3f6f07bb6a2109c364a6267497 .
+niiri:c6a240b5ad789d06fb0190076dcbb863 prov:wasDerivedFrom niiri:74ccd8c140ada8dc4af99773bc09dcbc .
 
-niiri:3921a44ffb5cf54649ee43045d6cc96a
+niiri:1b71ce972cf56fb139ab88975f4640c9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0013" ;
     nidm_clusterSizeInVoxels: "29"^^xsd:int ;
@@ -703,9 +703,9 @@ niiri:3921a44ffb5cf54649ee43045d6cc96a
     nidm_qValueFDR: "0.190729630640958"^^xsd:float ;
     nidm_clusterLabelId: "13"^^xsd:int .
 
-niiri:3921a44ffb5cf54649ee43045d6cc96a prov:wasDerivedFrom niiri:562d7f3f6f07bb6a2109c364a6267497 .
+niiri:1b71ce972cf56fb139ab88975f4640c9 prov:wasDerivedFrom niiri:74ccd8c140ada8dc4af99773bc09dcbc .
 
-niiri:d195c6d760a60eb9860a72f0fa5d33b6
+niiri:ca0dd10dbf94ba5d07f8de45f011307c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0014" ;
     nidm_clusterSizeInVoxels: "38"^^xsd:int ;
@@ -715,9 +715,9 @@ niiri:d195c6d760a60eb9860a72f0fa5d33b6
     nidm_qValueFDR: "0.130408510255373"^^xsd:float ;
     nidm_clusterLabelId: "14"^^xsd:int .
 
-niiri:d195c6d760a60eb9860a72f0fa5d33b6 prov:wasDerivedFrom niiri:562d7f3f6f07bb6a2109c364a6267497 .
+niiri:ca0dd10dbf94ba5d07f8de45f011307c prov:wasDerivedFrom niiri:74ccd8c140ada8dc4af99773bc09dcbc .
 
-niiri:eb6f2c1f9fab3eef26fb05dad9eee378
+niiri:cae6fd96eea7e9972a3dd49f5837e19f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0015" ;
     nidm_clusterSizeInVoxels: "134"^^xsd:int ;
@@ -727,9 +727,9 @@ niiri:eb6f2c1f9fab3eef26fb05dad9eee378
     nidm_qValueFDR: "0.00187402776443535"^^xsd:float ;
     nidm_clusterLabelId: "15"^^xsd:int .
 
-niiri:eb6f2c1f9fab3eef26fb05dad9eee378 prov:wasDerivedFrom niiri:562d7f3f6f07bb6a2109c364a6267497 .
+niiri:cae6fd96eea7e9972a3dd49f5837e19f prov:wasDerivedFrom niiri:74ccd8c140ada8dc4af99773bc09dcbc .
 
-niiri:3efe9387862f59b37bf90987a3a01074
+niiri:a5ea3c101aaf1b98c7ee58fcc76dff1b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0016" ;
     nidm_clusterSizeInVoxels: "76"^^xsd:int ;
@@ -739,9 +739,9 @@ niiri:3efe9387862f59b37bf90987a3a01074
     nidm_qValueFDR: "0.022111501908576"^^xsd:float ;
     nidm_clusterLabelId: "16"^^xsd:int .
 
-niiri:3efe9387862f59b37bf90987a3a01074 prov:wasDerivedFrom niiri:562d7f3f6f07bb6a2109c364a6267497 .
+niiri:a5ea3c101aaf1b98c7ee58fcc76dff1b prov:wasDerivedFrom niiri:74ccd8c140ada8dc4af99773bc09dcbc .
 
-niiri:4fec4e3138e166ee2892b0d3d91bb41e
+niiri:6f05166f31ef45c33808420434a13f55
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0017" ;
     nidm_clusterSizeInVoxels: "16"^^xsd:int ;
@@ -751,9 +751,9 @@ niiri:4fec4e3138e166ee2892b0d3d91bb41e
     nidm_qValueFDR: "0.324079280522016"^^xsd:float ;
     nidm_clusterLabelId: "17"^^xsd:int .
 
-niiri:4fec4e3138e166ee2892b0d3d91bb41e prov:wasDerivedFrom niiri:562d7f3f6f07bb6a2109c364a6267497 .
+niiri:6f05166f31ef45c33808420434a13f55 prov:wasDerivedFrom niiri:74ccd8c140ada8dc4af99773bc09dcbc .
 
-niiri:0b5064760982e8c270bd98284ecb06d3
+niiri:f686250b6fb996d621aa21cdf5cf6717
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0018" ;
     nidm_clusterSizeInVoxels: "26"^^xsd:int ;
@@ -763,9 +763,9 @@ niiri:0b5064760982e8c270bd98284ecb06d3
     nidm_qValueFDR: "0.205539497548942"^^xsd:float ;
     nidm_clusterLabelId: "18"^^xsd:int .
 
-niiri:0b5064760982e8c270bd98284ecb06d3 prov:wasDerivedFrom niiri:562d7f3f6f07bb6a2109c364a6267497 .
+niiri:f686250b6fb996d621aa21cdf5cf6717 prov:wasDerivedFrom niiri:74ccd8c140ada8dc4af99773bc09dcbc .
 
-niiri:71ab02bff3b085bb7b9a91d459a832f0
+niiri:36a0a86f1b5fa4bc787a9c7b7eba11a2
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0019" ;
     nidm_clusterSizeInVoxels: "29"^^xsd:int ;
@@ -775,9 +775,9 @@ niiri:71ab02bff3b085bb7b9a91d459a832f0
     nidm_qValueFDR: "0.190729630640958"^^xsd:float ;
     nidm_clusterLabelId: "19"^^xsd:int .
 
-niiri:71ab02bff3b085bb7b9a91d459a832f0 prov:wasDerivedFrom niiri:562d7f3f6f07bb6a2109c364a6267497 .
+niiri:36a0a86f1b5fa4bc787a9c7b7eba11a2 prov:wasDerivedFrom niiri:74ccd8c140ada8dc4af99773bc09dcbc .
 
-niiri:5e8275841ed71a0e7a9cc2f07fba7508
+niiri:ee27ca4fbf4487cbf6ede6f498d03b89
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0020" ;
     nidm_clusterSizeInVoxels: "10"^^xsd:int ;
@@ -787,9 +787,9 @@ niiri:5e8275841ed71a0e7a9cc2f07fba7508
     nidm_qValueFDR: "0.487222680733842"^^xsd:float ;
     nidm_clusterLabelId: "20"^^xsd:int .
 
-niiri:5e8275841ed71a0e7a9cc2f07fba7508 prov:wasDerivedFrom niiri:562d7f3f6f07bb6a2109c364a6267497 .
+niiri:ee27ca4fbf4487cbf6ede6f498d03b89 prov:wasDerivedFrom niiri:74ccd8c140ada8dc4af99773bc09dcbc .
 
-niiri:7d836a379d88c30e45968812bcbaec09
+niiri:f6df377f07bd1d85bb45726e6330c017
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0021" ;
     nidm_clusterSizeInVoxels: "49"^^xsd:int ;
@@ -799,9 +799,9 @@ niiri:7d836a379d88c30e45968812bcbaec09
     nidm_qValueFDR: "0.0707678054255747"^^xsd:float ;
     nidm_clusterLabelId: "21"^^xsd:int .
 
-niiri:7d836a379d88c30e45968812bcbaec09 prov:wasDerivedFrom niiri:562d7f3f6f07bb6a2109c364a6267497 .
+niiri:f6df377f07bd1d85bb45726e6330c017 prov:wasDerivedFrom niiri:74ccd8c140ada8dc4af99773bc09dcbc .
 
-niiri:6d9719aa34ea98f8ee1e2190f57a38c2
+niiri:0f57c541cf04642c5618cb3c8c754be3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0022" ;
     nidm_clusterSizeInVoxels: "21"^^xsd:int ;
@@ -811,9 +811,9 @@ niiri:6d9719aa34ea98f8ee1e2190f57a38c2
     nidm_qValueFDR: "0.255273713826051"^^xsd:float ;
     nidm_clusterLabelId: "22"^^xsd:int .
 
-niiri:6d9719aa34ea98f8ee1e2190f57a38c2 prov:wasDerivedFrom niiri:562d7f3f6f07bb6a2109c364a6267497 .
+niiri:0f57c541cf04642c5618cb3c8c754be3 prov:wasDerivedFrom niiri:74ccd8c140ada8dc4af99773bc09dcbc .
 
-niiri:7a9b91d6cb78bfe1263ffc584d3b69d2
+niiri:10dca7f82f910606e689ba8e2b5af3ff
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0023" ;
     nidm_clusterSizeInVoxels: "30"^^xsd:int ;
@@ -823,9 +823,9 @@ niiri:7a9b91d6cb78bfe1263ffc584d3b69d2
     nidm_qValueFDR: "0.190729630640958"^^xsd:float ;
     nidm_clusterLabelId: "23"^^xsd:int .
 
-niiri:7a9b91d6cb78bfe1263ffc584d3b69d2 prov:wasDerivedFrom niiri:562d7f3f6f07bb6a2109c364a6267497 .
+niiri:10dca7f82f910606e689ba8e2b5af3ff prov:wasDerivedFrom niiri:74ccd8c140ada8dc4af99773bc09dcbc .
 
-niiri:9dae134cd7326c7dd74b40d61a138556
+niiri:34abbea5b5b7e9caec8749719282f69d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0024" ;
     nidm_clusterSizeInVoxels: "27"^^xsd:int ;
@@ -835,9 +835,9 @@ niiri:9dae134cd7326c7dd74b40d61a138556
     nidm_qValueFDR: "0.199876794002946"^^xsd:float ;
     nidm_clusterLabelId: "24"^^xsd:int .
 
-niiri:9dae134cd7326c7dd74b40d61a138556 prov:wasDerivedFrom niiri:562d7f3f6f07bb6a2109c364a6267497 .
+niiri:34abbea5b5b7e9caec8749719282f69d prov:wasDerivedFrom niiri:74ccd8c140ada8dc4af99773bc09dcbc .
 
-niiri:a48e52ce82ef21945b533008203890a9
+niiri:f97396b2a54d55285f02d93b58dbe2b6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0025" ;
     nidm_clusterSizeInVoxels: "10"^^xsd:int ;
@@ -847,9 +847,9 @@ niiri:a48e52ce82ef21945b533008203890a9
     nidm_qValueFDR: "0.487222680733842"^^xsd:float ;
     nidm_clusterLabelId: "25"^^xsd:int .
 
-niiri:a48e52ce82ef21945b533008203890a9 prov:wasDerivedFrom niiri:562d7f3f6f07bb6a2109c364a6267497 .
+niiri:f97396b2a54d55285f02d93b58dbe2b6 prov:wasDerivedFrom niiri:74ccd8c140ada8dc4af99773bc09dcbc .
 
-niiri:33d2fed4b2c8785ed20bc8727adca85e
+niiri:a4357c1b32f8a28c66891660675a8ceb
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0026" ;
     nidm_clusterSizeInVoxels: "61"^^xsd:int ;
@@ -859,9 +859,9 @@ niiri:33d2fed4b2c8785ed20bc8727adca85e
     nidm_qValueFDR: "0.0447442257801353"^^xsd:float ;
     nidm_clusterLabelId: "26"^^xsd:int .
 
-niiri:33d2fed4b2c8785ed20bc8727adca85e prov:wasDerivedFrom niiri:562d7f3f6f07bb6a2109c364a6267497 .
+niiri:a4357c1b32f8a28c66891660675a8ceb prov:wasDerivedFrom niiri:74ccd8c140ada8dc4af99773bc09dcbc .
 
-niiri:32b9f8da6e89284036f980cbd853e723
+niiri:9e1f64e5a9ff6cda9c7c7070f1f8c2b9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0027" ;
     nidm_clusterSizeInVoxels: "19"^^xsd:int ;
@@ -871,9 +871,9 @@ niiri:32b9f8da6e89284036f980cbd853e723
     nidm_qValueFDR: "0.278639392496977"^^xsd:float ;
     nidm_clusterLabelId: "27"^^xsd:int .
 
-niiri:32b9f8da6e89284036f980cbd853e723 prov:wasDerivedFrom niiri:562d7f3f6f07bb6a2109c364a6267497 .
+niiri:9e1f64e5a9ff6cda9c7c7070f1f8c2b9 prov:wasDerivedFrom niiri:74ccd8c140ada8dc4af99773bc09dcbc .
 
-niiri:a4fb311adc8de77c87cd3e5be5ccc62b
+niiri:e13313ba9b9b954243d9c9332f3caf96
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0028" ;
     nidm_clusterSizeInVoxels: "14"^^xsd:int ;
@@ -883,9 +883,9 @@ niiri:a4fb311adc8de77c87cd3e5be5ccc62b
     nidm_qValueFDR: "0.374386664234061"^^xsd:float ;
     nidm_clusterLabelId: "28"^^xsd:int .
 
-niiri:a4fb311adc8de77c87cd3e5be5ccc62b prov:wasDerivedFrom niiri:562d7f3f6f07bb6a2109c364a6267497 .
+niiri:e13313ba9b9b954243d9c9332f3caf96 prov:wasDerivedFrom niiri:74ccd8c140ada8dc4af99773bc09dcbc .
 
-niiri:f5be0f8d59441b28ce308dfb011e10df
+niiri:63e1799e700f05ae3736bff33a2b65f4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0029" ;
     nidm_clusterSizeInVoxels: "18"^^xsd:int ;
@@ -895,9 +895,9 @@ niiri:f5be0f8d59441b28ce308dfb011e10df
     nidm_qValueFDR: "0.292253130241304"^^xsd:float ;
     nidm_clusterLabelId: "29"^^xsd:int .
 
-niiri:f5be0f8d59441b28ce308dfb011e10df prov:wasDerivedFrom niiri:562d7f3f6f07bb6a2109c364a6267497 .
+niiri:63e1799e700f05ae3736bff33a2b65f4 prov:wasDerivedFrom niiri:74ccd8c140ada8dc4af99773bc09dcbc .
 
-niiri:9771726b7a7da2b81302c08e984d21aa
+niiri:5dfbf6ab6301360ce96203aca13f8257
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0030" ;
     nidm_clusterSizeInVoxels: "28"^^xsd:int ;
@@ -907,9 +907,9 @@ niiri:9771726b7a7da2b81302c08e984d21aa
     nidm_qValueFDR: "0.194945641821685"^^xsd:float ;
     nidm_clusterLabelId: "30"^^xsd:int .
 
-niiri:9771726b7a7da2b81302c08e984d21aa prov:wasDerivedFrom niiri:562d7f3f6f07bb6a2109c364a6267497 .
+niiri:5dfbf6ab6301360ce96203aca13f8257 prov:wasDerivedFrom niiri:74ccd8c140ada8dc4af99773bc09dcbc .
 
-niiri:1081daf0e707c5e5ae15af9f18adc9a9
+niiri:82c6c5dde224f3815e887f0f89a10062
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0031" ;
     nidm_clusterSizeInVoxels: "21"^^xsd:int ;
@@ -919,9 +919,9 @@ niiri:1081daf0e707c5e5ae15af9f18adc9a9
     nidm_qValueFDR: "0.255273713826051"^^xsd:float ;
     nidm_clusterLabelId: "31"^^xsd:int .
 
-niiri:1081daf0e707c5e5ae15af9f18adc9a9 prov:wasDerivedFrom niiri:562d7f3f6f07bb6a2109c364a6267497 .
+niiri:82c6c5dde224f3815e887f0f89a10062 prov:wasDerivedFrom niiri:74ccd8c140ada8dc4af99773bc09dcbc .
 
-niiri:9294aac4eea8be1704ba4b297809e66d
+niiri:f9cd18224526a4801de142048b64a357
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0032" ;
     nidm_clusterSizeInVoxels: "29"^^xsd:int ;
@@ -931,9 +931,9 @@ niiri:9294aac4eea8be1704ba4b297809e66d
     nidm_qValueFDR: "0.190729630640958"^^xsd:float ;
     nidm_clusterLabelId: "32"^^xsd:int .
 
-niiri:9294aac4eea8be1704ba4b297809e66d prov:wasDerivedFrom niiri:562d7f3f6f07bb6a2109c364a6267497 .
+niiri:f9cd18224526a4801de142048b64a357 prov:wasDerivedFrom niiri:74ccd8c140ada8dc4af99773bc09dcbc .
 
-niiri:9c2b57d941c750a81bae56005ccc8439
+niiri:b2129866f39d8d89964577f80028f418
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0033" ;
     nidm_clusterSizeInVoxels: "24"^^xsd:int ;
@@ -943,9 +943,9 @@ niiri:9c2b57d941c750a81bae56005ccc8439
     nidm_qValueFDR: "0.228311147705098"^^xsd:float ;
     nidm_clusterLabelId: "33"^^xsd:int .
 
-niiri:9c2b57d941c750a81bae56005ccc8439 prov:wasDerivedFrom niiri:562d7f3f6f07bb6a2109c364a6267497 .
+niiri:b2129866f39d8d89964577f80028f418 prov:wasDerivedFrom niiri:74ccd8c140ada8dc4af99773bc09dcbc .
 
-niiri:8e5c49eb54e50609e5ba92b2b8409882
+niiri:1d15a2f17b8507a037170dff62d0df0f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0034" ;
     nidm_clusterSizeInVoxels: "12"^^xsd:int ;
@@ -955,9 +955,9 @@ niiri:8e5c49eb54e50609e5ba92b2b8409882
     nidm_qValueFDR: "0.42415320655688"^^xsd:float ;
     nidm_clusterLabelId: "34"^^xsd:int .
 
-niiri:8e5c49eb54e50609e5ba92b2b8409882 prov:wasDerivedFrom niiri:562d7f3f6f07bb6a2109c364a6267497 .
+niiri:1d15a2f17b8507a037170dff62d0df0f prov:wasDerivedFrom niiri:74ccd8c140ada8dc4af99773bc09dcbc .
 
-niiri:a03ba6625b79992ed07f93b8c01a2bae
+niiri:92cdcaac8dc15abca00aaf2035c3d353
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0035" ;
     nidm_clusterSizeInVoxels: "21"^^xsd:int ;
@@ -967,9 +967,9 @@ niiri:a03ba6625b79992ed07f93b8c01a2bae
     nidm_qValueFDR: "0.255273713826051"^^xsd:float ;
     nidm_clusterLabelId: "35"^^xsd:int .
 
-niiri:a03ba6625b79992ed07f93b8c01a2bae prov:wasDerivedFrom niiri:562d7f3f6f07bb6a2109c364a6267497 .
+niiri:92cdcaac8dc15abca00aaf2035c3d353 prov:wasDerivedFrom niiri:74ccd8c140ada8dc4af99773bc09dcbc .
 
-niiri:4ccc33b588ed17374f2c6edcb6528c8c
+niiri:a766e15fcf31e1d6ce69e989e67adf78
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0036" ;
     nidm_clusterSizeInVoxels: "16"^^xsd:int ;
@@ -979,9 +979,9 @@ niiri:4ccc33b588ed17374f2c6edcb6528c8c
     nidm_qValueFDR: "0.324079280522016"^^xsd:float ;
     nidm_clusterLabelId: "36"^^xsd:int .
 
-niiri:4ccc33b588ed17374f2c6edcb6528c8c prov:wasDerivedFrom niiri:562d7f3f6f07bb6a2109c364a6267497 .
+niiri:a766e15fcf31e1d6ce69e989e67adf78 prov:wasDerivedFrom niiri:74ccd8c140ada8dc4af99773bc09dcbc .
 
-niiri:9a0e43f3959fa34d67e65e823d6736df
+niiri:f364696f65c95b091099ba5aa2f33e2b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0037" ;
     nidm_clusterSizeInVoxels: "13"^^xsd:int ;
@@ -991,1008 +991,1008 @@ niiri:9a0e43f3959fa34d67e65e823d6736df
     nidm_qValueFDR: "0.39785224811166"^^xsd:float ;
     nidm_clusterLabelId: "37"^^xsd:int .
 
-niiri:9a0e43f3959fa34d67e65e823d6736df prov:wasDerivedFrom niiri:562d7f3f6f07bb6a2109c364a6267497 .
+niiri:f364696f65c95b091099ba5aa2f33e2b prov:wasDerivedFrom niiri:74ccd8c140ada8dc4af99773bc09dcbc .
 
-niiri:2ba80d8ffed5342d50948196439f6527
+niiri:60751fd1c75909c8f22f3188decc0b24
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0001" ;
-    prov:atLocation niiri:e416a98cd9f9a86a1e11956e784e23ab ;
+    prov:atLocation niiri:f857ed5b37db9d516826e1fe049e298e ;
     prov:value "7.92007970809937"^^xsd:float ;
     nidm_equivalentZStatistic: "6.94608360738412"^^xsd:float ;
     nidm_pValueUncorrected: "1.87783122385099e-12"^^xsd:float ;
     nidm_pValueFWER: "4.18813870695089e-07"^^xsd:float ;
     nidm_qValueFDR: "5.21674435923017e-06"^^xsd:float .
 
-niiri:e416a98cd9f9a86a1e11956e784e23ab
+niiri:f857ed5b37db9d516826e1fe049e298e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0001" ;
     nidm_coordinateVector: "[46,16,24]"^^xsd:string .
 
-niiri:2ba80d8ffed5342d50948196439f6527 prov:wasDerivedFrom niiri:4bcbccd66dbc3e748dc049ea28e790ec .
+niiri:60751fd1c75909c8f22f3188decc0b24 prov:wasDerivedFrom niiri:f3b96c552779d9374a531718147427d0 .
 
-niiri:20de7c3806a32f85e015eb70cefa029f
+niiri:b5e1aa9b45d83dea2221d28bd37262f2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0002" ;
-    prov:atLocation niiri:8c2d92b0d9e74f8ec893f2bf700309ad ;
+    prov:atLocation niiri:ed2331a7cf87add50918be5bd659afc1 ;
     prov:value "6.31603479385376"^^xsd:float ;
     nidm_equivalentZStatistic: "5.77079466112137"^^xsd:float ;
     nidm_pValueUncorrected: "3.94492849498107e-09"^^xsd:float ;
     nidm_pValueFWER: "0.000879943865776389"^^xsd:float ;
     nidm_qValueFDR: "0.000830722551601523"^^xsd:float .
 
-niiri:8c2d92b0d9e74f8ec893f2bf700309ad
+niiri:ed2331a7cf87add50918be5bd659afc1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0002" ;
     nidm_coordinateVector: "[32,24,-4]"^^xsd:string .
 
-niiri:20de7c3806a32f85e015eb70cefa029f prov:wasDerivedFrom niiri:4bcbccd66dbc3e748dc049ea28e790ec .
+niiri:b5e1aa9b45d83dea2221d28bd37262f2 prov:wasDerivedFrom niiri:f3b96c552779d9374a531718147427d0 .
 
-niiri:70dc65955934a45a8cf93fc4a9a8b52f
+niiri:32b931355eb48f34a576c74d8531d572
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0003" ;
-    prov:atLocation niiri:e7b89a98f83baac8975b9a70dc582435 ;
+    prov:atLocation niiri:280385c283fdc62462e4706eab377298 ;
     prov:value "5.68819808959961"^^xsd:float ;
     nidm_equivalentZStatistic: "5.27450168515333"^^xsd:float ;
     nidm_pValueUncorrected: "6.655864770444e-08"^^xsd:float ;
     nidm_pValueFWER: "0.0121028975026269"^^xsd:float ;
     nidm_qValueFDR: "0.00350091530962783"^^xsd:float .
 
-niiri:e7b89a98f83baac8975b9a70dc582435
+niiri:280385c283fdc62462e4706eab377298
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0003" ;
     nidm_coordinateVector: "[18,16,4]"^^xsd:string .
 
-niiri:70dc65955934a45a8cf93fc4a9a8b52f prov:wasDerivedFrom niiri:4bcbccd66dbc3e748dc049ea28e790ec .
+niiri:32b931355eb48f34a576c74d8531d572 prov:wasDerivedFrom niiri:f3b96c552779d9374a531718147427d0 .
 
-niiri:9b7a2eaa3e50c8c2eb1d223e98c25459
+niiri:f5951e733e9591d4ba75b0258296ccca
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0004" ;
-    prov:atLocation niiri:ce62716ad27ce3bd64069dc0e9d261d1 ;
+    prov:atLocation niiri:3efbdfe72d5b5db5c0a2617705ba8152 ;
     prov:value "7.11683940887451"^^xsd:float ;
     nidm_equivalentZStatistic: "6.37404871703245"^^xsd:float ;
     nidm_pValueUncorrected: "9.20510334623259e-11"^^xsd:float ;
     nidm_pValueFWER: "2.05325778424026e-05"^^xsd:float ;
     nidm_qValueFDR: "9.33757664730496e-05"^^xsd:float .
 
-niiri:ce62716ad27ce3bd64069dc0e9d261d1
+niiri:3efbdfe72d5b5db5c0a2617705ba8152
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0004" ;
     nidm_coordinateVector: "[34,-88,-2]"^^xsd:string .
 
-niiri:9b7a2eaa3e50c8c2eb1d223e98c25459 prov:wasDerivedFrom niiri:ede195e83c61c437e885525e08d7a512 .
+niiri:f5951e733e9591d4ba75b0258296ccca prov:wasDerivedFrom niiri:31281ad36fc49da248ac587f4076c953 .
 
-niiri:c280de68d27d9261d076492449efb758
+niiri:b2dfa583b093fac4721ad0ee8e3b22b6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0005" ;
-    prov:atLocation niiri:a2f3773d146316fec09ce151b201310b ;
+    prov:atLocation niiri:a828e9a512b1b18b628b6352b9841b81 ;
     prov:value "6.48292255401611"^^xsd:float ;
     nidm_equivalentZStatistic: "5.8992593141605"^^xsd:float ;
     nidm_pValueUncorrected: "1.82568493656277e-09"^^xsd:float ;
     nidm_pValueFWER: "0.000407231755366277"^^xsd:float ;
     nidm_qValueFDR: "0.000830722551601523"^^xsd:float .
 
-niiri:a2f3773d146316fec09ce151b201310b
+niiri:a828e9a512b1b18b628b6352b9841b81
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0005" ;
     nidm_coordinateVector: "[42,-72,-10]"^^xsd:string .
 
-niiri:c280de68d27d9261d076492449efb758 prov:wasDerivedFrom niiri:ede195e83c61c437e885525e08d7a512 .
+niiri:b2dfa583b093fac4721ad0ee8e3b22b6 prov:wasDerivedFrom niiri:31281ad36fc49da248ac587f4076c953 .
 
-niiri:7b2fa5ed8383543bfaab4a1eec24cade
+niiri:4d03394faeeb99576cb7d36401fb8e9e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0006" ;
-    prov:atLocation niiri:a74572cce81479e7589c91f54edfefb0 ;
+    prov:atLocation niiri:a3ad78691cb88bc080a2ad24b7f4624b ;
     prov:value "5.2275915145874"^^xsd:float ;
     nidm_equivalentZStatistic: "4.89738468004472"^^xsd:float ;
     nidm_pValueUncorrected: "4.85602978606003e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0670610253017228"^^xsd:float ;
     nidm_qValueFDR: "0.0118363293065346"^^xsd:float .
 
-niiri:a74572cce81479e7589c91f54edfefb0
+niiri:a3ad78691cb88bc080a2ad24b7f4624b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0006" ;
     nidm_coordinateVector: "[34,-86,12]"^^xsd:string .
 
-niiri:7b2fa5ed8383543bfaab4a1eec24cade prov:wasDerivedFrom niiri:ede195e83c61c437e885525e08d7a512 .
+niiri:4d03394faeeb99576cb7d36401fb8e9e prov:wasDerivedFrom niiri:31281ad36fc49da248ac587f4076c953 .
 
-niiri:9f386b0dea4861ac2a0e04e0b9a392a4
+niiri:ec9d4f0e234313738c8b9f2aa3bf749f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0007" ;
-    prov:atLocation niiri:0e869382af56c384af273063523cd969 ;
+    prov:atLocation niiri:a8570442309c47fdfec5293c10c727c3 ;
     prov:value "6.28007745742798"^^xsd:float ;
     nidm_equivalentZStatistic: "5.74292583422276"^^xsd:float ;
     nidm_pValueUncorrected: "4.65272453897825e-09"^^xsd:float ;
     nidm_pValueFWER: "0.00103782272796227"^^xsd:float ;
     nidm_qValueFDR: "0.000830722551601523"^^xsd:float .
 
-niiri:0e869382af56c384af273063523cd969
+niiri:a8570442309c47fdfec5293c10c727c3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0007" ;
     nidm_coordinateVector: "[8,18,50]"^^xsd:string .
 
-niiri:9f386b0dea4861ac2a0e04e0b9a392a4 prov:wasDerivedFrom niiri:fa5698ad69d25731ec095f4a19e6b769 .
+niiri:ec9d4f0e234313738c8b9f2aa3bf749f prov:wasDerivedFrom niiri:1bc8b121d587eb836f9b3b7858047889 .
 
-niiri:3629d6e2bdaa9ac9ea88966c4d3a93b3
+niiri:15dd1c92e83f1e367cd3e9341f2376b1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0008" ;
-    prov:atLocation niiri:06c5ec7e5ce2bc219ee52004d24e43e3 ;
+    prov:atLocation niiri:65533b720f685277b5ffaabaea192278 ;
     prov:value "6.15222215652466"^^xsd:float ;
     nidm_equivalentZStatistic: "5.64328512810061"^^xsd:float ;
     nidm_pValueUncorrected: "8.34178537356678e-09"^^xsd:float ;
     nidm_pValueFWER: "0.00186069357054308"^^xsd:float ;
     nidm_qValueFDR: "0.000972721201433817"^^xsd:float .
 
-niiri:06c5ec7e5ce2bc219ee52004d24e43e3
+niiri:65533b720f685277b5ffaabaea192278
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0008" ;
     nidm_coordinateVector: "[-6,12,52]"^^xsd:string .
 
-niiri:3629d6e2bdaa9ac9ea88966c4d3a93b3 prov:wasDerivedFrom niiri:fa5698ad69d25731ec095f4a19e6b769 .
+niiri:15dd1c92e83f1e367cd3e9341f2376b1 prov:wasDerivedFrom niiri:1bc8b121d587eb836f9b3b7858047889 .
 
-niiri:7c4d53aa4f995ab4fc1749a3bab2c536
+niiri:adae04095680f26a1da7f5413ac6928c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0009" ;
-    prov:atLocation niiri:e7dd4788aee3000f6f38f577ceac6361 ;
+    prov:atLocation niiri:ba57c8cb8e6498910435395572d4059b ;
     prov:value "5.98517084121704"^^xsd:float ;
     nidm_equivalentZStatistic: "5.51181334779297"^^xsd:float ;
     nidm_pValueUncorrected: "1.77577724747024e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00376326218366319"^^xsd:float ;
     nidm_qValueFDR: "0.00136419627856355"^^xsd:float .
 
-niiri:e7dd4788aee3000f6f38f577ceac6361
+niiri:ba57c8cb8e6498910435395572d4059b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0009" ;
     nidm_coordinateVector: "[8,32,38]"^^xsd:string .
 
-niiri:7c4d53aa4f995ab4fc1749a3bab2c536 prov:wasDerivedFrom niiri:fa5698ad69d25731ec095f4a19e6b769 .
+niiri:adae04095680f26a1da7f5413ac6928c prov:wasDerivedFrom niiri:1bc8b121d587eb836f9b3b7858047889 .
 
-niiri:c1e2029a13352a22de56a02c2cce423d
+niiri:81e12a87ecad9a224f78f5ba0436d093
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0010" ;
-    prov:atLocation niiri:c38bcefa6c9d8814a02ca72f46bc0ff2 ;
+    prov:atLocation niiri:4e8fd18340a3d30598d15370242d6def ;
     prov:value "6.25127363204956"^^xsd:float ;
     nidm_equivalentZStatistic: "5.72055271981637"^^xsd:float ;
     nidm_pValueUncorrected: "5.30890376104765e-09"^^xsd:float ;
     nidm_pValueFWER: "0.0011841880966994"^^xsd:float ;
     nidm_qValueFDR: "0.000830722551601523"^^xsd:float .
 
-niiri:c38bcefa6c9d8814a02ca72f46bc0ff2
+niiri:4e8fd18340a3d30598d15370242d6def
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0010" ;
     nidm_coordinateVector: "[52,-32,42]"^^xsd:string .
 
-niiri:c1e2029a13352a22de56a02c2cce423d prov:wasDerivedFrom niiri:887b2ca8650505f0a02eb266ef164521 .
+niiri:81e12a87ecad9a224f78f5ba0436d093 prov:wasDerivedFrom niiri:c131d22e9155057f870d66e758ece437 .
 
-niiri:50751fae275003a5f41afd4f8700c77d
+niiri:91ba3878269ac05538257d7f8ed10f1c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0011" ;
-    prov:atLocation niiri:ef692da1ebca004473eb6e5cad511d25 ;
+    prov:atLocation niiri:c83ef98d4875cea36cc2197877333dd8 ;
     prov:value "6.24752378463745"^^xsd:float ;
     nidm_equivalentZStatistic: "5.71763687476157"^^xsd:float ;
     nidm_pValueUncorrected: "5.40078304300806e-09"^^xsd:float ;
     nidm_pValueFWER: "0.00120468241369565"^^xsd:float ;
     nidm_qValueFDR: "0.000830722551601523"^^xsd:float .
 
-niiri:ef692da1ebca004473eb6e5cad511d25
+niiri:c83ef98d4875cea36cc2197877333dd8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0011" ;
     nidm_coordinateVector: "[40,-62,50]"^^xsd:string .
 
-niiri:50751fae275003a5f41afd4f8700c77d prov:wasDerivedFrom niiri:887b2ca8650505f0a02eb266ef164521 .
+niiri:91ba3878269ac05538257d7f8ed10f1c prov:wasDerivedFrom niiri:c131d22e9155057f870d66e758ece437 .
 
-niiri:6d6cd0efd4ce1458bdcd4da4659667d6
+niiri:30283203f0fdcfdedb7c6446c63aa51e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0012" ;
-    prov:atLocation niiri:bc4e0c1814e42357b7e77e4cf2e601bb ;
+    prov:atLocation niiri:732ed2e2fa65230309fc1469c052099e ;
     prov:value "5.70337772369385"^^xsd:float ;
     nidm_equivalentZStatistic: "5.28674301747281"^^xsd:float ;
     nidm_pValueUncorrected: "6.22566831420812e-08"^^xsd:float ;
     nidm_pValueFWER: "0.011413186758684"^^xsd:float ;
     nidm_qValueFDR: "0.00350091530962783"^^xsd:float .
 
-niiri:bc4e0c1814e42357b7e77e4cf2e601bb
+niiri:732ed2e2fa65230309fc1469c052099e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0012" ;
     nidm_coordinateVector: "[56,-44,52]"^^xsd:string .
 
-niiri:6d6cd0efd4ce1458bdcd4da4659667d6 prov:wasDerivedFrom niiri:887b2ca8650505f0a02eb266ef164521 .
+niiri:30283203f0fdcfdedb7c6446c63aa51e prov:wasDerivedFrom niiri:c131d22e9155057f870d66e758ece437 .
 
-niiri:c4ecc93c2106ef923943525cd0c59df7
+niiri:10d8dde0e7451af1a2cb3417fa3976a7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0013" ;
-    prov:atLocation niiri:62de976fac06b4198c82fe0cb8daa0ae ;
+    prov:atLocation niiri:793d5a5dcc585871596598e1989a5a00 ;
     prov:value "6.15371799468994"^^xsd:float ;
     nidm_equivalentZStatistic: "5.64445580026639"^^xsd:float ;
     nidm_pValueUncorrected: "8.285227171001e-09"^^xsd:float ;
     nidm_pValueFWER: "0.00184807786755337"^^xsd:float ;
     nidm_qValueFDR: "0.000972721201433817"^^xsd:float .
 
-niiri:62de976fac06b4198c82fe0cb8daa0ae
+niiri:793d5a5dcc585871596598e1989a5a00
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0013" ;
     nidm_coordinateVector: "[-28,-94,4]"^^xsd:string .
 
-niiri:c4ecc93c2106ef923943525cd0c59df7 prov:wasDerivedFrom niiri:6cda51ac561cc297977a65efb9fbcef6 .
+niiri:10d8dde0e7451af1a2cb3417fa3976a7 prov:wasDerivedFrom niiri:c0d0506786bef63ddf2f635fb7755534 .
 
-niiri:55129f7d132823acf97b88da1d788729
+niiri:d6edab9aa6b5ef4f0c295f9803943d19
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0014" ;
-    prov:atLocation niiri:65a37cf86891551eaa067326591b9b82 ;
+    prov:atLocation niiri:61351f75ee1916faadae7b2aadea0ff2 ;
     prov:value "3.71480798721313"^^xsd:float ;
     nidm_equivalentZStatistic: "3.58412084932714"^^xsd:float ;
     nidm_pValueUncorrected: "0.000169107736440521"^^xsd:float ;
     nidm_pValueFWER: "0.999869855188705"^^xsd:float ;
     nidm_qValueFDR: "0.383925327139989"^^xsd:float .
 
-niiri:65a37cf86891551eaa067326591b9b82
+niiri:61351f75ee1916faadae7b2aadea0ff2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0014" ;
     nidm_coordinateVector: "[-34,-84,-2]"^^xsd:string .
 
-niiri:55129f7d132823acf97b88da1d788729 prov:wasDerivedFrom niiri:6cda51ac561cc297977a65efb9fbcef6 .
+niiri:d6edab9aa6b5ef4f0c295f9803943d19 prov:wasDerivedFrom niiri:c0d0506786bef63ddf2f635fb7755534 .
 
-niiri:5377b5c42bb9a0949b27dee94ed9378d
+niiri:6f4c3201b3b10591156730aeb058f98d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0015" ;
-    prov:atLocation niiri:57d58b1ca384477433dbc1d8864e7fb5 ;
+    prov:atLocation niiri:1dd8f041cfdaf90d4500f0c9d0f92698 ;
     prov:value "6.10109901428223"^^xsd:float ;
     nidm_equivalentZStatistic: "5.60320502193174"^^xsd:float ;
     nidm_pValueUncorrected: "1.05212039080982e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00234682813060005"^^xsd:float ;
     nidm_qValueFDR: "0.00104518293275697"^^xsd:float .
 
-niiri:57d58b1ca384477433dbc1d8864e7fb5
+niiri:1dd8f041cfdaf90d4500f0c9d0f92698
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0015" ;
     nidm_coordinateVector: "[32,2,46]"^^xsd:string .
 
-niiri:5377b5c42bb9a0949b27dee94ed9378d prov:wasDerivedFrom niiri:1ca66ce425b243c3c0035c8186d99a15 .
+niiri:6f4c3201b3b10591156730aeb058f98d prov:wasDerivedFrom niiri:dccd359642442c550b8e126ef0768318 .
 
-niiri:672552bfeda4059be2453699b205003e
+niiri:e09718d2ea585b971df91ec9ab3ce111
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0016" ;
-    prov:atLocation niiri:c47dc48e25fd38babcfac75df201db12 ;
+    prov:atLocation niiri:31217090dc47a01657c91b5135f4774a ;
     prov:value "4.6086859703064"^^xsd:float ;
     nidm_equivalentZStatistic: "4.3736141683061"^^xsd:float ;
     nidm_pValueUncorrected: "6.11031435759912e-06"^^xsd:float ;
     nidm_pValueFWER: "0.453877178455514"^^xsd:float ;
     nidm_qValueFDR: "0.0599714495109201"^^xsd:float .
 
-niiri:c47dc48e25fd38babcfac75df201db12
+niiri:31217090dc47a01657c91b5135f4774a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0016" ;
     nidm_coordinateVector: "[28,4,58]"^^xsd:string .
 
-niiri:672552bfeda4059be2453699b205003e prov:wasDerivedFrom niiri:1ca66ce425b243c3c0035c8186d99a15 .
+niiri:e09718d2ea585b971df91ec9ab3ce111 prov:wasDerivedFrom niiri:dccd359642442c550b8e126ef0768318 .
 
-niiri:a5d5428ae77d82af81fd8ec72340a3b9
+niiri:bf8d2fa297b31faa11d9a75da96a1ecd
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0017" ;
-    prov:atLocation niiri:641e3d2651d7e53387c533f146750b49 ;
+    prov:atLocation niiri:1405899c5a02bcf163ebb333d48c9695 ;
     prov:value "3.98793148994446"^^xsd:float ;
     nidm_equivalentZStatistic: "3.82932508069717"^^xsd:float ;
     nidm_pValueUncorrected: "6.42475887594474e-05"^^xsd:float ;
     nidm_pValueFWER: "0.984644566584946"^^xsd:float ;
     nidm_qValueFDR: "0.233149120368192"^^xsd:float .
 
-niiri:641e3d2651d7e53387c533f146750b49
+niiri:1405899c5a02bcf163ebb333d48c9695
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0017" ;
     nidm_coordinateVector: "[42,4,48]"^^xsd:string .
 
-niiri:a5d5428ae77d82af81fd8ec72340a3b9 prov:wasDerivedFrom niiri:1ca66ce425b243c3c0035c8186d99a15 .
+niiri:bf8d2fa297b31faa11d9a75da96a1ecd prov:wasDerivedFrom niiri:dccd359642442c550b8e126ef0768318 .
 
-niiri:abff4adeaf3d10ac8b1eff4e23445323
+niiri:b1491cceb4af6aa6b3bf2ca1bf80d7ed
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0018" ;
-    prov:atLocation niiri:5909ae01ba922389005e6322fd2284a1 ;
+    prov:atLocation niiri:a5f8fb798258fe5ff8b0d433dc52e3d4 ;
     prov:value "5.98348569869995"^^xsd:float ;
     nidm_equivalentZStatistic: "5.51047970249337"^^xsd:float ;
     nidm_pValueUncorrected: "1.78928538652201e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00378871596531738"^^xsd:float ;
     nidm_qValueFDR: "0.00136419627856355"^^xsd:float .
 
-niiri:5909ae01ba922389005e6322fd2284a1
+niiri:a5f8fb798258fe5ff8b0d433dc52e3d4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0018" ;
     nidm_coordinateVector: "[-52,0,38]"^^xsd:string .
 
-niiri:abff4adeaf3d10ac8b1eff4e23445323 prov:wasDerivedFrom niiri:c69f007bda67f5e2a0a40c91717f128b .
+niiri:b1491cceb4af6aa6b3bf2ca1bf80d7ed prov:wasDerivedFrom niiri:4c25e0ccdac5828019bc6ab24105a598 .
 
-niiri:3670c9d957ad21491f858b62b748b05b
+niiri:4728f15a30a3478ad47a3573b31291a2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0019" ;
-    prov:atLocation niiri:bb4a0c3f5a62bc346e6319dbdb6605f7 ;
+    prov:atLocation niiri:7cb43e92d04918591f6c8f33a35fd1a4 ;
     prov:value "5.2253565788269"^^xsd:float ;
     nidm_equivalentZStatistic: "4.89552821543552"^^xsd:float ;
     nidm_pValueUncorrected: "4.90210114501011e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0675937275056587"^^xsd:float ;
     nidm_qValueFDR: "0.0118363293065346"^^xsd:float .
 
-niiri:bb4a0c3f5a62bc346e6319dbdb6605f7
+niiri:7cb43e92d04918591f6c8f33a35fd1a4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0019" ;
     nidm_coordinateVector: "[-60,8,20]"^^xsd:string .
 
-niiri:3670c9d957ad21491f858b62b748b05b prov:wasDerivedFrom niiri:c69f007bda67f5e2a0a40c91717f128b .
+niiri:4728f15a30a3478ad47a3573b31291a2 prov:wasDerivedFrom niiri:4c25e0ccdac5828019bc6ab24105a598 .
 
-niiri:39d19667145286e3ad7182d0806bfaa9
+niiri:2846f983f4248ecf39eb3d072230034f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0020" ;
-    prov:atLocation niiri:a0470afe66823c0a4aaa368fbb26ed16 ;
+    prov:atLocation niiri:f11c725020f0b62e517ee9feeaa492b4 ;
     prov:value "4.98950004577637"^^xsd:float ;
     nidm_equivalentZStatistic: "4.69817956585148"^^xsd:float ;
     nidm_pValueUncorrected: "1.31245304380023e-06"^^xsd:float ;
     nidm_pValueFWER: "0.151048137890434"^^xsd:float ;
     nidm_qValueFDR: "0.0233609510296683"^^xsd:float .
 
-niiri:a0470afe66823c0a4aaa368fbb26ed16
+niiri:f11c725020f0b62e517ee9feeaa492b4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0020" ;
     nidm_coordinateVector: "[-44,6,28]"^^xsd:string .
 
-niiri:39d19667145286e3ad7182d0806bfaa9 prov:wasDerivedFrom niiri:c69f007bda67f5e2a0a40c91717f128b .
+niiri:2846f983f4248ecf39eb3d072230034f prov:wasDerivedFrom niiri:4c25e0ccdac5828019bc6ab24105a598 .
 
-niiri:287c6a76f4bab73956e8836a41a3d561
+niiri:c839fd693cb9f15e4f75ff285bd20825
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0021" ;
-    prov:atLocation niiri:954b7c65ad1e956e482159d509289ea3 ;
+    prov:atLocation niiri:0d681cd86b3782448e46f423694c73cd ;
     prov:value "5.78093099594116"^^xsd:float ;
     nidm_equivalentZStatistic: "5.34909755317379"^^xsd:float ;
     nidm_pValueUncorrected: "4.41969442155354e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00844151822925698"^^xsd:float ;
     nidm_qValueFDR: "0.00286742427823329"^^xsd:float .
 
-niiri:954b7c65ad1e956e482159d509289ea3
+niiri:0d681cd86b3782448e46f423694c73cd
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0021" ;
     nidm_coordinateVector: "[-34,-2,52]"^^xsd:string .
 
-niiri:287c6a76f4bab73956e8836a41a3d561 prov:wasDerivedFrom niiri:8009c6c2577ffab297b9446c56ac691e .
+niiri:c839fd693cb9f15e4f75ff285bd20825 prov:wasDerivedFrom niiri:439c3d37a059fc0c9fe663876cd44696 .
 
-niiri:b88ea08754ef7ca35d6cc3a42c0b1ae9
+niiri:2fe2b34ab4c1433aecafed937c37e601
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0022" ;
-    prov:atLocation niiri:db2e556f7e44e2aa5d3ab23e5842cea4 ;
+    prov:atLocation niiri:1368b3660adcb57e09b9a1f1f88185f4 ;
     prov:value "5.40964078903198"^^xsd:float ;
     nidm_equivalentZStatistic: "5.04774404642803"^^xsd:float ;
     nidm_pValueUncorrected: "2.23528758724889e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0346958937061391"^^xsd:float ;
     nidm_qValueFDR: "0.00846044059259994"^^xsd:float .
 
-niiri:db2e556f7e44e2aa5d3ab23e5842cea4
+niiri:1368b3660adcb57e09b9a1f1f88185f4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0022" ;
     nidm_coordinateVector: "[-54,-46,58]"^^xsd:string .
 
-niiri:b88ea08754ef7ca35d6cc3a42c0b1ae9 prov:wasDerivedFrom niiri:ccbb2dcff74d28dda3be2c8bc2f59ef2 .
+niiri:2fe2b34ab4c1433aecafed937c37e601 prov:wasDerivedFrom niiri:e4902bb46a21f477eb5d9e386fc19878 .
 
-niiri:e4c0f5a5eb4b4c6266927153c72f5e73
+niiri:072b9ac5eb756bc6330b5dadc2697fbd
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0023" ;
-    prov:atLocation niiri:ccd488f99ad859d43858b5ff8551964a ;
+    prov:atLocation niiri:37e4188c492c5a4165b3dac3071e5850 ;
     prov:value "5.31841945648193"^^xsd:float ;
     nidm_equivalentZStatistic: "4.97261482231588"^^xsd:float ;
     nidm_pValueUncorrected: "3.30279114724163e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0484353441449864"^^xsd:float ;
     nidm_qValueFDR: "0.0106752417476244"^^xsd:float .
 
-niiri:ccd488f99ad859d43858b5ff8551964a
+niiri:37e4188c492c5a4165b3dac3071e5850
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0023" ;
     nidm_coordinateVector: "[-62,-38,48]"^^xsd:string .
 
-niiri:e4c0f5a5eb4b4c6266927153c72f5e73 prov:wasDerivedFrom niiri:86578a06fc311c81acbc580eb1d83642 .
+niiri:072b9ac5eb756bc6330b5dadc2697fbd prov:wasDerivedFrom niiri:392b01269887f7941cf41e331de9925c .
 
-niiri:7c7465214b57551e71b55c2a8308ed5c
+niiri:8267f3c7f7dd3ca73f48fdd78c883180
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0024" ;
-    prov:atLocation niiri:cc537fe44acdaad46beaaa820fcd1c22 ;
+    prov:atLocation niiri:2f52144540b5809f055058dec6116471 ;
     prov:value "4.57099342346191"^^xsd:float ;
     nidm_equivalentZStatistic: "4.34109644800954"^^xsd:float ;
     nidm_pValueUncorrected: "7.08867353027554e-06"^^xsd:float ;
     nidm_pValueFWER: "0.496004086968197"^^xsd:float ;
     nidm_qValueFDR: "0.0635474729952592"^^xsd:float .
 
-niiri:cc537fe44acdaad46beaaa820fcd1c22
+niiri:2f52144540b5809f055058dec6116471
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0024" ;
     nidm_coordinateVector: "[-60,-50,48]"^^xsd:string .
 
-niiri:7c7465214b57551e71b55c2a8308ed5c prov:wasDerivedFrom niiri:86578a06fc311c81acbc580eb1d83642 .
+niiri:8267f3c7f7dd3ca73f48fdd78c883180 prov:wasDerivedFrom niiri:392b01269887f7941cf41e331de9925c .
 
-niiri:769669dfd8c20fd64aa8f42df6cf71ae
+niiri:febe52264f5e54a6a5b0f5444ac1b68c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0025" ;
-    prov:atLocation niiri:039a4bc21a49d35121505ab11dfc0f15 ;
+    prov:atLocation niiri:bb31516c2b7139961eca38d0f885ab41 ;
     prov:value "5.30699443817139"^^xsd:float ;
     nidm_equivalentZStatistic: "4.96317509467693"^^xsd:float ;
     nidm_pValueUncorrected: "3.46750043123123e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0504786376455083"^^xsd:float ;
     nidm_qValueFDR: "0.0106752417476244"^^xsd:float .
 
-niiri:039a4bc21a49d35121505ab11dfc0f15
+niiri:bb31516c2b7139961eca38d0f885ab41
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0025" ;
     nidm_coordinateVector: "[32,40,16]"^^xsd:string .
 
-niiri:769669dfd8c20fd64aa8f42df6cf71ae prov:wasDerivedFrom niiri:9c4395321a8582f0da12ba759320292c .
+niiri:febe52264f5e54a6a5b0f5444ac1b68c prov:wasDerivedFrom niiri:7e231620402d8b69f99aa21ba8f6b058 .
 
-niiri:591a8417c1edc6a1145bc440c259e8b9
+niiri:7a9aad9b667e6ea2734b6e8dfe04acd7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0026" ;
-    prov:atLocation niiri:fe24dec61e5bd028e9862bb8234d07db ;
+    prov:atLocation niiri:45969fab01b5727b00223bf465f615c0 ;
     prov:value "4.5497465133667"^^xsd:float ;
     nidm_equivalentZStatistic: "4.32273570618355"^^xsd:float ;
     nidm_pValueUncorrected: "7.7053150754347e-06"^^xsd:float ;
     nidm_pValueFWER: "0.520378392891944"^^xsd:float ;
     nidm_qValueFDR: "0.0649997423676262"^^xsd:float .
 
-niiri:fe24dec61e5bd028e9862bb8234d07db
+niiri:45969fab01b5727b00223bf465f615c0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0026" ;
     nidm_coordinateVector: "[40,46,12]"^^xsd:string .
 
-niiri:591a8417c1edc6a1145bc440c259e8b9 prov:wasDerivedFrom niiri:9c4395321a8582f0da12ba759320292c .
+niiri:7a9aad9b667e6ea2734b6e8dfe04acd7 prov:wasDerivedFrom niiri:7e231620402d8b69f99aa21ba8f6b058 .
 
-niiri:0f02589e55ad49fadec50d378d54d41e
+niiri:685d9eb36c33716b1c7e61d0a5ffb870
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0027" ;
-    prov:atLocation niiri:ca18854e03c492e5b991337e774d0dc7 ;
+    prov:atLocation niiri:b5e6f22c3e4ceb8f75b6756624dc984f ;
     prov:value "4.31582498550415"^^xsd:float ;
     nidm_equivalentZStatistic: "4.11913273798974"^^xsd:float ;
     nidm_pValueUncorrected: "1.90150518718513e-05"^^xsd:float ;
     nidm_pValueFWER: "0.788829013385429"^^xsd:float ;
     nidm_qValueFDR: "0.116130094830597"^^xsd:float .
 
-niiri:ca18854e03c492e5b991337e774d0dc7
+niiri:b5e6f22c3e4ceb8f75b6756624dc984f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0027" ;
     nidm_coordinateVector: "[36,54,6]"^^xsd:string .
 
-niiri:0f02589e55ad49fadec50d378d54d41e prov:wasDerivedFrom niiri:9c4395321a8582f0da12ba759320292c .
+niiri:685d9eb36c33716b1c7e61d0a5ffb870 prov:wasDerivedFrom niiri:7e231620402d8b69f99aa21ba8f6b058 .
 
-niiri:3df5f1dea689940a961c1a59e79fb78e
+niiri:4c95fa10598ea9fed0a1913a9efd2fec
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0028" ;
-    prov:atLocation niiri:ae299c071e205411af94f37baf78ce3f ;
+    prov:atLocation niiri:44c91cfa2af752860c64b94ae533e716 ;
     prov:value "5.27030229568481"^^xsd:float ;
     nidm_equivalentZStatistic: "4.93281349716267"^^xsd:float ;
     nidm_pValueUncorrected: "4.05267701952816e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0575990926145485"^^xsd:float ;
     nidm_qValueFDR: "0.0110040663565173"^^xsd:float .
 
-niiri:ae299c071e205411af94f37baf78ce3f
+niiri:44c91cfa2af752860c64b94ae533e716
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0028" ;
     nidm_coordinateVector: "[40,26,48]"^^xsd:string .
 
-niiri:3df5f1dea689940a961c1a59e79fb78e prov:wasDerivedFrom niiri:e84befdceca7e9fb020e4e603e6d2441 .
+niiri:4c95fa10598ea9fed0a1913a9efd2fec prov:wasDerivedFrom niiri:c6a240b5ad789d06fb0190076dcbb863 .
 
-niiri:b10cf84edc33f058847a2c97a7caae0a
+niiri:a3e7b604bb117fab93742f1fd5e8f473
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0029" ;
-    prov:atLocation niiri:8e3afe311c73cc788f118e5f53e9ca7a ;
+    prov:atLocation niiri:1d6bbd703ff2243ac599b69731c47544 ;
     prov:value "4.93343877792358"^^xsd:float ;
     nidm_equivalentZStatistic: "4.65085575575197"^^xsd:float ;
     nidm_pValueUncorrected: "1.6528024058271e-06"^^xsd:float ;
     nidm_pValueFWER: "0.180887232162623"^^xsd:float ;
     nidm_qValueFDR: "0.0254967087736733"^^xsd:float .
 
-niiri:8e3afe311c73cc788f118e5f53e9ca7a
+niiri:1d6bbd703ff2243ac599b69731c47544
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0029" ;
     nidm_coordinateVector: "[-58,-30,-18]"^^xsd:string .
 
-niiri:b10cf84edc33f058847a2c97a7caae0a prov:wasDerivedFrom niiri:3921a44ffb5cf54649ee43045d6cc96a .
+niiri:a3e7b604bb117fab93742f1fd5e8f473 prov:wasDerivedFrom niiri:1b71ce972cf56fb139ab88975f4640c9 .
 
-niiri:31df4d204ab31be89ea5dd24f01fd78d
+niiri:58ec7f33f37bb7ef67d8acccf7b40081
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0030" ;
-    prov:atLocation niiri:a99d807ab49efc17f5a4f12e6bcb0853 ;
+    prov:atLocation niiri:4c332c72810f59b3208483ae780441ef ;
     prov:value "4.76414346694946"^^xsd:float ;
     nidm_equivalentZStatistic: "4.50698548813516"^^xsd:float ;
     nidm_pValueUncorrected: "3.287756441539e-06"^^xsd:float ;
     nidm_pValueFWER: "0.301278778226174"^^xsd:float ;
     nidm_qValueFDR: "0.0396433885053995"^^xsd:float .
 
-niiri:a99d807ab49efc17f5a4f12e6bcb0853
+niiri:4c332c72810f59b3208483ae780441ef
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0030" ;
     nidm_coordinateVector: "[-46,-66,-6]"^^xsd:string .
 
-niiri:31df4d204ab31be89ea5dd24f01fd78d prov:wasDerivedFrom niiri:d195c6d760a60eb9860a72f0fa5d33b6 .
+niiri:58ec7f33f37bb7ef67d8acccf7b40081 prov:wasDerivedFrom niiri:ca0dd10dbf94ba5d07f8de45f011307c .
 
-niiri:d5cc3fc341bf072546957897c7f0d343
+niiri:78bd497bb5dc90d3f2b4e3ced5e4fe7a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0031" ;
-    prov:atLocation niiri:ce9115dd9684d2946ac94d95e96a151d ;
+    prov:atLocation niiri:c699689651173fd2a45ae693a27b8ce4 ;
     prov:value "3.7637345790863"^^xsd:float ;
     nidm_equivalentZStatistic: "3.62829384243901"^^xsd:float ;
     nidm_pValueUncorrected: "0.000142650218672435"^^xsd:float ;
     nidm_pValueFWER: "0.999605970761399"^^xsd:float ;
     nidm_qValueFDR: "0.34409224637793"^^xsd:float .
 
-niiri:ce9115dd9684d2946ac94d95e96a151d
+niiri:c699689651173fd2a45ae693a27b8ce4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0031" ;
     nidm_coordinateVector: "[-54,-64,-8]"^^xsd:string .
 
-niiri:d5cc3fc341bf072546957897c7f0d343 prov:wasDerivedFrom niiri:d195c6d760a60eb9860a72f0fa5d33b6 .
+niiri:78bd497bb5dc90d3f2b4e3ced5e4fe7a prov:wasDerivedFrom niiri:ca0dd10dbf94ba5d07f8de45f011307c .
 
-niiri:83636273b177146ce249a14043f3bd81
+niiri:0635a977111ede7fa6bc63091cd0e675
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0032" ;
-    prov:atLocation niiri:f5ddd1fd9758595b3b0dd5266dc4a82f ;
+    prov:atLocation niiri:b5dbb05246499ae43a44b9697932ef7d ;
     prov:value "4.72232866287231"^^xsd:float ;
     nidm_equivalentZStatistic: "4.47122948835043"^^xsd:float ;
     nidm_pValueUncorrected: "3.88855941602095e-06"^^xsd:float ;
     nidm_pValueFWER: "0.338512677882141"^^xsd:float ;
     nidm_qValueFDR: "0.044836631144536"^^xsd:float .
 
-niiri:f5ddd1fd9758595b3b0dd5266dc4a82f
+niiri:b5dbb05246499ae43a44b9697932ef7d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0032" ;
     nidm_coordinateVector: "[58,-38,6]"^^xsd:string .
 
-niiri:83636273b177146ce249a14043f3bd81 prov:wasDerivedFrom niiri:eb6f2c1f9fab3eef26fb05dad9eee378 .
+niiri:0635a977111ede7fa6bc63091cd0e675 prov:wasDerivedFrom niiri:cae6fd96eea7e9972a3dd49f5837e19f .
 
-niiri:dfc942b6182952e994d59f93fa7cffc3
+niiri:ff64de7e90ef291344583e6b3ac31db1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0033" ;
-    prov:atLocation niiri:271055043356196b1fe09d2452976bcb ;
+    prov:atLocation niiri:cddf881c6e42c41e1712c3dcfd7cc65d ;
     prov:value "3.98372888565063"^^xsd:float ;
     nidm_equivalentZStatistic: "3.8255778871433"^^xsd:float ;
     nidm_pValueUncorrected: "6.52328381068878e-05"^^xsd:float ;
     nidm_pValueFWER: "0.985409231324461"^^xsd:float ;
     nidm_qValueFDR: "0.233731539105478"^^xsd:float .
 
-niiri:271055043356196b1fe09d2452976bcb
+niiri:cddf881c6e42c41e1712c3dcfd7cc65d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0033" ;
     nidm_coordinateVector: "[64,-30,-4]"^^xsd:string .
 
-niiri:dfc942b6182952e994d59f93fa7cffc3 prov:wasDerivedFrom niiri:eb6f2c1f9fab3eef26fb05dad9eee378 .
+niiri:ff64de7e90ef291344583e6b3ac31db1 prov:wasDerivedFrom niiri:cae6fd96eea7e9972a3dd49f5837e19f .
 
-niiri:549a1e66bb4d6d1a6980fc15ec7c687a
+niiri:ea99a82e713304e75f5d834789fc3609
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0034" ;
-    prov:atLocation niiri:2baa8daf20af089a3632fab6b3bd2f9b ;
+    prov:atLocation niiri:c72302c49efa40a4578b8e26bdabfb7b ;
     prov:value "3.50753784179688"^^xsd:float ;
     nidm_equivalentZStatistic: "3.39582098150001"^^xsd:float ;
     nidm_pValueUncorrected: "0.000342115474631921"^^xsd:float ;
     nidm_pValueFWER: "0.999999778829603"^^xsd:float ;
     nidm_qValueFDR: "0.564856004417035"^^xsd:float .
 
-niiri:2baa8daf20af089a3632fab6b3bd2f9b
+niiri:c72302c49efa40a4578b8e26bdabfb7b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0034" ;
     nidm_coordinateVector: "[60,-40,-12]"^^xsd:string .
 
-niiri:549a1e66bb4d6d1a6980fc15ec7c687a prov:wasDerivedFrom niiri:eb6f2c1f9fab3eef26fb05dad9eee378 .
+niiri:ea99a82e713304e75f5d834789fc3609 prov:wasDerivedFrom niiri:cae6fd96eea7e9972a3dd49f5837e19f .
 
-niiri:7371044958cc47404fd82f339ebb008b
+niiri:f229e485b8e3ee7f5cd9e3690d44e1dc
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0035" ;
-    prov:atLocation niiri:4c4a59d2ea3cd308f28682c6c74dacc2 ;
+    prov:atLocation niiri:35c5569d0795499fb727a1041cef0d38 ;
     prov:value "4.70483255386353"^^xsd:float ;
     nidm_equivalentZStatistic: "4.45624265093732"^^xsd:float ;
     nidm_pValueUncorrected: "4.17043099876224e-06"^^xsd:float ;
     nidm_pValueFWER: "0.354967306449537"^^xsd:float ;
     nidm_qValueFDR: "0.0466228196503302"^^xsd:float .
 
-niiri:4c4a59d2ea3cd308f28682c6c74dacc2
+niiri:35c5569d0795499fb727a1041cef0d38
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0035" ;
     nidm_coordinateVector: "[-36,-74,-14]"^^xsd:string .
 
-niiri:7371044958cc47404fd82f339ebb008b prov:wasDerivedFrom niiri:3efe9387862f59b37bf90987a3a01074 .
+niiri:f229e485b8e3ee7f5cd9e3690d44e1dc prov:wasDerivedFrom niiri:a5ea3c101aaf1b98c7ee58fcc76dff1b .
 
-niiri:d7b71fa497e0f8780396e93232c93a4e
+niiri:47c14511d37e558a3fb5b4c44e333292
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0036" ;
-    prov:atLocation niiri:5d39e0678df9edef83d5f57dab0be0bd ;
+    prov:atLocation niiri:e421002626e0d3b2155132ea5f9909af ;
     prov:value "4.08770418167114"^^xsd:float ;
     nidm_equivalentZStatistic: "3.91804495668"^^xsd:float ;
     nidm_pValueUncorrected: "4.46350297789166e-05"^^xsd:float ;
     nidm_pValueFWER: "0.955724279224547"^^xsd:float ;
     nidm_qValueFDR: "0.186719971332974"^^xsd:float .
 
-niiri:5d39e0678df9edef83d5f57dab0be0bd
+niiri:e421002626e0d3b2155132ea5f9909af
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0036" ;
     nidm_coordinateVector: "[-36,-68,-20]"^^xsd:string .
 
-niiri:d7b71fa497e0f8780396e93232c93a4e prov:wasDerivedFrom niiri:3efe9387862f59b37bf90987a3a01074 .
+niiri:47c14511d37e558a3fb5b4c44e333292 prov:wasDerivedFrom niiri:a5ea3c101aaf1b98c7ee58fcc76dff1b .
 
-niiri:d3498a22c3f387bce3184bd9d945a4b0
+niiri:e5ced5655aca3ab6d63936e6dbc4d14e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0037" ;
-    prov:atLocation niiri:470de650a3b555c25105787679347005 ;
+    prov:atLocation niiri:dcc9a77d6e6075391c18a887c0b9c878 ;
     prov:value "3.71012616157532"^^xsd:float ;
     nidm_equivalentZStatistic: "3.57988831343959"^^xsd:float ;
     nidm_pValueUncorrected: "0.000171870546999631"^^xsd:float ;
     nidm_pValueFWER: "0.999883757236262"^^xsd:float ;
     nidm_qValueFDR: "0.385893135248467"^^xsd:float .
 
-niiri:470de650a3b555c25105787679347005
+niiri:dcc9a77d6e6075391c18a887c0b9c878
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0037" ;
     nidm_coordinateVector: "[-30,-58,-16]"^^xsd:string .
 
-niiri:d3498a22c3f387bce3184bd9d945a4b0 prov:wasDerivedFrom niiri:3efe9387862f59b37bf90987a3a01074 .
+niiri:e5ced5655aca3ab6d63936e6dbc4d14e prov:wasDerivedFrom niiri:a5ea3c101aaf1b98c7ee58fcc76dff1b .
 
-niiri:4c2e1d5de4bf5e134f969677c839dcb0
+niiri:c84076330649c427ef2696347c4054ae
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0038" ;
-    prov:atLocation niiri:88ebd3fd625a43cc687be7c3b4700dc7 ;
+    prov:atLocation niiri:0aa3d7e4b295c6343a575906df312730 ;
     prov:value "4.59621620178223"^^xsd:float ;
     nidm_equivalentZStatistic: "4.36286413267216"^^xsd:float ;
     nidm_pValueUncorrected: "6.41853365035416e-06"^^xsd:float ;
     nidm_pValueFWER: "0.467637998233248"^^xsd:float ;
     nidm_qValueFDR: "0.0604181585485856"^^xsd:float .
 
-niiri:88ebd3fd625a43cc687be7c3b4700dc7
+niiri:0aa3d7e4b295c6343a575906df312730
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0038" ;
     nidm_coordinateVector: "[16,-98,6]"^^xsd:string .
 
-niiri:4c2e1d5de4bf5e134f969677c839dcb0 prov:wasDerivedFrom niiri:4fec4e3138e166ee2892b0d3d91bb41e .
+niiri:c84076330649c427ef2696347c4054ae prov:wasDerivedFrom niiri:6f05166f31ef45c33808420434a13f55 .
 
-niiri:a96ffbcdd2cd1748a4acbfbee1c8e854
+niiri:e2506b44ed692dcde07aecfe65313995
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0039" ;
-    prov:atLocation niiri:f0bed83aaf9d16bfbd628901bf04c3e1 ;
+    prov:atLocation niiri:1b80736cff1f2516ac52233b65e1d43d ;
     prov:value "4.57891654968262"^^xsd:float ;
     nidm_equivalentZStatistic: "4.34793761600864"^^xsd:float ;
     nidm_pValueUncorrected: "6.87118388575936e-06"^^xsd:float ;
     nidm_pValueFWER: "0.487021764768749"^^xsd:float ;
     nidm_qValueFDR: "0.0629240173925056"^^xsd:float .
 
-niiri:f0bed83aaf9d16bfbd628901bf04c3e1
+niiri:1b80736cff1f2516ac52233b65e1d43d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0039" ;
     nidm_coordinateVector: "[-60,-16,28]"^^xsd:string .
 
-niiri:a96ffbcdd2cd1748a4acbfbee1c8e854 prov:wasDerivedFrom niiri:0b5064760982e8c270bd98284ecb06d3 .
+niiri:e2506b44ed692dcde07aecfe65313995 prov:wasDerivedFrom niiri:f686250b6fb996d621aa21cdf5cf6717 .
 
-niiri:d0e988a4e21373a9557ce8b133dc489e
+niiri:a711ec92a5095b7cc31e6073cba60aeb
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0040" ;
-    prov:atLocation niiri:18cd91ecc562fcddb7007b0671e8606a ;
+    prov:atLocation niiri:bbea81c0dc1081250ce2a110d7d6270d ;
     prov:value "4.37013816833496"^^xsd:float ;
     nidm_equivalentZStatistic: "4.16664310578498"^^xsd:float ;
     nidm_pValueUncorrected: "1.54558935169247e-05"^^xsd:float ;
     nidm_pValueFWER: "0.730405153245217"^^xsd:float ;
     nidm_qValueFDR: "0.101858458171742"^^xsd:float .
 
-niiri:18cd91ecc562fcddb7007b0671e8606a
+niiri:bbea81c0dc1081250ce2a110d7d6270d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0040" ;
     nidm_coordinateVector: "[-52,-62,52]"^^xsd:string .
 
-niiri:d0e988a4e21373a9557ce8b133dc489e prov:wasDerivedFrom niiri:71ab02bff3b085bb7b9a91d459a832f0 .
+niiri:a711ec92a5095b7cc31e6073cba60aeb prov:wasDerivedFrom niiri:36a0a86f1b5fa4bc787a9c7b7eba11a2 .
 
-niiri:3b31a99a7423016e7748f2f4a6b35b55
+niiri:4babfa934e3c293ae57513a1dbf42b27
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0041" ;
-    prov:atLocation niiri:2097c555a217b1ea96a300093759a750 ;
+    prov:atLocation niiri:eb0e468fad0731dc048069a34964eba0 ;
     prov:value "4.24533367156982"^^xsd:float ;
     nidm_equivalentZStatistic: "4.05725918601008"^^xsd:float ;
     nidm_pValueUncorrected: "2.4825985211363e-05"^^xsd:float ;
     nidm_pValueFWER: "0.855631833511506"^^xsd:float ;
     nidm_qValueFDR: "0.135717263652471"^^xsd:float .
 
-niiri:2097c555a217b1ea96a300093759a750
+niiri:eb0e468fad0731dc048069a34964eba0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0041" ;
     nidm_coordinateVector: "[-18,-60,48]"^^xsd:string .
 
-niiri:3b31a99a7423016e7748f2f4a6b35b55 prov:wasDerivedFrom niiri:5e8275841ed71a0e7a9cc2f07fba7508 .
+niiri:4babfa934e3c293ae57513a1dbf42b27 prov:wasDerivedFrom niiri:ee27ca4fbf4487cbf6ede6f498d03b89 .
 
-niiri:5c80b51a06991a61ebc72500b74c3a33
+niiri:2c50f18e7e3b4acc2a572ba2fbdb7169
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0042" ;
-    prov:atLocation niiri:b1d91ba88a5a6a57c638fd74892d5b0c ;
+    prov:atLocation niiri:f37e4ddd039f0786c97ddd37a174dedd ;
     prov:value "4.22599840164185"^^xsd:float ;
     nidm_equivalentZStatistic: "4.04024618213588"^^xsd:float ;
     nidm_pValueUncorrected: "2.66975618669063e-05"^^xsd:float ;
     nidm_pValueFWER: "0.871760516202526"^^xsd:float ;
     nidm_qValueFDR: "0.138603763901635"^^xsd:float .
 
-niiri:b1d91ba88a5a6a57c638fd74892d5b0c
+niiri:f37e4ddd039f0786c97ddd37a174dedd
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0042" ;
     nidm_coordinateVector: "[-36,-74,-34]"^^xsd:string .
 
-niiri:5c80b51a06991a61ebc72500b74c3a33 prov:wasDerivedFrom niiri:7d836a379d88c30e45968812bcbaec09 .
+niiri:2c50f18e7e3b4acc2a572ba2fbdb7169 prov:wasDerivedFrom niiri:f6df377f07bd1d85bb45726e6330c017 .
 
-niiri:1644ed1eb30398c5afe76833898dfc59
+niiri:1ef0626fbe7b6528eb64d1fc1902fdff
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0043" ;
-    prov:atLocation niiri:e16b365b8144685b1efcdf60c337ea5b ;
+    prov:atLocation niiri:fa8d5f5a9b143e007389f2fdcb17fb3a ;
     prov:value "4.20391035079956"^^xsd:float ;
     nidm_equivalentZStatistic: "4.02078923241408"^^xsd:float ;
     nidm_pValueUncorrected: "2.900174224163e-05"^^xsd:float ;
     nidm_pValueFWER: "0.888907080881232"^^xsd:float ;
     nidm_qValueFDR: "0.143583628261646"^^xsd:float .
 
-niiri:e16b365b8144685b1efcdf60c337ea5b
+niiri:fa8d5f5a9b143e007389f2fdcb17fb3a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0043" ;
     nidm_coordinateVector: "[34,-54,-16]"^^xsd:string .
 
-niiri:1644ed1eb30398c5afe76833898dfc59 prov:wasDerivedFrom niiri:6d9719aa34ea98f8ee1e2190f57a38c2 .
+niiri:1ef0626fbe7b6528eb64d1fc1902fdff prov:wasDerivedFrom niiri:0f57c541cf04642c5618cb3c8c754be3 .
 
-niiri:3e7a43420e86cacea16dd57ac398f26c
+niiri:be786d3fdaa6a6946a7e31cca13afc20
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0044" ;
-    prov:atLocation niiri:16630efaff9edb2b8b01f9b07b105396 ;
+    prov:atLocation niiri:fd3442b98529d2f70ead87b5000c6342 ;
     prov:value "4.17404651641846"^^xsd:float ;
     nidm_equivalentZStatistic: "3.99444589181498"^^xsd:float ;
     nidm_pValueUncorrected: "3.24228638075574e-05"^^xsd:float ;
     nidm_pValueFWER: "0.909844421846994"^^xsd:float ;
     nidm_qValueFDR: "0.153735203854581"^^xsd:float .
 
-niiri:16630efaff9edb2b8b01f9b07b105396
+niiri:fd3442b98529d2f70ead87b5000c6342
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0044" ;
     nidm_coordinateVector: "[-40,-38,44]"^^xsd:string .
 
-niiri:3e7a43420e86cacea16dd57ac398f26c prov:wasDerivedFrom niiri:7a9b91d6cb78bfe1263ffc584d3b69d2 .
+niiri:be786d3fdaa6a6946a7e31cca13afc20 prov:wasDerivedFrom niiri:10dca7f82f910606e689ba8e2b5af3ff .
 
-niiri:f7ff1f673967cba21b75d59b4f4441aa
+niiri:d5463f9ce8c3e863106d9a205e4c2c3a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0045" ;
-    prov:atLocation niiri:eed02f4efb26f5a9fcb1510bc214de78 ;
+    prov:atLocation niiri:bf85679e3d6743985d98d3df6f63ab50 ;
     prov:value "4.12145137786865"^^xsd:float ;
     nidm_equivalentZStatistic: "3.94794832362008"^^xsd:float ;
     nidm_pValueUncorrected: "3.94119065879606e-05"^^xsd:float ;
     nidm_pValueFWER: "0.940339218142555"^^xsd:float ;
     nidm_qValueFDR: "0.172448885449819"^^xsd:float .
 
-niiri:eed02f4efb26f5a9fcb1510bc214de78
+niiri:bf85679e3d6743985d98d3df6f63ab50
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0045" ;
     nidm_coordinateVector: "[-48,-72,2]"^^xsd:string .
 
-niiri:f7ff1f673967cba21b75d59b4f4441aa prov:wasDerivedFrom niiri:9dae134cd7326c7dd74b40d61a138556 .
+niiri:d5463f9ce8c3e863106d9a205e4c2c3a prov:wasDerivedFrom niiri:34abbea5b5b7e9caec8749719282f69d .
 
-niiri:626924a6d4337fea901f4f8dfe33e2f7
+niiri:23d3e4257473feb39f485dec221abb31
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0046" ;
-    prov:atLocation niiri:a33af7316a855042e55451e73a000ab6 ;
+    prov:atLocation niiri:c3b3402429d4a8377c7a30cb88abe2dd ;
     prov:value "4.07333517074585"^^xsd:float ;
     nidm_equivalentZStatistic: "3.9052963692066"^^xsd:float ;
     nidm_pValueUncorrected: "4.70549882543025e-05"^^xsd:float ;
     nidm_pValueFWER: "0.961337330645756"^^xsd:float ;
     nidm_qValueFDR: "0.192831151077206"^^xsd:float .
 
-niiri:a33af7316a855042e55451e73a000ab6
+niiri:c3b3402429d4a8377c7a30cb88abe2dd
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0046" ;
     nidm_coordinateVector: "[20,-66,34]"^^xsd:string .
 
-niiri:626924a6d4337fea901f4f8dfe33e2f7 prov:wasDerivedFrom niiri:a48e52ce82ef21945b533008203890a9 .
+niiri:23d3e4257473feb39f485dec221abb31 prov:wasDerivedFrom niiri:f97396b2a54d55285f02d93b58dbe2b6 .
 
-niiri:b5f6132daca093e0f4ec3958d256c096
+niiri:7e76e2da1f22ce6b895d3014a33d1739
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0047" ;
-    prov:atLocation niiri:8ed08035bb65579ab8797d970606002d ;
+    prov:atLocation niiri:e04fc808b05489b451f47249a93ec634 ;
     prov:value "4.05762767791748"^^xsd:float ;
     nidm_equivalentZStatistic: "3.89134919103145"^^xsd:float ;
     nidm_pValueUncorrected: "4.98441713834286e-05"^^xsd:float ;
     nidm_pValueFWER: "0.966867400896655"^^xsd:float ;
     nidm_qValueFDR: "0.199920408224698"^^xsd:float .
 
-niiri:8ed08035bb65579ab8797d970606002d
+niiri:e04fc808b05489b451f47249a93ec634
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0047" ;
     nidm_coordinateVector: "[-46,-56,14]"^^xsd:string .
 
-niiri:b5f6132daca093e0f4ec3958d256c096 prov:wasDerivedFrom niiri:33d2fed4b2c8785ed20bc8727adca85e .
+niiri:7e76e2da1f22ce6b895d3014a33d1739 prov:wasDerivedFrom niiri:a4357c1b32f8a28c66891660675a8ceb .
 
-niiri:307dd4fcb4d0ba761f6d483e260a4dca
+niiri:a76fe1af0c08762eb9239007a5f9dc2c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0048" ;
-    prov:atLocation niiri:dd81e902b3add9d15a1e383709d09161 ;
+    prov:atLocation niiri:6e79740bd3660186f4fdf7f38fec1b3c ;
     prov:value "3.97341108322144"^^xsd:float ;
     nidm_equivalentZStatistic: "3.81637469850314"^^xsd:float ;
     nidm_pValueUncorrected: "6.7713399346081e-05"^^xsd:float ;
     nidm_pValueFWER: "0.987160063394768"^^xsd:float ;
     nidm_qValueFDR: "0.237117251115433"^^xsd:float .
 
-niiri:dd81e902b3add9d15a1e383709d09161
+niiri:6e79740bd3660186f4fdf7f38fec1b3c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0048" ;
     nidm_coordinateVector: "[-50,-50,20]"^^xsd:string .
 
-niiri:307dd4fcb4d0ba761f6d483e260a4dca prov:wasDerivedFrom niiri:33d2fed4b2c8785ed20bc8727adca85e .
+niiri:a76fe1af0c08762eb9239007a5f9dc2c prov:wasDerivedFrom niiri:a4357c1b32f8a28c66891660675a8ceb .
 
-niiri:053d94e39a8343d1f3d37f32c37e498d
+niiri:30853859b00c0b5c92d53d8e023cba9d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0049" ;
-    prov:atLocation niiri:a649b2531f6af9cadfdbd902b6239ce1 ;
+    prov:atLocation niiri:4799db48ff3ae922b73cc32f5cc0cd23 ;
     prov:value "4.03719234466553"^^xsd:float ;
     nidm_equivalentZStatistic: "3.87318677164159"^^xsd:float ;
     nidm_pValueUncorrected: "5.37107204765519e-05"^^xsd:float ;
     nidm_pValueFWER: "0.973166168280088"^^xsd:float ;
     nidm_qValueFDR: "0.210147957128937"^^xsd:float .
 
-niiri:a649b2531f6af9cadfdbd902b6239ce1
+niiri:4799db48ff3ae922b73cc32f5cc0cd23
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0049" ;
     nidm_coordinateVector: "[-48,2,50]"^^xsd:string .
 
-niiri:053d94e39a8343d1f3d37f32c37e498d prov:wasDerivedFrom niiri:32b9f8da6e89284036f980cbd853e723 .
+niiri:30853859b00c0b5c92d53d8e023cba9d prov:wasDerivedFrom niiri:9e1f64e5a9ff6cda9c7c7070f1f8c2b9 .
 
-niiri:130a50f3e4f7c1ba157f08f847c3080c
+niiri:356f79ecf79738d01b5b4b7026b7e188
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0050" ;
-    prov:atLocation niiri:009a265ff4488eb9a438b0d6ddbb84ea ;
+    prov:atLocation niiri:e472df3ca776655c319913d4e08d6e9b ;
     prov:value "4.0217924118042"^^xsd:float ;
     nidm_equivalentZStatistic: "3.85948683644491"^^xsd:float ;
     nidm_pValueUncorrected: "5.68126885931441e-05"^^xsd:float ;
     nidm_pValueFWER: "0.977286609355005"^^xsd:float ;
     nidm_qValueFDR: "0.217632520436791"^^xsd:float .
 
-niiri:009a265ff4488eb9a438b0d6ddbb84ea
+niiri:e472df3ca776655c319913d4e08d6e9b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0050" ;
     nidm_coordinateVector: "[-36,-40,-36]"^^xsd:string .
 
-niiri:130a50f3e4f7c1ba157f08f847c3080c prov:wasDerivedFrom niiri:a4fb311adc8de77c87cd3e5be5ccc62b .
+niiri:356f79ecf79738d01b5b4b7026b7e188 prov:wasDerivedFrom niiri:e13313ba9b9b954243d9c9332f3caf96 .
 
-niiri:19d5f914ae688cfe389fcf0a4f617fe0
+niiri:4265e2cdabcc64eab47a5d072484d937
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0051" ;
-    prov:atLocation niiri:44ee2fd2f419642665f597a6465e8c0e ;
+    prov:atLocation niiri:d80ff4fffd0d4464945b79660c578dad ;
     prov:value "3.9634416103363"^^xsd:float ;
     nidm_equivalentZStatistic: "3.80747753892992"^^xsd:float ;
     nidm_pValueUncorrected: "7.01957428701494e-05"^^xsd:float ;
     nidm_pValueFWER: "0.988689669381963"^^xsd:float ;
     nidm_qValueFDR: "0.237117251115433"^^xsd:float .
 
-niiri:44ee2fd2f419642665f597a6465e8c0e
+niiri:d80ff4fffd0d4464945b79660c578dad
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0051" ;
     nidm_coordinateVector: "[4,6,32]"^^xsd:string .
 
-niiri:19d5f914ae688cfe389fcf0a4f617fe0 prov:wasDerivedFrom niiri:f5be0f8d59441b28ce308dfb011e10df .
+niiri:4265e2cdabcc64eab47a5d072484d937 prov:wasDerivedFrom niiri:63e1799e700f05ae3736bff33a2b65f4 .
 
-niiri:266b7abb3e5d3b87d3a4e58d9921a054
+niiri:b6e09f6b679ea623d2841ff4bcf6291e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0052" ;
-    prov:atLocation niiri:0ed4387af330a4afa36d809baed370ef ;
+    prov:atLocation niiri:a59f8dea4edffbdd72892882c133b0e9 ;
     prov:value "3.96245408058167"^^xsd:float ;
     nidm_equivalentZStatistic: "3.80659597790245"^^xsd:float ;
     nidm_pValueUncorrected: "7.04463150378309e-05"^^xsd:float ;
     nidm_pValueFWER: "0.988832912076595"^^xsd:float ;
     nidm_qValueFDR: "0.237117251115433"^^xsd:float .
 
-niiri:0ed4387af330a4afa36d809baed370ef
+niiri:a59f8dea4edffbdd72892882c133b0e9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0052" ;
     nidm_coordinateVector: "[-50,-48,-16]"^^xsd:string .
 
-niiri:266b7abb3e5d3b87d3a4e58d9921a054 prov:wasDerivedFrom niiri:9771726b7a7da2b81302c08e984d21aa .
+niiri:b6e09f6b679ea623d2841ff4bcf6291e prov:wasDerivedFrom niiri:5dfbf6ab6301360ce96203aca13f8257 .
 
-niiri:0d35f7ec7f83e2f14c74fd13990016e3
+niiri:df0b4499eab340f0f5ffcf69ea26e94e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0053" ;
-    prov:atLocation niiri:67e777c1dbdb7316faaa66904161debf ;
+    prov:atLocation niiri:0f2c7e9dfacf69ad400623d015e16bf8 ;
     prov:value "3.9098813533783"^^xsd:float ;
     nidm_equivalentZStatistic: "3.75959988615137"^^xsd:float ;
     nidm_pValueUncorrected: "8.50926599039736e-05"^^xsd:float ;
     nidm_pValueFWER: "0.994607633788328"^^xsd:float ;
     nidm_qValueFDR: "0.264100967145263"^^xsd:float .
 
-niiri:67e777c1dbdb7316faaa66904161debf
+niiri:0f2c7e9dfacf69ad400623d015e16bf8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0053" ;
     nidm_coordinateVector: "[54,-24,-2]"^^xsd:string .
 
-niiri:0d35f7ec7f83e2f14c74fd13990016e3 prov:wasDerivedFrom niiri:1081daf0e707c5e5ae15af9f18adc9a9 .
+niiri:df0b4499eab340f0f5ffcf69ea26e94e prov:wasDerivedFrom niiri:82c6c5dde224f3815e887f0f89a10062 .
 
-niiri:f68f1b953350c246fef9a85a9bf855fb
+niiri:d0bc7891180bf59606c1dd42f7521b58
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0054" ;
-    prov:atLocation niiri:2e2b26028ce092cfea140bb304e19f4c ;
+    prov:atLocation niiri:fbd4fdf05f1b858456b20418252ad82e ;
     prov:value "3.90285301208496"^^xsd:float ;
     nidm_equivalentZStatistic: "3.75330746420074"^^xsd:float ;
     nidm_pValueUncorrected: "8.72582920719012e-05"^^xsd:float ;
     nidm_pValueFWER: "0.99514521861122"^^xsd:float ;
     nidm_qValueFDR: "0.264100967145263"^^xsd:float .
 
-niiri:2e2b26028ce092cfea140bb304e19f4c
+niiri:fbd4fdf05f1b858456b20418252ad82e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0054" ;
     nidm_coordinateVector: "[-36,-46,-18]"^^xsd:string .
 
-niiri:f68f1b953350c246fef9a85a9bf855fb prov:wasDerivedFrom niiri:9294aac4eea8be1704ba4b297809e66d .
+niiri:d0bc7891180bf59606c1dd42f7521b58 prov:wasDerivedFrom niiri:f9cd18224526a4801de142048b64a357 .
 
-niiri:b9275d20f8a295c49994d5edd49258f8
+niiri:048c50de4960b48aa105d96778779061
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0055" ;
-    prov:atLocation niiri:efed591f3e5ab7fbed32ccc0ef3bec8c ;
+    prov:atLocation niiri:fede7e0698f56da3b9f59e90e65c68a5 ;
     prov:value "3.8867518901825"^^xsd:float ;
     nidm_equivalentZStatistic: "3.73888373627584"^^xsd:float ;
     nidm_pValueUncorrected: "9.24195907030523e-05"^^xsd:float ;
     nidm_pValueFWER: "0.996210852184447"^^xsd:float ;
     nidm_qValueFDR: "0.271701156704036"^^xsd:float .
 
-niiri:efed591f3e5ab7fbed32ccc0ef3bec8c
+niiri:fede7e0698f56da3b9f59e90e65c68a5
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0055" ;
     nidm_coordinateVector: "[-50,-46,-32]"^^xsd:string .
 
-niiri:b9275d20f8a295c49994d5edd49258f8 prov:wasDerivedFrom niiri:9c2b57d941c750a81bae56005ccc8439 .
+niiri:048c50de4960b48aa105d96778779061 prov:wasDerivedFrom niiri:b2129866f39d8d89964577f80028f418 .
 
-niiri:b976b106d2604175d9d8fabebe71738c
+niiri:f6f60a34610b49cc5b443ce199ca79c0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0056" ;
-    prov:atLocation niiri:4287ceee774f285ae67d36f37051b681 ;
+    prov:atLocation niiri:18668f3157ce13938d310aebc49ef7b9 ;
     prov:value "3.82178378105164"^^xsd:float ;
     nidm_equivalentZStatistic: "3.68056404693028"^^xsd:float ;
     nidm_pValueUncorrected: "0.000116359297336222"^^xsd:float ;
     nidm_pValueFWER: "0.998750111206092"^^xsd:float ;
     nidm_qValueFDR: "0.307505393775956"^^xsd:float .
 
-niiri:4287ceee774f285ae67d36f37051b681
+niiri:18668f3157ce13938d310aebc49ef7b9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0056" ;
     nidm_coordinateVector: "[12,52,-12]"^^xsd:string .
 
-niiri:b976b106d2604175d9d8fabebe71738c prov:wasDerivedFrom niiri:8e5c49eb54e50609e5ba92b2b8409882 .
+niiri:f6f60a34610b49cc5b443ce199ca79c0 prov:wasDerivedFrom niiri:1d15a2f17b8507a037170dff62d0df0f .
 
-niiri:b336bf04be7eca644b00209bac65fea7
+niiri:6bd4ba02e7d4f4207d829a2c8b49bb4e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0057" ;
-    prov:atLocation niiri:59005f07096d9afe851f48ec3d9037cc ;
+    prov:atLocation niiri:ab3768ac2a57998c1f00e6093a6cdaf9 ;
     prov:value "3.7885959148407"^^xsd:float ;
     nidm_equivalentZStatistic: "3.65069869844077"^^xsd:float ;
     nidm_pValueUncorrected: "0.000130763947768786"^^xsd:float ;
     nidm_pValueFWER: "0.999340802437346"^^xsd:float ;
     nidm_qValueFDR: "0.325675502417125"^^xsd:float .
 
-niiri:59005f07096d9afe851f48ec3d9037cc
+niiri:ab3768ac2a57998c1f00e6093a6cdaf9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0057" ;
     nidm_coordinateVector: "[22,40,26]"^^xsd:string .
 
-niiri:b336bf04be7eca644b00209bac65fea7 prov:wasDerivedFrom niiri:a03ba6625b79992ed07f93b8c01a2bae .
+niiri:6bd4ba02e7d4f4207d829a2c8b49bb4e prov:wasDerivedFrom niiri:92cdcaac8dc15abca00aaf2035c3d353 .
 
-niiri:ea7af39876f2c2729bdc445fa0545560
+niiri:bae89a3df5e8c7b953547ae7d7534e95
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0058" ;
-    prov:atLocation niiri:729bff40deee62846b0525d048a7654a ;
+    prov:atLocation niiri:646c22a0ec339e5b474a3aaa23751b4d ;
     prov:value "3.65790581703186"^^xsd:float ;
     nidm_equivalentZStatistic: "3.53261354467296"^^xsd:float ;
     nidm_pValueUncorrected: "0.000205736742878826"^^xsd:float ;
     nidm_pValueFWER: "0.999969815552823"^^xsd:float ;
     nidm_qValueFDR: "0.430567192397012"^^xsd:float .
 
-niiri:729bff40deee62846b0525d048a7654a
+niiri:646c22a0ec339e5b474a3aaa23751b4d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0058" ;
     nidm_coordinateVector: "[52,-46,-12]"^^xsd:string .
 
-niiri:ea7af39876f2c2729bdc445fa0545560 prov:wasDerivedFrom niiri:4ccc33b588ed17374f2c6edcb6528c8c .
+niiri:bae89a3df5e8c7b953547ae7d7534e95 prov:wasDerivedFrom niiri:a766e15fcf31e1d6ce69e989e67adf78 .
 
-niiri:a55a0360fd92fc20c1300a071dfb10eb
+niiri:f2e5294144fb56653d91e924583c3e1b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0059" ;
-    prov:atLocation niiri:df3ba85030b17fc4596288509db3fc78 ;
+    prov:atLocation niiri:1330f955b402cf21c726b658b67095cd ;
     prov:value "3.55148839950562"^^xsd:float ;
     nidm_equivalentZStatistic: "3.43590473729199"^^xsd:float ;
     nidm_pValueUncorrected: "0.000295289297083445"^^xsd:float ;
     nidm_pValueFWER: "0.99999889206113"^^xsd:float ;
     nidm_qValueFDR: "0.518882279088377"^^xsd:float .
 
-niiri:df3ba85030b17fc4596288509db3fc78
+niiri:1330f955b402cf21c726b658b67095cd
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0059" ;
     nidm_coordinateVector: "[64,-34,16]"^^xsd:string .
 
-niiri:a55a0360fd92fc20c1300a071dfb10eb prov:wasDerivedFrom niiri:9a0e43f3959fa34d67e65e823d6736df .
+niiri:f2e5294144fb56653d91e924583c3e1b prov:wasDerivedFrom niiri:f364696f65c95b091099ba5aa2f33e2b .
 

--- a/spmexport/ex_spm_thr_voxelfdrp05/nidm.json
+++ b/spmexport/ex_spm_thr_voxelfdrp05/nidm.json
@@ -1,0 +1,11940 @@
+{
+  "prefix": {
+    "nidm": "http://purl.org/nidash/nidm#",
+    "niiri": "http://iri.nidash.org/",
+    "spm": "http://purl.org/nidash/spm#",
+    "neurolex": "http://neurolex.org/wiki/",
+    "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/",
+    "dct": "http://purl.org/dc/terms/",
+    "nfo": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#",
+    "dc": "http://purl.org/dc/elements/1.1/",
+    "dctype": "http://purl.org/dc/dcmitype/",
+    "obo": "http://purl.obolibrary.org/obo/",
+    "nidm_NIDMResults": "http://purl.org/nidash/nidm#NIDM_0000027",
+    "nidm_version": "http://purl.org/nidash/nidm#NIDM_0000127",
+    "nidm_spm_results_nidm": "http://purl.org/nidash/nidm#NIDM_0000168",
+    "nidm_softwareVersion": "http://purl.org/nidash/nidm#NIDM_0000122",
+    "nidm_NIDMResultsExport": "http://purl.org/nidash/nidm#NIDM_0000166"
+  },
+  "entity": {
+    "niiri:28ec28bc6b4f22ae6ce0d4910cd21172": {
+      "prov:type": [
+        {
+        "$": "prov:Bundle",
+        "type": "xsd:QName"
+        },
+        {
+        "$": "nidm_NIDMResults:",
+        "type": "xsd:QName"
+        }
+      ],
+      "prov:label": {
+        "$": "NIDM-Results",
+        "type": "xsd:string"
+      },
+      "nidm_version:": {
+        "$": "1.3.0",
+        "type": "xsd:string"
+      }
+    }
+  },
+  "activity": {
+    "niiri:1ab4e92c05dcd58443cc9cec8e73ba67": {
+      "prov:type": {
+        "$": "nidm_NIDMResultsExport:",
+        "type": "xsd:QName"
+      },
+      "prov:label": {
+        "$": "NIDM-Results export",
+        "type": "xsd:string"
+      }
+    }
+  },
+  "agent": {
+    "niiri:c3049f06eafd15e1a9333df90c4a3baf": {
+      "prov:type": [
+        {
+        "$": "nidm_spm_results_nidm:",
+        "type": "xsd:QName"
+        },
+        {
+        "$": "prov:SoftwareAgent",
+        "type": "xsd:QName"
+        }
+      ],
+      "prov:label": {
+        "$": "spm_results_nidm",
+        "type": "xsd:string"
+      },
+      "nidm_softwareVersion:": {
+        "$": "12.7057",
+        "type": "xsd:string"
+      }
+    }
+  },
+  "wasGeneratedBy": {
+    "_:wGB5": {
+      "prov:entity": "niiri:28ec28bc6b4f22ae6ce0d4910cd21172",
+      "prov:activity": "niiri:1ab4e92c05dcd58443cc9cec8e73ba67",
+      "prov:time": "2017-04-19T12:19:14"
+    }
+  },
+  "wasAssociatedWith": {
+    "_:wAW4": {
+      "prov:activity": "niiri:1ab4e92c05dcd58443cc9cec8e73ba67",
+      "prov:agent": "niiri:c3049f06eafd15e1a9333df90c4a3baf"
+    }
+  },
+  "bundle": {
+    "niiri:28ec28bc6b4f22ae6ce0d4910cd21172": {
+    "prefix": {
+        "nidm_softwareVersion": "http://purl.org/nidash/nidm#NIDM_0000122",
+        "nidm_CoordinateSpace": "http://purl.org/nidash/nidm#NIDM_0000016",
+        "nidm_voxelToWorldMapping": "http://purl.org/nidash/nidm#NIDM_0000132",
+        "nidm_voxelUnits": "http://purl.org/nidash/nidm#NIDM_0000133",
+        "nidm_voxelSize": "http://purl.org/nidash/nidm#NIDM_0000131",
+        "nidm_inWorldCoordinateSystem": "http://purl.org/nidash/nidm#NIDM_0000105",
+        "nidm_numberOfDimensions": "http://purl.org/nidash/nidm#NIDM_0000112",
+        "nidm_dimensionsInVoxels": "http://purl.org/nidash/nidm#NIDM_0000090",
+        "nlx_Imaginginstrument": "http://uri.neuinfo.org/nif/nifstd/birnlex_2094",
+        "nlx_Magneticresonanceimagingscanner": "http://uri.neuinfo.org/nif/nifstd/birnlex_2100",
+        "nidm_grandMeanScaling": "http://purl.org/nidash/nidm#NIDM_0000096",
+        "nidm_targetIntensity": "http://purl.org/nidash/nidm#NIDM_0000124",
+        "nidm_hasMRIProtocol": "http://purl.org/nidash/nidm#NIDM_0000172",
+        "nlx_FunctionalMRIprotocol": "http://uri.neuinfo.org/nif/nifstd/birnlex_2250",
+        "nidm_Data": "http://purl.org/nidash/nidm#NIDM_0000169",
+        "spm_DCTDriftModel": "http://purl.org/nidash/spm#SPM_0000002",
+        "spm_SPMsDriftCutoffPeriod": "http://purl.org/nidash/spm#SPM_0000001",
+        "nidm_hasDriftModel": "http://purl.org/nidash/nidm#NIDM_0000088",
+        "nidm_hasHRFBasis": "http://purl.org/nidash/nidm#NIDM_0000102",
+        "spm_SPMsCanonicalHRF": "http://purl.org/nidash/spm#SPM_0000004",
+        "nidm_DesignMatrix": "http://purl.org/nidash/nidm#NIDM_0000019",
+        "nidm_regressorNames": "http://purl.org/nidash/nidm#NIDM_0000021",
+        "nidm_hasErrorDependence": "http://purl.org/nidash/nidm#NIDM_0000100",
+        "obo_Toeplitzcovariancestructure": "http://purl.obolibrary.org/obo/STATO_0000357",
+        "nidm_dependenceMapWiseDependence": "http://purl.org/nidash/nidm#NIDM_0000089",
+        "nidm_ConstantParameter": "http://purl.org/nidash/nidm#NIDM_0000072",
+        "nidm_errorVarianceHomogeneous": "http://purl.org/nidash/nidm#NIDM_0000094",
+        "nidm_varianceMapWiseDependence": "http://purl.org/nidash/nidm#NIDM_0000126",
+        "nidm_IndependentParameter": "http://purl.org/nidash/nidm#NIDM_0000073",
+        "nidm_withEstimationMethod": "http://purl.org/nidash/nidm#NIDM_0000134",
+        "obo_generalizedleastsquaresestimation": "http://purl.obolibrary.org/obo/STATO_0000372",
+        "nidm_ErrorModel": "http://purl.org/nidash/nidm#NIDM_0000023",
+        "nidm_hasErrorDistribution": "http://purl.org/nidash/nidm#NIDM_0000101",
+        "obo_normaldistribution": "http://purl.obolibrary.org/obo/STATO_0000227",
+        "nidm_ModelParametersEstimation": "http://purl.org/nidash/nidm#NIDM_0000056",
+        "nidm_MaskMap": "http://purl.org/nidash/nidm#NIDM_0000054",
+        "nidm_isUserDefined": "http://purl.org/nidash/nidm#NIDM_0000106",
+        "nidm_inCoordinateSpace": "http://purl.org/nidash/nidm#NIDM_0000104",
+        "nidm_GrandMeanMap": "http://purl.org/nidash/nidm#NIDM_0000033",
+        "nidm_maskedMedian": "http://purl.org/nidash/nidm#NIDM_0000107",
+        "nidm_ParameterEstimateMap": "http://purl.org/nidash/nidm#NIDM_0000061",
+        "nidm_ResidualMeanSquaresMap": "http://purl.org/nidash/nidm#NIDM_0000066",
+        "nidm_ReselsPerVoxelMap": "http://purl.org/nidash/nidm#NIDM_0000144",
+        "obo_contrastweightmatrix": "http://purl.obolibrary.org/obo/STATO_0000323",
+        "nidm_statisticType": "http://purl.org/nidash/nidm#NIDM_0000123",
+        "obo_tstatistic": "http://purl.obolibrary.org/obo/STATO_0000176",
+        "nidm_contrastName": "http://purl.org/nidash/nidm#NIDM_0000085",
+        "nidm_ContrastEstimation": "http://purl.org/nidash/nidm#NIDM_0000001",
+        "nidm_StatisticMap": "http://purl.org/nidash/nidm#NIDM_0000076",
+        "nidm_errorDegreesOfFreedom": "http://purl.org/nidash/nidm#NIDM_0000093",
+        "nidm_effectDegreesOfFreedom": "http://purl.org/nidash/nidm#NIDM_0000091",
+        "nidm_ContrastMap": "http://purl.org/nidash/nidm#NIDM_0000002",
+        "nidm_ContrastStandardErrorMap": "http://purl.org/nidash/nidm#NIDM_0000013",
+        "obo_statistic": "http://purl.obolibrary.org/obo/STATO_0000039",
+        "nidm_PValueUncorrected": "http://purl.org/nidash/nidm#NIDM_0000160",
+        "obo_FWERadjustedpvalue": "http://purl.obolibrary.org/obo/OBI_0001265",
+        "obo_qvalue": "http://purl.obolibrary.org/obo/OBI_0001442",
+        "nidm_HeightThreshold": "http://purl.org/nidash/nidm#NIDM_0000034",
+        "nidm_equivalentThreshold": "http://purl.org/nidash/nidm#NIDM_0000161",
+        "nidm_ExtentThreshold": "http://purl.org/nidash/nidm#NIDM_0000026",
+        "nidm_clusterSizeInVoxels": "http://purl.org/nidash/nidm#NIDM_0000084",
+        "nidm_clusterSizeInResels": "http://purl.org/nidash/nidm#NIDM_0000156",
+        "nidm_PeakDefinitionCriteria": "http://purl.org/nidash/nidm#NIDM_0000063",
+        "nidm_maxNumberOfPeaksPerCluster": "http://purl.org/nidash/nidm#NIDM_0000108",
+        "nidm_minDistanceBetweenPeaks": "http://purl.org/nidash/nidm#NIDM_0000109",
+        "nidm_ClusterDefinitionCriteria": "http://purl.org/nidash/nidm#NIDM_0000007",
+        "nidm_hasConnectivityCriterion": "http://purl.org/nidash/nidm#NIDM_0000099",
+        "nidm_voxel18connected": "http://purl.org/nidash/nidm#NIDM_0000128",
+        "nidm_Inference": "http://purl.org/nidash/nidm#NIDM_0000049",
+        "nidm_hasAlternativeHypothesis": "http://purl.org/nidash/nidm#NIDM_0000097",
+        "nidm_OneTailedTest": "http://purl.org/nidash/nidm#NIDM_0000060",
+        "nidm_SearchSpaceMaskMap": "http://purl.org/nidash/nidm#NIDM_0000068",
+        "nidm_searchVolumeInVoxels": "http://purl.org/nidash/nidm#NIDM_0000121",
+        "nidm_searchVolumeInUnits": "http://purl.org/nidash/nidm#NIDM_0000136",
+        "nidm_reselSizeInVoxels": "http://purl.org/nidash/nidm#NIDM_0000148",
+        "nidm_searchVolumeInResels": "http://purl.org/nidash/nidm#NIDM_0000149",
+        "spm_searchVolumeReselsGeometry": "http://purl.org/nidash/spm#SPM_0000010",
+        "nidm_noiseFWHMInVoxels": "http://purl.org/nidash/nidm#NIDM_0000159",
+        "nidm_noiseFWHMInUnits": "http://purl.org/nidash/nidm#NIDM_0000157",
+        "nidm_randomFieldStationarity": "http://purl.org/nidash/nidm#NIDM_0000120",
+        "nidm_expectedNumberOfVoxelsPerCluster": "http://purl.org/nidash/nidm#NIDM_0000143",
+        "nidm_expectedNumberOfClusters": "http://purl.org/nidash/nidm#NIDM_0000141",
+        "nidm_heightCriticalThresholdFWE05": "http://purl.org/nidash/nidm#NIDM_0000147",
+        "nidm_heightCriticalThresholdFDR05": "http://purl.org/nidash/nidm#NIDM_0000146",
+        "spm_smallestSignificantClusterSizeInVoxelsFWE05": "http://purl.org/nidash/spm#SPM_0000014",
+        "nidm_ExcursionSetMap": "http://purl.org/nidash/nidm#NIDM_0000025",
+        "nidm_numberOfSupraThresholdClusters": "http://purl.org/nidash/nidm#NIDM_0000111",
+        "nidm_pValue": "http://purl.org/nidash/nidm#NIDM_0000114",
+        "nidm_hasClusterLabelsMap": "http://purl.org/nidash/nidm#NIDM_0000098",
+        "nidm_hasMaximumIntensityProjection": "http://purl.org/nidash/nidm#NIDM_0000138",
+        "nidm_ClusterLabelsMap": "http://purl.org/nidash/nidm#NIDM_0000008",
+        "nidm_SupraThresholdCluster": "http://purl.org/nidash/nidm#NIDM_0000070",
+        "nidm_pValueUncorrected": "http://purl.org/nidash/nidm#NIDM_0000116",
+        "nidm_pValueFWER": "http://purl.org/nidash/nidm#NIDM_0000115",
+        "nidm_qValueFDR": "http://purl.org/nidash/nidm#NIDM_0000119",
+        "nidm_clusterLabelId": "http://purl.org/nidash/nidm#NIDM_0000082",
+        "nidm_Peak": "http://purl.org/nidash/nidm#NIDM_0000062",
+        "nidm_equivalentZStatistic": "http://purl.org/nidash/nidm#NIDM_0000092",
+        "nidm_Coordinate": "http://purl.org/nidash/nidm#NIDM_0000015",
+        "nidm_coordinateVector": "http://purl.org/nidash/nidm#NIDM_0000086"
+    },
+    "entity": {
+        "niiri:4d80c0cd6d8f06cc5fa8312aea1fdf66": {
+            "prov:type": {
+                "$": "nidm_CoordinateSpace:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Coordinate space 1",
+                "type": "xsd:string"
+            },
+            "nidm_voxelToWorldMapping:": {
+                "$": "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]",
+                "type": "xsd:string"
+            },
+            "nidm_voxelUnits:": {
+                "$": "[\"mm\", \"mm\", \"mm\"]",
+                "type": "xsd:string"
+            },
+            "nidm_voxelSize:": {
+                "$": "[2, 2, 2]",
+                "type": "xsd:string"
+            },
+            "nidm_inWorldCoordinateSystem:": {
+                "$": "nidm_Ixi549CoordinateSystem:",
+                "type": "xsd:string"
+            },
+            "nidm_numberOfDimensions:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_dimensionsInVoxels:": {
+                "$": "[79,95,79]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:65f5e0c3410f30b555aa41ff7e65f3d4": {
+            "prov:type": [
+                {
+                "$": "prov:Collection",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Data:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Data",
+                "type": "xsd:string"
+            },
+            "nidm_grandMeanScaling:": {
+                "$": "true",
+                "type": "xsd:boolean"
+            },
+            "nidm_targetIntensity:": {
+                "$": "100",
+                "type": "xsd:float"
+            },
+            "nidm_hasMRIProtocol:": {
+                "$": "nlx_FunctionalMRIprotocol:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c7263de1e5c4d82e12588d8073c95d36": {
+            "prov:type": {
+                "$": "spm_DCTDriftModel:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "SPM's DCT Drift Model",
+                "type": "xsd:string"
+            },
+            "spm_SPMsDriftCutoffPeriod:": {
+                "$": "128",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d114849d6b0dd611879e4e55b5de49c6": {
+            "prov:type": {
+                "$": "nidm_DesignMatrix:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "DesignMatrix.csv",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "DesignMatrix.csv",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "text/csv",
+                "type": "xsd:string"
+            },
+            "dc:description": {
+                "$": "niiri:b5263ea4cabd52688f9ff17b32558902",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Design Matrix",
+                "type": "xsd:string"
+            },
+            "nidm_regressorNames:": {
+                "$": "[\"Sn(1) to*bf(1)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) constant\"]",
+                "type": "xsd:string"
+            },
+            "nidm_hasDriftModel:": {
+                "$": "niiri:c7263de1e5c4d82e12588d8073c95d36",
+                "type": "xsd:string"
+            },
+            "nidm_hasHRFBasis:": {
+                "$": "spm_SPMsCanonicalHRF:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b5263ea4cabd52688f9ff17b32558902": {
+            "prov:type": {
+                "$": "dctype:Image",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "DesignMatrix.png",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "DesignMatrix.png",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/png",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c2b879875530eeeb341e109f646bd0bb": {
+            "prov:type": {
+                "$": "nidm_ErrorModel:",
+                "type": "xsd:QName"
+            },
+            "nidm_hasErrorDistribution:": {
+                "$": "obo_normaldistribution:",
+                "type": "xsd:string"
+            },
+            "nidm_hasErrorDependence:": {
+                "$": "obo_Toeplitzcovariancestructure:",
+                "type": "xsd:string"
+            },
+            "nidm_dependenceMapWiseDependence:": {
+                "$": "nidm_ConstantParameter:",
+                "type": "xsd:string"
+            },
+            "nidm_errorVarianceHomogeneous:": {
+                "$": "true",
+                "type": "xsd:boolean"
+            },
+            "nidm_varianceMapWiseDependence:": {
+                "$": "nidm_IndependentParameter:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3da9457cb4e9a27e6ca5714485d63d58": {
+            "prov:type": {
+                "$": "nidm_MaskMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "Mask.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nidm_isUserDefined:": {
+                "$": "false",
+                "type": "xsd:boolean"
+            },
+            "nfo:fileName": {
+                "$": "Mask.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Mask",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:4d80c0cd6d8f06cc5fa8312aea1fdf66",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:dcc3a5e5bd34ab36eb3416ae867b7fb6": {
+            "prov:type": {
+                "$": "nidm_MaskMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "mask.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "36929e1f5f4143bd9cc818cd896a25f129961fab208c3a4438555f40444c08347b359142ee8c53ece6e8cca1627f49db0788a1fd3b9e2ecaef61999c6c6c67ac",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:aa66cc4786ebae74492d856291b12f31": {
+            "prov:type": {
+                "$": "nidm_GrandMeanMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "GrandMean.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "GrandMean.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Grand Mean Map",
+                "type": "xsd:string"
+            },
+            "nidm_maskedMedian:": {
+                "$": "111.557487487793",
+                "type": "xsd:float"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:4d80c0cd6d8f06cc5fa8312aea1fdf66",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "512157cc6bff89d9343a09b4068226eb3edd64a8cbcee861f06231767fae6f8d4819921182adebee083a9bf309afd65529ab04a92f0aa6b0038c8098550f6124",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b0a406128a699bce39d09638de7fbb11": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0001.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0001.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 1",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:4d80c0cd6d8f06cc5fa8312aea1fdf66",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5173be555c2ec5d890f39722a8ff9fad": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0001.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:95009d167a825475f9da93813a5eff0d": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0002.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0002.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 2",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:4d80c0cd6d8f06cc5fa8312aea1fdf66",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ec5d05a2244cdd38b1812f3fb5a35d09": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0002.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:89d2070b8724cba90b0701cbb65ee609": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0003.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0003.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 3",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:4d80c0cd6d8f06cc5fa8312aea1fdf66",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e4b178e7dce758cde4b2d2404cae0b85": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0003.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7afdd6ab4e20f8072056e7ad109e1a28": {
+            "prov:type": {
+                "$": "nidm_ResidualMeanSquaresMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ResidualMeanSquares.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ResidualMeanSquares.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Residual Mean Squares Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:4d80c0cd6d8f06cc5fa8312aea1fdf66",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "991abf563d795a43b1e2eef8643e57023f2e0b090b2031f05f839321fc0643df6f71d423486a1021519b6dc82f6b0f563e19f3fbd50cb16063bed54a0e192d3e",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:bf71d9330aaa4b58789fc468b13d0fde": {
+            "prov:type": {
+                "$": "nidm_ResidualMeanSquaresMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "ResMS.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "40b28d03fcf9a2f60b11f10d7fb83bf3618b234fb5aedf09df644cb7cbb6aab8c9f468897c1078166d455a3d04a83f4e3bf762cfca0b4ea982d7a4e406849f18",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3ae2261460b37724f66a583d13620d04": {
+            "prov:type": {
+                "$": "nidm_ReselsPerVoxelMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ReselsPerVoxel.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ReselsPerVoxel.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Resels per Voxel Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:4d80c0cd6d8f06cc5fa8312aea1fdf66",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "1a3f9216e145249ccc0b14b2bc337d6b38b81ad45e32768001fb22b35f0c2c0f3e2bce013b40c85f7dc0fc62723ac761ee7f7e1e6aff128a05f0ba7b8b8202a3",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:754590eadc87f59168e42a5f669d8b83": {
+            "prov:type": {
+                "$": "nidm_ReselsPerVoxelMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "RPV.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "4f76663162857f6b38b2a45a63b15a23b2ca8b338c283b69c1e71f2ea2f43797d045a733cd14e845be9c12f8b8f84d3931c599a08e8f6d77e99fab46ad87ab8f",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f2151889cbe45b2a41ece1a31d4608ed": {
+            "prov:type": {
+                "$": "obo_contrastweightmatrix:",
+                "type": "xsd:QName"
+            },
+            "nidm_statisticType:": {
+                "$": "obo_tstatistic:",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast: tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "[1, 0, 0]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:97a6f2d59ca3be4b5454a9ab78cdf8a3": {
+            "prov:type": {
+                "$": "nidm_StatisticMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "TStatistic.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "TStatistic.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "T-Statistic Map: tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "nidm_statisticType:": {
+                "$": "obo_tstatistic:",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "nidm_errorDegreesOfFreedom:": {
+                "$": "97.9999999998522",
+                "type": "xsd:float"
+            },
+            "nidm_effectDegreesOfFreedom:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:4d80c0cd6d8f06cc5fa8312aea1fdf66",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "9e1714c2d86a050b38b4e10a4d2d23253a24c5e1d228ae16a9c3be8872739278505ac0729ecab54265a717e3a54f9f782d0ed72eea904e0d482a6072bb817bd4",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c5d3fd2966a03a48d06d8890367cdebf": {
+            "prov:type": {
+                "$": "nidm_StatisticMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "spmT_0001.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "d288b1b0f117f64502555da13c5398dffa5bf5ff0b58951510e43d5388755bc185798802a92e98a07c7e313c6991066d2908f2a44aa5153ba23433da1335970f",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ea0fc93e4d1d634046b0ddea1c061c4f": {
+            "prov:type": {
+                "$": "nidm_ContrastMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "Contrast.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "Contrast.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast Map: tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:4d80c0cd6d8f06cc5fa8312aea1fdf66",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "fc5e2ad175243ee496db98f9b2e1b235c4c3bae1a8d7122ce461c897b537e40c49dfee5d6cf20f71c6a2bb9b5f0760fcb4ecd8fe2e9428910ef3d60d8f3c56a9",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:615aeb13ab7f18a00b6e56cef9a42324": {
+            "prov:type": {
+                "$": "nidm_ContrastMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "con_0001.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "d4aa46b3603ba508578e39751262d528cf6d1ed2e722ec46f1cd8194c50591e46b229deb8cb4f72d1b7e0e2640f3e6604be7a335301c5c8357f453e5d0d4daf2",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9349eafbf1e1c6deb40a7bbb8393c611": {
+            "prov:type": {
+                "$": "nidm_ContrastStandardErrorMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ContrastStandardError.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ContrastStandardError.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast Standard Error Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:4d80c0cd6d8f06cc5fa8312aea1fdf66",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "791d48f5d1adb15079a5289271ce0c4b95c56d69bfdb3e5d41b0d24eb538d3075e1cdd15502494b5a5a18c16eaa2153cb4847a996043fa48cdaf26e938a2576d",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:614f1836a4dabc08f6a40b74d83e4626": {
+            "prov:type": [
+                {
+                "$": "nidm_HeightThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_qvalue:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": ":Height Threshold: p<0.05 (FDR)",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "0.05",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentThreshold:": [
+                {
+                "$": "niiri:4ca33fc892cbd22caafe7e43289ea67c",
+                "type": "xsd:string"
+                },
+                {
+                "$": "niiri:351f1c49ad3573062df361946a82808a",
+                "type": "xsd:string"
+                }
+            ]
+        },
+        "niiri:4ca33fc892cbd22caafe7e43289ea67c": {
+            "prov:type": [
+                {
+                "$": "nidm_HeightThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_statistic:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Height Threshold: T=2.751981)",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.75198078155518",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:351f1c49ad3573062df361946a82808a": {
+            "prov:type": [
+                {
+                "$": "nidm_HeightThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_PValueUncorrected:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Height Threshold: p<0.003523 (unc.)",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "0.00352282952586247",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f0dedbabde9224b6cdcbfcacb9ea64eb": {
+            "prov:type": [
+                {
+                "$": "nidm_ExtentThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_statistic:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Extent Threshold: k>=0",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "0",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentThreshold:": [
+                {
+                "$": "niiri:e9f896312d2fd00ff4139f0c9d26b2ca",
+                "type": "xsd:string"
+                },
+                {
+                "$": "niiri:a607df3343e3516511d5da695cfc14df",
+                "type": "xsd:string"
+                }
+            ]
+        },
+        "niiri:e9f896312d2fd00ff4139f0c9d26b2ca": {
+            "prov:type": [
+                {
+                "$": "nidm_ExtentThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_FWERadjustedpvalue:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Extent Threshold",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a607df3343e3516511d5da695cfc14df": {
+            "prov:type": [
+                {
+                "$": "nidm_ExtentThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_PValueUncorrected:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Extent Threshold",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:25809641902137f5d84b8818fbf15a91": {
+            "prov:type": {
+                "$": "nidm_PeakDefinitionCriteria:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak Definition Criteria",
+                "type": "xsd:string"
+            },
+            "nidm_maxNumberOfPeaksPerCluster:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_minDistanceBetweenPeaks:": {
+                "$": "8",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c9584a376a996dc760652f9e9d414333": {
+            "prov:type": {
+                "$": "nidm_ClusterDefinitionCriteria:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Cluster Connectivity Criterion: 18",
+                "type": "xsd:string"
+            },
+            "nidm_hasConnectivityCriterion:": {
+                "$": "nidm_voxel18connected:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0337db714526a735c3f18f8b17802c96": {
+            "prov:type": {
+                "$": "nidm_SearchSpaceMaskMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "SearchSpaceMask.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "SearchSpaceMask.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Search Space Mask Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:4d80c0cd6d8f06cc5fa8312aea1fdf66",
+                "type": "xsd:string"
+            },
+            "nidm_searchVolumeInVoxels:": {
+                "$": "223057",
+                "type": "xsd:int"
+            },
+            "nidm_searchVolumeInUnits:": {
+                "$": "1784456",
+                "type": "xsd:float"
+            },
+            "nidm_reselSizeInVoxels:": {
+                "$": "65.5786964036542",
+                "type": "xsd:float"
+            },
+            "nidm_searchVolumeInResels:": {
+                "$": "3155.84193266257",
+                "type": "xsd:float"
+            },
+            "spm_searchVolumeReselsGeometry:": {
+                "$": "[6, 97.8140592306853, 965.938819261507, 3155.84193266257]",
+                "type": "xsd:string"
+            },
+            "nidm_noiseFWHMInVoxels:": {
+                "$": "[4.09118640605185, 4.0346308705955, 3.97291894351243]",
+                "type": "xsd:string"
+            },
+            "nidm_noiseFWHMInUnits:": {
+                "$": "[8.18237281210369, 8.069261741191, 7.94583788702486]",
+                "type": "xsd:string"
+            },
+            "nidm_randomFieldStationarity:": {
+                "$": "true",
+                "type": "xsd:boolean"
+            },
+            "nidm_expectedNumberOfVoxelsPerCluster:": {
+                "$": "11.2648844136176",
+                "type": "xsd:float"
+            },
+            "nidm_expectedNumberOfClusters:": {
+                "$": "78.1804634557495",
+                "type": "xsd:float"
+            },
+            "nidm_heightCriticalThresholdFWE05:": {
+                "$": "5.30963135104407",
+                "type": "xsd:float"
+            },
+            "nidm_heightCriticalThresholdFDR05:": {
+                "$": "2.75198073945778",
+                "type": "xsd:float"
+            },
+            "crypto:sha512": {
+                "$": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876",
+                "type": "xsd:string"
+            },
+            "spm_smallestSignificantClusterSizeInVoxelsFWE05:": {
+                "$": "417",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:dfc9c2736061f68baaf0d5518b47b332": {
+            "prov:type": {
+                "$": "nidm_ExcursionSetMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ExcursionSet.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ExcursionSet.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Excursion Set Map",
+                "type": "xsd:string"
+            },
+            "nidm_numberOfSupraThresholdClusters:": {
+                "$": "94",
+                "type": "xsd:int"
+            },
+            "nidm_pValue:": {
+                "$": "0.0447079143903081",
+                "type": "xsd:float"
+            },
+            "nidm_hasClusterLabelsMap:": {
+                "$": "niiri:332fb65e8d1c26a67e44333e6c989eb7",
+                "type": "xsd:string"
+            },
+            "nidm_hasMaximumIntensityProjection:": {
+                "$": "niiri:5938905a43f9833716520963e37ee9bc",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:4d80c0cd6d8f06cc5fa8312aea1fdf66",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "cf6122ef36510b627277417e8070ef8b21de0fcc302fb6c54bf9edeb988abef00c098ec6c42fcf12cd780102e22e349f9c18cd538751d947c730386ef4e7a1cd",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:332fb65e8d1c26a67e44333e6c989eb7": {
+            "prov:type": {
+                "$": "nidm_ClusterLabelsMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ClusterLabels.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ClusterLabels.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Cluster Labels Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:4d80c0cd6d8f06cc5fa8312aea1fdf66",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "a6e72a506c045df940a586a06217495a831daf3d177fe165daebb130d3e2e4e907672569967fc17d32833becda95fa6d98fd5aae15ff0d91681337ac0edcd529",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5938905a43f9833716520963e37ee9bc": {
+            "prov:type": {
+                "$": "dctype:Image",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "MaximumIntensityProjection.png",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "MaximumIntensityProjection.png",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/png",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:57b0b3487b8ceebf11e98e8506c169a2": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0001",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "10882",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "165.938034708992",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.90523177469239e-52",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "1",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:3d5c32984a0665ba596ff6cef71fcd0b": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0002",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "464",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "7.07546848970521",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.46600673096314e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "4.27325808851631e-05",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "2",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:2c413461a4c1a86447e1da248ab7545c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0003",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1082",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "16.4992605729764",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "9.72221700092388e-12",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "7.6008743743472e-10",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "3",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:e3f486aca3000e0c84fbdaf8a042398f": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0004",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "155",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "2.36357244806963",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000966188323290149",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0727546253784379",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "4",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c0ef61636e02d68816943e9c0c7be35d": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0005",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "468",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "7.13646390771991",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.03189156866348e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "3.93387876993501e-05",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "5",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:e9bd68a9b52a95e89ba7a7e17b4fa428": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0006",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "602",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "9.17981041121237",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.55299466223168e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "2.77774383550256e-06",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "6",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:7693eabf368839e957bc3cfe43c975e0": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0007",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "155",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "2.36357244806963",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000966188323290149",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0727546253784379",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "7",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:39b96655430c53f32e07621dbe8655c4": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0008",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "24",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.365972508088201",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.135096185329275",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99997411591819",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "8",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:90ea170edb9635f011af376c50f1eff8": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0009",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "66",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.00642439724255",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.019659726704423",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.784976196959257",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "9",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:d976336ac6ecb4bba1136f54b6de3e23": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0010",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "39",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.594705325643326",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0628608642474607",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.992660550947171",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "10",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:43ec173da0c3faa0f4491456aea575ce": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0011",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "62",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.945428979227852",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0230802080341633",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.835430344509021",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "11",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:a21087d5b0bdd477c690e1272139bf8a": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0012",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "417",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "6.35877232803249",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.4724427450224e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.000115109630595911",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "12",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:a4d3b6fc7cc84d91945916a3052dd21c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0013",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "130",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.98235108547775",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00208283102205462",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.150270057430811",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "13",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:d3e3d125a9ce7e2ce6bac0795d332509": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0014",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "22",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.335474799080851",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.151229882990552",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999266770754",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "14",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:0531c28556a1e0fba30c3ea1dd24f56e": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0015",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "40",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.609954180147001",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0599689762737744",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.990798625078006",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "15",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:22a4e1327d4f2f7349df156933a68889": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0016",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "44",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.670949598161701",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0498604149932155",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.979719802309727",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "16",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:661e97df890b4cd21b7b3cc4a2220e2e": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0017",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "9",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.137239690533075",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.353115016567812",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999998975",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "17",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:fb7297e8c19234947de7375e05901f89": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0018",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "26",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.396470217095551",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.121057745011785",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999922431613941",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "18",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c016e8a860699bda1ff422a1f501e63d": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0019",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "14",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.21348396305145",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.247209045891911",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999995959582",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "19",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c4fe065cafdebad144fa17a8ec71281b": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0020",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "102",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.55538315937485",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00523608159210795",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.335924403319093",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "20",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:b9447d9cb03b61ef6f6b29b2f726c748": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0021",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "35",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.533709907628626",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0762105313207416",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.997415374507942",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "21",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:fccd53239e801ce9120073c47ddcae13": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0022",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "11",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.167737399540425",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.304231432261983",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999953191",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "22",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:e8858d23bbbcba237e94c70004237a2f": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0023",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "60",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.914931270220502",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0250398009911991",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.858806395143279",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "23",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:a1e36a12612c98786c42d6e581a41938": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0024",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "20",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.169879909718968",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999998293882222",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "24",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:6aac454abbeb6462b826cd647eb086e0": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0025",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "106",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.61637857738955",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0045683114800732",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.300334355470534",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "25",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:7b28ee2c06d9f1eb5b4dab7494fe7a85": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0026",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "82",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.25040606930135",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.010663031377913",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.565535367161089",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "26",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:00aad4e5c367c7dee68c301c251cb2ce": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0027",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "50",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.762442725183751",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0381864669518656",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.949482510909652",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "27",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:904dc3e52037e77af188b63a3d3a6884": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0028",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "106",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.61637857738955",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0045683114800732",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.300334355470534",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "28",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:ffdea138243040f7b25be6c44f68510d": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0029",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "14",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.21348396305145",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.247209045891911",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999995959582",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "29",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f19e77aa11c450b96b368f822fcfd6ce": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0030",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "19",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.289728235569826",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.180311198128326",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999245200009",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "30",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:1b80b6984bddaf1c61a51a898d6acbea": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0031",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "37",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.564207616635976",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0691545455685726",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.995512836089743",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "31",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:2a6b200869ec06562d293e64de33e926": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0032",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0457465635110251",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.606262591428315",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "32",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:50eb3a7d09683191b4aed76432577ca4": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0033",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "14",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.21348396305145",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.247209045891911",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999995959582",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "33",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:3dc187c20fafa718374d3bf8209b869c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0034",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "14",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.21348396305145",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.247209045891911",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999995959582",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "34",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:2246deb8a6c721c27dda92f3dd869ffd": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0035",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "9",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.137239690533075",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.353115016567812",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999998975",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "35",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:50cb1d29d6f8a9cfe9515552c5bb7d31": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0036",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "12",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.1829862540441",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.283360599180691",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999976069",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "36",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:d6d69b36b9108bb0de66eeffba4d858e": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0037",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "7",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.106741981525725",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.414624064489355",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999992",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "37",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:e88a30db5e3821edb55a62d4b67f0ad1": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0038",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "14",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.21348396305145",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.247209045891911",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999995959582",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "38",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:a4ad9afd60a760f91d6916421b56fe6a": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0039",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "22",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.335474799080851",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.151229882990552",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999266770754",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "39",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:d3934b966af329378cc1a1307b94a530": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0040",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "18",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.27447938106615",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.191585077625515",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999687358966",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "40",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:546534eff08d214139c8884f815a2c20": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0041",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "25",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.381221362591876",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.127837700735227",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999954345605505",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "41",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:295cf12e37c01e14c3830d46154826a9": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0042",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "12",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.1829862540441",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.283360599180691",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999976069",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "42",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:aedc5c46b75f681aa273f0c65aba753d": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0043",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "17",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.259230526562475",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.203794876382713",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999879639916",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "43",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:03b802eb8ab278c3154b4ebae374f2f2": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0044",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "11",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.167737399540425",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.304231432261983",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999953191",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "44",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:33fb5b8990838fc1f2547ba3ff8437d2": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0045",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "31",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.472714489613926",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0930905581376341",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999309340057149",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "45",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f6f7f9d9bd2b440c679a5ff44f1cdb22": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0046",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "10",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.15248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.327355667114058",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999992323",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "46",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:cbbd42e6f42814091a8e0fc54b7ad3c4": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0047",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "23",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.350723653584526",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.142877147982206",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999985912203707",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "47",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:53fb996b754ceba84bda7b0e7b9bdc51": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0048",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0457465635110251",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.606262591428315",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "48",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:55bb03da7ee7d021560ed83a011342a9": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0049",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "7",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.106741981525725",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.414624064489355",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999992",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "49",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:ac7c392c52df7cdd1a6cd2c7335454d2": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0050",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.682557316733255",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "50",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c3f05dc9d300aa5acc02e364f1c3ee85": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0051",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0609954180147001",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.54539640994801",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "51",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:45b4ec73da86f70d949a94aa6ab8d4ab": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0052",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.682557316733255",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "52",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:54114a5d8df2f7e553a53e4b7d3f5bde": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0053",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "6",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0914931270220502",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.45185124173467",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "53",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:3f3ed8fe063a9052a3379a875a3af9b1": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0054",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.786165890418407",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "54",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:5721ae6aae6160ad82aced2d2fe68def": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0055",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.682557316733255",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "55",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:9326713bc412f1ec61f3bf20466a1174": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0056",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0609954180147001",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.54539640994801",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "56",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:ae9ba0f37d886eaa080e3238cefd1961": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0057",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "11",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.167737399540425",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.304231432261983",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999953191",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "57",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:55108dec00fcabdca0aa0fd19deac38c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0058",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.786165890418407",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "58",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:16a2d945f11329e9c381ee7f04a0ef0e": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0059",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "17",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.259230526562475",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.203794876382713",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999879639916",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "59",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:51de73f4c31fd22967b959166dfdd033": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0060",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "5",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0762442725183751",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.494859211467501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "60",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:5810f1d1820e723be51fc80ca74ca5e0": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0061",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "7",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.106741981525725",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.414624064489355",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999992",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "61",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:fb7f0c2c30196ccec28c3a6548a05c74": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0062",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0609954180147001",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.54539640994801",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "62",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c93f984974556da4e703249091c0b9e6": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0063",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0457465635110251",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.606262591428315",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "63",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:9e172783feebd728c2f558fb3b71f8e1": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0064",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "8",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.1219908360294",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.38199421699717",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999893",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "64",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:87ab73f90e90a5729c135961d1e370c8": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0065",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0457465635110251",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.606262591428315",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "65",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:837d4c2c41156c19f0fd118f410295ff": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0066",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "9",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.137239690533075",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.353115016567812",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999998975",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "66",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:045f09754798eebc086b923539ec80df": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0067",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "5",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0762442725183751",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.494859211467501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "67",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:80792993798dbd9f1e93a2b1f460edb7": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0068",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0457465635110251",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.606262591428315",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "68",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:90698016a8817129b734a925244ac3ee": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0069",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "6",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0914931270220502",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.45185124173467",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "69",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:e884b18d0db747fcf84bd707ac9dd705": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0070",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0609954180147001",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.54539640994801",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "70",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:2a3d19c51223db94f710da6fc4488efe": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0071",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.682557316733255",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "71",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:525402486d0c3b5a8a9cc4d79a236330": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0072",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0457465635110251",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.606262591428315",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "72",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:4c1d2eaf37081d773b0db5e10c96074d": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0073",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0457465635110251",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.606262591428315",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "73",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:91b4c6608ce19710d67c33b2473fc9b4": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0074",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "9",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.137239690533075",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.353115016567812",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999998975",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "74",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:9caa103a34dc60ce70ec535ac6e8b007": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0075",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.682557316733255",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "75",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:b860ec229f39bc9a1fbaafbcbf0a163f": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0076",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0457465635110251",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.606262591428315",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "76",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:236f07396a3abe7464d0d6adae038d7d": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0077",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0457465635110251",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.606262591428315",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "77",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:d3ccad413c80f4d335ba3f4f6b6355af": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0078",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.786165890418407",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "78",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:485d5921cf99fd18e2d2bc08962f1a89": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0079",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.786165890418407",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "79",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:fafeba66cc92ac8083e5897d50f4bcab": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0080",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.786165890418407",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "80",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:48a7f6254e1629604bc57865dff4d670": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0081",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.682557316733255",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "81",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:33e63ed9d657f0ba23cd9ffacda3e22d": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0082",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.786165890418407",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "82",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:768ca0ef2b170d430ebbd40ebb08cff0": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0083",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.682557316733255",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "83",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:8cf8073a323eec04d3968fab10115c2b": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0084",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.786165890418407",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "84",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:dba062dd06d4105f10d77f25b52b96c8": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0085",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.786165890418407",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "85",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c51b283e94df3fae6004dee4203f35fd": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0086",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.786165890418407",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "86",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c79437288e303b8f2bef9af3b70d4aaa": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0087",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.786165890418407",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "87",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:049f42c8eb4f2db2320a43cbbdd89f0f": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0088",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.786165890418407",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "88",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:4e6c7a95cd372d482b4ef655fa46f083": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0089",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.786165890418407",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "89",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:78623bac11315960aba0a8d855467f49": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0090",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.682557316733255",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "90",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:288a1fc03510b55eff121de5bf93e1f4": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0091",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.682557316733255",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "91",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f6ffc917f79709af0e39207ec0add7a4": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0092",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.786165890418407",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "92",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:bd77e4cd78d5c4dcb23a68309256720d": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0093",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.786165890418407",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "93",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:31f96dd2a2f7097e6993ae7eec0e23e6": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0094",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.786165890418407",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "[]",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "94",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:b9c38db488f3b5f13ba315ce84742e30": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0001",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:8a04d65607e38687cf6f2f55af3c4b47",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "7.92007970809937",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "6.94608360738412",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.87783122385099e-12",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "4.18813870695089e-07",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "2.5522089353025e-07",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:8a04d65607e38687cf6f2f55af3c4b47": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0001",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[46,16,24]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:04ccd45e7b91b1372b86446353f69dec": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0002",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:29e5728f14fe9e84f03df78c3017ad26",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.31603479385376",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.77079466112137",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.94492849498107e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.000879943865776389",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1.66027144486111e-05",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:29e5728f14fe9e84f03df78c3017ad26": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0002",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[32,24,-4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2a457ee39f92424bfbae62e7f4d9d06e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0003",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c2b44e5f1b4308bc87e8513b4536e33f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.28007745742798",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.74292583422276",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.65272453897825e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00103782272796227",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1.77570952010042e-05",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c2b44e5f1b4308bc87e8513b4536e33f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0003",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[8,18,50]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7e3917d8345a65fc26f145125eeaff8c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0004",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:022199204ee65e352230c02576678448",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "7.11683940887451",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "6.37404871703245",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "9.20510334623259e-11",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "2.05325778424026e-05",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1.80089716755871e-06",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:022199204ee65e352230c02576678448": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0004",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[34,-88,-2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9998cb50acce86cfac60c2fd8b263502": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0005",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:466cad218c9b7df56ce89ad0ecf3e24b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.48292255401611",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.8992593141605",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.82568493656277e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.000407231755366277",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "9.69599417538756e-06",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:466cad218c9b7df56ce89ad0ecf3e24b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0005",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[42,-72,-10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c556266836a943fb870f1bf711a68c3b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0006",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:848d1690f1e2bb56ae22b60a4853a423",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.2275915145874",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.89738468004472",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.85602978606003e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0670610253017228",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000213643333035659",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:848d1690f1e2bb56ae22b60a4853a423": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0006",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[34,-86,12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:701c37986a9dfafb2485113e75f3877e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0007",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:fea264e5d6f510b6beae51359071a22d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.25127363204956",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.72055271981637",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.30890376104765e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0011841880966994",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1.8796636455546e-05",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:fea264e5d6f510b6beae51359071a22d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0007",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[52,-32,42]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d32b6a2abe066703d0a3f16b4a3aa993": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0008",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a07d84f13ebe8c5e8d72a6474acfdba5",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.24752378463745",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.71763687476157",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.40078304300806e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00120468241369565",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1.88231627139945e-05",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a07d84f13ebe8c5e8d72a6474acfdba5": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0008",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[40,-62,50]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:74291dfbb196ec16f80fb44d57da12f7": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0009",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6a6fbc6d5237e3c663d814c9b35c8e58",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.70337772369385",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.28674301747281",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.22566831420812e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.011413186758684",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "6.56259978738852e-05",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6a6fbc6d5237e3c663d814c9b35c8e58": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0009",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[56,-44,52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9d53626c88b2f04c3eadecaebc4a1338": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0010",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f38aef95e58ae38118b8281fd53a7a2d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.15371799468994",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.64445580026639",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.285227171001e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00184807786755337",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "2.16474462112596e-05",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f38aef95e58ae38118b8281fd53a7a2d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0010",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-28,-94,4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:85a1438415db5a3489dd11e7fb441b39": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0011",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:511a1e02e40bbe8a2c504cf6e208fc17",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.12145137786865",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.94794832362008",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.94119065879606e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.940339218142555",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00279439847450823",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:511a1e02e40bbe8a2c504cf6e208fc17": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0011",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-48,-72,2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0b8f8f1954b573ce6421b1aec938a3f7": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0012",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:1fc4e37586cdc18ac0682a29ef38c240",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.71480798721313",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.58412084932714",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000169107736440521",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999869855188705",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00680567457240922",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:1fc4e37586cdc18ac0682a29ef38c240": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0012",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-34,-84,-2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:142bb500e57d8a428669aea190bd5682": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0013",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0782b83d56620cd233fa7bce24466953",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.10109901428223",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.60320502193174",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.05212039080982e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00234682813060005",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "2.40223937009298e-05",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0782b83d56620cd233fa7bce24466953": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0013",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[32,2,46]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:27d4ca2419ed8dd89da3969cf9682d0e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0014",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0d568f934c855dfafbe86e68adc1df30",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.6086859703064",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.3736141683061",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.11031435759912e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.453877178455514",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000974930295891631",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0d568f934c855dfafbe86e68adc1df30": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0014",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[28,4,58]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:029834627d73e77047973cf21bbf5d82": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0015",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:25d0d7e2c9b753537fd9c78f89590f89",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.98793148994446",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.82932508069717",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.42475887594474e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.984644566584946",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00375703605421318",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:25d0d7e2c9b753537fd9c78f89590f89": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0015",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[42,4,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1eb8465701fde4fde92186c425baf8ea": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0016",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:135821fbbd9471e39f9ac3fd7e16b87c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.98348569869995",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.51047970249337",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.78928538652201e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00378871596531738",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "3.24481811369927e-05",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:135821fbbd9471e39f9ac3fd7e16b87c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0016",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-52,0,38]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:64d0ab7126894908ae25023162e0af73": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0017",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4f3030c801f9431366edc8c63f75c9b4",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.2253565788269",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.89552821543552",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.90210114501011e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0675937275056587",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000215162374940066",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4f3030c801f9431366edc8c63f75c9b4": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0017",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-60,8,20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:90054102ef0485b0300d9ac541c05772": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0018",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d3242b8c5dc0ccc3ccff4404d4f25b7f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.98950004577637",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.69817956585148",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.31245304380023e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.151048137890434",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000410591908363075",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d3242b8c5dc0ccc3ccff4404d4f25b7f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0018",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-44,6,28]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ea92fe2eb5755d0ea83fe118d00128a1": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0019",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d7872b1aeb0444ca5dfdf2fc0a2d64db",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.78093099594116",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.34909755317379",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.41969442155354e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00844151822925698",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "5.41672415342571e-05",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d7872b1aeb0444ca5dfdf2fc0a2d64db": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0019",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-34,-2,52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7f8a4c8c46cb2689a3c019747955dc4b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0020",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:629f123a388bd84ac9308e75e74affde",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.40964078903198",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.04774404642803",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.23528758724889e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0346958937061391",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000135488206134068",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:629f123a388bd84ac9308e75e74affde": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0020",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-54,-46,58]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e2bc5fe4c987ff0ec0df74c742ff1117": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0021",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:55aa6bcca3d975a9a0166ca4aa1ebc70",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.31841945648193",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.97261482231588",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.30279114724163e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0484353441449864",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000170572072121087",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:55aa6bcca3d975a9a0166ca4aa1ebc70": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0021",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-62,-38,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:520fe1eb050426e3b07c4a893b9f7db1": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0022",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7926e4868dfde88503bc251f695fd8f8",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.57099342346191",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.34109644800954",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.08867353027554e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.496004086968197",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00106632293891518",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7926e4868dfde88503bc251f695fd8f8": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0022",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-60,-50,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c87a3b3343886155da34c9892eaae298": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0023",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:60dff4deb3f26445945f48fa10727baf",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.93343877792358",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.65085575575197",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.6528024058271e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.180887232162623",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000464319207635078",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:60dff4deb3f26445945f48fa10727baf": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0023",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-58,-30,-18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:90abc80db14d12280a0791c4ce7391f5": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0024",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:408220d56d93cbff661412dfa2054f5f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.76414346694946",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.50698548813516",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.287756441539e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.301278778226174",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000675964618846495",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:408220d56d93cbff661412dfa2054f5f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0024",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-46,-66,-6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e745debfe2f3499165a83cfbc9245de3": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0025",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0406b71827350fd798033287d2d9414b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.7637345790863",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.62829384243901",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000142650218672435",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999605970761399",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00612774880514626",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0406b71827350fd798033287d2d9414b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0025",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-54,-64,-8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2343e4d7eb8c6a1729b72035eaf717e4": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0026",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7cde57681c3e67757a6384d582c9f90e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.72232866287231",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.47122948835043",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.88855941602095e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.338512677882141",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000740481435956345",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7cde57681c3e67757a6384d582c9f90e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0026",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[58,-38,6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1a8a86f7d9c9f722317b24c2e78074af": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0027",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b28457b36627fc8c2b8fbac61ecb2964",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.98372888565063",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.8255778871433",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.52328381068878e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.985409231324461",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00379034013545227",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b28457b36627fc8c2b8fbac61ecb2964": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0027",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[64,-30,-4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:23b4a479f72f56fff23eeb6665cae807": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0028",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:8e0d84f185660b18429c95fb79db1336",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.9098813533783",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.75959988615137",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.50926599039736e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.994607633788328",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00444631553927497",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:8e0d84f185660b18429c95fb79db1336": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0028",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[54,-24,-2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:cb1ced392fd8df88e767db43c1bc0ed7": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0029",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:17aedfa63a871543b140ee883e7fa00a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.70483255386353",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.45624265093732",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.17043099876224e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.354967306449537",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000776498970788289",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:17aedfa63a871543b140ee883e7fa00a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0029",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-36,-74,-14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7f2c05eeb31277d29699a1a1dc5708b9": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0030",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c65773868ad3c3ee6565f44d2f503688",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.08770418167114",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.91804495668",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.46350297789166e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.955724279224547",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00301069792579844",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c65773868ad3c3ee6565f44d2f503688": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0030",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-36,-68,-20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:de55bbb80f52ecc8be8aa173a5d0c4c4": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0031",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:23023da27952d97ce5978f24d0201fb4",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.71012616157532",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.57988831343959",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000171870546999631",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999883757236262",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00687347140086337",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:23023da27952d97ce5978f24d0201fb4": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0031",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-30,-58,-16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:94ac82c373f762df7652cf2eee707fcf": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0032",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:65bafc594498c6ac36e3357ddb1e5cf9",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.59621620178223",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.36286413267216",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.41853365035416e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.467637998233248",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00100629980038701",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:65bafc594498c6ac36e3357ddb1e5cf9": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0032",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[16,-98,6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a3cbab4a2a30eece310c15c0975c7b8c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0033",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:2f7752391d49b36d1668a1bed931ebed",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.57891654968262",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.34793761600864",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.87118388575936e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.487021764768749",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00104840737781972",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:2f7752391d49b36d1668a1bed931ebed": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0033",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-60,-16,28]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:24e1979d3724b3518945e59d3fad2d5b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0034",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:da3399510a366ca55680d838c72b0f46",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.37013816833496",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.16664310578498",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.54558935169247e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.730405153245217",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00164483391358715",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:da3399510a366ca55680d838c72b0f46": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0034",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-52,-62,52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:90230b1d46674135f54f40a8eaaa6955": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0035",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6f47e3c2cf1ad6ee422a9cac44b388e2",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.30655717849731",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.11101155082742",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.96964745459161e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.798260223882423",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00188267859062858",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6f47e3c2cf1ad6ee422a9cac44b388e2": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0035",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-26,-92,32]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6ecb22dc01f666b06e37c52dda7e1cea": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0036",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:868adc42924955a9584f6bf2cdbbe62c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.24533367156982",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.05725918601008",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.4825985211363e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.855631833511506",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00216400098580605",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:868adc42924955a9584f6bf2cdbbe62c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0036",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-18,-60,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1147bd3222d74b8465b410daf5f551d9": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0037",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:23fcb7cf1cb30acabf1d069782179e41",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.22729349136353",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.04138628171284",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.65680735640483e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.870712357794855",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00224862910698152",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:23fcb7cf1cb30acabf1d069782179e41": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0037",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-20,-98,22]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0edd0549008deb53921ccec5934b3d03": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0038",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ca5f81484ccce6fc3e9387947befc7f8",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.22599840164185",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.04024618213588",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.66975618669063e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.871760516202526",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00224977618124126",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ca5f81484ccce6fc3e9387947befc7f8": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0038",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-36,-74,-34]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:cecb64ea54e0530f18d065bad589c2a6": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0039",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:8dfaaed3cdea8aa1695388a5f053616f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.86162257194519",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "2.79772486594084",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00257319651143795",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0401361290360738",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:8dfaaed3cdea8aa1695388a5f053616f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0039",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-44,-62,-32]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f7f872af0c034510f177bd8ce9bb0b0c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0040",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:8aeee6e06b00259350b3cf7d5bdf384c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.20391035079956",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.02078923241408",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.900174224163e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.888907080881232",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00235275290167977",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:8aeee6e06b00259350b3cf7d5bdf384c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0040",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[34,-54,-16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:36ff54739107c726560ff84ecfbec58e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0041",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:fee6ca7cc2a611c4fda7974781d37cbd",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.18721437454224",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.00606667297511",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.08691144208506e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.900934824371894",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00243416319862164",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:fee6ca7cc2a611c4fda7974781d37cbd": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0041",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[12,-100,20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e7e5af7d0c21e8aef18e2542948c6793": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0042",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:dc93b496593d4b472f2eb9fd7aca8b08",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.17404651641846",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.99444589181498",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.24228638075574e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.909844421846994",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00250424652987014",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:dc93b496593d4b472f2eb9fd7aca8b08": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0042",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-40,-38,44]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5eedc42ee231bb3e0801681a9ba98372": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0043",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ab81f14081ba25602d7d462d456bc0e6",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.07333517074585",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.9052963692066",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.70549882543025e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.961337330645756",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00311829811824681",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ab81f14081ba25602d7d462d456bc0e6": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0043",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[20,-66,34]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5a68064d075ad549c6b87de74be574de": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0044",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:53dd5f18ed8740b69c85f29f5098f9c1",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.05762767791748",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.89134919103145",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.98441713834286e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.966867400896655",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00322871741467698",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:53dd5f18ed8740b69c85f29f5098f9c1": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0044",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-46,-56,14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:69b3e9ba35baf225bd111d6d16f02c59": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0045",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:104c93687e188734b35ec18667237aa2",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.97341108322144",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.81637469850314",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.7713399346081e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.987160063394768",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0038799021604929",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:104c93687e188734b35ec18667237aa2": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0045",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-50,-50,20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5cddeb38ad7e027bd0de87a3a4bbef17": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0046",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a48ff748b6cbde7cfc7b801d780bf846",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.0217924118042",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.85948683644491",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.68126885931441e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.977286609355005",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00348825429991405",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a48ff748b6cbde7cfc7b801d780bf846": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0046",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-36,-40,-36]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3522180f8cbe6ef50347376f1bbf6edb": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0047",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:8f5650b5420113415c6871a4e4b78e5e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.8867518901825",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.73888373627584",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "9.24195907030523e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.996210852184447",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00468683023961801",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:8f5650b5420113415c6871a4e4b78e5e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0047",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-50,-46,-32]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4b7df6a7ed2935756536e850b92db30a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0048",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:40a9737c4433538d39217a005cfdb1fc",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.19474077224731",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.10821385730133",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000941109068576473",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999989",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0204319298365656",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:40a9737c4433538d39217a005cfdb1fc": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0048",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-44,-42,-36]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d9b3a050332d74bf0f36c7adfdb580c3": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0049",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c118718c36a03fe9a2bf929e397ff014",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.9634416103363",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.80747753892992",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.01957428701494e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.988689669381963",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00396363025696444",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c118718c36a03fe9a2bf929e397ff014": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0049",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[4,6,32]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f725218800cfd7000fbd0ad268a06710": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0050",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a46751b7d89671899ba59e831d6e41bc",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.96245408058167",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.80659597790245",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.04463150378309e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.988832912076595",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00397422792108106",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a46751b7d89671899ba59e831d6e41bc": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0050",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-50,-48,-16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:dad6f2d5c4ce67fa4e55fba569c0d484": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0051",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:3206daab4372447e234b9b148d6d815b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.90285301208496",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.75330746420074",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.72582920719012e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99514521861122",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00452170460938149",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3206daab4372447e234b9b148d6d815b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0051",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-36,-46,-18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:840283767e66dbd6e157c770ba828a93": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0052",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:20f83c4fa7511447b6828ed5c47b09b3",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.90759468078613",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.75755289319297",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.57915531067288e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.994787688943672",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00447445110574173",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:20f83c4fa7511447b6828ed5c47b09b3": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0052",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-14,-98,-4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0e31b662b4e33990fa038bbb4c5ba001": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0053",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ef4842b6c6cfe0f325e9e746c09cb167",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.86077284812927",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.7155862280194",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000101366555929516",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.997515005942308",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0049663224069025",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ef4842b6c6cfe0f325e9e746c09cb167": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0053",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[64,-30,-22]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:15315bb12a4c858854e329703938208d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0054",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a0c6fdfff1abb4112874eb223d64277f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.82178378105164",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.68056404693028",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000116359297336222",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.998750111206092",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00541658304290436",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a0c6fdfff1abb4112874eb223d64277f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0054",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[12,52,-12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b8c952b7eb0604aaeff8a4b3deed04f2": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0055",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:aca234cd238d14c51f2712b56326ccdf",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.80767583847046",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.66787455107711",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000122287561408974",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999041631710947",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00557619880333977",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:aca234cd238d14c51f2712b56326ccdf": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0055",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[22,-80,54]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:22efce75aa6c6dce7c1322da7c4c8a84": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0056",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:1db9cd1b4946a3ce9cb7d6f4d57e7825",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.78668808937073",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.64898036269368",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000131641613210109",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999365630484476",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00583459491796649",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:1db9cd1b4946a3ce9cb7d6f4d57e7825": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0056",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-22,-74,60]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:29cb61e520efc605169b4daa2aecadcf": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0057",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e4d533f3ae3530faa4fa88f80772d5ba",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.69408750534058",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.56538143418403",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000181663694368006",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999921818129803",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00709819832733513",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e4d533f3ae3530faa4fa88f80772d5ba": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0057",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[50,46,-12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:29adc4964dd5cb588824e8fafff57b8b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0058",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ceb814e013d5960988e46b1015a2eff0",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.65459251403809",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.52960997534834",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000208086348004177",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999972447579615",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00771736431800426",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ceb814e013d5960988e46b1015a2eff0": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0058",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[54,8,-36]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4bf8abf79b6ded57be5385b0e6aab4b9": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0059",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:8fcdd38710d6dfcd1b86f088e8cf04c0",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.60173606872559",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.48162963814792",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000249186237945009",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999994173508246",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00859988568288654",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:8fcdd38710d6dfcd1b86f088e8cf04c0": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0059",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-14,58,10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a5aa6fcfda734e3389f7bec2d9ad0a6f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0060",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4514318f9da72e1bef9803b37a732d29",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.58989810943604",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.47086705539024",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000259390388114844",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999995993033212",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00880900397523308",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4514318f9da72e1bef9803b37a732d29": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0060",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-66,-36,22]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f09170fc52ba782fe9bdfaf02ade3b10": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0061",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:2f13fba96e94db31ba13df7c745e67c2",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.56340670585632",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.44676015888715",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000283676007278189",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999998329299787",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00931482128100283",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:2f13fba96e94db31ba13df7c745e67c2": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0061",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[18,60,12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c0586c77c95a193830c8219325ca2256": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0062",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c1b0e76791ad2592aff2be5e27561f34",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.55537104606628",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.43944179853069",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000291457553818653",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999998731920076",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0094907493053886",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c1b0e76791ad2592aff2be5e27561f34": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0062",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-64,-34,8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:29b6d69627dd6dacdaa3a9b3c30d347f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0063",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7d14954855c9816b0a230a0df291fa29",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.54216623306274",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.42740966598884",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000304684504620178",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999202607737",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00978309810858832",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7d14954855c9816b0a230a0df291fa29": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0063",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-58,-32,22]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:afa91bed7d064469a4e66e23ca1c26f9": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0064",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6a2b0b0ce5882ce85cc24088d095d5f4",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.46738910675049",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.35913252154752",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000390937814553127",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999955890495",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0114444909736178",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6a2b0b0ce5882ce85cc24088d095d5f4": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0064",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[14,-14,72]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ce725d602d22bdbfcfb1d33ed8a51382": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0065",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6f48cd191b2923a4059fd4f816332e01",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.13905429840088",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.05659883446979",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00111931832184231",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0229711836666271",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6f48cd191b2923a4059fd4f816332e01": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0065",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[12,-16,64]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8d0242e530dd2b7ac61d63b861ffdfb2": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0066",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:610b4620d7a52f6451a8f5a7fe636e78",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.45441365242004",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.34726077209469",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000408071982705316",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999974583179",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0117929908461181",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:610b4620d7a52f6451a8f5a7fe636e78": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0066",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-38,-54,-42]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:409a5667ff5ace48db341b1d4b443b7b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0067",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7f0662b591e4d89dd3e64021c01d47a8",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.43198323249817",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.32672157755253",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000439370628491198",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999990548038",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0123661196896594",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7f0662b591e4d89dd3e64021c01d47a8": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0067",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[42,-42,14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:93fba29bbc2b01e814cebc5c1c0d1553": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0068",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4321078ea4b73fb1eebb645623318e8d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.40386486053467",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.30094422133281",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000481800187664638",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999997442132",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0131315419066298",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4321078ea4b73fb1eebb645623318e8d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0068",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[52,-42,18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e3c2f2c5c8877cf5d3301382557e5009": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0069",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:5a357afd9be7a34bbbde654f71b7451e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.36533284187317",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.26556677338515",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000546226226643243",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999624169",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0142364394435995",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:5a357afd9be7a34bbbde654f71b7451e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0069",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[44,-48,-26]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:cf455aa53879ce5eb8f2e701d72643c3": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0070",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c39b228e86e60d680bce4be9f24e6881",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.32532405853271",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.22876865896546",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000621622108231912",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999995642",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.015558079264466",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c39b228e86e60d680bce4be9f24e6881": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0070",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-54,-32,42]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e9c6bf15ba9e098b7b0cca458dc8cd21": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0071",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ec9d5559de25c81d98d87fac2fbe5dba",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.31892204284668",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.22287431730178",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000634556128578101",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.99999999996962",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0157616735622854",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ec9d5559de25c81d98d87fac2fbe5dba": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0071",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-16,4,62]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:93ecdc023889193376179f882fb09793": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0072",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a63341a7ce00061c582e0ccb012ef7e2",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.28136968612671",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.18826629952882",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000715643274853739",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999996665",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0170366752692093",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a63341a7ce00061c582e0ccb012ef7e2": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0072",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[56,-66,4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:cfedd59c6ad80ae5fe3df5fa3e086b64": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0073",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:000efbc6d4c9aeab7beaa0ab52208f9f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.26226496696472",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.17063765299814",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000760523733375762",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999998982",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0177274295203014",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:000efbc6d4c9aeab7beaa0ab52208f9f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0073",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-60,-14,10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b65cce8679c42572d912ca303840373a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0074",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4c2c5363ab8e8186172107f728368d86",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.25416302680969",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.16315726358056",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000780339994975288",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999392",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0180089199210036",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4c2c5363ab8e8186172107f728368d86": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0074",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-66,-46,8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b1da3428c34e2b43760ad5c2f4e2d0fa": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0075",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e9c17a2c6bd24ee4990476b4240509d1",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.24836373329163",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.15780125799237",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000794819459152607",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999582",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.018230089242935",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e9c17a2c6bd24ee4990476b4240509d1": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0075",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-68,-34,-8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ed0ad58b2c2c68d107db680a95fd120e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0076",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:eaa56e97c2a8bfdb44a80f726af2b864",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.23679161071777",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.14710967833961",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000824465484375092",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999804",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0186930131202947",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:eaa56e97c2a8bfdb44a80f726af2b864": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0076",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-56,34,-20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:81766c881aa79ffa1dca5be898876a89": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0077",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d1b58d5e6a4d1431d1749aa413e48000",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.22478008270264",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.13600649460504",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000856327054624684",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999913",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.019197465737185",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d1b58d5e6a4d1431d1749aa413e48000": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0077",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[8,-72,42]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6f9386b12ed4b5e1d223ee7299272af0": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0078",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:53635ca2d983f1354091759d739567d9",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.22331190109253",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.13464894829369",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000860299398633191",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999921",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0192710694895643",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:53635ca2d983f1354091759d739567d9": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0078",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[42,-86,12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:fb2e0b3836b38e971ed6c44595c76ce6": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0079",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a0a046d9c5ecbb0ae2f57dafe426178e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.17424750328064",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.08923296074259",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00100337008659268",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999998",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0213685540658751",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a0a046d9c5ecbb0ae2f57dafe426178e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0079",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[12,-86,50]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:bb4c57fd5df089908c6bcfc3efe6b9f9": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0080",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:803ec44036ba7fa1184f3d5d4fb202ef",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.15485405921936",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.07125564726837",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00106580278515289",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.999999999999999",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0222342074339062",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:803ec44036ba7fa1184f3d5d4fb202ef": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0080",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-60,-46,0]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:09e6296e10757ad10cecbc458943830b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0081",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4d5ab67b2c378b1ea426a6fb6bc53983",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.15112209320068",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.06779451986408",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00107822421513859",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0224117734411443",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4d5ab67b2c378b1ea426a6fb6bc53983": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0081",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[54,-22,-26]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:798ba4f1b0df8e048c40896efbc27bc1": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0082",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:1cd1d457fbb26bf7d7a2a157c4a8597b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.14736461639404",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.06430918903901",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00109086649800139",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0225800614737541",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:1cd1d457fbb26bf7d7a2a157c4a8597b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0082",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-50,-40,32]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:65faea3b6c2b60b8b3a4b771985ae82d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0083",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:3e9bbdd2259381c519f423e47e9d1700",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.14220976829529",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.05952680873208",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00110843472885702",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.022825630044905",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3e9bbdd2259381c519f423e47e9d1700": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0083",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-28,-64,-4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:efa6c4751eb0a691336a3cdb57edc4d4": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0084",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6bf46886efc953821efdbedfa918b17f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.0528359413147",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "2.97644965310987",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00145803479142037",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0273451681875923",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6bf46886efc953821efdbedfa918b17f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0084",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-32,-76,-2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:dfcb0da83436b538eda80129d69688fe": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0085",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:5594ee59f798566f25c3ce8826d865f7",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.13440585136414",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.05228482208755",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00113553246964015",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0232102144708915",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:5594ee59f798566f25c3ce8826d865f7": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0085",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-46,14,2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e974721ee82dbde15f9b39d69ec70d5a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0086",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:9258b6520b6d9e367a03d1229b82cd50",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.10635590553284",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.02623536858597",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00123809733665026",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0245458677588465",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:9258b6520b6d9e367a03d1229b82cd50": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0086",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-30,-64,-40]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:aa808c2c64b1d016870f13b853b07dde": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0087",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:df0ab6577fa3b98348187ba4d0505464",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.10515308380127",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.02511765947288",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00124268210298895",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0246072121840759",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:df0ab6577fa3b98348187ba4d0505464": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0087",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[48,34,-6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:bee1c5e3b563da49fb889d00a907068a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0088",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:058c979548e4a8a7bfcbe9709834c9a4",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.09994459152222",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.02027708985515",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0012627176367187",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0248683482689455",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:058c979548e4a8a7bfcbe9709834c9a4": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0088",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[14,52,24]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8c4cac3967178a072f8a1b26ec0be67c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0089",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f246f3356741cc6338e2b2af30aa3eda",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.09887838363647",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.01928607085125",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00126685581272745",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0249171839147233",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f246f3356741cc6338e2b2af30aa3eda": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0089",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-38,-78,8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ab0a345a1b23456828ee0bd75b928ed7": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0090",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f4174578f5d208031a34b2194cf74ee8",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.07387399673462",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "2.99603266917277",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00136758564431361",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0261754700848395",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f4174578f5d208031a34b2194cf74ee8": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0090",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[12,-18,52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ebb12b1fa798252b807914310e351b35": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0091",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:92b403d3f268a73ca193179c615086a4",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.05714297294617",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "2.98046014668547",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00143907843047086",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0271009625306751",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:92b403d3f268a73ca193179c615086a4": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0091",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-56,24,22]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:15d51008205872b18f614dedb8a4130b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0092",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:108fca12dc3621c31e0a6e7c66e5b2fd",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.05520439147949",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "2.97865512160875",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00144758220776409",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0272166039833409",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:108fca12dc3621c31e0a6e7c66e5b2fd": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0092",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[10,-8,6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6bfcfb8a7a78ca0a953b28b7ac785df9": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0093",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c09564cb0de3a7ac00f96ddeb6277f3c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.04858613014221",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "2.97249176352455",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00147696567841604",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0275869018911531",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c09564cb0de3a7ac00f96ddeb6277f3c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0093",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[18,-58,32]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ca809001af3d981e8831371d40cadda0": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0094",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7b18ac5074edd48ca6bda1186dbd2889",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.04525375366211",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "2.96938782009723",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00149196870031498",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0277581737585471",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7b18ac5074edd48ca6bda1186dbd2889": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0094",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-28,-30,-38]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a6ab7750f7aec3f30041a2426c3c5488": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0095",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d3c074a7ae3a7616d683ca666602e6ce",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.03322005271912",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "2.95817559801864",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00154732890171205",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.028466280131439",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d3c074a7ae3a7616d683ca666602e6ce": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0095",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[36,-58,38]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:571af20b9fc7a3650f23e4883c4c0db7": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0096",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7c59844a04f86ceb0022ff5eedfb7507",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.02379393577576",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "2.94938921855853",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00159201350826743",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0290329815576138",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7c59844a04f86ceb0022ff5eedfb7507": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0096",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[24,-64,-18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4109cffc49a21d458e8e3c4ec5bdec4b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0097",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ecb3f8e0de95691c6a806b7b47dda58b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.99292635917664",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "2.92059379223963",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00174682509072199",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0308676807763691",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ecb3f8e0de95691c6a806b7b47dda58b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0097",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[30,60,14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e75d8bde52802e14e982fc7e310fa7e5": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0098",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:dae318474344710c6bb95c6d28a6cecb",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.97051525115967",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "2.89966547896516",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0018678055138297",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0323068383068969",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:dae318474344710c6bb95c6d28a6cecb": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0098",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-32,14,60]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:896ea228d6022d6a6fbe18f3fecced44": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0099",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f41e73664c8531f0cd9110ce8757bc4f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.96238708496094",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "2.89207063814041",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00191355944745719",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.032831917036533",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f41e73664c8531f0cd9110ce8757bc4f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0099",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-14,4,16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3b2dfa543dfff0705b80fb76652786b5": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0100",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:559860f351aed5f67953b4429dea3d47",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.94971632957458",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "2.88022656424043",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00198694744230488",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0336756816327342",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:559860f351aed5f67953b4429dea3d47": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0100",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-64,-24,46]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:782068672fbbe3620c5f41b2464beaeb": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0101",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:042b46248a6389f83c7d559692df2f65",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.94846987724304",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "2.8790611260641",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00199430508764054",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0337569462213811",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:042b46248a6389f83c7d559692df2f65": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0101",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[50,-40,-40]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:325f64d356f613a0e0206309a641ecc0": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0102",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:267e0e982d25b38ad72635cd9afe6ff2",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.90027952194214",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "2.83396102798879",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00229874692151077",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.037104578234211",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:267e0e982d25b38ad72635cd9afe6ff2": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0102",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-30,22,52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:adfb5705362a8f1bdf0b807bde3dda91": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0103",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e29b1f0adc5419735354b19bd6a5f50b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.89968776702881",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "2.83340671662386",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0023027373793546",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0371395343086566",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e29b1f0adc5419735354b19bd6a5f50b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0103",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[8,-2,28]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a1698f36e3e1c0e83de4c62180a03384": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0104",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:faf116993450ab1d40f10c0ea345a2e4",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.88594245910645",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "2.82052775201409",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00239723631051436",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0381801662649124",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:faf116993450ab1d40f10c0ea345a2e4": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0104",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[14,-22,76]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:174c45a8d1e67a22fc26e791cf355a46": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0105",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:8ddea03b043d98f6868e7d29c28b4ad5",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.88162541389465",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "2.81648146341917",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00242764223383896",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0385303778515655",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:8ddea03b043d98f6868e7d29c28b4ad5": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0105",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[32,-80,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d3666814839586295a138503c43b05cb": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0106",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:700ca7e9988e82bcf89e1f9f7c4c125d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.86741852760315",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "2.80316111290485",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00253021914439433",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0396560213914501",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:700ca7e9988e82bcf89e1f9f7c4c125d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0106",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-22,4,8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:132f6eb140d7fc16eceeb304478171c2": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0107",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:9232cc449e5a68b19d9882c1045a5e8e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.86433458328247",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "2.80026870598453",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00255300420116833",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0399071683618212",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:9232cc449e5a68b19d9882c1045a5e8e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0107",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-22,-88,-8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c44f1d9e91a6e9fe1b09cd64614d61c2": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0108",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:9b89beb9deba464fb2b8daf018f2b058",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.8607702255249",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "2.7969253219898",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00257957281985488",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0402133860761281",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:9b89beb9deba464fb2b8daf018f2b058": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0108",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-40,12,10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:53fd4410e0451ea937aa0616970eb8c1": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0109",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:97d461a41363cb6f676aa66096ab6def",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.84392619132996",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "2.78111974914723",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00270858754422498",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.041614329014815",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:97d461a41363cb6f676aa66096ab6def": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0109",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[14,-8,36]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3469a97617a1acc2f9fa828b99843678": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0110",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:cb7e1ce722f6758ac5d4c15d377d77c2",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.84026050567627",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "2.77767879851976",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00273743545807803",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0419349799473709",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:cb7e1ce722f6758ac5d4c15d377d77c2": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0110",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[46,-40,4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:60c64006a9802f87bdbaffb4ec25a5b2": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0111",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:86ff68b3752b401bab1dea5b5679ac5b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.81844663619995",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "2.75719305463653",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0029149959934297",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0437990036423837",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:86ff68b3752b401bab1dea5b5679ac5b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0111",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[44,8,-20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:918936eb1d58155c78c560ab565b0202": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0112",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:8acf1763afbbc2c95b172b9578d29d2b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.7993757724762",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "2.73927048137962",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00307878458404665",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0454451203208682",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:8acf1763afbbc2c95b172b9578d29d2b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0112",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[14,-44,20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8d45ffd6ad4acc8edcfb248f110ba687": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0113",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f4e79acdb9c2e573b4d0b861b0156ed1",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.79517197608948",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "2.73531820941264",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0031159999373751",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0458305068946882",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f4e79acdb9c2e573b4d0b861b0156ed1": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0113",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[18,-14,44]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8ad18c7eb09ca5a3aab852d344491753": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0114",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ca5c06dc0433f9ffbb1a4ad5a02f8a10",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.79148125648499",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "2.73184784384814",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00314901097075382",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.046156489574122",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ca5c06dc0433f9ffbb1a4ad5a02f8a10": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0114",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[12,-6,34]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9c388cc5a4937ec66a020ba4a2721666": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0115",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7946fe79a1ae96f06dc46a97c7ed5fe7",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.78754210472107",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "2.72814339359783",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00318459572389584",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0465414965984294",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7946fe79a1ae96f06dc46a97c7ed5fe7": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0115",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-32,-62,-26]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:baa76c8f2997dbaae3d90e25b8c4bfd8": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0116",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f864654c4d54b3c64735888e578355e6",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.77749013900757",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "2.71868808084123",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00327706910125547",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0474666807455127",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f864654c4d54b3c64735888e578355e6": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0116",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[64,-10,22]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:34797ad5a5f0034f4a5cf71249cd89d8": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0117",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a9825b9be6fe20a5cb8645642659227e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.76671266555786",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "2.70854673720236",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00337892965855868",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0484988413841496",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a9825b9be6fe20a5cb8645642659227e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0117",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-22,-4,10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c04ece7485734e358071d757deeef557": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0118",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d534f09e73fec2932a43da85804923c2",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.7631950378418",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "2.70523593531943",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00341279457967081",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0488594652816085",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d534f09e73fec2932a43da85804923c2": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0118",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-42,-24,70]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:115008c56fcea7d4c5a2ee78582283c7": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0119",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:98a043770ac0d808800712f30d2fc24c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "2.75206708908081",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "2.69475970396491",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00352197048666147",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0499801129190164",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:98a043770ac0d808800712f30d2fc24c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0119",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-62,-20,46]",
+                "type": "xsd:string"
+            }
+        }
+    },
+    "activity": {
+        "niiri:07b5d61a16905b058dc07a10451e4f4f": {
+            "prov:type": {
+                "$": "nidm_ModelParametersEstimation:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Model parameters estimation",
+                "type": "xsd:string"
+            },
+            "nidm_withEstimationMethod:": {
+                "$": "obo_generalizedleastsquaresestimation:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:82fff8a2920d426af761ea65abc3f824": {
+            "prov:type": {
+                "$": "nidm_ContrastEstimation:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Contrast estimation",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:aa76de7328e3d13603b9e4c03167310d": {
+            "prov:type": {
+                "$": "nidm_Inference:",
+                "type": "xsd:QName"
+            },
+            "nidm_hasAlternativeHypothesis:": {
+                "$": "nidm_OneTailedTest:",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Inference",
+                "type": "xsd:string"
+            }
+        }
+    },
+    "agent": {
+        "niiri:6a56b7cc41090f34638cf50938e932eb": {
+            "prov:type": [
+                {
+                "$": "src_SPM:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "prov:SoftwareAgent",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "SPM",
+                "type": "xsd:string"
+            },
+            "nidm_softwareVersion:": {
+                "$": "12.6906",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c8fcc3ae56b4269cf1aaf34f24d3c6a1": {
+            "prov:type": [
+                {
+                "$": "nlx_Imaginginstrument:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nlx_Magneticresonanceimagingscanner:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "MRI Scanner",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:665c960b6edd432a6d053af0f35e8752": {
+            "prov:type": {
+                "$": "prov:Person",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Person",
+                "type": "xsd:string"
+            }
+        }
+    },
+    "wasGeneratedBy": {
+        "_:wGB20": {
+            "prov:entity": "niiri:3da9457cb4e9a27e6ca5714485d63d58",
+            "prov:activity": "niiri:07b5d61a16905b058dc07a10451e4f4f"
+        },
+        "_:wGB22": {
+            "prov:entity": "niiri:aa66cc4786ebae74492d856291b12f31",
+            "prov:activity": "niiri:07b5d61a16905b058dc07a10451e4f4f"
+        },
+        "_:wGB26": {
+            "prov:entity": "niiri:b0a406128a699bce39d09638de7fbb11",
+            "prov:activity": "niiri:07b5d61a16905b058dc07a10451e4f4f"
+        },
+        "_:wGB30": {
+            "prov:entity": "niiri:95009d167a825475f9da93813a5eff0d",
+            "prov:activity": "niiri:07b5d61a16905b058dc07a10451e4f4f"
+        },
+        "_:wGB34": {
+            "prov:entity": "niiri:89d2070b8724cba90b0701cbb65ee609",
+            "prov:activity": "niiri:07b5d61a16905b058dc07a10451e4f4f"
+        },
+        "_:wGB38": {
+            "prov:entity": "niiri:7afdd6ab4e20f8072056e7ad109e1a28",
+            "prov:activity": "niiri:07b5d61a16905b058dc07a10451e4f4f"
+        },
+        "_:wGB42": {
+            "prov:entity": "niiri:3ae2261460b37724f66a583d13620d04",
+            "prov:activity": "niiri:07b5d61a16905b058dc07a10451e4f4f"
+        },
+        "_:wGB56": {
+            "prov:entity": "niiri:97a6f2d59ca3be4b5454a9ab78cdf8a3",
+            "prov:activity": "niiri:82fff8a2920d426af761ea65abc3f824"
+        },
+        "_:wGB60": {
+            "prov:entity": "niiri:ea0fc93e4d1d634046b0ddea1c061c4f",
+            "prov:activity": "niiri:82fff8a2920d426af761ea65abc3f824"
+        },
+        "_:wGB62": {
+            "prov:entity": "niiri:9349eafbf1e1c6deb40a7bbb8393c611",
+            "prov:activity": "niiri:82fff8a2920d426af761ea65abc3f824"
+        },
+        "_:wGB81": {
+            "prov:entity": "niiri:0337db714526a735c3f18f8b17802c96",
+            "prov:activity": "niiri:aa76de7328e3d13603b9e4c03167310d"
+        },
+        "_:wGB85": {
+            "prov:entity": "niiri:dfc9c2736061f68baaf0d5518b47b332",
+            "prov:activity": "niiri:aa76de7328e3d13603b9e4c03167310d"
+        }
+    },
+    "used": {
+        "_:u14": {
+            "prov:activity": "niiri:07b5d61a16905b058dc07a10451e4f4f",
+            "prov:entity": "niiri:d114849d6b0dd611879e4e55b5de49c6"
+        },
+        "_:u15": {
+            "prov:activity": "niiri:07b5d61a16905b058dc07a10451e4f4f",
+            "prov:entity": "niiri:65f5e0c3410f30b555aa41ff7e65f3d4"
+        },
+        "_:u16": {
+            "prov:activity": "niiri:07b5d61a16905b058dc07a10451e4f4f",
+            "prov:entity": "niiri:c2b879875530eeeb341e109f646bd0bb"
+        },
+        "_:u46": {
+            "prov:activity": "niiri:82fff8a2920d426af761ea65abc3f824",
+            "prov:entity": "niiri:3da9457cb4e9a27e6ca5714485d63d58"
+        },
+        "_:u47": {
+            "prov:activity": "niiri:82fff8a2920d426af761ea65abc3f824",
+            "prov:entity": "niiri:7afdd6ab4e20f8072056e7ad109e1a28"
+        },
+        "_:u48": {
+            "prov:activity": "niiri:82fff8a2920d426af761ea65abc3f824",
+            "prov:entity": "niiri:d114849d6b0dd611879e4e55b5de49c6"
+        },
+        "_:u49": {
+            "prov:activity": "niiri:82fff8a2920d426af761ea65abc3f824",
+            "prov:entity": "niiri:f2151889cbe45b2a41ece1a31d4608ed"
+        },
+        "_:u50": {
+            "prov:activity": "niiri:82fff8a2920d426af761ea65abc3f824",
+            "prov:entity": "niiri:b0a406128a699bce39d09638de7fbb11"
+        },
+        "_:u51": {
+            "prov:activity": "niiri:82fff8a2920d426af761ea65abc3f824",
+            "prov:entity": "niiri:95009d167a825475f9da93813a5eff0d"
+        },
+        "_:u52": {
+            "prov:activity": "niiri:82fff8a2920d426af761ea65abc3f824",
+            "prov:entity": "niiri:89d2070b8724cba90b0701cbb65ee609"
+        },
+        "_:u73": {
+            "prov:activity": "niiri:aa76de7328e3d13603b9e4c03167310d",
+            "prov:entity": "niiri:614f1836a4dabc08f6a40b74d83e4626"
+        },
+        "_:u74": {
+            "prov:activity": "niiri:aa76de7328e3d13603b9e4c03167310d",
+            "prov:entity": "niiri:f0dedbabde9224b6cdcbfcacb9ea64eb"
+        },
+        "_:u75": {
+            "prov:activity": "niiri:aa76de7328e3d13603b9e4c03167310d",
+            "prov:entity": "niiri:97a6f2d59ca3be4b5454a9ab78cdf8a3"
+        },
+        "_:u76": {
+            "prov:activity": "niiri:aa76de7328e3d13603b9e4c03167310d",
+            "prov:entity": "niiri:3ae2261460b37724f66a583d13620d04"
+        },
+        "_:u77": {
+            "prov:activity": "niiri:aa76de7328e3d13603b9e4c03167310d",
+            "prov:entity": "niiri:3da9457cb4e9a27e6ca5714485d63d58"
+        },
+        "_:u78": {
+            "prov:activity": "niiri:aa76de7328e3d13603b9e4c03167310d",
+            "prov:entity": "niiri:25809641902137f5d84b8818fbf15a91"
+        },
+        "_:u79": {
+            "prov:activity": "niiri:aa76de7328e3d13603b9e4c03167310d",
+            "prov:entity": "niiri:c9584a376a996dc760652f9e9d414333"
+        }
+    },
+    "wasDerivedFrom": {
+        "_:wDF19": {
+            "prov:generatedEntity": "niiri:3da9457cb4e9a27e6ca5714485d63d58",
+            "prov:usedEntity": "niiri:dcc3a5e5bd34ab36eb3416ae867b7fb6"
+        },
+        "_:wDF25": {
+            "prov:generatedEntity": "niiri:b0a406128a699bce39d09638de7fbb11",
+            "prov:usedEntity": "niiri:5173be555c2ec5d890f39722a8ff9fad"
+        },
+        "_:wDF29": {
+            "prov:generatedEntity": "niiri:95009d167a825475f9da93813a5eff0d",
+            "prov:usedEntity": "niiri:ec5d05a2244cdd38b1812f3fb5a35d09"
+        },
+        "_:wDF33": {
+            "prov:generatedEntity": "niiri:89d2070b8724cba90b0701cbb65ee609",
+            "prov:usedEntity": "niiri:e4b178e7dce758cde4b2d2404cae0b85"
+        },
+        "_:wDF37": {
+            "prov:generatedEntity": "niiri:7afdd6ab4e20f8072056e7ad109e1a28",
+            "prov:usedEntity": "niiri:bf71d9330aaa4b58789fc468b13d0fde"
+        },
+        "_:wDF41": {
+            "prov:generatedEntity": "niiri:3ae2261460b37724f66a583d13620d04",
+            "prov:usedEntity": "niiri:754590eadc87f59168e42a5f669d8b83"
+        },
+        "_:wDF55": {
+            "prov:generatedEntity": "niiri:97a6f2d59ca3be4b5454a9ab78cdf8a3",
+            "prov:usedEntity": "niiri:c5d3fd2966a03a48d06d8890367cdebf"
+        },
+        "_:wDF59": {
+            "prov:generatedEntity": "niiri:ea0fc93e4d1d634046b0ddea1c061c4f",
+            "prov:usedEntity": "niiri:615aeb13ab7f18a00b6e56cef9a42324"
+        },
+        "_:wDF87": {
+            "prov:generatedEntity": "niiri:57b0b3487b8ceebf11e98e8506c169a2",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF89": {
+            "prov:generatedEntity": "niiri:3d5c32984a0665ba596ff6cef71fcd0b",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF91": {
+            "prov:generatedEntity": "niiri:2c413461a4c1a86447e1da248ab7545c",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF93": {
+            "prov:generatedEntity": "niiri:e3f486aca3000e0c84fbdaf8a042398f",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF95": {
+            "prov:generatedEntity": "niiri:c0ef61636e02d68816943e9c0c7be35d",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF97": {
+            "prov:generatedEntity": "niiri:e9bd68a9b52a95e89ba7a7e17b4fa428",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF99": {
+            "prov:generatedEntity": "niiri:7693eabf368839e957bc3cfe43c975e0",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF101": {
+            "prov:generatedEntity": "niiri:39b96655430c53f32e07621dbe8655c4",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF103": {
+            "prov:generatedEntity": "niiri:90ea170edb9635f011af376c50f1eff8",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF105": {
+            "prov:generatedEntity": "niiri:d976336ac6ecb4bba1136f54b6de3e23",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF107": {
+            "prov:generatedEntity": "niiri:43ec173da0c3faa0f4491456aea575ce",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF109": {
+            "prov:generatedEntity": "niiri:a21087d5b0bdd477c690e1272139bf8a",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF111": {
+            "prov:generatedEntity": "niiri:a4d3b6fc7cc84d91945916a3052dd21c",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF113": {
+            "prov:generatedEntity": "niiri:d3e3d125a9ce7e2ce6bac0795d332509",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF115": {
+            "prov:generatedEntity": "niiri:0531c28556a1e0fba30c3ea1dd24f56e",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF117": {
+            "prov:generatedEntity": "niiri:22a4e1327d4f2f7349df156933a68889",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF119": {
+            "prov:generatedEntity": "niiri:661e97df890b4cd21b7b3cc4a2220e2e",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF121": {
+            "prov:generatedEntity": "niiri:fb7297e8c19234947de7375e05901f89",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF123": {
+            "prov:generatedEntity": "niiri:c016e8a860699bda1ff422a1f501e63d",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF125": {
+            "prov:generatedEntity": "niiri:c4fe065cafdebad144fa17a8ec71281b",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF127": {
+            "prov:generatedEntity": "niiri:b9447d9cb03b61ef6f6b29b2f726c748",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF129": {
+            "prov:generatedEntity": "niiri:fccd53239e801ce9120073c47ddcae13",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF131": {
+            "prov:generatedEntity": "niiri:e8858d23bbbcba237e94c70004237a2f",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF133": {
+            "prov:generatedEntity": "niiri:a1e36a12612c98786c42d6e581a41938",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF135": {
+            "prov:generatedEntity": "niiri:6aac454abbeb6462b826cd647eb086e0",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF137": {
+            "prov:generatedEntity": "niiri:7b28ee2c06d9f1eb5b4dab7494fe7a85",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF139": {
+            "prov:generatedEntity": "niiri:00aad4e5c367c7dee68c301c251cb2ce",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF141": {
+            "prov:generatedEntity": "niiri:904dc3e52037e77af188b63a3d3a6884",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF143": {
+            "prov:generatedEntity": "niiri:ffdea138243040f7b25be6c44f68510d",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF145": {
+            "prov:generatedEntity": "niiri:f19e77aa11c450b96b368f822fcfd6ce",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF147": {
+            "prov:generatedEntity": "niiri:1b80b6984bddaf1c61a51a898d6acbea",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF149": {
+            "prov:generatedEntity": "niiri:2a6b200869ec06562d293e64de33e926",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF151": {
+            "prov:generatedEntity": "niiri:50eb3a7d09683191b4aed76432577ca4",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF153": {
+            "prov:generatedEntity": "niiri:3dc187c20fafa718374d3bf8209b869c",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF155": {
+            "prov:generatedEntity": "niiri:2246deb8a6c721c27dda92f3dd869ffd",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF157": {
+            "prov:generatedEntity": "niiri:50cb1d29d6f8a9cfe9515552c5bb7d31",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF159": {
+            "prov:generatedEntity": "niiri:d6d69b36b9108bb0de66eeffba4d858e",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF161": {
+            "prov:generatedEntity": "niiri:e88a30db5e3821edb55a62d4b67f0ad1",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF163": {
+            "prov:generatedEntity": "niiri:a4ad9afd60a760f91d6916421b56fe6a",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF165": {
+            "prov:generatedEntity": "niiri:d3934b966af329378cc1a1307b94a530",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF167": {
+            "prov:generatedEntity": "niiri:546534eff08d214139c8884f815a2c20",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF169": {
+            "prov:generatedEntity": "niiri:295cf12e37c01e14c3830d46154826a9",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF171": {
+            "prov:generatedEntity": "niiri:aedc5c46b75f681aa273f0c65aba753d",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF173": {
+            "prov:generatedEntity": "niiri:03b802eb8ab278c3154b4ebae374f2f2",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF175": {
+            "prov:generatedEntity": "niiri:33fb5b8990838fc1f2547ba3ff8437d2",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF177": {
+            "prov:generatedEntity": "niiri:f6f7f9d9bd2b440c679a5ff44f1cdb22",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF179": {
+            "prov:generatedEntity": "niiri:cbbd42e6f42814091a8e0fc54b7ad3c4",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF181": {
+            "prov:generatedEntity": "niiri:53fb996b754ceba84bda7b0e7b9bdc51",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF183": {
+            "prov:generatedEntity": "niiri:55bb03da7ee7d021560ed83a011342a9",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF185": {
+            "prov:generatedEntity": "niiri:ac7c392c52df7cdd1a6cd2c7335454d2",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF187": {
+            "prov:generatedEntity": "niiri:c3f05dc9d300aa5acc02e364f1c3ee85",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF189": {
+            "prov:generatedEntity": "niiri:45b4ec73da86f70d949a94aa6ab8d4ab",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF191": {
+            "prov:generatedEntity": "niiri:54114a5d8df2f7e553a53e4b7d3f5bde",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF193": {
+            "prov:generatedEntity": "niiri:3f3ed8fe063a9052a3379a875a3af9b1",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF195": {
+            "prov:generatedEntity": "niiri:5721ae6aae6160ad82aced2d2fe68def",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF197": {
+            "prov:generatedEntity": "niiri:9326713bc412f1ec61f3bf20466a1174",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF199": {
+            "prov:generatedEntity": "niiri:ae9ba0f37d886eaa080e3238cefd1961",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF201": {
+            "prov:generatedEntity": "niiri:55108dec00fcabdca0aa0fd19deac38c",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF203": {
+            "prov:generatedEntity": "niiri:16a2d945f11329e9c381ee7f04a0ef0e",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF205": {
+            "prov:generatedEntity": "niiri:51de73f4c31fd22967b959166dfdd033",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF207": {
+            "prov:generatedEntity": "niiri:5810f1d1820e723be51fc80ca74ca5e0",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF209": {
+            "prov:generatedEntity": "niiri:fb7f0c2c30196ccec28c3a6548a05c74",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF211": {
+            "prov:generatedEntity": "niiri:c93f984974556da4e703249091c0b9e6",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF213": {
+            "prov:generatedEntity": "niiri:9e172783feebd728c2f558fb3b71f8e1",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF215": {
+            "prov:generatedEntity": "niiri:87ab73f90e90a5729c135961d1e370c8",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF217": {
+            "prov:generatedEntity": "niiri:837d4c2c41156c19f0fd118f410295ff",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF219": {
+            "prov:generatedEntity": "niiri:045f09754798eebc086b923539ec80df",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF221": {
+            "prov:generatedEntity": "niiri:80792993798dbd9f1e93a2b1f460edb7",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF223": {
+            "prov:generatedEntity": "niiri:90698016a8817129b734a925244ac3ee",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF225": {
+            "prov:generatedEntity": "niiri:e884b18d0db747fcf84bd707ac9dd705",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF227": {
+            "prov:generatedEntity": "niiri:2a3d19c51223db94f710da6fc4488efe",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF229": {
+            "prov:generatedEntity": "niiri:525402486d0c3b5a8a9cc4d79a236330",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF231": {
+            "prov:generatedEntity": "niiri:4c1d2eaf37081d773b0db5e10c96074d",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF233": {
+            "prov:generatedEntity": "niiri:91b4c6608ce19710d67c33b2473fc9b4",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF235": {
+            "prov:generatedEntity": "niiri:9caa103a34dc60ce70ec535ac6e8b007",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF237": {
+            "prov:generatedEntity": "niiri:b860ec229f39bc9a1fbaafbcbf0a163f",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF239": {
+            "prov:generatedEntity": "niiri:236f07396a3abe7464d0d6adae038d7d",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF241": {
+            "prov:generatedEntity": "niiri:d3ccad413c80f4d335ba3f4f6b6355af",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF243": {
+            "prov:generatedEntity": "niiri:485d5921cf99fd18e2d2bc08962f1a89",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF245": {
+            "prov:generatedEntity": "niiri:fafeba66cc92ac8083e5897d50f4bcab",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF247": {
+            "prov:generatedEntity": "niiri:48a7f6254e1629604bc57865dff4d670",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF249": {
+            "prov:generatedEntity": "niiri:33e63ed9d657f0ba23cd9ffacda3e22d",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF251": {
+            "prov:generatedEntity": "niiri:768ca0ef2b170d430ebbd40ebb08cff0",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF253": {
+            "prov:generatedEntity": "niiri:8cf8073a323eec04d3968fab10115c2b",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF255": {
+            "prov:generatedEntity": "niiri:dba062dd06d4105f10d77f25b52b96c8",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF257": {
+            "prov:generatedEntity": "niiri:c51b283e94df3fae6004dee4203f35fd",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF259": {
+            "prov:generatedEntity": "niiri:c79437288e303b8f2bef9af3b70d4aaa",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF261": {
+            "prov:generatedEntity": "niiri:049f42c8eb4f2db2320a43cbbdd89f0f",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF263": {
+            "prov:generatedEntity": "niiri:4e6c7a95cd372d482b4ef655fa46f083",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF265": {
+            "prov:generatedEntity": "niiri:78623bac11315960aba0a8d855467f49",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF267": {
+            "prov:generatedEntity": "niiri:288a1fc03510b55eff121de5bf93e1f4",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF269": {
+            "prov:generatedEntity": "niiri:f6ffc917f79709af0e39207ec0add7a4",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF271": {
+            "prov:generatedEntity": "niiri:bd77e4cd78d5c4dcb23a68309256720d",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF273": {
+            "prov:generatedEntity": "niiri:31f96dd2a2f7097e6993ae7eec0e23e6",
+            "prov:usedEntity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
+        },
+        "_:wDF276": {
+            "prov:generatedEntity": "niiri:b9c38db488f3b5f13ba315ce84742e30",
+            "prov:usedEntity": "niiri:57b0b3487b8ceebf11e98e8506c169a2"
+        },
+        "_:wDF279": {
+            "prov:generatedEntity": "niiri:04ccd45e7b91b1372b86446353f69dec",
+            "prov:usedEntity": "niiri:57b0b3487b8ceebf11e98e8506c169a2"
+        },
+        "_:wDF282": {
+            "prov:generatedEntity": "niiri:2a457ee39f92424bfbae62e7f4d9d06e",
+            "prov:usedEntity": "niiri:57b0b3487b8ceebf11e98e8506c169a2"
+        },
+        "_:wDF285": {
+            "prov:generatedEntity": "niiri:7e3917d8345a65fc26f145125eeaff8c",
+            "prov:usedEntity": "niiri:3d5c32984a0665ba596ff6cef71fcd0b"
+        },
+        "_:wDF288": {
+            "prov:generatedEntity": "niiri:9998cb50acce86cfac60c2fd8b263502",
+            "prov:usedEntity": "niiri:3d5c32984a0665ba596ff6cef71fcd0b"
+        },
+        "_:wDF291": {
+            "prov:generatedEntity": "niiri:c556266836a943fb870f1bf711a68c3b",
+            "prov:usedEntity": "niiri:3d5c32984a0665ba596ff6cef71fcd0b"
+        },
+        "_:wDF294": {
+            "prov:generatedEntity": "niiri:701c37986a9dfafb2485113e75f3877e",
+            "prov:usedEntity": "niiri:2c413461a4c1a86447e1da248ab7545c"
+        },
+        "_:wDF297": {
+            "prov:generatedEntity": "niiri:d32b6a2abe066703d0a3f16b4a3aa993",
+            "prov:usedEntity": "niiri:2c413461a4c1a86447e1da248ab7545c"
+        },
+        "_:wDF300": {
+            "prov:generatedEntity": "niiri:74291dfbb196ec16f80fb44d57da12f7",
+            "prov:usedEntity": "niiri:2c413461a4c1a86447e1da248ab7545c"
+        },
+        "_:wDF303": {
+            "prov:generatedEntity": "niiri:9d53626c88b2f04c3eadecaebc4a1338",
+            "prov:usedEntity": "niiri:e3f486aca3000e0c84fbdaf8a042398f"
+        },
+        "_:wDF306": {
+            "prov:generatedEntity": "niiri:85a1438415db5a3489dd11e7fb441b39",
+            "prov:usedEntity": "niiri:e3f486aca3000e0c84fbdaf8a042398f"
+        },
+        "_:wDF309": {
+            "prov:generatedEntity": "niiri:0b8f8f1954b573ce6421b1aec938a3f7",
+            "prov:usedEntity": "niiri:e3f486aca3000e0c84fbdaf8a042398f"
+        },
+        "_:wDF312": {
+            "prov:generatedEntity": "niiri:142bb500e57d8a428669aea190bd5682",
+            "prov:usedEntity": "niiri:c0ef61636e02d68816943e9c0c7be35d"
+        },
+        "_:wDF315": {
+            "prov:generatedEntity": "niiri:27d4ca2419ed8dd89da3969cf9682d0e",
+            "prov:usedEntity": "niiri:c0ef61636e02d68816943e9c0c7be35d"
+        },
+        "_:wDF318": {
+            "prov:generatedEntity": "niiri:029834627d73e77047973cf21bbf5d82",
+            "prov:usedEntity": "niiri:c0ef61636e02d68816943e9c0c7be35d"
+        },
+        "_:wDF321": {
+            "prov:generatedEntity": "niiri:1eb8465701fde4fde92186c425baf8ea",
+            "prov:usedEntity": "niiri:e9bd68a9b52a95e89ba7a7e17b4fa428"
+        },
+        "_:wDF324": {
+            "prov:generatedEntity": "niiri:64d0ab7126894908ae25023162e0af73",
+            "prov:usedEntity": "niiri:e9bd68a9b52a95e89ba7a7e17b4fa428"
+        },
+        "_:wDF327": {
+            "prov:generatedEntity": "niiri:90054102ef0485b0300d9ac541c05772",
+            "prov:usedEntity": "niiri:e9bd68a9b52a95e89ba7a7e17b4fa428"
+        },
+        "_:wDF330": {
+            "prov:generatedEntity": "niiri:ea92fe2eb5755d0ea83fe118d00128a1",
+            "prov:usedEntity": "niiri:7693eabf368839e957bc3cfe43c975e0"
+        },
+        "_:wDF333": {
+            "prov:generatedEntity": "niiri:7f8a4c8c46cb2689a3c019747955dc4b",
+            "prov:usedEntity": "niiri:39b96655430c53f32e07621dbe8655c4"
+        },
+        "_:wDF336": {
+            "prov:generatedEntity": "niiri:e2bc5fe4c987ff0ec0df74c742ff1117",
+            "prov:usedEntity": "niiri:90ea170edb9635f011af376c50f1eff8"
+        },
+        "_:wDF339": {
+            "prov:generatedEntity": "niiri:520fe1eb050426e3b07c4a893b9f7db1",
+            "prov:usedEntity": "niiri:90ea170edb9635f011af376c50f1eff8"
+        },
+        "_:wDF342": {
+            "prov:generatedEntity": "niiri:c87a3b3343886155da34c9892eaae298",
+            "prov:usedEntity": "niiri:d976336ac6ecb4bba1136f54b6de3e23"
+        },
+        "_:wDF345": {
+            "prov:generatedEntity": "niiri:90abc80db14d12280a0791c4ce7391f5",
+            "prov:usedEntity": "niiri:43ec173da0c3faa0f4491456aea575ce"
+        },
+        "_:wDF348": {
+            "prov:generatedEntity": "niiri:e745debfe2f3499165a83cfbc9245de3",
+            "prov:usedEntity": "niiri:43ec173da0c3faa0f4491456aea575ce"
+        },
+        "_:wDF351": {
+            "prov:generatedEntity": "niiri:2343e4d7eb8c6a1729b72035eaf717e4",
+            "prov:usedEntity": "niiri:a21087d5b0bdd477c690e1272139bf8a"
+        },
+        "_:wDF354": {
+            "prov:generatedEntity": "niiri:1a8a86f7d9c9f722317b24c2e78074af",
+            "prov:usedEntity": "niiri:a21087d5b0bdd477c690e1272139bf8a"
+        },
+        "_:wDF357": {
+            "prov:generatedEntity": "niiri:23b4a479f72f56fff23eeb6665cae807",
+            "prov:usedEntity": "niiri:a21087d5b0bdd477c690e1272139bf8a"
+        },
+        "_:wDF360": {
+            "prov:generatedEntity": "niiri:cb1ced392fd8df88e767db43c1bc0ed7",
+            "prov:usedEntity": "niiri:a4d3b6fc7cc84d91945916a3052dd21c"
+        },
+        "_:wDF363": {
+            "prov:generatedEntity": "niiri:7f2c05eeb31277d29699a1a1dc5708b9",
+            "prov:usedEntity": "niiri:a4d3b6fc7cc84d91945916a3052dd21c"
+        },
+        "_:wDF366": {
+            "prov:generatedEntity": "niiri:de55bbb80f52ecc8be8aa173a5d0c4c4",
+            "prov:usedEntity": "niiri:a4d3b6fc7cc84d91945916a3052dd21c"
+        },
+        "_:wDF369": {
+            "prov:generatedEntity": "niiri:94ac82c373f762df7652cf2eee707fcf",
+            "prov:usedEntity": "niiri:d3e3d125a9ce7e2ce6bac0795d332509"
+        },
+        "_:wDF372": {
+            "prov:generatedEntity": "niiri:a3cbab4a2a30eece310c15c0975c7b8c",
+            "prov:usedEntity": "niiri:0531c28556a1e0fba30c3ea1dd24f56e"
+        },
+        "_:wDF375": {
+            "prov:generatedEntity": "niiri:24e1979d3724b3518945e59d3fad2d5b",
+            "prov:usedEntity": "niiri:22a4e1327d4f2f7349df156933a68889"
+        },
+        "_:wDF378": {
+            "prov:generatedEntity": "niiri:90230b1d46674135f54f40a8eaaa6955",
+            "prov:usedEntity": "niiri:661e97df890b4cd21b7b3cc4a2220e2e"
+        },
+        "_:wDF381": {
+            "prov:generatedEntity": "niiri:6ecb22dc01f666b06e37c52dda7e1cea",
+            "prov:usedEntity": "niiri:fb7297e8c19234947de7375e05901f89"
+        },
+        "_:wDF384": {
+            "prov:generatedEntity": "niiri:1147bd3222d74b8465b410daf5f551d9",
+            "prov:usedEntity": "niiri:c016e8a860699bda1ff422a1f501e63d"
+        },
+        "_:wDF387": {
+            "prov:generatedEntity": "niiri:0edd0549008deb53921ccec5934b3d03",
+            "prov:usedEntity": "niiri:c4fe065cafdebad144fa17a8ec71281b"
+        },
+        "_:wDF390": {
+            "prov:generatedEntity": "niiri:cecb64ea54e0530f18d065bad589c2a6",
+            "prov:usedEntity": "niiri:c4fe065cafdebad144fa17a8ec71281b"
+        },
+        "_:wDF393": {
+            "prov:generatedEntity": "niiri:f7f872af0c034510f177bd8ce9bb0b0c",
+            "prov:usedEntity": "niiri:b9447d9cb03b61ef6f6b29b2f726c748"
+        },
+        "_:wDF396": {
+            "prov:generatedEntity": "niiri:36ff54739107c726560ff84ecfbec58e",
+            "prov:usedEntity": "niiri:fccd53239e801ce9120073c47ddcae13"
+        },
+        "_:wDF399": {
+            "prov:generatedEntity": "niiri:e7e5af7d0c21e8aef18e2542948c6793",
+            "prov:usedEntity": "niiri:e8858d23bbbcba237e94c70004237a2f"
+        },
+        "_:wDF402": {
+            "prov:generatedEntity": "niiri:5eedc42ee231bb3e0801681a9ba98372",
+            "prov:usedEntity": "niiri:a1e36a12612c98786c42d6e581a41938"
+        },
+        "_:wDF405": {
+            "prov:generatedEntity": "niiri:5a68064d075ad549c6b87de74be574de",
+            "prov:usedEntity": "niiri:6aac454abbeb6462b826cd647eb086e0"
+        },
+        "_:wDF408": {
+            "prov:generatedEntity": "niiri:69b3e9ba35baf225bd111d6d16f02c59",
+            "prov:usedEntity": "niiri:6aac454abbeb6462b826cd647eb086e0"
+        },
+        "_:wDF411": {
+            "prov:generatedEntity": "niiri:5cddeb38ad7e027bd0de87a3a4bbef17",
+            "prov:usedEntity": "niiri:7b28ee2c06d9f1eb5b4dab7494fe7a85"
+        },
+        "_:wDF414": {
+            "prov:generatedEntity": "niiri:3522180f8cbe6ef50347376f1bbf6edb",
+            "prov:usedEntity": "niiri:7b28ee2c06d9f1eb5b4dab7494fe7a85"
+        },
+        "_:wDF417": {
+            "prov:generatedEntity": "niiri:4b7df6a7ed2935756536e850b92db30a",
+            "prov:usedEntity": "niiri:7b28ee2c06d9f1eb5b4dab7494fe7a85"
+        },
+        "_:wDF420": {
+            "prov:generatedEntity": "niiri:d9b3a050332d74bf0f36c7adfdb580c3",
+            "prov:usedEntity": "niiri:00aad4e5c367c7dee68c301c251cb2ce"
+        },
+        "_:wDF423": {
+            "prov:generatedEntity": "niiri:f725218800cfd7000fbd0ad268a06710",
+            "prov:usedEntity": "niiri:904dc3e52037e77af188b63a3d3a6884"
+        },
+        "_:wDF426": {
+            "prov:generatedEntity": "niiri:dad6f2d5c4ce67fa4e55fba569c0d484",
+            "prov:usedEntity": "niiri:904dc3e52037e77af188b63a3d3a6884"
+        },
+        "_:wDF429": {
+            "prov:generatedEntity": "niiri:840283767e66dbd6e157c770ba828a93",
+            "prov:usedEntity": "niiri:ffdea138243040f7b25be6c44f68510d"
+        },
+        "_:wDF432": {
+            "prov:generatedEntity": "niiri:0e31b662b4e33990fa038bbb4c5ba001",
+            "prov:usedEntity": "niiri:f19e77aa11c450b96b368f822fcfd6ce"
+        },
+        "_:wDF435": {
+            "prov:generatedEntity": "niiri:15315bb12a4c858854e329703938208d",
+            "prov:usedEntity": "niiri:1b80b6984bddaf1c61a51a898d6acbea"
+        },
+        "_:wDF438": {
+            "prov:generatedEntity": "niiri:b8c952b7eb0604aaeff8a4b3deed04f2",
+            "prov:usedEntity": "niiri:2a6b200869ec06562d293e64de33e926"
+        },
+        "_:wDF441": {
+            "prov:generatedEntity": "niiri:22efce75aa6c6dce7c1322da7c4c8a84",
+            "prov:usedEntity": "niiri:50eb3a7d09683191b4aed76432577ca4"
+        },
+        "_:wDF444": {
+            "prov:generatedEntity": "niiri:29cb61e520efc605169b4daa2aecadcf",
+            "prov:usedEntity": "niiri:3dc187c20fafa718374d3bf8209b869c"
+        },
+        "_:wDF447": {
+            "prov:generatedEntity": "niiri:29adc4964dd5cb588824e8fafff57b8b",
+            "prov:usedEntity": "niiri:2246deb8a6c721c27dda92f3dd869ffd"
+        },
+        "_:wDF450": {
+            "prov:generatedEntity": "niiri:4bf8abf79b6ded57be5385b0e6aab4b9",
+            "prov:usedEntity": "niiri:50cb1d29d6f8a9cfe9515552c5bb7d31"
+        },
+        "_:wDF453": {
+            "prov:generatedEntity": "niiri:a5aa6fcfda734e3389f7bec2d9ad0a6f",
+            "prov:usedEntity": "niiri:d6d69b36b9108bb0de66eeffba4d858e"
+        },
+        "_:wDF456": {
+            "prov:generatedEntity": "niiri:f09170fc52ba782fe9bdfaf02ade3b10",
+            "prov:usedEntity": "niiri:e88a30db5e3821edb55a62d4b67f0ad1"
+        },
+        "_:wDF459": {
+            "prov:generatedEntity": "niiri:c0586c77c95a193830c8219325ca2256",
+            "prov:usedEntity": "niiri:a4ad9afd60a760f91d6916421b56fe6a"
+        },
+        "_:wDF462": {
+            "prov:generatedEntity": "niiri:29b6d69627dd6dacdaa3a9b3c30d347f",
+            "prov:usedEntity": "niiri:d3934b966af329378cc1a1307b94a530"
+        },
+        "_:wDF465": {
+            "prov:generatedEntity": "niiri:afa91bed7d064469a4e66e23ca1c26f9",
+            "prov:usedEntity": "niiri:546534eff08d214139c8884f815a2c20"
+        },
+        "_:wDF468": {
+            "prov:generatedEntity": "niiri:ce725d602d22bdbfcfb1d33ed8a51382",
+            "prov:usedEntity": "niiri:546534eff08d214139c8884f815a2c20"
+        },
+        "_:wDF471": {
+            "prov:generatedEntity": "niiri:8d0242e530dd2b7ac61d63b861ffdfb2",
+            "prov:usedEntity": "niiri:295cf12e37c01e14c3830d46154826a9"
+        },
+        "_:wDF474": {
+            "prov:generatedEntity": "niiri:409a5667ff5ace48db341b1d4b443b7b",
+            "prov:usedEntity": "niiri:aedc5c46b75f681aa273f0c65aba753d"
+        },
+        "_:wDF477": {
+            "prov:generatedEntity": "niiri:93fba29bbc2b01e814cebc5c1c0d1553",
+            "prov:usedEntity": "niiri:03b802eb8ab278c3154b4ebae374f2f2"
+        },
+        "_:wDF480": {
+            "prov:generatedEntity": "niiri:e3c2f2c5c8877cf5d3301382557e5009",
+            "prov:usedEntity": "niiri:33fb5b8990838fc1f2547ba3ff8437d2"
+        },
+        "_:wDF483": {
+            "prov:generatedEntity": "niiri:cf455aa53879ce5eb8f2e701d72643c3",
+            "prov:usedEntity": "niiri:f6f7f9d9bd2b440c679a5ff44f1cdb22"
+        },
+        "_:wDF486": {
+            "prov:generatedEntity": "niiri:e9c6bf15ba9e098b7b0cca458dc8cd21",
+            "prov:usedEntity": "niiri:cbbd42e6f42814091a8e0fc54b7ad3c4"
+        },
+        "_:wDF489": {
+            "prov:generatedEntity": "niiri:93ecdc023889193376179f882fb09793",
+            "prov:usedEntity": "niiri:53fb996b754ceba84bda7b0e7b9bdc51"
+        },
+        "_:wDF492": {
+            "prov:generatedEntity": "niiri:cfedd59c6ad80ae5fe3df5fa3e086b64",
+            "prov:usedEntity": "niiri:55bb03da7ee7d021560ed83a011342a9"
+        },
+        "_:wDF495": {
+            "prov:generatedEntity": "niiri:b65cce8679c42572d912ca303840373a",
+            "prov:usedEntity": "niiri:ac7c392c52df7cdd1a6cd2c7335454d2"
+        },
+        "_:wDF498": {
+            "prov:generatedEntity": "niiri:b1da3428c34e2b43760ad5c2f4e2d0fa",
+            "prov:usedEntity": "niiri:c3f05dc9d300aa5acc02e364f1c3ee85"
+        },
+        "_:wDF501": {
+            "prov:generatedEntity": "niiri:ed0ad58b2c2c68d107db680a95fd120e",
+            "prov:usedEntity": "niiri:45b4ec73da86f70d949a94aa6ab8d4ab"
+        },
+        "_:wDF504": {
+            "prov:generatedEntity": "niiri:81766c881aa79ffa1dca5be898876a89",
+            "prov:usedEntity": "niiri:54114a5d8df2f7e553a53e4b7d3f5bde"
+        },
+        "_:wDF507": {
+            "prov:generatedEntity": "niiri:6f9386b12ed4b5e1d223ee7299272af0",
+            "prov:usedEntity": "niiri:3f3ed8fe063a9052a3379a875a3af9b1"
+        },
+        "_:wDF510": {
+            "prov:generatedEntity": "niiri:fb2e0b3836b38e971ed6c44595c76ce6",
+            "prov:usedEntity": "niiri:5721ae6aae6160ad82aced2d2fe68def"
+        },
+        "_:wDF513": {
+            "prov:generatedEntity": "niiri:bb4c57fd5df089908c6bcfc3efe6b9f9",
+            "prov:usedEntity": "niiri:9326713bc412f1ec61f3bf20466a1174"
+        },
+        "_:wDF516": {
+            "prov:generatedEntity": "niiri:09e6296e10757ad10cecbc458943830b",
+            "prov:usedEntity": "niiri:ae9ba0f37d886eaa080e3238cefd1961"
+        },
+        "_:wDF519": {
+            "prov:generatedEntity": "niiri:798ba4f1b0df8e048c40896efbc27bc1",
+            "prov:usedEntity": "niiri:55108dec00fcabdca0aa0fd19deac38c"
+        },
+        "_:wDF522": {
+            "prov:generatedEntity": "niiri:65faea3b6c2b60b8b3a4b771985ae82d",
+            "prov:usedEntity": "niiri:16a2d945f11329e9c381ee7f04a0ef0e"
+        },
+        "_:wDF525": {
+            "prov:generatedEntity": "niiri:efa6c4751eb0a691336a3cdb57edc4d4",
+            "prov:usedEntity": "niiri:16a2d945f11329e9c381ee7f04a0ef0e"
+        },
+        "_:wDF528": {
+            "prov:generatedEntity": "niiri:dfcb0da83436b538eda80129d69688fe",
+            "prov:usedEntity": "niiri:51de73f4c31fd22967b959166dfdd033"
+        },
+        "_:wDF531": {
+            "prov:generatedEntity": "niiri:e974721ee82dbde15f9b39d69ec70d5a",
+            "prov:usedEntity": "niiri:5810f1d1820e723be51fc80ca74ca5e0"
+        },
+        "_:wDF534": {
+            "prov:generatedEntity": "niiri:aa808c2c64b1d016870f13b853b07dde",
+            "prov:usedEntity": "niiri:fb7f0c2c30196ccec28c3a6548a05c74"
+        },
+        "_:wDF537": {
+            "prov:generatedEntity": "niiri:bee1c5e3b563da49fb889d00a907068a",
+            "prov:usedEntity": "niiri:c93f984974556da4e703249091c0b9e6"
+        },
+        "_:wDF540": {
+            "prov:generatedEntity": "niiri:8c4cac3967178a072f8a1b26ec0be67c",
+            "prov:usedEntity": "niiri:9e172783feebd728c2f558fb3b71f8e1"
+        },
+        "_:wDF543": {
+            "prov:generatedEntity": "niiri:ab0a345a1b23456828ee0bd75b928ed7",
+            "prov:usedEntity": "niiri:87ab73f90e90a5729c135961d1e370c8"
+        },
+        "_:wDF546": {
+            "prov:generatedEntity": "niiri:ebb12b1fa798252b807914310e351b35",
+            "prov:usedEntity": "niiri:837d4c2c41156c19f0fd118f410295ff"
+        },
+        "_:wDF549": {
+            "prov:generatedEntity": "niiri:15d51008205872b18f614dedb8a4130b",
+            "prov:usedEntity": "niiri:045f09754798eebc086b923539ec80df"
+        },
+        "_:wDF552": {
+            "prov:generatedEntity": "niiri:6bfcfb8a7a78ca0a953b28b7ac785df9",
+            "prov:usedEntity": "niiri:80792993798dbd9f1e93a2b1f460edb7"
+        },
+        "_:wDF555": {
+            "prov:generatedEntity": "niiri:ca809001af3d981e8831371d40cadda0",
+            "prov:usedEntity": "niiri:90698016a8817129b734a925244ac3ee"
+        },
+        "_:wDF558": {
+            "prov:generatedEntity": "niiri:a6ab7750f7aec3f30041a2426c3c5488",
+            "prov:usedEntity": "niiri:e884b18d0db747fcf84bd707ac9dd705"
+        },
+        "_:wDF561": {
+            "prov:generatedEntity": "niiri:571af20b9fc7a3650f23e4883c4c0db7",
+            "prov:usedEntity": "niiri:2a3d19c51223db94f710da6fc4488efe"
+        },
+        "_:wDF564": {
+            "prov:generatedEntity": "niiri:4109cffc49a21d458e8e3c4ec5bdec4b",
+            "prov:usedEntity": "niiri:525402486d0c3b5a8a9cc4d79a236330"
+        },
+        "_:wDF567": {
+            "prov:generatedEntity": "niiri:e75d8bde52802e14e982fc7e310fa7e5",
+            "prov:usedEntity": "niiri:4c1d2eaf37081d773b0db5e10c96074d"
+        },
+        "_:wDF570": {
+            "prov:generatedEntity": "niiri:896ea228d6022d6a6fbe18f3fecced44",
+            "prov:usedEntity": "niiri:91b4c6608ce19710d67c33b2473fc9b4"
+        },
+        "_:wDF573": {
+            "prov:generatedEntity": "niiri:3b2dfa543dfff0705b80fb76652786b5",
+            "prov:usedEntity": "niiri:9caa103a34dc60ce70ec535ac6e8b007"
+        },
+        "_:wDF576": {
+            "prov:generatedEntity": "niiri:782068672fbbe3620c5f41b2464beaeb",
+            "prov:usedEntity": "niiri:b860ec229f39bc9a1fbaafbcbf0a163f"
+        },
+        "_:wDF579": {
+            "prov:generatedEntity": "niiri:325f64d356f613a0e0206309a641ecc0",
+            "prov:usedEntity": "niiri:236f07396a3abe7464d0d6adae038d7d"
+        },
+        "_:wDF582": {
+            "prov:generatedEntity": "niiri:adfb5705362a8f1bdf0b807bde3dda91",
+            "prov:usedEntity": "niiri:d3ccad413c80f4d335ba3f4f6b6355af"
+        },
+        "_:wDF585": {
+            "prov:generatedEntity": "niiri:a1698f36e3e1c0e83de4c62180a03384",
+            "prov:usedEntity": "niiri:485d5921cf99fd18e2d2bc08962f1a89"
+        },
+        "_:wDF588": {
+            "prov:generatedEntity": "niiri:174c45a8d1e67a22fc26e791cf355a46",
+            "prov:usedEntity": "niiri:fafeba66cc92ac8083e5897d50f4bcab"
+        },
+        "_:wDF591": {
+            "prov:generatedEntity": "niiri:d3666814839586295a138503c43b05cb",
+            "prov:usedEntity": "niiri:48a7f6254e1629604bc57865dff4d670"
+        },
+        "_:wDF594": {
+            "prov:generatedEntity": "niiri:132f6eb140d7fc16eceeb304478171c2",
+            "prov:usedEntity": "niiri:33e63ed9d657f0ba23cd9ffacda3e22d"
+        },
+        "_:wDF597": {
+            "prov:generatedEntity": "niiri:c44f1d9e91a6e9fe1b09cd64614d61c2",
+            "prov:usedEntity": "niiri:768ca0ef2b170d430ebbd40ebb08cff0"
+        },
+        "_:wDF600": {
+            "prov:generatedEntity": "niiri:53fd4410e0451ea937aa0616970eb8c1",
+            "prov:usedEntity": "niiri:8cf8073a323eec04d3968fab10115c2b"
+        },
+        "_:wDF603": {
+            "prov:generatedEntity": "niiri:3469a97617a1acc2f9fa828b99843678",
+            "prov:usedEntity": "niiri:dba062dd06d4105f10d77f25b52b96c8"
+        },
+        "_:wDF606": {
+            "prov:generatedEntity": "niiri:60c64006a9802f87bdbaffb4ec25a5b2",
+            "prov:usedEntity": "niiri:c51b283e94df3fae6004dee4203f35fd"
+        },
+        "_:wDF609": {
+            "prov:generatedEntity": "niiri:918936eb1d58155c78c560ab565b0202",
+            "prov:usedEntity": "niiri:c79437288e303b8f2bef9af3b70d4aaa"
+        },
+        "_:wDF612": {
+            "prov:generatedEntity": "niiri:8d45ffd6ad4acc8edcfb248f110ba687",
+            "prov:usedEntity": "niiri:049f42c8eb4f2db2320a43cbbdd89f0f"
+        },
+        "_:wDF615": {
+            "prov:generatedEntity": "niiri:8ad18c7eb09ca5a3aab852d344491753",
+            "prov:usedEntity": "niiri:4e6c7a95cd372d482b4ef655fa46f083"
+        },
+        "_:wDF618": {
+            "prov:generatedEntity": "niiri:9c388cc5a4937ec66a020ba4a2721666",
+            "prov:usedEntity": "niiri:78623bac11315960aba0a8d855467f49"
+        },
+        "_:wDF621": {
+            "prov:generatedEntity": "niiri:baa76c8f2997dbaae3d90e25b8c4bfd8",
+            "prov:usedEntity": "niiri:288a1fc03510b55eff121de5bf93e1f4"
+        },
+        "_:wDF624": {
+            "prov:generatedEntity": "niiri:34797ad5a5f0034f4a5cf71249cd89d8",
+            "prov:usedEntity": "niiri:f6ffc917f79709af0e39207ec0add7a4"
+        },
+        "_:wDF627": {
+            "prov:generatedEntity": "niiri:c04ece7485734e358071d757deeef557",
+            "prov:usedEntity": "niiri:bd77e4cd78d5c4dcb23a68309256720d"
+        },
+        "_:wDF630": {
+            "prov:generatedEntity": "niiri:115008c56fcea7d4c5a2ee78582283c7",
+            "prov:usedEntity": "niiri:31f96dd2a2f7097e6993ae7eec0e23e6"
+        }
+    },
+    "wasAttributedTo": {
+        "_:wAT6": {
+            "prov:entity": "niiri:65f5e0c3410f30b555aa41ff7e65f3d4",
+            "prov:agent": "niiri:c8fcc3ae56b4269cf1aaf34f24d3c6a1"
+        },
+        "_:wAT7": {
+            "prov:entity": "niiri:65f5e0c3410f30b555aa41ff7e65f3d4",
+            "prov:agent": "niiri:665c960b6edd432a6d053af0f35e8752"
+        }
+    },
+    "wasAssociatedWith": {
+        "_:wAW13": {
+            "prov:activity": "niiri:07b5d61a16905b058dc07a10451e4f4f",
+            "prov:agent": "niiri:6a56b7cc41090f34638cf50938e932eb"
+        },
+        "_:wAW45": {
+            "prov:activity": "niiri:82fff8a2920d426af761ea65abc3f824",
+            "prov:agent": "niiri:6a56b7cc41090f34638cf50938e932eb"
+        },
+        "_:wAW72": {
+            "prov:activity": "niiri:aa76de7328e3d13603b9e4c03167310d",
+            "prov:agent": "niiri:6a56b7cc41090f34638cf50938e932eb"
+        }
+    }
+    }
+  }
+}

--- a/spmexport/ex_spm_thr_voxelfdrp05/nidm.jsonld
+++ b/spmexport/ex_spm_thr_voxelfdrp05/nidm.jsonld
@@ -7,7 +7,7 @@
       "niiri": "http://iri.nidash.org/",
       "spm": "http://purl.org/nidash/spm#",
       "neurolex": "http://neurolex.org/wiki/",
-      "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#",
+      "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/",
       "dct": "http://purl.org/dc/terms/",
       "nfo": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#",
       "dc": "http://purl.org/dc/elements/1.1/",
@@ -22,32 +22,32 @@
   ],
   "@graph": [
     {
-      "@id": "niiri:ffe3fa4336d45524c3958e75da8803ae",
-      "@type": ["prov:Entity","prov:Bundle","nidm_NIDMResults:"],
+      "@id": "niiri:28ec28bc6b4f22ae6ce0d4910cd21172",
+      "@type": ["prov:Entity","prov:Bundle","nidm_NIDMResults"],
       "rdfs:label": "NIDM-Results",
-      "nidm_version:": {"@type": "xsd:string", "@value": "1.3.0"}
+      "nidm_version": {"@type": "xsd:string", "@value": "1.3.0"}
     },
     {
-      "@id": "niiri:e6ef299886e9d54a66ffdfc8dea1c309",
-      "@type": ["prov:Agent","nidm_spm_results_nidm:","prov:SoftwareAgent"],
+      "@id": "niiri:c3049f06eafd15e1a9333df90c4a3baf",
+      "@type": ["prov:Agent","nidm_spm_results_nidm","prov:SoftwareAgent"],
       "rdfs:label": "spm_results_nidm",
-      "nidm_softwareVersion:": {"@type": "xsd:string", "@value": "12.6903"}
+      "nidm_softwareVersion": {"@type": "xsd:string", "@value": "12.7057"}
     },
     {
-      "@id": "niiri:dcf0770f9087d27e7cb8f73270781e1d",
-      "@type": ["prov:Activity","nidm_NIDMResultsExport:"],
+      "@id": "niiri:1ab4e92c05dcd58443cc9cec8e73ba67",
+      "@type": ["prov:Activity","nidm_NIDMResultsExport"],
       "rdfs:label": "NIDM-Results export"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:dcf0770f9087d27e7cb8f73270781e1d",
-      "agent": "niiri:e6ef299886e9d54a66ffdfc8dea1c309"
+      "activity_associated": "niiri:1ab4e92c05dcd58443cc9cec8e73ba67",
+      "agent": "niiri:c3049f06eafd15e1a9333df90c4a3baf"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:ffe3fa4336d45524c3958e75da8803ae",
-      "activity": "niiri:dcf0770f9087d27e7cb8f73270781e1d",
-      "atTime": "2016-12-07T16:09:54"
+      "entity_generated": "niiri:28ec28bc6b4f22ae6ce0d4910cd21172",
+      "activity": "niiri:1ab4e92c05dcd58443cc9cec8e73ba67",
+      "atTime": "2017-04-19T12:19:14"
     }
   ]
 },
@@ -158,571 +158,571 @@
       "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
     }
   ],
-  "@id": "niiri:ffe3fa4336d45524c3958e75da8803ae",
+  "@id": "niiri:28ec28bc6b4f22ae6ce0d4910cd21172",
   "@graph": [
     {
-      "@id": "niiri:64730f8ca3829b6ba8ce02b85a004bb2",
-      "@type": ["prov:Agent","src_SPM:","prov:SoftwareAgent"],
+      "@id": "niiri:6a56b7cc41090f34638cf50938e932eb",
+      "@type": ["prov:Agent","src_SPM","prov:SoftwareAgent"],
       "rdfs:label": "SPM",
-      "nidm_softwareVersion:": {"@type": "xsd:string", "@value": "12.12.2"}
+      "nidm_softwareVersion": {"@type": "xsd:string", "@value": "12.6906"}
     },
     {
-      "@id": "niiri:57bfb1702d234ee28692b281b4b06077",
-      "@type": ["prov:Entity","nidm_CoordinateSpace:"],
+      "@id": "niiri:4d80c0cd6d8f06cc5fa8312aea1fdf66",
+      "@type": ["prov:Entity","nidm_CoordinateSpace"],
       "rdfs:label": "Coordinate space 1",
-      "nidm_voxelToWorldMapping:": {"@type": "xsd:string", "@value": "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"},
-      "nidm_voxelUnits:": {"@type": "xsd:string", "@value": "[\"mm\", \"mm\", \"mm\"]"},
-      "nidm_voxelSize:": {"@type": "xsd:string", "@value": "[2, 2, 2]"},
-      "nidm_inWorldCoordinateSystem:": {"@id": "nidm_Ixi549CoordinateSystem:"},
-      "nidm_numberOfDimensions:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_dimensionsInVoxels:": {"@type": "xsd:string", "@value": "[79,95,79]"}
+      "nidm_voxelToWorldMapping": {"@type": "xsd:string", "@value": "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"},
+      "nidm_voxelUnits": {"@type": "xsd:string", "@value": "[\"mm\", \"mm\", \"mm\"]"},
+      "nidm_voxelSize": {"@type": "xsd:string", "@value": "[2, 2, 2]"},
+      "nidm_inWorldCoordinateSystem": {"@id": "nidm_Ixi549CoordinateSystem"},
+      "nidm_numberOfDimensions": {"@type": "xsd:int", "@value": "3"},
+      "nidm_dimensionsInVoxels": {"@type": "xsd:string", "@value": "[79,95,79]"}
     },
     {
-      "@id": "niiri:bce9b8acbff4fdaf027940f6885d0153",
-      "@type": ["prov:Agent","nlx_Imaginginstrument:","nlx_Magneticresonanceimagingscanner:"],
+      "@id": "niiri:c8fcc3ae56b4269cf1aaf34f24d3c6a1",
+      "@type": ["prov:Agent","nlx_Imaginginstrument","nlx_Magneticresonanceimagingscanner"],
       "rdfs:label": "MRI Scanner"
     },
     {
-      "@id": "niiri:554695cbbe6e60d18f5c8a5a92b96b76",
+      "@id": "niiri:665c960b6edd432a6d053af0f35e8752",
       "@type": ["prov:Agent","prov:Person"],
       "rdfs:label": "Person"
     },
     {
-      "@id": "niiri:e56d7b7be8d4dfcf0f1a64ac4d82a0c6",
-      "@type": ["prov:Entity","prov:Collection","nidm_Data:"],
+      "@id": "niiri:65f5e0c3410f30b555aa41ff7e65f3d4",
+      "@type": ["prov:Entity","prov:Collection","nidm_Data"],
       "rdfs:label": "Data",
-      "nidm_grandMeanScaling:": {"@type": "xsd:boolean", "@value": "true"},
-      "nidm_targetIntensity:": {"@type": "xsd:float", "@value": "100"},
-      "nidm_hasMRIProtocol:": {"@id": "nlx_FunctionalMRIprotocol:"}
+      "nidm_grandMeanScaling": {"@type": "xsd:boolean", "@value": "true"},
+      "nidm_targetIntensity": {"@type": "xsd:float", "@value": "100"},
+      "nidm_hasMRIProtocol": {"@id": "nlx_FunctionalMRIprotocol"}
     },
     {
       "@type": "prov:Attribution",
-      "entity_attributed": "niiri:e56d7b7be8d4dfcf0f1a64ac4d82a0c6",
-      "agent": "niiri:bce9b8acbff4fdaf027940f6885d0153"
+      "entity_attributed": "niiri:65f5e0c3410f30b555aa41ff7e65f3d4",
+      "agent": "niiri:c8fcc3ae56b4269cf1aaf34f24d3c6a1"
     },
     {
       "@type": "prov:Attribution",
-      "entity_attributed": "niiri:e56d7b7be8d4dfcf0f1a64ac4d82a0c6",
-      "agent": "niiri:554695cbbe6e60d18f5c8a5a92b96b76"
+      "entity_attributed": "niiri:65f5e0c3410f30b555aa41ff7e65f3d4",
+      "agent": "niiri:665c960b6edd432a6d053af0f35e8752"
     },
     {
-      "@id": "niiri:12d258f0ceb4375887e5079dfb41cf17",
-      "@type": ["prov:Entity","spm_DCTDriftModel:"],
+      "@id": "niiri:c7263de1e5c4d82e12588d8073c95d36",
+      "@type": ["prov:Entity","spm_DCTDriftModel"],
       "rdfs:label": "SPM's DCT Drift Model",
-      "spm_SPMsDriftCutoffPeriod:": {"@type": "xsd:float", "@value": "128"}
+      "spm_SPMsDriftCutoffPeriod": {"@type": "xsd:float", "@value": "128"}
     },
     {
-      "@id": "niiri:4414db3adc555942a3b666595c0251ef",
-      "@type": ["prov:Entity","nidm_DesignMatrix:"],
+      "@id": "niiri:d114849d6b0dd611879e4e55b5de49c6",
+      "@type": ["prov:Entity","nidm_DesignMatrix"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "DesignMatrix.csv"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "DesignMatrix.csv"},
       "dct:format": {"@type": "xsd:string", "@value": "text/csv"},
-      "dc:description": {"@id": "niiri:3dc0ef417b545a12ae8d2d5b1d2f7479"},
+      "dc:description": {"@id": "niiri:b5263ea4cabd52688f9ff17b32558902"},
       "rdfs:label": "Design Matrix",
-      "nidm_regressorNames:": {"@type": "xsd:string", "@value": "[\"Sn(1) to*bf(1)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) constant\"]"},
-      "nidm_hasDriftModel:": {"@id": "niiri:12d258f0ceb4375887e5079dfb41cf17"},
-      "nidm_hasHRFBasis:": {"@id": "spm_SPMsCanonicalHRF:"}
+      "nidm_regressorNames": {"@type": "xsd:string", "@value": "[\"Sn(1) to*bf(1)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) constant\"]"},
+      "nidm_hasDriftModel": {"@id": "niiri:c7263de1e5c4d82e12588d8073c95d36"},
+      "nidm_hasHRFBasis": {"@id": "spm_SPMsCanonicalHRF"}
     },
     {
-      "@id": "niiri:3dc0ef417b545a12ae8d2d5b1d2f7479",
+      "@id": "niiri:b5263ea4cabd52688f9ff17b32558902",
       "@type": ["prov:Entity","dctype:Image"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "DesignMatrix.png"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "DesignMatrix.png"},
       "dct:format": {"@type": "xsd:string", "@value": "image/png"}
     },
     {
-      "@id": "niiri:2dccedc0100cc2fe382a25cfa636a2b2",
-      "@type": ["prov:Entity","nidm_ErrorModel:"],
-      "nidm_hasErrorDistribution:": {"@id": "obo_normaldistribution:"},
-      "nidm_hasErrorDependence:": {"@id": "obo_Toeplitzcovariancestructure:"},
-      "nidm_dependenceMapWiseDependence:": {"@id": "nidm_ConstantParameter:"},
-      "nidm_errorVarianceHomogeneous:": {"@type": "xsd:boolean", "@value": "true"},
-      "nidm_varianceMapWiseDependence:": {"@id": "nidm_IndependentParameter:"}
+      "@id": "niiri:c2b879875530eeeb341e109f646bd0bb",
+      "@type": ["prov:Entity","nidm_ErrorModel"],
+      "nidm_hasErrorDistribution": {"@id": "obo_normaldistribution"},
+      "nidm_hasErrorDependence": {"@id": "obo_Toeplitzcovariancestructure"},
+      "nidm_dependenceMapWiseDependence": {"@id": "nidm_ConstantParameter"},
+      "nidm_errorVarianceHomogeneous": {"@type": "xsd:boolean", "@value": "true"},
+      "nidm_varianceMapWiseDependence": {"@id": "nidm_IndependentParameter"}
     },
     {
-      "@id": "niiri:daf9afd25368f73876302d229d3b2e17",
-      "@type": ["prov:Activity","nidm_ModelParametersEstimation:"],
+      "@id": "niiri:07b5d61a16905b058dc07a10451e4f4f",
+      "@type": ["prov:Activity","nidm_ModelParametersEstimation"],
       "rdfs:label": "Model parameters estimation",
-      "nidm_withEstimationMethod:": {"@id": "obo_generalizedleastsquaresestimation:"}
+      "nidm_withEstimationMethod": {"@id": "obo_generalizedleastsquaresestimation"}
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:daf9afd25368f73876302d229d3b2e17",
-      "agent": "niiri:64730f8ca3829b6ba8ce02b85a004bb2"
+      "activity_associated": "niiri:07b5d61a16905b058dc07a10451e4f4f",
+      "agent": "niiri:6a56b7cc41090f34638cf50938e932eb"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:daf9afd25368f73876302d229d3b2e17",
-      "entity": "niiri:4414db3adc555942a3b666595c0251ef"
+      "activity_using": "niiri:07b5d61a16905b058dc07a10451e4f4f",
+      "entity": "niiri:d114849d6b0dd611879e4e55b5de49c6"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:daf9afd25368f73876302d229d3b2e17",
-      "entity": "niiri:e56d7b7be8d4dfcf0f1a64ac4d82a0c6"
+      "activity_using": "niiri:07b5d61a16905b058dc07a10451e4f4f",
+      "entity": "niiri:65f5e0c3410f30b555aa41ff7e65f3d4"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:daf9afd25368f73876302d229d3b2e17",
-      "entity": "niiri:2dccedc0100cc2fe382a25cfa636a2b2"
+      "activity_using": "niiri:07b5d61a16905b058dc07a10451e4f4f",
+      "entity": "niiri:c2b879875530eeeb341e109f646bd0bb"
     },
     {
-      "@id": "niiri:72aa1f9e4b18c0a5675eca75f20b7534",
-      "@type": ["prov:Entity","nidm_MaskMap:"],
+      "@id": "niiri:3da9457cb4e9a27e6ca5714485d63d58",
+      "@type": ["prov:Entity","nidm_MaskMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "Mask.nii.gz"},
-      "nidm_isUserDefined:": {"@type": "xsd:boolean", "@value": "false"},
+      "nidm_isUserDefined": {"@type": "xsd:boolean", "@value": "false"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "Mask.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Mask",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:57bfb1702d234ee28692b281b4b06077"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:4d80c0cd6d8f06cc5fa8312aea1fdf66"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876"}
     },
     {
-      "@id": "niiri:b048dd55e6f4cb3c3ef373506f2332a1",
-      "@type": ["prov:Entity","nidm_MaskMap:"],
+      "@id": "niiri:dcc3a5e5bd34ab36eb3416ae867b7fb6",
+      "@type": ["prov:Entity","nidm_MaskMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "mask.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "36929e1f5f4143bd9cc818cd896a25f129961fab208c3a4438555f40444c08347b359142ee8c53ece6e8cca1627f49db0788a1fd3b9e2ecaef61999c6c6c67ac"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:72aa1f9e4b18c0a5675eca75f20b7534",
-      "entity": "niiri:b048dd55e6f4cb3c3ef373506f2332a1"
+      "entity_derived": "niiri:3da9457cb4e9a27e6ca5714485d63d58",
+      "entity": "niiri:dcc3a5e5bd34ab36eb3416ae867b7fb6"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:72aa1f9e4b18c0a5675eca75f20b7534",
-      "activity": "niiri:daf9afd25368f73876302d229d3b2e17"
+      "entity_generated": "niiri:3da9457cb4e9a27e6ca5714485d63d58",
+      "activity": "niiri:07b5d61a16905b058dc07a10451e4f4f"
     },
     {
-      "@id": "niiri:73e4b66f6e606cf029ee0cc5455efb87",
-      "@type": ["prov:Entity","nidm_GrandMeanMap:"],
+      "@id": "niiri:aa66cc4786ebae74492d856291b12f31",
+      "@type": ["prov:Entity","nidm_GrandMeanMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "GrandMean.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "GrandMean.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Grand Mean Map",
-      "nidm_maskedMedian:": {"@type": "xsd:float", "@value": "111.557487487793"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:57bfb1702d234ee28692b281b4b06077"},
+      "nidm_maskedMedian": {"@type": "xsd:float", "@value": "111.557487487793"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:4d80c0cd6d8f06cc5fa8312aea1fdf66"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "512157cc6bff89d9343a09b4068226eb3edd64a8cbcee861f06231767fae6f8d4819921182adebee083a9bf309afd65529ab04a92f0aa6b0038c8098550f6124"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:73e4b66f6e606cf029ee0cc5455efb87",
-      "activity": "niiri:daf9afd25368f73876302d229d3b2e17"
+      "entity_generated": "niiri:aa66cc4786ebae74492d856291b12f31",
+      "activity": "niiri:07b5d61a16905b058dc07a10451e4f4f"
     },
     {
-      "@id": "niiri:552da79a48d378687bacbdc1d379a41b",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:b0a406128a699bce39d09638de7fbb11",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0001.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0001.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 1",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:57bfb1702d234ee28692b281b4b06077"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:4d80c0cd6d8f06cc5fa8312aea1fdf66"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd"}
     },
     {
-      "@id": "niiri:7e08a288b3960525ccc0a4ddb3dbe1dd",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:5173be555c2ec5d890f39722a8ff9fad",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0001.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:552da79a48d378687bacbdc1d379a41b",
-      "entity": "niiri:7e08a288b3960525ccc0a4ddb3dbe1dd"
+      "entity_derived": "niiri:b0a406128a699bce39d09638de7fbb11",
+      "entity": "niiri:5173be555c2ec5d890f39722a8ff9fad"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:552da79a48d378687bacbdc1d379a41b",
-      "activity": "niiri:daf9afd25368f73876302d229d3b2e17"
+      "entity_generated": "niiri:b0a406128a699bce39d09638de7fbb11",
+      "activity": "niiri:07b5d61a16905b058dc07a10451e4f4f"
     },
     {
-      "@id": "niiri:26e7893496c9fff727b5d918177d86e4",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:95009d167a825475f9da93813a5eff0d",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0002.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0002.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 2",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:57bfb1702d234ee28692b281b4b06077"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:4d80c0cd6d8f06cc5fa8312aea1fdf66"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c"}
     },
     {
-      "@id": "niiri:4c05c1e39bbef96392984c45ce2c41b3",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:ec5d05a2244cdd38b1812f3fb5a35d09",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0002.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:26e7893496c9fff727b5d918177d86e4",
-      "entity": "niiri:4c05c1e39bbef96392984c45ce2c41b3"
+      "entity_derived": "niiri:95009d167a825475f9da93813a5eff0d",
+      "entity": "niiri:ec5d05a2244cdd38b1812f3fb5a35d09"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:26e7893496c9fff727b5d918177d86e4",
-      "activity": "niiri:daf9afd25368f73876302d229d3b2e17"
+      "entity_generated": "niiri:95009d167a825475f9da93813a5eff0d",
+      "activity": "niiri:07b5d61a16905b058dc07a10451e4f4f"
     },
     {
-      "@id": "niiri:f2ae10333ea3be73d8c5ba3182d14784",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:89d2070b8724cba90b0701cbb65ee609",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0003.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0003.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 3",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:57bfb1702d234ee28692b281b4b06077"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:4d80c0cd6d8f06cc5fa8312aea1fdf66"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373"}
     },
     {
-      "@id": "niiri:5f7f60416300c4d1739648a380e0efa1",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:e4b178e7dce758cde4b2d2404cae0b85",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0003.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f2ae10333ea3be73d8c5ba3182d14784",
-      "entity": "niiri:5f7f60416300c4d1739648a380e0efa1"
+      "entity_derived": "niiri:89d2070b8724cba90b0701cbb65ee609",
+      "entity": "niiri:e4b178e7dce758cde4b2d2404cae0b85"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:f2ae10333ea3be73d8c5ba3182d14784",
-      "activity": "niiri:daf9afd25368f73876302d229d3b2e17"
+      "entity_generated": "niiri:89d2070b8724cba90b0701cbb65ee609",
+      "activity": "niiri:07b5d61a16905b058dc07a10451e4f4f"
     },
     {
-      "@id": "niiri:7cbefce0a8261b298fcf42f53fd1c81a",
-      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap:"],
+      "@id": "niiri:7afdd6ab4e20f8072056e7ad109e1a28",
+      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ResidualMeanSquares.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ResidualMeanSquares.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Residual Mean Squares Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:57bfb1702d234ee28692b281b4b06077"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:4d80c0cd6d8f06cc5fa8312aea1fdf66"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "991abf563d795a43b1e2eef8643e57023f2e0b090b2031f05f839321fc0643df6f71d423486a1021519b6dc82f6b0f563e19f3fbd50cb16063bed54a0e192d3e"}
     },
     {
-      "@id": "niiri:d6dbf548bd2b5c60c7cf5c695db846df",
-      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap:"],
+      "@id": "niiri:bf71d9330aaa4b58789fc468b13d0fde",
+      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "ResMS.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "40b28d03fcf9a2f60b11f10d7fb83bf3618b234fb5aedf09df644cb7cbb6aab8c9f468897c1078166d455a3d04a83f4e3bf762cfca0b4ea982d7a4e406849f18"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7cbefce0a8261b298fcf42f53fd1c81a",
-      "entity": "niiri:d6dbf548bd2b5c60c7cf5c695db846df"
+      "entity_derived": "niiri:7afdd6ab4e20f8072056e7ad109e1a28",
+      "entity": "niiri:bf71d9330aaa4b58789fc468b13d0fde"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:7cbefce0a8261b298fcf42f53fd1c81a",
-      "activity": "niiri:daf9afd25368f73876302d229d3b2e17"
+      "entity_generated": "niiri:7afdd6ab4e20f8072056e7ad109e1a28",
+      "activity": "niiri:07b5d61a16905b058dc07a10451e4f4f"
     },
     {
-      "@id": "niiri:3b5abc82d35d734e1136daa4a8b2777b",
-      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap:"],
+      "@id": "niiri:3ae2261460b37724f66a583d13620d04",
+      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ReselsPerVoxel.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ReselsPerVoxel.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Resels per Voxel Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:57bfb1702d234ee28692b281b4b06077"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:4d80c0cd6d8f06cc5fa8312aea1fdf66"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "1a3f9216e145249ccc0b14b2bc337d6b38b81ad45e32768001fb22b35f0c2c0f3e2bce013b40c85f7dc0fc62723ac761ee7f7e1e6aff128a05f0ba7b8b8202a3"}
     },
     {
-      "@id": "niiri:de39366efadc505b76370266639f498e",
-      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap:"],
+      "@id": "niiri:754590eadc87f59168e42a5f669d8b83",
+      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "RPV.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "4f76663162857f6b38b2a45a63b15a23b2ca8b338c283b69c1e71f2ea2f43797d045a733cd14e845be9c12f8b8f84d3931c599a08e8f6d77e99fab46ad87ab8f"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3b5abc82d35d734e1136daa4a8b2777b",
-      "entity": "niiri:de39366efadc505b76370266639f498e"
+      "entity_derived": "niiri:3ae2261460b37724f66a583d13620d04",
+      "entity": "niiri:754590eadc87f59168e42a5f669d8b83"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:3b5abc82d35d734e1136daa4a8b2777b",
-      "activity": "niiri:daf9afd25368f73876302d229d3b2e17"
+      "entity_generated": "niiri:3ae2261460b37724f66a583d13620d04",
+      "activity": "niiri:07b5d61a16905b058dc07a10451e4f4f"
     },
     {
-      "@id": "niiri:5a41045d9499fd48e4c3d720cabedd8c",
-      "@type": ["prov:Entity","obo_contrastweightmatrix:"],
-      "nidm_statisticType:": {"@id": "obo_tstatistic:"},
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
+      "@id": "niiri:f2151889cbe45b2a41ece1a31d4608ed",
+      "@type": ["prov:Entity","obo_contrastweightmatrix"],
+      "nidm_statisticType": {"@id": "obo_tstatistic"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
       "rdfs:label": "Contrast: tone counting vs baseline",
       "prov:value": {"@type": "xsd:string", "@value": "[1, 0, 0]"}
     },
     {
-      "@id": "niiri:4aaa1af6ebac931110e1c92a59a53a3e",
-      "@type": ["prov:Activity","nidm_ContrastEstimation:"],
+      "@id": "niiri:82fff8a2920d426af761ea65abc3f824",
+      "@type": ["prov:Activity","nidm_ContrastEstimation"],
       "rdfs:label": "Contrast estimation"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:4aaa1af6ebac931110e1c92a59a53a3e",
-      "agent": "niiri:64730f8ca3829b6ba8ce02b85a004bb2"
+      "activity_associated": "niiri:82fff8a2920d426af761ea65abc3f824",
+      "agent": "niiri:6a56b7cc41090f34638cf50938e932eb"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:4aaa1af6ebac931110e1c92a59a53a3e",
-      "entity": "niiri:72aa1f9e4b18c0a5675eca75f20b7534"
+      "activity_using": "niiri:82fff8a2920d426af761ea65abc3f824",
+      "entity": "niiri:3da9457cb4e9a27e6ca5714485d63d58"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:4aaa1af6ebac931110e1c92a59a53a3e",
-      "entity": "niiri:7cbefce0a8261b298fcf42f53fd1c81a"
+      "activity_using": "niiri:82fff8a2920d426af761ea65abc3f824",
+      "entity": "niiri:7afdd6ab4e20f8072056e7ad109e1a28"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:4aaa1af6ebac931110e1c92a59a53a3e",
-      "entity": "niiri:4414db3adc555942a3b666595c0251ef"
+      "activity_using": "niiri:82fff8a2920d426af761ea65abc3f824",
+      "entity": "niiri:d114849d6b0dd611879e4e55b5de49c6"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:4aaa1af6ebac931110e1c92a59a53a3e",
-      "entity": "niiri:5a41045d9499fd48e4c3d720cabedd8c"
+      "activity_using": "niiri:82fff8a2920d426af761ea65abc3f824",
+      "entity": "niiri:f2151889cbe45b2a41ece1a31d4608ed"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:4aaa1af6ebac931110e1c92a59a53a3e",
-      "entity": "niiri:552da79a48d378687bacbdc1d379a41b"
+      "activity_using": "niiri:82fff8a2920d426af761ea65abc3f824",
+      "entity": "niiri:b0a406128a699bce39d09638de7fbb11"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:4aaa1af6ebac931110e1c92a59a53a3e",
-      "entity": "niiri:26e7893496c9fff727b5d918177d86e4"
+      "activity_using": "niiri:82fff8a2920d426af761ea65abc3f824",
+      "entity": "niiri:95009d167a825475f9da93813a5eff0d"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:4aaa1af6ebac931110e1c92a59a53a3e",
-      "entity": "niiri:f2ae10333ea3be73d8c5ba3182d14784"
+      "activity_using": "niiri:82fff8a2920d426af761ea65abc3f824",
+      "entity": "niiri:89d2070b8724cba90b0701cbb65ee609"
     },
     {
-      "@id": "niiri:530d3569bc598c79d5ac70217715e117",
-      "@type": ["prov:Entity","nidm_StatisticMap:"],
+      "@id": "niiri:97a6f2d59ca3be4b5454a9ab78cdf8a3",
+      "@type": ["prov:Entity","nidm_StatisticMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "TStatistic.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "TStatistic.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "T-Statistic Map: tone counting vs baseline",
-      "nidm_statisticType:": {"@id": "obo_tstatistic:"},
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
-      "nidm_errorDegreesOfFreedom:": {"@type": "xsd:float", "@value": "97.9999999998522"},
-      "nidm_effectDegreesOfFreedom:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:57bfb1702d234ee28692b281b4b06077"},
+      "nidm_statisticType": {"@id": "obo_tstatistic"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
+      "nidm_errorDegreesOfFreedom": {"@type": "xsd:float", "@value": "97.9999999998522"},
+      "nidm_effectDegreesOfFreedom": {"@type": "xsd:float", "@value": "1"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:4d80c0cd6d8f06cc5fa8312aea1fdf66"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "9e1714c2d86a050b38b4e10a4d2d23253a24c5e1d228ae16a9c3be8872739278505ac0729ecab54265a717e3a54f9f782d0ed72eea904e0d482a6072bb817bd4"}
     },
     {
-      "@id": "niiri:b787aa7bea228b9f18af1fcf0912027e",
-      "@type": ["prov:Entity","nidm_StatisticMap:"],
+      "@id": "niiri:c5d3fd2966a03a48d06d8890367cdebf",
+      "@type": ["prov:Entity","nidm_StatisticMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "spmT_0001.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "d288b1b0f117f64502555da13c5398dffa5bf5ff0b58951510e43d5388755bc185798802a92e98a07c7e313c6991066d2908f2a44aa5153ba23433da1335970f"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:530d3569bc598c79d5ac70217715e117",
-      "entity": "niiri:b787aa7bea228b9f18af1fcf0912027e"
+      "entity_derived": "niiri:97a6f2d59ca3be4b5454a9ab78cdf8a3",
+      "entity": "niiri:c5d3fd2966a03a48d06d8890367cdebf"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:530d3569bc598c79d5ac70217715e117",
-      "activity": "niiri:4aaa1af6ebac931110e1c92a59a53a3e"
+      "entity_generated": "niiri:97a6f2d59ca3be4b5454a9ab78cdf8a3",
+      "activity": "niiri:82fff8a2920d426af761ea65abc3f824"
     },
     {
-      "@id": "niiri:081ecb89bf33cb4e58a9be8521156796",
-      "@type": ["prov:Entity","nidm_ContrastMap:"],
+      "@id": "niiri:ea0fc93e4d1d634046b0ddea1c061c4f",
+      "@type": ["prov:Entity","nidm_ContrastMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "Contrast.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "Contrast.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Contrast Map: tone counting vs baseline",
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:57bfb1702d234ee28692b281b4b06077"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:4d80c0cd6d8f06cc5fa8312aea1fdf66"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "fc5e2ad175243ee496db98f9b2e1b235c4c3bae1a8d7122ce461c897b537e40c49dfee5d6cf20f71c6a2bb9b5f0760fcb4ecd8fe2e9428910ef3d60d8f3c56a9"}
     },
     {
-      "@id": "niiri:91dd538639ff8e756ee312f740250812",
-      "@type": ["prov:Entity","nidm_ContrastMap:"],
+      "@id": "niiri:615aeb13ab7f18a00b6e56cef9a42324",
+      "@type": ["prov:Entity","nidm_ContrastMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "con_0001.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "d4aa46b3603ba508578e39751262d528cf6d1ed2e722ec46f1cd8194c50591e46b229deb8cb4f72d1b7e0e2640f3e6604be7a335301c5c8357f453e5d0d4daf2"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:081ecb89bf33cb4e58a9be8521156796",
-      "entity": "niiri:91dd538639ff8e756ee312f740250812"
+      "entity_derived": "niiri:ea0fc93e4d1d634046b0ddea1c061c4f",
+      "entity": "niiri:615aeb13ab7f18a00b6e56cef9a42324"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:081ecb89bf33cb4e58a9be8521156796",
-      "activity": "niiri:4aaa1af6ebac931110e1c92a59a53a3e"
+      "entity_generated": "niiri:ea0fc93e4d1d634046b0ddea1c061c4f",
+      "activity": "niiri:82fff8a2920d426af761ea65abc3f824"
     },
     {
-      "@id": "niiri:2f932cba6601f6d4b44a86a0a888a950",
-      "@type": ["prov:Entity","nidm_ContrastStandardErrorMap:"],
+      "@id": "niiri:9349eafbf1e1c6deb40a7bbb8393c611",
+      "@type": ["prov:Entity","nidm_ContrastStandardErrorMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ContrastStandardError.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ContrastStandardError.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Contrast Standard Error Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:57bfb1702d234ee28692b281b4b06077"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:4d80c0cd6d8f06cc5fa8312aea1fdf66"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "791d48f5d1adb15079a5289271ce0c4b95c56d69bfdb3e5d41b0d24eb538d3075e1cdd15502494b5a5a18c16eaa2153cb4847a996043fa48cdaf26e938a2576d"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:2f932cba6601f6d4b44a86a0a888a950",
-      "activity": "niiri:4aaa1af6ebac931110e1c92a59a53a3e"
+      "entity_generated": "niiri:9349eafbf1e1c6deb40a7bbb8393c611",
+      "activity": "niiri:82fff8a2920d426af761ea65abc3f824"
     },
     {
-      "@id": "niiri:a523bb37afa0a13617991b5286230c4b",
-      "@type": ["prov:Entity","nidm_HeightThreshold:","obo_qvalue:"],
-      "rdfs:label": "Height Threshold: p<0.05 (FDR)",
+      "@id": "niiri:614f1836a4dabc08f6a40b74d83e4626",
+      "@type": ["prov:Entity","nidm_HeightThreshold","obo_qvalue"],
+      "rdfs:label": ":Height Threshold: p<0.05 (FDR)",
       "prov:value": {"@type": "xsd:float", "@value": "0.05"},
-      "nidm_equivalentThreshold:": [{"@id": "niiri:2eee45a8bb26d99eb05e525c350fb1c4"},{"@id": "niiri:67d13ef3bcf3b394d767df4c8be23715"}]
+      "nidm_equivalentThreshold": [{"@id": "niiri:4ca33fc892cbd22caafe7e43289ea67c"},{"@id": "niiri:351f1c49ad3573062df361946a82808a"}]
     },
     {
-      "@id": "niiri:2eee45a8bb26d99eb05e525c350fb1c4",
-      "@type": ["prov:Entity","nidm_HeightThreshold:","obo_statistic:"],
-      "rdfs:label": "Height Threshold",
+      "@id": "niiri:4ca33fc892cbd22caafe7e43289ea67c",
+      "@type": ["prov:Entity","nidm_HeightThreshold","obo_statistic"],
+      "rdfs:label": "Height Threshold: T=2.751981)",
       "prov:value": {"@type": "xsd:float", "@value": "2.75198078155518"}
     },
     {
-      "@id": "niiri:67d13ef3bcf3b394d767df4c8be23715",
-      "@type": ["prov:Entity","nidm_HeightThreshold:","nidm_PValueUncorrected:"],
-      "rdfs:label": "Height Threshold",
+      "@id": "niiri:351f1c49ad3573062df361946a82808a",
+      "@type": ["prov:Entity","nidm_HeightThreshold","nidm_PValueUncorrected"],
+      "rdfs:label": "Height Threshold: p<0.003523 (unc.)",
       "prov:value": {"@type": "xsd:float", "@value": "0.00352282952586247"}
     },
     {
-      "@id": "niiri:902960abf8589ac4279cafa49a50ab4e",
-      "@type": ["prov:Entity","nidm_ExtentThreshold:","obo_statistic:"],
+      "@id": "niiri:f0dedbabde9224b6cdcbfcacb9ea64eb",
+      "@type": ["prov:Entity","nidm_ExtentThreshold","obo_statistic"],
       "rdfs:label": "Extent Threshold: k>=0",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "0"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0"},
-      "nidm_equivalentThreshold:": [{"@id": "niiri:0b1604a315a17fa30779aeec1e47c679"},{"@id": "niiri:fd82f20a476b61a30200f544eb872bc8"}]
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "0"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0"},
+      "nidm_equivalentThreshold": [{"@id": "niiri:e9f896312d2fd00ff4139f0c9d26b2ca"},{"@id": "niiri:a607df3343e3516511d5da695cfc14df"}]
     },
     {
-      "@id": "niiri:0b1604a315a17fa30779aeec1e47c679",
-      "@type": ["prov:Entity","nidm_ExtentThreshold:","obo_FWERadjustedpvalue:"],
+      "@id": "niiri:e9f896312d2fd00ff4139f0c9d26b2ca",
+      "@type": ["prov:Entity","nidm_ExtentThreshold","obo_FWERadjustedpvalue"],
       "rdfs:label": "Extent Threshold",
       "prov:value": {"@type": "xsd:float", "@value": "1"}
     },
     {
-      "@id": "niiri:fd82f20a476b61a30200f544eb872bc8",
-      "@type": ["prov:Entity","nidm_ExtentThreshold:","nidm_PValueUncorrected:"],
+      "@id": "niiri:a607df3343e3516511d5da695cfc14df",
+      "@type": ["prov:Entity","nidm_ExtentThreshold","nidm_PValueUncorrected"],
       "rdfs:label": "Extent Threshold",
       "prov:value": {"@type": "xsd:float", "@value": "1"}
     },
     {
-      "@id": "niiri:87f4625e9e7d1cf73a2eec5c7d284104",
-      "@type": ["prov:Entity","nidm_PeakDefinitionCriteria:"],
+      "@id": "niiri:25809641902137f5d84b8818fbf15a91",
+      "@type": ["prov:Entity","nidm_PeakDefinitionCriteria"],
       "rdfs:label": "Peak Definition Criteria",
-      "nidm_maxNumberOfPeaksPerCluster:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_minDistanceBetweenPeaks:": {"@type": "xsd:float", "@value": "8"}
+      "nidm_maxNumberOfPeaksPerCluster": {"@type": "xsd:int", "@value": "3"},
+      "nidm_minDistanceBetweenPeaks": {"@type": "xsd:float", "@value": "8"}
     },
     {
-      "@id": "niiri:492f8dc66cc7151992954ec5f3b72262",
-      "@type": ["prov:Entity","nidm_ClusterDefinitionCriteria:"],
+      "@id": "niiri:c9584a376a996dc760652f9e9d414333",
+      "@type": ["prov:Entity","nidm_ClusterDefinitionCriteria"],
       "rdfs:label": "Cluster Connectivity Criterion: 18",
-      "nidm_hasConnectivityCriterion:": {"@id": "nidm_voxel18connected:"}
+      "nidm_hasConnectivityCriterion": {"@id": "nidm_voxel18connected"}
     },
     {
-      "@id": "niiri:023a908053ece2b7004e79fc8628c205",
-      "@type": ["prov:Activity","nidm_Inference:"],
-      "nidm_hasAlternativeHypothesis:": {"@id": "nidm_OneTailedTest:"},
+      "@id": "niiri:aa76de7328e3d13603b9e4c03167310d",
+      "@type": ["prov:Activity","nidm_Inference"],
+      "nidm_hasAlternativeHypothesis": {"@id": "nidm_OneTailedTest"},
       "rdfs:label": "Inference"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:023a908053ece2b7004e79fc8628c205",
-      "agent": "niiri:64730f8ca3829b6ba8ce02b85a004bb2"
+      "activity_associated": "niiri:aa76de7328e3d13603b9e4c03167310d",
+      "agent": "niiri:6a56b7cc41090f34638cf50938e932eb"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:023a908053ece2b7004e79fc8628c205",
-      "entity": "niiri:a523bb37afa0a13617991b5286230c4b"
+      "activity_using": "niiri:aa76de7328e3d13603b9e4c03167310d",
+      "entity": "niiri:614f1836a4dabc08f6a40b74d83e4626"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:023a908053ece2b7004e79fc8628c205",
-      "entity": "niiri:902960abf8589ac4279cafa49a50ab4e"
+      "activity_using": "niiri:aa76de7328e3d13603b9e4c03167310d",
+      "entity": "niiri:f0dedbabde9224b6cdcbfcacb9ea64eb"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:023a908053ece2b7004e79fc8628c205",
-      "entity": "niiri:530d3569bc598c79d5ac70217715e117"
+      "activity_using": "niiri:aa76de7328e3d13603b9e4c03167310d",
+      "entity": "niiri:97a6f2d59ca3be4b5454a9ab78cdf8a3"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:023a908053ece2b7004e79fc8628c205",
-      "entity": "niiri:3b5abc82d35d734e1136daa4a8b2777b"
+      "activity_using": "niiri:aa76de7328e3d13603b9e4c03167310d",
+      "entity": "niiri:3ae2261460b37724f66a583d13620d04"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:023a908053ece2b7004e79fc8628c205",
-      "entity": "niiri:72aa1f9e4b18c0a5675eca75f20b7534"
+      "activity_using": "niiri:aa76de7328e3d13603b9e4c03167310d",
+      "entity": "niiri:3da9457cb4e9a27e6ca5714485d63d58"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:023a908053ece2b7004e79fc8628c205",
-      "entity": "niiri:87f4625e9e7d1cf73a2eec5c7d284104"
+      "activity_using": "niiri:aa76de7328e3d13603b9e4c03167310d",
+      "entity": "niiri:25809641902137f5d84b8818fbf15a91"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:023a908053ece2b7004e79fc8628c205",
-      "entity": "niiri:492f8dc66cc7151992954ec5f3b72262"
+      "activity_using": "niiri:aa76de7328e3d13603b9e4c03167310d",
+      "entity": "niiri:c9584a376a996dc760652f9e9d414333"
     },
     {
-      "@id": "niiri:4716aca7a4cad737eb95dc877d0b86e8",
-      "@type": ["prov:Entity","nidm_SearchSpaceMaskMap:"],
+      "@id": "niiri:0337db714526a735c3f18f8b17802c96",
+      "@type": ["prov:Entity","nidm_SearchSpaceMaskMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "SearchSpaceMask.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "SearchSpaceMask.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Search Space Mask Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:57bfb1702d234ee28692b281b4b06077"},
-      "nidm_searchVolumeInVoxels:": {"@type": "xsd:int", "@value": "223057"},
-      "nidm_searchVolumeInUnits:": {"@type": "xsd:float", "@value": "1784456"},
-      "nidm_reselSizeInVoxels:": {"@type": "xsd:float", "@value": "65.5786964036542"},
-      "nidm_searchVolumeInResels:": {"@type": "xsd:float", "@value": "3155.84193266257"},
-      "spm_searchVolumeReselsGeometry:": {"@type": "xsd:string", "@value": "[6, 97.8140592306853, 965.938819261507, 3155.84193266257]"},
-      "nidm_noiseFWHMInVoxels:": {"@type": "xsd:string", "@value": "[4.09118640605185, 4.0346308705955, 3.97291894351243]"},
-      "nidm_noiseFWHMInUnits:": {"@type": "xsd:string", "@value": "[8.18237281210369, 8.069261741191, 7.94583788702486]"},
-      "nidm_randomFieldStationarity:": {"@type": "xsd:boolean", "@value": "true"},
-      "nidm_expectedNumberOfVoxelsPerCluster:": {"@type": "xsd:float", "@value": "11.2648844136176"},
-      "nidm_expectedNumberOfClusters:": {"@type": "xsd:float", "@value": "78.1804634557495"},
-      "nidm_heightCriticalThresholdFWE05:": {"@type": "xsd:float", "@value": "5.30963135104407"},
-      "nidm_heightCriticalThresholdFDR05:": {"@type": "xsd:float", "@value": "2.75198073945778"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:4d80c0cd6d8f06cc5fa8312aea1fdf66"},
+      "nidm_searchVolumeInVoxels": {"@type": "xsd:int", "@value": "223057"},
+      "nidm_searchVolumeInUnits": {"@type": "xsd:float", "@value": "1784456"},
+      "nidm_reselSizeInVoxels": {"@type": "xsd:float", "@value": "65.5786964036542"},
+      "nidm_searchVolumeInResels": {"@type": "xsd:float", "@value": "3155.84193266257"},
+      "spm_searchVolumeReselsGeometry": {"@type": "xsd:string", "@value": "[6, 97.8140592306853, 965.938819261507, 3155.84193266257]"},
+      "nidm_noiseFWHMInVoxels": {"@type": "xsd:string", "@value": "[4.09118640605185, 4.0346308705955, 3.97291894351243]"},
+      "nidm_noiseFWHMInUnits": {"@type": "xsd:string", "@value": "[8.18237281210369, 8.069261741191, 7.94583788702486]"},
+      "nidm_randomFieldStationarity": {"@type": "xsd:boolean", "@value": "true"},
+      "nidm_expectedNumberOfVoxelsPerCluster": {"@type": "xsd:float", "@value": "11.2648844136176"},
+      "nidm_expectedNumberOfClusters": {"@type": "xsd:float", "@value": "78.1804634557495"},
+      "nidm_heightCriticalThresholdFWE05": {"@type": "xsd:float", "@value": "5.30963135104407"},
+      "nidm_heightCriticalThresholdFDR05": {"@type": "xsd:float", "@value": "2.75198073945778"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876"},
-      "spm_smallestSignificantClusterSizeInVoxelsFWE05:": {"@type": "xsd:int", "@value": "417"}
+      "spm_smallestSignificantClusterSizeInVoxelsFWE05": {"@type": "xsd:int", "@value": "417"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:4716aca7a4cad737eb95dc877d0b86e8",
-      "activity": "niiri:023a908053ece2b7004e79fc8628c205"
+      "entity_generated": "niiri:0337db714526a735c3f18f8b17802c96",
+      "activity": "niiri:aa76de7328e3d13603b9e4c03167310d"
     },
     {
-      "@id": "niiri:cf2669065d68620b6d3d674c82341f68",
-      "@type": ["prov:Entity","nidm_ExcursionSetMap:"],
+      "@id": "niiri:dfc9c2736061f68baaf0d5518b47b332",
+      "@type": ["prov:Entity","nidm_ExcursionSetMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ExcursionSet.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ExcursionSet.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Excursion Set Map",
-      "nidm_numberOfSupraThresholdClusters:": {"@type": "xsd:int", "@value": "94"},
-      "nidm_pValue:": {"@type": "xsd:float", "@value": "0.0447079143903081"},
-      "nidm_hasClusterLabelsMap:": {"@id": "niiri:517d95139044cb76e80096f69d114fdf"},
-      "nidm_hasMaximumIntensityProjection:": {"@id": "niiri:9a5e8e987ce1ea3b0d9681600c7d6adc"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:57bfb1702d234ee28692b281b4b06077"},
+      "nidm_numberOfSupraThresholdClusters": {"@type": "xsd:int", "@value": "94"},
+      "nidm_pValue": {"@type": "xsd:float", "@value": "0.0447079143903081"},
+      "nidm_hasClusterLabelsMap": {"@id": "niiri:332fb65e8d1c26a67e44333e6c989eb7"},
+      "nidm_hasMaximumIntensityProjection": {"@id": "niiri:5938905a43f9833716520963e37ee9bc"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:4d80c0cd6d8f06cc5fa8312aea1fdf66"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "cf6122ef36510b627277417e8070ef8b21de0fcc302fb6c54bf9edeb988abef00c098ec6c42fcf12cd780102e22e349f9c18cd538751d947c730386ef4e7a1cd"}
     },
     {
-      "@id": "niiri:517d95139044cb76e80096f69d114fdf",
-      "@type": ["prov:Entity","nidm_ClusterLabelsMap:"],
+      "@id": "niiri:332fb65e8d1c26a67e44333e6c989eb7",
+      "@type": ["prov:Entity","nidm_ClusterLabelsMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ClusterLabels.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ClusterLabels.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Cluster Labels Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:57bfb1702d234ee28692b281b4b06077"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:4d80c0cd6d8f06cc5fa8312aea1fdf66"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "a6e72a506c045df940a586a06217495a831daf3d177fe165daebb130d3e2e4e907672569967fc17d32833becda95fa6d98fd5aae15ff0d91681337ac0edcd529"}
     },
     {
-      "@id": "niiri:9a5e8e987ce1ea3b0d9681600c7d6adc",
+      "@id": "niiri:5938905a43f9833716520963e37ee9bc",
       "@type": ["prov:Entity","dctype:Image"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "MaximumIntensityProjection.png"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "MaximumIntensityProjection.png"},
@@ -730,4130 +730,4130 @@
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:cf2669065d68620b6d3d674c82341f68",
-      "activity": "niiri:023a908053ece2b7004e79fc8628c205"
+      "entity_generated": "niiri:dfc9c2736061f68baaf0d5518b47b332",
+      "activity": "niiri:aa76de7328e3d13603b9e4c03167310d"
     },
     {
-      "@id": "niiri:242656e5fe9c4228886ce59df6e0a2ca",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:57b0b3487b8ceebf11e98e8506c169a2",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0001",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "10882"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "165.938034708992"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.90523177469239e-52"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "1"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "10882"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "165.938034708992"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.90523177469239e-52"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "1"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:242656e5fe9c4228886ce59df6e0a2ca",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:57b0b3487b8ceebf11e98e8506c169a2",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:c27bdfc6cef3bf3771769b92935b0e04",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:3d5c32984a0665ba596ff6cef71fcd0b",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0002",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "464"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "7.07546848970521"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.46600673096314e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "4.27325808851631e-05"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "2"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "464"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "7.07546848970521"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.46600673096314e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "4.27325808851631e-05"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "2"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c27bdfc6cef3bf3771769b92935b0e04",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:3d5c32984a0665ba596ff6cef71fcd0b",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:a158a75fe65c6add3c1257707728cdd4",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:2c413461a4c1a86447e1da248ab7545c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0003",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1082"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "16.4992605729764"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "9.72221700092388e-12"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "7.6008743743472e-10"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "3"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1082"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "16.4992605729764"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "9.72221700092388e-12"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "7.6008743743472e-10"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "3"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a158a75fe65c6add3c1257707728cdd4",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:2c413461a4c1a86447e1da248ab7545c",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:b89b511274698ad906aaf626aa9dafa2",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:e3f486aca3000e0c84fbdaf8a042398f",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0004",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "155"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "2.36357244806963"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000966188323290149"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0727546253784379"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "4"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "155"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "2.36357244806963"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000966188323290149"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0727546253784379"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "4"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b89b511274698ad906aaf626aa9dafa2",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:e3f486aca3000e0c84fbdaf8a042398f",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:fc1234dbcb5fecc84cb748f7a43e1791",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c0ef61636e02d68816943e9c0c7be35d",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0005",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "468"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "7.13646390771991"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.03189156866348e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "3.93387876993501e-05"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "5"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "468"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "7.13646390771991"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.03189156866348e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "3.93387876993501e-05"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "5"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:fc1234dbcb5fecc84cb748f7a43e1791",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:c0ef61636e02d68816943e9c0c7be35d",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:bc79ea489b7d5f8523a15f77de48e174",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:e9bd68a9b52a95e89ba7a7e17b4fa428",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0006",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "602"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "9.17981041121237"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.55299466223168e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "2.77774383550256e-06"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "6"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "602"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "9.17981041121237"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.55299466223168e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "2.77774383550256e-06"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "6"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:bc79ea489b7d5f8523a15f77de48e174",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:e9bd68a9b52a95e89ba7a7e17b4fa428",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:d1bded8abf09ebee39e58ad5cac474bf",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:7693eabf368839e957bc3cfe43c975e0",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0007",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "155"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "2.36357244806963"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000966188323290149"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0727546253784379"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "7"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "155"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "2.36357244806963"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000966188323290149"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0727546253784379"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "7"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d1bded8abf09ebee39e58ad5cac474bf",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:7693eabf368839e957bc3cfe43c975e0",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:2d4153f04704f26ae2b13f93cceec23b",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:39b96655430c53f32e07621dbe8655c4",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0008",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "24"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.365972508088201"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.135096185329275"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99997411591819"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "8"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "24"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.365972508088201"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.135096185329275"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99997411591819"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "8"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2d4153f04704f26ae2b13f93cceec23b",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:39b96655430c53f32e07621dbe8655c4",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:8702febb070c184ab840d84baa828f4c",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:90ea170edb9635f011af376c50f1eff8",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0009",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "66"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.00642439724255"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.019659726704423"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.784976196959257"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "9"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "66"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.00642439724255"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.019659726704423"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.784976196959257"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "9"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8702febb070c184ab840d84baa828f4c",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:90ea170edb9635f011af376c50f1eff8",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:554231ad3e2c8225e52d92a4328b14a9",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:d976336ac6ecb4bba1136f54b6de3e23",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0010",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "39"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.594705325643326"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0628608642474607"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.992660550947171"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "10"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "39"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.594705325643326"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0628608642474607"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.992660550947171"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "10"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:554231ad3e2c8225e52d92a4328b14a9",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:d976336ac6ecb4bba1136f54b6de3e23",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:8adb4939693aed81541cf6c7ab164844",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:43ec173da0c3faa0f4491456aea575ce",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0011",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "62"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.945428979227852"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0230802080341633"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.835430344509021"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "11"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "62"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.945428979227852"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0230802080341633"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.835430344509021"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "11"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8adb4939693aed81541cf6c7ab164844",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:43ec173da0c3faa0f4491456aea575ce",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:0a424073d2852615c9efd40e929d5259",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:a21087d5b0bdd477c690e1272139bf8a",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0012",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "417"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "6.35877232803249"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.4724427450224e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.000115109630595911"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "12"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "417"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "6.35877232803249"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.4724427450224e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.000115109630595911"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "12"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0a424073d2852615c9efd40e929d5259",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:a21087d5b0bdd477c690e1272139bf8a",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:c419557738905fde9064be2cef6f1449",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:a4d3b6fc7cc84d91945916a3052dd21c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0013",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "130"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.98235108547775"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00208283102205462"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.150270057430811"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "13"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "130"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.98235108547775"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00208283102205462"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.150270057430811"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "13"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c419557738905fde9064be2cef6f1449",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:a4d3b6fc7cc84d91945916a3052dd21c",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:4b5ae066ef253b812d649482610dbba7",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:d3e3d125a9ce7e2ce6bac0795d332509",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0014",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "22"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.335474799080851"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.151229882990552"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999266770754"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "14"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "22"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.335474799080851"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.151229882990552"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999266770754"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "14"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4b5ae066ef253b812d649482610dbba7",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:d3e3d125a9ce7e2ce6bac0795d332509",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:c27d8c4414a41bf2e1d9fe41a87f11b6",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:0531c28556a1e0fba30c3ea1dd24f56e",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0015",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "40"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.609954180147001"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0599689762737744"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.990798625078006"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "15"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "40"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.609954180147001"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0599689762737744"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.990798625078006"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "15"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c27d8c4414a41bf2e1d9fe41a87f11b6",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:0531c28556a1e0fba30c3ea1dd24f56e",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:63757a12c243d6f113a5c106a65341d3",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:22a4e1327d4f2f7349df156933a68889",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0016",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "44"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.670949598161701"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0498604149932155"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.979719802309727"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "16"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "44"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.670949598161701"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0498604149932155"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.979719802309727"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "16"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:63757a12c243d6f113a5c106a65341d3",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:22a4e1327d4f2f7349df156933a68889",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:64a23b7dfa188ea7c583dd955c4783b0",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:661e97df890b4cd21b7b3cc4a2220e2e",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0017",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "9"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.137239690533075"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.353115016567812"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999998975"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "17"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "9"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.137239690533075"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.353115016567812"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999998975"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "17"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:64a23b7dfa188ea7c583dd955c4783b0",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:661e97df890b4cd21b7b3cc4a2220e2e",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:c7fd5f4cdee71350124b35242a6b1709",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:fb7297e8c19234947de7375e05901f89",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0018",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "26"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.396470217095551"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.121057745011785"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999922431613941"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "18"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "26"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.396470217095551"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.121057745011785"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999922431613941"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "18"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c7fd5f4cdee71350124b35242a6b1709",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:fb7297e8c19234947de7375e05901f89",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:43b10bfa562e759c7c198b457de7cd8b",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c016e8a860699bda1ff422a1f501e63d",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0019",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "14"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.21348396305145"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.247209045891911"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999995959582"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "19"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "14"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.21348396305145"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.247209045891911"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999995959582"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "19"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:43b10bfa562e759c7c198b457de7cd8b",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:c016e8a860699bda1ff422a1f501e63d",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:94ae4aee00bdd503edae82f33c3e9515",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c4fe065cafdebad144fa17a8ec71281b",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0020",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "102"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.55538315937485"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00523608159210795"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.335924403319093"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "20"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "102"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.55538315937485"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00523608159210795"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.335924403319093"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "20"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:94ae4aee00bdd503edae82f33c3e9515",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:c4fe065cafdebad144fa17a8ec71281b",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:4f7b061f932253ef4a07d4d9f2fe8517",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:b9447d9cb03b61ef6f6b29b2f726c748",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0021",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "35"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.533709907628626"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0762105313207416"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.997415374507942"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "21"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "35"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.533709907628626"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0762105313207416"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.997415374507942"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "21"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4f7b061f932253ef4a07d4d9f2fe8517",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:b9447d9cb03b61ef6f6b29b2f726c748",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:0163fc34332a97aa514f22d9a18b4aef",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:fccd53239e801ce9120073c47ddcae13",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0022",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "11"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.167737399540425"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.304231432261983"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999953191"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "22"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "11"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.167737399540425"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.304231432261983"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999953191"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "22"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0163fc34332a97aa514f22d9a18b4aef",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:fccd53239e801ce9120073c47ddcae13",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:afb1b880058db996109597c9134c0944",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:e8858d23bbbcba237e94c70004237a2f",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0023",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "60"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.914931270220502"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0250398009911991"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.858806395143279"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "23"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "60"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.914931270220502"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0250398009911991"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.858806395143279"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "23"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:afb1b880058db996109597c9134c0944",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:e8858d23bbbcba237e94c70004237a2f",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:a3209dd94fcfcfc2e0d96d3475893c16",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:a1e36a12612c98786c42d6e581a41938",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0024",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "20"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.169879909718968"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999998293882222"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "24"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "20"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.169879909718968"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999998293882222"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "24"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a3209dd94fcfcfc2e0d96d3475893c16",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:a1e36a12612c98786c42d6e581a41938",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:0e0928e501c6272ac7fd3ddf2695e9f7",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:6aac454abbeb6462b826cd647eb086e0",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0025",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "106"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.61637857738955"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0045683114800732"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.300334355470534"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "25"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "106"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.61637857738955"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0045683114800732"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.300334355470534"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "25"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0e0928e501c6272ac7fd3ddf2695e9f7",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:6aac454abbeb6462b826cd647eb086e0",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:15ddf3a0750659085f821d46282e1a9c",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:7b28ee2c06d9f1eb5b4dab7494fe7a85",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0026",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "82"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.25040606930135"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.010663031377913"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.565535367161089"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "26"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "82"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.25040606930135"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.010663031377913"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.565535367161089"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "26"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:15ddf3a0750659085f821d46282e1a9c",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:7b28ee2c06d9f1eb5b4dab7494fe7a85",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:e037574456f8a483328c150e32419262",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:00aad4e5c367c7dee68c301c251cb2ce",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0027",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "50"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.762442725183751"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0381864669518656"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.949482510909652"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "27"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "50"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.762442725183751"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0381864669518656"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.949482510909652"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "27"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e037574456f8a483328c150e32419262",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:00aad4e5c367c7dee68c301c251cb2ce",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:cead124d94f280e9eb613273f575273f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:904dc3e52037e77af188b63a3d3a6884",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0028",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "106"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.61637857738955"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0045683114800732"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.300334355470534"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "28"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "106"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.61637857738955"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0045683114800732"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.300334355470534"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "28"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cead124d94f280e9eb613273f575273f",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:904dc3e52037e77af188b63a3d3a6884",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:9dee950d4d0d87d9847d4f2182442446",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:ffdea138243040f7b25be6c44f68510d",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0029",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "14"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.21348396305145"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.247209045891911"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999995959582"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "29"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "14"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.21348396305145"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.247209045891911"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999995959582"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "29"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9dee950d4d0d87d9847d4f2182442446",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:ffdea138243040f7b25be6c44f68510d",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:5bdb44212c11108bd9056913ba88493d",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f19e77aa11c450b96b368f822fcfd6ce",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0030",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "19"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.289728235569826"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.180311198128326"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999245200009"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "30"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "19"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.289728235569826"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.180311198128326"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999245200009"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "30"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5bdb44212c11108bd9056913ba88493d",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:f19e77aa11c450b96b368f822fcfd6ce",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:fcd93504620cb56307a63f5826ae493b",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:1b80b6984bddaf1c61a51a898d6acbea",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0031",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "37"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.564207616635976"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0691545455685726"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.995512836089743"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "31"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "37"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.564207616635976"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0691545455685726"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.995512836089743"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "31"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:fcd93504620cb56307a63f5826ae493b",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:1b80b6984bddaf1c61a51a898d6acbea",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:22f559c5bb43c4d1c00d4b2abbd64b80",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:2a6b200869ec06562d293e64de33e926",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0032",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0457465635110251"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.606262591428315"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "32"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0457465635110251"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.606262591428315"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "32"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:22f559c5bb43c4d1c00d4b2abbd64b80",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:2a6b200869ec06562d293e64de33e926",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:b58c8c56d192cbadcd924e0e299d45b7",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:50eb3a7d09683191b4aed76432577ca4",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0033",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "14"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.21348396305145"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.247209045891911"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999995959582"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "33"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "14"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.21348396305145"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.247209045891911"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999995959582"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "33"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b58c8c56d192cbadcd924e0e299d45b7",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:50eb3a7d09683191b4aed76432577ca4",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:6c6cb2c384c60e5d62243cf34af0708f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:3dc187c20fafa718374d3bf8209b869c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0034",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "14"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.21348396305145"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.247209045891911"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999995959582"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "34"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "14"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.21348396305145"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.247209045891911"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999995959582"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "34"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6c6cb2c384c60e5d62243cf34af0708f",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:3dc187c20fafa718374d3bf8209b869c",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:3c56acb507aa977c9b4ba549626f35b8",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:2246deb8a6c721c27dda92f3dd869ffd",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0035",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "9"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.137239690533075"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.353115016567812"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999998975"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "35"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "9"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.137239690533075"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.353115016567812"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999998975"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "35"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3c56acb507aa977c9b4ba549626f35b8",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:2246deb8a6c721c27dda92f3dd869ffd",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:d1dd3f03998183928446768008d538fd",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:50cb1d29d6f8a9cfe9515552c5bb7d31",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0036",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "12"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.1829862540441"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.283360599180691"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999976069"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "36"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "12"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.1829862540441"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.283360599180691"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999976069"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "36"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d1dd3f03998183928446768008d538fd",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:50cb1d29d6f8a9cfe9515552c5bb7d31",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:c68b211ae154a1466946b63df0f701aa",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:d6d69b36b9108bb0de66eeffba4d858e",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0037",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "7"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.106741981525725"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.414624064489355"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999992"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "37"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "7"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.106741981525725"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.414624064489355"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999992"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "37"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c68b211ae154a1466946b63df0f701aa",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:d6d69b36b9108bb0de66eeffba4d858e",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:322465548251da9db8f6eede832763a7",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:e88a30db5e3821edb55a62d4b67f0ad1",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0038",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "14"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.21348396305145"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.247209045891911"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999995959582"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "38"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "14"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.21348396305145"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.247209045891911"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999995959582"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "38"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:322465548251da9db8f6eede832763a7",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:e88a30db5e3821edb55a62d4b67f0ad1",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:2e9ce0e379ad93f22643b62153bb9323",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:a4ad9afd60a760f91d6916421b56fe6a",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0039",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "22"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.335474799080851"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.151229882990552"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999266770754"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "39"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "22"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.335474799080851"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.151229882990552"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999266770754"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "39"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2e9ce0e379ad93f22643b62153bb9323",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:a4ad9afd60a760f91d6916421b56fe6a",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:d51a48062d3b4def227e90a39b0954f5",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:d3934b966af329378cc1a1307b94a530",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0040",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "18"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.27447938106615"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.191585077625515"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999687358966"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "40"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "18"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.27447938106615"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.191585077625515"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999687358966"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "40"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d51a48062d3b4def227e90a39b0954f5",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:d3934b966af329378cc1a1307b94a530",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:0a272793669dad6178113ee531ec9cb8",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:546534eff08d214139c8884f815a2c20",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0041",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "25"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.381221362591876"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.127837700735227"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999954345605505"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "41"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "25"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.381221362591876"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.127837700735227"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999954345605505"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "41"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0a272793669dad6178113ee531ec9cb8",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:546534eff08d214139c8884f815a2c20",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:b184062d5a99600d689d67aaae002061",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:295cf12e37c01e14c3830d46154826a9",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0042",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "12"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.1829862540441"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.283360599180691"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999976069"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "42"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "12"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.1829862540441"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.283360599180691"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999976069"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "42"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b184062d5a99600d689d67aaae002061",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:295cf12e37c01e14c3830d46154826a9",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:f96aa71d40f8ee2a7f558cd844317641",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:aedc5c46b75f681aa273f0c65aba753d",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0043",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "17"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.259230526562475"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.203794876382713"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999879639916"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "43"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "17"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.259230526562475"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.203794876382713"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999879639916"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "43"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f96aa71d40f8ee2a7f558cd844317641",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:aedc5c46b75f681aa273f0c65aba753d",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:51f615915847dee59f46c38a3d61f56e",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:03b802eb8ab278c3154b4ebae374f2f2",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0044",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "11"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.167737399540425"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.304231432261983"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999953191"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "44"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "11"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.167737399540425"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.304231432261983"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999953191"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "44"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:51f615915847dee59f46c38a3d61f56e",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:03b802eb8ab278c3154b4ebae374f2f2",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:c80fb3c545c2f7392d3c65842860d0d3",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:33fb5b8990838fc1f2547ba3ff8437d2",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0045",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "31"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.472714489613926"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0930905581376341"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999309340057149"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "45"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "31"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.472714489613926"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0930905581376341"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999309340057149"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "45"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c80fb3c545c2f7392d3c65842860d0d3",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:33fb5b8990838fc1f2547ba3ff8437d2",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:3d5efcc91bde3190c3c7fc5ea37f55ab",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f6f7f9d9bd2b440c679a5ff44f1cdb22",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0046",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "10"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.15248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.327355667114058"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999992323"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "46"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "10"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.15248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.327355667114058"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999992323"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "46"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3d5efcc91bde3190c3c7fc5ea37f55ab",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:f6f7f9d9bd2b440c679a5ff44f1cdb22",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:74d3fcdb2a3222701acac8703cef46c6",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:cbbd42e6f42814091a8e0fc54b7ad3c4",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0047",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "23"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.350723653584526"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.142877147982206"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999985912203707"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "47"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "23"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.350723653584526"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.142877147982206"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999985912203707"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "47"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:74d3fcdb2a3222701acac8703cef46c6",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:cbbd42e6f42814091a8e0fc54b7ad3c4",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:b954d8c8fc0fa467f3ee6aedf1927f85",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:53fb996b754ceba84bda7b0e7b9bdc51",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0048",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0457465635110251"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.606262591428315"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "48"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0457465635110251"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.606262591428315"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "48"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b954d8c8fc0fa467f3ee6aedf1927f85",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:53fb996b754ceba84bda7b0e7b9bdc51",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:f173ac5c048181e317d9158611e01835",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:55bb03da7ee7d021560ed83a011342a9",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0049",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "7"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.106741981525725"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.414624064489355"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999992"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "49"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "7"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.106741981525725"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.414624064489355"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999992"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "49"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f173ac5c048181e317d9158611e01835",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:55bb03da7ee7d021560ed83a011342a9",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:efc36c20dd2a832167f0a44c579b5edf",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:ac7c392c52df7cdd1a6cd2c7335454d2",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0050",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.682557316733255"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "50"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.682557316733255"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "50"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:efc36c20dd2a832167f0a44c579b5edf",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:ac7c392c52df7cdd1a6cd2c7335454d2",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:163e964ab452049726722befe3edc8f1",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c3f05dc9d300aa5acc02e364f1c3ee85",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0051",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0609954180147001"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.54539640994801"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "51"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0609954180147001"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.54539640994801"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "51"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:163e964ab452049726722befe3edc8f1",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:c3f05dc9d300aa5acc02e364f1c3ee85",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:21e6a6198ca5dccffc1370c3dedbd678",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:45b4ec73da86f70d949a94aa6ab8d4ab",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0052",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.682557316733255"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "52"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.682557316733255"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "52"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:21e6a6198ca5dccffc1370c3dedbd678",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:45b4ec73da86f70d949a94aa6ab8d4ab",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:0c7d90a406ec1f922a7e807915ee6f49",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:54114a5d8df2f7e553a53e4b7d3f5bde",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0053",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "6"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0914931270220502"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.45185124173467"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "53"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "6"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0914931270220502"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.45185124173467"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "53"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0c7d90a406ec1f922a7e807915ee6f49",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:54114a5d8df2f7e553a53e4b7d3f5bde",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:10a509044b2676eb12c65b82844b5898",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:3f3ed8fe063a9052a3379a875a3af9b1",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0054",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.786165890418407"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "54"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.786165890418407"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "54"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:10a509044b2676eb12c65b82844b5898",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:3f3ed8fe063a9052a3379a875a3af9b1",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:da2d2cf59ea5cea8edce49ea2ffea951",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:5721ae6aae6160ad82aced2d2fe68def",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0055",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.682557316733255"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "55"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.682557316733255"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "55"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:da2d2cf59ea5cea8edce49ea2ffea951",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:5721ae6aae6160ad82aced2d2fe68def",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:67b60bb73ecda2bbfdba32287ba6e0f5",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:9326713bc412f1ec61f3bf20466a1174",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0056",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0609954180147001"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.54539640994801"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "56"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0609954180147001"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.54539640994801"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "56"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:67b60bb73ecda2bbfdba32287ba6e0f5",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:9326713bc412f1ec61f3bf20466a1174",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:9254bae1d5f58a099609a70c3d6c17bf",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:ae9ba0f37d886eaa080e3238cefd1961",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0057",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "11"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.167737399540425"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.304231432261983"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999953191"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "57"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "11"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.167737399540425"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.304231432261983"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999953191"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "57"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9254bae1d5f58a099609a70c3d6c17bf",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:ae9ba0f37d886eaa080e3238cefd1961",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:2e99faf6261612f5665eb4d13abf19a0",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:55108dec00fcabdca0aa0fd19deac38c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0058",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.786165890418407"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "58"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.786165890418407"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "58"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2e99faf6261612f5665eb4d13abf19a0",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:55108dec00fcabdca0aa0fd19deac38c",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:740eb5d4edc6fcd44873c0c8fc2a5c58",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:16a2d945f11329e9c381ee7f04a0ef0e",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0059",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "17"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.259230526562475"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.203794876382713"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999879639916"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "59"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "17"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.259230526562475"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.203794876382713"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999879639916"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "59"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:740eb5d4edc6fcd44873c0c8fc2a5c58",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:16a2d945f11329e9c381ee7f04a0ef0e",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:405b87d54648ec0203cb5bd92594a2e3",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:51de73f4c31fd22967b959166dfdd033",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0060",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "5"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0762442725183751"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.494859211467501"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "60"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "5"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0762442725183751"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.494859211467501"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "60"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:405b87d54648ec0203cb5bd92594a2e3",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:51de73f4c31fd22967b959166dfdd033",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:2eee6e1a0cc5eacabec145451549d653",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:5810f1d1820e723be51fc80ca74ca5e0",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0061",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "7"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.106741981525725"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.414624064489355"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999992"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "61"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "7"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.106741981525725"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.414624064489355"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999992"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "61"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2eee6e1a0cc5eacabec145451549d653",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:5810f1d1820e723be51fc80ca74ca5e0",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:e9970ca0786a9322adebcbbeda6cd715",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:fb7f0c2c30196ccec28c3a6548a05c74",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0062",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0609954180147001"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.54539640994801"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "62"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0609954180147001"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.54539640994801"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "62"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e9970ca0786a9322adebcbbeda6cd715",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:fb7f0c2c30196ccec28c3a6548a05c74",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:c0493caa11e0a7edcd8c852574b28687",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c93f984974556da4e703249091c0b9e6",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0063",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0457465635110251"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.606262591428315"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "63"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0457465635110251"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.606262591428315"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "63"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c0493caa11e0a7edcd8c852574b28687",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:c93f984974556da4e703249091c0b9e6",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:f710cfa09fe2aedf43455c358fac4b39",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:9e172783feebd728c2f558fb3b71f8e1",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0064",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "8"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.1219908360294"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.38199421699717"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999893"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "64"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "8"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.1219908360294"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.38199421699717"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999893"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "64"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f710cfa09fe2aedf43455c358fac4b39",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:9e172783feebd728c2f558fb3b71f8e1",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:bad70ba4fd8b4b695b72a83782c3e5f8",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:87ab73f90e90a5729c135961d1e370c8",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0065",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0457465635110251"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.606262591428315"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "65"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0457465635110251"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.606262591428315"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "65"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:bad70ba4fd8b4b695b72a83782c3e5f8",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:87ab73f90e90a5729c135961d1e370c8",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:c6c17361069913b5f4191614f68492f3",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:837d4c2c41156c19f0fd118f410295ff",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0066",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "9"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.137239690533075"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.353115016567812"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999998975"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "66"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "9"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.137239690533075"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.353115016567812"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999998975"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "66"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c6c17361069913b5f4191614f68492f3",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:837d4c2c41156c19f0fd118f410295ff",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:c2a152f43ee2d844f898782fd1ef7ec0",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:045f09754798eebc086b923539ec80df",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0067",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "5"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0762442725183751"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.494859211467501"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "67"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "5"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0762442725183751"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.494859211467501"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "67"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c2a152f43ee2d844f898782fd1ef7ec0",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:045f09754798eebc086b923539ec80df",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:f1fa812573c26840167e9f2bd0ba2bfa",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:80792993798dbd9f1e93a2b1f460edb7",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0068",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0457465635110251"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.606262591428315"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "68"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0457465635110251"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.606262591428315"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "68"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f1fa812573c26840167e9f2bd0ba2bfa",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:80792993798dbd9f1e93a2b1f460edb7",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:331525e1b9d0bddf9506ab65a075cd86",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:90698016a8817129b734a925244ac3ee",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0069",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "6"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0914931270220502"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.45185124173467"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "69"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "6"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0914931270220502"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.45185124173467"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "69"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:331525e1b9d0bddf9506ab65a075cd86",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:90698016a8817129b734a925244ac3ee",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:ea97b40b5a9be7fc9f6d62d9b525b485",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:e884b18d0db747fcf84bd707ac9dd705",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0070",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0609954180147001"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.54539640994801"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "70"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0609954180147001"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.54539640994801"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "70"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ea97b40b5a9be7fc9f6d62d9b525b485",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:e884b18d0db747fcf84bd707ac9dd705",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:1f3fb8e24c66864d879d2bc4e5971b17",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:2a3d19c51223db94f710da6fc4488efe",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0071",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.682557316733255"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "71"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.682557316733255"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "71"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1f3fb8e24c66864d879d2bc4e5971b17",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:2a3d19c51223db94f710da6fc4488efe",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:cd925f60fb17823aac5c3473215f8d7e",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:525402486d0c3b5a8a9cc4d79a236330",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0072",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0457465635110251"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.606262591428315"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "72"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0457465635110251"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.606262591428315"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "72"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cd925f60fb17823aac5c3473215f8d7e",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:525402486d0c3b5a8a9cc4d79a236330",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:9837099ef2efab920d421b33789218c3",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:4c1d2eaf37081d773b0db5e10c96074d",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0073",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0457465635110251"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.606262591428315"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "73"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0457465635110251"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.606262591428315"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "73"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9837099ef2efab920d421b33789218c3",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:4c1d2eaf37081d773b0db5e10c96074d",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:2165a25b8a630ef2f40a0401a9a3c680",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:91b4c6608ce19710d67c33b2473fc9b4",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0074",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "9"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.137239690533075"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.353115016567812"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999998975"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "74"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "9"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.137239690533075"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.353115016567812"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999998975"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "74"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2165a25b8a630ef2f40a0401a9a3c680",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:91b4c6608ce19710d67c33b2473fc9b4",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:4d83aeb570cac876251d053c07bf2d8e",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:9caa103a34dc60ce70ec535ac6e8b007",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0075",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.682557316733255"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "75"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.682557316733255"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "75"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4d83aeb570cac876251d053c07bf2d8e",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:9caa103a34dc60ce70ec535ac6e8b007",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:77a467097c18360546951b54cfc345c7",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:b860ec229f39bc9a1fbaafbcbf0a163f",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0076",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0457465635110251"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.606262591428315"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "76"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0457465635110251"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.606262591428315"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "76"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:77a467097c18360546951b54cfc345c7",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:b860ec229f39bc9a1fbaafbcbf0a163f",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:cd7ab160dc57440bc4255ac3aa507dd7",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:236f07396a3abe7464d0d6adae038d7d",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0077",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0457465635110251"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.606262591428315"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "77"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0457465635110251"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.606262591428315"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "77"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cd7ab160dc57440bc4255ac3aa507dd7",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:236f07396a3abe7464d0d6adae038d7d",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:601da24f17e65f186bb79a9adc3e0bf6",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:d3ccad413c80f4d335ba3f4f6b6355af",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0078",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.786165890418407"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "78"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.786165890418407"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "78"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:601da24f17e65f186bb79a9adc3e0bf6",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:d3ccad413c80f4d335ba3f4f6b6355af",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:6c59d25b5ac6fc02466875dc30d6cca4",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:485d5921cf99fd18e2d2bc08962f1a89",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0079",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.786165890418407"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "79"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.786165890418407"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "79"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6c59d25b5ac6fc02466875dc30d6cca4",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:485d5921cf99fd18e2d2bc08962f1a89",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:8d1a9f520760b76668ce56986561c536",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:fafeba66cc92ac8083e5897d50f4bcab",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0080",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.786165890418407"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "80"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.786165890418407"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "80"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8d1a9f520760b76668ce56986561c536",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:fafeba66cc92ac8083e5897d50f4bcab",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:9de0c2e42252737a8379e3e037d6d2aa",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:48a7f6254e1629604bc57865dff4d670",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0081",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.682557316733255"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "81"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.682557316733255"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "81"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9de0c2e42252737a8379e3e037d6d2aa",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:48a7f6254e1629604bc57865dff4d670",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:ac17f6aed0c480752633af7157a50790",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:33e63ed9d657f0ba23cd9ffacda3e22d",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0082",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.786165890418407"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "82"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.786165890418407"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "82"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ac17f6aed0c480752633af7157a50790",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:33e63ed9d657f0ba23cd9ffacda3e22d",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:09df787a9447add50b251d7691bf2f9c",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:768ca0ef2b170d430ebbd40ebb08cff0",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0083",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.682557316733255"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "83"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.682557316733255"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "83"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:09df787a9447add50b251d7691bf2f9c",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:768ca0ef2b170d430ebbd40ebb08cff0",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:5df3810b9f8634e5eabf4cf013d6d516",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:8cf8073a323eec04d3968fab10115c2b",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0084",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.786165890418407"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "84"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.786165890418407"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "84"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5df3810b9f8634e5eabf4cf013d6d516",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:8cf8073a323eec04d3968fab10115c2b",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:819baf737aaaa45787693a764f07e7c8",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:dba062dd06d4105f10d77f25b52b96c8",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0085",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.786165890418407"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "85"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.786165890418407"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "85"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:819baf737aaaa45787693a764f07e7c8",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:dba062dd06d4105f10d77f25b52b96c8",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:509244d6a4f71a5ff685cfe8e8ad90b4",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c51b283e94df3fae6004dee4203f35fd",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0086",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.786165890418407"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "86"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.786165890418407"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "86"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:509244d6a4f71a5ff685cfe8e8ad90b4",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:c51b283e94df3fae6004dee4203f35fd",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:085ae9e43b1853458f70bf9e0f5e48e8",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c79437288e303b8f2bef9af3b70d4aaa",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0087",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.786165890418407"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "87"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.786165890418407"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "87"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:085ae9e43b1853458f70bf9e0f5e48e8",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:c79437288e303b8f2bef9af3b70d4aaa",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:1e6213ed8f4367c38bb8e3df7596c194",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:049f42c8eb4f2db2320a43cbbdd89f0f",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0088",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.786165890418407"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "88"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.786165890418407"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "88"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1e6213ed8f4367c38bb8e3df7596c194",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:049f42c8eb4f2db2320a43cbbdd89f0f",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:2d1a3d2d688f08f62c34200978327796",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:4e6c7a95cd372d482b4ef655fa46f083",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0089",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.786165890418407"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "89"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.786165890418407"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "89"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2d1a3d2d688f08f62c34200978327796",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:4e6c7a95cd372d482b4ef655fa46f083",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:74938e3d61efe7611ba39208c8bc71d5",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:78623bac11315960aba0a8d855467f49",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0090",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.682557316733255"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "90"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.682557316733255"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "90"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:74938e3d61efe7611ba39208c8bc71d5",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:78623bac11315960aba0a8d855467f49",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:3e17a6b5e2e157b57784ecb5f6ffcdc1",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:288a1fc03510b55eff121de5bf93e1f4",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0091",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.682557316733255"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "91"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.682557316733255"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "91"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3e17a6b5e2e157b57784ecb5f6ffcdc1",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:288a1fc03510b55eff121de5bf93e1f4",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:1793e50c9d713624fbb8bba2d78ea464",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f6ffc917f79709af0e39207ec0add7a4",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0092",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.786165890418407"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "92"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.786165890418407"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "92"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1793e50c9d713624fbb8bba2d78ea464",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:f6ffc917f79709af0e39207ec0add7a4",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:8bfbe4bb02769474d9ccfb7795dcf200",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:bd77e4cd78d5c4dcb23a68309256720d",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0093",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.786165890418407"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "93"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.786165890418407"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "93"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8bfbe4bb02769474d9ccfb7795dcf200",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:bd77e4cd78d5c4dcb23a68309256720d",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:a6dbb6a94c7d5ef0b744a15cdc6d3ed6",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:31f96dd2a2f7097e6993ae7eec0e23e6",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0094",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.786165890418407"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "[]"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "94"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.786165890418407"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "[]"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "94"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a6dbb6a94c7d5ef0b744a15cdc6d3ed6",
-      "entity": "niiri:cf2669065d68620b6d3d674c82341f68"
+      "entity_derived": "niiri:31f96dd2a2f7097e6993ae7eec0e23e6",
+      "entity": "niiri:dfc9c2736061f68baaf0d5518b47b332"
     },
     {
-      "@id": "niiri:59bd62c168799a7d2ce2aafde21de893",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b9c38db488f3b5f13ba315ce84742e30",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0001",
-      "prov:atLocation": {"@id": "niiri:bab1f201287c11c422c9031ba4cda4b7"},
+      "prov:atLocation": {"@id": "niiri:8a04d65607e38687cf6f2f55af3c4b47"},
       "prov:value": {"@type": "xsd:float", "@value": "7.92007970809937"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "6.94608360738412"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.87783122385099e-12"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "4.18813870695089e-07"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "2.5522089353025e-07"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "6.94608360738412"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.87783122385099e-12"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "4.18813870695089e-07"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "2.5522089353025e-07"}
     },
     {
-      "@id": "niiri:bab1f201287c11c422c9031ba4cda4b7",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:8a04d65607e38687cf6f2f55af3c4b47",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0001",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[46,16,24]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[46,16,24]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:59bd62c168799a7d2ce2aafde21de893",
-      "entity": "niiri:242656e5fe9c4228886ce59df6e0a2ca"
+      "entity_derived": "niiri:b9c38db488f3b5f13ba315ce84742e30",
+      "entity": "niiri:57b0b3487b8ceebf11e98e8506c169a2"
     },
     {
-      "@id": "niiri:ac76e3266974911452e712b080f1cba7",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:04ccd45e7b91b1372b86446353f69dec",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0002",
-      "prov:atLocation": {"@id": "niiri:4a1f96130894e9ead1fd8442ec328e7f"},
+      "prov:atLocation": {"@id": "niiri:29e5728f14fe9e84f03df78c3017ad26"},
       "prov:value": {"@type": "xsd:float", "@value": "6.31603479385376"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.77079466112137"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.94492849498107e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.000879943865776389"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1.66027144486111e-05"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.77079466112137"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.94492849498107e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.000879943865776389"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1.66027144486111e-05"}
     },
     {
-      "@id": "niiri:4a1f96130894e9ead1fd8442ec328e7f",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:29e5728f14fe9e84f03df78c3017ad26",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0002",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[32,24,-4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[32,24,-4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ac76e3266974911452e712b080f1cba7",
-      "entity": "niiri:242656e5fe9c4228886ce59df6e0a2ca"
+      "entity_derived": "niiri:04ccd45e7b91b1372b86446353f69dec",
+      "entity": "niiri:57b0b3487b8ceebf11e98e8506c169a2"
     },
     {
-      "@id": "niiri:afa7fceb903b3e1d414b8a8438930089",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:2a457ee39f92424bfbae62e7f4d9d06e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0003",
-      "prov:atLocation": {"@id": "niiri:3e41af58f187a4c5dfea163d4c52be0d"},
+      "prov:atLocation": {"@id": "niiri:c2b44e5f1b4308bc87e8513b4536e33f"},
       "prov:value": {"@type": "xsd:float", "@value": "6.28007745742798"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.74292583422276"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.65272453897825e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00103782272796227"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1.77570952010042e-05"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.74292583422276"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.65272453897825e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00103782272796227"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1.77570952010042e-05"}
     },
     {
-      "@id": "niiri:3e41af58f187a4c5dfea163d4c52be0d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c2b44e5f1b4308bc87e8513b4536e33f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0003",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[8,18,50]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[8,18,50]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:afa7fceb903b3e1d414b8a8438930089",
-      "entity": "niiri:242656e5fe9c4228886ce59df6e0a2ca"
+      "entity_derived": "niiri:2a457ee39f92424bfbae62e7f4d9d06e",
+      "entity": "niiri:57b0b3487b8ceebf11e98e8506c169a2"
     },
     {
-      "@id": "niiri:8c512ded5d6b86efebd4dc5f68435795",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:7e3917d8345a65fc26f145125eeaff8c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0004",
-      "prov:atLocation": {"@id": "niiri:0d7a7c717f7888864745155d35f13670"},
+      "prov:atLocation": {"@id": "niiri:022199204ee65e352230c02576678448"},
       "prov:value": {"@type": "xsd:float", "@value": "7.11683940887451"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "6.37404871703245"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "9.20510334623259e-11"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "2.05325778424026e-05"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1.80089716755871e-06"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "6.37404871703245"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "9.20510334623259e-11"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "2.05325778424026e-05"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1.80089716755871e-06"}
     },
     {
-      "@id": "niiri:0d7a7c717f7888864745155d35f13670",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:022199204ee65e352230c02576678448",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0004",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[34,-88,-2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[34,-88,-2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8c512ded5d6b86efebd4dc5f68435795",
-      "entity": "niiri:c27bdfc6cef3bf3771769b92935b0e04"
+      "entity_derived": "niiri:7e3917d8345a65fc26f145125eeaff8c",
+      "entity": "niiri:3d5c32984a0665ba596ff6cef71fcd0b"
     },
     {
-      "@id": "niiri:3cae31dcb6f6ed70f732376eaf9014bb",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:9998cb50acce86cfac60c2fd8b263502",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0005",
-      "prov:atLocation": {"@id": "niiri:3751dbb7c47cefe7778635f003c84fe2"},
+      "prov:atLocation": {"@id": "niiri:466cad218c9b7df56ce89ad0ecf3e24b"},
       "prov:value": {"@type": "xsd:float", "@value": "6.48292255401611"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.8992593141605"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.82568493656277e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.000407231755366277"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "9.69599417538756e-06"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.8992593141605"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.82568493656277e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.000407231755366277"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "9.69599417538756e-06"}
     },
     {
-      "@id": "niiri:3751dbb7c47cefe7778635f003c84fe2",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:466cad218c9b7df56ce89ad0ecf3e24b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0005",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[42,-72,-10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[42,-72,-10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3cae31dcb6f6ed70f732376eaf9014bb",
-      "entity": "niiri:c27bdfc6cef3bf3771769b92935b0e04"
+      "entity_derived": "niiri:9998cb50acce86cfac60c2fd8b263502",
+      "entity": "niiri:3d5c32984a0665ba596ff6cef71fcd0b"
     },
     {
-      "@id": "niiri:399e5de584837ee5eded3180f313c694",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c556266836a943fb870f1bf711a68c3b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0006",
-      "prov:atLocation": {"@id": "niiri:d480d3bed748eb08ff2f4e7ac9de26e3"},
+      "prov:atLocation": {"@id": "niiri:848d1690f1e2bb56ae22b60a4853a423"},
       "prov:value": {"@type": "xsd:float", "@value": "5.2275915145874"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.89738468004472"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.85602978606003e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0670610253017228"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000213643333035659"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.89738468004472"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.85602978606003e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0670610253017228"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000213643333035659"}
     },
     {
-      "@id": "niiri:d480d3bed748eb08ff2f4e7ac9de26e3",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:848d1690f1e2bb56ae22b60a4853a423",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0006",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[34,-86,12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[34,-86,12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:399e5de584837ee5eded3180f313c694",
-      "entity": "niiri:c27bdfc6cef3bf3771769b92935b0e04"
+      "entity_derived": "niiri:c556266836a943fb870f1bf711a68c3b",
+      "entity": "niiri:3d5c32984a0665ba596ff6cef71fcd0b"
     },
     {
-      "@id": "niiri:446ee49c23f2baed98d69604ca1e2821",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:701c37986a9dfafb2485113e75f3877e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0007",
-      "prov:atLocation": {"@id": "niiri:a6964d722fb6ac6375b29f179e7ed286"},
+      "prov:atLocation": {"@id": "niiri:fea264e5d6f510b6beae51359071a22d"},
       "prov:value": {"@type": "xsd:float", "@value": "6.25127363204956"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.72055271981637"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.30890376104765e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0011841880966994"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1.8796636455546e-05"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.72055271981637"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.30890376104765e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0011841880966994"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1.8796636455546e-05"}
     },
     {
-      "@id": "niiri:a6964d722fb6ac6375b29f179e7ed286",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:fea264e5d6f510b6beae51359071a22d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0007",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[52,-32,42]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[52,-32,42]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:446ee49c23f2baed98d69604ca1e2821",
-      "entity": "niiri:a158a75fe65c6add3c1257707728cdd4"
+      "entity_derived": "niiri:701c37986a9dfafb2485113e75f3877e",
+      "entity": "niiri:2c413461a4c1a86447e1da248ab7545c"
     },
     {
-      "@id": "niiri:b8367086a4ae3910ef42568fc07a5337",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d32b6a2abe066703d0a3f16b4a3aa993",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0008",
-      "prov:atLocation": {"@id": "niiri:d61669b86138c7420cd4bba9ceebe0e7"},
+      "prov:atLocation": {"@id": "niiri:a07d84f13ebe8c5e8d72a6474acfdba5"},
       "prov:value": {"@type": "xsd:float", "@value": "6.24752378463745"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.71763687476157"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.40078304300806e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00120468241369565"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1.88231627139945e-05"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.71763687476157"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.40078304300806e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00120468241369565"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1.88231627139945e-05"}
     },
     {
-      "@id": "niiri:d61669b86138c7420cd4bba9ceebe0e7",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a07d84f13ebe8c5e8d72a6474acfdba5",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0008",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[40,-62,50]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[40,-62,50]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b8367086a4ae3910ef42568fc07a5337",
-      "entity": "niiri:a158a75fe65c6add3c1257707728cdd4"
+      "entity_derived": "niiri:d32b6a2abe066703d0a3f16b4a3aa993",
+      "entity": "niiri:2c413461a4c1a86447e1da248ab7545c"
     },
     {
-      "@id": "niiri:1a7f130947c22fff681ccf69af694f15",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:74291dfbb196ec16f80fb44d57da12f7",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0009",
-      "prov:atLocation": {"@id": "niiri:788e3620e0ed45d0a82f447cffe6d4d4"},
+      "prov:atLocation": {"@id": "niiri:6a6fbc6d5237e3c663d814c9b35c8e58"},
       "prov:value": {"@type": "xsd:float", "@value": "5.70337772369385"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.28674301747281"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.22566831420812e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.011413186758684"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "6.56259978738852e-05"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.28674301747281"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.22566831420812e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.011413186758684"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "6.56259978738852e-05"}
     },
     {
-      "@id": "niiri:788e3620e0ed45d0a82f447cffe6d4d4",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6a6fbc6d5237e3c663d814c9b35c8e58",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0009",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[56,-44,52]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[56,-44,52]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1a7f130947c22fff681ccf69af694f15",
-      "entity": "niiri:a158a75fe65c6add3c1257707728cdd4"
+      "entity_derived": "niiri:74291dfbb196ec16f80fb44d57da12f7",
+      "entity": "niiri:2c413461a4c1a86447e1da248ab7545c"
     },
     {
-      "@id": "niiri:284167e6e632f3a77aa8c66f34d3afa1",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:9d53626c88b2f04c3eadecaebc4a1338",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0010",
-      "prov:atLocation": {"@id": "niiri:a8471ca01bfcc1dc939a0dc95d6c9d19"},
+      "prov:atLocation": {"@id": "niiri:f38aef95e58ae38118b8281fd53a7a2d"},
       "prov:value": {"@type": "xsd:float", "@value": "6.15371799468994"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.64445580026639"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.285227171001e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00184807786755337"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "2.16474462112596e-05"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.64445580026639"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.285227171001e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00184807786755337"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "2.16474462112596e-05"}
     },
     {
-      "@id": "niiri:a8471ca01bfcc1dc939a0dc95d6c9d19",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f38aef95e58ae38118b8281fd53a7a2d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0010",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-28,-94,4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-28,-94,4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:284167e6e632f3a77aa8c66f34d3afa1",
-      "entity": "niiri:b89b511274698ad906aaf626aa9dafa2"
+      "entity_derived": "niiri:9d53626c88b2f04c3eadecaebc4a1338",
+      "entity": "niiri:e3f486aca3000e0c84fbdaf8a042398f"
     },
     {
-      "@id": "niiri:5bdc9b77f8fc5e237e47028d923d163e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:85a1438415db5a3489dd11e7fb441b39",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0011",
-      "prov:atLocation": {"@id": "niiri:b522b07293a6f4518fa50b217319c4a8"},
+      "prov:atLocation": {"@id": "niiri:511a1e02e40bbe8a2c504cf6e208fc17"},
       "prov:value": {"@type": "xsd:float", "@value": "4.12145137786865"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.94794832362008"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.94119065879606e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.940339218142555"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00279439847450823"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.94794832362008"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.94119065879606e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.940339218142555"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00279439847450823"}
     },
     {
-      "@id": "niiri:b522b07293a6f4518fa50b217319c4a8",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:511a1e02e40bbe8a2c504cf6e208fc17",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0011",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-48,-72,2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-48,-72,2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5bdc9b77f8fc5e237e47028d923d163e",
-      "entity": "niiri:b89b511274698ad906aaf626aa9dafa2"
+      "entity_derived": "niiri:85a1438415db5a3489dd11e7fb441b39",
+      "entity": "niiri:e3f486aca3000e0c84fbdaf8a042398f"
     },
     {
-      "@id": "niiri:079e4c994c16bc09170fcee726b4518a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0b8f8f1954b573ce6421b1aec938a3f7",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0012",
-      "prov:atLocation": {"@id": "niiri:1ddba39c46535390f0fd69c681884a3f"},
+      "prov:atLocation": {"@id": "niiri:1fc4e37586cdc18ac0682a29ef38c240"},
       "prov:value": {"@type": "xsd:float", "@value": "3.71480798721313"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.58412084932714"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000169107736440521"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999869855188705"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00680567457240922"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.58412084932714"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000169107736440521"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999869855188705"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00680567457240922"}
     },
     {
-      "@id": "niiri:1ddba39c46535390f0fd69c681884a3f",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:1fc4e37586cdc18ac0682a29ef38c240",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0012",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-34,-84,-2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-34,-84,-2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:079e4c994c16bc09170fcee726b4518a",
-      "entity": "niiri:b89b511274698ad906aaf626aa9dafa2"
+      "entity_derived": "niiri:0b8f8f1954b573ce6421b1aec938a3f7",
+      "entity": "niiri:e3f486aca3000e0c84fbdaf8a042398f"
     },
     {
-      "@id": "niiri:059832513a38a01ce4f087093cb867af",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:142bb500e57d8a428669aea190bd5682",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0013",
-      "prov:atLocation": {"@id": "niiri:9fc20a0c3e4ce3d2612d0df2e9024c9a"},
+      "prov:atLocation": {"@id": "niiri:0782b83d56620cd233fa7bce24466953"},
       "prov:value": {"@type": "xsd:float", "@value": "6.10109901428223"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.60320502193174"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.05212039080982e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00234682813060005"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "2.40223937009298e-05"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.60320502193174"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.05212039080982e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00234682813060005"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "2.40223937009298e-05"}
     },
     {
-      "@id": "niiri:9fc20a0c3e4ce3d2612d0df2e9024c9a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0782b83d56620cd233fa7bce24466953",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0013",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[32,2,46]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[32,2,46]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:059832513a38a01ce4f087093cb867af",
-      "entity": "niiri:fc1234dbcb5fecc84cb748f7a43e1791"
+      "entity_derived": "niiri:142bb500e57d8a428669aea190bd5682",
+      "entity": "niiri:c0ef61636e02d68816943e9c0c7be35d"
     },
     {
-      "@id": "niiri:2f45ceade93380accc658c5da6cfa736",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:27d4ca2419ed8dd89da3969cf9682d0e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0014",
-      "prov:atLocation": {"@id": "niiri:1b4b518827798cd3f59c0b51e6104fef"},
+      "prov:atLocation": {"@id": "niiri:0d568f934c855dfafbe86e68adc1df30"},
       "prov:value": {"@type": "xsd:float", "@value": "4.6086859703064"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.3736141683061"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.11031435759912e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.453877178455514"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000974930295891631"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.3736141683061"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.11031435759912e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.453877178455514"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000974930295891631"}
     },
     {
-      "@id": "niiri:1b4b518827798cd3f59c0b51e6104fef",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0d568f934c855dfafbe86e68adc1df30",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0014",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[28,4,58]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[28,4,58]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2f45ceade93380accc658c5da6cfa736",
-      "entity": "niiri:fc1234dbcb5fecc84cb748f7a43e1791"
+      "entity_derived": "niiri:27d4ca2419ed8dd89da3969cf9682d0e",
+      "entity": "niiri:c0ef61636e02d68816943e9c0c7be35d"
     },
     {
-      "@id": "niiri:0a3d7b0b9471c78e998be6f03e3ffddb",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:029834627d73e77047973cf21bbf5d82",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0015",
-      "prov:atLocation": {"@id": "niiri:ecdd4c231c5edbf3f7e27d479de42ba5"},
+      "prov:atLocation": {"@id": "niiri:25d0d7e2c9b753537fd9c78f89590f89"},
       "prov:value": {"@type": "xsd:float", "@value": "3.98793148994446"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.82932508069717"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.42475887594474e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.984644566584946"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00375703605421318"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.82932508069717"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.42475887594474e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.984644566584946"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00375703605421318"}
     },
     {
-      "@id": "niiri:ecdd4c231c5edbf3f7e27d479de42ba5",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:25d0d7e2c9b753537fd9c78f89590f89",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0015",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[42,4,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[42,4,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0a3d7b0b9471c78e998be6f03e3ffddb",
-      "entity": "niiri:fc1234dbcb5fecc84cb748f7a43e1791"
+      "entity_derived": "niiri:029834627d73e77047973cf21bbf5d82",
+      "entity": "niiri:c0ef61636e02d68816943e9c0c7be35d"
     },
     {
-      "@id": "niiri:4f27fa8d24c9ac5419e83770480394a6",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:1eb8465701fde4fde92186c425baf8ea",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0016",
-      "prov:atLocation": {"@id": "niiri:5f95462b6c927c6442ebd98010f6c107"},
+      "prov:atLocation": {"@id": "niiri:135821fbbd9471e39f9ac3fd7e16b87c"},
       "prov:value": {"@type": "xsd:float", "@value": "5.98348569869995"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.51047970249337"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.78928538652201e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00378871596531738"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "3.24481811369927e-05"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.51047970249337"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.78928538652201e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00378871596531738"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "3.24481811369927e-05"}
     },
     {
-      "@id": "niiri:5f95462b6c927c6442ebd98010f6c107",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:135821fbbd9471e39f9ac3fd7e16b87c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0016",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-52,0,38]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-52,0,38]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4f27fa8d24c9ac5419e83770480394a6",
-      "entity": "niiri:bc79ea489b7d5f8523a15f77de48e174"
+      "entity_derived": "niiri:1eb8465701fde4fde92186c425baf8ea",
+      "entity": "niiri:e9bd68a9b52a95e89ba7a7e17b4fa428"
     },
     {
-      "@id": "niiri:97c12cc0cda44056974e2945283ffd01",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:64d0ab7126894908ae25023162e0af73",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0017",
-      "prov:atLocation": {"@id": "niiri:e813708b85b3385396682b73754c1180"},
+      "prov:atLocation": {"@id": "niiri:4f3030c801f9431366edc8c63f75c9b4"},
       "prov:value": {"@type": "xsd:float", "@value": "5.2253565788269"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.89552821543552"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.90210114501011e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0675937275056587"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000215162374940066"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.89552821543552"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.90210114501011e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0675937275056587"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000215162374940066"}
     },
     {
-      "@id": "niiri:e813708b85b3385396682b73754c1180",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4f3030c801f9431366edc8c63f75c9b4",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0017",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-60,8,20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-60,8,20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:97c12cc0cda44056974e2945283ffd01",
-      "entity": "niiri:bc79ea489b7d5f8523a15f77de48e174"
+      "entity_derived": "niiri:64d0ab7126894908ae25023162e0af73",
+      "entity": "niiri:e9bd68a9b52a95e89ba7a7e17b4fa428"
     },
     {
-      "@id": "niiri:1c62f81c30210406837cae23e2eecd49",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:90054102ef0485b0300d9ac541c05772",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0018",
-      "prov:atLocation": {"@id": "niiri:7c68dc79ec7d72c3ea623b419061b65a"},
+      "prov:atLocation": {"@id": "niiri:d3242b8c5dc0ccc3ccff4404d4f25b7f"},
       "prov:value": {"@type": "xsd:float", "@value": "4.98950004577637"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.69817956585148"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.31245304380023e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.151048137890434"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000410591908363075"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.69817956585148"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.31245304380023e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.151048137890434"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000410591908363075"}
     },
     {
-      "@id": "niiri:7c68dc79ec7d72c3ea623b419061b65a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d3242b8c5dc0ccc3ccff4404d4f25b7f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0018",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-44,6,28]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-44,6,28]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1c62f81c30210406837cae23e2eecd49",
-      "entity": "niiri:bc79ea489b7d5f8523a15f77de48e174"
+      "entity_derived": "niiri:90054102ef0485b0300d9ac541c05772",
+      "entity": "niiri:e9bd68a9b52a95e89ba7a7e17b4fa428"
     },
     {
-      "@id": "niiri:0e19033ea8b6d5ccdfb0c3133ce0ac9f",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ea92fe2eb5755d0ea83fe118d00128a1",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0019",
-      "prov:atLocation": {"@id": "niiri:4d4d922dca0a2f0ae09e029939694900"},
+      "prov:atLocation": {"@id": "niiri:d7872b1aeb0444ca5dfdf2fc0a2d64db"},
       "prov:value": {"@type": "xsd:float", "@value": "5.78093099594116"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.34909755317379"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.41969442155354e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00844151822925698"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "5.41672415342571e-05"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.34909755317379"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.41969442155354e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00844151822925698"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "5.41672415342571e-05"}
     },
     {
-      "@id": "niiri:4d4d922dca0a2f0ae09e029939694900",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d7872b1aeb0444ca5dfdf2fc0a2d64db",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0019",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-34,-2,52]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-34,-2,52]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0e19033ea8b6d5ccdfb0c3133ce0ac9f",
-      "entity": "niiri:d1bded8abf09ebee39e58ad5cac474bf"
+      "entity_derived": "niiri:ea92fe2eb5755d0ea83fe118d00128a1",
+      "entity": "niiri:7693eabf368839e957bc3cfe43c975e0"
     },
     {
-      "@id": "niiri:9a178d511cb9fbd1ef89b1e25fe9e0a0",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:7f8a4c8c46cb2689a3c019747955dc4b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0020",
-      "prov:atLocation": {"@id": "niiri:9a062f32f9f2710625420b074299b00d"},
+      "prov:atLocation": {"@id": "niiri:629f123a388bd84ac9308e75e74affde"},
       "prov:value": {"@type": "xsd:float", "@value": "5.40964078903198"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.04774404642803"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.23528758724889e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0346958937061391"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000135488206134068"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.04774404642803"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.23528758724889e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0346958937061391"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000135488206134068"}
     },
     {
-      "@id": "niiri:9a062f32f9f2710625420b074299b00d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:629f123a388bd84ac9308e75e74affde",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0020",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-54,-46,58]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-54,-46,58]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9a178d511cb9fbd1ef89b1e25fe9e0a0",
-      "entity": "niiri:2d4153f04704f26ae2b13f93cceec23b"
+      "entity_derived": "niiri:7f8a4c8c46cb2689a3c019747955dc4b",
+      "entity": "niiri:39b96655430c53f32e07621dbe8655c4"
     },
     {
-      "@id": "niiri:c74b8735ab25da7815e27b3010834a67",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e2bc5fe4c987ff0ec0df74c742ff1117",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0021",
-      "prov:atLocation": {"@id": "niiri:8e4ec8f274a1bf93a0340e49c74e4add"},
+      "prov:atLocation": {"@id": "niiri:55aa6bcca3d975a9a0166ca4aa1ebc70"},
       "prov:value": {"@type": "xsd:float", "@value": "5.31841945648193"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.97261482231588"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.30279114724163e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0484353441449864"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000170572072121087"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.97261482231588"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.30279114724163e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0484353441449864"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000170572072121087"}
     },
     {
-      "@id": "niiri:8e4ec8f274a1bf93a0340e49c74e4add",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:55aa6bcca3d975a9a0166ca4aa1ebc70",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0021",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-62,-38,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-62,-38,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c74b8735ab25da7815e27b3010834a67",
-      "entity": "niiri:8702febb070c184ab840d84baa828f4c"
+      "entity_derived": "niiri:e2bc5fe4c987ff0ec0df74c742ff1117",
+      "entity": "niiri:90ea170edb9635f011af376c50f1eff8"
     },
     {
-      "@id": "niiri:a20d9e583e30f7d93121b8fed87330f4",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:520fe1eb050426e3b07c4a893b9f7db1",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0022",
-      "prov:atLocation": {"@id": "niiri:06de678d09f2fb0a4ed165d8130ce935"},
+      "prov:atLocation": {"@id": "niiri:7926e4868dfde88503bc251f695fd8f8"},
       "prov:value": {"@type": "xsd:float", "@value": "4.57099342346191"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.34109644800954"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.08867353027554e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.496004086968197"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00106632293891518"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.34109644800954"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.08867353027554e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.496004086968197"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00106632293891518"}
     },
     {
-      "@id": "niiri:06de678d09f2fb0a4ed165d8130ce935",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7926e4868dfde88503bc251f695fd8f8",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0022",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-60,-50,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-60,-50,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a20d9e583e30f7d93121b8fed87330f4",
-      "entity": "niiri:8702febb070c184ab840d84baa828f4c"
+      "entity_derived": "niiri:520fe1eb050426e3b07c4a893b9f7db1",
+      "entity": "niiri:90ea170edb9635f011af376c50f1eff8"
     },
     {
-      "@id": "niiri:30b7f0fd65f5eaa0304fa23930b236db",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c87a3b3343886155da34c9892eaae298",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0023",
-      "prov:atLocation": {"@id": "niiri:31c44f3796400492ee153284c21b8295"},
+      "prov:atLocation": {"@id": "niiri:60dff4deb3f26445945f48fa10727baf"},
       "prov:value": {"@type": "xsd:float", "@value": "4.93343877792358"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.65085575575197"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.6528024058271e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.180887232162623"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000464319207635078"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.65085575575197"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.6528024058271e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.180887232162623"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000464319207635078"}
     },
     {
-      "@id": "niiri:31c44f3796400492ee153284c21b8295",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:60dff4deb3f26445945f48fa10727baf",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0023",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-58,-30,-18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-58,-30,-18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:30b7f0fd65f5eaa0304fa23930b236db",
-      "entity": "niiri:554231ad3e2c8225e52d92a4328b14a9"
+      "entity_derived": "niiri:c87a3b3343886155da34c9892eaae298",
+      "entity": "niiri:d976336ac6ecb4bba1136f54b6de3e23"
     },
     {
-      "@id": "niiri:a14324aaf48260f874e7e335238459a9",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:90abc80db14d12280a0791c4ce7391f5",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0024",
-      "prov:atLocation": {"@id": "niiri:e739dc8e31d4a4699048e359c5577844"},
+      "prov:atLocation": {"@id": "niiri:408220d56d93cbff661412dfa2054f5f"},
       "prov:value": {"@type": "xsd:float", "@value": "4.76414346694946"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.50698548813516"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.287756441539e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.301278778226174"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000675964618846495"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.50698548813516"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.287756441539e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.301278778226174"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000675964618846495"}
     },
     {
-      "@id": "niiri:e739dc8e31d4a4699048e359c5577844",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:408220d56d93cbff661412dfa2054f5f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0024",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-46,-66,-6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-46,-66,-6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a14324aaf48260f874e7e335238459a9",
-      "entity": "niiri:8adb4939693aed81541cf6c7ab164844"
+      "entity_derived": "niiri:90abc80db14d12280a0791c4ce7391f5",
+      "entity": "niiri:43ec173da0c3faa0f4491456aea575ce"
     },
     {
-      "@id": "niiri:1f9eb4ad0953a5c6995db6937a61ee48",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e745debfe2f3499165a83cfbc9245de3",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0025",
-      "prov:atLocation": {"@id": "niiri:a69d5bbe441e843319f7f864e45b96eb"},
+      "prov:atLocation": {"@id": "niiri:0406b71827350fd798033287d2d9414b"},
       "prov:value": {"@type": "xsd:float", "@value": "3.7637345790863"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.62829384243901"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000142650218672435"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999605970761399"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00612774880514626"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.62829384243901"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000142650218672435"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999605970761399"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00612774880514626"}
     },
     {
-      "@id": "niiri:a69d5bbe441e843319f7f864e45b96eb",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0406b71827350fd798033287d2d9414b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0025",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-54,-64,-8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-54,-64,-8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1f9eb4ad0953a5c6995db6937a61ee48",
-      "entity": "niiri:8adb4939693aed81541cf6c7ab164844"
+      "entity_derived": "niiri:e745debfe2f3499165a83cfbc9245de3",
+      "entity": "niiri:43ec173da0c3faa0f4491456aea575ce"
     },
     {
-      "@id": "niiri:dca826c37d727ff060eaef05273fbc94",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:2343e4d7eb8c6a1729b72035eaf717e4",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0026",
-      "prov:atLocation": {"@id": "niiri:f648a22ca5dcb951a92dd503440b866a"},
+      "prov:atLocation": {"@id": "niiri:7cde57681c3e67757a6384d582c9f90e"},
       "prov:value": {"@type": "xsd:float", "@value": "4.72232866287231"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.47122948835043"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.88855941602095e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.338512677882141"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000740481435956345"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.47122948835043"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.88855941602095e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.338512677882141"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000740481435956345"}
     },
     {
-      "@id": "niiri:f648a22ca5dcb951a92dd503440b866a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7cde57681c3e67757a6384d582c9f90e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0026",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[58,-38,6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[58,-38,6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:dca826c37d727ff060eaef05273fbc94",
-      "entity": "niiri:0a424073d2852615c9efd40e929d5259"
+      "entity_derived": "niiri:2343e4d7eb8c6a1729b72035eaf717e4",
+      "entity": "niiri:a21087d5b0bdd477c690e1272139bf8a"
     },
     {
-      "@id": "niiri:88c8f744323deb96b36606d6021d61d0",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:1a8a86f7d9c9f722317b24c2e78074af",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0027",
-      "prov:atLocation": {"@id": "niiri:661f3404404dea746395a19c6fa468a8"},
+      "prov:atLocation": {"@id": "niiri:b28457b36627fc8c2b8fbac61ecb2964"},
       "prov:value": {"@type": "xsd:float", "@value": "3.98372888565063"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.8255778871433"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.52328381068878e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.985409231324461"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00379034013545227"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.8255778871433"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.52328381068878e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.985409231324461"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00379034013545227"}
     },
     {
-      "@id": "niiri:661f3404404dea746395a19c6fa468a8",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b28457b36627fc8c2b8fbac61ecb2964",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0027",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[64,-30,-4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[64,-30,-4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:88c8f744323deb96b36606d6021d61d0",
-      "entity": "niiri:0a424073d2852615c9efd40e929d5259"
+      "entity_derived": "niiri:1a8a86f7d9c9f722317b24c2e78074af",
+      "entity": "niiri:a21087d5b0bdd477c690e1272139bf8a"
     },
     {
-      "@id": "niiri:4f0a11ac7d60b564dc68ce7519a69b5e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:23b4a479f72f56fff23eeb6665cae807",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0028",
-      "prov:atLocation": {"@id": "niiri:56fcba156abac7fbf1e06c695735eef3"},
+      "prov:atLocation": {"@id": "niiri:8e0d84f185660b18429c95fb79db1336"},
       "prov:value": {"@type": "xsd:float", "@value": "3.9098813533783"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.75959988615137"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.50926599039736e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.994607633788328"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00444631553927497"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.75959988615137"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.50926599039736e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.994607633788328"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00444631553927497"}
     },
     {
-      "@id": "niiri:56fcba156abac7fbf1e06c695735eef3",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:8e0d84f185660b18429c95fb79db1336",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0028",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[54,-24,-2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[54,-24,-2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4f0a11ac7d60b564dc68ce7519a69b5e",
-      "entity": "niiri:0a424073d2852615c9efd40e929d5259"
+      "entity_derived": "niiri:23b4a479f72f56fff23eeb6665cae807",
+      "entity": "niiri:a21087d5b0bdd477c690e1272139bf8a"
     },
     {
-      "@id": "niiri:9b223970862df494031bc9faf1f4c78b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:cb1ced392fd8df88e767db43c1bc0ed7",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0029",
-      "prov:atLocation": {"@id": "niiri:c883d741a84bd31c13e914935c7d04f1"},
+      "prov:atLocation": {"@id": "niiri:17aedfa63a871543b140ee883e7fa00a"},
       "prov:value": {"@type": "xsd:float", "@value": "4.70483255386353"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.45624265093732"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.17043099876224e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.354967306449537"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000776498970788289"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.45624265093732"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.17043099876224e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.354967306449537"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000776498970788289"}
     },
     {
-      "@id": "niiri:c883d741a84bd31c13e914935c7d04f1",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:17aedfa63a871543b140ee883e7fa00a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0029",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-36,-74,-14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-36,-74,-14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9b223970862df494031bc9faf1f4c78b",
-      "entity": "niiri:c419557738905fde9064be2cef6f1449"
+      "entity_derived": "niiri:cb1ced392fd8df88e767db43c1bc0ed7",
+      "entity": "niiri:a4d3b6fc7cc84d91945916a3052dd21c"
     },
     {
-      "@id": "niiri:f171c32f91d32c0f51f4f396c0886f28",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:7f2c05eeb31277d29699a1a1dc5708b9",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0030",
-      "prov:atLocation": {"@id": "niiri:dfe8d905a23b80dd174425ba9b598fed"},
+      "prov:atLocation": {"@id": "niiri:c65773868ad3c3ee6565f44d2f503688"},
       "prov:value": {"@type": "xsd:float", "@value": "4.08770418167114"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.91804495668"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.46350297789166e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.955724279224547"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00301069792579844"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.91804495668"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.46350297789166e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.955724279224547"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00301069792579844"}
     },
     {
-      "@id": "niiri:dfe8d905a23b80dd174425ba9b598fed",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c65773868ad3c3ee6565f44d2f503688",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0030",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-36,-68,-20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-36,-68,-20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f171c32f91d32c0f51f4f396c0886f28",
-      "entity": "niiri:c419557738905fde9064be2cef6f1449"
+      "entity_derived": "niiri:7f2c05eeb31277d29699a1a1dc5708b9",
+      "entity": "niiri:a4d3b6fc7cc84d91945916a3052dd21c"
     },
     {
-      "@id": "niiri:7d4f723c0c0d768fc1a02933cd7da8ec",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:de55bbb80f52ecc8be8aa173a5d0c4c4",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0031",
-      "prov:atLocation": {"@id": "niiri:58760e96b02016370f0f9443e294f468"},
+      "prov:atLocation": {"@id": "niiri:23023da27952d97ce5978f24d0201fb4"},
       "prov:value": {"@type": "xsd:float", "@value": "3.71012616157532"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.57988831343959"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000171870546999631"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999883757236262"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00687347140086337"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.57988831343959"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000171870546999631"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999883757236262"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00687347140086337"}
     },
     {
-      "@id": "niiri:58760e96b02016370f0f9443e294f468",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:23023da27952d97ce5978f24d0201fb4",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0031",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-30,-58,-16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-30,-58,-16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7d4f723c0c0d768fc1a02933cd7da8ec",
-      "entity": "niiri:c419557738905fde9064be2cef6f1449"
+      "entity_derived": "niiri:de55bbb80f52ecc8be8aa173a5d0c4c4",
+      "entity": "niiri:a4d3b6fc7cc84d91945916a3052dd21c"
     },
     {
-      "@id": "niiri:f34c171fa368d7fae0a84902b32d26ab",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:94ac82c373f762df7652cf2eee707fcf",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0032",
-      "prov:atLocation": {"@id": "niiri:9f87622f9d1487269c1bd9a0ad59d8e2"},
+      "prov:atLocation": {"@id": "niiri:65bafc594498c6ac36e3357ddb1e5cf9"},
       "prov:value": {"@type": "xsd:float", "@value": "4.59621620178223"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.36286413267216"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.41853365035416e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.467637998233248"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00100629980038701"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.36286413267216"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.41853365035416e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.467637998233248"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00100629980038701"}
     },
     {
-      "@id": "niiri:9f87622f9d1487269c1bd9a0ad59d8e2",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:65bafc594498c6ac36e3357ddb1e5cf9",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0032",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[16,-98,6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[16,-98,6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f34c171fa368d7fae0a84902b32d26ab",
-      "entity": "niiri:4b5ae066ef253b812d649482610dbba7"
+      "entity_derived": "niiri:94ac82c373f762df7652cf2eee707fcf",
+      "entity": "niiri:d3e3d125a9ce7e2ce6bac0795d332509"
     },
     {
-      "@id": "niiri:ea18051b705fd4266580ebbdefd1cf08",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a3cbab4a2a30eece310c15c0975c7b8c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0033",
-      "prov:atLocation": {"@id": "niiri:132a1b66dcc9169a3a5a1e71bbe7d479"},
+      "prov:atLocation": {"@id": "niiri:2f7752391d49b36d1668a1bed931ebed"},
       "prov:value": {"@type": "xsd:float", "@value": "4.57891654968262"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.34793761600864"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.87118388575936e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.487021764768749"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00104840737781972"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.34793761600864"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.87118388575936e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.487021764768749"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00104840737781972"}
     },
     {
-      "@id": "niiri:132a1b66dcc9169a3a5a1e71bbe7d479",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:2f7752391d49b36d1668a1bed931ebed",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0033",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-60,-16,28]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-60,-16,28]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ea18051b705fd4266580ebbdefd1cf08",
-      "entity": "niiri:c27d8c4414a41bf2e1d9fe41a87f11b6"
+      "entity_derived": "niiri:a3cbab4a2a30eece310c15c0975c7b8c",
+      "entity": "niiri:0531c28556a1e0fba30c3ea1dd24f56e"
     },
     {
-      "@id": "niiri:3f5eb44d431119cfda5e57ae0f560d5a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:24e1979d3724b3518945e59d3fad2d5b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0034",
-      "prov:atLocation": {"@id": "niiri:61adef73114ec234f5f7b942b2699d4a"},
+      "prov:atLocation": {"@id": "niiri:da3399510a366ca55680d838c72b0f46"},
       "prov:value": {"@type": "xsd:float", "@value": "4.37013816833496"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.16664310578498"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.54558935169247e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.730405153245217"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00164483391358715"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.16664310578498"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.54558935169247e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.730405153245217"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00164483391358715"}
     },
     {
-      "@id": "niiri:61adef73114ec234f5f7b942b2699d4a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:da3399510a366ca55680d838c72b0f46",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0034",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-52,-62,52]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-52,-62,52]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3f5eb44d431119cfda5e57ae0f560d5a",
-      "entity": "niiri:63757a12c243d6f113a5c106a65341d3"
+      "entity_derived": "niiri:24e1979d3724b3518945e59d3fad2d5b",
+      "entity": "niiri:22a4e1327d4f2f7349df156933a68889"
     },
     {
-      "@id": "niiri:968450287bdafda68a39620f236330d8",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:90230b1d46674135f54f40a8eaaa6955",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0035",
-      "prov:atLocation": {"@id": "niiri:f55dd854fcfab6398e630bbf0bc54c1f"},
+      "prov:atLocation": {"@id": "niiri:6f47e3c2cf1ad6ee422a9cac44b388e2"},
       "prov:value": {"@type": "xsd:float", "@value": "4.30655717849731"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.11101155082742"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.96964745459161e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.798260223882423"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00188267859062858"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.11101155082742"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.96964745459161e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.798260223882423"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00188267859062858"}
     },
     {
-      "@id": "niiri:f55dd854fcfab6398e630bbf0bc54c1f",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6f47e3c2cf1ad6ee422a9cac44b388e2",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0035",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-26,-92,32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-26,-92,32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:968450287bdafda68a39620f236330d8",
-      "entity": "niiri:64a23b7dfa188ea7c583dd955c4783b0"
+      "entity_derived": "niiri:90230b1d46674135f54f40a8eaaa6955",
+      "entity": "niiri:661e97df890b4cd21b7b3cc4a2220e2e"
     },
     {
-      "@id": "niiri:66a1f9784198e645bd70e47493fcfc1e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:6ecb22dc01f666b06e37c52dda7e1cea",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0036",
-      "prov:atLocation": {"@id": "niiri:165705ccc37ab69befde79237446eddd"},
+      "prov:atLocation": {"@id": "niiri:868adc42924955a9584f6bf2cdbbe62c"},
       "prov:value": {"@type": "xsd:float", "@value": "4.24533367156982"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.05725918601008"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.4825985211363e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.855631833511506"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00216400098580605"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.05725918601008"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.4825985211363e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.855631833511506"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00216400098580605"}
     },
     {
-      "@id": "niiri:165705ccc37ab69befde79237446eddd",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:868adc42924955a9584f6bf2cdbbe62c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0036",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-18,-60,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-18,-60,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:66a1f9784198e645bd70e47493fcfc1e",
-      "entity": "niiri:c7fd5f4cdee71350124b35242a6b1709"
+      "entity_derived": "niiri:6ecb22dc01f666b06e37c52dda7e1cea",
+      "entity": "niiri:fb7297e8c19234947de7375e05901f89"
     },
     {
-      "@id": "niiri:f4a8a2fea797e1beb91fddefc276b32f",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:1147bd3222d74b8465b410daf5f551d9",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0037",
-      "prov:atLocation": {"@id": "niiri:62930e1ae7842cdd16785978ed6f01fb"},
+      "prov:atLocation": {"@id": "niiri:23fcb7cf1cb30acabf1d069782179e41"},
       "prov:value": {"@type": "xsd:float", "@value": "4.22729349136353"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.04138628171284"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.65680735640483e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.870712357794855"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00224862910698152"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.04138628171284"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.65680735640483e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.870712357794855"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00224862910698152"}
     },
     {
-      "@id": "niiri:62930e1ae7842cdd16785978ed6f01fb",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:23fcb7cf1cb30acabf1d069782179e41",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0037",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-20,-98,22]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-20,-98,22]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f4a8a2fea797e1beb91fddefc276b32f",
-      "entity": "niiri:43b10bfa562e759c7c198b457de7cd8b"
+      "entity_derived": "niiri:1147bd3222d74b8465b410daf5f551d9",
+      "entity": "niiri:c016e8a860699bda1ff422a1f501e63d"
     },
     {
-      "@id": "niiri:0667939b7025ee7fa4cd16ef0627ee59",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0edd0549008deb53921ccec5934b3d03",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0038",
-      "prov:atLocation": {"@id": "niiri:915e6b7f895b7accd4998d9eac95046f"},
+      "prov:atLocation": {"@id": "niiri:ca5f81484ccce6fc3e9387947befc7f8"},
       "prov:value": {"@type": "xsd:float", "@value": "4.22599840164185"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.04024618213588"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.66975618669063e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.871760516202526"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00224977618124126"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.04024618213588"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.66975618669063e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.871760516202526"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00224977618124126"}
     },
     {
-      "@id": "niiri:915e6b7f895b7accd4998d9eac95046f",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ca5f81484ccce6fc3e9387947befc7f8",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0038",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-36,-74,-34]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-36,-74,-34]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0667939b7025ee7fa4cd16ef0627ee59",
-      "entity": "niiri:94ae4aee00bdd503edae82f33c3e9515"
+      "entity_derived": "niiri:0edd0549008deb53921ccec5934b3d03",
+      "entity": "niiri:c4fe065cafdebad144fa17a8ec71281b"
     },
     {
-      "@id": "niiri:a7f2170a24f2f05d63133355bdd77f43",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:cecb64ea54e0530f18d065bad589c2a6",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0039",
-      "prov:atLocation": {"@id": "niiri:5cd8e4e2f6aefbc637d10e9378123002"},
+      "prov:atLocation": {"@id": "niiri:8dfaaed3cdea8aa1695388a5f053616f"},
       "prov:value": {"@type": "xsd:float", "@value": "2.86162257194519"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "2.79772486594084"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00257319651143795"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0401361290360738"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "2.79772486594084"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00257319651143795"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0401361290360738"}
     },
     {
-      "@id": "niiri:5cd8e4e2f6aefbc637d10e9378123002",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:8dfaaed3cdea8aa1695388a5f053616f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0039",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-44,-62,-32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-44,-62,-32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a7f2170a24f2f05d63133355bdd77f43",
-      "entity": "niiri:94ae4aee00bdd503edae82f33c3e9515"
+      "entity_derived": "niiri:cecb64ea54e0530f18d065bad589c2a6",
+      "entity": "niiri:c4fe065cafdebad144fa17a8ec71281b"
     },
     {
-      "@id": "niiri:63a3ca76c01c0d8659c77cba85d71f0d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f7f872af0c034510f177bd8ce9bb0b0c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0040",
-      "prov:atLocation": {"@id": "niiri:546d1d0bd9649ec9cb88e495502e1f61"},
+      "prov:atLocation": {"@id": "niiri:8aeee6e06b00259350b3cf7d5bdf384c"},
       "prov:value": {"@type": "xsd:float", "@value": "4.20391035079956"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.02078923241408"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.900174224163e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.888907080881232"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00235275290167977"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.02078923241408"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.900174224163e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.888907080881232"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00235275290167977"}
     },
     {
-      "@id": "niiri:546d1d0bd9649ec9cb88e495502e1f61",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:8aeee6e06b00259350b3cf7d5bdf384c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0040",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[34,-54,-16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[34,-54,-16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:63a3ca76c01c0d8659c77cba85d71f0d",
-      "entity": "niiri:4f7b061f932253ef4a07d4d9f2fe8517"
+      "entity_derived": "niiri:f7f872af0c034510f177bd8ce9bb0b0c",
+      "entity": "niiri:b9447d9cb03b61ef6f6b29b2f726c748"
     },
     {
-      "@id": "niiri:a9bd8e59595df4fd6670bcebc783e2fb",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:36ff54739107c726560ff84ecfbec58e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0041",
-      "prov:atLocation": {"@id": "niiri:5b02dccced55af630e4d693d63c58b72"},
+      "prov:atLocation": {"@id": "niiri:fee6ca7cc2a611c4fda7974781d37cbd"},
       "prov:value": {"@type": "xsd:float", "@value": "4.18721437454224"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.00606667297511"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.08691144208506e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.900934824371894"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00243416319862164"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.00606667297511"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.08691144208506e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.900934824371894"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00243416319862164"}
     },
     {
-      "@id": "niiri:5b02dccced55af630e4d693d63c58b72",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:fee6ca7cc2a611c4fda7974781d37cbd",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0041",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[12,-100,20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[12,-100,20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a9bd8e59595df4fd6670bcebc783e2fb",
-      "entity": "niiri:0163fc34332a97aa514f22d9a18b4aef"
+      "entity_derived": "niiri:36ff54739107c726560ff84ecfbec58e",
+      "entity": "niiri:fccd53239e801ce9120073c47ddcae13"
     },
     {
-      "@id": "niiri:4a2bbf2b0326642b3f66c7fb2b5f18fd",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e7e5af7d0c21e8aef18e2542948c6793",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0042",
-      "prov:atLocation": {"@id": "niiri:d12cd505628e3d8c6055e2a31cf5d9d0"},
+      "prov:atLocation": {"@id": "niiri:dc93b496593d4b472f2eb9fd7aca8b08"},
       "prov:value": {"@type": "xsd:float", "@value": "4.17404651641846"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.99444589181498"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.24228638075574e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.909844421846994"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00250424652987014"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.99444589181498"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.24228638075574e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.909844421846994"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00250424652987014"}
     },
     {
-      "@id": "niiri:d12cd505628e3d8c6055e2a31cf5d9d0",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:dc93b496593d4b472f2eb9fd7aca8b08",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0042",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-40,-38,44]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-40,-38,44]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4a2bbf2b0326642b3f66c7fb2b5f18fd",
-      "entity": "niiri:afb1b880058db996109597c9134c0944"
+      "entity_derived": "niiri:e7e5af7d0c21e8aef18e2542948c6793",
+      "entity": "niiri:e8858d23bbbcba237e94c70004237a2f"
     },
     {
-      "@id": "niiri:92a1a39a34a21b0345adc8771856b403",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5eedc42ee231bb3e0801681a9ba98372",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0043",
-      "prov:atLocation": {"@id": "niiri:99d132a290adb1a4ddd6e90191ab85b9"},
+      "prov:atLocation": {"@id": "niiri:ab81f14081ba25602d7d462d456bc0e6"},
       "prov:value": {"@type": "xsd:float", "@value": "4.07333517074585"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.9052963692066"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.70549882543025e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.961337330645756"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00311829811824681"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.9052963692066"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.70549882543025e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.961337330645756"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00311829811824681"}
     },
     {
-      "@id": "niiri:99d132a290adb1a4ddd6e90191ab85b9",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ab81f14081ba25602d7d462d456bc0e6",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0043",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[20,-66,34]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[20,-66,34]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:92a1a39a34a21b0345adc8771856b403",
-      "entity": "niiri:a3209dd94fcfcfc2e0d96d3475893c16"
+      "entity_derived": "niiri:5eedc42ee231bb3e0801681a9ba98372",
+      "entity": "niiri:a1e36a12612c98786c42d6e581a41938"
     },
     {
-      "@id": "niiri:aa2a89d1737724f1593952d9c18d40a4",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5a68064d075ad549c6b87de74be574de",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0044",
-      "prov:atLocation": {"@id": "niiri:29e692fa53e24c76ed2497c29ffcfdd2"},
+      "prov:atLocation": {"@id": "niiri:53dd5f18ed8740b69c85f29f5098f9c1"},
       "prov:value": {"@type": "xsd:float", "@value": "4.05762767791748"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.89134919103145"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.98441713834286e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.966867400896655"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00322871741467698"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.89134919103145"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.98441713834286e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.966867400896655"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00322871741467698"}
     },
     {
-      "@id": "niiri:29e692fa53e24c76ed2497c29ffcfdd2",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:53dd5f18ed8740b69c85f29f5098f9c1",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0044",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-46,-56,14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-46,-56,14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:aa2a89d1737724f1593952d9c18d40a4",
-      "entity": "niiri:0e0928e501c6272ac7fd3ddf2695e9f7"
+      "entity_derived": "niiri:5a68064d075ad549c6b87de74be574de",
+      "entity": "niiri:6aac454abbeb6462b826cd647eb086e0"
     },
     {
-      "@id": "niiri:20299a2e3c1a8789b6e669a167cd8a51",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:69b3e9ba35baf225bd111d6d16f02c59",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0045",
-      "prov:atLocation": {"@id": "niiri:c25f00e518298f017ca37cefaf776b5e"},
+      "prov:atLocation": {"@id": "niiri:104c93687e188734b35ec18667237aa2"},
       "prov:value": {"@type": "xsd:float", "@value": "3.97341108322144"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.81637469850314"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.7713399346081e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.987160063394768"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0038799021604929"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.81637469850314"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.7713399346081e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.987160063394768"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0038799021604929"}
     },
     {
-      "@id": "niiri:c25f00e518298f017ca37cefaf776b5e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:104c93687e188734b35ec18667237aa2",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0045",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-50,-50,20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-50,-50,20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:20299a2e3c1a8789b6e669a167cd8a51",
-      "entity": "niiri:0e0928e501c6272ac7fd3ddf2695e9f7"
+      "entity_derived": "niiri:69b3e9ba35baf225bd111d6d16f02c59",
+      "entity": "niiri:6aac454abbeb6462b826cd647eb086e0"
     },
     {
-      "@id": "niiri:cc2de1fc69206ea9e189278a76fe556c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5cddeb38ad7e027bd0de87a3a4bbef17",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0046",
-      "prov:atLocation": {"@id": "niiri:7f317302e0aa94a0d54fb816d3613b5d"},
+      "prov:atLocation": {"@id": "niiri:a48ff748b6cbde7cfc7b801d780bf846"},
       "prov:value": {"@type": "xsd:float", "@value": "4.0217924118042"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.85948683644491"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.68126885931441e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.977286609355005"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00348825429991405"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.85948683644491"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.68126885931441e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.977286609355005"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00348825429991405"}
     },
     {
-      "@id": "niiri:7f317302e0aa94a0d54fb816d3613b5d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a48ff748b6cbde7cfc7b801d780bf846",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0046",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-36,-40,-36]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-36,-40,-36]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cc2de1fc69206ea9e189278a76fe556c",
-      "entity": "niiri:15ddf3a0750659085f821d46282e1a9c"
+      "entity_derived": "niiri:5cddeb38ad7e027bd0de87a3a4bbef17",
+      "entity": "niiri:7b28ee2c06d9f1eb5b4dab7494fe7a85"
     },
     {
-      "@id": "niiri:ce86070fd4e8986d82b4bed2da9953d8",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3522180f8cbe6ef50347376f1bbf6edb",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0047",
-      "prov:atLocation": {"@id": "niiri:d620ea275f179536cab44837535ca252"},
+      "prov:atLocation": {"@id": "niiri:8f5650b5420113415c6871a4e4b78e5e"},
       "prov:value": {"@type": "xsd:float", "@value": "3.8867518901825"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.73888373627584"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "9.24195907030523e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.996210852184447"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00468683023961801"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.73888373627584"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "9.24195907030523e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.996210852184447"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00468683023961801"}
     },
     {
-      "@id": "niiri:d620ea275f179536cab44837535ca252",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:8f5650b5420113415c6871a4e4b78e5e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0047",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-50,-46,-32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-50,-46,-32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ce86070fd4e8986d82b4bed2da9953d8",
-      "entity": "niiri:15ddf3a0750659085f821d46282e1a9c"
+      "entity_derived": "niiri:3522180f8cbe6ef50347376f1bbf6edb",
+      "entity": "niiri:7b28ee2c06d9f1eb5b4dab7494fe7a85"
     },
     {
-      "@id": "niiri:68f91a82a53b5e5a690fda58a117d029",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:4b7df6a7ed2935756536e850b92db30a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0048",
-      "prov:atLocation": {"@id": "niiri:d5c9cbdb71145c0b71b7333ee309adfc"},
+      "prov:atLocation": {"@id": "niiri:40a9737c4433538d39217a005cfdb1fc"},
       "prov:value": {"@type": "xsd:float", "@value": "3.19474077224731"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.10821385730133"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000941109068576473"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999989"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0204319298365656"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.10821385730133"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000941109068576473"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999989"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0204319298365656"}
     },
     {
-      "@id": "niiri:d5c9cbdb71145c0b71b7333ee309adfc",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:40a9737c4433538d39217a005cfdb1fc",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0048",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-44,-42,-36]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-44,-42,-36]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:68f91a82a53b5e5a690fda58a117d029",
-      "entity": "niiri:15ddf3a0750659085f821d46282e1a9c"
+      "entity_derived": "niiri:4b7df6a7ed2935756536e850b92db30a",
+      "entity": "niiri:7b28ee2c06d9f1eb5b4dab7494fe7a85"
     },
     {
-      "@id": "niiri:f14ffa337966ed8f5ea7817efc9a370e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d9b3a050332d74bf0f36c7adfdb580c3",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0049",
-      "prov:atLocation": {"@id": "niiri:861f40e9acc61fd9f1fa2fe619e6c102"},
+      "prov:atLocation": {"@id": "niiri:c118718c36a03fe9a2bf929e397ff014"},
       "prov:value": {"@type": "xsd:float", "@value": "3.9634416103363"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.80747753892992"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.01957428701494e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.988689669381963"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00396363025696444"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.80747753892992"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.01957428701494e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.988689669381963"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00396363025696444"}
     },
     {
-      "@id": "niiri:861f40e9acc61fd9f1fa2fe619e6c102",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c118718c36a03fe9a2bf929e397ff014",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0049",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[4,6,32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[4,6,32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f14ffa337966ed8f5ea7817efc9a370e",
-      "entity": "niiri:e037574456f8a483328c150e32419262"
+      "entity_derived": "niiri:d9b3a050332d74bf0f36c7adfdb580c3",
+      "entity": "niiri:00aad4e5c367c7dee68c301c251cb2ce"
     },
     {
-      "@id": "niiri:37592d1480a9df2cdee73f855d4d7186",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f725218800cfd7000fbd0ad268a06710",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0050",
-      "prov:atLocation": {"@id": "niiri:9b5828c800e2682cdaeaaf29ae9a836e"},
+      "prov:atLocation": {"@id": "niiri:a46751b7d89671899ba59e831d6e41bc"},
       "prov:value": {"@type": "xsd:float", "@value": "3.96245408058167"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.80659597790245"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.04463150378309e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.988832912076595"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00397422792108106"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.80659597790245"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.04463150378309e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.988832912076595"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00397422792108106"}
     },
     {
-      "@id": "niiri:9b5828c800e2682cdaeaaf29ae9a836e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a46751b7d89671899ba59e831d6e41bc",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0050",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-50,-48,-16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-50,-48,-16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:37592d1480a9df2cdee73f855d4d7186",
-      "entity": "niiri:cead124d94f280e9eb613273f575273f"
+      "entity_derived": "niiri:f725218800cfd7000fbd0ad268a06710",
+      "entity": "niiri:904dc3e52037e77af188b63a3d3a6884"
     },
     {
-      "@id": "niiri:cc52c3ef3b10fd45f54b5ac8243904c1",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:dad6f2d5c4ce67fa4e55fba569c0d484",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0051",
-      "prov:atLocation": {"@id": "niiri:6c484caacee5601ee6af6744a0b59be1"},
+      "prov:atLocation": {"@id": "niiri:3206daab4372447e234b9b148d6d815b"},
       "prov:value": {"@type": "xsd:float", "@value": "3.90285301208496"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.75330746420074"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.72582920719012e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99514521861122"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00452170460938149"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.75330746420074"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.72582920719012e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99514521861122"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00452170460938149"}
     },
     {
-      "@id": "niiri:6c484caacee5601ee6af6744a0b59be1",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:3206daab4372447e234b9b148d6d815b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0051",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-36,-46,-18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-36,-46,-18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cc52c3ef3b10fd45f54b5ac8243904c1",
-      "entity": "niiri:cead124d94f280e9eb613273f575273f"
+      "entity_derived": "niiri:dad6f2d5c4ce67fa4e55fba569c0d484",
+      "entity": "niiri:904dc3e52037e77af188b63a3d3a6884"
     },
     {
-      "@id": "niiri:ce54001c574a8fe6263bf2fbcad328e5",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:840283767e66dbd6e157c770ba828a93",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0052",
-      "prov:atLocation": {"@id": "niiri:f6172039cefd32e90e0f2a247877862d"},
+      "prov:atLocation": {"@id": "niiri:20f83c4fa7511447b6828ed5c47b09b3"},
       "prov:value": {"@type": "xsd:float", "@value": "3.90759468078613"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.75755289319297"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.57915531067288e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.994787688943672"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00447445110574173"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.75755289319297"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.57915531067288e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.994787688943672"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00447445110574173"}
     },
     {
-      "@id": "niiri:f6172039cefd32e90e0f2a247877862d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:20f83c4fa7511447b6828ed5c47b09b3",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0052",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-14,-98,-4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-14,-98,-4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ce54001c574a8fe6263bf2fbcad328e5",
-      "entity": "niiri:9dee950d4d0d87d9847d4f2182442446"
+      "entity_derived": "niiri:840283767e66dbd6e157c770ba828a93",
+      "entity": "niiri:ffdea138243040f7b25be6c44f68510d"
     },
     {
-      "@id": "niiri:38afa6f16560eb4228a77492bbd3df91",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0e31b662b4e33990fa038bbb4c5ba001",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0053",
-      "prov:atLocation": {"@id": "niiri:2c89f81a86c483cac55f91d34afc320e"},
+      "prov:atLocation": {"@id": "niiri:ef4842b6c6cfe0f325e9e746c09cb167"},
       "prov:value": {"@type": "xsd:float", "@value": "3.86077284812927"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.7155862280194"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000101366555929516"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.997515005942308"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0049663224069025"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.7155862280194"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000101366555929516"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.997515005942308"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0049663224069025"}
     },
     {
-      "@id": "niiri:2c89f81a86c483cac55f91d34afc320e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ef4842b6c6cfe0f325e9e746c09cb167",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0053",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[64,-30,-22]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[64,-30,-22]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:38afa6f16560eb4228a77492bbd3df91",
-      "entity": "niiri:5bdb44212c11108bd9056913ba88493d"
+      "entity_derived": "niiri:0e31b662b4e33990fa038bbb4c5ba001",
+      "entity": "niiri:f19e77aa11c450b96b368f822fcfd6ce"
     },
     {
-      "@id": "niiri:6eff30308e3f7b2a6aaae1d55bb952e1",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:15315bb12a4c858854e329703938208d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0054",
-      "prov:atLocation": {"@id": "niiri:ae256fd213e1f17e08ad8f6851439f2b"},
+      "prov:atLocation": {"@id": "niiri:a0c6fdfff1abb4112874eb223d64277f"},
       "prov:value": {"@type": "xsd:float", "@value": "3.82178378105164"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.68056404693028"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000116359297336222"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.998750111206092"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00541658304290436"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.68056404693028"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000116359297336222"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.998750111206092"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00541658304290436"}
     },
     {
-      "@id": "niiri:ae256fd213e1f17e08ad8f6851439f2b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a0c6fdfff1abb4112874eb223d64277f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0054",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[12,52,-12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[12,52,-12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6eff30308e3f7b2a6aaae1d55bb952e1",
-      "entity": "niiri:fcd93504620cb56307a63f5826ae493b"
+      "entity_derived": "niiri:15315bb12a4c858854e329703938208d",
+      "entity": "niiri:1b80b6984bddaf1c61a51a898d6acbea"
     },
     {
-      "@id": "niiri:75c8a9043f4b6be09d078673121747b6",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b8c952b7eb0604aaeff8a4b3deed04f2",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0055",
-      "prov:atLocation": {"@id": "niiri:be3f17d08ed60e5574ba0acf6d820751"},
+      "prov:atLocation": {"@id": "niiri:aca234cd238d14c51f2712b56326ccdf"},
       "prov:value": {"@type": "xsd:float", "@value": "3.80767583847046"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.66787455107711"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000122287561408974"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999041631710947"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00557619880333977"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.66787455107711"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000122287561408974"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999041631710947"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00557619880333977"}
     },
     {
-      "@id": "niiri:be3f17d08ed60e5574ba0acf6d820751",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:aca234cd238d14c51f2712b56326ccdf",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0055",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[22,-80,54]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[22,-80,54]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:75c8a9043f4b6be09d078673121747b6",
-      "entity": "niiri:22f559c5bb43c4d1c00d4b2abbd64b80"
+      "entity_derived": "niiri:b8c952b7eb0604aaeff8a4b3deed04f2",
+      "entity": "niiri:2a6b200869ec06562d293e64de33e926"
     },
     {
-      "@id": "niiri:b15a28acac19d4f38e4dd5710e891ec5",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:22efce75aa6c6dce7c1322da7c4c8a84",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0056",
-      "prov:atLocation": {"@id": "niiri:1cfacce95e7f446ccd01b964dc08a5bc"},
+      "prov:atLocation": {"@id": "niiri:1db9cd1b4946a3ce9cb7d6f4d57e7825"},
       "prov:value": {"@type": "xsd:float", "@value": "3.78668808937073"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.64898036269368"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000131641613210109"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999365630484476"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00583459491796649"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.64898036269368"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000131641613210109"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999365630484476"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00583459491796649"}
     },
     {
-      "@id": "niiri:1cfacce95e7f446ccd01b964dc08a5bc",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:1db9cd1b4946a3ce9cb7d6f4d57e7825",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0056",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-22,-74,60]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-22,-74,60]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b15a28acac19d4f38e4dd5710e891ec5",
-      "entity": "niiri:b58c8c56d192cbadcd924e0e299d45b7"
+      "entity_derived": "niiri:22efce75aa6c6dce7c1322da7c4c8a84",
+      "entity": "niiri:50eb3a7d09683191b4aed76432577ca4"
     },
     {
-      "@id": "niiri:806b3ed136eea98cd29cfd76d1200da4",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:29cb61e520efc605169b4daa2aecadcf",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0057",
-      "prov:atLocation": {"@id": "niiri:3d8066545c7fc03066852405c620c751"},
+      "prov:atLocation": {"@id": "niiri:e4d533f3ae3530faa4fa88f80772d5ba"},
       "prov:value": {"@type": "xsd:float", "@value": "3.69408750534058"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.56538143418403"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000181663694368006"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999921818129803"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00709819832733513"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.56538143418403"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000181663694368006"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999921818129803"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00709819832733513"}
     },
     {
-      "@id": "niiri:3d8066545c7fc03066852405c620c751",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e4d533f3ae3530faa4fa88f80772d5ba",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0057",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[50,46,-12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[50,46,-12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:806b3ed136eea98cd29cfd76d1200da4",
-      "entity": "niiri:6c6cb2c384c60e5d62243cf34af0708f"
+      "entity_derived": "niiri:29cb61e520efc605169b4daa2aecadcf",
+      "entity": "niiri:3dc187c20fafa718374d3bf8209b869c"
     },
     {
-      "@id": "niiri:168bc36f0340173b89afe58b52d645b3",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:29adc4964dd5cb588824e8fafff57b8b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0058",
-      "prov:atLocation": {"@id": "niiri:b6a8846842116c223b47db823ce70f9b"},
+      "prov:atLocation": {"@id": "niiri:ceb814e013d5960988e46b1015a2eff0"},
       "prov:value": {"@type": "xsd:float", "@value": "3.65459251403809"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.52960997534834"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000208086348004177"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999972447579615"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00771736431800426"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.52960997534834"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000208086348004177"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999972447579615"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00771736431800426"}
     },
     {
-      "@id": "niiri:b6a8846842116c223b47db823ce70f9b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ceb814e013d5960988e46b1015a2eff0",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0058",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[54,8,-36]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[54,8,-36]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:168bc36f0340173b89afe58b52d645b3",
-      "entity": "niiri:3c56acb507aa977c9b4ba549626f35b8"
+      "entity_derived": "niiri:29adc4964dd5cb588824e8fafff57b8b",
+      "entity": "niiri:2246deb8a6c721c27dda92f3dd869ffd"
     },
     {
-      "@id": "niiri:923a557c9a8e587d39af24887e2f9584",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:4bf8abf79b6ded57be5385b0e6aab4b9",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0059",
-      "prov:atLocation": {"@id": "niiri:a36d1f5921f83d6b18f621f5cb0a6a28"},
+      "prov:atLocation": {"@id": "niiri:8fcdd38710d6dfcd1b86f088e8cf04c0"},
       "prov:value": {"@type": "xsd:float", "@value": "3.60173606872559"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.48162963814792"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000249186237945009"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999994173508246"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00859988568288654"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.48162963814792"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000249186237945009"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999994173508246"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00859988568288654"}
     },
     {
-      "@id": "niiri:a36d1f5921f83d6b18f621f5cb0a6a28",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:8fcdd38710d6dfcd1b86f088e8cf04c0",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0059",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-14,58,10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-14,58,10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:923a557c9a8e587d39af24887e2f9584",
-      "entity": "niiri:d1dd3f03998183928446768008d538fd"
+      "entity_derived": "niiri:4bf8abf79b6ded57be5385b0e6aab4b9",
+      "entity": "niiri:50cb1d29d6f8a9cfe9515552c5bb7d31"
     },
     {
-      "@id": "niiri:42179ac9c4345723a539eebfe78a10f8",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a5aa6fcfda734e3389f7bec2d9ad0a6f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0060",
-      "prov:atLocation": {"@id": "niiri:9e66be1d23413aacd4b5d556c13537cd"},
+      "prov:atLocation": {"@id": "niiri:4514318f9da72e1bef9803b37a732d29"},
       "prov:value": {"@type": "xsd:float", "@value": "3.58989810943604"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.47086705539024"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000259390388114844"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999995993033212"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00880900397523308"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.47086705539024"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000259390388114844"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999995993033212"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00880900397523308"}
     },
     {
-      "@id": "niiri:9e66be1d23413aacd4b5d556c13537cd",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4514318f9da72e1bef9803b37a732d29",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0060",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-66,-36,22]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-66,-36,22]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:42179ac9c4345723a539eebfe78a10f8",
-      "entity": "niiri:c68b211ae154a1466946b63df0f701aa"
+      "entity_derived": "niiri:a5aa6fcfda734e3389f7bec2d9ad0a6f",
+      "entity": "niiri:d6d69b36b9108bb0de66eeffba4d858e"
     },
     {
-      "@id": "niiri:3f060b71575fff91a2cb4104a83101ac",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f09170fc52ba782fe9bdfaf02ade3b10",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0061",
-      "prov:atLocation": {"@id": "niiri:f20412005fa2953bc1ce80e18b7010c6"},
+      "prov:atLocation": {"@id": "niiri:2f13fba96e94db31ba13df7c745e67c2"},
       "prov:value": {"@type": "xsd:float", "@value": "3.56340670585632"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.44676015888715"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000283676007278189"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999998329299787"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00931482128100283"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.44676015888715"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000283676007278189"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999998329299787"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00931482128100283"}
     },
     {
-      "@id": "niiri:f20412005fa2953bc1ce80e18b7010c6",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:2f13fba96e94db31ba13df7c745e67c2",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0061",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[18,60,12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[18,60,12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3f060b71575fff91a2cb4104a83101ac",
-      "entity": "niiri:322465548251da9db8f6eede832763a7"
+      "entity_derived": "niiri:f09170fc52ba782fe9bdfaf02ade3b10",
+      "entity": "niiri:e88a30db5e3821edb55a62d4b67f0ad1"
     },
     {
-      "@id": "niiri:6130a6f0559aee4c82170e809d706be5",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c0586c77c95a193830c8219325ca2256",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0062",
-      "prov:atLocation": {"@id": "niiri:3592d1ef3b4f87952389f36ed2b09e55"},
+      "prov:atLocation": {"@id": "niiri:c1b0e76791ad2592aff2be5e27561f34"},
       "prov:value": {"@type": "xsd:float", "@value": "3.55537104606628"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.43944179853069"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000291457553818653"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999998731920076"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0094907493053886"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.43944179853069"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000291457553818653"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999998731920076"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0094907493053886"}
     },
     {
-      "@id": "niiri:3592d1ef3b4f87952389f36ed2b09e55",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c1b0e76791ad2592aff2be5e27561f34",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0062",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-64,-34,8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-64,-34,8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6130a6f0559aee4c82170e809d706be5",
-      "entity": "niiri:2e9ce0e379ad93f22643b62153bb9323"
+      "entity_derived": "niiri:c0586c77c95a193830c8219325ca2256",
+      "entity": "niiri:a4ad9afd60a760f91d6916421b56fe6a"
     },
     {
-      "@id": "niiri:b6b2edacba7be6c3a7140b8545a7f21a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:29b6d69627dd6dacdaa3a9b3c30d347f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0063",
-      "prov:atLocation": {"@id": "niiri:b874b9f9fe3fd72bf03970d6f12de2ac"},
+      "prov:atLocation": {"@id": "niiri:7d14954855c9816b0a230a0df291fa29"},
       "prov:value": {"@type": "xsd:float", "@value": "3.54216623306274"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.42740966598884"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000304684504620178"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999202607737"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00978309810858832"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.42740966598884"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000304684504620178"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999202607737"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00978309810858832"}
     },
     {
-      "@id": "niiri:b874b9f9fe3fd72bf03970d6f12de2ac",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7d14954855c9816b0a230a0df291fa29",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0063",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-58,-32,22]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-58,-32,22]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b6b2edacba7be6c3a7140b8545a7f21a",
-      "entity": "niiri:d51a48062d3b4def227e90a39b0954f5"
+      "entity_derived": "niiri:29b6d69627dd6dacdaa3a9b3c30d347f",
+      "entity": "niiri:d3934b966af329378cc1a1307b94a530"
     },
     {
-      "@id": "niiri:6f7e3f89dbd79308a4785a293cdb1f12",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:afa91bed7d064469a4e66e23ca1c26f9",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0064",
-      "prov:atLocation": {"@id": "niiri:8795ca387edcfaf290621dbe37a0f708"},
+      "prov:atLocation": {"@id": "niiri:6a2b0b0ce5882ce85cc24088d095d5f4"},
       "prov:value": {"@type": "xsd:float", "@value": "3.46738910675049"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.35913252154752"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000390937814553127"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999955890495"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0114444909736178"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.35913252154752"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000390937814553127"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999955890495"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0114444909736178"}
     },
     {
-      "@id": "niiri:8795ca387edcfaf290621dbe37a0f708",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6a2b0b0ce5882ce85cc24088d095d5f4",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0064",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[14,-14,72]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[14,-14,72]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6f7e3f89dbd79308a4785a293cdb1f12",
-      "entity": "niiri:0a272793669dad6178113ee531ec9cb8"
+      "entity_derived": "niiri:afa91bed7d064469a4e66e23ca1c26f9",
+      "entity": "niiri:546534eff08d214139c8884f815a2c20"
     },
     {
-      "@id": "niiri:a28d458dd358ad059c8f392ac26194a5",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ce725d602d22bdbfcfb1d33ed8a51382",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0065",
-      "prov:atLocation": {"@id": "niiri:2f7f3bd4dbe1b1edac33113438602b5d"},
+      "prov:atLocation": {"@id": "niiri:6f48cd191b2923a4059fd4f816332e01"},
       "prov:value": {"@type": "xsd:float", "@value": "3.13905429840088"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.05659883446979"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00111931832184231"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0229711836666271"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.05659883446979"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00111931832184231"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0229711836666271"}
     },
     {
-      "@id": "niiri:2f7f3bd4dbe1b1edac33113438602b5d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6f48cd191b2923a4059fd4f816332e01",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0065",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[12,-16,64]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[12,-16,64]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a28d458dd358ad059c8f392ac26194a5",
-      "entity": "niiri:0a272793669dad6178113ee531ec9cb8"
+      "entity_derived": "niiri:ce725d602d22bdbfcfb1d33ed8a51382",
+      "entity": "niiri:546534eff08d214139c8884f815a2c20"
     },
     {
-      "@id": "niiri:d641c756b5f2f01c775915af29e9af97",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:8d0242e530dd2b7ac61d63b861ffdfb2",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0066",
-      "prov:atLocation": {"@id": "niiri:09e0f9d7466f514d85a5bb83d5bddc42"},
+      "prov:atLocation": {"@id": "niiri:610b4620d7a52f6451a8f5a7fe636e78"},
       "prov:value": {"@type": "xsd:float", "@value": "3.45441365242004"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.34726077209469"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000408071982705316"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999974583179"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0117929908461181"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.34726077209469"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000408071982705316"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999974583179"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0117929908461181"}
     },
     {
-      "@id": "niiri:09e0f9d7466f514d85a5bb83d5bddc42",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:610b4620d7a52f6451a8f5a7fe636e78",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0066",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-38,-54,-42]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-38,-54,-42]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d641c756b5f2f01c775915af29e9af97",
-      "entity": "niiri:b184062d5a99600d689d67aaae002061"
+      "entity_derived": "niiri:8d0242e530dd2b7ac61d63b861ffdfb2",
+      "entity": "niiri:295cf12e37c01e14c3830d46154826a9"
     },
     {
-      "@id": "niiri:bcce44a2aa9bec0a15e890be0dc92940",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:409a5667ff5ace48db341b1d4b443b7b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0067",
-      "prov:atLocation": {"@id": "niiri:c81be31babc76d12a713900b2de4754b"},
+      "prov:atLocation": {"@id": "niiri:7f0662b591e4d89dd3e64021c01d47a8"},
       "prov:value": {"@type": "xsd:float", "@value": "3.43198323249817"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.32672157755253"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000439370628491198"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999990548038"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0123661196896594"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.32672157755253"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000439370628491198"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999990548038"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0123661196896594"}
     },
     {
-      "@id": "niiri:c81be31babc76d12a713900b2de4754b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7f0662b591e4d89dd3e64021c01d47a8",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0067",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[42,-42,14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[42,-42,14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:bcce44a2aa9bec0a15e890be0dc92940",
-      "entity": "niiri:f96aa71d40f8ee2a7f558cd844317641"
+      "entity_derived": "niiri:409a5667ff5ace48db341b1d4b443b7b",
+      "entity": "niiri:aedc5c46b75f681aa273f0c65aba753d"
     },
     {
-      "@id": "niiri:0a79840910c04b4648c62541adfc354b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:93fba29bbc2b01e814cebc5c1c0d1553",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0068",
-      "prov:atLocation": {"@id": "niiri:1a5e81c9ea1818501dce8a2fe0b8e0bd"},
+      "prov:atLocation": {"@id": "niiri:4321078ea4b73fb1eebb645623318e8d"},
       "prov:value": {"@type": "xsd:float", "@value": "3.40386486053467"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.30094422133281"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000481800187664638"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999997442132"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0131315419066298"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.30094422133281"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000481800187664638"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999997442132"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0131315419066298"}
     },
     {
-      "@id": "niiri:1a5e81c9ea1818501dce8a2fe0b8e0bd",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4321078ea4b73fb1eebb645623318e8d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0068",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[52,-42,18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[52,-42,18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0a79840910c04b4648c62541adfc354b",
-      "entity": "niiri:51f615915847dee59f46c38a3d61f56e"
+      "entity_derived": "niiri:93fba29bbc2b01e814cebc5c1c0d1553",
+      "entity": "niiri:03b802eb8ab278c3154b4ebae374f2f2"
     },
     {
-      "@id": "niiri:e3fa837465caf5155f758b0ecd134b43",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e3c2f2c5c8877cf5d3301382557e5009",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0069",
-      "prov:atLocation": {"@id": "niiri:4371f24601e6942034ee127126a4f0a0"},
+      "prov:atLocation": {"@id": "niiri:5a357afd9be7a34bbbde654f71b7451e"},
       "prov:value": {"@type": "xsd:float", "@value": "3.36533284187317"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.26556677338515"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000546226226643243"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999624169"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0142364394435995"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.26556677338515"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000546226226643243"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999624169"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0142364394435995"}
     },
     {
-      "@id": "niiri:4371f24601e6942034ee127126a4f0a0",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:5a357afd9be7a34bbbde654f71b7451e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0069",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[44,-48,-26]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[44,-48,-26]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e3fa837465caf5155f758b0ecd134b43",
-      "entity": "niiri:c80fb3c545c2f7392d3c65842860d0d3"
+      "entity_derived": "niiri:e3c2f2c5c8877cf5d3301382557e5009",
+      "entity": "niiri:33fb5b8990838fc1f2547ba3ff8437d2"
     },
     {
-      "@id": "niiri:c0fa8162341c45f2054c25f6286dbb94",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:cf455aa53879ce5eb8f2e701d72643c3",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0070",
-      "prov:atLocation": {"@id": "niiri:2f8b9a2698662e3e122e522c43b6d850"},
+      "prov:atLocation": {"@id": "niiri:c39b228e86e60d680bce4be9f24e6881"},
       "prov:value": {"@type": "xsd:float", "@value": "3.32532405853271"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.22876865896546"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000621622108231912"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999995642"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.015558079264466"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.22876865896546"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000621622108231912"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999995642"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.015558079264466"}
     },
     {
-      "@id": "niiri:2f8b9a2698662e3e122e522c43b6d850",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c39b228e86e60d680bce4be9f24e6881",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0070",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-54,-32,42]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-54,-32,42]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c0fa8162341c45f2054c25f6286dbb94",
-      "entity": "niiri:3d5efcc91bde3190c3c7fc5ea37f55ab"
+      "entity_derived": "niiri:cf455aa53879ce5eb8f2e701d72643c3",
+      "entity": "niiri:f6f7f9d9bd2b440c679a5ff44f1cdb22"
     },
     {
-      "@id": "niiri:cea8246dfb359ca47a78c78daa3dcad0",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e9c6bf15ba9e098b7b0cca458dc8cd21",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0071",
-      "prov:atLocation": {"@id": "niiri:4c13f3c06b2bbf245f3adc61655db0e5"},
+      "prov:atLocation": {"@id": "niiri:ec9d5559de25c81d98d87fac2fbe5dba"},
       "prov:value": {"@type": "xsd:float", "@value": "3.31892204284668"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.22287431730178"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000634556128578101"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.99999999996962"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0157616735622854"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.22287431730178"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000634556128578101"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.99999999996962"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0157616735622854"}
     },
     {
-      "@id": "niiri:4c13f3c06b2bbf245f3adc61655db0e5",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ec9d5559de25c81d98d87fac2fbe5dba",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0071",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-16,4,62]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-16,4,62]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cea8246dfb359ca47a78c78daa3dcad0",
-      "entity": "niiri:74d3fcdb2a3222701acac8703cef46c6"
+      "entity_derived": "niiri:e9c6bf15ba9e098b7b0cca458dc8cd21",
+      "entity": "niiri:cbbd42e6f42814091a8e0fc54b7ad3c4"
     },
     {
-      "@id": "niiri:660f367fd60b36ce1f1dd169ad0f9009",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:93ecdc023889193376179f882fb09793",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0072",
-      "prov:atLocation": {"@id": "niiri:27690288a5f40fa598afa70d4027a13e"},
+      "prov:atLocation": {"@id": "niiri:a63341a7ce00061c582e0ccb012ef7e2"},
       "prov:value": {"@type": "xsd:float", "@value": "3.28136968612671"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.18826629952882"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000715643274853739"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999996665"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0170366752692093"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.18826629952882"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000715643274853739"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999996665"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0170366752692093"}
     },
     {
-      "@id": "niiri:27690288a5f40fa598afa70d4027a13e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a63341a7ce00061c582e0ccb012ef7e2",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0072",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[56,-66,4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[56,-66,4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:660f367fd60b36ce1f1dd169ad0f9009",
-      "entity": "niiri:b954d8c8fc0fa467f3ee6aedf1927f85"
+      "entity_derived": "niiri:93ecdc023889193376179f882fb09793",
+      "entity": "niiri:53fb996b754ceba84bda7b0e7b9bdc51"
     },
     {
-      "@id": "niiri:026aa253ca69ebe6c61b8c39515572ab",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:cfedd59c6ad80ae5fe3df5fa3e086b64",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0073",
-      "prov:atLocation": {"@id": "niiri:702b04e0cffcc06fe2aea8e3af9eea06"},
+      "prov:atLocation": {"@id": "niiri:000efbc6d4c9aeab7beaa0ab52208f9f"},
       "prov:value": {"@type": "xsd:float", "@value": "3.26226496696472"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.17063765299814"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000760523733375762"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999998982"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0177274295203014"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.17063765299814"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000760523733375762"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999998982"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0177274295203014"}
     },
     {
-      "@id": "niiri:702b04e0cffcc06fe2aea8e3af9eea06",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:000efbc6d4c9aeab7beaa0ab52208f9f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0073",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-60,-14,10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-60,-14,10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:026aa253ca69ebe6c61b8c39515572ab",
-      "entity": "niiri:f173ac5c048181e317d9158611e01835"
+      "entity_derived": "niiri:cfedd59c6ad80ae5fe3df5fa3e086b64",
+      "entity": "niiri:55bb03da7ee7d021560ed83a011342a9"
     },
     {
-      "@id": "niiri:9687774c1ec3385edc4abccdecb82a96",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b65cce8679c42572d912ca303840373a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0074",
-      "prov:atLocation": {"@id": "niiri:710d1fe094dc9e475168d989f31d6189"},
+      "prov:atLocation": {"@id": "niiri:4c2c5363ab8e8186172107f728368d86"},
       "prov:value": {"@type": "xsd:float", "@value": "3.25416302680969"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.16315726358056"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000780339994975288"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999392"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0180089199210036"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.16315726358056"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000780339994975288"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999392"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0180089199210036"}
     },
     {
-      "@id": "niiri:710d1fe094dc9e475168d989f31d6189",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4c2c5363ab8e8186172107f728368d86",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0074",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-66,-46,8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-66,-46,8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9687774c1ec3385edc4abccdecb82a96",
-      "entity": "niiri:efc36c20dd2a832167f0a44c579b5edf"
+      "entity_derived": "niiri:b65cce8679c42572d912ca303840373a",
+      "entity": "niiri:ac7c392c52df7cdd1a6cd2c7335454d2"
     },
     {
-      "@id": "niiri:ff91883c8433e0ddd5072e80cb8a47e4",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b1da3428c34e2b43760ad5c2f4e2d0fa",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0075",
-      "prov:atLocation": {"@id": "niiri:b04a7e9a2c6e095ae7b25dfcb0a77b3d"},
+      "prov:atLocation": {"@id": "niiri:e9c17a2c6bd24ee4990476b4240509d1"},
       "prov:value": {"@type": "xsd:float", "@value": "3.24836373329163"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.15780125799237"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000794819459152607"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999582"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.018230089242935"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.15780125799237"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000794819459152607"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999582"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.018230089242935"}
     },
     {
-      "@id": "niiri:b04a7e9a2c6e095ae7b25dfcb0a77b3d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e9c17a2c6bd24ee4990476b4240509d1",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0075",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-68,-34,-8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-68,-34,-8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ff91883c8433e0ddd5072e80cb8a47e4",
-      "entity": "niiri:163e964ab452049726722befe3edc8f1"
+      "entity_derived": "niiri:b1da3428c34e2b43760ad5c2f4e2d0fa",
+      "entity": "niiri:c3f05dc9d300aa5acc02e364f1c3ee85"
     },
     {
-      "@id": "niiri:9129c13d595e0c69ae8e9e6bf5e957b7",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ed0ad58b2c2c68d107db680a95fd120e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0076",
-      "prov:atLocation": {"@id": "niiri:c6091f20f8576aea9d5c66f11f75a731"},
+      "prov:atLocation": {"@id": "niiri:eaa56e97c2a8bfdb44a80f726af2b864"},
       "prov:value": {"@type": "xsd:float", "@value": "3.23679161071777"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.14710967833961"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000824465484375092"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999804"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0186930131202947"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.14710967833961"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000824465484375092"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999804"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0186930131202947"}
     },
     {
-      "@id": "niiri:c6091f20f8576aea9d5c66f11f75a731",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:eaa56e97c2a8bfdb44a80f726af2b864",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0076",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-56,34,-20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-56,34,-20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9129c13d595e0c69ae8e9e6bf5e957b7",
-      "entity": "niiri:21e6a6198ca5dccffc1370c3dedbd678"
+      "entity_derived": "niiri:ed0ad58b2c2c68d107db680a95fd120e",
+      "entity": "niiri:45b4ec73da86f70d949a94aa6ab8d4ab"
     },
     {
-      "@id": "niiri:4dac65ff67e34b44d67c615738e1959a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:81766c881aa79ffa1dca5be898876a89",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0077",
-      "prov:atLocation": {"@id": "niiri:24003d48a146e93b190750ccf1687fc1"},
+      "prov:atLocation": {"@id": "niiri:d1b58d5e6a4d1431d1749aa413e48000"},
       "prov:value": {"@type": "xsd:float", "@value": "3.22478008270264"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.13600649460504"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000856327054624684"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999913"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.019197465737185"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.13600649460504"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000856327054624684"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999913"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.019197465737185"}
     },
     {
-      "@id": "niiri:24003d48a146e93b190750ccf1687fc1",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d1b58d5e6a4d1431d1749aa413e48000",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0077",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[8,-72,42]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[8,-72,42]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4dac65ff67e34b44d67c615738e1959a",
-      "entity": "niiri:0c7d90a406ec1f922a7e807915ee6f49"
+      "entity_derived": "niiri:81766c881aa79ffa1dca5be898876a89",
+      "entity": "niiri:54114a5d8df2f7e553a53e4b7d3f5bde"
     },
     {
-      "@id": "niiri:483126d45625c69a637401f4d9bc9e0d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:6f9386b12ed4b5e1d223ee7299272af0",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0078",
-      "prov:atLocation": {"@id": "niiri:7e1f57ac19d274b35bc68139ac64cd41"},
+      "prov:atLocation": {"@id": "niiri:53635ca2d983f1354091759d739567d9"},
       "prov:value": {"@type": "xsd:float", "@value": "3.22331190109253"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.13464894829369"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000860299398633191"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999921"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0192710694895643"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.13464894829369"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000860299398633191"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999921"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0192710694895643"}
     },
     {
-      "@id": "niiri:7e1f57ac19d274b35bc68139ac64cd41",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:53635ca2d983f1354091759d739567d9",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0078",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[42,-86,12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[42,-86,12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:483126d45625c69a637401f4d9bc9e0d",
-      "entity": "niiri:10a509044b2676eb12c65b82844b5898"
+      "entity_derived": "niiri:6f9386b12ed4b5e1d223ee7299272af0",
+      "entity": "niiri:3f3ed8fe063a9052a3379a875a3af9b1"
     },
     {
-      "@id": "niiri:3436b437c3b46f5d7661548fa8892dc9",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:fb2e0b3836b38e971ed6c44595c76ce6",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0079",
-      "prov:atLocation": {"@id": "niiri:c1f3a692570ba93145684b88ac03623c"},
+      "prov:atLocation": {"@id": "niiri:a0a046d9c5ecbb0ae2f57dafe426178e"},
       "prov:value": {"@type": "xsd:float", "@value": "3.17424750328064"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.08923296074259"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00100337008659268"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999998"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0213685540658751"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.08923296074259"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00100337008659268"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999998"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0213685540658751"}
     },
     {
-      "@id": "niiri:c1f3a692570ba93145684b88ac03623c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a0a046d9c5ecbb0ae2f57dafe426178e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0079",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[12,-86,50]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[12,-86,50]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3436b437c3b46f5d7661548fa8892dc9",
-      "entity": "niiri:da2d2cf59ea5cea8edce49ea2ffea951"
+      "entity_derived": "niiri:fb2e0b3836b38e971ed6c44595c76ce6",
+      "entity": "niiri:5721ae6aae6160ad82aced2d2fe68def"
     },
     {
-      "@id": "niiri:fca7b1daf0d16df7fa5dc5fc1e9547a7",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:bb4c57fd5df089908c6bcfc3efe6b9f9",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0080",
-      "prov:atLocation": {"@id": "niiri:40d86b0aa78b634bb94de2b8e05b700b"},
+      "prov:atLocation": {"@id": "niiri:803ec44036ba7fa1184f3d5d4fb202ef"},
       "prov:value": {"@type": "xsd:float", "@value": "3.15485405921936"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.07125564726837"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00106580278515289"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.999999999999999"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0222342074339062"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.07125564726837"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00106580278515289"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.999999999999999"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0222342074339062"}
     },
     {
-      "@id": "niiri:40d86b0aa78b634bb94de2b8e05b700b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:803ec44036ba7fa1184f3d5d4fb202ef",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0080",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-60,-46,0]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-60,-46,0]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:fca7b1daf0d16df7fa5dc5fc1e9547a7",
-      "entity": "niiri:67b60bb73ecda2bbfdba32287ba6e0f5"
+      "entity_derived": "niiri:bb4c57fd5df089908c6bcfc3efe6b9f9",
+      "entity": "niiri:9326713bc412f1ec61f3bf20466a1174"
     },
     {
-      "@id": "niiri:417f0ba528d7af0c9a0da05faf0d440b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:09e6296e10757ad10cecbc458943830b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0081",
-      "prov:atLocation": {"@id": "niiri:d01b52ce865d52ca48655c89c7876625"},
+      "prov:atLocation": {"@id": "niiri:4d5ab67b2c378b1ea426a6fb6bc53983"},
       "prov:value": {"@type": "xsd:float", "@value": "3.15112209320068"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.06779451986408"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00107822421513859"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0224117734411443"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.06779451986408"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00107822421513859"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0224117734411443"}
     },
     {
-      "@id": "niiri:d01b52ce865d52ca48655c89c7876625",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4d5ab67b2c378b1ea426a6fb6bc53983",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0081",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[54,-22,-26]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[54,-22,-26]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:417f0ba528d7af0c9a0da05faf0d440b",
-      "entity": "niiri:9254bae1d5f58a099609a70c3d6c17bf"
+      "entity_derived": "niiri:09e6296e10757ad10cecbc458943830b",
+      "entity": "niiri:ae9ba0f37d886eaa080e3238cefd1961"
     },
     {
-      "@id": "niiri:ff9195ec7cf35de454c62035c63f56dc",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:798ba4f1b0df8e048c40896efbc27bc1",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0082",
-      "prov:atLocation": {"@id": "niiri:3fd9e322d4b1e294d241d381bf6ffcd6"},
+      "prov:atLocation": {"@id": "niiri:1cd1d457fbb26bf7d7a2a157c4a8597b"},
       "prov:value": {"@type": "xsd:float", "@value": "3.14736461639404"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.06430918903901"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00109086649800139"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0225800614737541"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.06430918903901"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00109086649800139"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0225800614737541"}
     },
     {
-      "@id": "niiri:3fd9e322d4b1e294d241d381bf6ffcd6",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:1cd1d457fbb26bf7d7a2a157c4a8597b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0082",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-50,-40,32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-50,-40,32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ff9195ec7cf35de454c62035c63f56dc",
-      "entity": "niiri:2e99faf6261612f5665eb4d13abf19a0"
+      "entity_derived": "niiri:798ba4f1b0df8e048c40896efbc27bc1",
+      "entity": "niiri:55108dec00fcabdca0aa0fd19deac38c"
     },
     {
-      "@id": "niiri:5a342762f2925add4bbdc285c8e2f927",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:65faea3b6c2b60b8b3a4b771985ae82d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0083",
-      "prov:atLocation": {"@id": "niiri:104a865be0fdfde1762e06512bc9761d"},
+      "prov:atLocation": {"@id": "niiri:3e9bbdd2259381c519f423e47e9d1700"},
       "prov:value": {"@type": "xsd:float", "@value": "3.14220976829529"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.05952680873208"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00110843472885702"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.022825630044905"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.05952680873208"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00110843472885702"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.022825630044905"}
     },
     {
-      "@id": "niiri:104a865be0fdfde1762e06512bc9761d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:3e9bbdd2259381c519f423e47e9d1700",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0083",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-28,-64,-4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-28,-64,-4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5a342762f2925add4bbdc285c8e2f927",
-      "entity": "niiri:740eb5d4edc6fcd44873c0c8fc2a5c58"
+      "entity_derived": "niiri:65faea3b6c2b60b8b3a4b771985ae82d",
+      "entity": "niiri:16a2d945f11329e9c381ee7f04a0ef0e"
     },
     {
-      "@id": "niiri:68d3052cb804ef06cc08406b5adbd091",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:efa6c4751eb0a691336a3cdb57edc4d4",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0084",
-      "prov:atLocation": {"@id": "niiri:287c733474fc79d5c29e6f70ca336295"},
+      "prov:atLocation": {"@id": "niiri:6bf46886efc953821efdbedfa918b17f"},
       "prov:value": {"@type": "xsd:float", "@value": "3.0528359413147"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "2.97644965310987"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00145803479142037"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0273451681875923"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "2.97644965310987"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00145803479142037"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0273451681875923"}
     },
     {
-      "@id": "niiri:287c733474fc79d5c29e6f70ca336295",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6bf46886efc953821efdbedfa918b17f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0084",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-32,-76,-2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-32,-76,-2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:68d3052cb804ef06cc08406b5adbd091",
-      "entity": "niiri:740eb5d4edc6fcd44873c0c8fc2a5c58"
+      "entity_derived": "niiri:efa6c4751eb0a691336a3cdb57edc4d4",
+      "entity": "niiri:16a2d945f11329e9c381ee7f04a0ef0e"
     },
     {
-      "@id": "niiri:4b8d539ddb954878a86d65e5d3543933",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:dfcb0da83436b538eda80129d69688fe",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0085",
-      "prov:atLocation": {"@id": "niiri:413b9fbe3bf1f6eccdba9db58505470d"},
+      "prov:atLocation": {"@id": "niiri:5594ee59f798566f25c3ce8826d865f7"},
       "prov:value": {"@type": "xsd:float", "@value": "3.13440585136414"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.05228482208755"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00113553246964015"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0232102144708915"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.05228482208755"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00113553246964015"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0232102144708915"}
     },
     {
-      "@id": "niiri:413b9fbe3bf1f6eccdba9db58505470d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:5594ee59f798566f25c3ce8826d865f7",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0085",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-46,14,2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-46,14,2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4b8d539ddb954878a86d65e5d3543933",
-      "entity": "niiri:405b87d54648ec0203cb5bd92594a2e3"
+      "entity_derived": "niiri:dfcb0da83436b538eda80129d69688fe",
+      "entity": "niiri:51de73f4c31fd22967b959166dfdd033"
     },
     {
-      "@id": "niiri:8a52ebc1a50c6dd8327cb70fed854ad7",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e974721ee82dbde15f9b39d69ec70d5a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0086",
-      "prov:atLocation": {"@id": "niiri:eda5d2dc3d29443f52d60ae5eb993fcb"},
+      "prov:atLocation": {"@id": "niiri:9258b6520b6d9e367a03d1229b82cd50"},
       "prov:value": {"@type": "xsd:float", "@value": "3.10635590553284"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.02623536858597"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00123809733665026"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0245458677588465"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.02623536858597"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00123809733665026"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0245458677588465"}
     },
     {
-      "@id": "niiri:eda5d2dc3d29443f52d60ae5eb993fcb",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:9258b6520b6d9e367a03d1229b82cd50",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0086",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-30,-64,-40]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-30,-64,-40]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8a52ebc1a50c6dd8327cb70fed854ad7",
-      "entity": "niiri:2eee6e1a0cc5eacabec145451549d653"
+      "entity_derived": "niiri:e974721ee82dbde15f9b39d69ec70d5a",
+      "entity": "niiri:5810f1d1820e723be51fc80ca74ca5e0"
     },
     {
-      "@id": "niiri:520a40e5305018b26be027ca1004e3d8",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:aa808c2c64b1d016870f13b853b07dde",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0087",
-      "prov:atLocation": {"@id": "niiri:2e161ca4ad8bc3eb7e42cc8936b7077b"},
+      "prov:atLocation": {"@id": "niiri:df0ab6577fa3b98348187ba4d0505464"},
       "prov:value": {"@type": "xsd:float", "@value": "3.10515308380127"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.02511765947288"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00124268210298895"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0246072121840759"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.02511765947288"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00124268210298895"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0246072121840759"}
     },
     {
-      "@id": "niiri:2e161ca4ad8bc3eb7e42cc8936b7077b",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:df0ab6577fa3b98348187ba4d0505464",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0087",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[48,34,-6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[48,34,-6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:520a40e5305018b26be027ca1004e3d8",
-      "entity": "niiri:e9970ca0786a9322adebcbbeda6cd715"
+      "entity_derived": "niiri:aa808c2c64b1d016870f13b853b07dde",
+      "entity": "niiri:fb7f0c2c30196ccec28c3a6548a05c74"
     },
     {
-      "@id": "niiri:35d6c499d7f28ddcfde5f4dd89270eae",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:bee1c5e3b563da49fb889d00a907068a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0088",
-      "prov:atLocation": {"@id": "niiri:d35296907d03c450df53708c0fd1ad9d"},
+      "prov:atLocation": {"@id": "niiri:058c979548e4a8a7bfcbe9709834c9a4"},
       "prov:value": {"@type": "xsd:float", "@value": "3.09994459152222"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.02027708985515"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0012627176367187"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0248683482689455"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.02027708985515"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0012627176367187"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0248683482689455"}
     },
     {
-      "@id": "niiri:d35296907d03c450df53708c0fd1ad9d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:058c979548e4a8a7bfcbe9709834c9a4",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0088",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[14,52,24]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[14,52,24]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:35d6c499d7f28ddcfde5f4dd89270eae",
-      "entity": "niiri:c0493caa11e0a7edcd8c852574b28687"
+      "entity_derived": "niiri:bee1c5e3b563da49fb889d00a907068a",
+      "entity": "niiri:c93f984974556da4e703249091c0b9e6"
     },
     {
-      "@id": "niiri:01ec2581154b19ffa8ddd2fe02f943e1",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:8c4cac3967178a072f8a1b26ec0be67c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0089",
-      "prov:atLocation": {"@id": "niiri:af1438298b059cec23b6d80713723732"},
+      "prov:atLocation": {"@id": "niiri:f246f3356741cc6338e2b2af30aa3eda"},
       "prov:value": {"@type": "xsd:float", "@value": "3.09887838363647"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.01928607085125"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00126685581272745"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0249171839147233"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.01928607085125"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00126685581272745"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0249171839147233"}
     },
     {
-      "@id": "niiri:af1438298b059cec23b6d80713723732",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f246f3356741cc6338e2b2af30aa3eda",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0089",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-38,-78,8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-38,-78,8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:01ec2581154b19ffa8ddd2fe02f943e1",
-      "entity": "niiri:f710cfa09fe2aedf43455c358fac4b39"
+      "entity_derived": "niiri:8c4cac3967178a072f8a1b26ec0be67c",
+      "entity": "niiri:9e172783feebd728c2f558fb3b71f8e1"
     },
     {
-      "@id": "niiri:c2d8054219b3febbb9aa86a9adfa49d7",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ab0a345a1b23456828ee0bd75b928ed7",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0090",
-      "prov:atLocation": {"@id": "niiri:2823c3c6bf54f87cd3a939971b785bae"},
+      "prov:atLocation": {"@id": "niiri:f4174578f5d208031a34b2194cf74ee8"},
       "prov:value": {"@type": "xsd:float", "@value": "3.07387399673462"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "2.99603266917277"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00136758564431361"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0261754700848395"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "2.99603266917277"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00136758564431361"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0261754700848395"}
     },
     {
-      "@id": "niiri:2823c3c6bf54f87cd3a939971b785bae",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f4174578f5d208031a34b2194cf74ee8",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0090",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[12,-18,52]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[12,-18,52]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c2d8054219b3febbb9aa86a9adfa49d7",
-      "entity": "niiri:bad70ba4fd8b4b695b72a83782c3e5f8"
+      "entity_derived": "niiri:ab0a345a1b23456828ee0bd75b928ed7",
+      "entity": "niiri:87ab73f90e90a5729c135961d1e370c8"
     },
     {
-      "@id": "niiri:b88cf1d5dd5ae08c0319548d360d84a8",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ebb12b1fa798252b807914310e351b35",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0091",
-      "prov:atLocation": {"@id": "niiri:070b5066c48b85a3d5857d0d72cec0da"},
+      "prov:atLocation": {"@id": "niiri:92b403d3f268a73ca193179c615086a4"},
       "prov:value": {"@type": "xsd:float", "@value": "3.05714297294617"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "2.98046014668547"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00143907843047086"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0271009625306751"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "2.98046014668547"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00143907843047086"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0271009625306751"}
     },
     {
-      "@id": "niiri:070b5066c48b85a3d5857d0d72cec0da",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:92b403d3f268a73ca193179c615086a4",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0091",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-56,24,22]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-56,24,22]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b88cf1d5dd5ae08c0319548d360d84a8",
-      "entity": "niiri:c6c17361069913b5f4191614f68492f3"
+      "entity_derived": "niiri:ebb12b1fa798252b807914310e351b35",
+      "entity": "niiri:837d4c2c41156c19f0fd118f410295ff"
     },
     {
-      "@id": "niiri:24336c500788d29d7135149ec2ce779c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:15d51008205872b18f614dedb8a4130b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0092",
-      "prov:atLocation": {"@id": "niiri:aad694a8670c6c69676fa756e98e6d45"},
+      "prov:atLocation": {"@id": "niiri:108fca12dc3621c31e0a6e7c66e5b2fd"},
       "prov:value": {"@type": "xsd:float", "@value": "3.05520439147949"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "2.97865512160875"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00144758220776409"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0272166039833409"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "2.97865512160875"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00144758220776409"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0272166039833409"}
     },
     {
-      "@id": "niiri:aad694a8670c6c69676fa756e98e6d45",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:108fca12dc3621c31e0a6e7c66e5b2fd",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0092",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[10,-8,6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[10,-8,6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:24336c500788d29d7135149ec2ce779c",
-      "entity": "niiri:c2a152f43ee2d844f898782fd1ef7ec0"
+      "entity_derived": "niiri:15d51008205872b18f614dedb8a4130b",
+      "entity": "niiri:045f09754798eebc086b923539ec80df"
     },
     {
-      "@id": "niiri:5eda93480ee3ffd1f381662199329769",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:6bfcfb8a7a78ca0a953b28b7ac785df9",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0093",
-      "prov:atLocation": {"@id": "niiri:3f16fdba575165258782a0b2a8c4a04a"},
+      "prov:atLocation": {"@id": "niiri:c09564cb0de3a7ac00f96ddeb6277f3c"},
       "prov:value": {"@type": "xsd:float", "@value": "3.04858613014221"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "2.97249176352455"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00147696567841604"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0275869018911531"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "2.97249176352455"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00147696567841604"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0275869018911531"}
     },
     {
-      "@id": "niiri:3f16fdba575165258782a0b2a8c4a04a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c09564cb0de3a7ac00f96ddeb6277f3c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0093",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[18,-58,32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[18,-58,32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5eda93480ee3ffd1f381662199329769",
-      "entity": "niiri:f1fa812573c26840167e9f2bd0ba2bfa"
+      "entity_derived": "niiri:6bfcfb8a7a78ca0a953b28b7ac785df9",
+      "entity": "niiri:80792993798dbd9f1e93a2b1f460edb7"
     },
     {
-      "@id": "niiri:a63b917b1a1ae6fbef2664bd8c8b0fb8",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ca809001af3d981e8831371d40cadda0",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0094",
-      "prov:atLocation": {"@id": "niiri:5f96f054d0f84bd356e6cdcca98e31ed"},
+      "prov:atLocation": {"@id": "niiri:7b18ac5074edd48ca6bda1186dbd2889"},
       "prov:value": {"@type": "xsd:float", "@value": "3.04525375366211"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "2.96938782009723"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00149196870031498"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0277581737585471"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "2.96938782009723"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00149196870031498"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0277581737585471"}
     },
     {
-      "@id": "niiri:5f96f054d0f84bd356e6cdcca98e31ed",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7b18ac5074edd48ca6bda1186dbd2889",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0094",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-28,-30,-38]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-28,-30,-38]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a63b917b1a1ae6fbef2664bd8c8b0fb8",
-      "entity": "niiri:331525e1b9d0bddf9506ab65a075cd86"
+      "entity_derived": "niiri:ca809001af3d981e8831371d40cadda0",
+      "entity": "niiri:90698016a8817129b734a925244ac3ee"
     },
     {
-      "@id": "niiri:0b42837168fde7814f8c5a64deb11d3f",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a6ab7750f7aec3f30041a2426c3c5488",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0095",
-      "prov:atLocation": {"@id": "niiri:eb2fbec15720b44b016e45ba73a42d42"},
+      "prov:atLocation": {"@id": "niiri:d3c074a7ae3a7616d683ca666602e6ce"},
       "prov:value": {"@type": "xsd:float", "@value": "3.03322005271912"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "2.95817559801864"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00154732890171205"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.028466280131439"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "2.95817559801864"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00154732890171205"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.028466280131439"}
     },
     {
-      "@id": "niiri:eb2fbec15720b44b016e45ba73a42d42",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d3c074a7ae3a7616d683ca666602e6ce",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0095",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[36,-58,38]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[36,-58,38]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0b42837168fde7814f8c5a64deb11d3f",
-      "entity": "niiri:ea97b40b5a9be7fc9f6d62d9b525b485"
+      "entity_derived": "niiri:a6ab7750f7aec3f30041a2426c3c5488",
+      "entity": "niiri:e884b18d0db747fcf84bd707ac9dd705"
     },
     {
-      "@id": "niiri:16cee8864e76cc07a63dcee5f8aa6c2a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:571af20b9fc7a3650f23e4883c4c0db7",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0096",
-      "prov:atLocation": {"@id": "niiri:34344ef5b3db05662af8bcf023a86389"},
+      "prov:atLocation": {"@id": "niiri:7c59844a04f86ceb0022ff5eedfb7507"},
       "prov:value": {"@type": "xsd:float", "@value": "3.02379393577576"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "2.94938921855853"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00159201350826743"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0290329815576138"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "2.94938921855853"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00159201350826743"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0290329815576138"}
     },
     {
-      "@id": "niiri:34344ef5b3db05662af8bcf023a86389",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7c59844a04f86ceb0022ff5eedfb7507",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0096",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[24,-64,-18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[24,-64,-18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:16cee8864e76cc07a63dcee5f8aa6c2a",
-      "entity": "niiri:1f3fb8e24c66864d879d2bc4e5971b17"
+      "entity_derived": "niiri:571af20b9fc7a3650f23e4883c4c0db7",
+      "entity": "niiri:2a3d19c51223db94f710da6fc4488efe"
     },
     {
-      "@id": "niiri:e624eb747155287eb697b51a461070b3",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:4109cffc49a21d458e8e3c4ec5bdec4b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0097",
-      "prov:atLocation": {"@id": "niiri:e66a73153861b4febee91591f53eaf66"},
+      "prov:atLocation": {"@id": "niiri:ecb3f8e0de95691c6a806b7b47dda58b"},
       "prov:value": {"@type": "xsd:float", "@value": "2.99292635917664"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "2.92059379223963"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00174682509072199"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0308676807763691"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "2.92059379223963"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00174682509072199"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0308676807763691"}
     },
     {
-      "@id": "niiri:e66a73153861b4febee91591f53eaf66",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ecb3f8e0de95691c6a806b7b47dda58b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0097",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[30,60,14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[30,60,14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e624eb747155287eb697b51a461070b3",
-      "entity": "niiri:cd925f60fb17823aac5c3473215f8d7e"
+      "entity_derived": "niiri:4109cffc49a21d458e8e3c4ec5bdec4b",
+      "entity": "niiri:525402486d0c3b5a8a9cc4d79a236330"
     },
     {
-      "@id": "niiri:a0ef595858724a33f32362e63fbd332e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e75d8bde52802e14e982fc7e310fa7e5",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0098",
-      "prov:atLocation": {"@id": "niiri:3abd4563bba5f10ac07ee46d7219ca37"},
+      "prov:atLocation": {"@id": "niiri:dae318474344710c6bb95c6d28a6cecb"},
       "prov:value": {"@type": "xsd:float", "@value": "2.97051525115967"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "2.89966547896516"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0018678055138297"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0323068383068969"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "2.89966547896516"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0018678055138297"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0323068383068969"}
     },
     {
-      "@id": "niiri:3abd4563bba5f10ac07ee46d7219ca37",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:dae318474344710c6bb95c6d28a6cecb",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0098",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-32,14,60]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-32,14,60]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a0ef595858724a33f32362e63fbd332e",
-      "entity": "niiri:9837099ef2efab920d421b33789218c3"
+      "entity_derived": "niiri:e75d8bde52802e14e982fc7e310fa7e5",
+      "entity": "niiri:4c1d2eaf37081d773b0db5e10c96074d"
     },
     {
-      "@id": "niiri:78b4e8e4ff89e57dcf9115aa9eb7d563",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:896ea228d6022d6a6fbe18f3fecced44",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0099",
-      "prov:atLocation": {"@id": "niiri:c460a7939ca8b3dd9eb5244f7019efd2"},
+      "prov:atLocation": {"@id": "niiri:f41e73664c8531f0cd9110ce8757bc4f"},
       "prov:value": {"@type": "xsd:float", "@value": "2.96238708496094"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "2.89207063814041"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00191355944745719"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.032831917036533"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "2.89207063814041"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00191355944745719"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.032831917036533"}
     },
     {
-      "@id": "niiri:c460a7939ca8b3dd9eb5244f7019efd2",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f41e73664c8531f0cd9110ce8757bc4f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0099",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-14,4,16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-14,4,16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:78b4e8e4ff89e57dcf9115aa9eb7d563",
-      "entity": "niiri:2165a25b8a630ef2f40a0401a9a3c680"
+      "entity_derived": "niiri:896ea228d6022d6a6fbe18f3fecced44",
+      "entity": "niiri:91b4c6608ce19710d67c33b2473fc9b4"
     },
     {
-      "@id": "niiri:a947d0e8f90dae8f7bb20b5e34e40ae8",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3b2dfa543dfff0705b80fb76652786b5",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0100",
-      "prov:atLocation": {"@id": "niiri:79829744c7182a80a5c5eab5c5427cfb"},
+      "prov:atLocation": {"@id": "niiri:559860f351aed5f67953b4429dea3d47"},
       "prov:value": {"@type": "xsd:float", "@value": "2.94971632957458"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "2.88022656424043"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00198694744230488"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0336756816327342"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "2.88022656424043"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00198694744230488"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0336756816327342"}
     },
     {
-      "@id": "niiri:79829744c7182a80a5c5eab5c5427cfb",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:559860f351aed5f67953b4429dea3d47",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0100",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-64,-24,46]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-64,-24,46]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a947d0e8f90dae8f7bb20b5e34e40ae8",
-      "entity": "niiri:4d83aeb570cac876251d053c07bf2d8e"
+      "entity_derived": "niiri:3b2dfa543dfff0705b80fb76652786b5",
+      "entity": "niiri:9caa103a34dc60ce70ec535ac6e8b007"
     },
     {
-      "@id": "niiri:15e23a118461c4bd677bc57965e15f92",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:782068672fbbe3620c5f41b2464beaeb",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0101",
-      "prov:atLocation": {"@id": "niiri:41db5a2935f74a5e15c37dcd6f3713e5"},
+      "prov:atLocation": {"@id": "niiri:042b46248a6389f83c7d559692df2f65"},
       "prov:value": {"@type": "xsd:float", "@value": "2.94846987724304"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "2.8790611260641"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00199430508764054"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0337569462213811"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "2.8790611260641"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00199430508764054"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0337569462213811"}
     },
     {
-      "@id": "niiri:41db5a2935f74a5e15c37dcd6f3713e5",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:042b46248a6389f83c7d559692df2f65",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0101",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[50,-40,-40]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[50,-40,-40]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:15e23a118461c4bd677bc57965e15f92",
-      "entity": "niiri:77a467097c18360546951b54cfc345c7"
+      "entity_derived": "niiri:782068672fbbe3620c5f41b2464beaeb",
+      "entity": "niiri:b860ec229f39bc9a1fbaafbcbf0a163f"
     },
     {
-      "@id": "niiri:abe7866bfffea9a244a1a8a6a34e0b14",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:325f64d356f613a0e0206309a641ecc0",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0102",
-      "prov:atLocation": {"@id": "niiri:1a2fdadb421ad94403de451225e07b04"},
+      "prov:atLocation": {"@id": "niiri:267e0e982d25b38ad72635cd9afe6ff2"},
       "prov:value": {"@type": "xsd:float", "@value": "2.90027952194214"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "2.83396102798879"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00229874692151077"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.037104578234211"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "2.83396102798879"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00229874692151077"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.037104578234211"}
     },
     {
-      "@id": "niiri:1a2fdadb421ad94403de451225e07b04",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:267e0e982d25b38ad72635cd9afe6ff2",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0102",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-30,22,52]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-30,22,52]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:abe7866bfffea9a244a1a8a6a34e0b14",
-      "entity": "niiri:cd7ab160dc57440bc4255ac3aa507dd7"
+      "entity_derived": "niiri:325f64d356f613a0e0206309a641ecc0",
+      "entity": "niiri:236f07396a3abe7464d0d6adae038d7d"
     },
     {
-      "@id": "niiri:23a933359f3bf83e996f41218570cf09",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:adfb5705362a8f1bdf0b807bde3dda91",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0103",
-      "prov:atLocation": {"@id": "niiri:544e50ae5ef3cd7827b8b0ddd2e75d26"},
+      "prov:atLocation": {"@id": "niiri:e29b1f0adc5419735354b19bd6a5f50b"},
       "prov:value": {"@type": "xsd:float", "@value": "2.89968776702881"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "2.83340671662386"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0023027373793546"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0371395343086566"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "2.83340671662386"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0023027373793546"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0371395343086566"}
     },
     {
-      "@id": "niiri:544e50ae5ef3cd7827b8b0ddd2e75d26",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e29b1f0adc5419735354b19bd6a5f50b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0103",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[8,-2,28]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[8,-2,28]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:23a933359f3bf83e996f41218570cf09",
-      "entity": "niiri:601da24f17e65f186bb79a9adc3e0bf6"
+      "entity_derived": "niiri:adfb5705362a8f1bdf0b807bde3dda91",
+      "entity": "niiri:d3ccad413c80f4d335ba3f4f6b6355af"
     },
     {
-      "@id": "niiri:7dbcf394d601ef9492f168f1c6806963",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a1698f36e3e1c0e83de4c62180a03384",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0104",
-      "prov:atLocation": {"@id": "niiri:75c41b43cc5a02b2b917412af36efbe0"},
+      "prov:atLocation": {"@id": "niiri:faf116993450ab1d40f10c0ea345a2e4"},
       "prov:value": {"@type": "xsd:float", "@value": "2.88594245910645"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "2.82052775201409"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00239723631051436"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0381801662649124"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "2.82052775201409"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00239723631051436"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0381801662649124"}
     },
     {
-      "@id": "niiri:75c41b43cc5a02b2b917412af36efbe0",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:faf116993450ab1d40f10c0ea345a2e4",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0104",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[14,-22,76]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[14,-22,76]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7dbcf394d601ef9492f168f1c6806963",
-      "entity": "niiri:6c59d25b5ac6fc02466875dc30d6cca4"
+      "entity_derived": "niiri:a1698f36e3e1c0e83de4c62180a03384",
+      "entity": "niiri:485d5921cf99fd18e2d2bc08962f1a89"
     },
     {
-      "@id": "niiri:deead949c1d304329e94df18762c2044",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:174c45a8d1e67a22fc26e791cf355a46",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0105",
-      "prov:atLocation": {"@id": "niiri:80c4f94fa7c2f79d659534c9112c703e"},
+      "prov:atLocation": {"@id": "niiri:8ddea03b043d98f6868e7d29c28b4ad5"},
       "prov:value": {"@type": "xsd:float", "@value": "2.88162541389465"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "2.81648146341917"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00242764223383896"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0385303778515655"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "2.81648146341917"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00242764223383896"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0385303778515655"}
     },
     {
-      "@id": "niiri:80c4f94fa7c2f79d659534c9112c703e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:8ddea03b043d98f6868e7d29c28b4ad5",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0105",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[32,-80,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[32,-80,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:deead949c1d304329e94df18762c2044",
-      "entity": "niiri:8d1a9f520760b76668ce56986561c536"
+      "entity_derived": "niiri:174c45a8d1e67a22fc26e791cf355a46",
+      "entity": "niiri:fafeba66cc92ac8083e5897d50f4bcab"
     },
     {
-      "@id": "niiri:246faa64a391753c92d9b7f37263f17b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d3666814839586295a138503c43b05cb",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0106",
-      "prov:atLocation": {"@id": "niiri:53ae8662ffa161ea38385eb6e1b86aa0"},
+      "prov:atLocation": {"@id": "niiri:700ca7e9988e82bcf89e1f9f7c4c125d"},
       "prov:value": {"@type": "xsd:float", "@value": "2.86741852760315"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "2.80316111290485"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00253021914439433"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0396560213914501"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "2.80316111290485"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00253021914439433"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0396560213914501"}
     },
     {
-      "@id": "niiri:53ae8662ffa161ea38385eb6e1b86aa0",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:700ca7e9988e82bcf89e1f9f7c4c125d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0106",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-22,4,8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-22,4,8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:246faa64a391753c92d9b7f37263f17b",
-      "entity": "niiri:9de0c2e42252737a8379e3e037d6d2aa"
+      "entity_derived": "niiri:d3666814839586295a138503c43b05cb",
+      "entity": "niiri:48a7f6254e1629604bc57865dff4d670"
     },
     {
-      "@id": "niiri:a6c9989bafc9174c51c423a27ac47b43",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:132f6eb140d7fc16eceeb304478171c2",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0107",
-      "prov:atLocation": {"@id": "niiri:824048bb1298f70821a5b93b00ff2faf"},
+      "prov:atLocation": {"@id": "niiri:9232cc449e5a68b19d9882c1045a5e8e"},
       "prov:value": {"@type": "xsd:float", "@value": "2.86433458328247"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "2.80026870598453"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00255300420116833"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0399071683618212"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "2.80026870598453"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00255300420116833"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0399071683618212"}
     },
     {
-      "@id": "niiri:824048bb1298f70821a5b93b00ff2faf",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:9232cc449e5a68b19d9882c1045a5e8e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0107",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-22,-88,-8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-22,-88,-8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a6c9989bafc9174c51c423a27ac47b43",
-      "entity": "niiri:ac17f6aed0c480752633af7157a50790"
+      "entity_derived": "niiri:132f6eb140d7fc16eceeb304478171c2",
+      "entity": "niiri:33e63ed9d657f0ba23cd9ffacda3e22d"
     },
     {
-      "@id": "niiri:1a49d43c3b450637f9f89f751c8f650b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c44f1d9e91a6e9fe1b09cd64614d61c2",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0108",
-      "prov:atLocation": {"@id": "niiri:43bc0dc3855d4a2b58dddfc7f9ab43fa"},
+      "prov:atLocation": {"@id": "niiri:9b89beb9deba464fb2b8daf018f2b058"},
       "prov:value": {"@type": "xsd:float", "@value": "2.8607702255249"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "2.7969253219898"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00257957281985488"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0402133860761281"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "2.7969253219898"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00257957281985488"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0402133860761281"}
     },
     {
-      "@id": "niiri:43bc0dc3855d4a2b58dddfc7f9ab43fa",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:9b89beb9deba464fb2b8daf018f2b058",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0108",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-40,12,10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-40,12,10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1a49d43c3b450637f9f89f751c8f650b",
-      "entity": "niiri:09df787a9447add50b251d7691bf2f9c"
+      "entity_derived": "niiri:c44f1d9e91a6e9fe1b09cd64614d61c2",
+      "entity": "niiri:768ca0ef2b170d430ebbd40ebb08cff0"
     },
     {
-      "@id": "niiri:e0b304712e9a3529ed451336ad288be3",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:53fd4410e0451ea937aa0616970eb8c1",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0109",
-      "prov:atLocation": {"@id": "niiri:9d6a02811a4473156dd2f200d3c8edcf"},
+      "prov:atLocation": {"@id": "niiri:97d461a41363cb6f676aa66096ab6def"},
       "prov:value": {"@type": "xsd:float", "@value": "2.84392619132996"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "2.78111974914723"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00270858754422498"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.041614329014815"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "2.78111974914723"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00270858754422498"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.041614329014815"}
     },
     {
-      "@id": "niiri:9d6a02811a4473156dd2f200d3c8edcf",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:97d461a41363cb6f676aa66096ab6def",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0109",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[14,-8,36]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[14,-8,36]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e0b304712e9a3529ed451336ad288be3",
-      "entity": "niiri:5df3810b9f8634e5eabf4cf013d6d516"
+      "entity_derived": "niiri:53fd4410e0451ea937aa0616970eb8c1",
+      "entity": "niiri:8cf8073a323eec04d3968fab10115c2b"
     },
     {
-      "@id": "niiri:9e4ce06ce9275316cf95c584d5bdcfa7",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3469a97617a1acc2f9fa828b99843678",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0110",
-      "prov:atLocation": {"@id": "niiri:02d1c6218be7e54215c6f38722de782e"},
+      "prov:atLocation": {"@id": "niiri:cb7e1ce722f6758ac5d4c15d377d77c2"},
       "prov:value": {"@type": "xsd:float", "@value": "2.84026050567627"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "2.77767879851976"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00273743545807803"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0419349799473709"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "2.77767879851976"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00273743545807803"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0419349799473709"}
     },
     {
-      "@id": "niiri:02d1c6218be7e54215c6f38722de782e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:cb7e1ce722f6758ac5d4c15d377d77c2",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0110",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[46,-40,4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[46,-40,4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9e4ce06ce9275316cf95c584d5bdcfa7",
-      "entity": "niiri:819baf737aaaa45787693a764f07e7c8"
+      "entity_derived": "niiri:3469a97617a1acc2f9fa828b99843678",
+      "entity": "niiri:dba062dd06d4105f10d77f25b52b96c8"
     },
     {
-      "@id": "niiri:af111ed4f4f05f94afad771c95aa7e4a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:60c64006a9802f87bdbaffb4ec25a5b2",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0111",
-      "prov:atLocation": {"@id": "niiri:92e75fdcba81b94553228641fee3084e"},
+      "prov:atLocation": {"@id": "niiri:86ff68b3752b401bab1dea5b5679ac5b"},
       "prov:value": {"@type": "xsd:float", "@value": "2.81844663619995"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "2.75719305463653"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0029149959934297"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0437990036423837"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "2.75719305463653"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0029149959934297"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0437990036423837"}
     },
     {
-      "@id": "niiri:92e75fdcba81b94553228641fee3084e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:86ff68b3752b401bab1dea5b5679ac5b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0111",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[44,8,-20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[44,8,-20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:af111ed4f4f05f94afad771c95aa7e4a",
-      "entity": "niiri:509244d6a4f71a5ff685cfe8e8ad90b4"
+      "entity_derived": "niiri:60c64006a9802f87bdbaffb4ec25a5b2",
+      "entity": "niiri:c51b283e94df3fae6004dee4203f35fd"
     },
     {
-      "@id": "niiri:9c829d114bba7d125c53fe5e6a6299a5",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:918936eb1d58155c78c560ab565b0202",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0112",
-      "prov:atLocation": {"@id": "niiri:be71c9d285f364508d6586985794e585"},
+      "prov:atLocation": {"@id": "niiri:8acf1763afbbc2c95b172b9578d29d2b"},
       "prov:value": {"@type": "xsd:float", "@value": "2.7993757724762"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "2.73927048137962"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00307878458404665"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0454451203208682"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "2.73927048137962"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00307878458404665"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0454451203208682"}
     },
     {
-      "@id": "niiri:be71c9d285f364508d6586985794e585",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:8acf1763afbbc2c95b172b9578d29d2b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0112",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[14,-44,20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[14,-44,20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9c829d114bba7d125c53fe5e6a6299a5",
-      "entity": "niiri:085ae9e43b1853458f70bf9e0f5e48e8"
+      "entity_derived": "niiri:918936eb1d58155c78c560ab565b0202",
+      "entity": "niiri:c79437288e303b8f2bef9af3b70d4aaa"
     },
     {
-      "@id": "niiri:361f98cb67ddd27527b90f76c037d6ce",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:8d45ffd6ad4acc8edcfb248f110ba687",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0113",
-      "prov:atLocation": {"@id": "niiri:71974ded62751ae232fca3b32c2554fe"},
+      "prov:atLocation": {"@id": "niiri:f4e79acdb9c2e573b4d0b861b0156ed1"},
       "prov:value": {"@type": "xsd:float", "@value": "2.79517197608948"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "2.73531820941264"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0031159999373751"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0458305068946882"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "2.73531820941264"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0031159999373751"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0458305068946882"}
     },
     {
-      "@id": "niiri:71974ded62751ae232fca3b32c2554fe",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f4e79acdb9c2e573b4d0b861b0156ed1",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0113",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[18,-14,44]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[18,-14,44]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:361f98cb67ddd27527b90f76c037d6ce",
-      "entity": "niiri:1e6213ed8f4367c38bb8e3df7596c194"
+      "entity_derived": "niiri:8d45ffd6ad4acc8edcfb248f110ba687",
+      "entity": "niiri:049f42c8eb4f2db2320a43cbbdd89f0f"
     },
     {
-      "@id": "niiri:ec20b0d9199c3e3ab387ec81b20d59ee",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:8ad18c7eb09ca5a3aab852d344491753",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0114",
-      "prov:atLocation": {"@id": "niiri:5f4da0675fc3f811891772a1b6cbf07e"},
+      "prov:atLocation": {"@id": "niiri:ca5c06dc0433f9ffbb1a4ad5a02f8a10"},
       "prov:value": {"@type": "xsd:float", "@value": "2.79148125648499"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "2.73184784384814"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00314901097075382"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.046156489574122"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "2.73184784384814"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00314901097075382"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.046156489574122"}
     },
     {
-      "@id": "niiri:5f4da0675fc3f811891772a1b6cbf07e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ca5c06dc0433f9ffbb1a4ad5a02f8a10",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0114",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[12,-6,34]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[12,-6,34]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ec20b0d9199c3e3ab387ec81b20d59ee",
-      "entity": "niiri:2d1a3d2d688f08f62c34200978327796"
+      "entity_derived": "niiri:8ad18c7eb09ca5a3aab852d344491753",
+      "entity": "niiri:4e6c7a95cd372d482b4ef655fa46f083"
     },
     {
-      "@id": "niiri:c41cf17e60ba4c3b108cc72dec760b61",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:9c388cc5a4937ec66a020ba4a2721666",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0115",
-      "prov:atLocation": {"@id": "niiri:039aa682b41eef2065b68b5a591ef554"},
+      "prov:atLocation": {"@id": "niiri:7946fe79a1ae96f06dc46a97c7ed5fe7"},
       "prov:value": {"@type": "xsd:float", "@value": "2.78754210472107"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "2.72814339359783"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00318459572389584"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0465414965984294"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "2.72814339359783"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00318459572389584"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0465414965984294"}
     },
     {
-      "@id": "niiri:039aa682b41eef2065b68b5a591ef554",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7946fe79a1ae96f06dc46a97c7ed5fe7",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0115",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-32,-62,-26]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-32,-62,-26]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c41cf17e60ba4c3b108cc72dec760b61",
-      "entity": "niiri:74938e3d61efe7611ba39208c8bc71d5"
+      "entity_derived": "niiri:9c388cc5a4937ec66a020ba4a2721666",
+      "entity": "niiri:78623bac11315960aba0a8d855467f49"
     },
     {
-      "@id": "niiri:bc239621815371d0a52da345fed7a4bf",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:baa76c8f2997dbaae3d90e25b8c4bfd8",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0116",
-      "prov:atLocation": {"@id": "niiri:ec381c235d39daa708455297f4e8f059"},
+      "prov:atLocation": {"@id": "niiri:f864654c4d54b3c64735888e578355e6"},
       "prov:value": {"@type": "xsd:float", "@value": "2.77749013900757"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "2.71868808084123"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00327706910125547"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0474666807455127"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "2.71868808084123"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00327706910125547"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0474666807455127"}
     },
     {
-      "@id": "niiri:ec381c235d39daa708455297f4e8f059",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f864654c4d54b3c64735888e578355e6",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0116",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[64,-10,22]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[64,-10,22]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:bc239621815371d0a52da345fed7a4bf",
-      "entity": "niiri:3e17a6b5e2e157b57784ecb5f6ffcdc1"
+      "entity_derived": "niiri:baa76c8f2997dbaae3d90e25b8c4bfd8",
+      "entity": "niiri:288a1fc03510b55eff121de5bf93e1f4"
     },
     {
-      "@id": "niiri:94663f914ec0c8870e0c3a0f317faa23",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:34797ad5a5f0034f4a5cf71249cd89d8",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0117",
-      "prov:atLocation": {"@id": "niiri:df2928cf310bb64ff0b74246eb178ac5"},
+      "prov:atLocation": {"@id": "niiri:a9825b9be6fe20a5cb8645642659227e"},
       "prov:value": {"@type": "xsd:float", "@value": "2.76671266555786"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "2.70854673720236"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00337892965855868"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0484988413841496"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "2.70854673720236"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00337892965855868"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0484988413841496"}
     },
     {
-      "@id": "niiri:df2928cf310bb64ff0b74246eb178ac5",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a9825b9be6fe20a5cb8645642659227e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0117",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-22,-4,10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-22,-4,10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:94663f914ec0c8870e0c3a0f317faa23",
-      "entity": "niiri:1793e50c9d713624fbb8bba2d78ea464"
+      "entity_derived": "niiri:34797ad5a5f0034f4a5cf71249cd89d8",
+      "entity": "niiri:f6ffc917f79709af0e39207ec0add7a4"
     },
     {
-      "@id": "niiri:810315dd3aa706cef0a31470abd08eca",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c04ece7485734e358071d757deeef557",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0118",
-      "prov:atLocation": {"@id": "niiri:86a2289f298aa4930b6e4ffa308cad83"},
+      "prov:atLocation": {"@id": "niiri:d534f09e73fec2932a43da85804923c2"},
       "prov:value": {"@type": "xsd:float", "@value": "2.7631950378418"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "2.70523593531943"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00341279457967081"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0488594652816085"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "2.70523593531943"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00341279457967081"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0488594652816085"}
     },
     {
-      "@id": "niiri:86a2289f298aa4930b6e4ffa308cad83",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d534f09e73fec2932a43da85804923c2",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0118",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-42,-24,70]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-42,-24,70]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:810315dd3aa706cef0a31470abd08eca",
-      "entity": "niiri:8bfbe4bb02769474d9ccfb7795dcf200"
+      "entity_derived": "niiri:c04ece7485734e358071d757deeef557",
+      "entity": "niiri:bd77e4cd78d5c4dcb23a68309256720d"
     },
     {
-      "@id": "niiri:c601459b7fe03095577074d9d5ef04ba",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:115008c56fcea7d4c5a2ee78582283c7",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0119",
-      "prov:atLocation": {"@id": "niiri:c32ce4a4616c298e4abecf93cfbe78bd"},
+      "prov:atLocation": {"@id": "niiri:98a043770ac0d808800712f30d2fc24c"},
       "prov:value": {"@type": "xsd:float", "@value": "2.75206708908081"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "2.69475970396491"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00352197048666147"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0499801129190164"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "2.69475970396491"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00352197048666147"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0499801129190164"}
     },
     {
-      "@id": "niiri:c32ce4a4616c298e4abecf93cfbe78bd",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:98a043770ac0d808800712f30d2fc24c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0119",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-62,-20,46]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-62,-20,46]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c601459b7fe03095577074d9d5ef04ba",
-      "entity": "niiri:a6dbb6a94c7d5ef0b744a15cdc6d3ed6"
+      "entity_derived": "niiri:115008c56fcea7d4c5a2ee78582283c7",
+      "entity": "niiri:31f96dd2a2f7097e6993ae7eec0e23e6"
     }
   ]
 }

--- a/spmexport/ex_spm_thr_voxelfdrp05/nidm.ttl
+++ b/spmexport/ex_spm_thr_voxelfdrp05/nidm.ttl
@@ -4,7 +4,7 @@
 @prefix niiri: <http://iri.nidash.org/> .
 @prefix spm: <http://purl.org/nidash/spm#> .
 @prefix neurolex: <http://neurolex.org/wiki/> .
-@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#> .
+@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
@@ -17,27 +17,27 @@
 @prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-niiri:ffe3fa4336d45524c3958e75da8803ae
+niiri:28ec28bc6b4f22ae6ce0d4910cd21172
   a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
   rdfs:label "NIDM-Results" ;
   nidm_version: "1.3.0"^^xsd:string .
 
-niiri:e6ef299886e9d54a66ffdfc8dea1c309
+niiri:c3049f06eafd15e1a9333df90c4a3baf
   a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
   rdfs:label "spm_results_nidm" ;
-  nidm_softwareVersion: "12.6903"^^xsd:string .
+  nidm_softwareVersion: "12.7057"^^xsd:string .
 
-niiri:dcf0770f9087d27e7cb8f73270781e1d
+niiri:1ab4e92c05dcd58443cc9cec8e73ba67
   a prov:Activity, nidm_NIDMResultsExport: ; 
   rdfs:label "NIDM-Results export" .
 
-niiri:dcf0770f9087d27e7cb8f73270781e1d prov:wasAssociatedWith niiri:e6ef299886e9d54a66ffdfc8dea1c309 .
+niiri:1ab4e92c05dcd58443cc9cec8e73ba67 prov:wasAssociatedWith niiri:c3049f06eafd15e1a9333df90c4a3baf .
 
 _:blank5 a prov:Generation .
 
-niiri:ffe3fa4336d45524c3958e75da8803ae prov:qualifiedGeneration _:blank5 .
+niiri:28ec28bc6b4f22ae6ce0d4910cd21172 prov:qualifiedGeneration _:blank5 .
 
-_:blank5 prov:atTime "2016-12-07T16:09:54"^^xsd:dateTime .
+_:blank5 prov:atTime "2017-04-19T12:19:14"^^xsd:dateTime .
 
 @prefix nidm_Ixi549CoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000050> .
 @prefix src_SPM: <http://scicrunch.org/resolver/SCR_007037> .
@@ -142,12 +142,12 @@ _:blank5 prov:atTime "2016-12-07T16:09:54"^^xsd:dateTime .
 @prefix nidm_Coordinate: <http://purl.org/nidash/nidm#NIDM_0000015> .
 @prefix nidm_coordinateVector: <http://purl.org/nidash/nidm#NIDM_0000086> .
 
-niiri:64730f8ca3829b6ba8ce02b85a004bb2
+niiri:6a56b7cc41090f34638cf50938e932eb
     a prov:Agent, src_SPM:, prov:SoftwareAgent ; 
     rdfs:label "SPM" ;
-    nidm_softwareVersion: "12.12.2"^^xsd:string .
+    nidm_softwareVersion: "12.6906"^^xsd:string .
 
-niiri:57bfb1702d234ee28692b281b4b06077
+niiri:4d80c0cd6d8f06cc5fa8312aea1fdf66
     a prov:Entity, nidm_CoordinateSpace: ; 
     rdfs:label "Coordinate space 1" ;
     nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
@@ -157,48 +157,48 @@ niiri:57bfb1702d234ee28692b281b4b06077
     nidm_numberOfDimensions: "3"^^xsd:int ;
     nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
 
-niiri:bce9b8acbff4fdaf027940f6885d0153
+niiri:c8fcc3ae56b4269cf1aaf34f24d3c6a1
     a prov:Agent, nlx_Imaginginstrument:, nlx_Magneticresonanceimagingscanner: ; 
     rdfs:label "MRI Scanner" .
 
-niiri:554695cbbe6e60d18f5c8a5a92b96b76
+niiri:665c960b6edd432a6d053af0f35e8752
     a prov:Agent, prov:Person ; 
     rdfs:label "Person" .
 
-niiri:e56d7b7be8d4dfcf0f1a64ac4d82a0c6
+niiri:65f5e0c3410f30b555aa41ff7e65f3d4
     a prov:Entity, prov:Collection, nidm_Data: ; 
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "true"^^xsd:boolean ;
     nidm_targetIntensity: "100"^^xsd:float ;
     nidm_hasMRIProtocol: nlx_FunctionalMRIprotocol: .
 
-niiri:e56d7b7be8d4dfcf0f1a64ac4d82a0c6 prov:wasAttributedTo niiri:bce9b8acbff4fdaf027940f6885d0153 .
+niiri:65f5e0c3410f30b555aa41ff7e65f3d4 prov:wasAttributedTo niiri:c8fcc3ae56b4269cf1aaf34f24d3c6a1 .
 
-niiri:e56d7b7be8d4dfcf0f1a64ac4d82a0c6 prov:wasAttributedTo niiri:554695cbbe6e60d18f5c8a5a92b96b76 .
+niiri:65f5e0c3410f30b555aa41ff7e65f3d4 prov:wasAttributedTo niiri:665c960b6edd432a6d053af0f35e8752 .
 
-niiri:12d258f0ceb4375887e5079dfb41cf17
+niiri:c7263de1e5c4d82e12588d8073c95d36
     a prov:Entity, spm_DCTDriftModel: ; 
     rdfs:label "SPM's DCT Drift Model" ;
     spm_SPMsDriftCutoffPeriod: "128"^^xsd:float .
 
-niiri:4414db3adc555942a3b666595c0251ef
+niiri:d114849d6b0dd611879e4e55b5de49c6
     a prov:Entity, nidm_DesignMatrix: ; 
     prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.csv"^^xsd:string ;
     dct:format "text/csv"^^xsd:string ;
-    dc:description niiri:3dc0ef417b545a12ae8d2d5b1d2f7479 ;
+    dc:description niiri:b5263ea4cabd52688f9ff17b32558902 ;
     rdfs:label "Design Matrix" ;
     nidm_regressorNames: "[\"Sn(1) to*bf(1)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) constant\"]"^^xsd:string ;
-    nidm_hasDriftModel: niiri:12d258f0ceb4375887e5079dfb41cf17 ;
+    nidm_hasDriftModel: niiri:c7263de1e5c4d82e12588d8073c95d36 ;
     nidm_hasHRFBasis: spm_SPMsCanonicalHRF: .
 
-niiri:3dc0ef417b545a12ae8d2d5b1d2f7479
+niiri:b5263ea4cabd52688f9ff17b32558902
     a prov:Entity, dctype:Image ; 
     prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:2dccedc0100cc2fe382a25cfa636a2b2
+niiri:c2b879875530eeeb341e109f646bd0bb
     a prov:Entity, nidm_ErrorModel: ; 
     nidm_hasErrorDistribution: obo_normaldistribution: ;
     nidm_hasErrorDependence: obo_Toeplitzcovariancestructure: ;
@@ -206,174 +206,174 @@ niiri:2dccedc0100cc2fe382a25cfa636a2b2
     nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
     nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
 
-niiri:daf9afd25368f73876302d229d3b2e17
+niiri:07b5d61a16905b058dc07a10451e4f4f
     a prov:Activity, nidm_ModelParametersEstimation: ; 
     rdfs:label "Model parameters estimation" ;
     nidm_withEstimationMethod: obo_generalizedleastsquaresestimation: .
 
-niiri:daf9afd25368f73876302d229d3b2e17 prov:wasAssociatedWith niiri:64730f8ca3829b6ba8ce02b85a004bb2 .
+niiri:07b5d61a16905b058dc07a10451e4f4f prov:wasAssociatedWith niiri:6a56b7cc41090f34638cf50938e932eb .
 
-niiri:daf9afd25368f73876302d229d3b2e17 prov:used niiri:4414db3adc555942a3b666595c0251ef .
+niiri:07b5d61a16905b058dc07a10451e4f4f prov:used niiri:d114849d6b0dd611879e4e55b5de49c6 .
 
-niiri:daf9afd25368f73876302d229d3b2e17 prov:used niiri:e56d7b7be8d4dfcf0f1a64ac4d82a0c6 .
+niiri:07b5d61a16905b058dc07a10451e4f4f prov:used niiri:65f5e0c3410f30b555aa41ff7e65f3d4 .
 
-niiri:daf9afd25368f73876302d229d3b2e17 prov:used niiri:2dccedc0100cc2fe382a25cfa636a2b2 .
+niiri:07b5d61a16905b058dc07a10451e4f4f prov:used niiri:c2b879875530eeeb341e109f646bd0bb .
 
-niiri:72aa1f9e4b18c0a5675eca75f20b7534
+niiri:3da9457cb4e9a27e6ca5714485d63d58
     a prov:Entity, nidm_MaskMap: ; 
     prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
     nidm_isUserDefined: "false"^^xsd:boolean ;
     nfo:fileName "Mask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Mask" ;
-    nidm_inCoordinateSpace: niiri:57bfb1702d234ee28692b281b4b06077 ;
+    nidm_inCoordinateSpace: niiri:4d80c0cd6d8f06cc5fa8312aea1fdf66 ;
     crypto:sha512 "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876"^^xsd:string .
 
-niiri:b048dd55e6f4cb3c3ef373506f2332a1
+niiri:dcc3a5e5bd34ab36eb3416ae867b7fb6
     a prov:Entity, nidm_MaskMap: ; 
     nfo:fileName "mask.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "36929e1f5f4143bd9cc818cd896a25f129961fab208c3a4438555f40444c08347b359142ee8c53ece6e8cca1627f49db0788a1fd3b9e2ecaef61999c6c6c67ac"^^xsd:string .
 
-niiri:72aa1f9e4b18c0a5675eca75f20b7534 prov:wasDerivedFrom niiri:b048dd55e6f4cb3c3ef373506f2332a1 .
+niiri:3da9457cb4e9a27e6ca5714485d63d58 prov:wasDerivedFrom niiri:dcc3a5e5bd34ab36eb3416ae867b7fb6 .
 
-niiri:72aa1f9e4b18c0a5675eca75f20b7534 prov:wasGeneratedBy niiri:daf9afd25368f73876302d229d3b2e17 .
+niiri:3da9457cb4e9a27e6ca5714485d63d58 prov:wasGeneratedBy niiri:07b5d61a16905b058dc07a10451e4f4f .
 
-niiri:73e4b66f6e606cf029ee0cc5455efb87
+niiri:aa66cc4786ebae74492d856291b12f31
     a prov:Entity, nidm_GrandMeanMap: ; 
     prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
     nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Grand Mean Map" ;
     nidm_maskedMedian: "111.557487487793"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:57bfb1702d234ee28692b281b4b06077 ;
+    nidm_inCoordinateSpace: niiri:4d80c0cd6d8f06cc5fa8312aea1fdf66 ;
     crypto:sha512 "512157cc6bff89d9343a09b4068226eb3edd64a8cbcee861f06231767fae6f8d4819921182adebee083a9bf309afd65529ab04a92f0aa6b0038c8098550f6124"^^xsd:string .
 
-niiri:73e4b66f6e606cf029ee0cc5455efb87 prov:wasGeneratedBy niiri:daf9afd25368f73876302d229d3b2e17 .
+niiri:aa66cc4786ebae74492d856291b12f31 prov:wasGeneratedBy niiri:07b5d61a16905b058dc07a10451e4f4f .
 
-niiri:552da79a48d378687bacbdc1d379a41b
+niiri:b0a406128a699bce39d09638de7fbb11
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0001.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0001.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 1" ;
-    nidm_inCoordinateSpace: niiri:57bfb1702d234ee28692b281b4b06077 ;
+    nidm_inCoordinateSpace: niiri:4d80c0cd6d8f06cc5fa8312aea1fdf66 ;
     crypto:sha512 "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd"^^xsd:string .
 
-niiri:7e08a288b3960525ccc0a4ddb3dbe1dd
+niiri:5173be555c2ec5d890f39722a8ff9fad
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd"^^xsd:string .
 
-niiri:552da79a48d378687bacbdc1d379a41b prov:wasDerivedFrom niiri:7e08a288b3960525ccc0a4ddb3dbe1dd .
+niiri:b0a406128a699bce39d09638de7fbb11 prov:wasDerivedFrom niiri:5173be555c2ec5d890f39722a8ff9fad .
 
-niiri:552da79a48d378687bacbdc1d379a41b prov:wasGeneratedBy niiri:daf9afd25368f73876302d229d3b2e17 .
+niiri:b0a406128a699bce39d09638de7fbb11 prov:wasGeneratedBy niiri:07b5d61a16905b058dc07a10451e4f4f .
 
-niiri:26e7893496c9fff727b5d918177d86e4
+niiri:95009d167a825475f9da93813a5eff0d
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0002.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0002.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 2" ;
-    nidm_inCoordinateSpace: niiri:57bfb1702d234ee28692b281b4b06077 ;
+    nidm_inCoordinateSpace: niiri:4d80c0cd6d8f06cc5fa8312aea1fdf66 ;
     crypto:sha512 "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c"^^xsd:string .
 
-niiri:4c05c1e39bbef96392984c45ce2c41b3
+niiri:ec5d05a2244cdd38b1812f3fb5a35d09
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0002.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c"^^xsd:string .
 
-niiri:26e7893496c9fff727b5d918177d86e4 prov:wasDerivedFrom niiri:4c05c1e39bbef96392984c45ce2c41b3 .
+niiri:95009d167a825475f9da93813a5eff0d prov:wasDerivedFrom niiri:ec5d05a2244cdd38b1812f3fb5a35d09 .
 
-niiri:26e7893496c9fff727b5d918177d86e4 prov:wasGeneratedBy niiri:daf9afd25368f73876302d229d3b2e17 .
+niiri:95009d167a825475f9da93813a5eff0d prov:wasGeneratedBy niiri:07b5d61a16905b058dc07a10451e4f4f .
 
-niiri:f2ae10333ea3be73d8c5ba3182d14784
+niiri:89d2070b8724cba90b0701cbb65ee609
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0003.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0003.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 3" ;
-    nidm_inCoordinateSpace: niiri:57bfb1702d234ee28692b281b4b06077 ;
+    nidm_inCoordinateSpace: niiri:4d80c0cd6d8f06cc5fa8312aea1fdf66 ;
     crypto:sha512 "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373"^^xsd:string .
 
-niiri:5f7f60416300c4d1739648a380e0efa1
+niiri:e4b178e7dce758cde4b2d2404cae0b85
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0003.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373"^^xsd:string .
 
-niiri:f2ae10333ea3be73d8c5ba3182d14784 prov:wasDerivedFrom niiri:5f7f60416300c4d1739648a380e0efa1 .
+niiri:89d2070b8724cba90b0701cbb65ee609 prov:wasDerivedFrom niiri:e4b178e7dce758cde4b2d2404cae0b85 .
 
-niiri:f2ae10333ea3be73d8c5ba3182d14784 prov:wasGeneratedBy niiri:daf9afd25368f73876302d229d3b2e17 .
+niiri:89d2070b8724cba90b0701cbb65ee609 prov:wasGeneratedBy niiri:07b5d61a16905b058dc07a10451e4f4f .
 
-niiri:7cbefce0a8261b298fcf42f53fd1c81a
+niiri:7afdd6ab4e20f8072056e7ad109e1a28
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Residual Mean Squares Map" ;
-    nidm_inCoordinateSpace: niiri:57bfb1702d234ee28692b281b4b06077 ;
+    nidm_inCoordinateSpace: niiri:4d80c0cd6d8f06cc5fa8312aea1fdf66 ;
     crypto:sha512 "991abf563d795a43b1e2eef8643e57023f2e0b090b2031f05f839321fc0643df6f71d423486a1021519b6dc82f6b0f563e19f3fbd50cb16063bed54a0e192d3e"^^xsd:string .
 
-niiri:d6dbf548bd2b5c60c7cf5c695db846df
+niiri:bf71d9330aaa4b58789fc468b13d0fde
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     nfo:fileName "ResMS.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "40b28d03fcf9a2f60b11f10d7fb83bf3618b234fb5aedf09df644cb7cbb6aab8c9f468897c1078166d455a3d04a83f4e3bf762cfca0b4ea982d7a4e406849f18"^^xsd:string .
 
-niiri:7cbefce0a8261b298fcf42f53fd1c81a prov:wasDerivedFrom niiri:d6dbf548bd2b5c60c7cf5c695db846df .
+niiri:7afdd6ab4e20f8072056e7ad109e1a28 prov:wasDerivedFrom niiri:bf71d9330aaa4b58789fc468b13d0fde .
 
-niiri:7cbefce0a8261b298fcf42f53fd1c81a prov:wasGeneratedBy niiri:daf9afd25368f73876302d229d3b2e17 .
+niiri:7afdd6ab4e20f8072056e7ad109e1a28 prov:wasGeneratedBy niiri:07b5d61a16905b058dc07a10451e4f4f .
 
-niiri:3b5abc82d35d734e1136daa4a8b2777b
+niiri:3ae2261460b37724f66a583d13620d04
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Resels per Voxel Map" ;
-    nidm_inCoordinateSpace: niiri:57bfb1702d234ee28692b281b4b06077 ;
+    nidm_inCoordinateSpace: niiri:4d80c0cd6d8f06cc5fa8312aea1fdf66 ;
     crypto:sha512 "1a3f9216e145249ccc0b14b2bc337d6b38b81ad45e32768001fb22b35f0c2c0f3e2bce013b40c85f7dc0fc62723ac761ee7f7e1e6aff128a05f0ba7b8b8202a3"^^xsd:string .
 
-niiri:de39366efadc505b76370266639f498e
+niiri:754590eadc87f59168e42a5f669d8b83
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     nfo:fileName "RPV.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "4f76663162857f6b38b2a45a63b15a23b2ca8b338c283b69c1e71f2ea2f43797d045a733cd14e845be9c12f8b8f84d3931c599a08e8f6d77e99fab46ad87ab8f"^^xsd:string .
 
-niiri:3b5abc82d35d734e1136daa4a8b2777b prov:wasDerivedFrom niiri:de39366efadc505b76370266639f498e .
+niiri:3ae2261460b37724f66a583d13620d04 prov:wasDerivedFrom niiri:754590eadc87f59168e42a5f669d8b83 .
 
-niiri:3b5abc82d35d734e1136daa4a8b2777b prov:wasGeneratedBy niiri:daf9afd25368f73876302d229d3b2e17 .
+niiri:3ae2261460b37724f66a583d13620d04 prov:wasGeneratedBy niiri:07b5d61a16905b058dc07a10451e4f4f .
 
-niiri:5a41045d9499fd48e4c3d720cabedd8c
+niiri:f2151889cbe45b2a41ece1a31d4608ed
     a prov:Entity, obo_contrastweightmatrix: ; 
     nidm_statisticType: obo_tstatistic: ;
     nidm_contrastName: "tone counting vs baseline"^^xsd:string ;
     rdfs:label "Contrast: tone counting vs baseline" ;
     prov:value "[1, 0, 0]"^^xsd:string .
 
-niiri:4aaa1af6ebac931110e1c92a59a53a3e
+niiri:82fff8a2920d426af761ea65abc3f824
     a prov:Activity, nidm_ContrastEstimation: ; 
     rdfs:label "Contrast estimation" .
 
-niiri:4aaa1af6ebac931110e1c92a59a53a3e prov:wasAssociatedWith niiri:64730f8ca3829b6ba8ce02b85a004bb2 .
+niiri:82fff8a2920d426af761ea65abc3f824 prov:wasAssociatedWith niiri:6a56b7cc41090f34638cf50938e932eb .
 
-niiri:4aaa1af6ebac931110e1c92a59a53a3e prov:used niiri:72aa1f9e4b18c0a5675eca75f20b7534 .
+niiri:82fff8a2920d426af761ea65abc3f824 prov:used niiri:3da9457cb4e9a27e6ca5714485d63d58 .
 
-niiri:4aaa1af6ebac931110e1c92a59a53a3e prov:used niiri:7cbefce0a8261b298fcf42f53fd1c81a .
+niiri:82fff8a2920d426af761ea65abc3f824 prov:used niiri:7afdd6ab4e20f8072056e7ad109e1a28 .
 
-niiri:4aaa1af6ebac931110e1c92a59a53a3e prov:used niiri:4414db3adc555942a3b666595c0251ef .
+niiri:82fff8a2920d426af761ea65abc3f824 prov:used niiri:d114849d6b0dd611879e4e55b5de49c6 .
 
-niiri:4aaa1af6ebac931110e1c92a59a53a3e prov:used niiri:5a41045d9499fd48e4c3d720cabedd8c .
+niiri:82fff8a2920d426af761ea65abc3f824 prov:used niiri:f2151889cbe45b2a41ece1a31d4608ed .
 
-niiri:4aaa1af6ebac931110e1c92a59a53a3e prov:used niiri:552da79a48d378687bacbdc1d379a41b .
+niiri:82fff8a2920d426af761ea65abc3f824 prov:used niiri:b0a406128a699bce39d09638de7fbb11 .
 
-niiri:4aaa1af6ebac931110e1c92a59a53a3e prov:used niiri:26e7893496c9fff727b5d918177d86e4 .
+niiri:82fff8a2920d426af761ea65abc3f824 prov:used niiri:95009d167a825475f9da93813a5eff0d .
 
-niiri:4aaa1af6ebac931110e1c92a59a53a3e prov:used niiri:f2ae10333ea3be73d8c5ba3182d14784 .
+niiri:82fff8a2920d426af761ea65abc3f824 prov:used niiri:89d2070b8724cba90b0701cbb65ee609 .
 
-niiri:530d3569bc598c79d5ac70217715e117
+niiri:97a6f2d59ca3be4b5454a9ab78cdf8a3
     a prov:Entity, nidm_StatisticMap: ; 
     prov:atLocation "TStatistic.nii.gz"^^xsd:anyURI ;
     nfo:fileName "TStatistic.nii.gz"^^xsd:string ;
@@ -383,124 +383,124 @@ niiri:530d3569bc598c79d5ac70217715e117
     nidm_contrastName: "tone counting vs baseline"^^xsd:string ;
     nidm_errorDegreesOfFreedom: "97.9999999998522"^^xsd:float ;
     nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:57bfb1702d234ee28692b281b4b06077 ;
+    nidm_inCoordinateSpace: niiri:4d80c0cd6d8f06cc5fa8312aea1fdf66 ;
     crypto:sha512 "9e1714c2d86a050b38b4e10a4d2d23253a24c5e1d228ae16a9c3be8872739278505ac0729ecab54265a717e3a54f9f782d0ed72eea904e0d482a6072bb817bd4"^^xsd:string .
 
-niiri:b787aa7bea228b9f18af1fcf0912027e
+niiri:c5d3fd2966a03a48d06d8890367cdebf
     a prov:Entity, nidm_StatisticMap: ; 
     nfo:fileName "spmT_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "d288b1b0f117f64502555da13c5398dffa5bf5ff0b58951510e43d5388755bc185798802a92e98a07c7e313c6991066d2908f2a44aa5153ba23433da1335970f"^^xsd:string .
 
-niiri:530d3569bc598c79d5ac70217715e117 prov:wasDerivedFrom niiri:b787aa7bea228b9f18af1fcf0912027e .
+niiri:97a6f2d59ca3be4b5454a9ab78cdf8a3 prov:wasDerivedFrom niiri:c5d3fd2966a03a48d06d8890367cdebf .
 
-niiri:530d3569bc598c79d5ac70217715e117 prov:wasGeneratedBy niiri:4aaa1af6ebac931110e1c92a59a53a3e .
+niiri:97a6f2d59ca3be4b5454a9ab78cdf8a3 prov:wasGeneratedBy niiri:82fff8a2920d426af761ea65abc3f824 .
 
-niiri:081ecb89bf33cb4e58a9be8521156796
+niiri:ea0fc93e4d1d634046b0ddea1c061c4f
     a prov:Entity, nidm_ContrastMap: ; 
     prov:atLocation "Contrast.nii.gz"^^xsd:anyURI ;
     nfo:fileName "Contrast.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Map: tone counting vs baseline" ;
     nidm_contrastName: "tone counting vs baseline"^^xsd:string ;
-    nidm_inCoordinateSpace: niiri:57bfb1702d234ee28692b281b4b06077 ;
+    nidm_inCoordinateSpace: niiri:4d80c0cd6d8f06cc5fa8312aea1fdf66 ;
     crypto:sha512 "fc5e2ad175243ee496db98f9b2e1b235c4c3bae1a8d7122ce461c897b537e40c49dfee5d6cf20f71c6a2bb9b5f0760fcb4ecd8fe2e9428910ef3d60d8f3c56a9"^^xsd:string .
 
-niiri:91dd538639ff8e756ee312f740250812
+niiri:615aeb13ab7f18a00b6e56cef9a42324
     a prov:Entity, nidm_ContrastMap: ; 
     nfo:fileName "con_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "d4aa46b3603ba508578e39751262d528cf6d1ed2e722ec46f1cd8194c50591e46b229deb8cb4f72d1b7e0e2640f3e6604be7a335301c5c8357f453e5d0d4daf2"^^xsd:string .
 
-niiri:081ecb89bf33cb4e58a9be8521156796 prov:wasDerivedFrom niiri:91dd538639ff8e756ee312f740250812 .
+niiri:ea0fc93e4d1d634046b0ddea1c061c4f prov:wasDerivedFrom niiri:615aeb13ab7f18a00b6e56cef9a42324 .
 
-niiri:081ecb89bf33cb4e58a9be8521156796 prov:wasGeneratedBy niiri:4aaa1af6ebac931110e1c92a59a53a3e .
+niiri:ea0fc93e4d1d634046b0ddea1c061c4f prov:wasGeneratedBy niiri:82fff8a2920d426af761ea65abc3f824 .
 
-niiri:2f932cba6601f6d4b44a86a0a888a950
+niiri:9349eafbf1e1c6deb40a7bbb8393c611
     a prov:Entity, nidm_ContrastStandardErrorMap: ; 
     prov:atLocation "ContrastStandardError.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ContrastStandardError.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Standard Error Map" ;
-    nidm_inCoordinateSpace: niiri:57bfb1702d234ee28692b281b4b06077 ;
+    nidm_inCoordinateSpace: niiri:4d80c0cd6d8f06cc5fa8312aea1fdf66 ;
     crypto:sha512 "791d48f5d1adb15079a5289271ce0c4b95c56d69bfdb3e5d41b0d24eb538d3075e1cdd15502494b5a5a18c16eaa2153cb4847a996043fa48cdaf26e938a2576d"^^xsd:string .
 
-niiri:2f932cba6601f6d4b44a86a0a888a950 prov:wasGeneratedBy niiri:4aaa1af6ebac931110e1c92a59a53a3e .
+niiri:9349eafbf1e1c6deb40a7bbb8393c611 prov:wasGeneratedBy niiri:82fff8a2920d426af761ea65abc3f824 .
 
-niiri:a523bb37afa0a13617991b5286230c4b
+niiri:614f1836a4dabc08f6a40b74d83e4626
     a prov:Entity, nidm_HeightThreshold:, obo_qvalue: ; 
-    rdfs:label "Height Threshold: p<0.05 (FDR)" ;
+    rdfs:label ":Height Threshold: p<0.05 (FDR)" ;
     prov:value "0.05"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:2eee45a8bb26d99eb05e525c350fb1c4 ;
-    nidm_equivalentThreshold: niiri:67d13ef3bcf3b394d767df4c8be23715 .
+    nidm_equivalentThreshold: niiri:4ca33fc892cbd22caafe7e43289ea67c ;
+    nidm_equivalentThreshold: niiri:351f1c49ad3573062df361946a82808a .
 
-niiri:2eee45a8bb26d99eb05e525c350fb1c4
+niiri:4ca33fc892cbd22caafe7e43289ea67c
     a prov:Entity, nidm_HeightThreshold:, obo_statistic: ; 
-    rdfs:label "Height Threshold" ;
+    rdfs:label "Height Threshold: T=2.751981)" ;
     prov:value "2.75198078155518"^^xsd:float .
 
-niiri:67d13ef3bcf3b394d767df4c8be23715
+niiri:351f1c49ad3573062df361946a82808a
     a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
-    rdfs:label "Height Threshold" ;
+    rdfs:label "Height Threshold: p<0.003523 (unc.)" ;
     prov:value "0.00352282952586247"^^xsd:float .
 
-niiri:902960abf8589ac4279cafa49a50ab4e
+niiri:f0dedbabde9224b6cdcbfcacb9ea64eb
     a prov:Entity, nidm_ExtentThreshold:, obo_statistic: ; 
     rdfs:label "Extent Threshold: k>=0" ;
     nidm_clusterSizeInVoxels: "0"^^xsd:int ;
     nidm_clusterSizeInResels: "0"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:0b1604a315a17fa30779aeec1e47c679 ;
-    nidm_equivalentThreshold: niiri:fd82f20a476b61a30200f544eb872bc8 .
+    nidm_equivalentThreshold: niiri:e9f896312d2fd00ff4139f0c9d26b2ca ;
+    nidm_equivalentThreshold: niiri:a607df3343e3516511d5da695cfc14df .
 
-niiri:0b1604a315a17fa30779aeec1e47c679
+niiri:e9f896312d2fd00ff4139f0c9d26b2ca
     a prov:Entity, nidm_ExtentThreshold:, obo_FWERadjustedpvalue: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:fd82f20a476b61a30200f544eb872bc8
+niiri:a607df3343e3516511d5da695cfc14df
     a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:87f4625e9e7d1cf73a2eec5c7d284104
+niiri:25809641902137f5d84b8818fbf15a91
     a prov:Entity, nidm_PeakDefinitionCriteria: ; 
     rdfs:label "Peak Definition Criteria" ;
     nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
     nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
 
-niiri:492f8dc66cc7151992954ec5f3b72262
+niiri:c9584a376a996dc760652f9e9d414333
     a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
     rdfs:label "Cluster Connectivity Criterion: 18" ;
     nidm_hasConnectivityCriterion: nidm_voxel18connected: .
 
-niiri:023a908053ece2b7004e79fc8628c205
+niiri:aa76de7328e3d13603b9e4c03167310d
     a prov:Activity, nidm_Inference: ; 
     nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
     rdfs:label "Inference" .
 
-niiri:023a908053ece2b7004e79fc8628c205 prov:wasAssociatedWith niiri:64730f8ca3829b6ba8ce02b85a004bb2 .
+niiri:aa76de7328e3d13603b9e4c03167310d prov:wasAssociatedWith niiri:6a56b7cc41090f34638cf50938e932eb .
 
-niiri:023a908053ece2b7004e79fc8628c205 prov:used niiri:a523bb37afa0a13617991b5286230c4b .
+niiri:aa76de7328e3d13603b9e4c03167310d prov:used niiri:614f1836a4dabc08f6a40b74d83e4626 .
 
-niiri:023a908053ece2b7004e79fc8628c205 prov:used niiri:902960abf8589ac4279cafa49a50ab4e .
+niiri:aa76de7328e3d13603b9e4c03167310d prov:used niiri:f0dedbabde9224b6cdcbfcacb9ea64eb .
 
-niiri:023a908053ece2b7004e79fc8628c205 prov:used niiri:530d3569bc598c79d5ac70217715e117 .
+niiri:aa76de7328e3d13603b9e4c03167310d prov:used niiri:97a6f2d59ca3be4b5454a9ab78cdf8a3 .
 
-niiri:023a908053ece2b7004e79fc8628c205 prov:used niiri:3b5abc82d35d734e1136daa4a8b2777b .
+niiri:aa76de7328e3d13603b9e4c03167310d prov:used niiri:3ae2261460b37724f66a583d13620d04 .
 
-niiri:023a908053ece2b7004e79fc8628c205 prov:used niiri:72aa1f9e4b18c0a5675eca75f20b7534 .
+niiri:aa76de7328e3d13603b9e4c03167310d prov:used niiri:3da9457cb4e9a27e6ca5714485d63d58 .
 
-niiri:023a908053ece2b7004e79fc8628c205 prov:used niiri:87f4625e9e7d1cf73a2eec5c7d284104 .
+niiri:aa76de7328e3d13603b9e4c03167310d prov:used niiri:25809641902137f5d84b8818fbf15a91 .
 
-niiri:023a908053ece2b7004e79fc8628c205 prov:used niiri:492f8dc66cc7151992954ec5f3b72262 .
+niiri:aa76de7328e3d13603b9e4c03167310d prov:used niiri:c9584a376a996dc760652f9e9d414333 .
 
-niiri:4716aca7a4cad737eb95dc877d0b86e8
+niiri:0337db714526a735c3f18f8b17802c96
     a prov:Entity, nidm_SearchSpaceMaskMap: ; 
     prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
     nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Search Space Mask Map" ;
-    nidm_inCoordinateSpace: niiri:57bfb1702d234ee28692b281b4b06077 ;
+    nidm_inCoordinateSpace: niiri:4d80c0cd6d8f06cc5fa8312aea1fdf66 ;
     nidm_searchVolumeInVoxels: "223057"^^xsd:int ;
     nidm_searchVolumeInUnits: "1784456"^^xsd:float ;
     nidm_reselSizeInVoxels: "65.5786964036542"^^xsd:float ;
@@ -516,9 +516,9 @@ niiri:4716aca7a4cad737eb95dc877d0b86e8
     crypto:sha512 "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876"^^xsd:string ;
     spm_smallestSignificantClusterSizeInVoxelsFWE05: "417"^^xsd:int .
 
-niiri:4716aca7a4cad737eb95dc877d0b86e8 prov:wasGeneratedBy niiri:023a908053ece2b7004e79fc8628c205 .
+niiri:0337db714526a735c3f18f8b17802c96 prov:wasGeneratedBy niiri:aa76de7328e3d13603b9e4c03167310d .
 
-niiri:cf2669065d68620b6d3d674c82341f68
+niiri:dfc9c2736061f68baaf0d5518b47b332
     a prov:Entity, nidm_ExcursionSetMap: ; 
     prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
@@ -526,29 +526,29 @@ niiri:cf2669065d68620b6d3d674c82341f68
     rdfs:label "Excursion Set Map" ;
     nidm_numberOfSupraThresholdClusters: "94"^^xsd:int ;
     nidm_pValue: "0.0447079143903081"^^xsd:float ;
-    nidm_hasClusterLabelsMap: niiri:517d95139044cb76e80096f69d114fdf ;
-    nidm_hasMaximumIntensityProjection: niiri:9a5e8e987ce1ea3b0d9681600c7d6adc ;
-    nidm_inCoordinateSpace: niiri:57bfb1702d234ee28692b281b4b06077 ;
+    nidm_hasClusterLabelsMap: niiri:332fb65e8d1c26a67e44333e6c989eb7 ;
+    nidm_hasMaximumIntensityProjection: niiri:5938905a43f9833716520963e37ee9bc ;
+    nidm_inCoordinateSpace: niiri:4d80c0cd6d8f06cc5fa8312aea1fdf66 ;
     crypto:sha512 "cf6122ef36510b627277417e8070ef8b21de0fcc302fb6c54bf9edeb988abef00c098ec6c42fcf12cd780102e22e349f9c18cd538751d947c730386ef4e7a1cd"^^xsd:string .
 
-niiri:517d95139044cb76e80096f69d114fdf
+niiri:332fb65e8d1c26a67e44333e6c989eb7
     a prov:Entity, nidm_ClusterLabelsMap: ; 
     prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Cluster Labels Map" ;
-    nidm_inCoordinateSpace: niiri:57bfb1702d234ee28692b281b4b06077 ;
+    nidm_inCoordinateSpace: niiri:4d80c0cd6d8f06cc5fa8312aea1fdf66 ;
     crypto:sha512 "a6e72a506c045df940a586a06217495a831daf3d177fe165daebb130d3e2e4e907672569967fc17d32833becda95fa6d98fd5aae15ff0d91681337ac0edcd529"^^xsd:string .
 
-niiri:9a5e8e987ce1ea3b0d9681600c7d6adc
+niiri:5938905a43f9833716520963e37ee9bc
     a prov:Entity, dctype:Image ; 
     prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
     nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:cf2669065d68620b6d3d674c82341f68 prov:wasGeneratedBy niiri:023a908053ece2b7004e79fc8628c205 .
+niiri:dfc9c2736061f68baaf0d5518b47b332 prov:wasGeneratedBy niiri:aa76de7328e3d13603b9e4c03167310d .
 
-niiri:242656e5fe9c4228886ce59df6e0a2ca
+niiri:57b0b3487b8ceebf11e98e8506c169a2
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0001" ;
     nidm_clusterSizeInVoxels: "10882"^^xsd:int ;
@@ -558,9 +558,9 @@ niiri:242656e5fe9c4228886ce59df6e0a2ca
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "1"^^xsd:int .
 
-niiri:242656e5fe9c4228886ce59df6e0a2ca prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:57b0b3487b8ceebf11e98e8506c169a2 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:c27bdfc6cef3bf3771769b92935b0e04
+niiri:3d5c32984a0665ba596ff6cef71fcd0b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0002" ;
     nidm_clusterSizeInVoxels: "464"^^xsd:int ;
@@ -570,9 +570,9 @@ niiri:c27bdfc6cef3bf3771769b92935b0e04
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "2"^^xsd:int .
 
-niiri:c27bdfc6cef3bf3771769b92935b0e04 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:3d5c32984a0665ba596ff6cef71fcd0b prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:a158a75fe65c6add3c1257707728cdd4
+niiri:2c413461a4c1a86447e1da248ab7545c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0003" ;
     nidm_clusterSizeInVoxels: "1082"^^xsd:int ;
@@ -582,9 +582,9 @@ niiri:a158a75fe65c6add3c1257707728cdd4
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "3"^^xsd:int .
 
-niiri:a158a75fe65c6add3c1257707728cdd4 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:2c413461a4c1a86447e1da248ab7545c prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:b89b511274698ad906aaf626aa9dafa2
+niiri:e3f486aca3000e0c84fbdaf8a042398f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0004" ;
     nidm_clusterSizeInVoxels: "155"^^xsd:int ;
@@ -594,9 +594,9 @@ niiri:b89b511274698ad906aaf626aa9dafa2
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "4"^^xsd:int .
 
-niiri:b89b511274698ad906aaf626aa9dafa2 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:e3f486aca3000e0c84fbdaf8a042398f prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:fc1234dbcb5fecc84cb748f7a43e1791
+niiri:c0ef61636e02d68816943e9c0c7be35d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0005" ;
     nidm_clusterSizeInVoxels: "468"^^xsd:int ;
@@ -606,9 +606,9 @@ niiri:fc1234dbcb5fecc84cb748f7a43e1791
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "5"^^xsd:int .
 
-niiri:fc1234dbcb5fecc84cb748f7a43e1791 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:c0ef61636e02d68816943e9c0c7be35d prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:bc79ea489b7d5f8523a15f77de48e174
+niiri:e9bd68a9b52a95e89ba7a7e17b4fa428
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0006" ;
     nidm_clusterSizeInVoxels: "602"^^xsd:int ;
@@ -618,9 +618,9 @@ niiri:bc79ea489b7d5f8523a15f77de48e174
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "6"^^xsd:int .
 
-niiri:bc79ea489b7d5f8523a15f77de48e174 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:e9bd68a9b52a95e89ba7a7e17b4fa428 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:d1bded8abf09ebee39e58ad5cac474bf
+niiri:7693eabf368839e957bc3cfe43c975e0
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0007" ;
     nidm_clusterSizeInVoxels: "155"^^xsd:int ;
@@ -630,9 +630,9 @@ niiri:d1bded8abf09ebee39e58ad5cac474bf
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "7"^^xsd:int .
 
-niiri:d1bded8abf09ebee39e58ad5cac474bf prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:7693eabf368839e957bc3cfe43c975e0 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:2d4153f04704f26ae2b13f93cceec23b
+niiri:39b96655430c53f32e07621dbe8655c4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0008" ;
     nidm_clusterSizeInVoxels: "24"^^xsd:int ;
@@ -642,9 +642,9 @@ niiri:2d4153f04704f26ae2b13f93cceec23b
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "8"^^xsd:int .
 
-niiri:2d4153f04704f26ae2b13f93cceec23b prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:39b96655430c53f32e07621dbe8655c4 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:8702febb070c184ab840d84baa828f4c
+niiri:90ea170edb9635f011af376c50f1eff8
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0009" ;
     nidm_clusterSizeInVoxels: "66"^^xsd:int ;
@@ -654,9 +654,9 @@ niiri:8702febb070c184ab840d84baa828f4c
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "9"^^xsd:int .
 
-niiri:8702febb070c184ab840d84baa828f4c prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:90ea170edb9635f011af376c50f1eff8 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:554231ad3e2c8225e52d92a4328b14a9
+niiri:d976336ac6ecb4bba1136f54b6de3e23
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0010" ;
     nidm_clusterSizeInVoxels: "39"^^xsd:int ;
@@ -666,9 +666,9 @@ niiri:554231ad3e2c8225e52d92a4328b14a9
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "10"^^xsd:int .
 
-niiri:554231ad3e2c8225e52d92a4328b14a9 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:d976336ac6ecb4bba1136f54b6de3e23 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:8adb4939693aed81541cf6c7ab164844
+niiri:43ec173da0c3faa0f4491456aea575ce
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0011" ;
     nidm_clusterSizeInVoxels: "62"^^xsd:int ;
@@ -678,9 +678,9 @@ niiri:8adb4939693aed81541cf6c7ab164844
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "11"^^xsd:int .
 
-niiri:8adb4939693aed81541cf6c7ab164844 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:43ec173da0c3faa0f4491456aea575ce prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:0a424073d2852615c9efd40e929d5259
+niiri:a21087d5b0bdd477c690e1272139bf8a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0012" ;
     nidm_clusterSizeInVoxels: "417"^^xsd:int ;
@@ -690,9 +690,9 @@ niiri:0a424073d2852615c9efd40e929d5259
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "12"^^xsd:int .
 
-niiri:0a424073d2852615c9efd40e929d5259 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:a21087d5b0bdd477c690e1272139bf8a prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:c419557738905fde9064be2cef6f1449
+niiri:a4d3b6fc7cc84d91945916a3052dd21c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0013" ;
     nidm_clusterSizeInVoxels: "130"^^xsd:int ;
@@ -702,9 +702,9 @@ niiri:c419557738905fde9064be2cef6f1449
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "13"^^xsd:int .
 
-niiri:c419557738905fde9064be2cef6f1449 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:a4d3b6fc7cc84d91945916a3052dd21c prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:4b5ae066ef253b812d649482610dbba7
+niiri:d3e3d125a9ce7e2ce6bac0795d332509
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0014" ;
     nidm_clusterSizeInVoxels: "22"^^xsd:int ;
@@ -714,9 +714,9 @@ niiri:4b5ae066ef253b812d649482610dbba7
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "14"^^xsd:int .
 
-niiri:4b5ae066ef253b812d649482610dbba7 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:d3e3d125a9ce7e2ce6bac0795d332509 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:c27d8c4414a41bf2e1d9fe41a87f11b6
+niiri:0531c28556a1e0fba30c3ea1dd24f56e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0015" ;
     nidm_clusterSizeInVoxels: "40"^^xsd:int ;
@@ -726,9 +726,9 @@ niiri:c27d8c4414a41bf2e1d9fe41a87f11b6
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "15"^^xsd:int .
 
-niiri:c27d8c4414a41bf2e1d9fe41a87f11b6 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:0531c28556a1e0fba30c3ea1dd24f56e prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:63757a12c243d6f113a5c106a65341d3
+niiri:22a4e1327d4f2f7349df156933a68889
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0016" ;
     nidm_clusterSizeInVoxels: "44"^^xsd:int ;
@@ -738,9 +738,9 @@ niiri:63757a12c243d6f113a5c106a65341d3
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "16"^^xsd:int .
 
-niiri:63757a12c243d6f113a5c106a65341d3 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:22a4e1327d4f2f7349df156933a68889 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:64a23b7dfa188ea7c583dd955c4783b0
+niiri:661e97df890b4cd21b7b3cc4a2220e2e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0017" ;
     nidm_clusterSizeInVoxels: "9"^^xsd:int ;
@@ -750,9 +750,9 @@ niiri:64a23b7dfa188ea7c583dd955c4783b0
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "17"^^xsd:int .
 
-niiri:64a23b7dfa188ea7c583dd955c4783b0 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:661e97df890b4cd21b7b3cc4a2220e2e prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:c7fd5f4cdee71350124b35242a6b1709
+niiri:fb7297e8c19234947de7375e05901f89
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0018" ;
     nidm_clusterSizeInVoxels: "26"^^xsd:int ;
@@ -762,9 +762,9 @@ niiri:c7fd5f4cdee71350124b35242a6b1709
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "18"^^xsd:int .
 
-niiri:c7fd5f4cdee71350124b35242a6b1709 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:fb7297e8c19234947de7375e05901f89 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:43b10bfa562e759c7c198b457de7cd8b
+niiri:c016e8a860699bda1ff422a1f501e63d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0019" ;
     nidm_clusterSizeInVoxels: "14"^^xsd:int ;
@@ -774,9 +774,9 @@ niiri:43b10bfa562e759c7c198b457de7cd8b
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "19"^^xsd:int .
 
-niiri:43b10bfa562e759c7c198b457de7cd8b prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:c016e8a860699bda1ff422a1f501e63d prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:94ae4aee00bdd503edae82f33c3e9515
+niiri:c4fe065cafdebad144fa17a8ec71281b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0020" ;
     nidm_clusterSizeInVoxels: "102"^^xsd:int ;
@@ -786,9 +786,9 @@ niiri:94ae4aee00bdd503edae82f33c3e9515
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "20"^^xsd:int .
 
-niiri:94ae4aee00bdd503edae82f33c3e9515 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:c4fe065cafdebad144fa17a8ec71281b prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:4f7b061f932253ef4a07d4d9f2fe8517
+niiri:b9447d9cb03b61ef6f6b29b2f726c748
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0021" ;
     nidm_clusterSizeInVoxels: "35"^^xsd:int ;
@@ -798,9 +798,9 @@ niiri:4f7b061f932253ef4a07d4d9f2fe8517
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "21"^^xsd:int .
 
-niiri:4f7b061f932253ef4a07d4d9f2fe8517 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:b9447d9cb03b61ef6f6b29b2f726c748 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:0163fc34332a97aa514f22d9a18b4aef
+niiri:fccd53239e801ce9120073c47ddcae13
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0022" ;
     nidm_clusterSizeInVoxels: "11"^^xsd:int ;
@@ -810,9 +810,9 @@ niiri:0163fc34332a97aa514f22d9a18b4aef
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "22"^^xsd:int .
 
-niiri:0163fc34332a97aa514f22d9a18b4aef prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:fccd53239e801ce9120073c47ddcae13 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:afb1b880058db996109597c9134c0944
+niiri:e8858d23bbbcba237e94c70004237a2f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0023" ;
     nidm_clusterSizeInVoxels: "60"^^xsd:int ;
@@ -822,9 +822,9 @@ niiri:afb1b880058db996109597c9134c0944
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "23"^^xsd:int .
 
-niiri:afb1b880058db996109597c9134c0944 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:e8858d23bbbcba237e94c70004237a2f prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:a3209dd94fcfcfc2e0d96d3475893c16
+niiri:a1e36a12612c98786c42d6e581a41938
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0024" ;
     nidm_clusterSizeInVoxels: "20"^^xsd:int ;
@@ -834,9 +834,9 @@ niiri:a3209dd94fcfcfc2e0d96d3475893c16
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "24"^^xsd:int .
 
-niiri:a3209dd94fcfcfc2e0d96d3475893c16 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:a1e36a12612c98786c42d6e581a41938 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:0e0928e501c6272ac7fd3ddf2695e9f7
+niiri:6aac454abbeb6462b826cd647eb086e0
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0025" ;
     nidm_clusterSizeInVoxels: "106"^^xsd:int ;
@@ -846,9 +846,9 @@ niiri:0e0928e501c6272ac7fd3ddf2695e9f7
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "25"^^xsd:int .
 
-niiri:0e0928e501c6272ac7fd3ddf2695e9f7 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:6aac454abbeb6462b826cd647eb086e0 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:15ddf3a0750659085f821d46282e1a9c
+niiri:7b28ee2c06d9f1eb5b4dab7494fe7a85
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0026" ;
     nidm_clusterSizeInVoxels: "82"^^xsd:int ;
@@ -858,9 +858,9 @@ niiri:15ddf3a0750659085f821d46282e1a9c
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "26"^^xsd:int .
 
-niiri:15ddf3a0750659085f821d46282e1a9c prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:7b28ee2c06d9f1eb5b4dab7494fe7a85 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:e037574456f8a483328c150e32419262
+niiri:00aad4e5c367c7dee68c301c251cb2ce
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0027" ;
     nidm_clusterSizeInVoxels: "50"^^xsd:int ;
@@ -870,9 +870,9 @@ niiri:e037574456f8a483328c150e32419262
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "27"^^xsd:int .
 
-niiri:e037574456f8a483328c150e32419262 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:00aad4e5c367c7dee68c301c251cb2ce prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:cead124d94f280e9eb613273f575273f
+niiri:904dc3e52037e77af188b63a3d3a6884
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0028" ;
     nidm_clusterSizeInVoxels: "106"^^xsd:int ;
@@ -882,9 +882,9 @@ niiri:cead124d94f280e9eb613273f575273f
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "28"^^xsd:int .
 
-niiri:cead124d94f280e9eb613273f575273f prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:904dc3e52037e77af188b63a3d3a6884 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:9dee950d4d0d87d9847d4f2182442446
+niiri:ffdea138243040f7b25be6c44f68510d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0029" ;
     nidm_clusterSizeInVoxels: "14"^^xsd:int ;
@@ -894,9 +894,9 @@ niiri:9dee950d4d0d87d9847d4f2182442446
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "29"^^xsd:int .
 
-niiri:9dee950d4d0d87d9847d4f2182442446 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:ffdea138243040f7b25be6c44f68510d prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:5bdb44212c11108bd9056913ba88493d
+niiri:f19e77aa11c450b96b368f822fcfd6ce
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0030" ;
     nidm_clusterSizeInVoxels: "19"^^xsd:int ;
@@ -906,9 +906,9 @@ niiri:5bdb44212c11108bd9056913ba88493d
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "30"^^xsd:int .
 
-niiri:5bdb44212c11108bd9056913ba88493d prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:f19e77aa11c450b96b368f822fcfd6ce prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:fcd93504620cb56307a63f5826ae493b
+niiri:1b80b6984bddaf1c61a51a898d6acbea
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0031" ;
     nidm_clusterSizeInVoxels: "37"^^xsd:int ;
@@ -918,9 +918,9 @@ niiri:fcd93504620cb56307a63f5826ae493b
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "31"^^xsd:int .
 
-niiri:fcd93504620cb56307a63f5826ae493b prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:1b80b6984bddaf1c61a51a898d6acbea prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:22f559c5bb43c4d1c00d4b2abbd64b80
+niiri:2a6b200869ec06562d293e64de33e926
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0032" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -930,9 +930,9 @@ niiri:22f559c5bb43c4d1c00d4b2abbd64b80
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "32"^^xsd:int .
 
-niiri:22f559c5bb43c4d1c00d4b2abbd64b80 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:2a6b200869ec06562d293e64de33e926 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:b58c8c56d192cbadcd924e0e299d45b7
+niiri:50eb3a7d09683191b4aed76432577ca4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0033" ;
     nidm_clusterSizeInVoxels: "14"^^xsd:int ;
@@ -942,9 +942,9 @@ niiri:b58c8c56d192cbadcd924e0e299d45b7
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "33"^^xsd:int .
 
-niiri:b58c8c56d192cbadcd924e0e299d45b7 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:50eb3a7d09683191b4aed76432577ca4 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:6c6cb2c384c60e5d62243cf34af0708f
+niiri:3dc187c20fafa718374d3bf8209b869c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0034" ;
     nidm_clusterSizeInVoxels: "14"^^xsd:int ;
@@ -954,9 +954,9 @@ niiri:6c6cb2c384c60e5d62243cf34af0708f
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "34"^^xsd:int .
 
-niiri:6c6cb2c384c60e5d62243cf34af0708f prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:3dc187c20fafa718374d3bf8209b869c prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:3c56acb507aa977c9b4ba549626f35b8
+niiri:2246deb8a6c721c27dda92f3dd869ffd
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0035" ;
     nidm_clusterSizeInVoxels: "9"^^xsd:int ;
@@ -966,9 +966,9 @@ niiri:3c56acb507aa977c9b4ba549626f35b8
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "35"^^xsd:int .
 
-niiri:3c56acb507aa977c9b4ba549626f35b8 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:2246deb8a6c721c27dda92f3dd869ffd prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:d1dd3f03998183928446768008d538fd
+niiri:50cb1d29d6f8a9cfe9515552c5bb7d31
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0036" ;
     nidm_clusterSizeInVoxels: "12"^^xsd:int ;
@@ -978,9 +978,9 @@ niiri:d1dd3f03998183928446768008d538fd
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "36"^^xsd:int .
 
-niiri:d1dd3f03998183928446768008d538fd prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:50cb1d29d6f8a9cfe9515552c5bb7d31 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:c68b211ae154a1466946b63df0f701aa
+niiri:d6d69b36b9108bb0de66eeffba4d858e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0037" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -990,9 +990,9 @@ niiri:c68b211ae154a1466946b63df0f701aa
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "37"^^xsd:int .
 
-niiri:c68b211ae154a1466946b63df0f701aa prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:d6d69b36b9108bb0de66eeffba4d858e prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:322465548251da9db8f6eede832763a7
+niiri:e88a30db5e3821edb55a62d4b67f0ad1
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0038" ;
     nidm_clusterSizeInVoxels: "14"^^xsd:int ;
@@ -1002,9 +1002,9 @@ niiri:322465548251da9db8f6eede832763a7
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "38"^^xsd:int .
 
-niiri:322465548251da9db8f6eede832763a7 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:e88a30db5e3821edb55a62d4b67f0ad1 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:2e9ce0e379ad93f22643b62153bb9323
+niiri:a4ad9afd60a760f91d6916421b56fe6a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0039" ;
     nidm_clusterSizeInVoxels: "22"^^xsd:int ;
@@ -1014,9 +1014,9 @@ niiri:2e9ce0e379ad93f22643b62153bb9323
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "39"^^xsd:int .
 
-niiri:2e9ce0e379ad93f22643b62153bb9323 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:a4ad9afd60a760f91d6916421b56fe6a prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:d51a48062d3b4def227e90a39b0954f5
+niiri:d3934b966af329378cc1a1307b94a530
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0040" ;
     nidm_clusterSizeInVoxels: "18"^^xsd:int ;
@@ -1026,9 +1026,9 @@ niiri:d51a48062d3b4def227e90a39b0954f5
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "40"^^xsd:int .
 
-niiri:d51a48062d3b4def227e90a39b0954f5 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:d3934b966af329378cc1a1307b94a530 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:0a272793669dad6178113ee531ec9cb8
+niiri:546534eff08d214139c8884f815a2c20
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0041" ;
     nidm_clusterSizeInVoxels: "25"^^xsd:int ;
@@ -1038,9 +1038,9 @@ niiri:0a272793669dad6178113ee531ec9cb8
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "41"^^xsd:int .
 
-niiri:0a272793669dad6178113ee531ec9cb8 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:546534eff08d214139c8884f815a2c20 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:b184062d5a99600d689d67aaae002061
+niiri:295cf12e37c01e14c3830d46154826a9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0042" ;
     nidm_clusterSizeInVoxels: "12"^^xsd:int ;
@@ -1050,9 +1050,9 @@ niiri:b184062d5a99600d689d67aaae002061
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "42"^^xsd:int .
 
-niiri:b184062d5a99600d689d67aaae002061 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:295cf12e37c01e14c3830d46154826a9 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:f96aa71d40f8ee2a7f558cd844317641
+niiri:aedc5c46b75f681aa273f0c65aba753d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0043" ;
     nidm_clusterSizeInVoxels: "17"^^xsd:int ;
@@ -1062,9 +1062,9 @@ niiri:f96aa71d40f8ee2a7f558cd844317641
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "43"^^xsd:int .
 
-niiri:f96aa71d40f8ee2a7f558cd844317641 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:aedc5c46b75f681aa273f0c65aba753d prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:51f615915847dee59f46c38a3d61f56e
+niiri:03b802eb8ab278c3154b4ebae374f2f2
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0044" ;
     nidm_clusterSizeInVoxels: "11"^^xsd:int ;
@@ -1074,9 +1074,9 @@ niiri:51f615915847dee59f46c38a3d61f56e
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "44"^^xsd:int .
 
-niiri:51f615915847dee59f46c38a3d61f56e prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:03b802eb8ab278c3154b4ebae374f2f2 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:c80fb3c545c2f7392d3c65842860d0d3
+niiri:33fb5b8990838fc1f2547ba3ff8437d2
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0045" ;
     nidm_clusterSizeInVoxels: "31"^^xsd:int ;
@@ -1086,9 +1086,9 @@ niiri:c80fb3c545c2f7392d3c65842860d0d3
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "45"^^xsd:int .
 
-niiri:c80fb3c545c2f7392d3c65842860d0d3 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:33fb5b8990838fc1f2547ba3ff8437d2 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:3d5efcc91bde3190c3c7fc5ea37f55ab
+niiri:f6f7f9d9bd2b440c679a5ff44f1cdb22
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0046" ;
     nidm_clusterSizeInVoxels: "10"^^xsd:int ;
@@ -1098,9 +1098,9 @@ niiri:3d5efcc91bde3190c3c7fc5ea37f55ab
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "46"^^xsd:int .
 
-niiri:3d5efcc91bde3190c3c7fc5ea37f55ab prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:f6f7f9d9bd2b440c679a5ff44f1cdb22 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:74d3fcdb2a3222701acac8703cef46c6
+niiri:cbbd42e6f42814091a8e0fc54b7ad3c4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0047" ;
     nidm_clusterSizeInVoxels: "23"^^xsd:int ;
@@ -1110,9 +1110,9 @@ niiri:74d3fcdb2a3222701acac8703cef46c6
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "47"^^xsd:int .
 
-niiri:74d3fcdb2a3222701acac8703cef46c6 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:cbbd42e6f42814091a8e0fc54b7ad3c4 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:b954d8c8fc0fa467f3ee6aedf1927f85
+niiri:53fb996b754ceba84bda7b0e7b9bdc51
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0048" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1122,9 +1122,9 @@ niiri:b954d8c8fc0fa467f3ee6aedf1927f85
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "48"^^xsd:int .
 
-niiri:b954d8c8fc0fa467f3ee6aedf1927f85 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:53fb996b754ceba84bda7b0e7b9bdc51 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:f173ac5c048181e317d9158611e01835
+niiri:55bb03da7ee7d021560ed83a011342a9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0049" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -1134,9 +1134,9 @@ niiri:f173ac5c048181e317d9158611e01835
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "49"^^xsd:int .
 
-niiri:f173ac5c048181e317d9158611e01835 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:55bb03da7ee7d021560ed83a011342a9 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:efc36c20dd2a832167f0a44c579b5edf
+niiri:ac7c392c52df7cdd1a6cd2c7335454d2
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0050" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1146,9 +1146,9 @@ niiri:efc36c20dd2a832167f0a44c579b5edf
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "50"^^xsd:int .
 
-niiri:efc36c20dd2a832167f0a44c579b5edf prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:ac7c392c52df7cdd1a6cd2c7335454d2 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:163e964ab452049726722befe3edc8f1
+niiri:c3f05dc9d300aa5acc02e364f1c3ee85
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0051" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1158,9 +1158,9 @@ niiri:163e964ab452049726722befe3edc8f1
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "51"^^xsd:int .
 
-niiri:163e964ab452049726722befe3edc8f1 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:c3f05dc9d300aa5acc02e364f1c3ee85 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:21e6a6198ca5dccffc1370c3dedbd678
+niiri:45b4ec73da86f70d949a94aa6ab8d4ab
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0052" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1170,9 +1170,9 @@ niiri:21e6a6198ca5dccffc1370c3dedbd678
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "52"^^xsd:int .
 
-niiri:21e6a6198ca5dccffc1370c3dedbd678 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:45b4ec73da86f70d949a94aa6ab8d4ab prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:0c7d90a406ec1f922a7e807915ee6f49
+niiri:54114a5d8df2f7e553a53e4b7d3f5bde
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0053" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -1182,9 +1182,9 @@ niiri:0c7d90a406ec1f922a7e807915ee6f49
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "53"^^xsd:int .
 
-niiri:0c7d90a406ec1f922a7e807915ee6f49 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:54114a5d8df2f7e553a53e4b7d3f5bde prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:10a509044b2676eb12c65b82844b5898
+niiri:3f3ed8fe063a9052a3379a875a3af9b1
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0054" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1194,9 +1194,9 @@ niiri:10a509044b2676eb12c65b82844b5898
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "54"^^xsd:int .
 
-niiri:10a509044b2676eb12c65b82844b5898 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:3f3ed8fe063a9052a3379a875a3af9b1 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:da2d2cf59ea5cea8edce49ea2ffea951
+niiri:5721ae6aae6160ad82aced2d2fe68def
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0055" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1206,9 +1206,9 @@ niiri:da2d2cf59ea5cea8edce49ea2ffea951
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "55"^^xsd:int .
 
-niiri:da2d2cf59ea5cea8edce49ea2ffea951 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:5721ae6aae6160ad82aced2d2fe68def prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:67b60bb73ecda2bbfdba32287ba6e0f5
+niiri:9326713bc412f1ec61f3bf20466a1174
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0056" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1218,9 +1218,9 @@ niiri:67b60bb73ecda2bbfdba32287ba6e0f5
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "56"^^xsd:int .
 
-niiri:67b60bb73ecda2bbfdba32287ba6e0f5 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:9326713bc412f1ec61f3bf20466a1174 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:9254bae1d5f58a099609a70c3d6c17bf
+niiri:ae9ba0f37d886eaa080e3238cefd1961
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0057" ;
     nidm_clusterSizeInVoxels: "11"^^xsd:int ;
@@ -1230,9 +1230,9 @@ niiri:9254bae1d5f58a099609a70c3d6c17bf
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "57"^^xsd:int .
 
-niiri:9254bae1d5f58a099609a70c3d6c17bf prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:ae9ba0f37d886eaa080e3238cefd1961 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:2e99faf6261612f5665eb4d13abf19a0
+niiri:55108dec00fcabdca0aa0fd19deac38c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0058" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1242,9 +1242,9 @@ niiri:2e99faf6261612f5665eb4d13abf19a0
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "58"^^xsd:int .
 
-niiri:2e99faf6261612f5665eb4d13abf19a0 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:55108dec00fcabdca0aa0fd19deac38c prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:740eb5d4edc6fcd44873c0c8fc2a5c58
+niiri:16a2d945f11329e9c381ee7f04a0ef0e
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0059" ;
     nidm_clusterSizeInVoxels: "17"^^xsd:int ;
@@ -1254,9 +1254,9 @@ niiri:740eb5d4edc6fcd44873c0c8fc2a5c58
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "59"^^xsd:int .
 
-niiri:740eb5d4edc6fcd44873c0c8fc2a5c58 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:16a2d945f11329e9c381ee7f04a0ef0e prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:405b87d54648ec0203cb5bd92594a2e3
+niiri:51de73f4c31fd22967b959166dfdd033
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0060" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -1266,9 +1266,9 @@ niiri:405b87d54648ec0203cb5bd92594a2e3
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "60"^^xsd:int .
 
-niiri:405b87d54648ec0203cb5bd92594a2e3 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:51de73f4c31fd22967b959166dfdd033 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:2eee6e1a0cc5eacabec145451549d653
+niiri:5810f1d1820e723be51fc80ca74ca5e0
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0061" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -1278,9 +1278,9 @@ niiri:2eee6e1a0cc5eacabec145451549d653
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "61"^^xsd:int .
 
-niiri:2eee6e1a0cc5eacabec145451549d653 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:5810f1d1820e723be51fc80ca74ca5e0 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:e9970ca0786a9322adebcbbeda6cd715
+niiri:fb7f0c2c30196ccec28c3a6548a05c74
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0062" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1290,9 +1290,9 @@ niiri:e9970ca0786a9322adebcbbeda6cd715
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "62"^^xsd:int .
 
-niiri:e9970ca0786a9322adebcbbeda6cd715 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:fb7f0c2c30196ccec28c3a6548a05c74 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:c0493caa11e0a7edcd8c852574b28687
+niiri:c93f984974556da4e703249091c0b9e6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0063" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1302,9 +1302,9 @@ niiri:c0493caa11e0a7edcd8c852574b28687
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "63"^^xsd:int .
 
-niiri:c0493caa11e0a7edcd8c852574b28687 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:c93f984974556da4e703249091c0b9e6 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:f710cfa09fe2aedf43455c358fac4b39
+niiri:9e172783feebd728c2f558fb3b71f8e1
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0064" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -1314,9 +1314,9 @@ niiri:f710cfa09fe2aedf43455c358fac4b39
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "64"^^xsd:int .
 
-niiri:f710cfa09fe2aedf43455c358fac4b39 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:9e172783feebd728c2f558fb3b71f8e1 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:bad70ba4fd8b4b695b72a83782c3e5f8
+niiri:87ab73f90e90a5729c135961d1e370c8
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0065" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1326,9 +1326,9 @@ niiri:bad70ba4fd8b4b695b72a83782c3e5f8
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "65"^^xsd:int .
 
-niiri:bad70ba4fd8b4b695b72a83782c3e5f8 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:87ab73f90e90a5729c135961d1e370c8 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:c6c17361069913b5f4191614f68492f3
+niiri:837d4c2c41156c19f0fd118f410295ff
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0066" ;
     nidm_clusterSizeInVoxels: "9"^^xsd:int ;
@@ -1338,9 +1338,9 @@ niiri:c6c17361069913b5f4191614f68492f3
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "66"^^xsd:int .
 
-niiri:c6c17361069913b5f4191614f68492f3 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:837d4c2c41156c19f0fd118f410295ff prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:c2a152f43ee2d844f898782fd1ef7ec0
+niiri:045f09754798eebc086b923539ec80df
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0067" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -1350,9 +1350,9 @@ niiri:c2a152f43ee2d844f898782fd1ef7ec0
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "67"^^xsd:int .
 
-niiri:c2a152f43ee2d844f898782fd1ef7ec0 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:045f09754798eebc086b923539ec80df prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:f1fa812573c26840167e9f2bd0ba2bfa
+niiri:80792993798dbd9f1e93a2b1f460edb7
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0068" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1362,9 +1362,9 @@ niiri:f1fa812573c26840167e9f2bd0ba2bfa
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "68"^^xsd:int .
 
-niiri:f1fa812573c26840167e9f2bd0ba2bfa prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:80792993798dbd9f1e93a2b1f460edb7 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:331525e1b9d0bddf9506ab65a075cd86
+niiri:90698016a8817129b734a925244ac3ee
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0069" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -1374,9 +1374,9 @@ niiri:331525e1b9d0bddf9506ab65a075cd86
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "69"^^xsd:int .
 
-niiri:331525e1b9d0bddf9506ab65a075cd86 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:90698016a8817129b734a925244ac3ee prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:ea97b40b5a9be7fc9f6d62d9b525b485
+niiri:e884b18d0db747fcf84bd707ac9dd705
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0070" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1386,9 +1386,9 @@ niiri:ea97b40b5a9be7fc9f6d62d9b525b485
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "70"^^xsd:int .
 
-niiri:ea97b40b5a9be7fc9f6d62d9b525b485 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:e884b18d0db747fcf84bd707ac9dd705 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:1f3fb8e24c66864d879d2bc4e5971b17
+niiri:2a3d19c51223db94f710da6fc4488efe
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0071" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1398,9 +1398,9 @@ niiri:1f3fb8e24c66864d879d2bc4e5971b17
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "71"^^xsd:int .
 
-niiri:1f3fb8e24c66864d879d2bc4e5971b17 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:2a3d19c51223db94f710da6fc4488efe prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:cd925f60fb17823aac5c3473215f8d7e
+niiri:525402486d0c3b5a8a9cc4d79a236330
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0072" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1410,9 +1410,9 @@ niiri:cd925f60fb17823aac5c3473215f8d7e
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "72"^^xsd:int .
 
-niiri:cd925f60fb17823aac5c3473215f8d7e prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:525402486d0c3b5a8a9cc4d79a236330 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:9837099ef2efab920d421b33789218c3
+niiri:4c1d2eaf37081d773b0db5e10c96074d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0073" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1422,9 +1422,9 @@ niiri:9837099ef2efab920d421b33789218c3
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "73"^^xsd:int .
 
-niiri:9837099ef2efab920d421b33789218c3 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:4c1d2eaf37081d773b0db5e10c96074d prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:2165a25b8a630ef2f40a0401a9a3c680
+niiri:91b4c6608ce19710d67c33b2473fc9b4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0074" ;
     nidm_clusterSizeInVoxels: "9"^^xsd:int ;
@@ -1434,9 +1434,9 @@ niiri:2165a25b8a630ef2f40a0401a9a3c680
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "74"^^xsd:int .
 
-niiri:2165a25b8a630ef2f40a0401a9a3c680 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:91b4c6608ce19710d67c33b2473fc9b4 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:4d83aeb570cac876251d053c07bf2d8e
+niiri:9caa103a34dc60ce70ec535ac6e8b007
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0075" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1446,9 +1446,9 @@ niiri:4d83aeb570cac876251d053c07bf2d8e
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "75"^^xsd:int .
 
-niiri:4d83aeb570cac876251d053c07bf2d8e prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:9caa103a34dc60ce70ec535ac6e8b007 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:77a467097c18360546951b54cfc345c7
+niiri:b860ec229f39bc9a1fbaafbcbf0a163f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0076" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1458,9 +1458,9 @@ niiri:77a467097c18360546951b54cfc345c7
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "76"^^xsd:int .
 
-niiri:77a467097c18360546951b54cfc345c7 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:b860ec229f39bc9a1fbaafbcbf0a163f prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:cd7ab160dc57440bc4255ac3aa507dd7
+niiri:236f07396a3abe7464d0d6adae038d7d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0077" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1470,9 +1470,9 @@ niiri:cd7ab160dc57440bc4255ac3aa507dd7
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "77"^^xsd:int .
 
-niiri:cd7ab160dc57440bc4255ac3aa507dd7 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:236f07396a3abe7464d0d6adae038d7d prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:601da24f17e65f186bb79a9adc3e0bf6
+niiri:d3ccad413c80f4d335ba3f4f6b6355af
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0078" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1482,9 +1482,9 @@ niiri:601da24f17e65f186bb79a9adc3e0bf6
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "78"^^xsd:int .
 
-niiri:601da24f17e65f186bb79a9adc3e0bf6 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:d3ccad413c80f4d335ba3f4f6b6355af prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:6c59d25b5ac6fc02466875dc30d6cca4
+niiri:485d5921cf99fd18e2d2bc08962f1a89
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0079" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1494,9 +1494,9 @@ niiri:6c59d25b5ac6fc02466875dc30d6cca4
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "79"^^xsd:int .
 
-niiri:6c59d25b5ac6fc02466875dc30d6cca4 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:485d5921cf99fd18e2d2bc08962f1a89 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:8d1a9f520760b76668ce56986561c536
+niiri:fafeba66cc92ac8083e5897d50f4bcab
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0080" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1506,9 +1506,9 @@ niiri:8d1a9f520760b76668ce56986561c536
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "80"^^xsd:int .
 
-niiri:8d1a9f520760b76668ce56986561c536 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:fafeba66cc92ac8083e5897d50f4bcab prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:9de0c2e42252737a8379e3e037d6d2aa
+niiri:48a7f6254e1629604bc57865dff4d670
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0081" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1518,9 +1518,9 @@ niiri:9de0c2e42252737a8379e3e037d6d2aa
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "81"^^xsd:int .
 
-niiri:9de0c2e42252737a8379e3e037d6d2aa prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:48a7f6254e1629604bc57865dff4d670 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:ac17f6aed0c480752633af7157a50790
+niiri:33e63ed9d657f0ba23cd9ffacda3e22d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0082" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1530,9 +1530,9 @@ niiri:ac17f6aed0c480752633af7157a50790
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "82"^^xsd:int .
 
-niiri:ac17f6aed0c480752633af7157a50790 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:33e63ed9d657f0ba23cd9ffacda3e22d prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:09df787a9447add50b251d7691bf2f9c
+niiri:768ca0ef2b170d430ebbd40ebb08cff0
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0083" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1542,9 +1542,9 @@ niiri:09df787a9447add50b251d7691bf2f9c
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "83"^^xsd:int .
 
-niiri:09df787a9447add50b251d7691bf2f9c prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:768ca0ef2b170d430ebbd40ebb08cff0 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:5df3810b9f8634e5eabf4cf013d6d516
+niiri:8cf8073a323eec04d3968fab10115c2b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0084" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1554,9 +1554,9 @@ niiri:5df3810b9f8634e5eabf4cf013d6d516
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "84"^^xsd:int .
 
-niiri:5df3810b9f8634e5eabf4cf013d6d516 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:8cf8073a323eec04d3968fab10115c2b prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:819baf737aaaa45787693a764f07e7c8
+niiri:dba062dd06d4105f10d77f25b52b96c8
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0085" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1566,9 +1566,9 @@ niiri:819baf737aaaa45787693a764f07e7c8
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "85"^^xsd:int .
 
-niiri:819baf737aaaa45787693a764f07e7c8 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:dba062dd06d4105f10d77f25b52b96c8 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:509244d6a4f71a5ff685cfe8e8ad90b4
+niiri:c51b283e94df3fae6004dee4203f35fd
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0086" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1578,9 +1578,9 @@ niiri:509244d6a4f71a5ff685cfe8e8ad90b4
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "86"^^xsd:int .
 
-niiri:509244d6a4f71a5ff685cfe8e8ad90b4 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:c51b283e94df3fae6004dee4203f35fd prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:085ae9e43b1853458f70bf9e0f5e48e8
+niiri:c79437288e303b8f2bef9af3b70d4aaa
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0087" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1590,9 +1590,9 @@ niiri:085ae9e43b1853458f70bf9e0f5e48e8
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "87"^^xsd:int .
 
-niiri:085ae9e43b1853458f70bf9e0f5e48e8 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:c79437288e303b8f2bef9af3b70d4aaa prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:1e6213ed8f4367c38bb8e3df7596c194
+niiri:049f42c8eb4f2db2320a43cbbdd89f0f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0088" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1602,9 +1602,9 @@ niiri:1e6213ed8f4367c38bb8e3df7596c194
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "88"^^xsd:int .
 
-niiri:1e6213ed8f4367c38bb8e3df7596c194 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:049f42c8eb4f2db2320a43cbbdd89f0f prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:2d1a3d2d688f08f62c34200978327796
+niiri:4e6c7a95cd372d482b4ef655fa46f083
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0089" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1614,9 +1614,9 @@ niiri:2d1a3d2d688f08f62c34200978327796
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "89"^^xsd:int .
 
-niiri:2d1a3d2d688f08f62c34200978327796 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:4e6c7a95cd372d482b4ef655fa46f083 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:74938e3d61efe7611ba39208c8bc71d5
+niiri:78623bac11315960aba0a8d855467f49
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0090" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1626,9 +1626,9 @@ niiri:74938e3d61efe7611ba39208c8bc71d5
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "90"^^xsd:int .
 
-niiri:74938e3d61efe7611ba39208c8bc71d5 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:78623bac11315960aba0a8d855467f49 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:3e17a6b5e2e157b57784ecb5f6ffcdc1
+niiri:288a1fc03510b55eff121de5bf93e1f4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0091" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1638,9 +1638,9 @@ niiri:3e17a6b5e2e157b57784ecb5f6ffcdc1
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "91"^^xsd:int .
 
-niiri:3e17a6b5e2e157b57784ecb5f6ffcdc1 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:288a1fc03510b55eff121de5bf93e1f4 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:1793e50c9d713624fbb8bba2d78ea464
+niiri:f6ffc917f79709af0e39207ec0add7a4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0092" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1650,9 +1650,9 @@ niiri:1793e50c9d713624fbb8bba2d78ea464
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "92"^^xsd:int .
 
-niiri:1793e50c9d713624fbb8bba2d78ea464 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:f6ffc917f79709af0e39207ec0add7a4 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:8bfbe4bb02769474d9ccfb7795dcf200
+niiri:bd77e4cd78d5c4dcb23a68309256720d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0093" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1662,9 +1662,9 @@ niiri:8bfbe4bb02769474d9ccfb7795dcf200
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "93"^^xsd:int .
 
-niiri:8bfbe4bb02769474d9ccfb7795dcf200 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:bd77e4cd78d5c4dcb23a68309256720d prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:a6dbb6a94c7d5ef0b744a15cdc6d3ed6
+niiri:31f96dd2a2f7097e6993ae7eec0e23e6
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0094" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1674,2028 +1674,2028 @@ niiri:a6dbb6a94c7d5ef0b744a15cdc6d3ed6
     nidm_qValueFDR: "[]"^^xsd:float ;
     nidm_clusterLabelId: "94"^^xsd:int .
 
-niiri:a6dbb6a94c7d5ef0b744a15cdc6d3ed6 prov:wasDerivedFrom niiri:cf2669065d68620b6d3d674c82341f68 .
+niiri:31f96dd2a2f7097e6993ae7eec0e23e6 prov:wasDerivedFrom niiri:dfc9c2736061f68baaf0d5518b47b332 .
 
-niiri:59bd62c168799a7d2ce2aafde21de893
+niiri:b9c38db488f3b5f13ba315ce84742e30
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0001" ;
-    prov:atLocation niiri:bab1f201287c11c422c9031ba4cda4b7 ;
+    prov:atLocation niiri:8a04d65607e38687cf6f2f55af3c4b47 ;
     prov:value "7.92007970809937"^^xsd:float ;
     nidm_equivalentZStatistic: "6.94608360738412"^^xsd:float ;
     nidm_pValueUncorrected: "1.87783122385099e-12"^^xsd:float ;
     nidm_pValueFWER: "4.18813870695089e-07"^^xsd:float ;
     nidm_qValueFDR: "2.5522089353025e-07"^^xsd:float .
 
-niiri:bab1f201287c11c422c9031ba4cda4b7
+niiri:8a04d65607e38687cf6f2f55af3c4b47
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0001" ;
     nidm_coordinateVector: "[46,16,24]"^^xsd:string .
 
-niiri:59bd62c168799a7d2ce2aafde21de893 prov:wasDerivedFrom niiri:242656e5fe9c4228886ce59df6e0a2ca .
+niiri:b9c38db488f3b5f13ba315ce84742e30 prov:wasDerivedFrom niiri:57b0b3487b8ceebf11e98e8506c169a2 .
 
-niiri:ac76e3266974911452e712b080f1cba7
+niiri:04ccd45e7b91b1372b86446353f69dec
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0002" ;
-    prov:atLocation niiri:4a1f96130894e9ead1fd8442ec328e7f ;
+    prov:atLocation niiri:29e5728f14fe9e84f03df78c3017ad26 ;
     prov:value "6.31603479385376"^^xsd:float ;
     nidm_equivalentZStatistic: "5.77079466112137"^^xsd:float ;
     nidm_pValueUncorrected: "3.94492849498107e-09"^^xsd:float ;
     nidm_pValueFWER: "0.000879943865776389"^^xsd:float ;
     nidm_qValueFDR: "1.66027144486111e-05"^^xsd:float .
 
-niiri:4a1f96130894e9ead1fd8442ec328e7f
+niiri:29e5728f14fe9e84f03df78c3017ad26
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0002" ;
     nidm_coordinateVector: "[32,24,-4]"^^xsd:string .
 
-niiri:ac76e3266974911452e712b080f1cba7 prov:wasDerivedFrom niiri:242656e5fe9c4228886ce59df6e0a2ca .
+niiri:04ccd45e7b91b1372b86446353f69dec prov:wasDerivedFrom niiri:57b0b3487b8ceebf11e98e8506c169a2 .
 
-niiri:afa7fceb903b3e1d414b8a8438930089
+niiri:2a457ee39f92424bfbae62e7f4d9d06e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0003" ;
-    prov:atLocation niiri:3e41af58f187a4c5dfea163d4c52be0d ;
+    prov:atLocation niiri:c2b44e5f1b4308bc87e8513b4536e33f ;
     prov:value "6.28007745742798"^^xsd:float ;
     nidm_equivalentZStatistic: "5.74292583422276"^^xsd:float ;
     nidm_pValueUncorrected: "4.65272453897825e-09"^^xsd:float ;
     nidm_pValueFWER: "0.00103782272796227"^^xsd:float ;
     nidm_qValueFDR: "1.77570952010042e-05"^^xsd:float .
 
-niiri:3e41af58f187a4c5dfea163d4c52be0d
+niiri:c2b44e5f1b4308bc87e8513b4536e33f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0003" ;
     nidm_coordinateVector: "[8,18,50]"^^xsd:string .
 
-niiri:afa7fceb903b3e1d414b8a8438930089 prov:wasDerivedFrom niiri:242656e5fe9c4228886ce59df6e0a2ca .
+niiri:2a457ee39f92424bfbae62e7f4d9d06e prov:wasDerivedFrom niiri:57b0b3487b8ceebf11e98e8506c169a2 .
 
-niiri:8c512ded5d6b86efebd4dc5f68435795
+niiri:7e3917d8345a65fc26f145125eeaff8c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0004" ;
-    prov:atLocation niiri:0d7a7c717f7888864745155d35f13670 ;
+    prov:atLocation niiri:022199204ee65e352230c02576678448 ;
     prov:value "7.11683940887451"^^xsd:float ;
     nidm_equivalentZStatistic: "6.37404871703245"^^xsd:float ;
     nidm_pValueUncorrected: "9.20510334623259e-11"^^xsd:float ;
     nidm_pValueFWER: "2.05325778424026e-05"^^xsd:float ;
     nidm_qValueFDR: "1.80089716755871e-06"^^xsd:float .
 
-niiri:0d7a7c717f7888864745155d35f13670
+niiri:022199204ee65e352230c02576678448
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0004" ;
     nidm_coordinateVector: "[34,-88,-2]"^^xsd:string .
 
-niiri:8c512ded5d6b86efebd4dc5f68435795 prov:wasDerivedFrom niiri:c27bdfc6cef3bf3771769b92935b0e04 .
+niiri:7e3917d8345a65fc26f145125eeaff8c prov:wasDerivedFrom niiri:3d5c32984a0665ba596ff6cef71fcd0b .
 
-niiri:3cae31dcb6f6ed70f732376eaf9014bb
+niiri:9998cb50acce86cfac60c2fd8b263502
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0005" ;
-    prov:atLocation niiri:3751dbb7c47cefe7778635f003c84fe2 ;
+    prov:atLocation niiri:466cad218c9b7df56ce89ad0ecf3e24b ;
     prov:value "6.48292255401611"^^xsd:float ;
     nidm_equivalentZStatistic: "5.8992593141605"^^xsd:float ;
     nidm_pValueUncorrected: "1.82568493656277e-09"^^xsd:float ;
     nidm_pValueFWER: "0.000407231755366277"^^xsd:float ;
     nidm_qValueFDR: "9.69599417538756e-06"^^xsd:float .
 
-niiri:3751dbb7c47cefe7778635f003c84fe2
+niiri:466cad218c9b7df56ce89ad0ecf3e24b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0005" ;
     nidm_coordinateVector: "[42,-72,-10]"^^xsd:string .
 
-niiri:3cae31dcb6f6ed70f732376eaf9014bb prov:wasDerivedFrom niiri:c27bdfc6cef3bf3771769b92935b0e04 .
+niiri:9998cb50acce86cfac60c2fd8b263502 prov:wasDerivedFrom niiri:3d5c32984a0665ba596ff6cef71fcd0b .
 
-niiri:399e5de584837ee5eded3180f313c694
+niiri:c556266836a943fb870f1bf711a68c3b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0006" ;
-    prov:atLocation niiri:d480d3bed748eb08ff2f4e7ac9de26e3 ;
+    prov:atLocation niiri:848d1690f1e2bb56ae22b60a4853a423 ;
     prov:value "5.2275915145874"^^xsd:float ;
     nidm_equivalentZStatistic: "4.89738468004472"^^xsd:float ;
     nidm_pValueUncorrected: "4.85602978606003e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0670610253017228"^^xsd:float ;
     nidm_qValueFDR: "0.000213643333035659"^^xsd:float .
 
-niiri:d480d3bed748eb08ff2f4e7ac9de26e3
+niiri:848d1690f1e2bb56ae22b60a4853a423
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0006" ;
     nidm_coordinateVector: "[34,-86,12]"^^xsd:string .
 
-niiri:399e5de584837ee5eded3180f313c694 prov:wasDerivedFrom niiri:c27bdfc6cef3bf3771769b92935b0e04 .
+niiri:c556266836a943fb870f1bf711a68c3b prov:wasDerivedFrom niiri:3d5c32984a0665ba596ff6cef71fcd0b .
 
-niiri:446ee49c23f2baed98d69604ca1e2821
+niiri:701c37986a9dfafb2485113e75f3877e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0007" ;
-    prov:atLocation niiri:a6964d722fb6ac6375b29f179e7ed286 ;
+    prov:atLocation niiri:fea264e5d6f510b6beae51359071a22d ;
     prov:value "6.25127363204956"^^xsd:float ;
     nidm_equivalentZStatistic: "5.72055271981637"^^xsd:float ;
     nidm_pValueUncorrected: "5.30890376104765e-09"^^xsd:float ;
     nidm_pValueFWER: "0.0011841880966994"^^xsd:float ;
     nidm_qValueFDR: "1.8796636455546e-05"^^xsd:float .
 
-niiri:a6964d722fb6ac6375b29f179e7ed286
+niiri:fea264e5d6f510b6beae51359071a22d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0007" ;
     nidm_coordinateVector: "[52,-32,42]"^^xsd:string .
 
-niiri:446ee49c23f2baed98d69604ca1e2821 prov:wasDerivedFrom niiri:a158a75fe65c6add3c1257707728cdd4 .
+niiri:701c37986a9dfafb2485113e75f3877e prov:wasDerivedFrom niiri:2c413461a4c1a86447e1da248ab7545c .
 
-niiri:b8367086a4ae3910ef42568fc07a5337
+niiri:d32b6a2abe066703d0a3f16b4a3aa993
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0008" ;
-    prov:atLocation niiri:d61669b86138c7420cd4bba9ceebe0e7 ;
+    prov:atLocation niiri:a07d84f13ebe8c5e8d72a6474acfdba5 ;
     prov:value "6.24752378463745"^^xsd:float ;
     nidm_equivalentZStatistic: "5.71763687476157"^^xsd:float ;
     nidm_pValueUncorrected: "5.40078304300806e-09"^^xsd:float ;
     nidm_pValueFWER: "0.00120468241369565"^^xsd:float ;
     nidm_qValueFDR: "1.88231627139945e-05"^^xsd:float .
 
-niiri:d61669b86138c7420cd4bba9ceebe0e7
+niiri:a07d84f13ebe8c5e8d72a6474acfdba5
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0008" ;
     nidm_coordinateVector: "[40,-62,50]"^^xsd:string .
 
-niiri:b8367086a4ae3910ef42568fc07a5337 prov:wasDerivedFrom niiri:a158a75fe65c6add3c1257707728cdd4 .
+niiri:d32b6a2abe066703d0a3f16b4a3aa993 prov:wasDerivedFrom niiri:2c413461a4c1a86447e1da248ab7545c .
 
-niiri:1a7f130947c22fff681ccf69af694f15
+niiri:74291dfbb196ec16f80fb44d57da12f7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0009" ;
-    prov:atLocation niiri:788e3620e0ed45d0a82f447cffe6d4d4 ;
+    prov:atLocation niiri:6a6fbc6d5237e3c663d814c9b35c8e58 ;
     prov:value "5.70337772369385"^^xsd:float ;
     nidm_equivalentZStatistic: "5.28674301747281"^^xsd:float ;
     nidm_pValueUncorrected: "6.22566831420812e-08"^^xsd:float ;
     nidm_pValueFWER: "0.011413186758684"^^xsd:float ;
     nidm_qValueFDR: "6.56259978738852e-05"^^xsd:float .
 
-niiri:788e3620e0ed45d0a82f447cffe6d4d4
+niiri:6a6fbc6d5237e3c663d814c9b35c8e58
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0009" ;
     nidm_coordinateVector: "[56,-44,52]"^^xsd:string .
 
-niiri:1a7f130947c22fff681ccf69af694f15 prov:wasDerivedFrom niiri:a158a75fe65c6add3c1257707728cdd4 .
+niiri:74291dfbb196ec16f80fb44d57da12f7 prov:wasDerivedFrom niiri:2c413461a4c1a86447e1da248ab7545c .
 
-niiri:284167e6e632f3a77aa8c66f34d3afa1
+niiri:9d53626c88b2f04c3eadecaebc4a1338
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0010" ;
-    prov:atLocation niiri:a8471ca01bfcc1dc939a0dc95d6c9d19 ;
+    prov:atLocation niiri:f38aef95e58ae38118b8281fd53a7a2d ;
     prov:value "6.15371799468994"^^xsd:float ;
     nidm_equivalentZStatistic: "5.64445580026639"^^xsd:float ;
     nidm_pValueUncorrected: "8.285227171001e-09"^^xsd:float ;
     nidm_pValueFWER: "0.00184807786755337"^^xsd:float ;
     nidm_qValueFDR: "2.16474462112596e-05"^^xsd:float .
 
-niiri:a8471ca01bfcc1dc939a0dc95d6c9d19
+niiri:f38aef95e58ae38118b8281fd53a7a2d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0010" ;
     nidm_coordinateVector: "[-28,-94,4]"^^xsd:string .
 
-niiri:284167e6e632f3a77aa8c66f34d3afa1 prov:wasDerivedFrom niiri:b89b511274698ad906aaf626aa9dafa2 .
+niiri:9d53626c88b2f04c3eadecaebc4a1338 prov:wasDerivedFrom niiri:e3f486aca3000e0c84fbdaf8a042398f .
 
-niiri:5bdc9b77f8fc5e237e47028d923d163e
+niiri:85a1438415db5a3489dd11e7fb441b39
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0011" ;
-    prov:atLocation niiri:b522b07293a6f4518fa50b217319c4a8 ;
+    prov:atLocation niiri:511a1e02e40bbe8a2c504cf6e208fc17 ;
     prov:value "4.12145137786865"^^xsd:float ;
     nidm_equivalentZStatistic: "3.94794832362008"^^xsd:float ;
     nidm_pValueUncorrected: "3.94119065879606e-05"^^xsd:float ;
     nidm_pValueFWER: "0.940339218142555"^^xsd:float ;
     nidm_qValueFDR: "0.00279439847450823"^^xsd:float .
 
-niiri:b522b07293a6f4518fa50b217319c4a8
+niiri:511a1e02e40bbe8a2c504cf6e208fc17
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0011" ;
     nidm_coordinateVector: "[-48,-72,2]"^^xsd:string .
 
-niiri:5bdc9b77f8fc5e237e47028d923d163e prov:wasDerivedFrom niiri:b89b511274698ad906aaf626aa9dafa2 .
+niiri:85a1438415db5a3489dd11e7fb441b39 prov:wasDerivedFrom niiri:e3f486aca3000e0c84fbdaf8a042398f .
 
-niiri:079e4c994c16bc09170fcee726b4518a
+niiri:0b8f8f1954b573ce6421b1aec938a3f7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0012" ;
-    prov:atLocation niiri:1ddba39c46535390f0fd69c681884a3f ;
+    prov:atLocation niiri:1fc4e37586cdc18ac0682a29ef38c240 ;
     prov:value "3.71480798721313"^^xsd:float ;
     nidm_equivalentZStatistic: "3.58412084932714"^^xsd:float ;
     nidm_pValueUncorrected: "0.000169107736440521"^^xsd:float ;
     nidm_pValueFWER: "0.999869855188705"^^xsd:float ;
     nidm_qValueFDR: "0.00680567457240922"^^xsd:float .
 
-niiri:1ddba39c46535390f0fd69c681884a3f
+niiri:1fc4e37586cdc18ac0682a29ef38c240
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0012" ;
     nidm_coordinateVector: "[-34,-84,-2]"^^xsd:string .
 
-niiri:079e4c994c16bc09170fcee726b4518a prov:wasDerivedFrom niiri:b89b511274698ad906aaf626aa9dafa2 .
+niiri:0b8f8f1954b573ce6421b1aec938a3f7 prov:wasDerivedFrom niiri:e3f486aca3000e0c84fbdaf8a042398f .
 
-niiri:059832513a38a01ce4f087093cb867af
+niiri:142bb500e57d8a428669aea190bd5682
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0013" ;
-    prov:atLocation niiri:9fc20a0c3e4ce3d2612d0df2e9024c9a ;
+    prov:atLocation niiri:0782b83d56620cd233fa7bce24466953 ;
     prov:value "6.10109901428223"^^xsd:float ;
     nidm_equivalentZStatistic: "5.60320502193174"^^xsd:float ;
     nidm_pValueUncorrected: "1.05212039080982e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00234682813060005"^^xsd:float ;
     nidm_qValueFDR: "2.40223937009298e-05"^^xsd:float .
 
-niiri:9fc20a0c3e4ce3d2612d0df2e9024c9a
+niiri:0782b83d56620cd233fa7bce24466953
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0013" ;
     nidm_coordinateVector: "[32,2,46]"^^xsd:string .
 
-niiri:059832513a38a01ce4f087093cb867af prov:wasDerivedFrom niiri:fc1234dbcb5fecc84cb748f7a43e1791 .
+niiri:142bb500e57d8a428669aea190bd5682 prov:wasDerivedFrom niiri:c0ef61636e02d68816943e9c0c7be35d .
 
-niiri:2f45ceade93380accc658c5da6cfa736
+niiri:27d4ca2419ed8dd89da3969cf9682d0e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0014" ;
-    prov:atLocation niiri:1b4b518827798cd3f59c0b51e6104fef ;
+    prov:atLocation niiri:0d568f934c855dfafbe86e68adc1df30 ;
     prov:value "4.6086859703064"^^xsd:float ;
     nidm_equivalentZStatistic: "4.3736141683061"^^xsd:float ;
     nidm_pValueUncorrected: "6.11031435759912e-06"^^xsd:float ;
     nidm_pValueFWER: "0.453877178455514"^^xsd:float ;
     nidm_qValueFDR: "0.000974930295891631"^^xsd:float .
 
-niiri:1b4b518827798cd3f59c0b51e6104fef
+niiri:0d568f934c855dfafbe86e68adc1df30
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0014" ;
     nidm_coordinateVector: "[28,4,58]"^^xsd:string .
 
-niiri:2f45ceade93380accc658c5da6cfa736 prov:wasDerivedFrom niiri:fc1234dbcb5fecc84cb748f7a43e1791 .
+niiri:27d4ca2419ed8dd89da3969cf9682d0e prov:wasDerivedFrom niiri:c0ef61636e02d68816943e9c0c7be35d .
 
-niiri:0a3d7b0b9471c78e998be6f03e3ffddb
+niiri:029834627d73e77047973cf21bbf5d82
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0015" ;
-    prov:atLocation niiri:ecdd4c231c5edbf3f7e27d479de42ba5 ;
+    prov:atLocation niiri:25d0d7e2c9b753537fd9c78f89590f89 ;
     prov:value "3.98793148994446"^^xsd:float ;
     nidm_equivalentZStatistic: "3.82932508069717"^^xsd:float ;
     nidm_pValueUncorrected: "6.42475887594474e-05"^^xsd:float ;
     nidm_pValueFWER: "0.984644566584946"^^xsd:float ;
     nidm_qValueFDR: "0.00375703605421318"^^xsd:float .
 
-niiri:ecdd4c231c5edbf3f7e27d479de42ba5
+niiri:25d0d7e2c9b753537fd9c78f89590f89
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0015" ;
     nidm_coordinateVector: "[42,4,48]"^^xsd:string .
 
-niiri:0a3d7b0b9471c78e998be6f03e3ffddb prov:wasDerivedFrom niiri:fc1234dbcb5fecc84cb748f7a43e1791 .
+niiri:029834627d73e77047973cf21bbf5d82 prov:wasDerivedFrom niiri:c0ef61636e02d68816943e9c0c7be35d .
 
-niiri:4f27fa8d24c9ac5419e83770480394a6
+niiri:1eb8465701fde4fde92186c425baf8ea
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0016" ;
-    prov:atLocation niiri:5f95462b6c927c6442ebd98010f6c107 ;
+    prov:atLocation niiri:135821fbbd9471e39f9ac3fd7e16b87c ;
     prov:value "5.98348569869995"^^xsd:float ;
     nidm_equivalentZStatistic: "5.51047970249337"^^xsd:float ;
     nidm_pValueUncorrected: "1.78928538652201e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00378871596531738"^^xsd:float ;
     nidm_qValueFDR: "3.24481811369927e-05"^^xsd:float .
 
-niiri:5f95462b6c927c6442ebd98010f6c107
+niiri:135821fbbd9471e39f9ac3fd7e16b87c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0016" ;
     nidm_coordinateVector: "[-52,0,38]"^^xsd:string .
 
-niiri:4f27fa8d24c9ac5419e83770480394a6 prov:wasDerivedFrom niiri:bc79ea489b7d5f8523a15f77de48e174 .
+niiri:1eb8465701fde4fde92186c425baf8ea prov:wasDerivedFrom niiri:e9bd68a9b52a95e89ba7a7e17b4fa428 .
 
-niiri:97c12cc0cda44056974e2945283ffd01
+niiri:64d0ab7126894908ae25023162e0af73
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0017" ;
-    prov:atLocation niiri:e813708b85b3385396682b73754c1180 ;
+    prov:atLocation niiri:4f3030c801f9431366edc8c63f75c9b4 ;
     prov:value "5.2253565788269"^^xsd:float ;
     nidm_equivalentZStatistic: "4.89552821543552"^^xsd:float ;
     nidm_pValueUncorrected: "4.90210114501011e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0675937275056587"^^xsd:float ;
     nidm_qValueFDR: "0.000215162374940066"^^xsd:float .
 
-niiri:e813708b85b3385396682b73754c1180
+niiri:4f3030c801f9431366edc8c63f75c9b4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0017" ;
     nidm_coordinateVector: "[-60,8,20]"^^xsd:string .
 
-niiri:97c12cc0cda44056974e2945283ffd01 prov:wasDerivedFrom niiri:bc79ea489b7d5f8523a15f77de48e174 .
+niiri:64d0ab7126894908ae25023162e0af73 prov:wasDerivedFrom niiri:e9bd68a9b52a95e89ba7a7e17b4fa428 .
 
-niiri:1c62f81c30210406837cae23e2eecd49
+niiri:90054102ef0485b0300d9ac541c05772
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0018" ;
-    prov:atLocation niiri:7c68dc79ec7d72c3ea623b419061b65a ;
+    prov:atLocation niiri:d3242b8c5dc0ccc3ccff4404d4f25b7f ;
     prov:value "4.98950004577637"^^xsd:float ;
     nidm_equivalentZStatistic: "4.69817956585148"^^xsd:float ;
     nidm_pValueUncorrected: "1.31245304380023e-06"^^xsd:float ;
     nidm_pValueFWER: "0.151048137890434"^^xsd:float ;
     nidm_qValueFDR: "0.000410591908363075"^^xsd:float .
 
-niiri:7c68dc79ec7d72c3ea623b419061b65a
+niiri:d3242b8c5dc0ccc3ccff4404d4f25b7f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0018" ;
     nidm_coordinateVector: "[-44,6,28]"^^xsd:string .
 
-niiri:1c62f81c30210406837cae23e2eecd49 prov:wasDerivedFrom niiri:bc79ea489b7d5f8523a15f77de48e174 .
+niiri:90054102ef0485b0300d9ac541c05772 prov:wasDerivedFrom niiri:e9bd68a9b52a95e89ba7a7e17b4fa428 .
 
-niiri:0e19033ea8b6d5ccdfb0c3133ce0ac9f
+niiri:ea92fe2eb5755d0ea83fe118d00128a1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0019" ;
-    prov:atLocation niiri:4d4d922dca0a2f0ae09e029939694900 ;
+    prov:atLocation niiri:d7872b1aeb0444ca5dfdf2fc0a2d64db ;
     prov:value "5.78093099594116"^^xsd:float ;
     nidm_equivalentZStatistic: "5.34909755317379"^^xsd:float ;
     nidm_pValueUncorrected: "4.41969442155354e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00844151822925698"^^xsd:float ;
     nidm_qValueFDR: "5.41672415342571e-05"^^xsd:float .
 
-niiri:4d4d922dca0a2f0ae09e029939694900
+niiri:d7872b1aeb0444ca5dfdf2fc0a2d64db
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0019" ;
     nidm_coordinateVector: "[-34,-2,52]"^^xsd:string .
 
-niiri:0e19033ea8b6d5ccdfb0c3133ce0ac9f prov:wasDerivedFrom niiri:d1bded8abf09ebee39e58ad5cac474bf .
+niiri:ea92fe2eb5755d0ea83fe118d00128a1 prov:wasDerivedFrom niiri:7693eabf368839e957bc3cfe43c975e0 .
 
-niiri:9a178d511cb9fbd1ef89b1e25fe9e0a0
+niiri:7f8a4c8c46cb2689a3c019747955dc4b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0020" ;
-    prov:atLocation niiri:9a062f32f9f2710625420b074299b00d ;
+    prov:atLocation niiri:629f123a388bd84ac9308e75e74affde ;
     prov:value "5.40964078903198"^^xsd:float ;
     nidm_equivalentZStatistic: "5.04774404642803"^^xsd:float ;
     nidm_pValueUncorrected: "2.23528758724889e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0346958937061391"^^xsd:float ;
     nidm_qValueFDR: "0.000135488206134068"^^xsd:float .
 
-niiri:9a062f32f9f2710625420b074299b00d
+niiri:629f123a388bd84ac9308e75e74affde
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0020" ;
     nidm_coordinateVector: "[-54,-46,58]"^^xsd:string .
 
-niiri:9a178d511cb9fbd1ef89b1e25fe9e0a0 prov:wasDerivedFrom niiri:2d4153f04704f26ae2b13f93cceec23b .
+niiri:7f8a4c8c46cb2689a3c019747955dc4b prov:wasDerivedFrom niiri:39b96655430c53f32e07621dbe8655c4 .
 
-niiri:c74b8735ab25da7815e27b3010834a67
+niiri:e2bc5fe4c987ff0ec0df74c742ff1117
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0021" ;
-    prov:atLocation niiri:8e4ec8f274a1bf93a0340e49c74e4add ;
+    prov:atLocation niiri:55aa6bcca3d975a9a0166ca4aa1ebc70 ;
     prov:value "5.31841945648193"^^xsd:float ;
     nidm_equivalentZStatistic: "4.97261482231588"^^xsd:float ;
     nidm_pValueUncorrected: "3.30279114724163e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0484353441449864"^^xsd:float ;
     nidm_qValueFDR: "0.000170572072121087"^^xsd:float .
 
-niiri:8e4ec8f274a1bf93a0340e49c74e4add
+niiri:55aa6bcca3d975a9a0166ca4aa1ebc70
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0021" ;
     nidm_coordinateVector: "[-62,-38,48]"^^xsd:string .
 
-niiri:c74b8735ab25da7815e27b3010834a67 prov:wasDerivedFrom niiri:8702febb070c184ab840d84baa828f4c .
+niiri:e2bc5fe4c987ff0ec0df74c742ff1117 prov:wasDerivedFrom niiri:90ea170edb9635f011af376c50f1eff8 .
 
-niiri:a20d9e583e30f7d93121b8fed87330f4
+niiri:520fe1eb050426e3b07c4a893b9f7db1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0022" ;
-    prov:atLocation niiri:06de678d09f2fb0a4ed165d8130ce935 ;
+    prov:atLocation niiri:7926e4868dfde88503bc251f695fd8f8 ;
     prov:value "4.57099342346191"^^xsd:float ;
     nidm_equivalentZStatistic: "4.34109644800954"^^xsd:float ;
     nidm_pValueUncorrected: "7.08867353027554e-06"^^xsd:float ;
     nidm_pValueFWER: "0.496004086968197"^^xsd:float ;
     nidm_qValueFDR: "0.00106632293891518"^^xsd:float .
 
-niiri:06de678d09f2fb0a4ed165d8130ce935
+niiri:7926e4868dfde88503bc251f695fd8f8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0022" ;
     nidm_coordinateVector: "[-60,-50,48]"^^xsd:string .
 
-niiri:a20d9e583e30f7d93121b8fed87330f4 prov:wasDerivedFrom niiri:8702febb070c184ab840d84baa828f4c .
+niiri:520fe1eb050426e3b07c4a893b9f7db1 prov:wasDerivedFrom niiri:90ea170edb9635f011af376c50f1eff8 .
 
-niiri:30b7f0fd65f5eaa0304fa23930b236db
+niiri:c87a3b3343886155da34c9892eaae298
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0023" ;
-    prov:atLocation niiri:31c44f3796400492ee153284c21b8295 ;
+    prov:atLocation niiri:60dff4deb3f26445945f48fa10727baf ;
     prov:value "4.93343877792358"^^xsd:float ;
     nidm_equivalentZStatistic: "4.65085575575197"^^xsd:float ;
     nidm_pValueUncorrected: "1.6528024058271e-06"^^xsd:float ;
     nidm_pValueFWER: "0.180887232162623"^^xsd:float ;
     nidm_qValueFDR: "0.000464319207635078"^^xsd:float .
 
-niiri:31c44f3796400492ee153284c21b8295
+niiri:60dff4deb3f26445945f48fa10727baf
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0023" ;
     nidm_coordinateVector: "[-58,-30,-18]"^^xsd:string .
 
-niiri:30b7f0fd65f5eaa0304fa23930b236db prov:wasDerivedFrom niiri:554231ad3e2c8225e52d92a4328b14a9 .
+niiri:c87a3b3343886155da34c9892eaae298 prov:wasDerivedFrom niiri:d976336ac6ecb4bba1136f54b6de3e23 .
 
-niiri:a14324aaf48260f874e7e335238459a9
+niiri:90abc80db14d12280a0791c4ce7391f5
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0024" ;
-    prov:atLocation niiri:e739dc8e31d4a4699048e359c5577844 ;
+    prov:atLocation niiri:408220d56d93cbff661412dfa2054f5f ;
     prov:value "4.76414346694946"^^xsd:float ;
     nidm_equivalentZStatistic: "4.50698548813516"^^xsd:float ;
     nidm_pValueUncorrected: "3.287756441539e-06"^^xsd:float ;
     nidm_pValueFWER: "0.301278778226174"^^xsd:float ;
     nidm_qValueFDR: "0.000675964618846495"^^xsd:float .
 
-niiri:e739dc8e31d4a4699048e359c5577844
+niiri:408220d56d93cbff661412dfa2054f5f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0024" ;
     nidm_coordinateVector: "[-46,-66,-6]"^^xsd:string .
 
-niiri:a14324aaf48260f874e7e335238459a9 prov:wasDerivedFrom niiri:8adb4939693aed81541cf6c7ab164844 .
+niiri:90abc80db14d12280a0791c4ce7391f5 prov:wasDerivedFrom niiri:43ec173da0c3faa0f4491456aea575ce .
 
-niiri:1f9eb4ad0953a5c6995db6937a61ee48
+niiri:e745debfe2f3499165a83cfbc9245de3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0025" ;
-    prov:atLocation niiri:a69d5bbe441e843319f7f864e45b96eb ;
+    prov:atLocation niiri:0406b71827350fd798033287d2d9414b ;
     prov:value "3.7637345790863"^^xsd:float ;
     nidm_equivalentZStatistic: "3.62829384243901"^^xsd:float ;
     nidm_pValueUncorrected: "0.000142650218672435"^^xsd:float ;
     nidm_pValueFWER: "0.999605970761399"^^xsd:float ;
     nidm_qValueFDR: "0.00612774880514626"^^xsd:float .
 
-niiri:a69d5bbe441e843319f7f864e45b96eb
+niiri:0406b71827350fd798033287d2d9414b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0025" ;
     nidm_coordinateVector: "[-54,-64,-8]"^^xsd:string .
 
-niiri:1f9eb4ad0953a5c6995db6937a61ee48 prov:wasDerivedFrom niiri:8adb4939693aed81541cf6c7ab164844 .
+niiri:e745debfe2f3499165a83cfbc9245de3 prov:wasDerivedFrom niiri:43ec173da0c3faa0f4491456aea575ce .
 
-niiri:dca826c37d727ff060eaef05273fbc94
+niiri:2343e4d7eb8c6a1729b72035eaf717e4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0026" ;
-    prov:atLocation niiri:f648a22ca5dcb951a92dd503440b866a ;
+    prov:atLocation niiri:7cde57681c3e67757a6384d582c9f90e ;
     prov:value "4.72232866287231"^^xsd:float ;
     nidm_equivalentZStatistic: "4.47122948835043"^^xsd:float ;
     nidm_pValueUncorrected: "3.88855941602095e-06"^^xsd:float ;
     nidm_pValueFWER: "0.338512677882141"^^xsd:float ;
     nidm_qValueFDR: "0.000740481435956345"^^xsd:float .
 
-niiri:f648a22ca5dcb951a92dd503440b866a
+niiri:7cde57681c3e67757a6384d582c9f90e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0026" ;
     nidm_coordinateVector: "[58,-38,6]"^^xsd:string .
 
-niiri:dca826c37d727ff060eaef05273fbc94 prov:wasDerivedFrom niiri:0a424073d2852615c9efd40e929d5259 .
+niiri:2343e4d7eb8c6a1729b72035eaf717e4 prov:wasDerivedFrom niiri:a21087d5b0bdd477c690e1272139bf8a .
 
-niiri:88c8f744323deb96b36606d6021d61d0
+niiri:1a8a86f7d9c9f722317b24c2e78074af
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0027" ;
-    prov:atLocation niiri:661f3404404dea746395a19c6fa468a8 ;
+    prov:atLocation niiri:b28457b36627fc8c2b8fbac61ecb2964 ;
     prov:value "3.98372888565063"^^xsd:float ;
     nidm_equivalentZStatistic: "3.8255778871433"^^xsd:float ;
     nidm_pValueUncorrected: "6.52328381068878e-05"^^xsd:float ;
     nidm_pValueFWER: "0.985409231324461"^^xsd:float ;
     nidm_qValueFDR: "0.00379034013545227"^^xsd:float .
 
-niiri:661f3404404dea746395a19c6fa468a8
+niiri:b28457b36627fc8c2b8fbac61ecb2964
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0027" ;
     nidm_coordinateVector: "[64,-30,-4]"^^xsd:string .
 
-niiri:88c8f744323deb96b36606d6021d61d0 prov:wasDerivedFrom niiri:0a424073d2852615c9efd40e929d5259 .
+niiri:1a8a86f7d9c9f722317b24c2e78074af prov:wasDerivedFrom niiri:a21087d5b0bdd477c690e1272139bf8a .
 
-niiri:4f0a11ac7d60b564dc68ce7519a69b5e
+niiri:23b4a479f72f56fff23eeb6665cae807
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0028" ;
-    prov:atLocation niiri:56fcba156abac7fbf1e06c695735eef3 ;
+    prov:atLocation niiri:8e0d84f185660b18429c95fb79db1336 ;
     prov:value "3.9098813533783"^^xsd:float ;
     nidm_equivalentZStatistic: "3.75959988615137"^^xsd:float ;
     nidm_pValueUncorrected: "8.50926599039736e-05"^^xsd:float ;
     nidm_pValueFWER: "0.994607633788328"^^xsd:float ;
     nidm_qValueFDR: "0.00444631553927497"^^xsd:float .
 
-niiri:56fcba156abac7fbf1e06c695735eef3
+niiri:8e0d84f185660b18429c95fb79db1336
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0028" ;
     nidm_coordinateVector: "[54,-24,-2]"^^xsd:string .
 
-niiri:4f0a11ac7d60b564dc68ce7519a69b5e prov:wasDerivedFrom niiri:0a424073d2852615c9efd40e929d5259 .
+niiri:23b4a479f72f56fff23eeb6665cae807 prov:wasDerivedFrom niiri:a21087d5b0bdd477c690e1272139bf8a .
 
-niiri:9b223970862df494031bc9faf1f4c78b
+niiri:cb1ced392fd8df88e767db43c1bc0ed7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0029" ;
-    prov:atLocation niiri:c883d741a84bd31c13e914935c7d04f1 ;
+    prov:atLocation niiri:17aedfa63a871543b140ee883e7fa00a ;
     prov:value "4.70483255386353"^^xsd:float ;
     nidm_equivalentZStatistic: "4.45624265093732"^^xsd:float ;
     nidm_pValueUncorrected: "4.17043099876224e-06"^^xsd:float ;
     nidm_pValueFWER: "0.354967306449537"^^xsd:float ;
     nidm_qValueFDR: "0.000776498970788289"^^xsd:float .
 
-niiri:c883d741a84bd31c13e914935c7d04f1
+niiri:17aedfa63a871543b140ee883e7fa00a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0029" ;
     nidm_coordinateVector: "[-36,-74,-14]"^^xsd:string .
 
-niiri:9b223970862df494031bc9faf1f4c78b prov:wasDerivedFrom niiri:c419557738905fde9064be2cef6f1449 .
+niiri:cb1ced392fd8df88e767db43c1bc0ed7 prov:wasDerivedFrom niiri:a4d3b6fc7cc84d91945916a3052dd21c .
 
-niiri:f171c32f91d32c0f51f4f396c0886f28
+niiri:7f2c05eeb31277d29699a1a1dc5708b9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0030" ;
-    prov:atLocation niiri:dfe8d905a23b80dd174425ba9b598fed ;
+    prov:atLocation niiri:c65773868ad3c3ee6565f44d2f503688 ;
     prov:value "4.08770418167114"^^xsd:float ;
     nidm_equivalentZStatistic: "3.91804495668"^^xsd:float ;
     nidm_pValueUncorrected: "4.46350297789166e-05"^^xsd:float ;
     nidm_pValueFWER: "0.955724279224547"^^xsd:float ;
     nidm_qValueFDR: "0.00301069792579844"^^xsd:float .
 
-niiri:dfe8d905a23b80dd174425ba9b598fed
+niiri:c65773868ad3c3ee6565f44d2f503688
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0030" ;
     nidm_coordinateVector: "[-36,-68,-20]"^^xsd:string .
 
-niiri:f171c32f91d32c0f51f4f396c0886f28 prov:wasDerivedFrom niiri:c419557738905fde9064be2cef6f1449 .
+niiri:7f2c05eeb31277d29699a1a1dc5708b9 prov:wasDerivedFrom niiri:a4d3b6fc7cc84d91945916a3052dd21c .
 
-niiri:7d4f723c0c0d768fc1a02933cd7da8ec
+niiri:de55bbb80f52ecc8be8aa173a5d0c4c4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0031" ;
-    prov:atLocation niiri:58760e96b02016370f0f9443e294f468 ;
+    prov:atLocation niiri:23023da27952d97ce5978f24d0201fb4 ;
     prov:value "3.71012616157532"^^xsd:float ;
     nidm_equivalentZStatistic: "3.57988831343959"^^xsd:float ;
     nidm_pValueUncorrected: "0.000171870546999631"^^xsd:float ;
     nidm_pValueFWER: "0.999883757236262"^^xsd:float ;
     nidm_qValueFDR: "0.00687347140086337"^^xsd:float .
 
-niiri:58760e96b02016370f0f9443e294f468
+niiri:23023da27952d97ce5978f24d0201fb4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0031" ;
     nidm_coordinateVector: "[-30,-58,-16]"^^xsd:string .
 
-niiri:7d4f723c0c0d768fc1a02933cd7da8ec prov:wasDerivedFrom niiri:c419557738905fde9064be2cef6f1449 .
+niiri:de55bbb80f52ecc8be8aa173a5d0c4c4 prov:wasDerivedFrom niiri:a4d3b6fc7cc84d91945916a3052dd21c .
 
-niiri:f34c171fa368d7fae0a84902b32d26ab
+niiri:94ac82c373f762df7652cf2eee707fcf
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0032" ;
-    prov:atLocation niiri:9f87622f9d1487269c1bd9a0ad59d8e2 ;
+    prov:atLocation niiri:65bafc594498c6ac36e3357ddb1e5cf9 ;
     prov:value "4.59621620178223"^^xsd:float ;
     nidm_equivalentZStatistic: "4.36286413267216"^^xsd:float ;
     nidm_pValueUncorrected: "6.41853365035416e-06"^^xsd:float ;
     nidm_pValueFWER: "0.467637998233248"^^xsd:float ;
     nidm_qValueFDR: "0.00100629980038701"^^xsd:float .
 
-niiri:9f87622f9d1487269c1bd9a0ad59d8e2
+niiri:65bafc594498c6ac36e3357ddb1e5cf9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0032" ;
     nidm_coordinateVector: "[16,-98,6]"^^xsd:string .
 
-niiri:f34c171fa368d7fae0a84902b32d26ab prov:wasDerivedFrom niiri:4b5ae066ef253b812d649482610dbba7 .
+niiri:94ac82c373f762df7652cf2eee707fcf prov:wasDerivedFrom niiri:d3e3d125a9ce7e2ce6bac0795d332509 .
 
-niiri:ea18051b705fd4266580ebbdefd1cf08
+niiri:a3cbab4a2a30eece310c15c0975c7b8c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0033" ;
-    prov:atLocation niiri:132a1b66dcc9169a3a5a1e71bbe7d479 ;
+    prov:atLocation niiri:2f7752391d49b36d1668a1bed931ebed ;
     prov:value "4.57891654968262"^^xsd:float ;
     nidm_equivalentZStatistic: "4.34793761600864"^^xsd:float ;
     nidm_pValueUncorrected: "6.87118388575936e-06"^^xsd:float ;
     nidm_pValueFWER: "0.487021764768749"^^xsd:float ;
     nidm_qValueFDR: "0.00104840737781972"^^xsd:float .
 
-niiri:132a1b66dcc9169a3a5a1e71bbe7d479
+niiri:2f7752391d49b36d1668a1bed931ebed
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0033" ;
     nidm_coordinateVector: "[-60,-16,28]"^^xsd:string .
 
-niiri:ea18051b705fd4266580ebbdefd1cf08 prov:wasDerivedFrom niiri:c27d8c4414a41bf2e1d9fe41a87f11b6 .
+niiri:a3cbab4a2a30eece310c15c0975c7b8c prov:wasDerivedFrom niiri:0531c28556a1e0fba30c3ea1dd24f56e .
 
-niiri:3f5eb44d431119cfda5e57ae0f560d5a
+niiri:24e1979d3724b3518945e59d3fad2d5b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0034" ;
-    prov:atLocation niiri:61adef73114ec234f5f7b942b2699d4a ;
+    prov:atLocation niiri:da3399510a366ca55680d838c72b0f46 ;
     prov:value "4.37013816833496"^^xsd:float ;
     nidm_equivalentZStatistic: "4.16664310578498"^^xsd:float ;
     nidm_pValueUncorrected: "1.54558935169247e-05"^^xsd:float ;
     nidm_pValueFWER: "0.730405153245217"^^xsd:float ;
     nidm_qValueFDR: "0.00164483391358715"^^xsd:float .
 
-niiri:61adef73114ec234f5f7b942b2699d4a
+niiri:da3399510a366ca55680d838c72b0f46
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0034" ;
     nidm_coordinateVector: "[-52,-62,52]"^^xsd:string .
 
-niiri:3f5eb44d431119cfda5e57ae0f560d5a prov:wasDerivedFrom niiri:63757a12c243d6f113a5c106a65341d3 .
+niiri:24e1979d3724b3518945e59d3fad2d5b prov:wasDerivedFrom niiri:22a4e1327d4f2f7349df156933a68889 .
 
-niiri:968450287bdafda68a39620f236330d8
+niiri:90230b1d46674135f54f40a8eaaa6955
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0035" ;
-    prov:atLocation niiri:f55dd854fcfab6398e630bbf0bc54c1f ;
+    prov:atLocation niiri:6f47e3c2cf1ad6ee422a9cac44b388e2 ;
     prov:value "4.30655717849731"^^xsd:float ;
     nidm_equivalentZStatistic: "4.11101155082742"^^xsd:float ;
     nidm_pValueUncorrected: "1.96964745459161e-05"^^xsd:float ;
     nidm_pValueFWER: "0.798260223882423"^^xsd:float ;
     nidm_qValueFDR: "0.00188267859062858"^^xsd:float .
 
-niiri:f55dd854fcfab6398e630bbf0bc54c1f
+niiri:6f47e3c2cf1ad6ee422a9cac44b388e2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0035" ;
     nidm_coordinateVector: "[-26,-92,32]"^^xsd:string .
 
-niiri:968450287bdafda68a39620f236330d8 prov:wasDerivedFrom niiri:64a23b7dfa188ea7c583dd955c4783b0 .
+niiri:90230b1d46674135f54f40a8eaaa6955 prov:wasDerivedFrom niiri:661e97df890b4cd21b7b3cc4a2220e2e .
 
-niiri:66a1f9784198e645bd70e47493fcfc1e
+niiri:6ecb22dc01f666b06e37c52dda7e1cea
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0036" ;
-    prov:atLocation niiri:165705ccc37ab69befde79237446eddd ;
+    prov:atLocation niiri:868adc42924955a9584f6bf2cdbbe62c ;
     prov:value "4.24533367156982"^^xsd:float ;
     nidm_equivalentZStatistic: "4.05725918601008"^^xsd:float ;
     nidm_pValueUncorrected: "2.4825985211363e-05"^^xsd:float ;
     nidm_pValueFWER: "0.855631833511506"^^xsd:float ;
     nidm_qValueFDR: "0.00216400098580605"^^xsd:float .
 
-niiri:165705ccc37ab69befde79237446eddd
+niiri:868adc42924955a9584f6bf2cdbbe62c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0036" ;
     nidm_coordinateVector: "[-18,-60,48]"^^xsd:string .
 
-niiri:66a1f9784198e645bd70e47493fcfc1e prov:wasDerivedFrom niiri:c7fd5f4cdee71350124b35242a6b1709 .
+niiri:6ecb22dc01f666b06e37c52dda7e1cea prov:wasDerivedFrom niiri:fb7297e8c19234947de7375e05901f89 .
 
-niiri:f4a8a2fea797e1beb91fddefc276b32f
+niiri:1147bd3222d74b8465b410daf5f551d9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0037" ;
-    prov:atLocation niiri:62930e1ae7842cdd16785978ed6f01fb ;
+    prov:atLocation niiri:23fcb7cf1cb30acabf1d069782179e41 ;
     prov:value "4.22729349136353"^^xsd:float ;
     nidm_equivalentZStatistic: "4.04138628171284"^^xsd:float ;
     nidm_pValueUncorrected: "2.65680735640483e-05"^^xsd:float ;
     nidm_pValueFWER: "0.870712357794855"^^xsd:float ;
     nidm_qValueFDR: "0.00224862910698152"^^xsd:float .
 
-niiri:62930e1ae7842cdd16785978ed6f01fb
+niiri:23fcb7cf1cb30acabf1d069782179e41
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0037" ;
     nidm_coordinateVector: "[-20,-98,22]"^^xsd:string .
 
-niiri:f4a8a2fea797e1beb91fddefc276b32f prov:wasDerivedFrom niiri:43b10bfa562e759c7c198b457de7cd8b .
+niiri:1147bd3222d74b8465b410daf5f551d9 prov:wasDerivedFrom niiri:c016e8a860699bda1ff422a1f501e63d .
 
-niiri:0667939b7025ee7fa4cd16ef0627ee59
+niiri:0edd0549008deb53921ccec5934b3d03
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0038" ;
-    prov:atLocation niiri:915e6b7f895b7accd4998d9eac95046f ;
+    prov:atLocation niiri:ca5f81484ccce6fc3e9387947befc7f8 ;
     prov:value "4.22599840164185"^^xsd:float ;
     nidm_equivalentZStatistic: "4.04024618213588"^^xsd:float ;
     nidm_pValueUncorrected: "2.66975618669063e-05"^^xsd:float ;
     nidm_pValueFWER: "0.871760516202526"^^xsd:float ;
     nidm_qValueFDR: "0.00224977618124126"^^xsd:float .
 
-niiri:915e6b7f895b7accd4998d9eac95046f
+niiri:ca5f81484ccce6fc3e9387947befc7f8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0038" ;
     nidm_coordinateVector: "[-36,-74,-34]"^^xsd:string .
 
-niiri:0667939b7025ee7fa4cd16ef0627ee59 prov:wasDerivedFrom niiri:94ae4aee00bdd503edae82f33c3e9515 .
+niiri:0edd0549008deb53921ccec5934b3d03 prov:wasDerivedFrom niiri:c4fe065cafdebad144fa17a8ec71281b .
 
-niiri:a7f2170a24f2f05d63133355bdd77f43
+niiri:cecb64ea54e0530f18d065bad589c2a6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0039" ;
-    prov:atLocation niiri:5cd8e4e2f6aefbc637d10e9378123002 ;
+    prov:atLocation niiri:8dfaaed3cdea8aa1695388a5f053616f ;
     prov:value "2.86162257194519"^^xsd:float ;
     nidm_equivalentZStatistic: "2.79772486594084"^^xsd:float ;
     nidm_pValueUncorrected: "0.00257319651143795"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0401361290360738"^^xsd:float .
 
-niiri:5cd8e4e2f6aefbc637d10e9378123002
+niiri:8dfaaed3cdea8aa1695388a5f053616f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0039" ;
     nidm_coordinateVector: "[-44,-62,-32]"^^xsd:string .
 
-niiri:a7f2170a24f2f05d63133355bdd77f43 prov:wasDerivedFrom niiri:94ae4aee00bdd503edae82f33c3e9515 .
+niiri:cecb64ea54e0530f18d065bad589c2a6 prov:wasDerivedFrom niiri:c4fe065cafdebad144fa17a8ec71281b .
 
-niiri:63a3ca76c01c0d8659c77cba85d71f0d
+niiri:f7f872af0c034510f177bd8ce9bb0b0c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0040" ;
-    prov:atLocation niiri:546d1d0bd9649ec9cb88e495502e1f61 ;
+    prov:atLocation niiri:8aeee6e06b00259350b3cf7d5bdf384c ;
     prov:value "4.20391035079956"^^xsd:float ;
     nidm_equivalentZStatistic: "4.02078923241408"^^xsd:float ;
     nidm_pValueUncorrected: "2.900174224163e-05"^^xsd:float ;
     nidm_pValueFWER: "0.888907080881232"^^xsd:float ;
     nidm_qValueFDR: "0.00235275290167977"^^xsd:float .
 
-niiri:546d1d0bd9649ec9cb88e495502e1f61
+niiri:8aeee6e06b00259350b3cf7d5bdf384c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0040" ;
     nidm_coordinateVector: "[34,-54,-16]"^^xsd:string .
 
-niiri:63a3ca76c01c0d8659c77cba85d71f0d prov:wasDerivedFrom niiri:4f7b061f932253ef4a07d4d9f2fe8517 .
+niiri:f7f872af0c034510f177bd8ce9bb0b0c prov:wasDerivedFrom niiri:b9447d9cb03b61ef6f6b29b2f726c748 .
 
-niiri:a9bd8e59595df4fd6670bcebc783e2fb
+niiri:36ff54739107c726560ff84ecfbec58e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0041" ;
-    prov:atLocation niiri:5b02dccced55af630e4d693d63c58b72 ;
+    prov:atLocation niiri:fee6ca7cc2a611c4fda7974781d37cbd ;
     prov:value "4.18721437454224"^^xsd:float ;
     nidm_equivalentZStatistic: "4.00606667297511"^^xsd:float ;
     nidm_pValueUncorrected: "3.08691144208506e-05"^^xsd:float ;
     nidm_pValueFWER: "0.900934824371894"^^xsd:float ;
     nidm_qValueFDR: "0.00243416319862164"^^xsd:float .
 
-niiri:5b02dccced55af630e4d693d63c58b72
+niiri:fee6ca7cc2a611c4fda7974781d37cbd
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0041" ;
     nidm_coordinateVector: "[12,-100,20]"^^xsd:string .
 
-niiri:a9bd8e59595df4fd6670bcebc783e2fb prov:wasDerivedFrom niiri:0163fc34332a97aa514f22d9a18b4aef .
+niiri:36ff54739107c726560ff84ecfbec58e prov:wasDerivedFrom niiri:fccd53239e801ce9120073c47ddcae13 .
 
-niiri:4a2bbf2b0326642b3f66c7fb2b5f18fd
+niiri:e7e5af7d0c21e8aef18e2542948c6793
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0042" ;
-    prov:atLocation niiri:d12cd505628e3d8c6055e2a31cf5d9d0 ;
+    prov:atLocation niiri:dc93b496593d4b472f2eb9fd7aca8b08 ;
     prov:value "4.17404651641846"^^xsd:float ;
     nidm_equivalentZStatistic: "3.99444589181498"^^xsd:float ;
     nidm_pValueUncorrected: "3.24228638075574e-05"^^xsd:float ;
     nidm_pValueFWER: "0.909844421846994"^^xsd:float ;
     nidm_qValueFDR: "0.00250424652987014"^^xsd:float .
 
-niiri:d12cd505628e3d8c6055e2a31cf5d9d0
+niiri:dc93b496593d4b472f2eb9fd7aca8b08
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0042" ;
     nidm_coordinateVector: "[-40,-38,44]"^^xsd:string .
 
-niiri:4a2bbf2b0326642b3f66c7fb2b5f18fd prov:wasDerivedFrom niiri:afb1b880058db996109597c9134c0944 .
+niiri:e7e5af7d0c21e8aef18e2542948c6793 prov:wasDerivedFrom niiri:e8858d23bbbcba237e94c70004237a2f .
 
-niiri:92a1a39a34a21b0345adc8771856b403
+niiri:5eedc42ee231bb3e0801681a9ba98372
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0043" ;
-    prov:atLocation niiri:99d132a290adb1a4ddd6e90191ab85b9 ;
+    prov:atLocation niiri:ab81f14081ba25602d7d462d456bc0e6 ;
     prov:value "4.07333517074585"^^xsd:float ;
     nidm_equivalentZStatistic: "3.9052963692066"^^xsd:float ;
     nidm_pValueUncorrected: "4.70549882543025e-05"^^xsd:float ;
     nidm_pValueFWER: "0.961337330645756"^^xsd:float ;
     nidm_qValueFDR: "0.00311829811824681"^^xsd:float .
 
-niiri:99d132a290adb1a4ddd6e90191ab85b9
+niiri:ab81f14081ba25602d7d462d456bc0e6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0043" ;
     nidm_coordinateVector: "[20,-66,34]"^^xsd:string .
 
-niiri:92a1a39a34a21b0345adc8771856b403 prov:wasDerivedFrom niiri:a3209dd94fcfcfc2e0d96d3475893c16 .
+niiri:5eedc42ee231bb3e0801681a9ba98372 prov:wasDerivedFrom niiri:a1e36a12612c98786c42d6e581a41938 .
 
-niiri:aa2a89d1737724f1593952d9c18d40a4
+niiri:5a68064d075ad549c6b87de74be574de
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0044" ;
-    prov:atLocation niiri:29e692fa53e24c76ed2497c29ffcfdd2 ;
+    prov:atLocation niiri:53dd5f18ed8740b69c85f29f5098f9c1 ;
     prov:value "4.05762767791748"^^xsd:float ;
     nidm_equivalentZStatistic: "3.89134919103145"^^xsd:float ;
     nidm_pValueUncorrected: "4.98441713834286e-05"^^xsd:float ;
     nidm_pValueFWER: "0.966867400896655"^^xsd:float ;
     nidm_qValueFDR: "0.00322871741467698"^^xsd:float .
 
-niiri:29e692fa53e24c76ed2497c29ffcfdd2
+niiri:53dd5f18ed8740b69c85f29f5098f9c1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0044" ;
     nidm_coordinateVector: "[-46,-56,14]"^^xsd:string .
 
-niiri:aa2a89d1737724f1593952d9c18d40a4 prov:wasDerivedFrom niiri:0e0928e501c6272ac7fd3ddf2695e9f7 .
+niiri:5a68064d075ad549c6b87de74be574de prov:wasDerivedFrom niiri:6aac454abbeb6462b826cd647eb086e0 .
 
-niiri:20299a2e3c1a8789b6e669a167cd8a51
+niiri:69b3e9ba35baf225bd111d6d16f02c59
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0045" ;
-    prov:atLocation niiri:c25f00e518298f017ca37cefaf776b5e ;
+    prov:atLocation niiri:104c93687e188734b35ec18667237aa2 ;
     prov:value "3.97341108322144"^^xsd:float ;
     nidm_equivalentZStatistic: "3.81637469850314"^^xsd:float ;
     nidm_pValueUncorrected: "6.7713399346081e-05"^^xsd:float ;
     nidm_pValueFWER: "0.987160063394768"^^xsd:float ;
     nidm_qValueFDR: "0.0038799021604929"^^xsd:float .
 
-niiri:c25f00e518298f017ca37cefaf776b5e
+niiri:104c93687e188734b35ec18667237aa2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0045" ;
     nidm_coordinateVector: "[-50,-50,20]"^^xsd:string .
 
-niiri:20299a2e3c1a8789b6e669a167cd8a51 prov:wasDerivedFrom niiri:0e0928e501c6272ac7fd3ddf2695e9f7 .
+niiri:69b3e9ba35baf225bd111d6d16f02c59 prov:wasDerivedFrom niiri:6aac454abbeb6462b826cd647eb086e0 .
 
-niiri:cc2de1fc69206ea9e189278a76fe556c
+niiri:5cddeb38ad7e027bd0de87a3a4bbef17
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0046" ;
-    prov:atLocation niiri:7f317302e0aa94a0d54fb816d3613b5d ;
+    prov:atLocation niiri:a48ff748b6cbde7cfc7b801d780bf846 ;
     prov:value "4.0217924118042"^^xsd:float ;
     nidm_equivalentZStatistic: "3.85948683644491"^^xsd:float ;
     nidm_pValueUncorrected: "5.68126885931441e-05"^^xsd:float ;
     nidm_pValueFWER: "0.977286609355005"^^xsd:float ;
     nidm_qValueFDR: "0.00348825429991405"^^xsd:float .
 
-niiri:7f317302e0aa94a0d54fb816d3613b5d
+niiri:a48ff748b6cbde7cfc7b801d780bf846
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0046" ;
     nidm_coordinateVector: "[-36,-40,-36]"^^xsd:string .
 
-niiri:cc2de1fc69206ea9e189278a76fe556c prov:wasDerivedFrom niiri:15ddf3a0750659085f821d46282e1a9c .
+niiri:5cddeb38ad7e027bd0de87a3a4bbef17 prov:wasDerivedFrom niiri:7b28ee2c06d9f1eb5b4dab7494fe7a85 .
 
-niiri:ce86070fd4e8986d82b4bed2da9953d8
+niiri:3522180f8cbe6ef50347376f1bbf6edb
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0047" ;
-    prov:atLocation niiri:d620ea275f179536cab44837535ca252 ;
+    prov:atLocation niiri:8f5650b5420113415c6871a4e4b78e5e ;
     prov:value "3.8867518901825"^^xsd:float ;
     nidm_equivalentZStatistic: "3.73888373627584"^^xsd:float ;
     nidm_pValueUncorrected: "9.24195907030523e-05"^^xsd:float ;
     nidm_pValueFWER: "0.996210852184447"^^xsd:float ;
     nidm_qValueFDR: "0.00468683023961801"^^xsd:float .
 
-niiri:d620ea275f179536cab44837535ca252
+niiri:8f5650b5420113415c6871a4e4b78e5e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0047" ;
     nidm_coordinateVector: "[-50,-46,-32]"^^xsd:string .
 
-niiri:ce86070fd4e8986d82b4bed2da9953d8 prov:wasDerivedFrom niiri:15ddf3a0750659085f821d46282e1a9c .
+niiri:3522180f8cbe6ef50347376f1bbf6edb prov:wasDerivedFrom niiri:7b28ee2c06d9f1eb5b4dab7494fe7a85 .
 
-niiri:68f91a82a53b5e5a690fda58a117d029
+niiri:4b7df6a7ed2935756536e850b92db30a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0048" ;
-    prov:atLocation niiri:d5c9cbdb71145c0b71b7333ee309adfc ;
+    prov:atLocation niiri:40a9737c4433538d39217a005cfdb1fc ;
     prov:value "3.19474077224731"^^xsd:float ;
     nidm_equivalentZStatistic: "3.10821385730133"^^xsd:float ;
     nidm_pValueUncorrected: "0.000941109068576473"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999989"^^xsd:float ;
     nidm_qValueFDR: "0.0204319298365656"^^xsd:float .
 
-niiri:d5c9cbdb71145c0b71b7333ee309adfc
+niiri:40a9737c4433538d39217a005cfdb1fc
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0048" ;
     nidm_coordinateVector: "[-44,-42,-36]"^^xsd:string .
 
-niiri:68f91a82a53b5e5a690fda58a117d029 prov:wasDerivedFrom niiri:15ddf3a0750659085f821d46282e1a9c .
+niiri:4b7df6a7ed2935756536e850b92db30a prov:wasDerivedFrom niiri:7b28ee2c06d9f1eb5b4dab7494fe7a85 .
 
-niiri:f14ffa337966ed8f5ea7817efc9a370e
+niiri:d9b3a050332d74bf0f36c7adfdb580c3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0049" ;
-    prov:atLocation niiri:861f40e9acc61fd9f1fa2fe619e6c102 ;
+    prov:atLocation niiri:c118718c36a03fe9a2bf929e397ff014 ;
     prov:value "3.9634416103363"^^xsd:float ;
     nidm_equivalentZStatistic: "3.80747753892992"^^xsd:float ;
     nidm_pValueUncorrected: "7.01957428701494e-05"^^xsd:float ;
     nidm_pValueFWER: "0.988689669381963"^^xsd:float ;
     nidm_qValueFDR: "0.00396363025696444"^^xsd:float .
 
-niiri:861f40e9acc61fd9f1fa2fe619e6c102
+niiri:c118718c36a03fe9a2bf929e397ff014
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0049" ;
     nidm_coordinateVector: "[4,6,32]"^^xsd:string .
 
-niiri:f14ffa337966ed8f5ea7817efc9a370e prov:wasDerivedFrom niiri:e037574456f8a483328c150e32419262 .
+niiri:d9b3a050332d74bf0f36c7adfdb580c3 prov:wasDerivedFrom niiri:00aad4e5c367c7dee68c301c251cb2ce .
 
-niiri:37592d1480a9df2cdee73f855d4d7186
+niiri:f725218800cfd7000fbd0ad268a06710
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0050" ;
-    prov:atLocation niiri:9b5828c800e2682cdaeaaf29ae9a836e ;
+    prov:atLocation niiri:a46751b7d89671899ba59e831d6e41bc ;
     prov:value "3.96245408058167"^^xsd:float ;
     nidm_equivalentZStatistic: "3.80659597790245"^^xsd:float ;
     nidm_pValueUncorrected: "7.04463150378309e-05"^^xsd:float ;
     nidm_pValueFWER: "0.988832912076595"^^xsd:float ;
     nidm_qValueFDR: "0.00397422792108106"^^xsd:float .
 
-niiri:9b5828c800e2682cdaeaaf29ae9a836e
+niiri:a46751b7d89671899ba59e831d6e41bc
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0050" ;
     nidm_coordinateVector: "[-50,-48,-16]"^^xsd:string .
 
-niiri:37592d1480a9df2cdee73f855d4d7186 prov:wasDerivedFrom niiri:cead124d94f280e9eb613273f575273f .
+niiri:f725218800cfd7000fbd0ad268a06710 prov:wasDerivedFrom niiri:904dc3e52037e77af188b63a3d3a6884 .
 
-niiri:cc52c3ef3b10fd45f54b5ac8243904c1
+niiri:dad6f2d5c4ce67fa4e55fba569c0d484
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0051" ;
-    prov:atLocation niiri:6c484caacee5601ee6af6744a0b59be1 ;
+    prov:atLocation niiri:3206daab4372447e234b9b148d6d815b ;
     prov:value "3.90285301208496"^^xsd:float ;
     nidm_equivalentZStatistic: "3.75330746420074"^^xsd:float ;
     nidm_pValueUncorrected: "8.72582920719012e-05"^^xsd:float ;
     nidm_pValueFWER: "0.99514521861122"^^xsd:float ;
     nidm_qValueFDR: "0.00452170460938149"^^xsd:float .
 
-niiri:6c484caacee5601ee6af6744a0b59be1
+niiri:3206daab4372447e234b9b148d6d815b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0051" ;
     nidm_coordinateVector: "[-36,-46,-18]"^^xsd:string .
 
-niiri:cc52c3ef3b10fd45f54b5ac8243904c1 prov:wasDerivedFrom niiri:cead124d94f280e9eb613273f575273f .
+niiri:dad6f2d5c4ce67fa4e55fba569c0d484 prov:wasDerivedFrom niiri:904dc3e52037e77af188b63a3d3a6884 .
 
-niiri:ce54001c574a8fe6263bf2fbcad328e5
+niiri:840283767e66dbd6e157c770ba828a93
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0052" ;
-    prov:atLocation niiri:f6172039cefd32e90e0f2a247877862d ;
+    prov:atLocation niiri:20f83c4fa7511447b6828ed5c47b09b3 ;
     prov:value "3.90759468078613"^^xsd:float ;
     nidm_equivalentZStatistic: "3.75755289319297"^^xsd:float ;
     nidm_pValueUncorrected: "8.57915531067288e-05"^^xsd:float ;
     nidm_pValueFWER: "0.994787688943672"^^xsd:float ;
     nidm_qValueFDR: "0.00447445110574173"^^xsd:float .
 
-niiri:f6172039cefd32e90e0f2a247877862d
+niiri:20f83c4fa7511447b6828ed5c47b09b3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0052" ;
     nidm_coordinateVector: "[-14,-98,-4]"^^xsd:string .
 
-niiri:ce54001c574a8fe6263bf2fbcad328e5 prov:wasDerivedFrom niiri:9dee950d4d0d87d9847d4f2182442446 .
+niiri:840283767e66dbd6e157c770ba828a93 prov:wasDerivedFrom niiri:ffdea138243040f7b25be6c44f68510d .
 
-niiri:38afa6f16560eb4228a77492bbd3df91
+niiri:0e31b662b4e33990fa038bbb4c5ba001
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0053" ;
-    prov:atLocation niiri:2c89f81a86c483cac55f91d34afc320e ;
+    prov:atLocation niiri:ef4842b6c6cfe0f325e9e746c09cb167 ;
     prov:value "3.86077284812927"^^xsd:float ;
     nidm_equivalentZStatistic: "3.7155862280194"^^xsd:float ;
     nidm_pValueUncorrected: "0.000101366555929516"^^xsd:float ;
     nidm_pValueFWER: "0.997515005942308"^^xsd:float ;
     nidm_qValueFDR: "0.0049663224069025"^^xsd:float .
 
-niiri:2c89f81a86c483cac55f91d34afc320e
+niiri:ef4842b6c6cfe0f325e9e746c09cb167
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0053" ;
     nidm_coordinateVector: "[64,-30,-22]"^^xsd:string .
 
-niiri:38afa6f16560eb4228a77492bbd3df91 prov:wasDerivedFrom niiri:5bdb44212c11108bd9056913ba88493d .
+niiri:0e31b662b4e33990fa038bbb4c5ba001 prov:wasDerivedFrom niiri:f19e77aa11c450b96b368f822fcfd6ce .
 
-niiri:6eff30308e3f7b2a6aaae1d55bb952e1
+niiri:15315bb12a4c858854e329703938208d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0054" ;
-    prov:atLocation niiri:ae256fd213e1f17e08ad8f6851439f2b ;
+    prov:atLocation niiri:a0c6fdfff1abb4112874eb223d64277f ;
     prov:value "3.82178378105164"^^xsd:float ;
     nidm_equivalentZStatistic: "3.68056404693028"^^xsd:float ;
     nidm_pValueUncorrected: "0.000116359297336222"^^xsd:float ;
     nidm_pValueFWER: "0.998750111206092"^^xsd:float ;
     nidm_qValueFDR: "0.00541658304290436"^^xsd:float .
 
-niiri:ae256fd213e1f17e08ad8f6851439f2b
+niiri:a0c6fdfff1abb4112874eb223d64277f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0054" ;
     nidm_coordinateVector: "[12,52,-12]"^^xsd:string .
 
-niiri:6eff30308e3f7b2a6aaae1d55bb952e1 prov:wasDerivedFrom niiri:fcd93504620cb56307a63f5826ae493b .
+niiri:15315bb12a4c858854e329703938208d prov:wasDerivedFrom niiri:1b80b6984bddaf1c61a51a898d6acbea .
 
-niiri:75c8a9043f4b6be09d078673121747b6
+niiri:b8c952b7eb0604aaeff8a4b3deed04f2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0055" ;
-    prov:atLocation niiri:be3f17d08ed60e5574ba0acf6d820751 ;
+    prov:atLocation niiri:aca234cd238d14c51f2712b56326ccdf ;
     prov:value "3.80767583847046"^^xsd:float ;
     nidm_equivalentZStatistic: "3.66787455107711"^^xsd:float ;
     nidm_pValueUncorrected: "0.000122287561408974"^^xsd:float ;
     nidm_pValueFWER: "0.999041631710947"^^xsd:float ;
     nidm_qValueFDR: "0.00557619880333977"^^xsd:float .
 
-niiri:be3f17d08ed60e5574ba0acf6d820751
+niiri:aca234cd238d14c51f2712b56326ccdf
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0055" ;
     nidm_coordinateVector: "[22,-80,54]"^^xsd:string .
 
-niiri:75c8a9043f4b6be09d078673121747b6 prov:wasDerivedFrom niiri:22f559c5bb43c4d1c00d4b2abbd64b80 .
+niiri:b8c952b7eb0604aaeff8a4b3deed04f2 prov:wasDerivedFrom niiri:2a6b200869ec06562d293e64de33e926 .
 
-niiri:b15a28acac19d4f38e4dd5710e891ec5
+niiri:22efce75aa6c6dce7c1322da7c4c8a84
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0056" ;
-    prov:atLocation niiri:1cfacce95e7f446ccd01b964dc08a5bc ;
+    prov:atLocation niiri:1db9cd1b4946a3ce9cb7d6f4d57e7825 ;
     prov:value "3.78668808937073"^^xsd:float ;
     nidm_equivalentZStatistic: "3.64898036269368"^^xsd:float ;
     nidm_pValueUncorrected: "0.000131641613210109"^^xsd:float ;
     nidm_pValueFWER: "0.999365630484476"^^xsd:float ;
     nidm_qValueFDR: "0.00583459491796649"^^xsd:float .
 
-niiri:1cfacce95e7f446ccd01b964dc08a5bc
+niiri:1db9cd1b4946a3ce9cb7d6f4d57e7825
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0056" ;
     nidm_coordinateVector: "[-22,-74,60]"^^xsd:string .
 
-niiri:b15a28acac19d4f38e4dd5710e891ec5 prov:wasDerivedFrom niiri:b58c8c56d192cbadcd924e0e299d45b7 .
+niiri:22efce75aa6c6dce7c1322da7c4c8a84 prov:wasDerivedFrom niiri:50eb3a7d09683191b4aed76432577ca4 .
 
-niiri:806b3ed136eea98cd29cfd76d1200da4
+niiri:29cb61e520efc605169b4daa2aecadcf
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0057" ;
-    prov:atLocation niiri:3d8066545c7fc03066852405c620c751 ;
+    prov:atLocation niiri:e4d533f3ae3530faa4fa88f80772d5ba ;
     prov:value "3.69408750534058"^^xsd:float ;
     nidm_equivalentZStatistic: "3.56538143418403"^^xsd:float ;
     nidm_pValueUncorrected: "0.000181663694368006"^^xsd:float ;
     nidm_pValueFWER: "0.999921818129803"^^xsd:float ;
     nidm_qValueFDR: "0.00709819832733513"^^xsd:float .
 
-niiri:3d8066545c7fc03066852405c620c751
+niiri:e4d533f3ae3530faa4fa88f80772d5ba
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0057" ;
     nidm_coordinateVector: "[50,46,-12]"^^xsd:string .
 
-niiri:806b3ed136eea98cd29cfd76d1200da4 prov:wasDerivedFrom niiri:6c6cb2c384c60e5d62243cf34af0708f .
+niiri:29cb61e520efc605169b4daa2aecadcf prov:wasDerivedFrom niiri:3dc187c20fafa718374d3bf8209b869c .
 
-niiri:168bc36f0340173b89afe58b52d645b3
+niiri:29adc4964dd5cb588824e8fafff57b8b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0058" ;
-    prov:atLocation niiri:b6a8846842116c223b47db823ce70f9b ;
+    prov:atLocation niiri:ceb814e013d5960988e46b1015a2eff0 ;
     prov:value "3.65459251403809"^^xsd:float ;
     nidm_equivalentZStatistic: "3.52960997534834"^^xsd:float ;
     nidm_pValueUncorrected: "0.000208086348004177"^^xsd:float ;
     nidm_pValueFWER: "0.999972447579615"^^xsd:float ;
     nidm_qValueFDR: "0.00771736431800426"^^xsd:float .
 
-niiri:b6a8846842116c223b47db823ce70f9b
+niiri:ceb814e013d5960988e46b1015a2eff0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0058" ;
     nidm_coordinateVector: "[54,8,-36]"^^xsd:string .
 
-niiri:168bc36f0340173b89afe58b52d645b3 prov:wasDerivedFrom niiri:3c56acb507aa977c9b4ba549626f35b8 .
+niiri:29adc4964dd5cb588824e8fafff57b8b prov:wasDerivedFrom niiri:2246deb8a6c721c27dda92f3dd869ffd .
 
-niiri:923a557c9a8e587d39af24887e2f9584
+niiri:4bf8abf79b6ded57be5385b0e6aab4b9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0059" ;
-    prov:atLocation niiri:a36d1f5921f83d6b18f621f5cb0a6a28 ;
+    prov:atLocation niiri:8fcdd38710d6dfcd1b86f088e8cf04c0 ;
     prov:value "3.60173606872559"^^xsd:float ;
     nidm_equivalentZStatistic: "3.48162963814792"^^xsd:float ;
     nidm_pValueUncorrected: "0.000249186237945009"^^xsd:float ;
     nidm_pValueFWER: "0.999994173508246"^^xsd:float ;
     nidm_qValueFDR: "0.00859988568288654"^^xsd:float .
 
-niiri:a36d1f5921f83d6b18f621f5cb0a6a28
+niiri:8fcdd38710d6dfcd1b86f088e8cf04c0
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0059" ;
     nidm_coordinateVector: "[-14,58,10]"^^xsd:string .
 
-niiri:923a557c9a8e587d39af24887e2f9584 prov:wasDerivedFrom niiri:d1dd3f03998183928446768008d538fd .
+niiri:4bf8abf79b6ded57be5385b0e6aab4b9 prov:wasDerivedFrom niiri:50cb1d29d6f8a9cfe9515552c5bb7d31 .
 
-niiri:42179ac9c4345723a539eebfe78a10f8
+niiri:a5aa6fcfda734e3389f7bec2d9ad0a6f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0060" ;
-    prov:atLocation niiri:9e66be1d23413aacd4b5d556c13537cd ;
+    prov:atLocation niiri:4514318f9da72e1bef9803b37a732d29 ;
     prov:value "3.58989810943604"^^xsd:float ;
     nidm_equivalentZStatistic: "3.47086705539024"^^xsd:float ;
     nidm_pValueUncorrected: "0.000259390388114844"^^xsd:float ;
     nidm_pValueFWER: "0.999995993033212"^^xsd:float ;
     nidm_qValueFDR: "0.00880900397523308"^^xsd:float .
 
-niiri:9e66be1d23413aacd4b5d556c13537cd
+niiri:4514318f9da72e1bef9803b37a732d29
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0060" ;
     nidm_coordinateVector: "[-66,-36,22]"^^xsd:string .
 
-niiri:42179ac9c4345723a539eebfe78a10f8 prov:wasDerivedFrom niiri:c68b211ae154a1466946b63df0f701aa .
+niiri:a5aa6fcfda734e3389f7bec2d9ad0a6f prov:wasDerivedFrom niiri:d6d69b36b9108bb0de66eeffba4d858e .
 
-niiri:3f060b71575fff91a2cb4104a83101ac
+niiri:f09170fc52ba782fe9bdfaf02ade3b10
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0061" ;
-    prov:atLocation niiri:f20412005fa2953bc1ce80e18b7010c6 ;
+    prov:atLocation niiri:2f13fba96e94db31ba13df7c745e67c2 ;
     prov:value "3.56340670585632"^^xsd:float ;
     nidm_equivalentZStatistic: "3.44676015888715"^^xsd:float ;
     nidm_pValueUncorrected: "0.000283676007278189"^^xsd:float ;
     nidm_pValueFWER: "0.999998329299787"^^xsd:float ;
     nidm_qValueFDR: "0.00931482128100283"^^xsd:float .
 
-niiri:f20412005fa2953bc1ce80e18b7010c6
+niiri:2f13fba96e94db31ba13df7c745e67c2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0061" ;
     nidm_coordinateVector: "[18,60,12]"^^xsd:string .
 
-niiri:3f060b71575fff91a2cb4104a83101ac prov:wasDerivedFrom niiri:322465548251da9db8f6eede832763a7 .
+niiri:f09170fc52ba782fe9bdfaf02ade3b10 prov:wasDerivedFrom niiri:e88a30db5e3821edb55a62d4b67f0ad1 .
 
-niiri:6130a6f0559aee4c82170e809d706be5
+niiri:c0586c77c95a193830c8219325ca2256
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0062" ;
-    prov:atLocation niiri:3592d1ef3b4f87952389f36ed2b09e55 ;
+    prov:atLocation niiri:c1b0e76791ad2592aff2be5e27561f34 ;
     prov:value "3.55537104606628"^^xsd:float ;
     nidm_equivalentZStatistic: "3.43944179853069"^^xsd:float ;
     nidm_pValueUncorrected: "0.000291457553818653"^^xsd:float ;
     nidm_pValueFWER: "0.999998731920076"^^xsd:float ;
     nidm_qValueFDR: "0.0094907493053886"^^xsd:float .
 
-niiri:3592d1ef3b4f87952389f36ed2b09e55
+niiri:c1b0e76791ad2592aff2be5e27561f34
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0062" ;
     nidm_coordinateVector: "[-64,-34,8]"^^xsd:string .
 
-niiri:6130a6f0559aee4c82170e809d706be5 prov:wasDerivedFrom niiri:2e9ce0e379ad93f22643b62153bb9323 .
+niiri:c0586c77c95a193830c8219325ca2256 prov:wasDerivedFrom niiri:a4ad9afd60a760f91d6916421b56fe6a .
 
-niiri:b6b2edacba7be6c3a7140b8545a7f21a
+niiri:29b6d69627dd6dacdaa3a9b3c30d347f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0063" ;
-    prov:atLocation niiri:b874b9f9fe3fd72bf03970d6f12de2ac ;
+    prov:atLocation niiri:7d14954855c9816b0a230a0df291fa29 ;
     prov:value "3.54216623306274"^^xsd:float ;
     nidm_equivalentZStatistic: "3.42740966598884"^^xsd:float ;
     nidm_pValueUncorrected: "0.000304684504620178"^^xsd:float ;
     nidm_pValueFWER: "0.999999202607737"^^xsd:float ;
     nidm_qValueFDR: "0.00978309810858832"^^xsd:float .
 
-niiri:b874b9f9fe3fd72bf03970d6f12de2ac
+niiri:7d14954855c9816b0a230a0df291fa29
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0063" ;
     nidm_coordinateVector: "[-58,-32,22]"^^xsd:string .
 
-niiri:b6b2edacba7be6c3a7140b8545a7f21a prov:wasDerivedFrom niiri:d51a48062d3b4def227e90a39b0954f5 .
+niiri:29b6d69627dd6dacdaa3a9b3c30d347f prov:wasDerivedFrom niiri:d3934b966af329378cc1a1307b94a530 .
 
-niiri:6f7e3f89dbd79308a4785a293cdb1f12
+niiri:afa91bed7d064469a4e66e23ca1c26f9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0064" ;
-    prov:atLocation niiri:8795ca387edcfaf290621dbe37a0f708 ;
+    prov:atLocation niiri:6a2b0b0ce5882ce85cc24088d095d5f4 ;
     prov:value "3.46738910675049"^^xsd:float ;
     nidm_equivalentZStatistic: "3.35913252154752"^^xsd:float ;
     nidm_pValueUncorrected: "0.000390937814553127"^^xsd:float ;
     nidm_pValueFWER: "0.999999955890495"^^xsd:float ;
     nidm_qValueFDR: "0.0114444909736178"^^xsd:float .
 
-niiri:8795ca387edcfaf290621dbe37a0f708
+niiri:6a2b0b0ce5882ce85cc24088d095d5f4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0064" ;
     nidm_coordinateVector: "[14,-14,72]"^^xsd:string .
 
-niiri:6f7e3f89dbd79308a4785a293cdb1f12 prov:wasDerivedFrom niiri:0a272793669dad6178113ee531ec9cb8 .
+niiri:afa91bed7d064469a4e66e23ca1c26f9 prov:wasDerivedFrom niiri:546534eff08d214139c8884f815a2c20 .
 
-niiri:a28d458dd358ad059c8f392ac26194a5
+niiri:ce725d602d22bdbfcfb1d33ed8a51382
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0065" ;
-    prov:atLocation niiri:2f7f3bd4dbe1b1edac33113438602b5d ;
+    prov:atLocation niiri:6f48cd191b2923a4059fd4f816332e01 ;
     prov:value "3.13905429840088"^^xsd:float ;
     nidm_equivalentZStatistic: "3.05659883446979"^^xsd:float ;
     nidm_pValueUncorrected: "0.00111931832184231"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0229711836666271"^^xsd:float .
 
-niiri:2f7f3bd4dbe1b1edac33113438602b5d
+niiri:6f48cd191b2923a4059fd4f816332e01
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0065" ;
     nidm_coordinateVector: "[12,-16,64]"^^xsd:string .
 
-niiri:a28d458dd358ad059c8f392ac26194a5 prov:wasDerivedFrom niiri:0a272793669dad6178113ee531ec9cb8 .
+niiri:ce725d602d22bdbfcfb1d33ed8a51382 prov:wasDerivedFrom niiri:546534eff08d214139c8884f815a2c20 .
 
-niiri:d641c756b5f2f01c775915af29e9af97
+niiri:8d0242e530dd2b7ac61d63b861ffdfb2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0066" ;
-    prov:atLocation niiri:09e0f9d7466f514d85a5bb83d5bddc42 ;
+    prov:atLocation niiri:610b4620d7a52f6451a8f5a7fe636e78 ;
     prov:value "3.45441365242004"^^xsd:float ;
     nidm_equivalentZStatistic: "3.34726077209469"^^xsd:float ;
     nidm_pValueUncorrected: "0.000408071982705316"^^xsd:float ;
     nidm_pValueFWER: "0.999999974583179"^^xsd:float ;
     nidm_qValueFDR: "0.0117929908461181"^^xsd:float .
 
-niiri:09e0f9d7466f514d85a5bb83d5bddc42
+niiri:610b4620d7a52f6451a8f5a7fe636e78
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0066" ;
     nidm_coordinateVector: "[-38,-54,-42]"^^xsd:string .
 
-niiri:d641c756b5f2f01c775915af29e9af97 prov:wasDerivedFrom niiri:b184062d5a99600d689d67aaae002061 .
+niiri:8d0242e530dd2b7ac61d63b861ffdfb2 prov:wasDerivedFrom niiri:295cf12e37c01e14c3830d46154826a9 .
 
-niiri:bcce44a2aa9bec0a15e890be0dc92940
+niiri:409a5667ff5ace48db341b1d4b443b7b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0067" ;
-    prov:atLocation niiri:c81be31babc76d12a713900b2de4754b ;
+    prov:atLocation niiri:7f0662b591e4d89dd3e64021c01d47a8 ;
     prov:value "3.43198323249817"^^xsd:float ;
     nidm_equivalentZStatistic: "3.32672157755253"^^xsd:float ;
     nidm_pValueUncorrected: "0.000439370628491198"^^xsd:float ;
     nidm_pValueFWER: "0.999999990548038"^^xsd:float ;
     nidm_qValueFDR: "0.0123661196896594"^^xsd:float .
 
-niiri:c81be31babc76d12a713900b2de4754b
+niiri:7f0662b591e4d89dd3e64021c01d47a8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0067" ;
     nidm_coordinateVector: "[42,-42,14]"^^xsd:string .
 
-niiri:bcce44a2aa9bec0a15e890be0dc92940 prov:wasDerivedFrom niiri:f96aa71d40f8ee2a7f558cd844317641 .
+niiri:409a5667ff5ace48db341b1d4b443b7b prov:wasDerivedFrom niiri:aedc5c46b75f681aa273f0c65aba753d .
 
-niiri:0a79840910c04b4648c62541adfc354b
+niiri:93fba29bbc2b01e814cebc5c1c0d1553
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0068" ;
-    prov:atLocation niiri:1a5e81c9ea1818501dce8a2fe0b8e0bd ;
+    prov:atLocation niiri:4321078ea4b73fb1eebb645623318e8d ;
     prov:value "3.40386486053467"^^xsd:float ;
     nidm_equivalentZStatistic: "3.30094422133281"^^xsd:float ;
     nidm_pValueUncorrected: "0.000481800187664638"^^xsd:float ;
     nidm_pValueFWER: "0.999999997442132"^^xsd:float ;
     nidm_qValueFDR: "0.0131315419066298"^^xsd:float .
 
-niiri:1a5e81c9ea1818501dce8a2fe0b8e0bd
+niiri:4321078ea4b73fb1eebb645623318e8d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0068" ;
     nidm_coordinateVector: "[52,-42,18]"^^xsd:string .
 
-niiri:0a79840910c04b4648c62541adfc354b prov:wasDerivedFrom niiri:51f615915847dee59f46c38a3d61f56e .
+niiri:93fba29bbc2b01e814cebc5c1c0d1553 prov:wasDerivedFrom niiri:03b802eb8ab278c3154b4ebae374f2f2 .
 
-niiri:e3fa837465caf5155f758b0ecd134b43
+niiri:e3c2f2c5c8877cf5d3301382557e5009
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0069" ;
-    prov:atLocation niiri:4371f24601e6942034ee127126a4f0a0 ;
+    prov:atLocation niiri:5a357afd9be7a34bbbde654f71b7451e ;
     prov:value "3.36533284187317"^^xsd:float ;
     nidm_equivalentZStatistic: "3.26556677338515"^^xsd:float ;
     nidm_pValueUncorrected: "0.000546226226643243"^^xsd:float ;
     nidm_pValueFWER: "0.999999999624169"^^xsd:float ;
     nidm_qValueFDR: "0.0142364394435995"^^xsd:float .
 
-niiri:4371f24601e6942034ee127126a4f0a0
+niiri:5a357afd9be7a34bbbde654f71b7451e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0069" ;
     nidm_coordinateVector: "[44,-48,-26]"^^xsd:string .
 
-niiri:e3fa837465caf5155f758b0ecd134b43 prov:wasDerivedFrom niiri:c80fb3c545c2f7392d3c65842860d0d3 .
+niiri:e3c2f2c5c8877cf5d3301382557e5009 prov:wasDerivedFrom niiri:33fb5b8990838fc1f2547ba3ff8437d2 .
 
-niiri:c0fa8162341c45f2054c25f6286dbb94
+niiri:cf455aa53879ce5eb8f2e701d72643c3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0070" ;
-    prov:atLocation niiri:2f8b9a2698662e3e122e522c43b6d850 ;
+    prov:atLocation niiri:c39b228e86e60d680bce4be9f24e6881 ;
     prov:value "3.32532405853271"^^xsd:float ;
     nidm_equivalentZStatistic: "3.22876865896546"^^xsd:float ;
     nidm_pValueUncorrected: "0.000621622108231912"^^xsd:float ;
     nidm_pValueFWER: "0.99999999995642"^^xsd:float ;
     nidm_qValueFDR: "0.015558079264466"^^xsd:float .
 
-niiri:2f8b9a2698662e3e122e522c43b6d850
+niiri:c39b228e86e60d680bce4be9f24e6881
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0070" ;
     nidm_coordinateVector: "[-54,-32,42]"^^xsd:string .
 
-niiri:c0fa8162341c45f2054c25f6286dbb94 prov:wasDerivedFrom niiri:3d5efcc91bde3190c3c7fc5ea37f55ab .
+niiri:cf455aa53879ce5eb8f2e701d72643c3 prov:wasDerivedFrom niiri:f6f7f9d9bd2b440c679a5ff44f1cdb22 .
 
-niiri:cea8246dfb359ca47a78c78daa3dcad0
+niiri:e9c6bf15ba9e098b7b0cca458dc8cd21
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0071" ;
-    prov:atLocation niiri:4c13f3c06b2bbf245f3adc61655db0e5 ;
+    prov:atLocation niiri:ec9d5559de25c81d98d87fac2fbe5dba ;
     prov:value "3.31892204284668"^^xsd:float ;
     nidm_equivalentZStatistic: "3.22287431730178"^^xsd:float ;
     nidm_pValueUncorrected: "0.000634556128578101"^^xsd:float ;
     nidm_pValueFWER: "0.99999999996962"^^xsd:float ;
     nidm_qValueFDR: "0.0157616735622854"^^xsd:float .
 
-niiri:4c13f3c06b2bbf245f3adc61655db0e5
+niiri:ec9d5559de25c81d98d87fac2fbe5dba
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0071" ;
     nidm_coordinateVector: "[-16,4,62]"^^xsd:string .
 
-niiri:cea8246dfb359ca47a78c78daa3dcad0 prov:wasDerivedFrom niiri:74d3fcdb2a3222701acac8703cef46c6 .
+niiri:e9c6bf15ba9e098b7b0cca458dc8cd21 prov:wasDerivedFrom niiri:cbbd42e6f42814091a8e0fc54b7ad3c4 .
 
-niiri:660f367fd60b36ce1f1dd169ad0f9009
+niiri:93ecdc023889193376179f882fb09793
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0072" ;
-    prov:atLocation niiri:27690288a5f40fa598afa70d4027a13e ;
+    prov:atLocation niiri:a63341a7ce00061c582e0ccb012ef7e2 ;
     prov:value "3.28136968612671"^^xsd:float ;
     nidm_equivalentZStatistic: "3.18826629952882"^^xsd:float ;
     nidm_pValueUncorrected: "0.000715643274853739"^^xsd:float ;
     nidm_pValueFWER: "0.999999999996665"^^xsd:float ;
     nidm_qValueFDR: "0.0170366752692093"^^xsd:float .
 
-niiri:27690288a5f40fa598afa70d4027a13e
+niiri:a63341a7ce00061c582e0ccb012ef7e2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0072" ;
     nidm_coordinateVector: "[56,-66,4]"^^xsd:string .
 
-niiri:660f367fd60b36ce1f1dd169ad0f9009 prov:wasDerivedFrom niiri:b954d8c8fc0fa467f3ee6aedf1927f85 .
+niiri:93ecdc023889193376179f882fb09793 prov:wasDerivedFrom niiri:53fb996b754ceba84bda7b0e7b9bdc51 .
 
-niiri:026aa253ca69ebe6c61b8c39515572ab
+niiri:cfedd59c6ad80ae5fe3df5fa3e086b64
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0073" ;
-    prov:atLocation niiri:702b04e0cffcc06fe2aea8e3af9eea06 ;
+    prov:atLocation niiri:000efbc6d4c9aeab7beaa0ab52208f9f ;
     prov:value "3.26226496696472"^^xsd:float ;
     nidm_equivalentZStatistic: "3.17063765299814"^^xsd:float ;
     nidm_pValueUncorrected: "0.000760523733375762"^^xsd:float ;
     nidm_pValueFWER: "0.999999999998982"^^xsd:float ;
     nidm_qValueFDR: "0.0177274295203014"^^xsd:float .
 
-niiri:702b04e0cffcc06fe2aea8e3af9eea06
+niiri:000efbc6d4c9aeab7beaa0ab52208f9f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0073" ;
     nidm_coordinateVector: "[-60,-14,10]"^^xsd:string .
 
-niiri:026aa253ca69ebe6c61b8c39515572ab prov:wasDerivedFrom niiri:f173ac5c048181e317d9158611e01835 .
+niiri:cfedd59c6ad80ae5fe3df5fa3e086b64 prov:wasDerivedFrom niiri:55bb03da7ee7d021560ed83a011342a9 .
 
-niiri:9687774c1ec3385edc4abccdecb82a96
+niiri:b65cce8679c42572d912ca303840373a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0074" ;
-    prov:atLocation niiri:710d1fe094dc9e475168d989f31d6189 ;
+    prov:atLocation niiri:4c2c5363ab8e8186172107f728368d86 ;
     prov:value "3.25416302680969"^^xsd:float ;
     nidm_equivalentZStatistic: "3.16315726358056"^^xsd:float ;
     nidm_pValueUncorrected: "0.000780339994975288"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999392"^^xsd:float ;
     nidm_qValueFDR: "0.0180089199210036"^^xsd:float .
 
-niiri:710d1fe094dc9e475168d989f31d6189
+niiri:4c2c5363ab8e8186172107f728368d86
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0074" ;
     nidm_coordinateVector: "[-66,-46,8]"^^xsd:string .
 
-niiri:9687774c1ec3385edc4abccdecb82a96 prov:wasDerivedFrom niiri:efc36c20dd2a832167f0a44c579b5edf .
+niiri:b65cce8679c42572d912ca303840373a prov:wasDerivedFrom niiri:ac7c392c52df7cdd1a6cd2c7335454d2 .
 
-niiri:ff91883c8433e0ddd5072e80cb8a47e4
+niiri:b1da3428c34e2b43760ad5c2f4e2d0fa
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0075" ;
-    prov:atLocation niiri:b04a7e9a2c6e095ae7b25dfcb0a77b3d ;
+    prov:atLocation niiri:e9c17a2c6bd24ee4990476b4240509d1 ;
     prov:value "3.24836373329163"^^xsd:float ;
     nidm_equivalentZStatistic: "3.15780125799237"^^xsd:float ;
     nidm_pValueUncorrected: "0.000794819459152607"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999582"^^xsd:float ;
     nidm_qValueFDR: "0.018230089242935"^^xsd:float .
 
-niiri:b04a7e9a2c6e095ae7b25dfcb0a77b3d
+niiri:e9c17a2c6bd24ee4990476b4240509d1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0075" ;
     nidm_coordinateVector: "[-68,-34,-8]"^^xsd:string .
 
-niiri:ff91883c8433e0ddd5072e80cb8a47e4 prov:wasDerivedFrom niiri:163e964ab452049726722befe3edc8f1 .
+niiri:b1da3428c34e2b43760ad5c2f4e2d0fa prov:wasDerivedFrom niiri:c3f05dc9d300aa5acc02e364f1c3ee85 .
 
-niiri:9129c13d595e0c69ae8e9e6bf5e957b7
+niiri:ed0ad58b2c2c68d107db680a95fd120e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0076" ;
-    prov:atLocation niiri:c6091f20f8576aea9d5c66f11f75a731 ;
+    prov:atLocation niiri:eaa56e97c2a8bfdb44a80f726af2b864 ;
     prov:value "3.23679161071777"^^xsd:float ;
     nidm_equivalentZStatistic: "3.14710967833961"^^xsd:float ;
     nidm_pValueUncorrected: "0.000824465484375092"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999804"^^xsd:float ;
     nidm_qValueFDR: "0.0186930131202947"^^xsd:float .
 
-niiri:c6091f20f8576aea9d5c66f11f75a731
+niiri:eaa56e97c2a8bfdb44a80f726af2b864
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0076" ;
     nidm_coordinateVector: "[-56,34,-20]"^^xsd:string .
 
-niiri:9129c13d595e0c69ae8e9e6bf5e957b7 prov:wasDerivedFrom niiri:21e6a6198ca5dccffc1370c3dedbd678 .
+niiri:ed0ad58b2c2c68d107db680a95fd120e prov:wasDerivedFrom niiri:45b4ec73da86f70d949a94aa6ab8d4ab .
 
-niiri:4dac65ff67e34b44d67c615738e1959a
+niiri:81766c881aa79ffa1dca5be898876a89
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0077" ;
-    prov:atLocation niiri:24003d48a146e93b190750ccf1687fc1 ;
+    prov:atLocation niiri:d1b58d5e6a4d1431d1749aa413e48000 ;
     prov:value "3.22478008270264"^^xsd:float ;
     nidm_equivalentZStatistic: "3.13600649460504"^^xsd:float ;
     nidm_pValueUncorrected: "0.000856327054624684"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999913"^^xsd:float ;
     nidm_qValueFDR: "0.019197465737185"^^xsd:float .
 
-niiri:24003d48a146e93b190750ccf1687fc1
+niiri:d1b58d5e6a4d1431d1749aa413e48000
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0077" ;
     nidm_coordinateVector: "[8,-72,42]"^^xsd:string .
 
-niiri:4dac65ff67e34b44d67c615738e1959a prov:wasDerivedFrom niiri:0c7d90a406ec1f922a7e807915ee6f49 .
+niiri:81766c881aa79ffa1dca5be898876a89 prov:wasDerivedFrom niiri:54114a5d8df2f7e553a53e4b7d3f5bde .
 
-niiri:483126d45625c69a637401f4d9bc9e0d
+niiri:6f9386b12ed4b5e1d223ee7299272af0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0078" ;
-    prov:atLocation niiri:7e1f57ac19d274b35bc68139ac64cd41 ;
+    prov:atLocation niiri:53635ca2d983f1354091759d739567d9 ;
     prov:value "3.22331190109253"^^xsd:float ;
     nidm_equivalentZStatistic: "3.13464894829369"^^xsd:float ;
     nidm_pValueUncorrected: "0.000860299398633191"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999921"^^xsd:float ;
     nidm_qValueFDR: "0.0192710694895643"^^xsd:float .
 
-niiri:7e1f57ac19d274b35bc68139ac64cd41
+niiri:53635ca2d983f1354091759d739567d9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0078" ;
     nidm_coordinateVector: "[42,-86,12]"^^xsd:string .
 
-niiri:483126d45625c69a637401f4d9bc9e0d prov:wasDerivedFrom niiri:10a509044b2676eb12c65b82844b5898 .
+niiri:6f9386b12ed4b5e1d223ee7299272af0 prov:wasDerivedFrom niiri:3f3ed8fe063a9052a3379a875a3af9b1 .
 
-niiri:3436b437c3b46f5d7661548fa8892dc9
+niiri:fb2e0b3836b38e971ed6c44595c76ce6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0079" ;
-    prov:atLocation niiri:c1f3a692570ba93145684b88ac03623c ;
+    prov:atLocation niiri:a0a046d9c5ecbb0ae2f57dafe426178e ;
     prov:value "3.17424750328064"^^xsd:float ;
     nidm_equivalentZStatistic: "3.08923296074259"^^xsd:float ;
     nidm_pValueUncorrected: "0.00100337008659268"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999998"^^xsd:float ;
     nidm_qValueFDR: "0.0213685540658751"^^xsd:float .
 
-niiri:c1f3a692570ba93145684b88ac03623c
+niiri:a0a046d9c5ecbb0ae2f57dafe426178e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0079" ;
     nidm_coordinateVector: "[12,-86,50]"^^xsd:string .
 
-niiri:3436b437c3b46f5d7661548fa8892dc9 prov:wasDerivedFrom niiri:da2d2cf59ea5cea8edce49ea2ffea951 .
+niiri:fb2e0b3836b38e971ed6c44595c76ce6 prov:wasDerivedFrom niiri:5721ae6aae6160ad82aced2d2fe68def .
 
-niiri:fca7b1daf0d16df7fa5dc5fc1e9547a7
+niiri:bb4c57fd5df089908c6bcfc3efe6b9f9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0080" ;
-    prov:atLocation niiri:40d86b0aa78b634bb94de2b8e05b700b ;
+    prov:atLocation niiri:803ec44036ba7fa1184f3d5d4fb202ef ;
     prov:value "3.15485405921936"^^xsd:float ;
     nidm_equivalentZStatistic: "3.07125564726837"^^xsd:float ;
     nidm_pValueUncorrected: "0.00106580278515289"^^xsd:float ;
     nidm_pValueFWER: "0.999999999999999"^^xsd:float ;
     nidm_qValueFDR: "0.0222342074339062"^^xsd:float .
 
-niiri:40d86b0aa78b634bb94de2b8e05b700b
+niiri:803ec44036ba7fa1184f3d5d4fb202ef
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0080" ;
     nidm_coordinateVector: "[-60,-46,0]"^^xsd:string .
 
-niiri:fca7b1daf0d16df7fa5dc5fc1e9547a7 prov:wasDerivedFrom niiri:67b60bb73ecda2bbfdba32287ba6e0f5 .
+niiri:bb4c57fd5df089908c6bcfc3efe6b9f9 prov:wasDerivedFrom niiri:9326713bc412f1ec61f3bf20466a1174 .
 
-niiri:417f0ba528d7af0c9a0da05faf0d440b
+niiri:09e6296e10757ad10cecbc458943830b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0081" ;
-    prov:atLocation niiri:d01b52ce865d52ca48655c89c7876625 ;
+    prov:atLocation niiri:4d5ab67b2c378b1ea426a6fb6bc53983 ;
     prov:value "3.15112209320068"^^xsd:float ;
     nidm_equivalentZStatistic: "3.06779451986408"^^xsd:float ;
     nidm_pValueUncorrected: "0.00107822421513859"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0224117734411443"^^xsd:float .
 
-niiri:d01b52ce865d52ca48655c89c7876625
+niiri:4d5ab67b2c378b1ea426a6fb6bc53983
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0081" ;
     nidm_coordinateVector: "[54,-22,-26]"^^xsd:string .
 
-niiri:417f0ba528d7af0c9a0da05faf0d440b prov:wasDerivedFrom niiri:9254bae1d5f58a099609a70c3d6c17bf .
+niiri:09e6296e10757ad10cecbc458943830b prov:wasDerivedFrom niiri:ae9ba0f37d886eaa080e3238cefd1961 .
 
-niiri:ff9195ec7cf35de454c62035c63f56dc
+niiri:798ba4f1b0df8e048c40896efbc27bc1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0082" ;
-    prov:atLocation niiri:3fd9e322d4b1e294d241d381bf6ffcd6 ;
+    prov:atLocation niiri:1cd1d457fbb26bf7d7a2a157c4a8597b ;
     prov:value "3.14736461639404"^^xsd:float ;
     nidm_equivalentZStatistic: "3.06430918903901"^^xsd:float ;
     nidm_pValueUncorrected: "0.00109086649800139"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0225800614737541"^^xsd:float .
 
-niiri:3fd9e322d4b1e294d241d381bf6ffcd6
+niiri:1cd1d457fbb26bf7d7a2a157c4a8597b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0082" ;
     nidm_coordinateVector: "[-50,-40,32]"^^xsd:string .
 
-niiri:ff9195ec7cf35de454c62035c63f56dc prov:wasDerivedFrom niiri:2e99faf6261612f5665eb4d13abf19a0 .
+niiri:798ba4f1b0df8e048c40896efbc27bc1 prov:wasDerivedFrom niiri:55108dec00fcabdca0aa0fd19deac38c .
 
-niiri:5a342762f2925add4bbdc285c8e2f927
+niiri:65faea3b6c2b60b8b3a4b771985ae82d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0083" ;
-    prov:atLocation niiri:104a865be0fdfde1762e06512bc9761d ;
+    prov:atLocation niiri:3e9bbdd2259381c519f423e47e9d1700 ;
     prov:value "3.14220976829529"^^xsd:float ;
     nidm_equivalentZStatistic: "3.05952680873208"^^xsd:float ;
     nidm_pValueUncorrected: "0.00110843472885702"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.022825630044905"^^xsd:float .
 
-niiri:104a865be0fdfde1762e06512bc9761d
+niiri:3e9bbdd2259381c519f423e47e9d1700
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0083" ;
     nidm_coordinateVector: "[-28,-64,-4]"^^xsd:string .
 
-niiri:5a342762f2925add4bbdc285c8e2f927 prov:wasDerivedFrom niiri:740eb5d4edc6fcd44873c0c8fc2a5c58 .
+niiri:65faea3b6c2b60b8b3a4b771985ae82d prov:wasDerivedFrom niiri:16a2d945f11329e9c381ee7f04a0ef0e .
 
-niiri:68d3052cb804ef06cc08406b5adbd091
+niiri:efa6c4751eb0a691336a3cdb57edc4d4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0084" ;
-    prov:atLocation niiri:287c733474fc79d5c29e6f70ca336295 ;
+    prov:atLocation niiri:6bf46886efc953821efdbedfa918b17f ;
     prov:value "3.0528359413147"^^xsd:float ;
     nidm_equivalentZStatistic: "2.97644965310987"^^xsd:float ;
     nidm_pValueUncorrected: "0.00145803479142037"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0273451681875923"^^xsd:float .
 
-niiri:287c733474fc79d5c29e6f70ca336295
+niiri:6bf46886efc953821efdbedfa918b17f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0084" ;
     nidm_coordinateVector: "[-32,-76,-2]"^^xsd:string .
 
-niiri:68d3052cb804ef06cc08406b5adbd091 prov:wasDerivedFrom niiri:740eb5d4edc6fcd44873c0c8fc2a5c58 .
+niiri:efa6c4751eb0a691336a3cdb57edc4d4 prov:wasDerivedFrom niiri:16a2d945f11329e9c381ee7f04a0ef0e .
 
-niiri:4b8d539ddb954878a86d65e5d3543933
+niiri:dfcb0da83436b538eda80129d69688fe
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0085" ;
-    prov:atLocation niiri:413b9fbe3bf1f6eccdba9db58505470d ;
+    prov:atLocation niiri:5594ee59f798566f25c3ce8826d865f7 ;
     prov:value "3.13440585136414"^^xsd:float ;
     nidm_equivalentZStatistic: "3.05228482208755"^^xsd:float ;
     nidm_pValueUncorrected: "0.00113553246964015"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0232102144708915"^^xsd:float .
 
-niiri:413b9fbe3bf1f6eccdba9db58505470d
+niiri:5594ee59f798566f25c3ce8826d865f7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0085" ;
     nidm_coordinateVector: "[-46,14,2]"^^xsd:string .
 
-niiri:4b8d539ddb954878a86d65e5d3543933 prov:wasDerivedFrom niiri:405b87d54648ec0203cb5bd92594a2e3 .
+niiri:dfcb0da83436b538eda80129d69688fe prov:wasDerivedFrom niiri:51de73f4c31fd22967b959166dfdd033 .
 
-niiri:8a52ebc1a50c6dd8327cb70fed854ad7
+niiri:e974721ee82dbde15f9b39d69ec70d5a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0086" ;
-    prov:atLocation niiri:eda5d2dc3d29443f52d60ae5eb993fcb ;
+    prov:atLocation niiri:9258b6520b6d9e367a03d1229b82cd50 ;
     prov:value "3.10635590553284"^^xsd:float ;
     nidm_equivalentZStatistic: "3.02623536858597"^^xsd:float ;
     nidm_pValueUncorrected: "0.00123809733665026"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0245458677588465"^^xsd:float .
 
-niiri:eda5d2dc3d29443f52d60ae5eb993fcb
+niiri:9258b6520b6d9e367a03d1229b82cd50
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0086" ;
     nidm_coordinateVector: "[-30,-64,-40]"^^xsd:string .
 
-niiri:8a52ebc1a50c6dd8327cb70fed854ad7 prov:wasDerivedFrom niiri:2eee6e1a0cc5eacabec145451549d653 .
+niiri:e974721ee82dbde15f9b39d69ec70d5a prov:wasDerivedFrom niiri:5810f1d1820e723be51fc80ca74ca5e0 .
 
-niiri:520a40e5305018b26be027ca1004e3d8
+niiri:aa808c2c64b1d016870f13b853b07dde
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0087" ;
-    prov:atLocation niiri:2e161ca4ad8bc3eb7e42cc8936b7077b ;
+    prov:atLocation niiri:df0ab6577fa3b98348187ba4d0505464 ;
     prov:value "3.10515308380127"^^xsd:float ;
     nidm_equivalentZStatistic: "3.02511765947288"^^xsd:float ;
     nidm_pValueUncorrected: "0.00124268210298895"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0246072121840759"^^xsd:float .
 
-niiri:2e161ca4ad8bc3eb7e42cc8936b7077b
+niiri:df0ab6577fa3b98348187ba4d0505464
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0087" ;
     nidm_coordinateVector: "[48,34,-6]"^^xsd:string .
 
-niiri:520a40e5305018b26be027ca1004e3d8 prov:wasDerivedFrom niiri:e9970ca0786a9322adebcbbeda6cd715 .
+niiri:aa808c2c64b1d016870f13b853b07dde prov:wasDerivedFrom niiri:fb7f0c2c30196ccec28c3a6548a05c74 .
 
-niiri:35d6c499d7f28ddcfde5f4dd89270eae
+niiri:bee1c5e3b563da49fb889d00a907068a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0088" ;
-    prov:atLocation niiri:d35296907d03c450df53708c0fd1ad9d ;
+    prov:atLocation niiri:058c979548e4a8a7bfcbe9709834c9a4 ;
     prov:value "3.09994459152222"^^xsd:float ;
     nidm_equivalentZStatistic: "3.02027708985515"^^xsd:float ;
     nidm_pValueUncorrected: "0.0012627176367187"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0248683482689455"^^xsd:float .
 
-niiri:d35296907d03c450df53708c0fd1ad9d
+niiri:058c979548e4a8a7bfcbe9709834c9a4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0088" ;
     nidm_coordinateVector: "[14,52,24]"^^xsd:string .
 
-niiri:35d6c499d7f28ddcfde5f4dd89270eae prov:wasDerivedFrom niiri:c0493caa11e0a7edcd8c852574b28687 .
+niiri:bee1c5e3b563da49fb889d00a907068a prov:wasDerivedFrom niiri:c93f984974556da4e703249091c0b9e6 .
 
-niiri:01ec2581154b19ffa8ddd2fe02f943e1
+niiri:8c4cac3967178a072f8a1b26ec0be67c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0089" ;
-    prov:atLocation niiri:af1438298b059cec23b6d80713723732 ;
+    prov:atLocation niiri:f246f3356741cc6338e2b2af30aa3eda ;
     prov:value "3.09887838363647"^^xsd:float ;
     nidm_equivalentZStatistic: "3.01928607085125"^^xsd:float ;
     nidm_pValueUncorrected: "0.00126685581272745"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0249171839147233"^^xsd:float .
 
-niiri:af1438298b059cec23b6d80713723732
+niiri:f246f3356741cc6338e2b2af30aa3eda
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0089" ;
     nidm_coordinateVector: "[-38,-78,8]"^^xsd:string .
 
-niiri:01ec2581154b19ffa8ddd2fe02f943e1 prov:wasDerivedFrom niiri:f710cfa09fe2aedf43455c358fac4b39 .
+niiri:8c4cac3967178a072f8a1b26ec0be67c prov:wasDerivedFrom niiri:9e172783feebd728c2f558fb3b71f8e1 .
 
-niiri:c2d8054219b3febbb9aa86a9adfa49d7
+niiri:ab0a345a1b23456828ee0bd75b928ed7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0090" ;
-    prov:atLocation niiri:2823c3c6bf54f87cd3a939971b785bae ;
+    prov:atLocation niiri:f4174578f5d208031a34b2194cf74ee8 ;
     prov:value "3.07387399673462"^^xsd:float ;
     nidm_equivalentZStatistic: "2.99603266917277"^^xsd:float ;
     nidm_pValueUncorrected: "0.00136758564431361"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0261754700848395"^^xsd:float .
 
-niiri:2823c3c6bf54f87cd3a939971b785bae
+niiri:f4174578f5d208031a34b2194cf74ee8
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0090" ;
     nidm_coordinateVector: "[12,-18,52]"^^xsd:string .
 
-niiri:c2d8054219b3febbb9aa86a9adfa49d7 prov:wasDerivedFrom niiri:bad70ba4fd8b4b695b72a83782c3e5f8 .
+niiri:ab0a345a1b23456828ee0bd75b928ed7 prov:wasDerivedFrom niiri:87ab73f90e90a5729c135961d1e370c8 .
 
-niiri:b88cf1d5dd5ae08c0319548d360d84a8
+niiri:ebb12b1fa798252b807914310e351b35
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0091" ;
-    prov:atLocation niiri:070b5066c48b85a3d5857d0d72cec0da ;
+    prov:atLocation niiri:92b403d3f268a73ca193179c615086a4 ;
     prov:value "3.05714297294617"^^xsd:float ;
     nidm_equivalentZStatistic: "2.98046014668547"^^xsd:float ;
     nidm_pValueUncorrected: "0.00143907843047086"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0271009625306751"^^xsd:float .
 
-niiri:070b5066c48b85a3d5857d0d72cec0da
+niiri:92b403d3f268a73ca193179c615086a4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0091" ;
     nidm_coordinateVector: "[-56,24,22]"^^xsd:string .
 
-niiri:b88cf1d5dd5ae08c0319548d360d84a8 prov:wasDerivedFrom niiri:c6c17361069913b5f4191614f68492f3 .
+niiri:ebb12b1fa798252b807914310e351b35 prov:wasDerivedFrom niiri:837d4c2c41156c19f0fd118f410295ff .
 
-niiri:24336c500788d29d7135149ec2ce779c
+niiri:15d51008205872b18f614dedb8a4130b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0092" ;
-    prov:atLocation niiri:aad694a8670c6c69676fa756e98e6d45 ;
+    prov:atLocation niiri:108fca12dc3621c31e0a6e7c66e5b2fd ;
     prov:value "3.05520439147949"^^xsd:float ;
     nidm_equivalentZStatistic: "2.97865512160875"^^xsd:float ;
     nidm_pValueUncorrected: "0.00144758220776409"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0272166039833409"^^xsd:float .
 
-niiri:aad694a8670c6c69676fa756e98e6d45
+niiri:108fca12dc3621c31e0a6e7c66e5b2fd
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0092" ;
     nidm_coordinateVector: "[10,-8,6]"^^xsd:string .
 
-niiri:24336c500788d29d7135149ec2ce779c prov:wasDerivedFrom niiri:c2a152f43ee2d844f898782fd1ef7ec0 .
+niiri:15d51008205872b18f614dedb8a4130b prov:wasDerivedFrom niiri:045f09754798eebc086b923539ec80df .
 
-niiri:5eda93480ee3ffd1f381662199329769
+niiri:6bfcfb8a7a78ca0a953b28b7ac785df9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0093" ;
-    prov:atLocation niiri:3f16fdba575165258782a0b2a8c4a04a ;
+    prov:atLocation niiri:c09564cb0de3a7ac00f96ddeb6277f3c ;
     prov:value "3.04858613014221"^^xsd:float ;
     nidm_equivalentZStatistic: "2.97249176352455"^^xsd:float ;
     nidm_pValueUncorrected: "0.00147696567841604"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0275869018911531"^^xsd:float .
 
-niiri:3f16fdba575165258782a0b2a8c4a04a
+niiri:c09564cb0de3a7ac00f96ddeb6277f3c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0093" ;
     nidm_coordinateVector: "[18,-58,32]"^^xsd:string .
 
-niiri:5eda93480ee3ffd1f381662199329769 prov:wasDerivedFrom niiri:f1fa812573c26840167e9f2bd0ba2bfa .
+niiri:6bfcfb8a7a78ca0a953b28b7ac785df9 prov:wasDerivedFrom niiri:80792993798dbd9f1e93a2b1f460edb7 .
 
-niiri:a63b917b1a1ae6fbef2664bd8c8b0fb8
+niiri:ca809001af3d981e8831371d40cadda0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0094" ;
-    prov:atLocation niiri:5f96f054d0f84bd356e6cdcca98e31ed ;
+    prov:atLocation niiri:7b18ac5074edd48ca6bda1186dbd2889 ;
     prov:value "3.04525375366211"^^xsd:float ;
     nidm_equivalentZStatistic: "2.96938782009723"^^xsd:float ;
     nidm_pValueUncorrected: "0.00149196870031498"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0277581737585471"^^xsd:float .
 
-niiri:5f96f054d0f84bd356e6cdcca98e31ed
+niiri:7b18ac5074edd48ca6bda1186dbd2889
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0094" ;
     nidm_coordinateVector: "[-28,-30,-38]"^^xsd:string .
 
-niiri:a63b917b1a1ae6fbef2664bd8c8b0fb8 prov:wasDerivedFrom niiri:331525e1b9d0bddf9506ab65a075cd86 .
+niiri:ca809001af3d981e8831371d40cadda0 prov:wasDerivedFrom niiri:90698016a8817129b734a925244ac3ee .
 
-niiri:0b42837168fde7814f8c5a64deb11d3f
+niiri:a6ab7750f7aec3f30041a2426c3c5488
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0095" ;
-    prov:atLocation niiri:eb2fbec15720b44b016e45ba73a42d42 ;
+    prov:atLocation niiri:d3c074a7ae3a7616d683ca666602e6ce ;
     prov:value "3.03322005271912"^^xsd:float ;
     nidm_equivalentZStatistic: "2.95817559801864"^^xsd:float ;
     nidm_pValueUncorrected: "0.00154732890171205"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.028466280131439"^^xsd:float .
 
-niiri:eb2fbec15720b44b016e45ba73a42d42
+niiri:d3c074a7ae3a7616d683ca666602e6ce
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0095" ;
     nidm_coordinateVector: "[36,-58,38]"^^xsd:string .
 
-niiri:0b42837168fde7814f8c5a64deb11d3f prov:wasDerivedFrom niiri:ea97b40b5a9be7fc9f6d62d9b525b485 .
+niiri:a6ab7750f7aec3f30041a2426c3c5488 prov:wasDerivedFrom niiri:e884b18d0db747fcf84bd707ac9dd705 .
 
-niiri:16cee8864e76cc07a63dcee5f8aa6c2a
+niiri:571af20b9fc7a3650f23e4883c4c0db7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0096" ;
-    prov:atLocation niiri:34344ef5b3db05662af8bcf023a86389 ;
+    prov:atLocation niiri:7c59844a04f86ceb0022ff5eedfb7507 ;
     prov:value "3.02379393577576"^^xsd:float ;
     nidm_equivalentZStatistic: "2.94938921855853"^^xsd:float ;
     nidm_pValueUncorrected: "0.00159201350826743"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0290329815576138"^^xsd:float .
 
-niiri:34344ef5b3db05662af8bcf023a86389
+niiri:7c59844a04f86ceb0022ff5eedfb7507
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0096" ;
     nidm_coordinateVector: "[24,-64,-18]"^^xsd:string .
 
-niiri:16cee8864e76cc07a63dcee5f8aa6c2a prov:wasDerivedFrom niiri:1f3fb8e24c66864d879d2bc4e5971b17 .
+niiri:571af20b9fc7a3650f23e4883c4c0db7 prov:wasDerivedFrom niiri:2a3d19c51223db94f710da6fc4488efe .
 
-niiri:e624eb747155287eb697b51a461070b3
+niiri:4109cffc49a21d458e8e3c4ec5bdec4b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0097" ;
-    prov:atLocation niiri:e66a73153861b4febee91591f53eaf66 ;
+    prov:atLocation niiri:ecb3f8e0de95691c6a806b7b47dda58b ;
     prov:value "2.99292635917664"^^xsd:float ;
     nidm_equivalentZStatistic: "2.92059379223963"^^xsd:float ;
     nidm_pValueUncorrected: "0.00174682509072199"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0308676807763691"^^xsd:float .
 
-niiri:e66a73153861b4febee91591f53eaf66
+niiri:ecb3f8e0de95691c6a806b7b47dda58b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0097" ;
     nidm_coordinateVector: "[30,60,14]"^^xsd:string .
 
-niiri:e624eb747155287eb697b51a461070b3 prov:wasDerivedFrom niiri:cd925f60fb17823aac5c3473215f8d7e .
+niiri:4109cffc49a21d458e8e3c4ec5bdec4b prov:wasDerivedFrom niiri:525402486d0c3b5a8a9cc4d79a236330 .
 
-niiri:a0ef595858724a33f32362e63fbd332e
+niiri:e75d8bde52802e14e982fc7e310fa7e5
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0098" ;
-    prov:atLocation niiri:3abd4563bba5f10ac07ee46d7219ca37 ;
+    prov:atLocation niiri:dae318474344710c6bb95c6d28a6cecb ;
     prov:value "2.97051525115967"^^xsd:float ;
     nidm_equivalentZStatistic: "2.89966547896516"^^xsd:float ;
     nidm_pValueUncorrected: "0.0018678055138297"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0323068383068969"^^xsd:float .
 
-niiri:3abd4563bba5f10ac07ee46d7219ca37
+niiri:dae318474344710c6bb95c6d28a6cecb
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0098" ;
     nidm_coordinateVector: "[-32,14,60]"^^xsd:string .
 
-niiri:a0ef595858724a33f32362e63fbd332e prov:wasDerivedFrom niiri:9837099ef2efab920d421b33789218c3 .
+niiri:e75d8bde52802e14e982fc7e310fa7e5 prov:wasDerivedFrom niiri:4c1d2eaf37081d773b0db5e10c96074d .
 
-niiri:78b4e8e4ff89e57dcf9115aa9eb7d563
+niiri:896ea228d6022d6a6fbe18f3fecced44
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0099" ;
-    prov:atLocation niiri:c460a7939ca8b3dd9eb5244f7019efd2 ;
+    prov:atLocation niiri:f41e73664c8531f0cd9110ce8757bc4f ;
     prov:value "2.96238708496094"^^xsd:float ;
     nidm_equivalentZStatistic: "2.89207063814041"^^xsd:float ;
     nidm_pValueUncorrected: "0.00191355944745719"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.032831917036533"^^xsd:float .
 
-niiri:c460a7939ca8b3dd9eb5244f7019efd2
+niiri:f41e73664c8531f0cd9110ce8757bc4f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0099" ;
     nidm_coordinateVector: "[-14,4,16]"^^xsd:string .
 
-niiri:78b4e8e4ff89e57dcf9115aa9eb7d563 prov:wasDerivedFrom niiri:2165a25b8a630ef2f40a0401a9a3c680 .
+niiri:896ea228d6022d6a6fbe18f3fecced44 prov:wasDerivedFrom niiri:91b4c6608ce19710d67c33b2473fc9b4 .
 
-niiri:a947d0e8f90dae8f7bb20b5e34e40ae8
+niiri:3b2dfa543dfff0705b80fb76652786b5
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0100" ;
-    prov:atLocation niiri:79829744c7182a80a5c5eab5c5427cfb ;
+    prov:atLocation niiri:559860f351aed5f67953b4429dea3d47 ;
     prov:value "2.94971632957458"^^xsd:float ;
     nidm_equivalentZStatistic: "2.88022656424043"^^xsd:float ;
     nidm_pValueUncorrected: "0.00198694744230488"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0336756816327342"^^xsd:float .
 
-niiri:79829744c7182a80a5c5eab5c5427cfb
+niiri:559860f351aed5f67953b4429dea3d47
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0100" ;
     nidm_coordinateVector: "[-64,-24,46]"^^xsd:string .
 
-niiri:a947d0e8f90dae8f7bb20b5e34e40ae8 prov:wasDerivedFrom niiri:4d83aeb570cac876251d053c07bf2d8e .
+niiri:3b2dfa543dfff0705b80fb76652786b5 prov:wasDerivedFrom niiri:9caa103a34dc60ce70ec535ac6e8b007 .
 
-niiri:15e23a118461c4bd677bc57965e15f92
+niiri:782068672fbbe3620c5f41b2464beaeb
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0101" ;
-    prov:atLocation niiri:41db5a2935f74a5e15c37dcd6f3713e5 ;
+    prov:atLocation niiri:042b46248a6389f83c7d559692df2f65 ;
     prov:value "2.94846987724304"^^xsd:float ;
     nidm_equivalentZStatistic: "2.8790611260641"^^xsd:float ;
     nidm_pValueUncorrected: "0.00199430508764054"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0337569462213811"^^xsd:float .
 
-niiri:41db5a2935f74a5e15c37dcd6f3713e5
+niiri:042b46248a6389f83c7d559692df2f65
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0101" ;
     nidm_coordinateVector: "[50,-40,-40]"^^xsd:string .
 
-niiri:15e23a118461c4bd677bc57965e15f92 prov:wasDerivedFrom niiri:77a467097c18360546951b54cfc345c7 .
+niiri:782068672fbbe3620c5f41b2464beaeb prov:wasDerivedFrom niiri:b860ec229f39bc9a1fbaafbcbf0a163f .
 
-niiri:abe7866bfffea9a244a1a8a6a34e0b14
+niiri:325f64d356f613a0e0206309a641ecc0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0102" ;
-    prov:atLocation niiri:1a2fdadb421ad94403de451225e07b04 ;
+    prov:atLocation niiri:267e0e982d25b38ad72635cd9afe6ff2 ;
     prov:value "2.90027952194214"^^xsd:float ;
     nidm_equivalentZStatistic: "2.83396102798879"^^xsd:float ;
     nidm_pValueUncorrected: "0.00229874692151077"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.037104578234211"^^xsd:float .
 
-niiri:1a2fdadb421ad94403de451225e07b04
+niiri:267e0e982d25b38ad72635cd9afe6ff2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0102" ;
     nidm_coordinateVector: "[-30,22,52]"^^xsd:string .
 
-niiri:abe7866bfffea9a244a1a8a6a34e0b14 prov:wasDerivedFrom niiri:cd7ab160dc57440bc4255ac3aa507dd7 .
+niiri:325f64d356f613a0e0206309a641ecc0 prov:wasDerivedFrom niiri:236f07396a3abe7464d0d6adae038d7d .
 
-niiri:23a933359f3bf83e996f41218570cf09
+niiri:adfb5705362a8f1bdf0b807bde3dda91
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0103" ;
-    prov:atLocation niiri:544e50ae5ef3cd7827b8b0ddd2e75d26 ;
+    prov:atLocation niiri:e29b1f0adc5419735354b19bd6a5f50b ;
     prov:value "2.89968776702881"^^xsd:float ;
     nidm_equivalentZStatistic: "2.83340671662386"^^xsd:float ;
     nidm_pValueUncorrected: "0.0023027373793546"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0371395343086566"^^xsd:float .
 
-niiri:544e50ae5ef3cd7827b8b0ddd2e75d26
+niiri:e29b1f0adc5419735354b19bd6a5f50b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0103" ;
     nidm_coordinateVector: "[8,-2,28]"^^xsd:string .
 
-niiri:23a933359f3bf83e996f41218570cf09 prov:wasDerivedFrom niiri:601da24f17e65f186bb79a9adc3e0bf6 .
+niiri:adfb5705362a8f1bdf0b807bde3dda91 prov:wasDerivedFrom niiri:d3ccad413c80f4d335ba3f4f6b6355af .
 
-niiri:7dbcf394d601ef9492f168f1c6806963
+niiri:a1698f36e3e1c0e83de4c62180a03384
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0104" ;
-    prov:atLocation niiri:75c41b43cc5a02b2b917412af36efbe0 ;
+    prov:atLocation niiri:faf116993450ab1d40f10c0ea345a2e4 ;
     prov:value "2.88594245910645"^^xsd:float ;
     nidm_equivalentZStatistic: "2.82052775201409"^^xsd:float ;
     nidm_pValueUncorrected: "0.00239723631051436"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0381801662649124"^^xsd:float .
 
-niiri:75c41b43cc5a02b2b917412af36efbe0
+niiri:faf116993450ab1d40f10c0ea345a2e4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0104" ;
     nidm_coordinateVector: "[14,-22,76]"^^xsd:string .
 
-niiri:7dbcf394d601ef9492f168f1c6806963 prov:wasDerivedFrom niiri:6c59d25b5ac6fc02466875dc30d6cca4 .
+niiri:a1698f36e3e1c0e83de4c62180a03384 prov:wasDerivedFrom niiri:485d5921cf99fd18e2d2bc08962f1a89 .
 
-niiri:deead949c1d304329e94df18762c2044
+niiri:174c45a8d1e67a22fc26e791cf355a46
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0105" ;
-    prov:atLocation niiri:80c4f94fa7c2f79d659534c9112c703e ;
+    prov:atLocation niiri:8ddea03b043d98f6868e7d29c28b4ad5 ;
     prov:value "2.88162541389465"^^xsd:float ;
     nidm_equivalentZStatistic: "2.81648146341917"^^xsd:float ;
     nidm_pValueUncorrected: "0.00242764223383896"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0385303778515655"^^xsd:float .
 
-niiri:80c4f94fa7c2f79d659534c9112c703e
+niiri:8ddea03b043d98f6868e7d29c28b4ad5
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0105" ;
     nidm_coordinateVector: "[32,-80,48]"^^xsd:string .
 
-niiri:deead949c1d304329e94df18762c2044 prov:wasDerivedFrom niiri:8d1a9f520760b76668ce56986561c536 .
+niiri:174c45a8d1e67a22fc26e791cf355a46 prov:wasDerivedFrom niiri:fafeba66cc92ac8083e5897d50f4bcab .
 
-niiri:246faa64a391753c92d9b7f37263f17b
+niiri:d3666814839586295a138503c43b05cb
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0106" ;
-    prov:atLocation niiri:53ae8662ffa161ea38385eb6e1b86aa0 ;
+    prov:atLocation niiri:700ca7e9988e82bcf89e1f9f7c4c125d ;
     prov:value "2.86741852760315"^^xsd:float ;
     nidm_equivalentZStatistic: "2.80316111290485"^^xsd:float ;
     nidm_pValueUncorrected: "0.00253021914439433"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0396560213914501"^^xsd:float .
 
-niiri:53ae8662ffa161ea38385eb6e1b86aa0
+niiri:700ca7e9988e82bcf89e1f9f7c4c125d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0106" ;
     nidm_coordinateVector: "[-22,4,8]"^^xsd:string .
 
-niiri:246faa64a391753c92d9b7f37263f17b prov:wasDerivedFrom niiri:9de0c2e42252737a8379e3e037d6d2aa .
+niiri:d3666814839586295a138503c43b05cb prov:wasDerivedFrom niiri:48a7f6254e1629604bc57865dff4d670 .
 
-niiri:a6c9989bafc9174c51c423a27ac47b43
+niiri:132f6eb140d7fc16eceeb304478171c2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0107" ;
-    prov:atLocation niiri:824048bb1298f70821a5b93b00ff2faf ;
+    prov:atLocation niiri:9232cc449e5a68b19d9882c1045a5e8e ;
     prov:value "2.86433458328247"^^xsd:float ;
     nidm_equivalentZStatistic: "2.80026870598453"^^xsd:float ;
     nidm_pValueUncorrected: "0.00255300420116833"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0399071683618212"^^xsd:float .
 
-niiri:824048bb1298f70821a5b93b00ff2faf
+niiri:9232cc449e5a68b19d9882c1045a5e8e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0107" ;
     nidm_coordinateVector: "[-22,-88,-8]"^^xsd:string .
 
-niiri:a6c9989bafc9174c51c423a27ac47b43 prov:wasDerivedFrom niiri:ac17f6aed0c480752633af7157a50790 .
+niiri:132f6eb140d7fc16eceeb304478171c2 prov:wasDerivedFrom niiri:33e63ed9d657f0ba23cd9ffacda3e22d .
 
-niiri:1a49d43c3b450637f9f89f751c8f650b
+niiri:c44f1d9e91a6e9fe1b09cd64614d61c2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0108" ;
-    prov:atLocation niiri:43bc0dc3855d4a2b58dddfc7f9ab43fa ;
+    prov:atLocation niiri:9b89beb9deba464fb2b8daf018f2b058 ;
     prov:value "2.8607702255249"^^xsd:float ;
     nidm_equivalentZStatistic: "2.7969253219898"^^xsd:float ;
     nidm_pValueUncorrected: "0.00257957281985488"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0402133860761281"^^xsd:float .
 
-niiri:43bc0dc3855d4a2b58dddfc7f9ab43fa
+niiri:9b89beb9deba464fb2b8daf018f2b058
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0108" ;
     nidm_coordinateVector: "[-40,12,10]"^^xsd:string .
 
-niiri:1a49d43c3b450637f9f89f751c8f650b prov:wasDerivedFrom niiri:09df787a9447add50b251d7691bf2f9c .
+niiri:c44f1d9e91a6e9fe1b09cd64614d61c2 prov:wasDerivedFrom niiri:768ca0ef2b170d430ebbd40ebb08cff0 .
 
-niiri:e0b304712e9a3529ed451336ad288be3
+niiri:53fd4410e0451ea937aa0616970eb8c1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0109" ;
-    prov:atLocation niiri:9d6a02811a4473156dd2f200d3c8edcf ;
+    prov:atLocation niiri:97d461a41363cb6f676aa66096ab6def ;
     prov:value "2.84392619132996"^^xsd:float ;
     nidm_equivalentZStatistic: "2.78111974914723"^^xsd:float ;
     nidm_pValueUncorrected: "0.00270858754422498"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.041614329014815"^^xsd:float .
 
-niiri:9d6a02811a4473156dd2f200d3c8edcf
+niiri:97d461a41363cb6f676aa66096ab6def
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0109" ;
     nidm_coordinateVector: "[14,-8,36]"^^xsd:string .
 
-niiri:e0b304712e9a3529ed451336ad288be3 prov:wasDerivedFrom niiri:5df3810b9f8634e5eabf4cf013d6d516 .
+niiri:53fd4410e0451ea937aa0616970eb8c1 prov:wasDerivedFrom niiri:8cf8073a323eec04d3968fab10115c2b .
 
-niiri:9e4ce06ce9275316cf95c584d5bdcfa7
+niiri:3469a97617a1acc2f9fa828b99843678
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0110" ;
-    prov:atLocation niiri:02d1c6218be7e54215c6f38722de782e ;
+    prov:atLocation niiri:cb7e1ce722f6758ac5d4c15d377d77c2 ;
     prov:value "2.84026050567627"^^xsd:float ;
     nidm_equivalentZStatistic: "2.77767879851976"^^xsd:float ;
     nidm_pValueUncorrected: "0.00273743545807803"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0419349799473709"^^xsd:float .
 
-niiri:02d1c6218be7e54215c6f38722de782e
+niiri:cb7e1ce722f6758ac5d4c15d377d77c2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0110" ;
     nidm_coordinateVector: "[46,-40,4]"^^xsd:string .
 
-niiri:9e4ce06ce9275316cf95c584d5bdcfa7 prov:wasDerivedFrom niiri:819baf737aaaa45787693a764f07e7c8 .
+niiri:3469a97617a1acc2f9fa828b99843678 prov:wasDerivedFrom niiri:dba062dd06d4105f10d77f25b52b96c8 .
 
-niiri:af111ed4f4f05f94afad771c95aa7e4a
+niiri:60c64006a9802f87bdbaffb4ec25a5b2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0111" ;
-    prov:atLocation niiri:92e75fdcba81b94553228641fee3084e ;
+    prov:atLocation niiri:86ff68b3752b401bab1dea5b5679ac5b ;
     prov:value "2.81844663619995"^^xsd:float ;
     nidm_equivalentZStatistic: "2.75719305463653"^^xsd:float ;
     nidm_pValueUncorrected: "0.0029149959934297"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0437990036423837"^^xsd:float .
 
-niiri:92e75fdcba81b94553228641fee3084e
+niiri:86ff68b3752b401bab1dea5b5679ac5b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0111" ;
     nidm_coordinateVector: "[44,8,-20]"^^xsd:string .
 
-niiri:af111ed4f4f05f94afad771c95aa7e4a prov:wasDerivedFrom niiri:509244d6a4f71a5ff685cfe8e8ad90b4 .
+niiri:60c64006a9802f87bdbaffb4ec25a5b2 prov:wasDerivedFrom niiri:c51b283e94df3fae6004dee4203f35fd .
 
-niiri:9c829d114bba7d125c53fe5e6a6299a5
+niiri:918936eb1d58155c78c560ab565b0202
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0112" ;
-    prov:atLocation niiri:be71c9d285f364508d6586985794e585 ;
+    prov:atLocation niiri:8acf1763afbbc2c95b172b9578d29d2b ;
     prov:value "2.7993757724762"^^xsd:float ;
     nidm_equivalentZStatistic: "2.73927048137962"^^xsd:float ;
     nidm_pValueUncorrected: "0.00307878458404665"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0454451203208682"^^xsd:float .
 
-niiri:be71c9d285f364508d6586985794e585
+niiri:8acf1763afbbc2c95b172b9578d29d2b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0112" ;
     nidm_coordinateVector: "[14,-44,20]"^^xsd:string .
 
-niiri:9c829d114bba7d125c53fe5e6a6299a5 prov:wasDerivedFrom niiri:085ae9e43b1853458f70bf9e0f5e48e8 .
+niiri:918936eb1d58155c78c560ab565b0202 prov:wasDerivedFrom niiri:c79437288e303b8f2bef9af3b70d4aaa .
 
-niiri:361f98cb67ddd27527b90f76c037d6ce
+niiri:8d45ffd6ad4acc8edcfb248f110ba687
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0113" ;
-    prov:atLocation niiri:71974ded62751ae232fca3b32c2554fe ;
+    prov:atLocation niiri:f4e79acdb9c2e573b4d0b861b0156ed1 ;
     prov:value "2.79517197608948"^^xsd:float ;
     nidm_equivalentZStatistic: "2.73531820941264"^^xsd:float ;
     nidm_pValueUncorrected: "0.0031159999373751"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0458305068946882"^^xsd:float .
 
-niiri:71974ded62751ae232fca3b32c2554fe
+niiri:f4e79acdb9c2e573b4d0b861b0156ed1
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0113" ;
     nidm_coordinateVector: "[18,-14,44]"^^xsd:string .
 
-niiri:361f98cb67ddd27527b90f76c037d6ce prov:wasDerivedFrom niiri:1e6213ed8f4367c38bb8e3df7596c194 .
+niiri:8d45ffd6ad4acc8edcfb248f110ba687 prov:wasDerivedFrom niiri:049f42c8eb4f2db2320a43cbbdd89f0f .
 
-niiri:ec20b0d9199c3e3ab387ec81b20d59ee
+niiri:8ad18c7eb09ca5a3aab852d344491753
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0114" ;
-    prov:atLocation niiri:5f4da0675fc3f811891772a1b6cbf07e ;
+    prov:atLocation niiri:ca5c06dc0433f9ffbb1a4ad5a02f8a10 ;
     prov:value "2.79148125648499"^^xsd:float ;
     nidm_equivalentZStatistic: "2.73184784384814"^^xsd:float ;
     nidm_pValueUncorrected: "0.00314901097075382"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.046156489574122"^^xsd:float .
 
-niiri:5f4da0675fc3f811891772a1b6cbf07e
+niiri:ca5c06dc0433f9ffbb1a4ad5a02f8a10
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0114" ;
     nidm_coordinateVector: "[12,-6,34]"^^xsd:string .
 
-niiri:ec20b0d9199c3e3ab387ec81b20d59ee prov:wasDerivedFrom niiri:2d1a3d2d688f08f62c34200978327796 .
+niiri:8ad18c7eb09ca5a3aab852d344491753 prov:wasDerivedFrom niiri:4e6c7a95cd372d482b4ef655fa46f083 .
 
-niiri:c41cf17e60ba4c3b108cc72dec760b61
+niiri:9c388cc5a4937ec66a020ba4a2721666
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0115" ;
-    prov:atLocation niiri:039aa682b41eef2065b68b5a591ef554 ;
+    prov:atLocation niiri:7946fe79a1ae96f06dc46a97c7ed5fe7 ;
     prov:value "2.78754210472107"^^xsd:float ;
     nidm_equivalentZStatistic: "2.72814339359783"^^xsd:float ;
     nidm_pValueUncorrected: "0.00318459572389584"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0465414965984294"^^xsd:float .
 
-niiri:039aa682b41eef2065b68b5a591ef554
+niiri:7946fe79a1ae96f06dc46a97c7ed5fe7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0115" ;
     nidm_coordinateVector: "[-32,-62,-26]"^^xsd:string .
 
-niiri:c41cf17e60ba4c3b108cc72dec760b61 prov:wasDerivedFrom niiri:74938e3d61efe7611ba39208c8bc71d5 .
+niiri:9c388cc5a4937ec66a020ba4a2721666 prov:wasDerivedFrom niiri:78623bac11315960aba0a8d855467f49 .
 
-niiri:bc239621815371d0a52da345fed7a4bf
+niiri:baa76c8f2997dbaae3d90e25b8c4bfd8
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0116" ;
-    prov:atLocation niiri:ec381c235d39daa708455297f4e8f059 ;
+    prov:atLocation niiri:f864654c4d54b3c64735888e578355e6 ;
     prov:value "2.77749013900757"^^xsd:float ;
     nidm_equivalentZStatistic: "2.71868808084123"^^xsd:float ;
     nidm_pValueUncorrected: "0.00327706910125547"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0474666807455127"^^xsd:float .
 
-niiri:ec381c235d39daa708455297f4e8f059
+niiri:f864654c4d54b3c64735888e578355e6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0116" ;
     nidm_coordinateVector: "[64,-10,22]"^^xsd:string .
 
-niiri:bc239621815371d0a52da345fed7a4bf prov:wasDerivedFrom niiri:3e17a6b5e2e157b57784ecb5f6ffcdc1 .
+niiri:baa76c8f2997dbaae3d90e25b8c4bfd8 prov:wasDerivedFrom niiri:288a1fc03510b55eff121de5bf93e1f4 .
 
-niiri:94663f914ec0c8870e0c3a0f317faa23
+niiri:34797ad5a5f0034f4a5cf71249cd89d8
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0117" ;
-    prov:atLocation niiri:df2928cf310bb64ff0b74246eb178ac5 ;
+    prov:atLocation niiri:a9825b9be6fe20a5cb8645642659227e ;
     prov:value "2.76671266555786"^^xsd:float ;
     nidm_equivalentZStatistic: "2.70854673720236"^^xsd:float ;
     nidm_pValueUncorrected: "0.00337892965855868"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0484988413841496"^^xsd:float .
 
-niiri:df2928cf310bb64ff0b74246eb178ac5
+niiri:a9825b9be6fe20a5cb8645642659227e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0117" ;
     nidm_coordinateVector: "[-22,-4,10]"^^xsd:string .
 
-niiri:94663f914ec0c8870e0c3a0f317faa23 prov:wasDerivedFrom niiri:1793e50c9d713624fbb8bba2d78ea464 .
+niiri:34797ad5a5f0034f4a5cf71249cd89d8 prov:wasDerivedFrom niiri:f6ffc917f79709af0e39207ec0add7a4 .
 
-niiri:810315dd3aa706cef0a31470abd08eca
+niiri:c04ece7485734e358071d757deeef557
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0118" ;
-    prov:atLocation niiri:86a2289f298aa4930b6e4ffa308cad83 ;
+    prov:atLocation niiri:d534f09e73fec2932a43da85804923c2 ;
     prov:value "2.7631950378418"^^xsd:float ;
     nidm_equivalentZStatistic: "2.70523593531943"^^xsd:float ;
     nidm_pValueUncorrected: "0.00341279457967081"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0488594652816085"^^xsd:float .
 
-niiri:86a2289f298aa4930b6e4ffa308cad83
+niiri:d534f09e73fec2932a43da85804923c2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0118" ;
     nidm_coordinateVector: "[-42,-24,70]"^^xsd:string .
 
-niiri:810315dd3aa706cef0a31470abd08eca prov:wasDerivedFrom niiri:8bfbe4bb02769474d9ccfb7795dcf200 .
+niiri:c04ece7485734e358071d757deeef557 prov:wasDerivedFrom niiri:bd77e4cd78d5c4dcb23a68309256720d .
 
-niiri:c601459b7fe03095577074d9d5ef04ba
+niiri:115008c56fcea7d4c5a2ee78582283c7
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0119" ;
-    prov:atLocation niiri:c32ce4a4616c298e4abecf93cfbe78bd ;
+    prov:atLocation niiri:98a043770ac0d808800712f30d2fc24c ;
     prov:value "2.75206708908081"^^xsd:float ;
     nidm_equivalentZStatistic: "2.69475970396491"^^xsd:float ;
     nidm_pValueUncorrected: "0.00352197048666147"^^xsd:float ;
     nidm_pValueFWER: "1"^^xsd:float ;
     nidm_qValueFDR: "0.0499801129190164"^^xsd:float .
 
-niiri:c32ce4a4616c298e4abecf93cfbe78bd
+niiri:98a043770ac0d808800712f30d2fc24c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0119" ;
     nidm_coordinateVector: "[-62,-20,46]"^^xsd:string .
 
-niiri:c601459b7fe03095577074d9d5ef04ba prov:wasDerivedFrom niiri:a6dbb6a94c7d5ef0b744a15cdc6d3ed6 .
+niiri:115008c56fcea7d4c5a2ee78582283c7 prov:wasDerivedFrom niiri:31f96dd2a2f7097e6993ae7eec0e23e6 .
 

--- a/spmexport/ex_spm_thr_voxelfwep05/nidm.json
+++ b/spmexport/ex_spm_thr_voxelfwep05/nidm.json
@@ -1,0 +1,3448 @@
+{
+  "prefix": {
+    "nidm": "http://purl.org/nidash/nidm#",
+    "niiri": "http://iri.nidash.org/",
+    "spm": "http://purl.org/nidash/spm#",
+    "neurolex": "http://neurolex.org/wiki/",
+    "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/",
+    "dct": "http://purl.org/dc/terms/",
+    "nfo": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#",
+    "dc": "http://purl.org/dc/elements/1.1/",
+    "dctype": "http://purl.org/dc/dcmitype/",
+    "obo": "http://purl.obolibrary.org/obo/",
+    "nidm_NIDMResults": "http://purl.org/nidash/nidm#NIDM_0000027",
+    "nidm_version": "http://purl.org/nidash/nidm#NIDM_0000127",
+    "nidm_spm_results_nidm": "http://purl.org/nidash/nidm#NIDM_0000168",
+    "nidm_softwareVersion": "http://purl.org/nidash/nidm#NIDM_0000122",
+    "nidm_NIDMResultsExport": "http://purl.org/nidash/nidm#NIDM_0000166"
+  },
+  "entity": {
+    "niiri:d085af3e055d03b41e58ff791604e130": {
+      "prov:type": [
+        {
+        "$": "prov:Bundle",
+        "type": "xsd:QName"
+        },
+        {
+        "$": "nidm_NIDMResults:",
+        "type": "xsd:QName"
+        }
+      ],
+      "prov:label": {
+        "$": "NIDM-Results",
+        "type": "xsd:string"
+      },
+      "nidm_version:": {
+        "$": "1.3.0",
+        "type": "xsd:string"
+      }
+    }
+  },
+  "activity": {
+    "niiri:55fc5c1d9802e26a9bae0c11e872ca8f": {
+      "prov:type": {
+        "$": "nidm_NIDMResultsExport:",
+        "type": "xsd:QName"
+      },
+      "prov:label": {
+        "$": "NIDM-Results export",
+        "type": "xsd:string"
+      }
+    }
+  },
+  "agent": {
+    "niiri:fb236c1eb16f0c705e70a281f202e4e0": {
+      "prov:type": [
+        {
+        "$": "nidm_spm_results_nidm:",
+        "type": "xsd:QName"
+        },
+        {
+        "$": "prov:SoftwareAgent",
+        "type": "xsd:QName"
+        }
+      ],
+      "prov:label": {
+        "$": "spm_results_nidm",
+        "type": "xsd:string"
+      },
+      "nidm_softwareVersion:": {
+        "$": "12.7057",
+        "type": "xsd:string"
+      }
+    }
+  },
+  "wasGeneratedBy": {
+    "_:wGB5": {
+      "prov:entity": "niiri:d085af3e055d03b41e58ff791604e130",
+      "prov:activity": "niiri:55fc5c1d9802e26a9bae0c11e872ca8f",
+      "prov:time": "2017-04-19T12:19:21"
+    }
+  },
+  "wasAssociatedWith": {
+    "_:wAW4": {
+      "prov:activity": "niiri:55fc5c1d9802e26a9bae0c11e872ca8f",
+      "prov:agent": "niiri:fb236c1eb16f0c705e70a281f202e4e0"
+    }
+  },
+  "bundle": {
+    "niiri:d085af3e055d03b41e58ff791604e130": {
+    "prefix": {
+        "nidm_softwareVersion": "http://purl.org/nidash/nidm#NIDM_0000122",
+        "nidm_CoordinateSpace": "http://purl.org/nidash/nidm#NIDM_0000016",
+        "nidm_voxelToWorldMapping": "http://purl.org/nidash/nidm#NIDM_0000132",
+        "nidm_voxelUnits": "http://purl.org/nidash/nidm#NIDM_0000133",
+        "nidm_voxelSize": "http://purl.org/nidash/nidm#NIDM_0000131",
+        "nidm_inWorldCoordinateSystem": "http://purl.org/nidash/nidm#NIDM_0000105",
+        "nidm_numberOfDimensions": "http://purl.org/nidash/nidm#NIDM_0000112",
+        "nidm_dimensionsInVoxels": "http://purl.org/nidash/nidm#NIDM_0000090",
+        "nlx_Imaginginstrument": "http://uri.neuinfo.org/nif/nifstd/birnlex_2094",
+        "nlx_Magneticresonanceimagingscanner": "http://uri.neuinfo.org/nif/nifstd/birnlex_2100",
+        "nidm_grandMeanScaling": "http://purl.org/nidash/nidm#NIDM_0000096",
+        "nidm_targetIntensity": "http://purl.org/nidash/nidm#NIDM_0000124",
+        "nidm_hasMRIProtocol": "http://purl.org/nidash/nidm#NIDM_0000172",
+        "nlx_FunctionalMRIprotocol": "http://uri.neuinfo.org/nif/nifstd/birnlex_2250",
+        "nidm_Data": "http://purl.org/nidash/nidm#NIDM_0000169",
+        "spm_DCTDriftModel": "http://purl.org/nidash/spm#SPM_0000002",
+        "spm_SPMsDriftCutoffPeriod": "http://purl.org/nidash/spm#SPM_0000001",
+        "nidm_hasDriftModel": "http://purl.org/nidash/nidm#NIDM_0000088",
+        "nidm_hasHRFBasis": "http://purl.org/nidash/nidm#NIDM_0000102",
+        "spm_SPMsCanonicalHRF": "http://purl.org/nidash/spm#SPM_0000004",
+        "nidm_DesignMatrix": "http://purl.org/nidash/nidm#NIDM_0000019",
+        "nidm_regressorNames": "http://purl.org/nidash/nidm#NIDM_0000021",
+        "nidm_hasErrorDependence": "http://purl.org/nidash/nidm#NIDM_0000100",
+        "obo_Toeplitzcovariancestructure": "http://purl.obolibrary.org/obo/STATO_0000357",
+        "nidm_dependenceMapWiseDependence": "http://purl.org/nidash/nidm#NIDM_0000089",
+        "nidm_ConstantParameter": "http://purl.org/nidash/nidm#NIDM_0000072",
+        "nidm_errorVarianceHomogeneous": "http://purl.org/nidash/nidm#NIDM_0000094",
+        "nidm_varianceMapWiseDependence": "http://purl.org/nidash/nidm#NIDM_0000126",
+        "nidm_IndependentParameter": "http://purl.org/nidash/nidm#NIDM_0000073",
+        "nidm_withEstimationMethod": "http://purl.org/nidash/nidm#NIDM_0000134",
+        "obo_generalizedleastsquaresestimation": "http://purl.obolibrary.org/obo/STATO_0000372",
+        "nidm_ErrorModel": "http://purl.org/nidash/nidm#NIDM_0000023",
+        "nidm_hasErrorDistribution": "http://purl.org/nidash/nidm#NIDM_0000101",
+        "obo_normaldistribution": "http://purl.obolibrary.org/obo/STATO_0000227",
+        "nidm_ModelParametersEstimation": "http://purl.org/nidash/nidm#NIDM_0000056",
+        "nidm_MaskMap": "http://purl.org/nidash/nidm#NIDM_0000054",
+        "nidm_isUserDefined": "http://purl.org/nidash/nidm#NIDM_0000106",
+        "nidm_inCoordinateSpace": "http://purl.org/nidash/nidm#NIDM_0000104",
+        "nidm_GrandMeanMap": "http://purl.org/nidash/nidm#NIDM_0000033",
+        "nidm_maskedMedian": "http://purl.org/nidash/nidm#NIDM_0000107",
+        "nidm_ParameterEstimateMap": "http://purl.org/nidash/nidm#NIDM_0000061",
+        "nidm_ResidualMeanSquaresMap": "http://purl.org/nidash/nidm#NIDM_0000066",
+        "nidm_ReselsPerVoxelMap": "http://purl.org/nidash/nidm#NIDM_0000144",
+        "obo_contrastweightmatrix": "http://purl.obolibrary.org/obo/STATO_0000323",
+        "nidm_statisticType": "http://purl.org/nidash/nidm#NIDM_0000123",
+        "obo_tstatistic": "http://purl.obolibrary.org/obo/STATO_0000176",
+        "nidm_contrastName": "http://purl.org/nidash/nidm#NIDM_0000085",
+        "nidm_ContrastEstimation": "http://purl.org/nidash/nidm#NIDM_0000001",
+        "nidm_StatisticMap": "http://purl.org/nidash/nidm#NIDM_0000076",
+        "nidm_errorDegreesOfFreedom": "http://purl.org/nidash/nidm#NIDM_0000093",
+        "nidm_effectDegreesOfFreedom": "http://purl.org/nidash/nidm#NIDM_0000091",
+        "nidm_ContrastMap": "http://purl.org/nidash/nidm#NIDM_0000002",
+        "nidm_ContrastStandardErrorMap": "http://purl.org/nidash/nidm#NIDM_0000013",
+        "obo_statistic": "http://purl.obolibrary.org/obo/STATO_0000039",
+        "nidm_PValueUncorrected": "http://purl.org/nidash/nidm#NIDM_0000160",
+        "obo_FWERadjustedpvalue": "http://purl.obolibrary.org/obo/OBI_0001265",
+        "nidm_HeightThreshold": "http://purl.org/nidash/nidm#NIDM_0000034",
+        "nidm_equivalentThreshold": "http://purl.org/nidash/nidm#NIDM_0000161",
+        "nidm_ExtentThreshold": "http://purl.org/nidash/nidm#NIDM_0000026",
+        "nidm_clusterSizeInVoxels": "http://purl.org/nidash/nidm#NIDM_0000084",
+        "nidm_clusterSizeInResels": "http://purl.org/nidash/nidm#NIDM_0000156",
+        "nidm_PeakDefinitionCriteria": "http://purl.org/nidash/nidm#NIDM_0000063",
+        "nidm_maxNumberOfPeaksPerCluster": "http://purl.org/nidash/nidm#NIDM_0000108",
+        "nidm_minDistanceBetweenPeaks": "http://purl.org/nidash/nidm#NIDM_0000109",
+        "nidm_ClusterDefinitionCriteria": "http://purl.org/nidash/nidm#NIDM_0000007",
+        "nidm_hasConnectivityCriterion": "http://purl.org/nidash/nidm#NIDM_0000099",
+        "nidm_voxel18connected": "http://purl.org/nidash/nidm#NIDM_0000128",
+        "nidm_Inference": "http://purl.org/nidash/nidm#NIDM_0000049",
+        "nidm_hasAlternativeHypothesis": "http://purl.org/nidash/nidm#NIDM_0000097",
+        "nidm_OneTailedTest": "http://purl.org/nidash/nidm#NIDM_0000060",
+        "nidm_SearchSpaceMaskMap": "http://purl.org/nidash/nidm#NIDM_0000068",
+        "nidm_searchVolumeInVoxels": "http://purl.org/nidash/nidm#NIDM_0000121",
+        "nidm_searchVolumeInUnits": "http://purl.org/nidash/nidm#NIDM_0000136",
+        "nidm_reselSizeInVoxels": "http://purl.org/nidash/nidm#NIDM_0000148",
+        "nidm_searchVolumeInResels": "http://purl.org/nidash/nidm#NIDM_0000149",
+        "spm_searchVolumeReselsGeometry": "http://purl.org/nidash/spm#SPM_0000010",
+        "nidm_noiseFWHMInVoxels": "http://purl.org/nidash/nidm#NIDM_0000159",
+        "nidm_noiseFWHMInUnits": "http://purl.org/nidash/nidm#NIDM_0000157",
+        "nidm_randomFieldStationarity": "http://purl.org/nidash/nidm#NIDM_0000120",
+        "nidm_expectedNumberOfVoxelsPerCluster": "http://purl.org/nidash/nidm#NIDM_0000143",
+        "nidm_expectedNumberOfClusters": "http://purl.org/nidash/nidm#NIDM_0000141",
+        "nidm_heightCriticalThresholdFWE05": "http://purl.org/nidash/nidm#NIDM_0000147",
+        "nidm_heightCriticalThresholdFDR05": "http://purl.org/nidash/nidm#NIDM_0000146",
+        "spm_smallestSignificantClusterSizeInVoxelsFWE05": "http://purl.org/nidash/spm#SPM_0000014",
+        "spm_smallestSignificantClusterSizeInVoxelsFDR05": "http://purl.org/nidash/spm#SPM_0000013",
+        "nidm_ExcursionSetMap": "http://purl.org/nidash/nidm#NIDM_0000025",
+        "nidm_numberOfSupraThresholdClusters": "http://purl.org/nidash/nidm#NIDM_0000111",
+        "nidm_pValue": "http://purl.org/nidash/nidm#NIDM_0000114",
+        "nidm_hasClusterLabelsMap": "http://purl.org/nidash/nidm#NIDM_0000098",
+        "nidm_hasMaximumIntensityProjection": "http://purl.org/nidash/nidm#NIDM_0000138",
+        "nidm_ClusterLabelsMap": "http://purl.org/nidash/nidm#NIDM_0000008",
+        "nidm_SupraThresholdCluster": "http://purl.org/nidash/nidm#NIDM_0000070",
+        "nidm_pValueUncorrected": "http://purl.org/nidash/nidm#NIDM_0000116",
+        "nidm_pValueFWER": "http://purl.org/nidash/nidm#NIDM_0000115",
+        "nidm_qValueFDR": "http://purl.org/nidash/nidm#NIDM_0000119",
+        "nidm_clusterLabelId": "http://purl.org/nidash/nidm#NIDM_0000082",
+        "nidm_Peak": "http://purl.org/nidash/nidm#NIDM_0000062",
+        "nidm_equivalentZStatistic": "http://purl.org/nidash/nidm#NIDM_0000092",
+        "nidm_Coordinate": "http://purl.org/nidash/nidm#NIDM_0000015",
+        "nidm_coordinateVector": "http://purl.org/nidash/nidm#NIDM_0000086"
+    },
+    "entity": {
+        "niiri:3be25c24ad21044b41a1490e0f682fbe": {
+            "prov:type": {
+                "$": "nidm_CoordinateSpace:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Coordinate space 1",
+                "type": "xsd:string"
+            },
+            "nidm_voxelToWorldMapping:": {
+                "$": "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]",
+                "type": "xsd:string"
+            },
+            "nidm_voxelUnits:": {
+                "$": "[\"mm\", \"mm\", \"mm\"]",
+                "type": "xsd:string"
+            },
+            "nidm_voxelSize:": {
+                "$": "[2, 2, 2]",
+                "type": "xsd:string"
+            },
+            "nidm_inWorldCoordinateSystem:": {
+                "$": "nidm_Ixi549CoordinateSystem:",
+                "type": "xsd:string"
+            },
+            "nidm_numberOfDimensions:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_dimensionsInVoxels:": {
+                "$": "[79,95,79]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a408442578dc3ad4a6905f9711e6a6c3": {
+            "prov:type": [
+                {
+                "$": "prov:Collection",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Data:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Data",
+                "type": "xsd:string"
+            },
+            "nidm_grandMeanScaling:": {
+                "$": "true",
+                "type": "xsd:boolean"
+            },
+            "nidm_targetIntensity:": {
+                "$": "100",
+                "type": "xsd:float"
+            },
+            "nidm_hasMRIProtocol:": {
+                "$": "nlx_FunctionalMRIprotocol:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f0a4cf13c5d07c9f613050a20c1fb410": {
+            "prov:type": {
+                "$": "spm_DCTDriftModel:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "SPM's DCT Drift Model",
+                "type": "xsd:string"
+            },
+            "spm_SPMsDriftCutoffPeriod:": {
+                "$": "128",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7e38970ca6e0c04540e0958cfd68a076": {
+            "prov:type": {
+                "$": "nidm_DesignMatrix:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "DesignMatrix.csv",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "DesignMatrix.csv",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "text/csv",
+                "type": "xsd:string"
+            },
+            "dc:description": {
+                "$": "niiri:7dd586f3a19dd8e4ad066d8b0d3fae59",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Design Matrix",
+                "type": "xsd:string"
+            },
+            "nidm_regressorNames:": {
+                "$": "[\"Sn(1) to*bf(1)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) constant\"]",
+                "type": "xsd:string"
+            },
+            "nidm_hasDriftModel:": {
+                "$": "niiri:f0a4cf13c5d07c9f613050a20c1fb410",
+                "type": "xsd:string"
+            },
+            "nidm_hasHRFBasis:": {
+                "$": "spm_SPMsCanonicalHRF:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7dd586f3a19dd8e4ad066d8b0d3fae59": {
+            "prov:type": {
+                "$": "dctype:Image",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "DesignMatrix.png",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "DesignMatrix.png",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/png",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6f865b9d321b1a0b96e5376fd02d63ef": {
+            "prov:type": {
+                "$": "nidm_ErrorModel:",
+                "type": "xsd:QName"
+            },
+            "nidm_hasErrorDistribution:": {
+                "$": "obo_normaldistribution:",
+                "type": "xsd:string"
+            },
+            "nidm_hasErrorDependence:": {
+                "$": "obo_Toeplitzcovariancestructure:",
+                "type": "xsd:string"
+            },
+            "nidm_dependenceMapWiseDependence:": {
+                "$": "nidm_ConstantParameter:",
+                "type": "xsd:string"
+            },
+            "nidm_errorVarianceHomogeneous:": {
+                "$": "true",
+                "type": "xsd:boolean"
+            },
+            "nidm_varianceMapWiseDependence:": {
+                "$": "nidm_IndependentParameter:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:93aaa88123d0eb90e6fdecebf810f8ea": {
+            "prov:type": {
+                "$": "nidm_MaskMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "Mask.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nidm_isUserDefined:": {
+                "$": "false",
+                "type": "xsd:boolean"
+            },
+            "nfo:fileName": {
+                "$": "Mask.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Mask",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:3be25c24ad21044b41a1490e0f682fbe",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b9432ea6450538366288502c57b612c8": {
+            "prov:type": {
+                "$": "nidm_MaskMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "mask.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "36929e1f5f4143bd9cc818cd896a25f129961fab208c3a4438555f40444c08347b359142ee8c53ece6e8cca1627f49db0788a1fd3b9e2ecaef61999c6c6c67ac",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f6a969c39d0994e548cee708ab2235b8": {
+            "prov:type": {
+                "$": "nidm_GrandMeanMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "GrandMean.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "GrandMean.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Grand Mean Map",
+                "type": "xsd:string"
+            },
+            "nidm_maskedMedian:": {
+                "$": "111.557487487793",
+                "type": "xsd:float"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:3be25c24ad21044b41a1490e0f682fbe",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "512157cc6bff89d9343a09b4068226eb3edd64a8cbcee861f06231767fae6f8d4819921182adebee083a9bf309afd65529ab04a92f0aa6b0038c8098550f6124",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:496fab100c7ba03c3adaf6aa62510d80": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0001.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0001.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 1",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:3be25c24ad21044b41a1490e0f682fbe",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1f32cb91cd9bb85763a6e2ea06c295b1": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0001.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:aad4f64b78f4368cc8545781af63aeeb": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0002.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0002.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 2",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:3be25c24ad21044b41a1490e0f682fbe",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8890ba1e2038c1a9257fc78e24e62373": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0002.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9f8e0d06fd0a9c289c938c9e062c5aec": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0003.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0003.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 3",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:3be25c24ad21044b41a1490e0f682fbe",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4418d957014ed912ea3172a7f573bb8e": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0003.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:47932f62f0b280c5b5907959d9b94b4e": {
+            "prov:type": {
+                "$": "nidm_ResidualMeanSquaresMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ResidualMeanSquares.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ResidualMeanSquares.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Residual Mean Squares Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:3be25c24ad21044b41a1490e0f682fbe",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "991abf563d795a43b1e2eef8643e57023f2e0b090b2031f05f839321fc0643df6f71d423486a1021519b6dc82f6b0f563e19f3fbd50cb16063bed54a0e192d3e",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:cc2c7bdd65030f68b7d32e21eb4af9f8": {
+            "prov:type": {
+                "$": "nidm_ResidualMeanSquaresMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "ResMS.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "40b28d03fcf9a2f60b11f10d7fb83bf3618b234fb5aedf09df644cb7cbb6aab8c9f468897c1078166d455a3d04a83f4e3bf762cfca0b4ea982d7a4e406849f18",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6dda6fa299c24eac1686b577a1c4e494": {
+            "prov:type": {
+                "$": "nidm_ReselsPerVoxelMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ReselsPerVoxel.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ReselsPerVoxel.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Resels per Voxel Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:3be25c24ad21044b41a1490e0f682fbe",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "1a3f9216e145249ccc0b14b2bc337d6b38b81ad45e32768001fb22b35f0c2c0f3e2bce013b40c85f7dc0fc62723ac761ee7f7e1e6aff128a05f0ba7b8b8202a3",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9fa6f41590f6fa9fe1449b0b7f65fc88": {
+            "prov:type": {
+                "$": "nidm_ReselsPerVoxelMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "RPV.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "4f76663162857f6b38b2a45a63b15a23b2ca8b338c283b69c1e71f2ea2f43797d045a733cd14e845be9c12f8b8f84d3931c599a08e8f6d77e99fab46ad87ab8f",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:720cff657408138421d0937c76c9977e": {
+            "prov:type": {
+                "$": "obo_contrastweightmatrix:",
+                "type": "xsd:QName"
+            },
+            "nidm_statisticType:": {
+                "$": "obo_tstatistic:",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast: tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "[1, 0, 0]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9e31766e27104879ffdde1e5cc7cfca0": {
+            "prov:type": {
+                "$": "nidm_StatisticMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "TStatistic.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "TStatistic.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "T-Statistic Map: tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "nidm_statisticType:": {
+                "$": "obo_tstatistic:",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "nidm_errorDegreesOfFreedom:": {
+                "$": "97.9999999998522",
+                "type": "xsd:float"
+            },
+            "nidm_effectDegreesOfFreedom:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:3be25c24ad21044b41a1490e0f682fbe",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "9e1714c2d86a050b38b4e10a4d2d23253a24c5e1d228ae16a9c3be8872739278505ac0729ecab54265a717e3a54f9f782d0ed72eea904e0d482a6072bb817bd4",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4c17423a353140952a61dff8ed7694f1": {
+            "prov:type": {
+                "$": "nidm_StatisticMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "spmT_0001.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "d288b1b0f117f64502555da13c5398dffa5bf5ff0b58951510e43d5388755bc185798802a92e98a07c7e313c6991066d2908f2a44aa5153ba23433da1335970f",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:408aa82e300c1bcdfaa6514d653e1ce2": {
+            "prov:type": {
+                "$": "nidm_ContrastMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "Contrast.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "Contrast.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast Map: tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:3be25c24ad21044b41a1490e0f682fbe",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "fc5e2ad175243ee496db98f9b2e1b235c4c3bae1a8d7122ce461c897b537e40c49dfee5d6cf20f71c6a2bb9b5f0760fcb4ecd8fe2e9428910ef3d60d8f3c56a9",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:cff88ab938d4b310b3c713cd35e0fe37": {
+            "prov:type": {
+                "$": "nidm_ContrastMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "con_0001.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "d4aa46b3603ba508578e39751262d528cf6d1ed2e722ec46f1cd8194c50591e46b229deb8cb4f72d1b7e0e2640f3e6604be7a335301c5c8357f453e5d0d4daf2",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:07a068606e54965b58e412b432e2dad0": {
+            "prov:type": {
+                "$": "nidm_ContrastStandardErrorMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ContrastStandardError.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ContrastStandardError.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast Standard Error Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:3be25c24ad21044b41a1490e0f682fbe",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "791d48f5d1adb15079a5289271ce0c4b95c56d69bfdb3e5d41b0d24eb538d3075e1cdd15502494b5a5a18c16eaa2153cb4847a996043fa48cdaf26e938a2576d",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:703d6663b8b0a7e5af770bf42097a7a5": {
+            "prov:type": [
+                {
+                "$": "nidm_HeightThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_FWERadjustedpvalue:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Height Threshold: p<0.050000 (FWE)",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "0.0499999999999967",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentThreshold:": [
+                {
+                "$": "niiri:87e79402ab52e67f17ce83dce886d63d",
+                "type": "xsd:string"
+                },
+                {
+                "$": "niiri:da5b4e4633c1626f16d7753556c47622",
+                "type": "xsd:string"
+                }
+            ]
+        },
+        "niiri:87e79402ab52e67f17ce83dce886d63d": {
+            "prov:type": [
+                {
+                "$": "nidm_HeightThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_statistic:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Height Threshold: T=5.309631)",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.30963135104407",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:da5b4e4633c1626f16d7753556c47622": {
+            "prov:type": [
+                {
+                "$": "nidm_HeightThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_PValueUncorrected:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Height Threshold: p<0.000000 (unc.)",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "3.42878635595234e-07",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3a5d48d8e1368e4d94c100cf543902e9": {
+            "prov:type": [
+                {
+                "$": "nidm_ExtentThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_statistic:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Extent Threshold: k>=0",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "0",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentThreshold:": [
+                {
+                "$": "niiri:9cb8b91842cd77b672741eb02ea56b65",
+                "type": "xsd:string"
+                },
+                {
+                "$": "niiri:a968ca4e2c9ad53ae495a34b0aff3ef1",
+                "type": "xsd:string"
+                }
+            ]
+        },
+        "niiri:9cb8b91842cd77b672741eb02ea56b65": {
+            "prov:type": [
+                {
+                "$": "nidm_ExtentThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_FWERadjustedpvalue:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Extent Threshold",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a968ca4e2c9ad53ae495a34b0aff3ef1": {
+            "prov:type": [
+                {
+                "$": "nidm_ExtentThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_PValueUncorrected:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Extent Threshold",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b3769611f936098c6d9afc7f67ffa3db": {
+            "prov:type": {
+                "$": "nidm_PeakDefinitionCriteria:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak Definition Criteria",
+                "type": "xsd:string"
+            },
+            "nidm_maxNumberOfPeaksPerCluster:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_minDistanceBetweenPeaks:": {
+                "$": "8",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0c26b2da6d51d1ddd8679deddd2d40f9": {
+            "prov:type": {
+                "$": "nidm_ClusterDefinitionCriteria:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Cluster Connectivity Criterion: 18",
+                "type": "xsd:string"
+            },
+            "nidm_hasConnectivityCriterion:": {
+                "$": "nidm_voxel18connected:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:affcc7f63cecbd281de0115f299e13ad": {
+            "prov:type": {
+                "$": "nidm_SearchSpaceMaskMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "SearchSpaceMask.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "SearchSpaceMask.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Search Space Mask Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:3be25c24ad21044b41a1490e0f682fbe",
+                "type": "xsd:string"
+            },
+            "nidm_searchVolumeInVoxels:": {
+                "$": "223057",
+                "type": "xsd:int"
+            },
+            "nidm_searchVolumeInUnits:": {
+                "$": "1784456",
+                "type": "xsd:float"
+            },
+            "nidm_reselSizeInVoxels:": {
+                "$": "65.5786964036542",
+                "type": "xsd:float"
+            },
+            "nidm_searchVolumeInResels:": {
+                "$": "3155.84193266257",
+                "type": "xsd:float"
+            },
+            "spm_searchVolumeReselsGeometry:": {
+                "$": "[6, 97.8140592306853, 965.938819261507, 3155.84193266257]",
+                "type": "xsd:string"
+            },
+            "nidm_noiseFWHMInVoxels:": {
+                "$": "[4.09118640605185, 4.0346308705955, 3.97291894351243]",
+                "type": "xsd:string"
+            },
+            "nidm_noiseFWHMInUnits:": {
+                "$": "[8.18237281210369, 8.069261741191, 7.94583788702486]",
+                "type": "xsd:string"
+            },
+            "nidm_randomFieldStationarity:": {
+                "$": "true",
+                "type": "xsd:boolean"
+            },
+            "nidm_expectedNumberOfVoxelsPerCluster:": {
+                "$": "1.51258369895942",
+                "type": "xsd:float"
+            },
+            "nidm_expectedNumberOfClusters:": {
+                "$": "0.0512932943875468",
+                "type": "xsd:float"
+            },
+            "nidm_heightCriticalThresholdFWE05:": {
+                "$": "5.30963135104407",
+                "type": "xsd:float"
+            },
+            "nidm_heightCriticalThresholdFDR05:": {
+                "$": "7.11683940887451",
+                "type": "xsd:float"
+            },
+            "crypto:sha512": {
+                "$": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876",
+                "type": "xsd:string"
+            },
+            "spm_smallestSignificantClusterSizeInVoxelsFWE05:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "spm_smallestSignificantClusterSizeInVoxelsFDR05:": {
+                "$": "8",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:a3de06f5c7d45a76d1c3457418a9e61f": {
+            "prov:type": {
+                "$": "nidm_ExcursionSetMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ExcursionSet.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ExcursionSet.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Excursion Set Map",
+                "type": "xsd:string"
+            },
+            "nidm_numberOfSupraThresholdClusters:": {
+                "$": "20",
+                "type": "xsd:int"
+            },
+            "nidm_pValue:": {
+                "$": "0",
+                "type": "xsd:float"
+            },
+            "nidm_hasClusterLabelsMap:": {
+                "$": "niiri:1ed0d3c61d4035abac6d7a8a92b5b5f4",
+                "type": "xsd:string"
+            },
+            "nidm_hasMaximumIntensityProjection:": {
+                "$": "niiri:f4a88590bef4ba051367275e27b75c25",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:3be25c24ad21044b41a1490e0f682fbe",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "265cb94fb9c73751fd120863a3f69a3dde7f5117f8da44dc6df2fb096c8ce3d98b375d48d4f6c2760f68a99b111229eaa4af4f2420e0540aa25cdc1ea265f77f",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1ed0d3c61d4035abac6d7a8a92b5b5f4": {
+            "prov:type": {
+                "$": "nidm_ClusterLabelsMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ClusterLabels.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ClusterLabels.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Cluster Labels Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:3be25c24ad21044b41a1490e0f682fbe",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "593cccacd254c0341525c4f72f09eeef0276c39f43887eac64d62883472fe3e6b331d55e3d80bc906686031d59034546bf594a3161a90eb01553b77ca481cb45",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f4a88590bef4ba051367275e27b75c25": {
+            "prov:type": {
+                "$": "dctype:Image",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "MaximumIntensityProjection.png",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "MaximumIntensityProjection.png",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/png",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:155481980ff1c28f6346fa37f1ee5ef4": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0001",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "124",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.8908579584557",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.23439277848581e-10",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "6.33160190943727e-12",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "2.46878555697161e-09",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "1",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f35f708a48ecddb6ea1a7e5fb2de3313": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0002",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "43",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.655700743658026",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.2860598428039e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "6.59662243607251e-07",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "6.43029921401949e-05",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "2",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:d9d669c3d9951cd5e034e1af813346b3": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0003",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "19",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.289728235569826",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00145461500200589",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "7.4609212112664e-05",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00415604286287398",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "3",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:7e1b3b0f62b55d18a395035fc7feee73": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0004",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "62",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.945428979227852",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.72804953447324e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "2.93810527018934e-08",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "5.72804953447324e-06",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "4",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:119c3306aea58b790a250dbf6a0c5f81": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0005",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "40",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.609954180147001",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.18508327799242e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1.12080057024233e-06",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "8.74033311196969e-05",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "5",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c3280a96b8b08a46c09804cff4f111ff": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0006",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "14",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.21348396305145",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00484589318609991",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.000248530936833968",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0107686515246665",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "6",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:15fc3f6b34f2cc43294db8febc2aa39d": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0007",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "6",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0914931270220502",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0483371945181382",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00247630283936606",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0743649146432896",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "7",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:ea4c51e6004ff6ca79763dfba6bceff9": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0008",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "8",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.1219908360294",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.02547536845608",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00130586219280271",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0424589474268",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "8",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:dc0951f37176f78fb716ea89f0b324b0": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0009",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "22",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.335474799080851",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000743778885823435",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "3.8150141614568e-05",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00247926295274478",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "9",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:0262c15e4838598f01a6cef257cb8e12": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0010",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "15",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.228732817555125",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00377073221731598",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.000193394574537264",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00942683054328996",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "10",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c1725b381104011cabad0fc0b26d85db": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0011",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "47",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.716696161672726",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.46364387091367e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "3.31541532894164e-07",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "4.30909591394245e-05",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "11",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:381dea70ad1c9ee61377f917ea0ce85d": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0012",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "8",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.1219908360294",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.02547536845608",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00130586219280271",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0424589474268",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "12",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:9b79a74d8af6455c348a5ada6380936b": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0013",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0457465635110251",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.148302764082867",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00757807781266262",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.17447384009749",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "13",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c2c282bcebcafee73ac596184605c302": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0014",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "8",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.1219908360294",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.02547536845608",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00130586219280271",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0424589474268",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "14",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:76b1ed7cd5606b2d502e4a5ee6dfe343": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0015",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "5",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0762442725183751",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0683702233066033",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00350079188048824",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0911602977421377",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "15",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:010ce656a5e597d871ca20ab1aa2a631": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0016",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0609954180147001",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0990646745487638",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00506846527740179",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.123830843185955",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "16",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:2083b75818d091b6724ed0adf40223ab": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0017",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "5",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0762442725183751",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0683702233066033",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00350079188048824",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0911602977421377",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "17",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:e8fd4bf9f34c220cd368e846c6651d35": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0018",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.399512266692318",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0202837600401362",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.399512266692318",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "18",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:4458d8f762604f7ee56c5d3e6ea96fca": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0019",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.399512266692318",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0202837600401362",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.399512266692318",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "19",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:a2f1489aa082c9cb44338fd916006ecb": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0020",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.399512266692318",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0202837600401362",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.399512266692318",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "20",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:5e6a56f172ddef202b4da0e41f9cac40": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0001",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:98fc89ff01c715d715f3acefc9df825b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "7.92007970809937",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "6.94608360738412",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.87783122385099e-12",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "4.18813870695089e-07",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000459866237621553",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:98fc89ff01c715d715f3acefc9df825b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0001",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[46,16,24]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2529591f9d1d6e7c2816bfaa6448acf1": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0002",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:12bfe02a34239f27f80049317c87f105",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "7.11683940887451",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "6.37404871703245",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "9.20510334623259e-11",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "2.05325778424026e-05",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00823125678700628",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:12bfe02a34239f27f80049317c87f105": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0002",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[34,-88,-2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6f9210e7353860292c6d8dfce2015490": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0003",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b3ef8b609fa00ef16a539437e5692e6d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.48292255401611",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.8992593141605",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.82568493656277e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.000407231755366277",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0732298207475789",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b3ef8b609fa00ef16a539437e5692e6d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0003",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[42,-72,-10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1bd531de3356dab29c9e4ed53addc58b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0004",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:096c52d0ef5b5dd96bf7ba644803410a",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.31603479385376",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.77079466112137",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.94492849498107e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.000879943865776389",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0732298207475789",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:096c52d0ef5b5dd96bf7ba644803410a": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0004",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[32,24,-4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ee2aed7c69b3aab0d47c0baab7ec0dbf": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0005",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:72e36f2d9291f6b80ff10852dd16c763",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.28007745742798",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.74292583422276",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.65272453897825e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00103782272796227",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0732298207475789",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:72e36f2d9291f6b80ff10852dd16c763": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0005",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[8,18,50]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:87f773c2297ccd49c8420518043f9edf": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0006",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:5c7506968ab01933f2a034010a609dab",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.25127363204956",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.72055271981637",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.30890376104765e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0011841880966994",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0732298207475789",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:5c7506968ab01933f2a034010a609dab": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0006",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[52,-32,42]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0078f20a5b83c1a2beec64a3a6188b9d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0007",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:3e1a6cc0a26ff99d9a700b7d7c44ee3f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.24752378463745",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.71763687476157",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.40078304300806e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00120468241369565",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0732298207475789",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3e1a6cc0a26ff99d9a700b7d7c44ee3f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0007",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[40,-62,50]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4fef5b8d7f9adb35cbb0ab5a325d482f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0008",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:902931c952cefdae6730925980730073",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.15371799468994",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.64445580026639",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.285227171001e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00184807786755337",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0857472799805926",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:902931c952cefdae6730925980730073": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0008",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-28,-94,4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6cfbefeaeca5e8720b0f89cc117f6383": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0009",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:811c5d9c038c996d8bf02e2801564ed3",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.15222215652466",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.64328512810061",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.34178537356678e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00186069357054308",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0857472799805926",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:811c5d9c038c996d8bf02e2801564ed3": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0009",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-6,12,52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b7eb4e3f8d2498601ec7a4ca2effb8ea": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0010",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:79b9d17e894c966e15c06bd6c13bf05f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.10109901428223",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.60320502193174",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.05212039080982e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00234682813060005",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0921349235875033",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:79b9d17e894c966e15c06bd6c13bf05f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0010",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[32,2,46]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:aed78746ebe2a394f8866cd7a9c4f06f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0011",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:49e035f041eb5be11a7e4f6b92049929",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.98517084121704",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.51181334779297",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.77577724747024e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00376326218366319",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.120256575135861",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:49e035f041eb5be11a7e4f6b92049929": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0011",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[8,32,38]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:587e3f84df2982a9fcd650238d95b213": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0012",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c87e82c19dd1913ed127e81e7df62ead",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.98348569869995",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.51047970249337",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.78928538652201e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00378871596531738",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.120256575135861",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c87e82c19dd1913ed127e81e7df62ead": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0012",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-52,0,38]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b8a49440e2e03d17ed64aecab9015fc9": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0013",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:2ce90da342b2373309ec7dd9cb0060b4",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.78093099594116",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.34909755317379",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.41969442155354e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00844151822925698",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.252769068923751",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:2ce90da342b2373309ec7dd9cb0060b4": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0013",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-34,-2,52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:096335e30681a87cc44956be7c2fd010": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0014",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:1108c3d99e6277aed8f925abd4ce55a4",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.70337772369385",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.28674301747281",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.22566831420812e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.011413186758684",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.308612544684445",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:1108c3d99e6277aed8f925abd4ce55a4": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0014",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[56,-44,52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a3dbc64398559529658b7a5a0ef78d1e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0015",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:023eb3a7010e9a8c9cb41ce2d7b56c70",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.69516134262085",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.28011855642631",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.45501619933597e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0117816592148946",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.308612544684445",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:023eb3a7010e9a8c9cb41ce2d7b56c70": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0015",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[60,-36,54]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ae3818cc45d2c9fb41dffe82e4c2d818": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0016",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:133c50d19ae417bae4232fa6ae5d2b0b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.68819808959961",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.27450168515333",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.655864770444e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0121028975026269",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.308612544684445",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:133c50d19ae417bae4232fa6ae5d2b0b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0016",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[18,16,4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d1aca860b0cc6a11b313c4acf1dc02e0": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0017",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:fecb191253e64a6ef9b1108c7ab7b6bf",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.61174583435059",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.21266637309498",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "9.30727468428927e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0162336583380834",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.380850485465036",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:fecb191253e64a6ef9b1108c7ab7b6bf": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0017",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[44,-70,50]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:bdf5c277bd5f8597a6d660daa5603065": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0018",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:347aa567ee2073ea9f5e876e0f70a34e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.60917520523071",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.21058195491799",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "9.41245997809759e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0163938142285941",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.380850485465036",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:347aa567ee2073ea9f5e876e0f70a34e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0018",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-30,26,2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4356eedee0d987414ac03b8e6d290dff": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0019",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e4749d25f84cd00e691fa81d14d76866",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.40964078903198",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.04774404642803",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.23528758724889e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0346958937061391",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.745804416705928",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e4749d25f84cd00e691fa81d14d76866": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0019",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-54,-46,58]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f6aeea95598409a388840e0dc81f791c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0020",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:92870da8ac439dc467665d0abd4b7c66",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.33153486251831",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.98344293282216",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.12313708672463e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0461854110301809",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.958749429114292",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:92870da8ac439dc467665d0abd4b7c66": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0020",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[52,-48,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5825ee7b2aaed90133518e138ec17012": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0021",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:82709dcc930c91a7e1305d3dea811c97",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.31841945648193",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.97261482231588",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.30279114724163e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0484353441449864",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.967916832880998",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:82709dcc930c91a7e1305d3dea811c97": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0021",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-62,-38,48]",
+                "type": "xsd:string"
+            }
+        }
+    },
+    "activity": {
+        "niiri:8046eef7fa36943b17e5e6602af44bf4": {
+            "prov:type": {
+                "$": "nidm_ModelParametersEstimation:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Model parameters estimation",
+                "type": "xsd:string"
+            },
+            "nidm_withEstimationMethod:": {
+                "$": "obo_generalizedleastsquaresestimation:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:762a33bdcc17b1b2d48897c26bcf8007": {
+            "prov:type": {
+                "$": "nidm_ContrastEstimation:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Contrast estimation",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:bb244e720c06e715f97d3d6a86a4da4a": {
+            "prov:type": {
+                "$": "nidm_Inference:",
+                "type": "xsd:QName"
+            },
+            "nidm_hasAlternativeHypothesis:": {
+                "$": "nidm_OneTailedTest:",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Inference",
+                "type": "xsd:string"
+            }
+        }
+    },
+    "agent": {
+        "niiri:74d6e660a818385ae6d5eebb86f94754": {
+            "prov:type": [
+                {
+                "$": "src_SPM:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "prov:SoftwareAgent",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "SPM",
+                "type": "xsd:string"
+            },
+            "nidm_softwareVersion:": {
+                "$": "12.6906",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c7590e1ec3de239c8cddebbdc6fd6db9": {
+            "prov:type": [
+                {
+                "$": "nlx_Imaginginstrument:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nlx_Magneticresonanceimagingscanner:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "MRI Scanner",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d28c7cdb3446f62771c499c458755d38": {
+            "prov:type": {
+                "$": "prov:Person",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Person",
+                "type": "xsd:string"
+            }
+        }
+    },
+    "wasGeneratedBy": {
+        "_:wGB20": {
+            "prov:entity": "niiri:93aaa88123d0eb90e6fdecebf810f8ea",
+            "prov:activity": "niiri:8046eef7fa36943b17e5e6602af44bf4"
+        },
+        "_:wGB22": {
+            "prov:entity": "niiri:f6a969c39d0994e548cee708ab2235b8",
+            "prov:activity": "niiri:8046eef7fa36943b17e5e6602af44bf4"
+        },
+        "_:wGB26": {
+            "prov:entity": "niiri:496fab100c7ba03c3adaf6aa62510d80",
+            "prov:activity": "niiri:8046eef7fa36943b17e5e6602af44bf4"
+        },
+        "_:wGB30": {
+            "prov:entity": "niiri:aad4f64b78f4368cc8545781af63aeeb",
+            "prov:activity": "niiri:8046eef7fa36943b17e5e6602af44bf4"
+        },
+        "_:wGB34": {
+            "prov:entity": "niiri:9f8e0d06fd0a9c289c938c9e062c5aec",
+            "prov:activity": "niiri:8046eef7fa36943b17e5e6602af44bf4"
+        },
+        "_:wGB38": {
+            "prov:entity": "niiri:47932f62f0b280c5b5907959d9b94b4e",
+            "prov:activity": "niiri:8046eef7fa36943b17e5e6602af44bf4"
+        },
+        "_:wGB42": {
+            "prov:entity": "niiri:6dda6fa299c24eac1686b577a1c4e494",
+            "prov:activity": "niiri:8046eef7fa36943b17e5e6602af44bf4"
+        },
+        "_:wGB56": {
+            "prov:entity": "niiri:9e31766e27104879ffdde1e5cc7cfca0",
+            "prov:activity": "niiri:762a33bdcc17b1b2d48897c26bcf8007"
+        },
+        "_:wGB60": {
+            "prov:entity": "niiri:408aa82e300c1bcdfaa6514d653e1ce2",
+            "prov:activity": "niiri:762a33bdcc17b1b2d48897c26bcf8007"
+        },
+        "_:wGB62": {
+            "prov:entity": "niiri:07a068606e54965b58e412b432e2dad0",
+            "prov:activity": "niiri:762a33bdcc17b1b2d48897c26bcf8007"
+        },
+        "_:wGB81": {
+            "prov:entity": "niiri:affcc7f63cecbd281de0115f299e13ad",
+            "prov:activity": "niiri:bb244e720c06e715f97d3d6a86a4da4a"
+        },
+        "_:wGB85": {
+            "prov:entity": "niiri:a3de06f5c7d45a76d1c3457418a9e61f",
+            "prov:activity": "niiri:bb244e720c06e715f97d3d6a86a4da4a"
+        }
+    },
+    "used": {
+        "_:u14": {
+            "prov:activity": "niiri:8046eef7fa36943b17e5e6602af44bf4",
+            "prov:entity": "niiri:7e38970ca6e0c04540e0958cfd68a076"
+        },
+        "_:u15": {
+            "prov:activity": "niiri:8046eef7fa36943b17e5e6602af44bf4",
+            "prov:entity": "niiri:a408442578dc3ad4a6905f9711e6a6c3"
+        },
+        "_:u16": {
+            "prov:activity": "niiri:8046eef7fa36943b17e5e6602af44bf4",
+            "prov:entity": "niiri:6f865b9d321b1a0b96e5376fd02d63ef"
+        },
+        "_:u46": {
+            "prov:activity": "niiri:762a33bdcc17b1b2d48897c26bcf8007",
+            "prov:entity": "niiri:93aaa88123d0eb90e6fdecebf810f8ea"
+        },
+        "_:u47": {
+            "prov:activity": "niiri:762a33bdcc17b1b2d48897c26bcf8007",
+            "prov:entity": "niiri:47932f62f0b280c5b5907959d9b94b4e"
+        },
+        "_:u48": {
+            "prov:activity": "niiri:762a33bdcc17b1b2d48897c26bcf8007",
+            "prov:entity": "niiri:7e38970ca6e0c04540e0958cfd68a076"
+        },
+        "_:u49": {
+            "prov:activity": "niiri:762a33bdcc17b1b2d48897c26bcf8007",
+            "prov:entity": "niiri:720cff657408138421d0937c76c9977e"
+        },
+        "_:u50": {
+            "prov:activity": "niiri:762a33bdcc17b1b2d48897c26bcf8007",
+            "prov:entity": "niiri:496fab100c7ba03c3adaf6aa62510d80"
+        },
+        "_:u51": {
+            "prov:activity": "niiri:762a33bdcc17b1b2d48897c26bcf8007",
+            "prov:entity": "niiri:aad4f64b78f4368cc8545781af63aeeb"
+        },
+        "_:u52": {
+            "prov:activity": "niiri:762a33bdcc17b1b2d48897c26bcf8007",
+            "prov:entity": "niiri:9f8e0d06fd0a9c289c938c9e062c5aec"
+        },
+        "_:u73": {
+            "prov:activity": "niiri:bb244e720c06e715f97d3d6a86a4da4a",
+            "prov:entity": "niiri:703d6663b8b0a7e5af770bf42097a7a5"
+        },
+        "_:u74": {
+            "prov:activity": "niiri:bb244e720c06e715f97d3d6a86a4da4a",
+            "prov:entity": "niiri:3a5d48d8e1368e4d94c100cf543902e9"
+        },
+        "_:u75": {
+            "prov:activity": "niiri:bb244e720c06e715f97d3d6a86a4da4a",
+            "prov:entity": "niiri:9e31766e27104879ffdde1e5cc7cfca0"
+        },
+        "_:u76": {
+            "prov:activity": "niiri:bb244e720c06e715f97d3d6a86a4da4a",
+            "prov:entity": "niiri:6dda6fa299c24eac1686b577a1c4e494"
+        },
+        "_:u77": {
+            "prov:activity": "niiri:bb244e720c06e715f97d3d6a86a4da4a",
+            "prov:entity": "niiri:93aaa88123d0eb90e6fdecebf810f8ea"
+        },
+        "_:u78": {
+            "prov:activity": "niiri:bb244e720c06e715f97d3d6a86a4da4a",
+            "prov:entity": "niiri:b3769611f936098c6d9afc7f67ffa3db"
+        },
+        "_:u79": {
+            "prov:activity": "niiri:bb244e720c06e715f97d3d6a86a4da4a",
+            "prov:entity": "niiri:0c26b2da6d51d1ddd8679deddd2d40f9"
+        }
+    },
+    "wasDerivedFrom": {
+        "_:wDF19": {
+            "prov:generatedEntity": "niiri:93aaa88123d0eb90e6fdecebf810f8ea",
+            "prov:usedEntity": "niiri:b9432ea6450538366288502c57b612c8"
+        },
+        "_:wDF25": {
+            "prov:generatedEntity": "niiri:496fab100c7ba03c3adaf6aa62510d80",
+            "prov:usedEntity": "niiri:1f32cb91cd9bb85763a6e2ea06c295b1"
+        },
+        "_:wDF29": {
+            "prov:generatedEntity": "niiri:aad4f64b78f4368cc8545781af63aeeb",
+            "prov:usedEntity": "niiri:8890ba1e2038c1a9257fc78e24e62373"
+        },
+        "_:wDF33": {
+            "prov:generatedEntity": "niiri:9f8e0d06fd0a9c289c938c9e062c5aec",
+            "prov:usedEntity": "niiri:4418d957014ed912ea3172a7f573bb8e"
+        },
+        "_:wDF37": {
+            "prov:generatedEntity": "niiri:47932f62f0b280c5b5907959d9b94b4e",
+            "prov:usedEntity": "niiri:cc2c7bdd65030f68b7d32e21eb4af9f8"
+        },
+        "_:wDF41": {
+            "prov:generatedEntity": "niiri:6dda6fa299c24eac1686b577a1c4e494",
+            "prov:usedEntity": "niiri:9fa6f41590f6fa9fe1449b0b7f65fc88"
+        },
+        "_:wDF55": {
+            "prov:generatedEntity": "niiri:9e31766e27104879ffdde1e5cc7cfca0",
+            "prov:usedEntity": "niiri:4c17423a353140952a61dff8ed7694f1"
+        },
+        "_:wDF59": {
+            "prov:generatedEntity": "niiri:408aa82e300c1bcdfaa6514d653e1ce2",
+            "prov:usedEntity": "niiri:cff88ab938d4b310b3c713cd35e0fe37"
+        },
+        "_:wDF87": {
+            "prov:generatedEntity": "niiri:155481980ff1c28f6346fa37f1ee5ef4",
+            "prov:usedEntity": "niiri:a3de06f5c7d45a76d1c3457418a9e61f"
+        },
+        "_:wDF89": {
+            "prov:generatedEntity": "niiri:f35f708a48ecddb6ea1a7e5fb2de3313",
+            "prov:usedEntity": "niiri:a3de06f5c7d45a76d1c3457418a9e61f"
+        },
+        "_:wDF91": {
+            "prov:generatedEntity": "niiri:d9d669c3d9951cd5e034e1af813346b3",
+            "prov:usedEntity": "niiri:a3de06f5c7d45a76d1c3457418a9e61f"
+        },
+        "_:wDF93": {
+            "prov:generatedEntity": "niiri:7e1b3b0f62b55d18a395035fc7feee73",
+            "prov:usedEntity": "niiri:a3de06f5c7d45a76d1c3457418a9e61f"
+        },
+        "_:wDF95": {
+            "prov:generatedEntity": "niiri:119c3306aea58b790a250dbf6a0c5f81",
+            "prov:usedEntity": "niiri:a3de06f5c7d45a76d1c3457418a9e61f"
+        },
+        "_:wDF97": {
+            "prov:generatedEntity": "niiri:c3280a96b8b08a46c09804cff4f111ff",
+            "prov:usedEntity": "niiri:a3de06f5c7d45a76d1c3457418a9e61f"
+        },
+        "_:wDF99": {
+            "prov:generatedEntity": "niiri:15fc3f6b34f2cc43294db8febc2aa39d",
+            "prov:usedEntity": "niiri:a3de06f5c7d45a76d1c3457418a9e61f"
+        },
+        "_:wDF101": {
+            "prov:generatedEntity": "niiri:ea4c51e6004ff6ca79763dfba6bceff9",
+            "prov:usedEntity": "niiri:a3de06f5c7d45a76d1c3457418a9e61f"
+        },
+        "_:wDF103": {
+            "prov:generatedEntity": "niiri:dc0951f37176f78fb716ea89f0b324b0",
+            "prov:usedEntity": "niiri:a3de06f5c7d45a76d1c3457418a9e61f"
+        },
+        "_:wDF105": {
+            "prov:generatedEntity": "niiri:0262c15e4838598f01a6cef257cb8e12",
+            "prov:usedEntity": "niiri:a3de06f5c7d45a76d1c3457418a9e61f"
+        },
+        "_:wDF107": {
+            "prov:generatedEntity": "niiri:c1725b381104011cabad0fc0b26d85db",
+            "prov:usedEntity": "niiri:a3de06f5c7d45a76d1c3457418a9e61f"
+        },
+        "_:wDF109": {
+            "prov:generatedEntity": "niiri:381dea70ad1c9ee61377f917ea0ce85d",
+            "prov:usedEntity": "niiri:a3de06f5c7d45a76d1c3457418a9e61f"
+        },
+        "_:wDF111": {
+            "prov:generatedEntity": "niiri:9b79a74d8af6455c348a5ada6380936b",
+            "prov:usedEntity": "niiri:a3de06f5c7d45a76d1c3457418a9e61f"
+        },
+        "_:wDF113": {
+            "prov:generatedEntity": "niiri:c2c282bcebcafee73ac596184605c302",
+            "prov:usedEntity": "niiri:a3de06f5c7d45a76d1c3457418a9e61f"
+        },
+        "_:wDF115": {
+            "prov:generatedEntity": "niiri:76b1ed7cd5606b2d502e4a5ee6dfe343",
+            "prov:usedEntity": "niiri:a3de06f5c7d45a76d1c3457418a9e61f"
+        },
+        "_:wDF117": {
+            "prov:generatedEntity": "niiri:010ce656a5e597d871ca20ab1aa2a631",
+            "prov:usedEntity": "niiri:a3de06f5c7d45a76d1c3457418a9e61f"
+        },
+        "_:wDF119": {
+            "prov:generatedEntity": "niiri:2083b75818d091b6724ed0adf40223ab",
+            "prov:usedEntity": "niiri:a3de06f5c7d45a76d1c3457418a9e61f"
+        },
+        "_:wDF121": {
+            "prov:generatedEntity": "niiri:e8fd4bf9f34c220cd368e846c6651d35",
+            "prov:usedEntity": "niiri:a3de06f5c7d45a76d1c3457418a9e61f"
+        },
+        "_:wDF123": {
+            "prov:generatedEntity": "niiri:4458d8f762604f7ee56c5d3e6ea96fca",
+            "prov:usedEntity": "niiri:a3de06f5c7d45a76d1c3457418a9e61f"
+        },
+        "_:wDF125": {
+            "prov:generatedEntity": "niiri:a2f1489aa082c9cb44338fd916006ecb",
+            "prov:usedEntity": "niiri:a3de06f5c7d45a76d1c3457418a9e61f"
+        },
+        "_:wDF128": {
+            "prov:generatedEntity": "niiri:5e6a56f172ddef202b4da0e41f9cac40",
+            "prov:usedEntity": "niiri:155481980ff1c28f6346fa37f1ee5ef4"
+        },
+        "_:wDF131": {
+            "prov:generatedEntity": "niiri:2529591f9d1d6e7c2816bfaa6448acf1",
+            "prov:usedEntity": "niiri:f35f708a48ecddb6ea1a7e5fb2de3313"
+        },
+        "_:wDF134": {
+            "prov:generatedEntity": "niiri:6f9210e7353860292c6d8dfce2015490",
+            "prov:usedEntity": "niiri:d9d669c3d9951cd5e034e1af813346b3"
+        },
+        "_:wDF137": {
+            "prov:generatedEntity": "niiri:1bd531de3356dab29c9e4ed53addc58b",
+            "prov:usedEntity": "niiri:7e1b3b0f62b55d18a395035fc7feee73"
+        },
+        "_:wDF140": {
+            "prov:generatedEntity": "niiri:ee2aed7c69b3aab0d47c0baab7ec0dbf",
+            "prov:usedEntity": "niiri:119c3306aea58b790a250dbf6a0c5f81"
+        },
+        "_:wDF143": {
+            "prov:generatedEntity": "niiri:87f773c2297ccd49c8420518043f9edf",
+            "prov:usedEntity": "niiri:c3280a96b8b08a46c09804cff4f111ff"
+        },
+        "_:wDF146": {
+            "prov:generatedEntity": "niiri:0078f20a5b83c1a2beec64a3a6188b9d",
+            "prov:usedEntity": "niiri:15fc3f6b34f2cc43294db8febc2aa39d"
+        },
+        "_:wDF149": {
+            "prov:generatedEntity": "niiri:4fef5b8d7f9adb35cbb0ab5a325d482f",
+            "prov:usedEntity": "niiri:ea4c51e6004ff6ca79763dfba6bceff9"
+        },
+        "_:wDF152": {
+            "prov:generatedEntity": "niiri:6cfbefeaeca5e8720b0f89cc117f6383",
+            "prov:usedEntity": "niiri:dc0951f37176f78fb716ea89f0b324b0"
+        },
+        "_:wDF155": {
+            "prov:generatedEntity": "niiri:b7eb4e3f8d2498601ec7a4ca2effb8ea",
+            "prov:usedEntity": "niiri:0262c15e4838598f01a6cef257cb8e12"
+        },
+        "_:wDF158": {
+            "prov:generatedEntity": "niiri:aed78746ebe2a394f8866cd7a9c4f06f",
+            "prov:usedEntity": "niiri:c1725b381104011cabad0fc0b26d85db"
+        },
+        "_:wDF161": {
+            "prov:generatedEntity": "niiri:587e3f84df2982a9fcd650238d95b213",
+            "prov:usedEntity": "niiri:381dea70ad1c9ee61377f917ea0ce85d"
+        },
+        "_:wDF164": {
+            "prov:generatedEntity": "niiri:b8a49440e2e03d17ed64aecab9015fc9",
+            "prov:usedEntity": "niiri:9b79a74d8af6455c348a5ada6380936b"
+        },
+        "_:wDF167": {
+            "prov:generatedEntity": "niiri:096335e30681a87cc44956be7c2fd010",
+            "prov:usedEntity": "niiri:c2c282bcebcafee73ac596184605c302"
+        },
+        "_:wDF170": {
+            "prov:generatedEntity": "niiri:a3dbc64398559529658b7a5a0ef78d1e",
+            "prov:usedEntity": "niiri:c2c282bcebcafee73ac596184605c302"
+        },
+        "_:wDF173": {
+            "prov:generatedEntity": "niiri:ae3818cc45d2c9fb41dffe82e4c2d818",
+            "prov:usedEntity": "niiri:76b1ed7cd5606b2d502e4a5ee6dfe343"
+        },
+        "_:wDF176": {
+            "prov:generatedEntity": "niiri:d1aca860b0cc6a11b313c4acf1dc02e0",
+            "prov:usedEntity": "niiri:010ce656a5e597d871ca20ab1aa2a631"
+        },
+        "_:wDF179": {
+            "prov:generatedEntity": "niiri:bdf5c277bd5f8597a6d660daa5603065",
+            "prov:usedEntity": "niiri:2083b75818d091b6724ed0adf40223ab"
+        },
+        "_:wDF182": {
+            "prov:generatedEntity": "niiri:4356eedee0d987414ac03b8e6d290dff",
+            "prov:usedEntity": "niiri:e8fd4bf9f34c220cd368e846c6651d35"
+        },
+        "_:wDF185": {
+            "prov:generatedEntity": "niiri:f6aeea95598409a388840e0dc81f791c",
+            "prov:usedEntity": "niiri:4458d8f762604f7ee56c5d3e6ea96fca"
+        },
+        "_:wDF188": {
+            "prov:generatedEntity": "niiri:5825ee7b2aaed90133518e138ec17012",
+            "prov:usedEntity": "niiri:a2f1489aa082c9cb44338fd916006ecb"
+        }
+    },
+    "wasAttributedTo": {
+        "_:wAT6": {
+            "prov:entity": "niiri:a408442578dc3ad4a6905f9711e6a6c3",
+            "prov:agent": "niiri:c7590e1ec3de239c8cddebbdc6fd6db9"
+        },
+        "_:wAT7": {
+            "prov:entity": "niiri:a408442578dc3ad4a6905f9711e6a6c3",
+            "prov:agent": "niiri:d28c7cdb3446f62771c499c458755d38"
+        }
+    },
+    "wasAssociatedWith": {
+        "_:wAW13": {
+            "prov:activity": "niiri:8046eef7fa36943b17e5e6602af44bf4",
+            "prov:agent": "niiri:74d6e660a818385ae6d5eebb86f94754"
+        },
+        "_:wAW45": {
+            "prov:activity": "niiri:762a33bdcc17b1b2d48897c26bcf8007",
+            "prov:agent": "niiri:74d6e660a818385ae6d5eebb86f94754"
+        },
+        "_:wAW72": {
+            "prov:activity": "niiri:bb244e720c06e715f97d3d6a86a4da4a",
+            "prov:agent": "niiri:74d6e660a818385ae6d5eebb86f94754"
+        }
+    }
+    }
+  }
+}

--- a/spmexport/ex_spm_thr_voxelfwep05/nidm.jsonld
+++ b/spmexport/ex_spm_thr_voxelfwep05/nidm.jsonld
@@ -7,7 +7,7 @@
       "niiri": "http://iri.nidash.org/",
       "spm": "http://purl.org/nidash/spm#",
       "neurolex": "http://neurolex.org/wiki/",
-      "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#",
+      "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/",
       "dct": "http://purl.org/dc/terms/",
       "nfo": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#",
       "dc": "http://purl.org/dc/elements/1.1/",
@@ -22,32 +22,32 @@
   ],
   "@graph": [
     {
-      "@id": "niiri:9f53dd73cbac66be53e9518c2ae4933a",
-      "@type": ["prov:Entity","prov:Bundle","nidm_NIDMResults:"],
+      "@id": "niiri:d085af3e055d03b41e58ff791604e130",
+      "@type": ["prov:Entity","prov:Bundle","nidm_NIDMResults"],
       "rdfs:label": "NIDM-Results",
-      "nidm_version:": {"@type": "xsd:string", "@value": "1.3.0"}
+      "nidm_version": {"@type": "xsd:string", "@value": "1.3.0"}
     },
     {
-      "@id": "niiri:6d3fb4b3a9cefb8ce233767bb9cefd80",
-      "@type": ["prov:Agent","nidm_spm_results_nidm:","prov:SoftwareAgent"],
+      "@id": "niiri:fb236c1eb16f0c705e70a281f202e4e0",
+      "@type": ["prov:Agent","nidm_spm_results_nidm","prov:SoftwareAgent"],
       "rdfs:label": "spm_results_nidm",
-      "nidm_softwareVersion:": {"@type": "xsd:string", "@value": "12.6903"}
+      "nidm_softwareVersion": {"@type": "xsd:string", "@value": "12.7057"}
     },
     {
-      "@id": "niiri:0f5c3add36a4e0a0b3a663b951c26795",
-      "@type": ["prov:Activity","nidm_NIDMResultsExport:"],
+      "@id": "niiri:55fc5c1d9802e26a9bae0c11e872ca8f",
+      "@type": ["prov:Activity","nidm_NIDMResultsExport"],
       "rdfs:label": "NIDM-Results export"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:0f5c3add36a4e0a0b3a663b951c26795",
-      "agent": "niiri:6d3fb4b3a9cefb8ce233767bb9cefd80"
+      "activity_associated": "niiri:55fc5c1d9802e26a9bae0c11e872ca8f",
+      "agent": "niiri:fb236c1eb16f0c705e70a281f202e4e0"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:9f53dd73cbac66be53e9518c2ae4933a",
-      "activity": "niiri:0f5c3add36a4e0a0b3a663b951c26795",
-      "atTime": "2016-12-07T16:10:02"
+      "entity_generated": "niiri:d085af3e055d03b41e58ff791604e130",
+      "activity": "niiri:55fc5c1d9802e26a9bae0c11e872ca8f",
+      "atTime": "2017-04-19T12:19:21"
     }
   ]
 },
@@ -158,572 +158,572 @@
       "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
     }
   ],
-  "@id": "niiri:9f53dd73cbac66be53e9518c2ae4933a",
+  "@id": "niiri:d085af3e055d03b41e58ff791604e130",
   "@graph": [
     {
-      "@id": "niiri:52f92964e671e1d8d4081235cbd4d416",
-      "@type": ["prov:Agent","src_SPM:","prov:SoftwareAgent"],
+      "@id": "niiri:74d6e660a818385ae6d5eebb86f94754",
+      "@type": ["prov:Agent","src_SPM","prov:SoftwareAgent"],
       "rdfs:label": "SPM",
-      "nidm_softwareVersion:": {"@type": "xsd:string", "@value": "12.12.2"}
+      "nidm_softwareVersion": {"@type": "xsd:string", "@value": "12.6906"}
     },
     {
-      "@id": "niiri:1127eeccd626c09c472b158bcb760db8",
-      "@type": ["prov:Entity","nidm_CoordinateSpace:"],
+      "@id": "niiri:3be25c24ad21044b41a1490e0f682fbe",
+      "@type": ["prov:Entity","nidm_CoordinateSpace"],
       "rdfs:label": "Coordinate space 1",
-      "nidm_voxelToWorldMapping:": {"@type": "xsd:string", "@value": "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"},
-      "nidm_voxelUnits:": {"@type": "xsd:string", "@value": "[\"mm\", \"mm\", \"mm\"]"},
-      "nidm_voxelSize:": {"@type": "xsd:string", "@value": "[2, 2, 2]"},
-      "nidm_inWorldCoordinateSystem:": {"@id": "nidm_Ixi549CoordinateSystem:"},
-      "nidm_numberOfDimensions:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_dimensionsInVoxels:": {"@type": "xsd:string", "@value": "[79,95,79]"}
+      "nidm_voxelToWorldMapping": {"@type": "xsd:string", "@value": "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"},
+      "nidm_voxelUnits": {"@type": "xsd:string", "@value": "[\"mm\", \"mm\", \"mm\"]"},
+      "nidm_voxelSize": {"@type": "xsd:string", "@value": "[2, 2, 2]"},
+      "nidm_inWorldCoordinateSystem": {"@id": "nidm_Ixi549CoordinateSystem"},
+      "nidm_numberOfDimensions": {"@type": "xsd:int", "@value": "3"},
+      "nidm_dimensionsInVoxels": {"@type": "xsd:string", "@value": "[79,95,79]"}
     },
     {
-      "@id": "niiri:381e016a29b69e234756ea3c76fb09db",
-      "@type": ["prov:Agent","nlx_Imaginginstrument:","nlx_Magneticresonanceimagingscanner:"],
+      "@id": "niiri:c7590e1ec3de239c8cddebbdc6fd6db9",
+      "@type": ["prov:Agent","nlx_Imaginginstrument","nlx_Magneticresonanceimagingscanner"],
       "rdfs:label": "MRI Scanner"
     },
     {
-      "@id": "niiri:24d307e96d4355161221fea37984ca3d",
+      "@id": "niiri:d28c7cdb3446f62771c499c458755d38",
       "@type": ["prov:Agent","prov:Person"],
       "rdfs:label": "Person"
     },
     {
-      "@id": "niiri:9c389356d338253eeebec534a36dc9fb",
-      "@type": ["prov:Entity","prov:Collection","nidm_Data:"],
+      "@id": "niiri:a408442578dc3ad4a6905f9711e6a6c3",
+      "@type": ["prov:Entity","prov:Collection","nidm_Data"],
       "rdfs:label": "Data",
-      "nidm_grandMeanScaling:": {"@type": "xsd:boolean", "@value": "true"},
-      "nidm_targetIntensity:": {"@type": "xsd:float", "@value": "100"},
-      "nidm_hasMRIProtocol:": {"@id": "nlx_FunctionalMRIprotocol:"}
+      "nidm_grandMeanScaling": {"@type": "xsd:boolean", "@value": "true"},
+      "nidm_targetIntensity": {"@type": "xsd:float", "@value": "100"},
+      "nidm_hasMRIProtocol": {"@id": "nlx_FunctionalMRIprotocol"}
     },
     {
       "@type": "prov:Attribution",
-      "entity_attributed": "niiri:9c389356d338253eeebec534a36dc9fb",
-      "agent": "niiri:381e016a29b69e234756ea3c76fb09db"
+      "entity_attributed": "niiri:a408442578dc3ad4a6905f9711e6a6c3",
+      "agent": "niiri:c7590e1ec3de239c8cddebbdc6fd6db9"
     },
     {
       "@type": "prov:Attribution",
-      "entity_attributed": "niiri:9c389356d338253eeebec534a36dc9fb",
-      "agent": "niiri:24d307e96d4355161221fea37984ca3d"
+      "entity_attributed": "niiri:a408442578dc3ad4a6905f9711e6a6c3",
+      "agent": "niiri:d28c7cdb3446f62771c499c458755d38"
     },
     {
-      "@id": "niiri:af7d6bd128fbc8207bced46564d596c7",
-      "@type": ["prov:Entity","spm_DCTDriftModel:"],
+      "@id": "niiri:f0a4cf13c5d07c9f613050a20c1fb410",
+      "@type": ["prov:Entity","spm_DCTDriftModel"],
       "rdfs:label": "SPM's DCT Drift Model",
-      "spm_SPMsDriftCutoffPeriod:": {"@type": "xsd:float", "@value": "128"}
+      "spm_SPMsDriftCutoffPeriod": {"@type": "xsd:float", "@value": "128"}
     },
     {
-      "@id": "niiri:d5494df7777ae492a16186e356e4067e",
-      "@type": ["prov:Entity","nidm_DesignMatrix:"],
+      "@id": "niiri:7e38970ca6e0c04540e0958cfd68a076",
+      "@type": ["prov:Entity","nidm_DesignMatrix"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "DesignMatrix.csv"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "DesignMatrix.csv"},
       "dct:format": {"@type": "xsd:string", "@value": "text/csv"},
-      "dc:description": {"@id": "niiri:85c1bf902b50fd68db2a21fe1ce95322"},
+      "dc:description": {"@id": "niiri:7dd586f3a19dd8e4ad066d8b0d3fae59"},
       "rdfs:label": "Design Matrix",
-      "nidm_regressorNames:": {"@type": "xsd:string", "@value": "[\"Sn(1) to*bf(1)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) constant\"]"},
-      "nidm_hasDriftModel:": {"@id": "niiri:af7d6bd128fbc8207bced46564d596c7"},
-      "nidm_hasHRFBasis:": {"@id": "spm_SPMsCanonicalHRF:"}
+      "nidm_regressorNames": {"@type": "xsd:string", "@value": "[\"Sn(1) to*bf(1)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) constant\"]"},
+      "nidm_hasDriftModel": {"@id": "niiri:f0a4cf13c5d07c9f613050a20c1fb410"},
+      "nidm_hasHRFBasis": {"@id": "spm_SPMsCanonicalHRF"}
     },
     {
-      "@id": "niiri:85c1bf902b50fd68db2a21fe1ce95322",
+      "@id": "niiri:7dd586f3a19dd8e4ad066d8b0d3fae59",
       "@type": ["prov:Entity","dctype:Image"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "DesignMatrix.png"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "DesignMatrix.png"},
       "dct:format": {"@type": "xsd:string", "@value": "image/png"}
     },
     {
-      "@id": "niiri:fafe4f020120967e1209b04b4047a6d8",
-      "@type": ["prov:Entity","nidm_ErrorModel:"],
-      "nidm_hasErrorDistribution:": {"@id": "obo_normaldistribution:"},
-      "nidm_hasErrorDependence:": {"@id": "obo_Toeplitzcovariancestructure:"},
-      "nidm_dependenceMapWiseDependence:": {"@id": "nidm_ConstantParameter:"},
-      "nidm_errorVarianceHomogeneous:": {"@type": "xsd:boolean", "@value": "true"},
-      "nidm_varianceMapWiseDependence:": {"@id": "nidm_IndependentParameter:"}
+      "@id": "niiri:6f865b9d321b1a0b96e5376fd02d63ef",
+      "@type": ["prov:Entity","nidm_ErrorModel"],
+      "nidm_hasErrorDistribution": {"@id": "obo_normaldistribution"},
+      "nidm_hasErrorDependence": {"@id": "obo_Toeplitzcovariancestructure"},
+      "nidm_dependenceMapWiseDependence": {"@id": "nidm_ConstantParameter"},
+      "nidm_errorVarianceHomogeneous": {"@type": "xsd:boolean", "@value": "true"},
+      "nidm_varianceMapWiseDependence": {"@id": "nidm_IndependentParameter"}
     },
     {
-      "@id": "niiri:9901152e1edbdcc6b11265389688c067",
-      "@type": ["prov:Activity","nidm_ModelParametersEstimation:"],
+      "@id": "niiri:8046eef7fa36943b17e5e6602af44bf4",
+      "@type": ["prov:Activity","nidm_ModelParametersEstimation"],
       "rdfs:label": "Model parameters estimation",
-      "nidm_withEstimationMethod:": {"@id": "obo_generalizedleastsquaresestimation:"}
+      "nidm_withEstimationMethod": {"@id": "obo_generalizedleastsquaresestimation"}
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:9901152e1edbdcc6b11265389688c067",
-      "agent": "niiri:52f92964e671e1d8d4081235cbd4d416"
+      "activity_associated": "niiri:8046eef7fa36943b17e5e6602af44bf4",
+      "agent": "niiri:74d6e660a818385ae6d5eebb86f94754"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:9901152e1edbdcc6b11265389688c067",
-      "entity": "niiri:d5494df7777ae492a16186e356e4067e"
+      "activity_using": "niiri:8046eef7fa36943b17e5e6602af44bf4",
+      "entity": "niiri:7e38970ca6e0c04540e0958cfd68a076"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:9901152e1edbdcc6b11265389688c067",
-      "entity": "niiri:9c389356d338253eeebec534a36dc9fb"
+      "activity_using": "niiri:8046eef7fa36943b17e5e6602af44bf4",
+      "entity": "niiri:a408442578dc3ad4a6905f9711e6a6c3"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:9901152e1edbdcc6b11265389688c067",
-      "entity": "niiri:fafe4f020120967e1209b04b4047a6d8"
+      "activity_using": "niiri:8046eef7fa36943b17e5e6602af44bf4",
+      "entity": "niiri:6f865b9d321b1a0b96e5376fd02d63ef"
     },
     {
-      "@id": "niiri:c94d3131e2527389b29e033e4981de4b",
-      "@type": ["prov:Entity","nidm_MaskMap:"],
+      "@id": "niiri:93aaa88123d0eb90e6fdecebf810f8ea",
+      "@type": ["prov:Entity","nidm_MaskMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "Mask.nii.gz"},
-      "nidm_isUserDefined:": {"@type": "xsd:boolean", "@value": "false"},
+      "nidm_isUserDefined": {"@type": "xsd:boolean", "@value": "false"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "Mask.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Mask",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:1127eeccd626c09c472b158bcb760db8"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:3be25c24ad21044b41a1490e0f682fbe"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876"}
     },
     {
-      "@id": "niiri:e8dce15e30732db359639d389c2aba1c",
-      "@type": ["prov:Entity","nidm_MaskMap:"],
+      "@id": "niiri:b9432ea6450538366288502c57b612c8",
+      "@type": ["prov:Entity","nidm_MaskMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "mask.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "36929e1f5f4143bd9cc818cd896a25f129961fab208c3a4438555f40444c08347b359142ee8c53ece6e8cca1627f49db0788a1fd3b9e2ecaef61999c6c6c67ac"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c94d3131e2527389b29e033e4981de4b",
-      "entity": "niiri:e8dce15e30732db359639d389c2aba1c"
+      "entity_derived": "niiri:93aaa88123d0eb90e6fdecebf810f8ea",
+      "entity": "niiri:b9432ea6450538366288502c57b612c8"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:c94d3131e2527389b29e033e4981de4b",
-      "activity": "niiri:9901152e1edbdcc6b11265389688c067"
+      "entity_generated": "niiri:93aaa88123d0eb90e6fdecebf810f8ea",
+      "activity": "niiri:8046eef7fa36943b17e5e6602af44bf4"
     },
     {
-      "@id": "niiri:3a7a8d534182ba1b22f26cd278915417",
-      "@type": ["prov:Entity","nidm_GrandMeanMap:"],
+      "@id": "niiri:f6a969c39d0994e548cee708ab2235b8",
+      "@type": ["prov:Entity","nidm_GrandMeanMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "GrandMean.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "GrandMean.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Grand Mean Map",
-      "nidm_maskedMedian:": {"@type": "xsd:float", "@value": "111.557487487793"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:1127eeccd626c09c472b158bcb760db8"},
+      "nidm_maskedMedian": {"@type": "xsd:float", "@value": "111.557487487793"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:3be25c24ad21044b41a1490e0f682fbe"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "512157cc6bff89d9343a09b4068226eb3edd64a8cbcee861f06231767fae6f8d4819921182adebee083a9bf309afd65529ab04a92f0aa6b0038c8098550f6124"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:3a7a8d534182ba1b22f26cd278915417",
-      "activity": "niiri:9901152e1edbdcc6b11265389688c067"
+      "entity_generated": "niiri:f6a969c39d0994e548cee708ab2235b8",
+      "activity": "niiri:8046eef7fa36943b17e5e6602af44bf4"
     },
     {
-      "@id": "niiri:6d5f38b4cf5fcc51002ecf487245e8bf",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:496fab100c7ba03c3adaf6aa62510d80",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0001.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0001.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 1",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:1127eeccd626c09c472b158bcb760db8"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:3be25c24ad21044b41a1490e0f682fbe"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd"}
     },
     {
-      "@id": "niiri:8660e77d634f2c673d9632bf88e8978f",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:1f32cb91cd9bb85763a6e2ea06c295b1",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0001.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6d5f38b4cf5fcc51002ecf487245e8bf",
-      "entity": "niiri:8660e77d634f2c673d9632bf88e8978f"
+      "entity_derived": "niiri:496fab100c7ba03c3adaf6aa62510d80",
+      "entity": "niiri:1f32cb91cd9bb85763a6e2ea06c295b1"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:6d5f38b4cf5fcc51002ecf487245e8bf",
-      "activity": "niiri:9901152e1edbdcc6b11265389688c067"
+      "entity_generated": "niiri:496fab100c7ba03c3adaf6aa62510d80",
+      "activity": "niiri:8046eef7fa36943b17e5e6602af44bf4"
     },
     {
-      "@id": "niiri:68d5d8de26c5bbf881cee5708b10409d",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:aad4f64b78f4368cc8545781af63aeeb",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0002.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0002.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 2",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:1127eeccd626c09c472b158bcb760db8"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:3be25c24ad21044b41a1490e0f682fbe"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c"}
     },
     {
-      "@id": "niiri:7609134ba457289c21bce5fbc0cfbcb0",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:8890ba1e2038c1a9257fc78e24e62373",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0002.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:68d5d8de26c5bbf881cee5708b10409d",
-      "entity": "niiri:7609134ba457289c21bce5fbc0cfbcb0"
+      "entity_derived": "niiri:aad4f64b78f4368cc8545781af63aeeb",
+      "entity": "niiri:8890ba1e2038c1a9257fc78e24e62373"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:68d5d8de26c5bbf881cee5708b10409d",
-      "activity": "niiri:9901152e1edbdcc6b11265389688c067"
+      "entity_generated": "niiri:aad4f64b78f4368cc8545781af63aeeb",
+      "activity": "niiri:8046eef7fa36943b17e5e6602af44bf4"
     },
     {
-      "@id": "niiri:c472a3264f2854cfa09ed3e9ed65cdae",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:9f8e0d06fd0a9c289c938c9e062c5aec",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0003.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0003.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 3",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:1127eeccd626c09c472b158bcb760db8"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:3be25c24ad21044b41a1490e0f682fbe"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373"}
     },
     {
-      "@id": "niiri:f721c3a9d1f9739dc70e18f5f57f2604",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:4418d957014ed912ea3172a7f573bb8e",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0003.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c472a3264f2854cfa09ed3e9ed65cdae",
-      "entity": "niiri:f721c3a9d1f9739dc70e18f5f57f2604"
+      "entity_derived": "niiri:9f8e0d06fd0a9c289c938c9e062c5aec",
+      "entity": "niiri:4418d957014ed912ea3172a7f573bb8e"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:c472a3264f2854cfa09ed3e9ed65cdae",
-      "activity": "niiri:9901152e1edbdcc6b11265389688c067"
+      "entity_generated": "niiri:9f8e0d06fd0a9c289c938c9e062c5aec",
+      "activity": "niiri:8046eef7fa36943b17e5e6602af44bf4"
     },
     {
-      "@id": "niiri:f8270f04e628178e3f2cf1af6df1fdaa",
-      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap:"],
+      "@id": "niiri:47932f62f0b280c5b5907959d9b94b4e",
+      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ResidualMeanSquares.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ResidualMeanSquares.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Residual Mean Squares Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:1127eeccd626c09c472b158bcb760db8"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:3be25c24ad21044b41a1490e0f682fbe"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "991abf563d795a43b1e2eef8643e57023f2e0b090b2031f05f839321fc0643df6f71d423486a1021519b6dc82f6b0f563e19f3fbd50cb16063bed54a0e192d3e"}
     },
     {
-      "@id": "niiri:260de665f44e1d8b8277860f9efe6331",
-      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap:"],
+      "@id": "niiri:cc2c7bdd65030f68b7d32e21eb4af9f8",
+      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "ResMS.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "40b28d03fcf9a2f60b11f10d7fb83bf3618b234fb5aedf09df644cb7cbb6aab8c9f468897c1078166d455a3d04a83f4e3bf762cfca0b4ea982d7a4e406849f18"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f8270f04e628178e3f2cf1af6df1fdaa",
-      "entity": "niiri:260de665f44e1d8b8277860f9efe6331"
+      "entity_derived": "niiri:47932f62f0b280c5b5907959d9b94b4e",
+      "entity": "niiri:cc2c7bdd65030f68b7d32e21eb4af9f8"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:f8270f04e628178e3f2cf1af6df1fdaa",
-      "activity": "niiri:9901152e1edbdcc6b11265389688c067"
+      "entity_generated": "niiri:47932f62f0b280c5b5907959d9b94b4e",
+      "activity": "niiri:8046eef7fa36943b17e5e6602af44bf4"
     },
     {
-      "@id": "niiri:449f64d462b57d4f54e0bb6abddf4400",
-      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap:"],
+      "@id": "niiri:6dda6fa299c24eac1686b577a1c4e494",
+      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ReselsPerVoxel.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ReselsPerVoxel.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Resels per Voxel Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:1127eeccd626c09c472b158bcb760db8"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:3be25c24ad21044b41a1490e0f682fbe"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "1a3f9216e145249ccc0b14b2bc337d6b38b81ad45e32768001fb22b35f0c2c0f3e2bce013b40c85f7dc0fc62723ac761ee7f7e1e6aff128a05f0ba7b8b8202a3"}
     },
     {
-      "@id": "niiri:bbbe81a27a24949db6149dd406cddb95",
-      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap:"],
+      "@id": "niiri:9fa6f41590f6fa9fe1449b0b7f65fc88",
+      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "RPV.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "4f76663162857f6b38b2a45a63b15a23b2ca8b338c283b69c1e71f2ea2f43797d045a733cd14e845be9c12f8b8f84d3931c599a08e8f6d77e99fab46ad87ab8f"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:449f64d462b57d4f54e0bb6abddf4400",
-      "entity": "niiri:bbbe81a27a24949db6149dd406cddb95"
+      "entity_derived": "niiri:6dda6fa299c24eac1686b577a1c4e494",
+      "entity": "niiri:9fa6f41590f6fa9fe1449b0b7f65fc88"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:449f64d462b57d4f54e0bb6abddf4400",
-      "activity": "niiri:9901152e1edbdcc6b11265389688c067"
+      "entity_generated": "niiri:6dda6fa299c24eac1686b577a1c4e494",
+      "activity": "niiri:8046eef7fa36943b17e5e6602af44bf4"
     },
     {
-      "@id": "niiri:88dc071de92a25a2e0c9dcc7db77b6d3",
-      "@type": ["prov:Entity","obo_contrastweightmatrix:"],
-      "nidm_statisticType:": {"@id": "obo_tstatistic:"},
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
+      "@id": "niiri:720cff657408138421d0937c76c9977e",
+      "@type": ["prov:Entity","obo_contrastweightmatrix"],
+      "nidm_statisticType": {"@id": "obo_tstatistic"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
       "rdfs:label": "Contrast: tone counting vs baseline",
       "prov:value": {"@type": "xsd:string", "@value": "[1, 0, 0]"}
     },
     {
-      "@id": "niiri:3d18e1203d5106e7daa8878637c03253",
-      "@type": ["prov:Activity","nidm_ContrastEstimation:"],
+      "@id": "niiri:762a33bdcc17b1b2d48897c26bcf8007",
+      "@type": ["prov:Activity","nidm_ContrastEstimation"],
       "rdfs:label": "Contrast estimation"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:3d18e1203d5106e7daa8878637c03253",
-      "agent": "niiri:52f92964e671e1d8d4081235cbd4d416"
+      "activity_associated": "niiri:762a33bdcc17b1b2d48897c26bcf8007",
+      "agent": "niiri:74d6e660a818385ae6d5eebb86f94754"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:3d18e1203d5106e7daa8878637c03253",
-      "entity": "niiri:c94d3131e2527389b29e033e4981de4b"
+      "activity_using": "niiri:762a33bdcc17b1b2d48897c26bcf8007",
+      "entity": "niiri:93aaa88123d0eb90e6fdecebf810f8ea"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:3d18e1203d5106e7daa8878637c03253",
-      "entity": "niiri:f8270f04e628178e3f2cf1af6df1fdaa"
+      "activity_using": "niiri:762a33bdcc17b1b2d48897c26bcf8007",
+      "entity": "niiri:47932f62f0b280c5b5907959d9b94b4e"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:3d18e1203d5106e7daa8878637c03253",
-      "entity": "niiri:d5494df7777ae492a16186e356e4067e"
+      "activity_using": "niiri:762a33bdcc17b1b2d48897c26bcf8007",
+      "entity": "niiri:7e38970ca6e0c04540e0958cfd68a076"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:3d18e1203d5106e7daa8878637c03253",
-      "entity": "niiri:88dc071de92a25a2e0c9dcc7db77b6d3"
+      "activity_using": "niiri:762a33bdcc17b1b2d48897c26bcf8007",
+      "entity": "niiri:720cff657408138421d0937c76c9977e"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:3d18e1203d5106e7daa8878637c03253",
-      "entity": "niiri:6d5f38b4cf5fcc51002ecf487245e8bf"
+      "activity_using": "niiri:762a33bdcc17b1b2d48897c26bcf8007",
+      "entity": "niiri:496fab100c7ba03c3adaf6aa62510d80"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:3d18e1203d5106e7daa8878637c03253",
-      "entity": "niiri:68d5d8de26c5bbf881cee5708b10409d"
+      "activity_using": "niiri:762a33bdcc17b1b2d48897c26bcf8007",
+      "entity": "niiri:aad4f64b78f4368cc8545781af63aeeb"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:3d18e1203d5106e7daa8878637c03253",
-      "entity": "niiri:c472a3264f2854cfa09ed3e9ed65cdae"
+      "activity_using": "niiri:762a33bdcc17b1b2d48897c26bcf8007",
+      "entity": "niiri:9f8e0d06fd0a9c289c938c9e062c5aec"
     },
     {
-      "@id": "niiri:a5292be8959cf336f6446ca7c7862413",
-      "@type": ["prov:Entity","nidm_StatisticMap:"],
+      "@id": "niiri:9e31766e27104879ffdde1e5cc7cfca0",
+      "@type": ["prov:Entity","nidm_StatisticMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "TStatistic.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "TStatistic.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "T-Statistic Map: tone counting vs baseline",
-      "nidm_statisticType:": {"@id": "obo_tstatistic:"},
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
-      "nidm_errorDegreesOfFreedom:": {"@type": "xsd:float", "@value": "97.9999999998522"},
-      "nidm_effectDegreesOfFreedom:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:1127eeccd626c09c472b158bcb760db8"},
+      "nidm_statisticType": {"@id": "obo_tstatistic"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
+      "nidm_errorDegreesOfFreedom": {"@type": "xsd:float", "@value": "97.9999999998522"},
+      "nidm_effectDegreesOfFreedom": {"@type": "xsd:float", "@value": "1"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:3be25c24ad21044b41a1490e0f682fbe"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "9e1714c2d86a050b38b4e10a4d2d23253a24c5e1d228ae16a9c3be8872739278505ac0729ecab54265a717e3a54f9f782d0ed72eea904e0d482a6072bb817bd4"}
     },
     {
-      "@id": "niiri:4676a34b60d2f621bd1c38c4a5559a49",
-      "@type": ["prov:Entity","nidm_StatisticMap:"],
+      "@id": "niiri:4c17423a353140952a61dff8ed7694f1",
+      "@type": ["prov:Entity","nidm_StatisticMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "spmT_0001.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "d288b1b0f117f64502555da13c5398dffa5bf5ff0b58951510e43d5388755bc185798802a92e98a07c7e313c6991066d2908f2a44aa5153ba23433da1335970f"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a5292be8959cf336f6446ca7c7862413",
-      "entity": "niiri:4676a34b60d2f621bd1c38c4a5559a49"
+      "entity_derived": "niiri:9e31766e27104879ffdde1e5cc7cfca0",
+      "entity": "niiri:4c17423a353140952a61dff8ed7694f1"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:a5292be8959cf336f6446ca7c7862413",
-      "activity": "niiri:3d18e1203d5106e7daa8878637c03253"
+      "entity_generated": "niiri:9e31766e27104879ffdde1e5cc7cfca0",
+      "activity": "niiri:762a33bdcc17b1b2d48897c26bcf8007"
     },
     {
-      "@id": "niiri:9bf979a8424e5c8381ed186a464dafd0",
-      "@type": ["prov:Entity","nidm_ContrastMap:"],
+      "@id": "niiri:408aa82e300c1bcdfaa6514d653e1ce2",
+      "@type": ["prov:Entity","nidm_ContrastMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "Contrast.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "Contrast.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Contrast Map: tone counting vs baseline",
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:1127eeccd626c09c472b158bcb760db8"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:3be25c24ad21044b41a1490e0f682fbe"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "fc5e2ad175243ee496db98f9b2e1b235c4c3bae1a8d7122ce461c897b537e40c49dfee5d6cf20f71c6a2bb9b5f0760fcb4ecd8fe2e9428910ef3d60d8f3c56a9"}
     },
     {
-      "@id": "niiri:166e30b1433b6a886b27bc045c33c3f4",
-      "@type": ["prov:Entity","nidm_ContrastMap:"],
+      "@id": "niiri:cff88ab938d4b310b3c713cd35e0fe37",
+      "@type": ["prov:Entity","nidm_ContrastMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "con_0001.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "d4aa46b3603ba508578e39751262d528cf6d1ed2e722ec46f1cd8194c50591e46b229deb8cb4f72d1b7e0e2640f3e6604be7a335301c5c8357f453e5d0d4daf2"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9bf979a8424e5c8381ed186a464dafd0",
-      "entity": "niiri:166e30b1433b6a886b27bc045c33c3f4"
+      "entity_derived": "niiri:408aa82e300c1bcdfaa6514d653e1ce2",
+      "entity": "niiri:cff88ab938d4b310b3c713cd35e0fe37"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:9bf979a8424e5c8381ed186a464dafd0",
-      "activity": "niiri:3d18e1203d5106e7daa8878637c03253"
+      "entity_generated": "niiri:408aa82e300c1bcdfaa6514d653e1ce2",
+      "activity": "niiri:762a33bdcc17b1b2d48897c26bcf8007"
     },
     {
-      "@id": "niiri:edb80ffff51690671b2437a48f367b46",
-      "@type": ["prov:Entity","nidm_ContrastStandardErrorMap:"],
+      "@id": "niiri:07a068606e54965b58e412b432e2dad0",
+      "@type": ["prov:Entity","nidm_ContrastStandardErrorMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ContrastStandardError.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ContrastStandardError.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Contrast Standard Error Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:1127eeccd626c09c472b158bcb760db8"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:3be25c24ad21044b41a1490e0f682fbe"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "791d48f5d1adb15079a5289271ce0c4b95c56d69bfdb3e5d41b0d24eb538d3075e1cdd15502494b5a5a18c16eaa2153cb4847a996043fa48cdaf26e938a2576d"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:edb80ffff51690671b2437a48f367b46",
-      "activity": "niiri:3d18e1203d5106e7daa8878637c03253"
+      "entity_generated": "niiri:07a068606e54965b58e412b432e2dad0",
+      "activity": "niiri:762a33bdcc17b1b2d48897c26bcf8007"
     },
     {
-      "@id": "niiri:ab9638a722e6781f49cb6679ce6d0186",
-      "@type": ["prov:Entity","nidm_HeightThreshold:","obo_FWERadjustedpvalue:"],
+      "@id": "niiri:703d6663b8b0a7e5af770bf42097a7a5",
+      "@type": ["prov:Entity","nidm_HeightThreshold","obo_FWERadjustedpvalue"],
       "rdfs:label": "Height Threshold: p<0.050000 (FWE)",
       "prov:value": {"@type": "xsd:float", "@value": "0.0499999999999967"},
-      "nidm_equivalentThreshold:": [{"@id": "niiri:df5d1bc86395c77a43f625cc82ff0d80"},{"@id": "niiri:137006717871910c9d0f148009c727c1"}]
+      "nidm_equivalentThreshold": [{"@id": "niiri:87e79402ab52e67f17ce83dce886d63d"},{"@id": "niiri:da5b4e4633c1626f16d7753556c47622"}]
     },
     {
-      "@id": "niiri:df5d1bc86395c77a43f625cc82ff0d80",
-      "@type": ["prov:Entity","nidm_HeightThreshold:","obo_statistic:"],
-      "rdfs:label": "Height Threshold",
+      "@id": "niiri:87e79402ab52e67f17ce83dce886d63d",
+      "@type": ["prov:Entity","nidm_HeightThreshold","obo_statistic"],
+      "rdfs:label": "Height Threshold: T=5.309631)",
       "prov:value": {"@type": "xsd:float", "@value": "5.30963135104407"}
     },
     {
-      "@id": "niiri:137006717871910c9d0f148009c727c1",
-      "@type": ["prov:Entity","nidm_HeightThreshold:","nidm_PValueUncorrected:"],
-      "rdfs:label": "Height Threshold",
+      "@id": "niiri:da5b4e4633c1626f16d7753556c47622",
+      "@type": ["prov:Entity","nidm_HeightThreshold","nidm_PValueUncorrected"],
+      "rdfs:label": "Height Threshold: p<0.000000 (unc.)",
       "prov:value": {"@type": "xsd:float", "@value": "3.42878635595234e-07"}
     },
     {
-      "@id": "niiri:ea3d63b1b41ccc3e3a69810e1a717f88",
-      "@type": ["prov:Entity","nidm_ExtentThreshold:","obo_statistic:"],
+      "@id": "niiri:3a5d48d8e1368e4d94c100cf543902e9",
+      "@type": ["prov:Entity","nidm_ExtentThreshold","obo_statistic"],
       "rdfs:label": "Extent Threshold: k>=0",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "0"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0"},
-      "nidm_equivalentThreshold:": [{"@id": "niiri:b536f0ba7a0a67e91feeed9ca64cb19c"},{"@id": "niiri:da619a636b99bf0fa78bb8a62ec8e6b2"}]
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "0"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0"},
+      "nidm_equivalentThreshold": [{"@id": "niiri:9cb8b91842cd77b672741eb02ea56b65"},{"@id": "niiri:a968ca4e2c9ad53ae495a34b0aff3ef1"}]
     },
     {
-      "@id": "niiri:b536f0ba7a0a67e91feeed9ca64cb19c",
-      "@type": ["prov:Entity","nidm_ExtentThreshold:","obo_FWERadjustedpvalue:"],
+      "@id": "niiri:9cb8b91842cd77b672741eb02ea56b65",
+      "@type": ["prov:Entity","nidm_ExtentThreshold","obo_FWERadjustedpvalue"],
       "rdfs:label": "Extent Threshold",
       "prov:value": {"@type": "xsd:float", "@value": "1"}
     },
     {
-      "@id": "niiri:da619a636b99bf0fa78bb8a62ec8e6b2",
-      "@type": ["prov:Entity","nidm_ExtentThreshold:","nidm_PValueUncorrected:"],
+      "@id": "niiri:a968ca4e2c9ad53ae495a34b0aff3ef1",
+      "@type": ["prov:Entity","nidm_ExtentThreshold","nidm_PValueUncorrected"],
       "rdfs:label": "Extent Threshold",
       "prov:value": {"@type": "xsd:float", "@value": "1"}
     },
     {
-      "@id": "niiri:648962244cdcb3f84950de7035a522c7",
-      "@type": ["prov:Entity","nidm_PeakDefinitionCriteria:"],
+      "@id": "niiri:b3769611f936098c6d9afc7f67ffa3db",
+      "@type": ["prov:Entity","nidm_PeakDefinitionCriteria"],
       "rdfs:label": "Peak Definition Criteria",
-      "nidm_maxNumberOfPeaksPerCluster:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_minDistanceBetweenPeaks:": {"@type": "xsd:float", "@value": "8"}
+      "nidm_maxNumberOfPeaksPerCluster": {"@type": "xsd:int", "@value": "3"},
+      "nidm_minDistanceBetweenPeaks": {"@type": "xsd:float", "@value": "8"}
     },
     {
-      "@id": "niiri:22dfacf7ee18da508be60ad1eb7f743b",
-      "@type": ["prov:Entity","nidm_ClusterDefinitionCriteria:"],
+      "@id": "niiri:0c26b2da6d51d1ddd8679deddd2d40f9",
+      "@type": ["prov:Entity","nidm_ClusterDefinitionCriteria"],
       "rdfs:label": "Cluster Connectivity Criterion: 18",
-      "nidm_hasConnectivityCriterion:": {"@id": "nidm_voxel18connected:"}
+      "nidm_hasConnectivityCriterion": {"@id": "nidm_voxel18connected"}
     },
     {
-      "@id": "niiri:85336313a51ea40ecee23f961cfe0ca3",
-      "@type": ["prov:Activity","nidm_Inference:"],
-      "nidm_hasAlternativeHypothesis:": {"@id": "nidm_OneTailedTest:"},
+      "@id": "niiri:bb244e720c06e715f97d3d6a86a4da4a",
+      "@type": ["prov:Activity","nidm_Inference"],
+      "nidm_hasAlternativeHypothesis": {"@id": "nidm_OneTailedTest"},
       "rdfs:label": "Inference"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:85336313a51ea40ecee23f961cfe0ca3",
-      "agent": "niiri:52f92964e671e1d8d4081235cbd4d416"
+      "activity_associated": "niiri:bb244e720c06e715f97d3d6a86a4da4a",
+      "agent": "niiri:74d6e660a818385ae6d5eebb86f94754"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:85336313a51ea40ecee23f961cfe0ca3",
-      "entity": "niiri:ab9638a722e6781f49cb6679ce6d0186"
+      "activity_using": "niiri:bb244e720c06e715f97d3d6a86a4da4a",
+      "entity": "niiri:703d6663b8b0a7e5af770bf42097a7a5"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:85336313a51ea40ecee23f961cfe0ca3",
-      "entity": "niiri:ea3d63b1b41ccc3e3a69810e1a717f88"
+      "activity_using": "niiri:bb244e720c06e715f97d3d6a86a4da4a",
+      "entity": "niiri:3a5d48d8e1368e4d94c100cf543902e9"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:85336313a51ea40ecee23f961cfe0ca3",
-      "entity": "niiri:a5292be8959cf336f6446ca7c7862413"
+      "activity_using": "niiri:bb244e720c06e715f97d3d6a86a4da4a",
+      "entity": "niiri:9e31766e27104879ffdde1e5cc7cfca0"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:85336313a51ea40ecee23f961cfe0ca3",
-      "entity": "niiri:449f64d462b57d4f54e0bb6abddf4400"
+      "activity_using": "niiri:bb244e720c06e715f97d3d6a86a4da4a",
+      "entity": "niiri:6dda6fa299c24eac1686b577a1c4e494"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:85336313a51ea40ecee23f961cfe0ca3",
-      "entity": "niiri:c94d3131e2527389b29e033e4981de4b"
+      "activity_using": "niiri:bb244e720c06e715f97d3d6a86a4da4a",
+      "entity": "niiri:93aaa88123d0eb90e6fdecebf810f8ea"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:85336313a51ea40ecee23f961cfe0ca3",
-      "entity": "niiri:648962244cdcb3f84950de7035a522c7"
+      "activity_using": "niiri:bb244e720c06e715f97d3d6a86a4da4a",
+      "entity": "niiri:b3769611f936098c6d9afc7f67ffa3db"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:85336313a51ea40ecee23f961cfe0ca3",
-      "entity": "niiri:22dfacf7ee18da508be60ad1eb7f743b"
+      "activity_using": "niiri:bb244e720c06e715f97d3d6a86a4da4a",
+      "entity": "niiri:0c26b2da6d51d1ddd8679deddd2d40f9"
     },
     {
-      "@id": "niiri:25eaac69fdefeb840e2ba86ef15eb0c1",
-      "@type": ["prov:Entity","nidm_SearchSpaceMaskMap:"],
+      "@id": "niiri:affcc7f63cecbd281de0115f299e13ad",
+      "@type": ["prov:Entity","nidm_SearchSpaceMaskMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "SearchSpaceMask.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "SearchSpaceMask.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Search Space Mask Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:1127eeccd626c09c472b158bcb760db8"},
-      "nidm_searchVolumeInVoxels:": {"@type": "xsd:int", "@value": "223057"},
-      "nidm_searchVolumeInUnits:": {"@type": "xsd:float", "@value": "1784456"},
-      "nidm_reselSizeInVoxels:": {"@type": "xsd:float", "@value": "65.5786964036542"},
-      "nidm_searchVolumeInResels:": {"@type": "xsd:float", "@value": "3155.84193266257"},
-      "spm_searchVolumeReselsGeometry:": {"@type": "xsd:string", "@value": "[6, 97.8140592306853, 965.938819261507, 3155.84193266257]"},
-      "nidm_noiseFWHMInVoxels:": {"@type": "xsd:string", "@value": "[4.09118640605185, 4.0346308705955, 3.97291894351243]"},
-      "nidm_noiseFWHMInUnits:": {"@type": "xsd:string", "@value": "[8.18237281210369, 8.069261741191, 7.94583788702486]"},
-      "nidm_randomFieldStationarity:": {"@type": "xsd:boolean", "@value": "true"},
-      "nidm_expectedNumberOfVoxelsPerCluster:": {"@type": "xsd:float", "@value": "1.51258369895942"},
-      "nidm_expectedNumberOfClusters:": {"@type": "xsd:float", "@value": "0.0512932943875468"},
-      "nidm_heightCriticalThresholdFWE05:": {"@type": "xsd:float", "@value": "5.30963135104407"},
-      "nidm_heightCriticalThresholdFDR05:": {"@type": "xsd:float", "@value": "7.11683940887451"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:3be25c24ad21044b41a1490e0f682fbe"},
+      "nidm_searchVolumeInVoxels": {"@type": "xsd:int", "@value": "223057"},
+      "nidm_searchVolumeInUnits": {"@type": "xsd:float", "@value": "1784456"},
+      "nidm_reselSizeInVoxels": {"@type": "xsd:float", "@value": "65.5786964036542"},
+      "nidm_searchVolumeInResels": {"@type": "xsd:float", "@value": "3155.84193266257"},
+      "spm_searchVolumeReselsGeometry": {"@type": "xsd:string", "@value": "[6, 97.8140592306853, 965.938819261507, 3155.84193266257]"},
+      "nidm_noiseFWHMInVoxels": {"@type": "xsd:string", "@value": "[4.09118640605185, 4.0346308705955, 3.97291894351243]"},
+      "nidm_noiseFWHMInUnits": {"@type": "xsd:string", "@value": "[8.18237281210369, 8.069261741191, 7.94583788702486]"},
+      "nidm_randomFieldStationarity": {"@type": "xsd:boolean", "@value": "true"},
+      "nidm_expectedNumberOfVoxelsPerCluster": {"@type": "xsd:float", "@value": "1.51258369895942"},
+      "nidm_expectedNumberOfClusters": {"@type": "xsd:float", "@value": "0.0512932943875468"},
+      "nidm_heightCriticalThresholdFWE05": {"@type": "xsd:float", "@value": "5.30963135104407"},
+      "nidm_heightCriticalThresholdFDR05": {"@type": "xsd:float", "@value": "7.11683940887451"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876"},
-      "spm_smallestSignificantClusterSizeInVoxelsFWE05:": {"@type": "xsd:int", "@value": "1"},
-      "spm_smallestSignificantClusterSizeInVoxelsFDR05:": {"@type": "xsd:int", "@value": "8"}
+      "spm_smallestSignificantClusterSizeInVoxelsFWE05": {"@type": "xsd:int", "@value": "1"},
+      "spm_smallestSignificantClusterSizeInVoxelsFDR05": {"@type": "xsd:int", "@value": "8"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:25eaac69fdefeb840e2ba86ef15eb0c1",
-      "activity": "niiri:85336313a51ea40ecee23f961cfe0ca3"
+      "entity_generated": "niiri:affcc7f63cecbd281de0115f299e13ad",
+      "activity": "niiri:bb244e720c06e715f97d3d6a86a4da4a"
     },
     {
-      "@id": "niiri:628ed5e363137da007004818bec3bff7",
-      "@type": ["prov:Entity","nidm_ExcursionSetMap:"],
+      "@id": "niiri:a3de06f5c7d45a76d1c3457418a9e61f",
+      "@type": ["prov:Entity","nidm_ExcursionSetMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ExcursionSet.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ExcursionSet.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Excursion Set Map",
-      "nidm_numberOfSupraThresholdClusters:": {"@type": "xsd:int", "@value": "20"},
-      "nidm_pValue:": {"@type": "xsd:float", "@value": "0"},
-      "nidm_hasClusterLabelsMap:": {"@id": "niiri:51265c693499479f0b95041a2109ec12"},
-      "nidm_hasMaximumIntensityProjection:": {"@id": "niiri:57aa0ae449bb4f57b30028d3d40429d2"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:1127eeccd626c09c472b158bcb760db8"},
+      "nidm_numberOfSupraThresholdClusters": {"@type": "xsd:int", "@value": "20"},
+      "nidm_pValue": {"@type": "xsd:float", "@value": "0"},
+      "nidm_hasClusterLabelsMap": {"@id": "niiri:1ed0d3c61d4035abac6d7a8a92b5b5f4"},
+      "nidm_hasMaximumIntensityProjection": {"@id": "niiri:f4a88590bef4ba051367275e27b75c25"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:3be25c24ad21044b41a1490e0f682fbe"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "265cb94fb9c73751fd120863a3f69a3dde7f5117f8da44dc6df2fb096c8ce3d98b375d48d4f6c2760f68a99b111229eaa4af4f2420e0540aa25cdc1ea265f77f"}
     },
     {
-      "@id": "niiri:51265c693499479f0b95041a2109ec12",
-      "@type": ["prov:Entity","nidm_ClusterLabelsMap:"],
+      "@id": "niiri:1ed0d3c61d4035abac6d7a8a92b5b5f4",
+      "@type": ["prov:Entity","nidm_ClusterLabelsMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ClusterLabels.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ClusterLabels.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Cluster Labels Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:1127eeccd626c09c472b158bcb760db8"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:3be25c24ad21044b41a1490e0f682fbe"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "593cccacd254c0341525c4f72f09eeef0276c39f43887eac64d62883472fe3e6b331d55e3d80bc906686031d59034546bf594a3161a90eb01553b77ca481cb45"}
     },
     {
-      "@id": "niiri:57aa0ae449bb4f57b30028d3d40429d2",
+      "@id": "niiri:f4a88590bef4ba051367275e27b75c25",
       "@type": ["prov:Entity","dctype:Image"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "MaximumIntensityProjection.png"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "MaximumIntensityProjection.png"},
@@ -731,790 +731,790 @@
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:628ed5e363137da007004818bec3bff7",
-      "activity": "niiri:85336313a51ea40ecee23f961cfe0ca3"
+      "entity_generated": "niiri:a3de06f5c7d45a76d1c3457418a9e61f",
+      "activity": "niiri:bb244e720c06e715f97d3d6a86a4da4a"
     },
     {
-      "@id": "niiri:c51c746038ebe18ddcd5ba77c41c8878",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:155481980ff1c28f6346fa37f1ee5ef4",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0001",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "124"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.8908579584557"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.23439277848581e-10"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "6.33160190943727e-12"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "2.46878555697161e-09"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "1"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "124"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.8908579584557"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.23439277848581e-10"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "6.33160190943727e-12"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "2.46878555697161e-09"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "1"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c51c746038ebe18ddcd5ba77c41c8878",
-      "entity": "niiri:628ed5e363137da007004818bec3bff7"
+      "entity_derived": "niiri:155481980ff1c28f6346fa37f1ee5ef4",
+      "entity": "niiri:a3de06f5c7d45a76d1c3457418a9e61f"
     },
     {
-      "@id": "niiri:3b684cec3a71a7e7ee23ab3e5ae5ed46",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f35f708a48ecddb6ea1a7e5fb2de3313",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0002",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "43"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.655700743658026"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.2860598428039e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "6.59662243607251e-07"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "6.43029921401949e-05"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "2"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "43"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.655700743658026"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.2860598428039e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "6.59662243607251e-07"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "6.43029921401949e-05"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "2"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3b684cec3a71a7e7ee23ab3e5ae5ed46",
-      "entity": "niiri:628ed5e363137da007004818bec3bff7"
+      "entity_derived": "niiri:f35f708a48ecddb6ea1a7e5fb2de3313",
+      "entity": "niiri:a3de06f5c7d45a76d1c3457418a9e61f"
     },
     {
-      "@id": "niiri:ca441cca951d825d8ff7f38c616fbb51",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:d9d669c3d9951cd5e034e1af813346b3",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0003",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "19"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.289728235569826"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00145461500200589"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "7.4609212112664e-05"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00415604286287398"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "3"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "19"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.289728235569826"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00145461500200589"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "7.4609212112664e-05"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00415604286287398"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "3"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ca441cca951d825d8ff7f38c616fbb51",
-      "entity": "niiri:628ed5e363137da007004818bec3bff7"
+      "entity_derived": "niiri:d9d669c3d9951cd5e034e1af813346b3",
+      "entity": "niiri:a3de06f5c7d45a76d1c3457418a9e61f"
     },
     {
-      "@id": "niiri:9eea553f10bd8f4b3795cb0ec668d04a",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:7e1b3b0f62b55d18a395035fc7feee73",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0004",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "62"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.945428979227852"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.72804953447324e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "2.93810527018934e-08"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "5.72804953447324e-06"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "4"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "62"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.945428979227852"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.72804953447324e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "2.93810527018934e-08"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "5.72804953447324e-06"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "4"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9eea553f10bd8f4b3795cb0ec668d04a",
-      "entity": "niiri:628ed5e363137da007004818bec3bff7"
+      "entity_derived": "niiri:7e1b3b0f62b55d18a395035fc7feee73",
+      "entity": "niiri:a3de06f5c7d45a76d1c3457418a9e61f"
     },
     {
-      "@id": "niiri:2d914f94e173af2f1db4279a36559ade",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:119c3306aea58b790a250dbf6a0c5f81",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0005",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "40"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.609954180147001"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.18508327799242e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1.12080057024233e-06"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "8.74033311196969e-05"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "5"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "40"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.609954180147001"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.18508327799242e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1.12080057024233e-06"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "8.74033311196969e-05"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "5"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2d914f94e173af2f1db4279a36559ade",
-      "entity": "niiri:628ed5e363137da007004818bec3bff7"
+      "entity_derived": "niiri:119c3306aea58b790a250dbf6a0c5f81",
+      "entity": "niiri:a3de06f5c7d45a76d1c3457418a9e61f"
     },
     {
-      "@id": "niiri:45e7bec8674ce00242a3ca1ba3e28aa4",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c3280a96b8b08a46c09804cff4f111ff",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0006",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "14"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.21348396305145"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00484589318609991"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.000248530936833968"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0107686515246665"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "6"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "14"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.21348396305145"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00484589318609991"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.000248530936833968"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0107686515246665"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "6"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:45e7bec8674ce00242a3ca1ba3e28aa4",
-      "entity": "niiri:628ed5e363137da007004818bec3bff7"
+      "entity_derived": "niiri:c3280a96b8b08a46c09804cff4f111ff",
+      "entity": "niiri:a3de06f5c7d45a76d1c3457418a9e61f"
     },
     {
-      "@id": "niiri:4b4c73793148b97c0ff9a401778d980d",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:15fc3f6b34f2cc43294db8febc2aa39d",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0007",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "6"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0914931270220502"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0483371945181382"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00247630283936606"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0743649146432896"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "7"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "6"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0914931270220502"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0483371945181382"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00247630283936606"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0743649146432896"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "7"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4b4c73793148b97c0ff9a401778d980d",
-      "entity": "niiri:628ed5e363137da007004818bec3bff7"
+      "entity_derived": "niiri:15fc3f6b34f2cc43294db8febc2aa39d",
+      "entity": "niiri:a3de06f5c7d45a76d1c3457418a9e61f"
     },
     {
-      "@id": "niiri:1b44a27650bde23878594a9485c4d6d3",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:ea4c51e6004ff6ca79763dfba6bceff9",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0008",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "8"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.1219908360294"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.02547536845608"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00130586219280271"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0424589474268"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "8"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "8"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.1219908360294"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.02547536845608"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00130586219280271"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0424589474268"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "8"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1b44a27650bde23878594a9485c4d6d3",
-      "entity": "niiri:628ed5e363137da007004818bec3bff7"
+      "entity_derived": "niiri:ea4c51e6004ff6ca79763dfba6bceff9",
+      "entity": "niiri:a3de06f5c7d45a76d1c3457418a9e61f"
     },
     {
-      "@id": "niiri:e9d92af50d7554f83a3d9f3b4072a7c1",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:dc0951f37176f78fb716ea89f0b324b0",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0009",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "22"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.335474799080851"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000743778885823435"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "3.8150141614568e-05"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00247926295274478"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "9"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "22"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.335474799080851"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000743778885823435"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "3.8150141614568e-05"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00247926295274478"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "9"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e9d92af50d7554f83a3d9f3b4072a7c1",
-      "entity": "niiri:628ed5e363137da007004818bec3bff7"
+      "entity_derived": "niiri:dc0951f37176f78fb716ea89f0b324b0",
+      "entity": "niiri:a3de06f5c7d45a76d1c3457418a9e61f"
     },
     {
-      "@id": "niiri:90ea7ec9beaea62022ae06ebf7877811",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:0262c15e4838598f01a6cef257cb8e12",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0010",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "15"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.228732817555125"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00377073221731598"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.000193394574537264"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00942683054328996"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "10"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "15"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.228732817555125"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00377073221731598"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.000193394574537264"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00942683054328996"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "10"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:90ea7ec9beaea62022ae06ebf7877811",
-      "entity": "niiri:628ed5e363137da007004818bec3bff7"
+      "entity_derived": "niiri:0262c15e4838598f01a6cef257cb8e12",
+      "entity": "niiri:a3de06f5c7d45a76d1c3457418a9e61f"
     },
     {
-      "@id": "niiri:246e46a571dda4f915565e71d61cb338",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c1725b381104011cabad0fc0b26d85db",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0011",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "47"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.716696161672726"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.46364387091367e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "3.31541532894164e-07"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "4.30909591394245e-05"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "11"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "47"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.716696161672726"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.46364387091367e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "3.31541532894164e-07"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "4.30909591394245e-05"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "11"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:246e46a571dda4f915565e71d61cb338",
-      "entity": "niiri:628ed5e363137da007004818bec3bff7"
+      "entity_derived": "niiri:c1725b381104011cabad0fc0b26d85db",
+      "entity": "niiri:a3de06f5c7d45a76d1c3457418a9e61f"
     },
     {
-      "@id": "niiri:8c078951dde09de372f14e68653a15e1",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:381dea70ad1c9ee61377f917ea0ce85d",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0012",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "8"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.1219908360294"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.02547536845608"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00130586219280271"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0424589474268"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "12"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "8"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.1219908360294"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.02547536845608"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00130586219280271"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0424589474268"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "12"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8c078951dde09de372f14e68653a15e1",
-      "entity": "niiri:628ed5e363137da007004818bec3bff7"
+      "entity_derived": "niiri:381dea70ad1c9ee61377f917ea0ce85d",
+      "entity": "niiri:a3de06f5c7d45a76d1c3457418a9e61f"
     },
     {
-      "@id": "niiri:500eb4af4185b2297823a2218c285d60",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:9b79a74d8af6455c348a5ada6380936b",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0013",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0457465635110251"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.148302764082867"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00757807781266262"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.17447384009749"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "13"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0457465635110251"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.148302764082867"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00757807781266262"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.17447384009749"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "13"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:500eb4af4185b2297823a2218c285d60",
-      "entity": "niiri:628ed5e363137da007004818bec3bff7"
+      "entity_derived": "niiri:9b79a74d8af6455c348a5ada6380936b",
+      "entity": "niiri:a3de06f5c7d45a76d1c3457418a9e61f"
     },
     {
-      "@id": "niiri:4768dfb4cd05c9ffe1d3d7d1f35cfe3d",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c2c282bcebcafee73ac596184605c302",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0014",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "8"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.1219908360294"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.02547536845608"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00130586219280271"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0424589474268"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "14"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "8"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.1219908360294"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.02547536845608"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00130586219280271"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0424589474268"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "14"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4768dfb4cd05c9ffe1d3d7d1f35cfe3d",
-      "entity": "niiri:628ed5e363137da007004818bec3bff7"
+      "entity_derived": "niiri:c2c282bcebcafee73ac596184605c302",
+      "entity": "niiri:a3de06f5c7d45a76d1c3457418a9e61f"
     },
     {
-      "@id": "niiri:a405d942872d5b85c1b4326d3a87b92c",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:76b1ed7cd5606b2d502e4a5ee6dfe343",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0015",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "5"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0762442725183751"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0683702233066033"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00350079188048824"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0911602977421377"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "15"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "5"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0762442725183751"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0683702233066033"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00350079188048824"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0911602977421377"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "15"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a405d942872d5b85c1b4326d3a87b92c",
-      "entity": "niiri:628ed5e363137da007004818bec3bff7"
+      "entity_derived": "niiri:76b1ed7cd5606b2d502e4a5ee6dfe343",
+      "entity": "niiri:a3de06f5c7d45a76d1c3457418a9e61f"
     },
     {
-      "@id": "niiri:bd8460a11fb14617fc43ac91658b693e",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:010ce656a5e597d871ca20ab1aa2a631",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0016",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0609954180147001"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0990646745487638"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00506846527740179"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.123830843185955"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "16"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0609954180147001"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0990646745487638"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00506846527740179"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.123830843185955"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "16"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:bd8460a11fb14617fc43ac91658b693e",
-      "entity": "niiri:628ed5e363137da007004818bec3bff7"
+      "entity_derived": "niiri:010ce656a5e597d871ca20ab1aa2a631",
+      "entity": "niiri:a3de06f5c7d45a76d1c3457418a9e61f"
     },
     {
-      "@id": "niiri:8e7d24425dd5859e85ca7c28c012c5cd",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:2083b75818d091b6724ed0adf40223ab",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0017",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "5"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0762442725183751"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0683702233066033"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00350079188048824"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0911602977421377"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "17"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "5"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0762442725183751"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0683702233066033"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00350079188048824"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0911602977421377"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "17"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8e7d24425dd5859e85ca7c28c012c5cd",
-      "entity": "niiri:628ed5e363137da007004818bec3bff7"
+      "entity_derived": "niiri:2083b75818d091b6724ed0adf40223ab",
+      "entity": "niiri:a3de06f5c7d45a76d1c3457418a9e61f"
     },
     {
-      "@id": "niiri:59f598a957aabf6559fffdd51d733944",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:e8fd4bf9f34c220cd368e846c6651d35",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0018",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.399512266692318"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0202837600401362"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.399512266692318"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "18"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.399512266692318"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0202837600401362"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.399512266692318"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "18"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:59f598a957aabf6559fffdd51d733944",
-      "entity": "niiri:628ed5e363137da007004818bec3bff7"
+      "entity_derived": "niiri:e8fd4bf9f34c220cd368e846c6651d35",
+      "entity": "niiri:a3de06f5c7d45a76d1c3457418a9e61f"
     },
     {
-      "@id": "niiri:3f6eaa65d9b555818ce062afbbcb140b",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:4458d8f762604f7ee56c5d3e6ea96fca",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0019",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.399512266692318"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0202837600401362"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.399512266692318"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "19"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.399512266692318"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0202837600401362"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.399512266692318"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "19"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3f6eaa65d9b555818ce062afbbcb140b",
-      "entity": "niiri:628ed5e363137da007004818bec3bff7"
+      "entity_derived": "niiri:4458d8f762604f7ee56c5d3e6ea96fca",
+      "entity": "niiri:a3de06f5c7d45a76d1c3457418a9e61f"
     },
     {
-      "@id": "niiri:608052d2152344776bc043455c610be4",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:a2f1489aa082c9cb44338fd916006ecb",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0020",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.399512266692318"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0202837600401362"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.399512266692318"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "20"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.399512266692318"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0202837600401362"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.399512266692318"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "20"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:608052d2152344776bc043455c610be4",
-      "entity": "niiri:628ed5e363137da007004818bec3bff7"
+      "entity_derived": "niiri:a2f1489aa082c9cb44338fd916006ecb",
+      "entity": "niiri:a3de06f5c7d45a76d1c3457418a9e61f"
     },
     {
-      "@id": "niiri:01fcf9c0155b66439a6aa5860d0ac913",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5e6a56f172ddef202b4da0e41f9cac40",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0001",
-      "prov:atLocation": {"@id": "niiri:1d0398d8e569eb0353ff666b30dcdf39"},
+      "prov:atLocation": {"@id": "niiri:98fc89ff01c715d715f3acefc9df825b"},
       "prov:value": {"@type": "xsd:float", "@value": "7.92007970809937"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "6.94608360738412"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.87783122385099e-12"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "4.18813870695089e-07"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000459866237621553"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "6.94608360738412"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.87783122385099e-12"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "4.18813870695089e-07"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000459866237621553"}
     },
     {
-      "@id": "niiri:1d0398d8e569eb0353ff666b30dcdf39",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:98fc89ff01c715d715f3acefc9df825b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0001",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[46,16,24]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[46,16,24]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:01fcf9c0155b66439a6aa5860d0ac913",
-      "entity": "niiri:c51c746038ebe18ddcd5ba77c41c8878"
+      "entity_derived": "niiri:5e6a56f172ddef202b4da0e41f9cac40",
+      "entity": "niiri:155481980ff1c28f6346fa37f1ee5ef4"
     },
     {
-      "@id": "niiri:ef463294a81411e6150bb2869901d7cc",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:2529591f9d1d6e7c2816bfaa6448acf1",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0002",
-      "prov:atLocation": {"@id": "niiri:fa744f32234852bc21e3ac20fe196313"},
+      "prov:atLocation": {"@id": "niiri:12bfe02a34239f27f80049317c87f105"},
       "prov:value": {"@type": "xsd:float", "@value": "7.11683940887451"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "6.37404871703245"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "9.20510334623259e-11"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "2.05325778424026e-05"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00823125678700628"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "6.37404871703245"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "9.20510334623259e-11"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "2.05325778424026e-05"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00823125678700628"}
     },
     {
-      "@id": "niiri:fa744f32234852bc21e3ac20fe196313",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:12bfe02a34239f27f80049317c87f105",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0002",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[34,-88,-2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[34,-88,-2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ef463294a81411e6150bb2869901d7cc",
-      "entity": "niiri:3b684cec3a71a7e7ee23ab3e5ae5ed46"
+      "entity_derived": "niiri:2529591f9d1d6e7c2816bfaa6448acf1",
+      "entity": "niiri:f35f708a48ecddb6ea1a7e5fb2de3313"
     },
     {
-      "@id": "niiri:e3f3a93c80561477075dacb11687288c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:6f9210e7353860292c6d8dfce2015490",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0003",
-      "prov:atLocation": {"@id": "niiri:e504c44421975e00e0819270bf92e746"},
+      "prov:atLocation": {"@id": "niiri:b3ef8b609fa00ef16a539437e5692e6d"},
       "prov:value": {"@type": "xsd:float", "@value": "6.48292255401611"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.8992593141605"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.82568493656277e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.000407231755366277"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0732298207475789"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.8992593141605"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.82568493656277e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.000407231755366277"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0732298207475789"}
     },
     {
-      "@id": "niiri:e504c44421975e00e0819270bf92e746",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b3ef8b609fa00ef16a539437e5692e6d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0003",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[42,-72,-10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[42,-72,-10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e3f3a93c80561477075dacb11687288c",
-      "entity": "niiri:ca441cca951d825d8ff7f38c616fbb51"
+      "entity_derived": "niiri:6f9210e7353860292c6d8dfce2015490",
+      "entity": "niiri:d9d669c3d9951cd5e034e1af813346b3"
     },
     {
-      "@id": "niiri:b00846122635c838b5c53bc9f994a426",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:1bd531de3356dab29c9e4ed53addc58b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0004",
-      "prov:atLocation": {"@id": "niiri:f64ad27b983a615df0c4ac02fae24146"},
+      "prov:atLocation": {"@id": "niiri:096c52d0ef5b5dd96bf7ba644803410a"},
       "prov:value": {"@type": "xsd:float", "@value": "6.31603479385376"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.77079466112137"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.94492849498107e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.000879943865776389"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0732298207475789"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.77079466112137"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.94492849498107e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.000879943865776389"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0732298207475789"}
     },
     {
-      "@id": "niiri:f64ad27b983a615df0c4ac02fae24146",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:096c52d0ef5b5dd96bf7ba644803410a",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0004",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[32,24,-4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[32,24,-4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b00846122635c838b5c53bc9f994a426",
-      "entity": "niiri:9eea553f10bd8f4b3795cb0ec668d04a"
+      "entity_derived": "niiri:1bd531de3356dab29c9e4ed53addc58b",
+      "entity": "niiri:7e1b3b0f62b55d18a395035fc7feee73"
     },
     {
-      "@id": "niiri:3e029b308699eb615152399d9b9e9a57",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ee2aed7c69b3aab0d47c0baab7ec0dbf",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0005",
-      "prov:atLocation": {"@id": "niiri:f308af61c2b895cc4b000546d7cb6daa"},
+      "prov:atLocation": {"@id": "niiri:72e36f2d9291f6b80ff10852dd16c763"},
       "prov:value": {"@type": "xsd:float", "@value": "6.28007745742798"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.74292583422276"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.65272453897825e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00103782272796227"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0732298207475789"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.74292583422276"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.65272453897825e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00103782272796227"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0732298207475789"}
     },
     {
-      "@id": "niiri:f308af61c2b895cc4b000546d7cb6daa",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:72e36f2d9291f6b80ff10852dd16c763",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0005",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[8,18,50]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[8,18,50]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3e029b308699eb615152399d9b9e9a57",
-      "entity": "niiri:2d914f94e173af2f1db4279a36559ade"
+      "entity_derived": "niiri:ee2aed7c69b3aab0d47c0baab7ec0dbf",
+      "entity": "niiri:119c3306aea58b790a250dbf6a0c5f81"
     },
     {
-      "@id": "niiri:321e44b5f208d13cc7d475411e273e1a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:87f773c2297ccd49c8420518043f9edf",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0006",
-      "prov:atLocation": {"@id": "niiri:471942bd9e2ce557c043ab383d7446ce"},
+      "prov:atLocation": {"@id": "niiri:5c7506968ab01933f2a034010a609dab"},
       "prov:value": {"@type": "xsd:float", "@value": "6.25127363204956"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.72055271981637"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.30890376104765e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0011841880966994"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0732298207475789"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.72055271981637"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.30890376104765e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0011841880966994"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0732298207475789"}
     },
     {
-      "@id": "niiri:471942bd9e2ce557c043ab383d7446ce",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:5c7506968ab01933f2a034010a609dab",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0006",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[52,-32,42]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[52,-32,42]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:321e44b5f208d13cc7d475411e273e1a",
-      "entity": "niiri:45e7bec8674ce00242a3ca1ba3e28aa4"
+      "entity_derived": "niiri:87f773c2297ccd49c8420518043f9edf",
+      "entity": "niiri:c3280a96b8b08a46c09804cff4f111ff"
     },
     {
-      "@id": "niiri:bd94858235a93a6b2c4bac257ddaa4ca",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0078f20a5b83c1a2beec64a3a6188b9d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0007",
-      "prov:atLocation": {"@id": "niiri:a9691554a0a728a8a1f3f85d8cf5fb09"},
+      "prov:atLocation": {"@id": "niiri:3e1a6cc0a26ff99d9a700b7d7c44ee3f"},
       "prov:value": {"@type": "xsd:float", "@value": "6.24752378463745"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.71763687476157"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.40078304300806e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00120468241369565"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0732298207475789"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.71763687476157"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.40078304300806e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00120468241369565"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0732298207475789"}
     },
     {
-      "@id": "niiri:a9691554a0a728a8a1f3f85d8cf5fb09",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:3e1a6cc0a26ff99d9a700b7d7c44ee3f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0007",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[40,-62,50]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[40,-62,50]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:bd94858235a93a6b2c4bac257ddaa4ca",
-      "entity": "niiri:4b4c73793148b97c0ff9a401778d980d"
+      "entity_derived": "niiri:0078f20a5b83c1a2beec64a3a6188b9d",
+      "entity": "niiri:15fc3f6b34f2cc43294db8febc2aa39d"
     },
     {
-      "@id": "niiri:d4ce2f741b5177b2f48f4711f75a7d36",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:4fef5b8d7f9adb35cbb0ab5a325d482f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0008",
-      "prov:atLocation": {"@id": "niiri:062ddacf1229773d0a7cfaef9ad28c2e"},
+      "prov:atLocation": {"@id": "niiri:902931c952cefdae6730925980730073"},
       "prov:value": {"@type": "xsd:float", "@value": "6.15371799468994"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.64445580026639"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.285227171001e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00184807786755337"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0857472799805926"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.64445580026639"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.285227171001e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00184807786755337"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0857472799805926"}
     },
     {
-      "@id": "niiri:062ddacf1229773d0a7cfaef9ad28c2e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:902931c952cefdae6730925980730073",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0008",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-28,-94,4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-28,-94,4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d4ce2f741b5177b2f48f4711f75a7d36",
-      "entity": "niiri:1b44a27650bde23878594a9485c4d6d3"
+      "entity_derived": "niiri:4fef5b8d7f9adb35cbb0ab5a325d482f",
+      "entity": "niiri:ea4c51e6004ff6ca79763dfba6bceff9"
     },
     {
-      "@id": "niiri:17f208e257dd52e4e6d458b8d89f5d40",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:6cfbefeaeca5e8720b0f89cc117f6383",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0009",
-      "prov:atLocation": {"@id": "niiri:cd1f2290f59badd4a55efe1ccb1e71d4"},
+      "prov:atLocation": {"@id": "niiri:811c5d9c038c996d8bf02e2801564ed3"},
       "prov:value": {"@type": "xsd:float", "@value": "6.15222215652466"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.64328512810061"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.34178537356678e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00186069357054308"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0857472799805926"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.64328512810061"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.34178537356678e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00186069357054308"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0857472799805926"}
     },
     {
-      "@id": "niiri:cd1f2290f59badd4a55efe1ccb1e71d4",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:811c5d9c038c996d8bf02e2801564ed3",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0009",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-6,12,52]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-6,12,52]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:17f208e257dd52e4e6d458b8d89f5d40",
-      "entity": "niiri:e9d92af50d7554f83a3d9f3b4072a7c1"
+      "entity_derived": "niiri:6cfbefeaeca5e8720b0f89cc117f6383",
+      "entity": "niiri:dc0951f37176f78fb716ea89f0b324b0"
     },
     {
-      "@id": "niiri:352d04c79c650e14027a708964e8f510",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b7eb4e3f8d2498601ec7a4ca2effb8ea",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0010",
-      "prov:atLocation": {"@id": "niiri:67c8a60abf2c666b7908fed7d652e533"},
+      "prov:atLocation": {"@id": "niiri:79b9d17e894c966e15c06bd6c13bf05f"},
       "prov:value": {"@type": "xsd:float", "@value": "6.10109901428223"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.60320502193174"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.05212039080982e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00234682813060005"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0921349235875033"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.60320502193174"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.05212039080982e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00234682813060005"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0921349235875033"}
     },
     {
-      "@id": "niiri:67c8a60abf2c666b7908fed7d652e533",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:79b9d17e894c966e15c06bd6c13bf05f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0010",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[32,2,46]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[32,2,46]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:352d04c79c650e14027a708964e8f510",
-      "entity": "niiri:90ea7ec9beaea62022ae06ebf7877811"
+      "entity_derived": "niiri:b7eb4e3f8d2498601ec7a4ca2effb8ea",
+      "entity": "niiri:0262c15e4838598f01a6cef257cb8e12"
     },
     {
-      "@id": "niiri:81ce3b3269904151fb0ecdbc124d95bb",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:aed78746ebe2a394f8866cd7a9c4f06f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0011",
-      "prov:atLocation": {"@id": "niiri:d84e98c56883ed6bfe424a5e84a83f27"},
+      "prov:atLocation": {"@id": "niiri:49e035f041eb5be11a7e4f6b92049929"},
       "prov:value": {"@type": "xsd:float", "@value": "5.98517084121704"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.51181334779297"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.77577724747024e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00376326218366319"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.120256575135861"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.51181334779297"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.77577724747024e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00376326218366319"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.120256575135861"}
     },
     {
-      "@id": "niiri:d84e98c56883ed6bfe424a5e84a83f27",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:49e035f041eb5be11a7e4f6b92049929",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0011",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[8,32,38]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[8,32,38]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:81ce3b3269904151fb0ecdbc124d95bb",
-      "entity": "niiri:246e46a571dda4f915565e71d61cb338"
+      "entity_derived": "niiri:aed78746ebe2a394f8866cd7a9c4f06f",
+      "entity": "niiri:c1725b381104011cabad0fc0b26d85db"
     },
     {
-      "@id": "niiri:455629387d24ec1307e080b239615b91",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:587e3f84df2982a9fcd650238d95b213",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0012",
-      "prov:atLocation": {"@id": "niiri:6cf22a24114949b2d4e89b31b7939729"},
+      "prov:atLocation": {"@id": "niiri:c87e82c19dd1913ed127e81e7df62ead"},
       "prov:value": {"@type": "xsd:float", "@value": "5.98348569869995"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.51047970249337"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.78928538652201e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00378871596531738"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.120256575135861"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.51047970249337"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.78928538652201e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00378871596531738"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.120256575135861"}
     },
     {
-      "@id": "niiri:6cf22a24114949b2d4e89b31b7939729",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c87e82c19dd1913ed127e81e7df62ead",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0012",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-52,0,38]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-52,0,38]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:455629387d24ec1307e080b239615b91",
-      "entity": "niiri:8c078951dde09de372f14e68653a15e1"
+      "entity_derived": "niiri:587e3f84df2982a9fcd650238d95b213",
+      "entity": "niiri:381dea70ad1c9ee61377f917ea0ce85d"
     },
     {
-      "@id": "niiri:2debbfc8c141684976875c93e2828b56",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b8a49440e2e03d17ed64aecab9015fc9",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0013",
-      "prov:atLocation": {"@id": "niiri:bcf41b99033863bde09f076ff61cc9c9"},
+      "prov:atLocation": {"@id": "niiri:2ce90da342b2373309ec7dd9cb0060b4"},
       "prov:value": {"@type": "xsd:float", "@value": "5.78093099594116"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.34909755317379"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.41969442155354e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00844151822925698"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.252769068923751"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.34909755317379"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.41969442155354e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00844151822925698"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.252769068923751"}
     },
     {
-      "@id": "niiri:bcf41b99033863bde09f076ff61cc9c9",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:2ce90da342b2373309ec7dd9cb0060b4",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0013",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-34,-2,52]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-34,-2,52]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2debbfc8c141684976875c93e2828b56",
-      "entity": "niiri:500eb4af4185b2297823a2218c285d60"
+      "entity_derived": "niiri:b8a49440e2e03d17ed64aecab9015fc9",
+      "entity": "niiri:9b79a74d8af6455c348a5ada6380936b"
     },
     {
-      "@id": "niiri:48a84fe52bfe8a9bc97d81d516e93eab",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:096335e30681a87cc44956be7c2fd010",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0014",
-      "prov:atLocation": {"@id": "niiri:dcfa8004ef96dd2ad82d8c6d4d743e11"},
+      "prov:atLocation": {"@id": "niiri:1108c3d99e6277aed8f925abd4ce55a4"},
       "prov:value": {"@type": "xsd:float", "@value": "5.70337772369385"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.28674301747281"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.22566831420812e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.011413186758684"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.308612544684445"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.28674301747281"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.22566831420812e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.011413186758684"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.308612544684445"}
     },
     {
-      "@id": "niiri:dcfa8004ef96dd2ad82d8c6d4d743e11",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:1108c3d99e6277aed8f925abd4ce55a4",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0014",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[56,-44,52]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[56,-44,52]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:48a84fe52bfe8a9bc97d81d516e93eab",
-      "entity": "niiri:4768dfb4cd05c9ffe1d3d7d1f35cfe3d"
+      "entity_derived": "niiri:096335e30681a87cc44956be7c2fd010",
+      "entity": "niiri:c2c282bcebcafee73ac596184605c302"
     },
     {
-      "@id": "niiri:a42a2c3c5ac00250af7180012243e75e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a3dbc64398559529658b7a5a0ef78d1e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0015",
-      "prov:atLocation": {"@id": "niiri:238916df0c0077e32bc3af02acb6ef43"},
+      "prov:atLocation": {"@id": "niiri:023eb3a7010e9a8c9cb41ce2d7b56c70"},
       "prov:value": {"@type": "xsd:float", "@value": "5.69516134262085"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.28011855642631"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.45501619933597e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0117816592148946"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.308612544684445"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.28011855642631"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.45501619933597e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0117816592148946"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.308612544684445"}
     },
     {
-      "@id": "niiri:238916df0c0077e32bc3af02acb6ef43",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:023eb3a7010e9a8c9cb41ce2d7b56c70",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0015",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[60,-36,54]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[60,-36,54]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a42a2c3c5ac00250af7180012243e75e",
-      "entity": "niiri:4768dfb4cd05c9ffe1d3d7d1f35cfe3d"
+      "entity_derived": "niiri:a3dbc64398559529658b7a5a0ef78d1e",
+      "entity": "niiri:c2c282bcebcafee73ac596184605c302"
     },
     {
-      "@id": "niiri:082f64e2aa5b5b8cd247e40e766ca56c",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ae3818cc45d2c9fb41dffe82e4c2d818",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0016",
-      "prov:atLocation": {"@id": "niiri:10370a1f89214bbcbb792d11302cef5d"},
+      "prov:atLocation": {"@id": "niiri:133c50d19ae417bae4232fa6ae5d2b0b"},
       "prov:value": {"@type": "xsd:float", "@value": "5.68819808959961"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.27450168515333"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.655864770444e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0121028975026269"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.308612544684445"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.27450168515333"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.655864770444e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0121028975026269"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.308612544684445"}
     },
     {
-      "@id": "niiri:10370a1f89214bbcbb792d11302cef5d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:133c50d19ae417bae4232fa6ae5d2b0b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0016",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[18,16,4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[18,16,4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:082f64e2aa5b5b8cd247e40e766ca56c",
-      "entity": "niiri:a405d942872d5b85c1b4326d3a87b92c"
+      "entity_derived": "niiri:ae3818cc45d2c9fb41dffe82e4c2d818",
+      "entity": "niiri:76b1ed7cd5606b2d502e4a5ee6dfe343"
     },
     {
-      "@id": "niiri:3bc26b9b32bf0e6fe8f1737adfee300a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d1aca860b0cc6a11b313c4acf1dc02e0",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0017",
-      "prov:atLocation": {"@id": "niiri:babd90d36c8e8bfe59433ea16a67d1f6"},
+      "prov:atLocation": {"@id": "niiri:fecb191253e64a6ef9b1108c7ab7b6bf"},
       "prov:value": {"@type": "xsd:float", "@value": "5.61174583435059"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.21266637309498"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "9.30727468428927e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0162336583380834"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.380850485465036"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.21266637309498"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "9.30727468428927e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0162336583380834"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.380850485465036"}
     },
     {
-      "@id": "niiri:babd90d36c8e8bfe59433ea16a67d1f6",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:fecb191253e64a6ef9b1108c7ab7b6bf",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0017",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[44,-70,50]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[44,-70,50]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3bc26b9b32bf0e6fe8f1737adfee300a",
-      "entity": "niiri:bd8460a11fb14617fc43ac91658b693e"
+      "entity_derived": "niiri:d1aca860b0cc6a11b313c4acf1dc02e0",
+      "entity": "niiri:010ce656a5e597d871ca20ab1aa2a631"
     },
     {
-      "@id": "niiri:6b27ae009371c8a2c5d7d3a5d1f0ace8",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:bdf5c277bd5f8597a6d660daa5603065",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0018",
-      "prov:atLocation": {"@id": "niiri:ef6890d992247ecc9ee034c031a58cd2"},
+      "prov:atLocation": {"@id": "niiri:347aa567ee2073ea9f5e876e0f70a34e"},
       "prov:value": {"@type": "xsd:float", "@value": "5.60917520523071"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.21058195491799"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "9.41245997809759e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0163938142285941"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.380850485465036"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.21058195491799"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "9.41245997809759e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0163938142285941"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.380850485465036"}
     },
     {
-      "@id": "niiri:ef6890d992247ecc9ee034c031a58cd2",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:347aa567ee2073ea9f5e876e0f70a34e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0018",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-30,26,2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-30,26,2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6b27ae009371c8a2c5d7d3a5d1f0ace8",
-      "entity": "niiri:8e7d24425dd5859e85ca7c28c012c5cd"
+      "entity_derived": "niiri:bdf5c277bd5f8597a6d660daa5603065",
+      "entity": "niiri:2083b75818d091b6724ed0adf40223ab"
     },
     {
-      "@id": "niiri:b04d3d3fe5c0a0c74423665bded90e49",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:4356eedee0d987414ac03b8e6d290dff",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0019",
-      "prov:atLocation": {"@id": "niiri:f79eb9d2caa2df659c784dafdc0ef394"},
+      "prov:atLocation": {"@id": "niiri:e4749d25f84cd00e691fa81d14d76866"},
       "prov:value": {"@type": "xsd:float", "@value": "5.40964078903198"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.04774404642803"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.23528758724889e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0346958937061391"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.745804416705928"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.04774404642803"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.23528758724889e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0346958937061391"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.745804416705928"}
     },
     {
-      "@id": "niiri:f79eb9d2caa2df659c784dafdc0ef394",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e4749d25f84cd00e691fa81d14d76866",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0019",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-54,-46,58]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-54,-46,58]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b04d3d3fe5c0a0c74423665bded90e49",
-      "entity": "niiri:59f598a957aabf6559fffdd51d733944"
+      "entity_derived": "niiri:4356eedee0d987414ac03b8e6d290dff",
+      "entity": "niiri:e8fd4bf9f34c220cd368e846c6651d35"
     },
     {
-      "@id": "niiri:4b418090a3653aae03ff113b2f9fd399",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f6aeea95598409a388840e0dc81f791c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0020",
-      "prov:atLocation": {"@id": "niiri:2da14cbac6023c14727bb21b3cfada62"},
+      "prov:atLocation": {"@id": "niiri:92870da8ac439dc467665d0abd4b7c66"},
       "prov:value": {"@type": "xsd:float", "@value": "5.33153486251831"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.98344293282216"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.12313708672463e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0461854110301809"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.958749429114292"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.98344293282216"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.12313708672463e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0461854110301809"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.958749429114292"}
     },
     {
-      "@id": "niiri:2da14cbac6023c14727bb21b3cfada62",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:92870da8ac439dc467665d0abd4b7c66",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0020",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[52,-48,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[52,-48,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4b418090a3653aae03ff113b2f9fd399",
-      "entity": "niiri:3f6eaa65d9b555818ce062afbbcb140b"
+      "entity_derived": "niiri:f6aeea95598409a388840e0dc81f791c",
+      "entity": "niiri:4458d8f762604f7ee56c5d3e6ea96fca"
     },
     {
-      "@id": "niiri:1a2b7de790d155cd659f2b3cf1cee080",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5825ee7b2aaed90133518e138ec17012",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0021",
-      "prov:atLocation": {"@id": "niiri:109938df788cc89af85897914e12926f"},
+      "prov:atLocation": {"@id": "niiri:82709dcc930c91a7e1305d3dea811c97"},
       "prov:value": {"@type": "xsd:float", "@value": "5.31841945648193"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.97261482231588"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.30279114724163e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0484353441449864"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.967916832880998"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.97261482231588"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.30279114724163e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0484353441449864"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.967916832880998"}
     },
     {
-      "@id": "niiri:109938df788cc89af85897914e12926f",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:82709dcc930c91a7e1305d3dea811c97",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0021",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-62,-38,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-62,-38,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1a2b7de790d155cd659f2b3cf1cee080",
-      "entity": "niiri:608052d2152344776bc043455c610be4"
+      "entity_derived": "niiri:5825ee7b2aaed90133518e138ec17012",
+      "entity": "niiri:a2f1489aa082c9cb44338fd916006ecb"
     }
   ]
 }

--- a/spmexport/ex_spm_thr_voxelfwep05/nidm.ttl
+++ b/spmexport/ex_spm_thr_voxelfwep05/nidm.ttl
@@ -4,7 +4,7 @@
 @prefix niiri: <http://iri.nidash.org/> .
 @prefix spm: <http://purl.org/nidash/spm#> .
 @prefix neurolex: <http://neurolex.org/wiki/> .
-@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#> .
+@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
@@ -17,27 +17,27 @@
 @prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-niiri:9f53dd73cbac66be53e9518c2ae4933a
+niiri:d085af3e055d03b41e58ff791604e130
   a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
   rdfs:label "NIDM-Results" ;
   nidm_version: "1.3.0"^^xsd:string .
 
-niiri:6d3fb4b3a9cefb8ce233767bb9cefd80
+niiri:fb236c1eb16f0c705e70a281f202e4e0
   a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
   rdfs:label "spm_results_nidm" ;
-  nidm_softwareVersion: "12.6903"^^xsd:string .
+  nidm_softwareVersion: "12.7057"^^xsd:string .
 
-niiri:0f5c3add36a4e0a0b3a663b951c26795
+niiri:55fc5c1d9802e26a9bae0c11e872ca8f
   a prov:Activity, nidm_NIDMResultsExport: ; 
   rdfs:label "NIDM-Results export" .
 
-niiri:0f5c3add36a4e0a0b3a663b951c26795 prov:wasAssociatedWith niiri:6d3fb4b3a9cefb8ce233767bb9cefd80 .
+niiri:55fc5c1d9802e26a9bae0c11e872ca8f prov:wasAssociatedWith niiri:fb236c1eb16f0c705e70a281f202e4e0 .
 
 _:blank5 a prov:Generation .
 
-niiri:9f53dd73cbac66be53e9518c2ae4933a prov:qualifiedGeneration _:blank5 .
+niiri:d085af3e055d03b41e58ff791604e130 prov:qualifiedGeneration _:blank5 .
 
-_:blank5 prov:atTime "2016-12-07T16:10:02"^^xsd:dateTime .
+_:blank5 prov:atTime "2017-04-19T12:19:21"^^xsd:dateTime .
 
 @prefix nidm_Ixi549CoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000050> .
 @prefix src_SPM: <http://scicrunch.org/resolver/SCR_007037> .
@@ -142,12 +142,12 @@ _:blank5 prov:atTime "2016-12-07T16:10:02"^^xsd:dateTime .
 @prefix nidm_Coordinate: <http://purl.org/nidash/nidm#NIDM_0000015> .
 @prefix nidm_coordinateVector: <http://purl.org/nidash/nidm#NIDM_0000086> .
 
-niiri:52f92964e671e1d8d4081235cbd4d416
+niiri:74d6e660a818385ae6d5eebb86f94754
     a prov:Agent, src_SPM:, prov:SoftwareAgent ; 
     rdfs:label "SPM" ;
-    nidm_softwareVersion: "12.12.2"^^xsd:string .
+    nidm_softwareVersion: "12.6906"^^xsd:string .
 
-niiri:1127eeccd626c09c472b158bcb760db8
+niiri:3be25c24ad21044b41a1490e0f682fbe
     a prov:Entity, nidm_CoordinateSpace: ; 
     rdfs:label "Coordinate space 1" ;
     nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
@@ -157,48 +157,48 @@ niiri:1127eeccd626c09c472b158bcb760db8
     nidm_numberOfDimensions: "3"^^xsd:int ;
     nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
 
-niiri:381e016a29b69e234756ea3c76fb09db
+niiri:c7590e1ec3de239c8cddebbdc6fd6db9
     a prov:Agent, nlx_Imaginginstrument:, nlx_Magneticresonanceimagingscanner: ; 
     rdfs:label "MRI Scanner" .
 
-niiri:24d307e96d4355161221fea37984ca3d
+niiri:d28c7cdb3446f62771c499c458755d38
     a prov:Agent, prov:Person ; 
     rdfs:label "Person" .
 
-niiri:9c389356d338253eeebec534a36dc9fb
+niiri:a408442578dc3ad4a6905f9711e6a6c3
     a prov:Entity, prov:Collection, nidm_Data: ; 
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "true"^^xsd:boolean ;
     nidm_targetIntensity: "100"^^xsd:float ;
     nidm_hasMRIProtocol: nlx_FunctionalMRIprotocol: .
 
-niiri:9c389356d338253eeebec534a36dc9fb prov:wasAttributedTo niiri:381e016a29b69e234756ea3c76fb09db .
+niiri:a408442578dc3ad4a6905f9711e6a6c3 prov:wasAttributedTo niiri:c7590e1ec3de239c8cddebbdc6fd6db9 .
 
-niiri:9c389356d338253eeebec534a36dc9fb prov:wasAttributedTo niiri:24d307e96d4355161221fea37984ca3d .
+niiri:a408442578dc3ad4a6905f9711e6a6c3 prov:wasAttributedTo niiri:d28c7cdb3446f62771c499c458755d38 .
 
-niiri:af7d6bd128fbc8207bced46564d596c7
+niiri:f0a4cf13c5d07c9f613050a20c1fb410
     a prov:Entity, spm_DCTDriftModel: ; 
     rdfs:label "SPM's DCT Drift Model" ;
     spm_SPMsDriftCutoffPeriod: "128"^^xsd:float .
 
-niiri:d5494df7777ae492a16186e356e4067e
+niiri:7e38970ca6e0c04540e0958cfd68a076
     a prov:Entity, nidm_DesignMatrix: ; 
     prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.csv"^^xsd:string ;
     dct:format "text/csv"^^xsd:string ;
-    dc:description niiri:85c1bf902b50fd68db2a21fe1ce95322 ;
+    dc:description niiri:7dd586f3a19dd8e4ad066d8b0d3fae59 ;
     rdfs:label "Design Matrix" ;
     nidm_regressorNames: "[\"Sn(1) to*bf(1)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) constant\"]"^^xsd:string ;
-    nidm_hasDriftModel: niiri:af7d6bd128fbc8207bced46564d596c7 ;
+    nidm_hasDriftModel: niiri:f0a4cf13c5d07c9f613050a20c1fb410 ;
     nidm_hasHRFBasis: spm_SPMsCanonicalHRF: .
 
-niiri:85c1bf902b50fd68db2a21fe1ce95322
+niiri:7dd586f3a19dd8e4ad066d8b0d3fae59
     a prov:Entity, dctype:Image ; 
     prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:fafe4f020120967e1209b04b4047a6d8
+niiri:6f865b9d321b1a0b96e5376fd02d63ef
     a prov:Entity, nidm_ErrorModel: ; 
     nidm_hasErrorDistribution: obo_normaldistribution: ;
     nidm_hasErrorDependence: obo_Toeplitzcovariancestructure: ;
@@ -206,174 +206,174 @@ niiri:fafe4f020120967e1209b04b4047a6d8
     nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
     nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
 
-niiri:9901152e1edbdcc6b11265389688c067
+niiri:8046eef7fa36943b17e5e6602af44bf4
     a prov:Activity, nidm_ModelParametersEstimation: ; 
     rdfs:label "Model parameters estimation" ;
     nidm_withEstimationMethod: obo_generalizedleastsquaresestimation: .
 
-niiri:9901152e1edbdcc6b11265389688c067 prov:wasAssociatedWith niiri:52f92964e671e1d8d4081235cbd4d416 .
+niiri:8046eef7fa36943b17e5e6602af44bf4 prov:wasAssociatedWith niiri:74d6e660a818385ae6d5eebb86f94754 .
 
-niiri:9901152e1edbdcc6b11265389688c067 prov:used niiri:d5494df7777ae492a16186e356e4067e .
+niiri:8046eef7fa36943b17e5e6602af44bf4 prov:used niiri:7e38970ca6e0c04540e0958cfd68a076 .
 
-niiri:9901152e1edbdcc6b11265389688c067 prov:used niiri:9c389356d338253eeebec534a36dc9fb .
+niiri:8046eef7fa36943b17e5e6602af44bf4 prov:used niiri:a408442578dc3ad4a6905f9711e6a6c3 .
 
-niiri:9901152e1edbdcc6b11265389688c067 prov:used niiri:fafe4f020120967e1209b04b4047a6d8 .
+niiri:8046eef7fa36943b17e5e6602af44bf4 prov:used niiri:6f865b9d321b1a0b96e5376fd02d63ef .
 
-niiri:c94d3131e2527389b29e033e4981de4b
+niiri:93aaa88123d0eb90e6fdecebf810f8ea
     a prov:Entity, nidm_MaskMap: ; 
     prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
     nidm_isUserDefined: "false"^^xsd:boolean ;
     nfo:fileName "Mask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Mask" ;
-    nidm_inCoordinateSpace: niiri:1127eeccd626c09c472b158bcb760db8 ;
+    nidm_inCoordinateSpace: niiri:3be25c24ad21044b41a1490e0f682fbe ;
     crypto:sha512 "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876"^^xsd:string .
 
-niiri:e8dce15e30732db359639d389c2aba1c
+niiri:b9432ea6450538366288502c57b612c8
     a prov:Entity, nidm_MaskMap: ; 
     nfo:fileName "mask.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "36929e1f5f4143bd9cc818cd896a25f129961fab208c3a4438555f40444c08347b359142ee8c53ece6e8cca1627f49db0788a1fd3b9e2ecaef61999c6c6c67ac"^^xsd:string .
 
-niiri:c94d3131e2527389b29e033e4981de4b prov:wasDerivedFrom niiri:e8dce15e30732db359639d389c2aba1c .
+niiri:93aaa88123d0eb90e6fdecebf810f8ea prov:wasDerivedFrom niiri:b9432ea6450538366288502c57b612c8 .
 
-niiri:c94d3131e2527389b29e033e4981de4b prov:wasGeneratedBy niiri:9901152e1edbdcc6b11265389688c067 .
+niiri:93aaa88123d0eb90e6fdecebf810f8ea prov:wasGeneratedBy niiri:8046eef7fa36943b17e5e6602af44bf4 .
 
-niiri:3a7a8d534182ba1b22f26cd278915417
+niiri:f6a969c39d0994e548cee708ab2235b8
     a prov:Entity, nidm_GrandMeanMap: ; 
     prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
     nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Grand Mean Map" ;
     nidm_maskedMedian: "111.557487487793"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:1127eeccd626c09c472b158bcb760db8 ;
+    nidm_inCoordinateSpace: niiri:3be25c24ad21044b41a1490e0f682fbe ;
     crypto:sha512 "512157cc6bff89d9343a09b4068226eb3edd64a8cbcee861f06231767fae6f8d4819921182adebee083a9bf309afd65529ab04a92f0aa6b0038c8098550f6124"^^xsd:string .
 
-niiri:3a7a8d534182ba1b22f26cd278915417 prov:wasGeneratedBy niiri:9901152e1edbdcc6b11265389688c067 .
+niiri:f6a969c39d0994e548cee708ab2235b8 prov:wasGeneratedBy niiri:8046eef7fa36943b17e5e6602af44bf4 .
 
-niiri:6d5f38b4cf5fcc51002ecf487245e8bf
+niiri:496fab100c7ba03c3adaf6aa62510d80
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0001.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0001.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 1" ;
-    nidm_inCoordinateSpace: niiri:1127eeccd626c09c472b158bcb760db8 ;
+    nidm_inCoordinateSpace: niiri:3be25c24ad21044b41a1490e0f682fbe ;
     crypto:sha512 "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd"^^xsd:string .
 
-niiri:8660e77d634f2c673d9632bf88e8978f
+niiri:1f32cb91cd9bb85763a6e2ea06c295b1
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd"^^xsd:string .
 
-niiri:6d5f38b4cf5fcc51002ecf487245e8bf prov:wasDerivedFrom niiri:8660e77d634f2c673d9632bf88e8978f .
+niiri:496fab100c7ba03c3adaf6aa62510d80 prov:wasDerivedFrom niiri:1f32cb91cd9bb85763a6e2ea06c295b1 .
 
-niiri:6d5f38b4cf5fcc51002ecf487245e8bf prov:wasGeneratedBy niiri:9901152e1edbdcc6b11265389688c067 .
+niiri:496fab100c7ba03c3adaf6aa62510d80 prov:wasGeneratedBy niiri:8046eef7fa36943b17e5e6602af44bf4 .
 
-niiri:68d5d8de26c5bbf881cee5708b10409d
+niiri:aad4f64b78f4368cc8545781af63aeeb
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0002.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0002.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 2" ;
-    nidm_inCoordinateSpace: niiri:1127eeccd626c09c472b158bcb760db8 ;
+    nidm_inCoordinateSpace: niiri:3be25c24ad21044b41a1490e0f682fbe ;
     crypto:sha512 "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c"^^xsd:string .
 
-niiri:7609134ba457289c21bce5fbc0cfbcb0
+niiri:8890ba1e2038c1a9257fc78e24e62373
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0002.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c"^^xsd:string .
 
-niiri:68d5d8de26c5bbf881cee5708b10409d prov:wasDerivedFrom niiri:7609134ba457289c21bce5fbc0cfbcb0 .
+niiri:aad4f64b78f4368cc8545781af63aeeb prov:wasDerivedFrom niiri:8890ba1e2038c1a9257fc78e24e62373 .
 
-niiri:68d5d8de26c5bbf881cee5708b10409d prov:wasGeneratedBy niiri:9901152e1edbdcc6b11265389688c067 .
+niiri:aad4f64b78f4368cc8545781af63aeeb prov:wasGeneratedBy niiri:8046eef7fa36943b17e5e6602af44bf4 .
 
-niiri:c472a3264f2854cfa09ed3e9ed65cdae
+niiri:9f8e0d06fd0a9c289c938c9e062c5aec
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0003.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0003.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 3" ;
-    nidm_inCoordinateSpace: niiri:1127eeccd626c09c472b158bcb760db8 ;
+    nidm_inCoordinateSpace: niiri:3be25c24ad21044b41a1490e0f682fbe ;
     crypto:sha512 "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373"^^xsd:string .
 
-niiri:f721c3a9d1f9739dc70e18f5f57f2604
+niiri:4418d957014ed912ea3172a7f573bb8e
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0003.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373"^^xsd:string .
 
-niiri:c472a3264f2854cfa09ed3e9ed65cdae prov:wasDerivedFrom niiri:f721c3a9d1f9739dc70e18f5f57f2604 .
+niiri:9f8e0d06fd0a9c289c938c9e062c5aec prov:wasDerivedFrom niiri:4418d957014ed912ea3172a7f573bb8e .
 
-niiri:c472a3264f2854cfa09ed3e9ed65cdae prov:wasGeneratedBy niiri:9901152e1edbdcc6b11265389688c067 .
+niiri:9f8e0d06fd0a9c289c938c9e062c5aec prov:wasGeneratedBy niiri:8046eef7fa36943b17e5e6602af44bf4 .
 
-niiri:f8270f04e628178e3f2cf1af6df1fdaa
+niiri:47932f62f0b280c5b5907959d9b94b4e
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Residual Mean Squares Map" ;
-    nidm_inCoordinateSpace: niiri:1127eeccd626c09c472b158bcb760db8 ;
+    nidm_inCoordinateSpace: niiri:3be25c24ad21044b41a1490e0f682fbe ;
     crypto:sha512 "991abf563d795a43b1e2eef8643e57023f2e0b090b2031f05f839321fc0643df6f71d423486a1021519b6dc82f6b0f563e19f3fbd50cb16063bed54a0e192d3e"^^xsd:string .
 
-niiri:260de665f44e1d8b8277860f9efe6331
+niiri:cc2c7bdd65030f68b7d32e21eb4af9f8
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     nfo:fileName "ResMS.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "40b28d03fcf9a2f60b11f10d7fb83bf3618b234fb5aedf09df644cb7cbb6aab8c9f468897c1078166d455a3d04a83f4e3bf762cfca0b4ea982d7a4e406849f18"^^xsd:string .
 
-niiri:f8270f04e628178e3f2cf1af6df1fdaa prov:wasDerivedFrom niiri:260de665f44e1d8b8277860f9efe6331 .
+niiri:47932f62f0b280c5b5907959d9b94b4e prov:wasDerivedFrom niiri:cc2c7bdd65030f68b7d32e21eb4af9f8 .
 
-niiri:f8270f04e628178e3f2cf1af6df1fdaa prov:wasGeneratedBy niiri:9901152e1edbdcc6b11265389688c067 .
+niiri:47932f62f0b280c5b5907959d9b94b4e prov:wasGeneratedBy niiri:8046eef7fa36943b17e5e6602af44bf4 .
 
-niiri:449f64d462b57d4f54e0bb6abddf4400
+niiri:6dda6fa299c24eac1686b577a1c4e494
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Resels per Voxel Map" ;
-    nidm_inCoordinateSpace: niiri:1127eeccd626c09c472b158bcb760db8 ;
+    nidm_inCoordinateSpace: niiri:3be25c24ad21044b41a1490e0f682fbe ;
     crypto:sha512 "1a3f9216e145249ccc0b14b2bc337d6b38b81ad45e32768001fb22b35f0c2c0f3e2bce013b40c85f7dc0fc62723ac761ee7f7e1e6aff128a05f0ba7b8b8202a3"^^xsd:string .
 
-niiri:bbbe81a27a24949db6149dd406cddb95
+niiri:9fa6f41590f6fa9fe1449b0b7f65fc88
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     nfo:fileName "RPV.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "4f76663162857f6b38b2a45a63b15a23b2ca8b338c283b69c1e71f2ea2f43797d045a733cd14e845be9c12f8b8f84d3931c599a08e8f6d77e99fab46ad87ab8f"^^xsd:string .
 
-niiri:449f64d462b57d4f54e0bb6abddf4400 prov:wasDerivedFrom niiri:bbbe81a27a24949db6149dd406cddb95 .
+niiri:6dda6fa299c24eac1686b577a1c4e494 prov:wasDerivedFrom niiri:9fa6f41590f6fa9fe1449b0b7f65fc88 .
 
-niiri:449f64d462b57d4f54e0bb6abddf4400 prov:wasGeneratedBy niiri:9901152e1edbdcc6b11265389688c067 .
+niiri:6dda6fa299c24eac1686b577a1c4e494 prov:wasGeneratedBy niiri:8046eef7fa36943b17e5e6602af44bf4 .
 
-niiri:88dc071de92a25a2e0c9dcc7db77b6d3
+niiri:720cff657408138421d0937c76c9977e
     a prov:Entity, obo_contrastweightmatrix: ; 
     nidm_statisticType: obo_tstatistic: ;
     nidm_contrastName: "tone counting vs baseline"^^xsd:string ;
     rdfs:label "Contrast: tone counting vs baseline" ;
     prov:value "[1, 0, 0]"^^xsd:string .
 
-niiri:3d18e1203d5106e7daa8878637c03253
+niiri:762a33bdcc17b1b2d48897c26bcf8007
     a prov:Activity, nidm_ContrastEstimation: ; 
     rdfs:label "Contrast estimation" .
 
-niiri:3d18e1203d5106e7daa8878637c03253 prov:wasAssociatedWith niiri:52f92964e671e1d8d4081235cbd4d416 .
+niiri:762a33bdcc17b1b2d48897c26bcf8007 prov:wasAssociatedWith niiri:74d6e660a818385ae6d5eebb86f94754 .
 
-niiri:3d18e1203d5106e7daa8878637c03253 prov:used niiri:c94d3131e2527389b29e033e4981de4b .
+niiri:762a33bdcc17b1b2d48897c26bcf8007 prov:used niiri:93aaa88123d0eb90e6fdecebf810f8ea .
 
-niiri:3d18e1203d5106e7daa8878637c03253 prov:used niiri:f8270f04e628178e3f2cf1af6df1fdaa .
+niiri:762a33bdcc17b1b2d48897c26bcf8007 prov:used niiri:47932f62f0b280c5b5907959d9b94b4e .
 
-niiri:3d18e1203d5106e7daa8878637c03253 prov:used niiri:d5494df7777ae492a16186e356e4067e .
+niiri:762a33bdcc17b1b2d48897c26bcf8007 prov:used niiri:7e38970ca6e0c04540e0958cfd68a076 .
 
-niiri:3d18e1203d5106e7daa8878637c03253 prov:used niiri:88dc071de92a25a2e0c9dcc7db77b6d3 .
+niiri:762a33bdcc17b1b2d48897c26bcf8007 prov:used niiri:720cff657408138421d0937c76c9977e .
 
-niiri:3d18e1203d5106e7daa8878637c03253 prov:used niiri:6d5f38b4cf5fcc51002ecf487245e8bf .
+niiri:762a33bdcc17b1b2d48897c26bcf8007 prov:used niiri:496fab100c7ba03c3adaf6aa62510d80 .
 
-niiri:3d18e1203d5106e7daa8878637c03253 prov:used niiri:68d5d8de26c5bbf881cee5708b10409d .
+niiri:762a33bdcc17b1b2d48897c26bcf8007 prov:used niiri:aad4f64b78f4368cc8545781af63aeeb .
 
-niiri:3d18e1203d5106e7daa8878637c03253 prov:used niiri:c472a3264f2854cfa09ed3e9ed65cdae .
+niiri:762a33bdcc17b1b2d48897c26bcf8007 prov:used niiri:9f8e0d06fd0a9c289c938c9e062c5aec .
 
-niiri:a5292be8959cf336f6446ca7c7862413
+niiri:9e31766e27104879ffdde1e5cc7cfca0
     a prov:Entity, nidm_StatisticMap: ; 
     prov:atLocation "TStatistic.nii.gz"^^xsd:anyURI ;
     nfo:fileName "TStatistic.nii.gz"^^xsd:string ;
@@ -383,124 +383,124 @@ niiri:a5292be8959cf336f6446ca7c7862413
     nidm_contrastName: "tone counting vs baseline"^^xsd:string ;
     nidm_errorDegreesOfFreedom: "97.9999999998522"^^xsd:float ;
     nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:1127eeccd626c09c472b158bcb760db8 ;
+    nidm_inCoordinateSpace: niiri:3be25c24ad21044b41a1490e0f682fbe ;
     crypto:sha512 "9e1714c2d86a050b38b4e10a4d2d23253a24c5e1d228ae16a9c3be8872739278505ac0729ecab54265a717e3a54f9f782d0ed72eea904e0d482a6072bb817bd4"^^xsd:string .
 
-niiri:4676a34b60d2f621bd1c38c4a5559a49
+niiri:4c17423a353140952a61dff8ed7694f1
     a prov:Entity, nidm_StatisticMap: ; 
     nfo:fileName "spmT_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "d288b1b0f117f64502555da13c5398dffa5bf5ff0b58951510e43d5388755bc185798802a92e98a07c7e313c6991066d2908f2a44aa5153ba23433da1335970f"^^xsd:string .
 
-niiri:a5292be8959cf336f6446ca7c7862413 prov:wasDerivedFrom niiri:4676a34b60d2f621bd1c38c4a5559a49 .
+niiri:9e31766e27104879ffdde1e5cc7cfca0 prov:wasDerivedFrom niiri:4c17423a353140952a61dff8ed7694f1 .
 
-niiri:a5292be8959cf336f6446ca7c7862413 prov:wasGeneratedBy niiri:3d18e1203d5106e7daa8878637c03253 .
+niiri:9e31766e27104879ffdde1e5cc7cfca0 prov:wasGeneratedBy niiri:762a33bdcc17b1b2d48897c26bcf8007 .
 
-niiri:9bf979a8424e5c8381ed186a464dafd0
+niiri:408aa82e300c1bcdfaa6514d653e1ce2
     a prov:Entity, nidm_ContrastMap: ; 
     prov:atLocation "Contrast.nii.gz"^^xsd:anyURI ;
     nfo:fileName "Contrast.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Map: tone counting vs baseline" ;
     nidm_contrastName: "tone counting vs baseline"^^xsd:string ;
-    nidm_inCoordinateSpace: niiri:1127eeccd626c09c472b158bcb760db8 ;
+    nidm_inCoordinateSpace: niiri:3be25c24ad21044b41a1490e0f682fbe ;
     crypto:sha512 "fc5e2ad175243ee496db98f9b2e1b235c4c3bae1a8d7122ce461c897b537e40c49dfee5d6cf20f71c6a2bb9b5f0760fcb4ecd8fe2e9428910ef3d60d8f3c56a9"^^xsd:string .
 
-niiri:166e30b1433b6a886b27bc045c33c3f4
+niiri:cff88ab938d4b310b3c713cd35e0fe37
     a prov:Entity, nidm_ContrastMap: ; 
     nfo:fileName "con_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "d4aa46b3603ba508578e39751262d528cf6d1ed2e722ec46f1cd8194c50591e46b229deb8cb4f72d1b7e0e2640f3e6604be7a335301c5c8357f453e5d0d4daf2"^^xsd:string .
 
-niiri:9bf979a8424e5c8381ed186a464dafd0 prov:wasDerivedFrom niiri:166e30b1433b6a886b27bc045c33c3f4 .
+niiri:408aa82e300c1bcdfaa6514d653e1ce2 prov:wasDerivedFrom niiri:cff88ab938d4b310b3c713cd35e0fe37 .
 
-niiri:9bf979a8424e5c8381ed186a464dafd0 prov:wasGeneratedBy niiri:3d18e1203d5106e7daa8878637c03253 .
+niiri:408aa82e300c1bcdfaa6514d653e1ce2 prov:wasGeneratedBy niiri:762a33bdcc17b1b2d48897c26bcf8007 .
 
-niiri:edb80ffff51690671b2437a48f367b46
+niiri:07a068606e54965b58e412b432e2dad0
     a prov:Entity, nidm_ContrastStandardErrorMap: ; 
     prov:atLocation "ContrastStandardError.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ContrastStandardError.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Standard Error Map" ;
-    nidm_inCoordinateSpace: niiri:1127eeccd626c09c472b158bcb760db8 ;
+    nidm_inCoordinateSpace: niiri:3be25c24ad21044b41a1490e0f682fbe ;
     crypto:sha512 "791d48f5d1adb15079a5289271ce0c4b95c56d69bfdb3e5d41b0d24eb538d3075e1cdd15502494b5a5a18c16eaa2153cb4847a996043fa48cdaf26e938a2576d"^^xsd:string .
 
-niiri:edb80ffff51690671b2437a48f367b46 prov:wasGeneratedBy niiri:3d18e1203d5106e7daa8878637c03253 .
+niiri:07a068606e54965b58e412b432e2dad0 prov:wasGeneratedBy niiri:762a33bdcc17b1b2d48897c26bcf8007 .
 
-niiri:ab9638a722e6781f49cb6679ce6d0186
+niiri:703d6663b8b0a7e5af770bf42097a7a5
     a prov:Entity, nidm_HeightThreshold:, obo_FWERadjustedpvalue: ; 
     rdfs:label "Height Threshold: p<0.050000 (FWE)" ;
     prov:value "0.0499999999999967"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:df5d1bc86395c77a43f625cc82ff0d80 ;
-    nidm_equivalentThreshold: niiri:137006717871910c9d0f148009c727c1 .
+    nidm_equivalentThreshold: niiri:87e79402ab52e67f17ce83dce886d63d ;
+    nidm_equivalentThreshold: niiri:da5b4e4633c1626f16d7753556c47622 .
 
-niiri:df5d1bc86395c77a43f625cc82ff0d80
+niiri:87e79402ab52e67f17ce83dce886d63d
     a prov:Entity, nidm_HeightThreshold:, obo_statistic: ; 
-    rdfs:label "Height Threshold" ;
+    rdfs:label "Height Threshold: T=5.309631)" ;
     prov:value "5.30963135104407"^^xsd:float .
 
-niiri:137006717871910c9d0f148009c727c1
+niiri:da5b4e4633c1626f16d7753556c47622
     a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
-    rdfs:label "Height Threshold" ;
+    rdfs:label "Height Threshold: p<0.000000 (unc.)" ;
     prov:value "3.42878635595234e-07"^^xsd:float .
 
-niiri:ea3d63b1b41ccc3e3a69810e1a717f88
+niiri:3a5d48d8e1368e4d94c100cf543902e9
     a prov:Entity, nidm_ExtentThreshold:, obo_statistic: ; 
     rdfs:label "Extent Threshold: k>=0" ;
     nidm_clusterSizeInVoxels: "0"^^xsd:int ;
     nidm_clusterSizeInResels: "0"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:b536f0ba7a0a67e91feeed9ca64cb19c ;
-    nidm_equivalentThreshold: niiri:da619a636b99bf0fa78bb8a62ec8e6b2 .
+    nidm_equivalentThreshold: niiri:9cb8b91842cd77b672741eb02ea56b65 ;
+    nidm_equivalentThreshold: niiri:a968ca4e2c9ad53ae495a34b0aff3ef1 .
 
-niiri:b536f0ba7a0a67e91feeed9ca64cb19c
+niiri:9cb8b91842cd77b672741eb02ea56b65
     a prov:Entity, nidm_ExtentThreshold:, obo_FWERadjustedpvalue: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:da619a636b99bf0fa78bb8a62ec8e6b2
+niiri:a968ca4e2c9ad53ae495a34b0aff3ef1
     a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:648962244cdcb3f84950de7035a522c7
+niiri:b3769611f936098c6d9afc7f67ffa3db
     a prov:Entity, nidm_PeakDefinitionCriteria: ; 
     rdfs:label "Peak Definition Criteria" ;
     nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
     nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
 
-niiri:22dfacf7ee18da508be60ad1eb7f743b
+niiri:0c26b2da6d51d1ddd8679deddd2d40f9
     a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
     rdfs:label "Cluster Connectivity Criterion: 18" ;
     nidm_hasConnectivityCriterion: nidm_voxel18connected: .
 
-niiri:85336313a51ea40ecee23f961cfe0ca3
+niiri:bb244e720c06e715f97d3d6a86a4da4a
     a prov:Activity, nidm_Inference: ; 
     nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
     rdfs:label "Inference" .
 
-niiri:85336313a51ea40ecee23f961cfe0ca3 prov:wasAssociatedWith niiri:52f92964e671e1d8d4081235cbd4d416 .
+niiri:bb244e720c06e715f97d3d6a86a4da4a prov:wasAssociatedWith niiri:74d6e660a818385ae6d5eebb86f94754 .
 
-niiri:85336313a51ea40ecee23f961cfe0ca3 prov:used niiri:ab9638a722e6781f49cb6679ce6d0186 .
+niiri:bb244e720c06e715f97d3d6a86a4da4a prov:used niiri:703d6663b8b0a7e5af770bf42097a7a5 .
 
-niiri:85336313a51ea40ecee23f961cfe0ca3 prov:used niiri:ea3d63b1b41ccc3e3a69810e1a717f88 .
+niiri:bb244e720c06e715f97d3d6a86a4da4a prov:used niiri:3a5d48d8e1368e4d94c100cf543902e9 .
 
-niiri:85336313a51ea40ecee23f961cfe0ca3 prov:used niiri:a5292be8959cf336f6446ca7c7862413 .
+niiri:bb244e720c06e715f97d3d6a86a4da4a prov:used niiri:9e31766e27104879ffdde1e5cc7cfca0 .
 
-niiri:85336313a51ea40ecee23f961cfe0ca3 prov:used niiri:449f64d462b57d4f54e0bb6abddf4400 .
+niiri:bb244e720c06e715f97d3d6a86a4da4a prov:used niiri:6dda6fa299c24eac1686b577a1c4e494 .
 
-niiri:85336313a51ea40ecee23f961cfe0ca3 prov:used niiri:c94d3131e2527389b29e033e4981de4b .
+niiri:bb244e720c06e715f97d3d6a86a4da4a prov:used niiri:93aaa88123d0eb90e6fdecebf810f8ea .
 
-niiri:85336313a51ea40ecee23f961cfe0ca3 prov:used niiri:648962244cdcb3f84950de7035a522c7 .
+niiri:bb244e720c06e715f97d3d6a86a4da4a prov:used niiri:b3769611f936098c6d9afc7f67ffa3db .
 
-niiri:85336313a51ea40ecee23f961cfe0ca3 prov:used niiri:22dfacf7ee18da508be60ad1eb7f743b .
+niiri:bb244e720c06e715f97d3d6a86a4da4a prov:used niiri:0c26b2da6d51d1ddd8679deddd2d40f9 .
 
-niiri:25eaac69fdefeb840e2ba86ef15eb0c1
+niiri:affcc7f63cecbd281de0115f299e13ad
     a prov:Entity, nidm_SearchSpaceMaskMap: ; 
     prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
     nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Search Space Mask Map" ;
-    nidm_inCoordinateSpace: niiri:1127eeccd626c09c472b158bcb760db8 ;
+    nidm_inCoordinateSpace: niiri:3be25c24ad21044b41a1490e0f682fbe ;
     nidm_searchVolumeInVoxels: "223057"^^xsd:int ;
     nidm_searchVolumeInUnits: "1784456"^^xsd:float ;
     nidm_reselSizeInVoxels: "65.5786964036542"^^xsd:float ;
@@ -517,9 +517,9 @@ niiri:25eaac69fdefeb840e2ba86ef15eb0c1
     spm_smallestSignificantClusterSizeInVoxelsFWE05: "1"^^xsd:int ;
     spm_smallestSignificantClusterSizeInVoxelsFDR05: "8"^^xsd:int .
 
-niiri:25eaac69fdefeb840e2ba86ef15eb0c1 prov:wasGeneratedBy niiri:85336313a51ea40ecee23f961cfe0ca3 .
+niiri:affcc7f63cecbd281de0115f299e13ad prov:wasGeneratedBy niiri:bb244e720c06e715f97d3d6a86a4da4a .
 
-niiri:628ed5e363137da007004818bec3bff7
+niiri:a3de06f5c7d45a76d1c3457418a9e61f
     a prov:Entity, nidm_ExcursionSetMap: ; 
     prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
@@ -527,29 +527,29 @@ niiri:628ed5e363137da007004818bec3bff7
     rdfs:label "Excursion Set Map" ;
     nidm_numberOfSupraThresholdClusters: "20"^^xsd:int ;
     nidm_pValue: "0"^^xsd:float ;
-    nidm_hasClusterLabelsMap: niiri:51265c693499479f0b95041a2109ec12 ;
-    nidm_hasMaximumIntensityProjection: niiri:57aa0ae449bb4f57b30028d3d40429d2 ;
-    nidm_inCoordinateSpace: niiri:1127eeccd626c09c472b158bcb760db8 ;
+    nidm_hasClusterLabelsMap: niiri:1ed0d3c61d4035abac6d7a8a92b5b5f4 ;
+    nidm_hasMaximumIntensityProjection: niiri:f4a88590bef4ba051367275e27b75c25 ;
+    nidm_inCoordinateSpace: niiri:3be25c24ad21044b41a1490e0f682fbe ;
     crypto:sha512 "265cb94fb9c73751fd120863a3f69a3dde7f5117f8da44dc6df2fb096c8ce3d98b375d48d4f6c2760f68a99b111229eaa4af4f2420e0540aa25cdc1ea265f77f"^^xsd:string .
 
-niiri:51265c693499479f0b95041a2109ec12
+niiri:1ed0d3c61d4035abac6d7a8a92b5b5f4
     a prov:Entity, nidm_ClusterLabelsMap: ; 
     prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Cluster Labels Map" ;
-    nidm_inCoordinateSpace: niiri:1127eeccd626c09c472b158bcb760db8 ;
+    nidm_inCoordinateSpace: niiri:3be25c24ad21044b41a1490e0f682fbe ;
     crypto:sha512 "593cccacd254c0341525c4f72f09eeef0276c39f43887eac64d62883472fe3e6b331d55e3d80bc906686031d59034546bf594a3161a90eb01553b77ca481cb45"^^xsd:string .
 
-niiri:57aa0ae449bb4f57b30028d3d40429d2
+niiri:f4a88590bef4ba051367275e27b75c25
     a prov:Entity, dctype:Image ; 
     prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
     nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:628ed5e363137da007004818bec3bff7 prov:wasGeneratedBy niiri:85336313a51ea40ecee23f961cfe0ca3 .
+niiri:a3de06f5c7d45a76d1c3457418a9e61f prov:wasGeneratedBy niiri:bb244e720c06e715f97d3d6a86a4da4a .
 
-niiri:c51c746038ebe18ddcd5ba77c41c8878
+niiri:155481980ff1c28f6346fa37f1ee5ef4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0001" ;
     nidm_clusterSizeInVoxels: "124"^^xsd:int ;
@@ -559,9 +559,9 @@ niiri:c51c746038ebe18ddcd5ba77c41c8878
     nidm_qValueFDR: "2.46878555697161e-09"^^xsd:float ;
     nidm_clusterLabelId: "1"^^xsd:int .
 
-niiri:c51c746038ebe18ddcd5ba77c41c8878 prov:wasDerivedFrom niiri:628ed5e363137da007004818bec3bff7 .
+niiri:155481980ff1c28f6346fa37f1ee5ef4 prov:wasDerivedFrom niiri:a3de06f5c7d45a76d1c3457418a9e61f .
 
-niiri:3b684cec3a71a7e7ee23ab3e5ae5ed46
+niiri:f35f708a48ecddb6ea1a7e5fb2de3313
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0002" ;
     nidm_clusterSizeInVoxels: "43"^^xsd:int ;
@@ -571,9 +571,9 @@ niiri:3b684cec3a71a7e7ee23ab3e5ae5ed46
     nidm_qValueFDR: "6.43029921401949e-05"^^xsd:float ;
     nidm_clusterLabelId: "2"^^xsd:int .
 
-niiri:3b684cec3a71a7e7ee23ab3e5ae5ed46 prov:wasDerivedFrom niiri:628ed5e363137da007004818bec3bff7 .
+niiri:f35f708a48ecddb6ea1a7e5fb2de3313 prov:wasDerivedFrom niiri:a3de06f5c7d45a76d1c3457418a9e61f .
 
-niiri:ca441cca951d825d8ff7f38c616fbb51
+niiri:d9d669c3d9951cd5e034e1af813346b3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0003" ;
     nidm_clusterSizeInVoxels: "19"^^xsd:int ;
@@ -583,9 +583,9 @@ niiri:ca441cca951d825d8ff7f38c616fbb51
     nidm_qValueFDR: "0.00415604286287398"^^xsd:float ;
     nidm_clusterLabelId: "3"^^xsd:int .
 
-niiri:ca441cca951d825d8ff7f38c616fbb51 prov:wasDerivedFrom niiri:628ed5e363137da007004818bec3bff7 .
+niiri:d9d669c3d9951cd5e034e1af813346b3 prov:wasDerivedFrom niiri:a3de06f5c7d45a76d1c3457418a9e61f .
 
-niiri:9eea553f10bd8f4b3795cb0ec668d04a
+niiri:7e1b3b0f62b55d18a395035fc7feee73
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0004" ;
     nidm_clusterSizeInVoxels: "62"^^xsd:int ;
@@ -595,9 +595,9 @@ niiri:9eea553f10bd8f4b3795cb0ec668d04a
     nidm_qValueFDR: "5.72804953447324e-06"^^xsd:float ;
     nidm_clusterLabelId: "4"^^xsd:int .
 
-niiri:9eea553f10bd8f4b3795cb0ec668d04a prov:wasDerivedFrom niiri:628ed5e363137da007004818bec3bff7 .
+niiri:7e1b3b0f62b55d18a395035fc7feee73 prov:wasDerivedFrom niiri:a3de06f5c7d45a76d1c3457418a9e61f .
 
-niiri:2d914f94e173af2f1db4279a36559ade
+niiri:119c3306aea58b790a250dbf6a0c5f81
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0005" ;
     nidm_clusterSizeInVoxels: "40"^^xsd:int ;
@@ -607,9 +607,9 @@ niiri:2d914f94e173af2f1db4279a36559ade
     nidm_qValueFDR: "8.74033311196969e-05"^^xsd:float ;
     nidm_clusterLabelId: "5"^^xsd:int .
 
-niiri:2d914f94e173af2f1db4279a36559ade prov:wasDerivedFrom niiri:628ed5e363137da007004818bec3bff7 .
+niiri:119c3306aea58b790a250dbf6a0c5f81 prov:wasDerivedFrom niiri:a3de06f5c7d45a76d1c3457418a9e61f .
 
-niiri:45e7bec8674ce00242a3ca1ba3e28aa4
+niiri:c3280a96b8b08a46c09804cff4f111ff
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0006" ;
     nidm_clusterSizeInVoxels: "14"^^xsd:int ;
@@ -619,9 +619,9 @@ niiri:45e7bec8674ce00242a3ca1ba3e28aa4
     nidm_qValueFDR: "0.0107686515246665"^^xsd:float ;
     nidm_clusterLabelId: "6"^^xsd:int .
 
-niiri:45e7bec8674ce00242a3ca1ba3e28aa4 prov:wasDerivedFrom niiri:628ed5e363137da007004818bec3bff7 .
+niiri:c3280a96b8b08a46c09804cff4f111ff prov:wasDerivedFrom niiri:a3de06f5c7d45a76d1c3457418a9e61f .
 
-niiri:4b4c73793148b97c0ff9a401778d980d
+niiri:15fc3f6b34f2cc43294db8febc2aa39d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0007" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -631,9 +631,9 @@ niiri:4b4c73793148b97c0ff9a401778d980d
     nidm_qValueFDR: "0.0743649146432896"^^xsd:float ;
     nidm_clusterLabelId: "7"^^xsd:int .
 
-niiri:4b4c73793148b97c0ff9a401778d980d prov:wasDerivedFrom niiri:628ed5e363137da007004818bec3bff7 .
+niiri:15fc3f6b34f2cc43294db8febc2aa39d prov:wasDerivedFrom niiri:a3de06f5c7d45a76d1c3457418a9e61f .
 
-niiri:1b44a27650bde23878594a9485c4d6d3
+niiri:ea4c51e6004ff6ca79763dfba6bceff9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0008" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -643,9 +643,9 @@ niiri:1b44a27650bde23878594a9485c4d6d3
     nidm_qValueFDR: "0.0424589474268"^^xsd:float ;
     nidm_clusterLabelId: "8"^^xsd:int .
 
-niiri:1b44a27650bde23878594a9485c4d6d3 prov:wasDerivedFrom niiri:628ed5e363137da007004818bec3bff7 .
+niiri:ea4c51e6004ff6ca79763dfba6bceff9 prov:wasDerivedFrom niiri:a3de06f5c7d45a76d1c3457418a9e61f .
 
-niiri:e9d92af50d7554f83a3d9f3b4072a7c1
+niiri:dc0951f37176f78fb716ea89f0b324b0
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0009" ;
     nidm_clusterSizeInVoxels: "22"^^xsd:int ;
@@ -655,9 +655,9 @@ niiri:e9d92af50d7554f83a3d9f3b4072a7c1
     nidm_qValueFDR: "0.00247926295274478"^^xsd:float ;
     nidm_clusterLabelId: "9"^^xsd:int .
 
-niiri:e9d92af50d7554f83a3d9f3b4072a7c1 prov:wasDerivedFrom niiri:628ed5e363137da007004818bec3bff7 .
+niiri:dc0951f37176f78fb716ea89f0b324b0 prov:wasDerivedFrom niiri:a3de06f5c7d45a76d1c3457418a9e61f .
 
-niiri:90ea7ec9beaea62022ae06ebf7877811
+niiri:0262c15e4838598f01a6cef257cb8e12
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0010" ;
     nidm_clusterSizeInVoxels: "15"^^xsd:int ;
@@ -667,9 +667,9 @@ niiri:90ea7ec9beaea62022ae06ebf7877811
     nidm_qValueFDR: "0.00942683054328996"^^xsd:float ;
     nidm_clusterLabelId: "10"^^xsd:int .
 
-niiri:90ea7ec9beaea62022ae06ebf7877811 prov:wasDerivedFrom niiri:628ed5e363137da007004818bec3bff7 .
+niiri:0262c15e4838598f01a6cef257cb8e12 prov:wasDerivedFrom niiri:a3de06f5c7d45a76d1c3457418a9e61f .
 
-niiri:246e46a571dda4f915565e71d61cb338
+niiri:c1725b381104011cabad0fc0b26d85db
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0011" ;
     nidm_clusterSizeInVoxels: "47"^^xsd:int ;
@@ -679,9 +679,9 @@ niiri:246e46a571dda4f915565e71d61cb338
     nidm_qValueFDR: "4.30909591394245e-05"^^xsd:float ;
     nidm_clusterLabelId: "11"^^xsd:int .
 
-niiri:246e46a571dda4f915565e71d61cb338 prov:wasDerivedFrom niiri:628ed5e363137da007004818bec3bff7 .
+niiri:c1725b381104011cabad0fc0b26d85db prov:wasDerivedFrom niiri:a3de06f5c7d45a76d1c3457418a9e61f .
 
-niiri:8c078951dde09de372f14e68653a15e1
+niiri:381dea70ad1c9ee61377f917ea0ce85d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0012" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -691,9 +691,9 @@ niiri:8c078951dde09de372f14e68653a15e1
     nidm_qValueFDR: "0.0424589474268"^^xsd:float ;
     nidm_clusterLabelId: "12"^^xsd:int .
 
-niiri:8c078951dde09de372f14e68653a15e1 prov:wasDerivedFrom niiri:628ed5e363137da007004818bec3bff7 .
+niiri:381dea70ad1c9ee61377f917ea0ce85d prov:wasDerivedFrom niiri:a3de06f5c7d45a76d1c3457418a9e61f .
 
-niiri:500eb4af4185b2297823a2218c285d60
+niiri:9b79a74d8af6455c348a5ada6380936b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0013" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -703,9 +703,9 @@ niiri:500eb4af4185b2297823a2218c285d60
     nidm_qValueFDR: "0.17447384009749"^^xsd:float ;
     nidm_clusterLabelId: "13"^^xsd:int .
 
-niiri:500eb4af4185b2297823a2218c285d60 prov:wasDerivedFrom niiri:628ed5e363137da007004818bec3bff7 .
+niiri:9b79a74d8af6455c348a5ada6380936b prov:wasDerivedFrom niiri:a3de06f5c7d45a76d1c3457418a9e61f .
 
-niiri:4768dfb4cd05c9ffe1d3d7d1f35cfe3d
+niiri:c2c282bcebcafee73ac596184605c302
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0014" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -715,9 +715,9 @@ niiri:4768dfb4cd05c9ffe1d3d7d1f35cfe3d
     nidm_qValueFDR: "0.0424589474268"^^xsd:float ;
     nidm_clusterLabelId: "14"^^xsd:int .
 
-niiri:4768dfb4cd05c9ffe1d3d7d1f35cfe3d prov:wasDerivedFrom niiri:628ed5e363137da007004818bec3bff7 .
+niiri:c2c282bcebcafee73ac596184605c302 prov:wasDerivedFrom niiri:a3de06f5c7d45a76d1c3457418a9e61f .
 
-niiri:a405d942872d5b85c1b4326d3a87b92c
+niiri:76b1ed7cd5606b2d502e4a5ee6dfe343
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0015" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -727,9 +727,9 @@ niiri:a405d942872d5b85c1b4326d3a87b92c
     nidm_qValueFDR: "0.0911602977421377"^^xsd:float ;
     nidm_clusterLabelId: "15"^^xsd:int .
 
-niiri:a405d942872d5b85c1b4326d3a87b92c prov:wasDerivedFrom niiri:628ed5e363137da007004818bec3bff7 .
+niiri:76b1ed7cd5606b2d502e4a5ee6dfe343 prov:wasDerivedFrom niiri:a3de06f5c7d45a76d1c3457418a9e61f .
 
-niiri:bd8460a11fb14617fc43ac91658b693e
+niiri:010ce656a5e597d871ca20ab1aa2a631
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0016" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -739,9 +739,9 @@ niiri:bd8460a11fb14617fc43ac91658b693e
     nidm_qValueFDR: "0.123830843185955"^^xsd:float ;
     nidm_clusterLabelId: "16"^^xsd:int .
 
-niiri:bd8460a11fb14617fc43ac91658b693e prov:wasDerivedFrom niiri:628ed5e363137da007004818bec3bff7 .
+niiri:010ce656a5e597d871ca20ab1aa2a631 prov:wasDerivedFrom niiri:a3de06f5c7d45a76d1c3457418a9e61f .
 
-niiri:8e7d24425dd5859e85ca7c28c012c5cd
+niiri:2083b75818d091b6724ed0adf40223ab
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0017" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -751,9 +751,9 @@ niiri:8e7d24425dd5859e85ca7c28c012c5cd
     nidm_qValueFDR: "0.0911602977421377"^^xsd:float ;
     nidm_clusterLabelId: "17"^^xsd:int .
 
-niiri:8e7d24425dd5859e85ca7c28c012c5cd prov:wasDerivedFrom niiri:628ed5e363137da007004818bec3bff7 .
+niiri:2083b75818d091b6724ed0adf40223ab prov:wasDerivedFrom niiri:a3de06f5c7d45a76d1c3457418a9e61f .
 
-niiri:59f598a957aabf6559fffdd51d733944
+niiri:e8fd4bf9f34c220cd368e846c6651d35
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0018" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -763,9 +763,9 @@ niiri:59f598a957aabf6559fffdd51d733944
     nidm_qValueFDR: "0.399512266692318"^^xsd:float ;
     nidm_clusterLabelId: "18"^^xsd:int .
 
-niiri:59f598a957aabf6559fffdd51d733944 prov:wasDerivedFrom niiri:628ed5e363137da007004818bec3bff7 .
+niiri:e8fd4bf9f34c220cd368e846c6651d35 prov:wasDerivedFrom niiri:a3de06f5c7d45a76d1c3457418a9e61f .
 
-niiri:3f6eaa65d9b555818ce062afbbcb140b
+niiri:4458d8f762604f7ee56c5d3e6ea96fca
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0019" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -775,9 +775,9 @@ niiri:3f6eaa65d9b555818ce062afbbcb140b
     nidm_qValueFDR: "0.399512266692318"^^xsd:float ;
     nidm_clusterLabelId: "19"^^xsd:int .
 
-niiri:3f6eaa65d9b555818ce062afbbcb140b prov:wasDerivedFrom niiri:628ed5e363137da007004818bec3bff7 .
+niiri:4458d8f762604f7ee56c5d3e6ea96fca prov:wasDerivedFrom niiri:a3de06f5c7d45a76d1c3457418a9e61f .
 
-niiri:608052d2152344776bc043455c610be4
+niiri:a2f1489aa082c9cb44338fd916006ecb
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0020" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -787,362 +787,362 @@ niiri:608052d2152344776bc043455c610be4
     nidm_qValueFDR: "0.399512266692318"^^xsd:float ;
     nidm_clusterLabelId: "20"^^xsd:int .
 
-niiri:608052d2152344776bc043455c610be4 prov:wasDerivedFrom niiri:628ed5e363137da007004818bec3bff7 .
+niiri:a2f1489aa082c9cb44338fd916006ecb prov:wasDerivedFrom niiri:a3de06f5c7d45a76d1c3457418a9e61f .
 
-niiri:01fcf9c0155b66439a6aa5860d0ac913
+niiri:5e6a56f172ddef202b4da0e41f9cac40
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0001" ;
-    prov:atLocation niiri:1d0398d8e569eb0353ff666b30dcdf39 ;
+    prov:atLocation niiri:98fc89ff01c715d715f3acefc9df825b ;
     prov:value "7.92007970809937"^^xsd:float ;
     nidm_equivalentZStatistic: "6.94608360738412"^^xsd:float ;
     nidm_pValueUncorrected: "1.87783122385099e-12"^^xsd:float ;
     nidm_pValueFWER: "4.18813870695089e-07"^^xsd:float ;
     nidm_qValueFDR: "0.000459866237621553"^^xsd:float .
 
-niiri:1d0398d8e569eb0353ff666b30dcdf39
+niiri:98fc89ff01c715d715f3acefc9df825b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0001" ;
     nidm_coordinateVector: "[46,16,24]"^^xsd:string .
 
-niiri:01fcf9c0155b66439a6aa5860d0ac913 prov:wasDerivedFrom niiri:c51c746038ebe18ddcd5ba77c41c8878 .
+niiri:5e6a56f172ddef202b4da0e41f9cac40 prov:wasDerivedFrom niiri:155481980ff1c28f6346fa37f1ee5ef4 .
 
-niiri:ef463294a81411e6150bb2869901d7cc
+niiri:2529591f9d1d6e7c2816bfaa6448acf1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0002" ;
-    prov:atLocation niiri:fa744f32234852bc21e3ac20fe196313 ;
+    prov:atLocation niiri:12bfe02a34239f27f80049317c87f105 ;
     prov:value "7.11683940887451"^^xsd:float ;
     nidm_equivalentZStatistic: "6.37404871703245"^^xsd:float ;
     nidm_pValueUncorrected: "9.20510334623259e-11"^^xsd:float ;
     nidm_pValueFWER: "2.05325778424026e-05"^^xsd:float ;
     nidm_qValueFDR: "0.00823125678700628"^^xsd:float .
 
-niiri:fa744f32234852bc21e3ac20fe196313
+niiri:12bfe02a34239f27f80049317c87f105
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0002" ;
     nidm_coordinateVector: "[34,-88,-2]"^^xsd:string .
 
-niiri:ef463294a81411e6150bb2869901d7cc prov:wasDerivedFrom niiri:3b684cec3a71a7e7ee23ab3e5ae5ed46 .
+niiri:2529591f9d1d6e7c2816bfaa6448acf1 prov:wasDerivedFrom niiri:f35f708a48ecddb6ea1a7e5fb2de3313 .
 
-niiri:e3f3a93c80561477075dacb11687288c
+niiri:6f9210e7353860292c6d8dfce2015490
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0003" ;
-    prov:atLocation niiri:e504c44421975e00e0819270bf92e746 ;
+    prov:atLocation niiri:b3ef8b609fa00ef16a539437e5692e6d ;
     prov:value "6.48292255401611"^^xsd:float ;
     nidm_equivalentZStatistic: "5.8992593141605"^^xsd:float ;
     nidm_pValueUncorrected: "1.82568493656277e-09"^^xsd:float ;
     nidm_pValueFWER: "0.000407231755366277"^^xsd:float ;
     nidm_qValueFDR: "0.0732298207475789"^^xsd:float .
 
-niiri:e504c44421975e00e0819270bf92e746
+niiri:b3ef8b609fa00ef16a539437e5692e6d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0003" ;
     nidm_coordinateVector: "[42,-72,-10]"^^xsd:string .
 
-niiri:e3f3a93c80561477075dacb11687288c prov:wasDerivedFrom niiri:ca441cca951d825d8ff7f38c616fbb51 .
+niiri:6f9210e7353860292c6d8dfce2015490 prov:wasDerivedFrom niiri:d9d669c3d9951cd5e034e1af813346b3 .
 
-niiri:b00846122635c838b5c53bc9f994a426
+niiri:1bd531de3356dab29c9e4ed53addc58b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0004" ;
-    prov:atLocation niiri:f64ad27b983a615df0c4ac02fae24146 ;
+    prov:atLocation niiri:096c52d0ef5b5dd96bf7ba644803410a ;
     prov:value "6.31603479385376"^^xsd:float ;
     nidm_equivalentZStatistic: "5.77079466112137"^^xsd:float ;
     nidm_pValueUncorrected: "3.94492849498107e-09"^^xsd:float ;
     nidm_pValueFWER: "0.000879943865776389"^^xsd:float ;
     nidm_qValueFDR: "0.0732298207475789"^^xsd:float .
 
-niiri:f64ad27b983a615df0c4ac02fae24146
+niiri:096c52d0ef5b5dd96bf7ba644803410a
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0004" ;
     nidm_coordinateVector: "[32,24,-4]"^^xsd:string .
 
-niiri:b00846122635c838b5c53bc9f994a426 prov:wasDerivedFrom niiri:9eea553f10bd8f4b3795cb0ec668d04a .
+niiri:1bd531de3356dab29c9e4ed53addc58b prov:wasDerivedFrom niiri:7e1b3b0f62b55d18a395035fc7feee73 .
 
-niiri:3e029b308699eb615152399d9b9e9a57
+niiri:ee2aed7c69b3aab0d47c0baab7ec0dbf
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0005" ;
-    prov:atLocation niiri:f308af61c2b895cc4b000546d7cb6daa ;
+    prov:atLocation niiri:72e36f2d9291f6b80ff10852dd16c763 ;
     prov:value "6.28007745742798"^^xsd:float ;
     nidm_equivalentZStatistic: "5.74292583422276"^^xsd:float ;
     nidm_pValueUncorrected: "4.65272453897825e-09"^^xsd:float ;
     nidm_pValueFWER: "0.00103782272796227"^^xsd:float ;
     nidm_qValueFDR: "0.0732298207475789"^^xsd:float .
 
-niiri:f308af61c2b895cc4b000546d7cb6daa
+niiri:72e36f2d9291f6b80ff10852dd16c763
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0005" ;
     nidm_coordinateVector: "[8,18,50]"^^xsd:string .
 
-niiri:3e029b308699eb615152399d9b9e9a57 prov:wasDerivedFrom niiri:2d914f94e173af2f1db4279a36559ade .
+niiri:ee2aed7c69b3aab0d47c0baab7ec0dbf prov:wasDerivedFrom niiri:119c3306aea58b790a250dbf6a0c5f81 .
 
-niiri:321e44b5f208d13cc7d475411e273e1a
+niiri:87f773c2297ccd49c8420518043f9edf
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0006" ;
-    prov:atLocation niiri:471942bd9e2ce557c043ab383d7446ce ;
+    prov:atLocation niiri:5c7506968ab01933f2a034010a609dab ;
     prov:value "6.25127363204956"^^xsd:float ;
     nidm_equivalentZStatistic: "5.72055271981637"^^xsd:float ;
     nidm_pValueUncorrected: "5.30890376104765e-09"^^xsd:float ;
     nidm_pValueFWER: "0.0011841880966994"^^xsd:float ;
     nidm_qValueFDR: "0.0732298207475789"^^xsd:float .
 
-niiri:471942bd9e2ce557c043ab383d7446ce
+niiri:5c7506968ab01933f2a034010a609dab
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0006" ;
     nidm_coordinateVector: "[52,-32,42]"^^xsd:string .
 
-niiri:321e44b5f208d13cc7d475411e273e1a prov:wasDerivedFrom niiri:45e7bec8674ce00242a3ca1ba3e28aa4 .
+niiri:87f773c2297ccd49c8420518043f9edf prov:wasDerivedFrom niiri:c3280a96b8b08a46c09804cff4f111ff .
 
-niiri:bd94858235a93a6b2c4bac257ddaa4ca
+niiri:0078f20a5b83c1a2beec64a3a6188b9d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0007" ;
-    prov:atLocation niiri:a9691554a0a728a8a1f3f85d8cf5fb09 ;
+    prov:atLocation niiri:3e1a6cc0a26ff99d9a700b7d7c44ee3f ;
     prov:value "6.24752378463745"^^xsd:float ;
     nidm_equivalentZStatistic: "5.71763687476157"^^xsd:float ;
     nidm_pValueUncorrected: "5.40078304300806e-09"^^xsd:float ;
     nidm_pValueFWER: "0.00120468241369565"^^xsd:float ;
     nidm_qValueFDR: "0.0732298207475789"^^xsd:float .
 
-niiri:a9691554a0a728a8a1f3f85d8cf5fb09
+niiri:3e1a6cc0a26ff99d9a700b7d7c44ee3f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0007" ;
     nidm_coordinateVector: "[40,-62,50]"^^xsd:string .
 
-niiri:bd94858235a93a6b2c4bac257ddaa4ca prov:wasDerivedFrom niiri:4b4c73793148b97c0ff9a401778d980d .
+niiri:0078f20a5b83c1a2beec64a3a6188b9d prov:wasDerivedFrom niiri:15fc3f6b34f2cc43294db8febc2aa39d .
 
-niiri:d4ce2f741b5177b2f48f4711f75a7d36
+niiri:4fef5b8d7f9adb35cbb0ab5a325d482f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0008" ;
-    prov:atLocation niiri:062ddacf1229773d0a7cfaef9ad28c2e ;
+    prov:atLocation niiri:902931c952cefdae6730925980730073 ;
     prov:value "6.15371799468994"^^xsd:float ;
     nidm_equivalentZStatistic: "5.64445580026639"^^xsd:float ;
     nidm_pValueUncorrected: "8.285227171001e-09"^^xsd:float ;
     nidm_pValueFWER: "0.00184807786755337"^^xsd:float ;
     nidm_qValueFDR: "0.0857472799805926"^^xsd:float .
 
-niiri:062ddacf1229773d0a7cfaef9ad28c2e
+niiri:902931c952cefdae6730925980730073
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0008" ;
     nidm_coordinateVector: "[-28,-94,4]"^^xsd:string .
 
-niiri:d4ce2f741b5177b2f48f4711f75a7d36 prov:wasDerivedFrom niiri:1b44a27650bde23878594a9485c4d6d3 .
+niiri:4fef5b8d7f9adb35cbb0ab5a325d482f prov:wasDerivedFrom niiri:ea4c51e6004ff6ca79763dfba6bceff9 .
 
-niiri:17f208e257dd52e4e6d458b8d89f5d40
+niiri:6cfbefeaeca5e8720b0f89cc117f6383
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0009" ;
-    prov:atLocation niiri:cd1f2290f59badd4a55efe1ccb1e71d4 ;
+    prov:atLocation niiri:811c5d9c038c996d8bf02e2801564ed3 ;
     prov:value "6.15222215652466"^^xsd:float ;
     nidm_equivalentZStatistic: "5.64328512810061"^^xsd:float ;
     nidm_pValueUncorrected: "8.34178537356678e-09"^^xsd:float ;
     nidm_pValueFWER: "0.00186069357054308"^^xsd:float ;
     nidm_qValueFDR: "0.0857472799805926"^^xsd:float .
 
-niiri:cd1f2290f59badd4a55efe1ccb1e71d4
+niiri:811c5d9c038c996d8bf02e2801564ed3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0009" ;
     nidm_coordinateVector: "[-6,12,52]"^^xsd:string .
 
-niiri:17f208e257dd52e4e6d458b8d89f5d40 prov:wasDerivedFrom niiri:e9d92af50d7554f83a3d9f3b4072a7c1 .
+niiri:6cfbefeaeca5e8720b0f89cc117f6383 prov:wasDerivedFrom niiri:dc0951f37176f78fb716ea89f0b324b0 .
 
-niiri:352d04c79c650e14027a708964e8f510
+niiri:b7eb4e3f8d2498601ec7a4ca2effb8ea
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0010" ;
-    prov:atLocation niiri:67c8a60abf2c666b7908fed7d652e533 ;
+    prov:atLocation niiri:79b9d17e894c966e15c06bd6c13bf05f ;
     prov:value "6.10109901428223"^^xsd:float ;
     nidm_equivalentZStatistic: "5.60320502193174"^^xsd:float ;
     nidm_pValueUncorrected: "1.05212039080982e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00234682813060005"^^xsd:float ;
     nidm_qValueFDR: "0.0921349235875033"^^xsd:float .
 
-niiri:67c8a60abf2c666b7908fed7d652e533
+niiri:79b9d17e894c966e15c06bd6c13bf05f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0010" ;
     nidm_coordinateVector: "[32,2,46]"^^xsd:string .
 
-niiri:352d04c79c650e14027a708964e8f510 prov:wasDerivedFrom niiri:90ea7ec9beaea62022ae06ebf7877811 .
+niiri:b7eb4e3f8d2498601ec7a4ca2effb8ea prov:wasDerivedFrom niiri:0262c15e4838598f01a6cef257cb8e12 .
 
-niiri:81ce3b3269904151fb0ecdbc124d95bb
+niiri:aed78746ebe2a394f8866cd7a9c4f06f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0011" ;
-    prov:atLocation niiri:d84e98c56883ed6bfe424a5e84a83f27 ;
+    prov:atLocation niiri:49e035f041eb5be11a7e4f6b92049929 ;
     prov:value "5.98517084121704"^^xsd:float ;
     nidm_equivalentZStatistic: "5.51181334779297"^^xsd:float ;
     nidm_pValueUncorrected: "1.77577724747024e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00376326218366319"^^xsd:float ;
     nidm_qValueFDR: "0.120256575135861"^^xsd:float .
 
-niiri:d84e98c56883ed6bfe424a5e84a83f27
+niiri:49e035f041eb5be11a7e4f6b92049929
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0011" ;
     nidm_coordinateVector: "[8,32,38]"^^xsd:string .
 
-niiri:81ce3b3269904151fb0ecdbc124d95bb prov:wasDerivedFrom niiri:246e46a571dda4f915565e71d61cb338 .
+niiri:aed78746ebe2a394f8866cd7a9c4f06f prov:wasDerivedFrom niiri:c1725b381104011cabad0fc0b26d85db .
 
-niiri:455629387d24ec1307e080b239615b91
+niiri:587e3f84df2982a9fcd650238d95b213
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0012" ;
-    prov:atLocation niiri:6cf22a24114949b2d4e89b31b7939729 ;
+    prov:atLocation niiri:c87e82c19dd1913ed127e81e7df62ead ;
     prov:value "5.98348569869995"^^xsd:float ;
     nidm_equivalentZStatistic: "5.51047970249337"^^xsd:float ;
     nidm_pValueUncorrected: "1.78928538652201e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00378871596531738"^^xsd:float ;
     nidm_qValueFDR: "0.120256575135861"^^xsd:float .
 
-niiri:6cf22a24114949b2d4e89b31b7939729
+niiri:c87e82c19dd1913ed127e81e7df62ead
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0012" ;
     nidm_coordinateVector: "[-52,0,38]"^^xsd:string .
 
-niiri:455629387d24ec1307e080b239615b91 prov:wasDerivedFrom niiri:8c078951dde09de372f14e68653a15e1 .
+niiri:587e3f84df2982a9fcd650238d95b213 prov:wasDerivedFrom niiri:381dea70ad1c9ee61377f917ea0ce85d .
 
-niiri:2debbfc8c141684976875c93e2828b56
+niiri:b8a49440e2e03d17ed64aecab9015fc9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0013" ;
-    prov:atLocation niiri:bcf41b99033863bde09f076ff61cc9c9 ;
+    prov:atLocation niiri:2ce90da342b2373309ec7dd9cb0060b4 ;
     prov:value "5.78093099594116"^^xsd:float ;
     nidm_equivalentZStatistic: "5.34909755317379"^^xsd:float ;
     nidm_pValueUncorrected: "4.41969442155354e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00844151822925698"^^xsd:float ;
     nidm_qValueFDR: "0.252769068923751"^^xsd:float .
 
-niiri:bcf41b99033863bde09f076ff61cc9c9
+niiri:2ce90da342b2373309ec7dd9cb0060b4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0013" ;
     nidm_coordinateVector: "[-34,-2,52]"^^xsd:string .
 
-niiri:2debbfc8c141684976875c93e2828b56 prov:wasDerivedFrom niiri:500eb4af4185b2297823a2218c285d60 .
+niiri:b8a49440e2e03d17ed64aecab9015fc9 prov:wasDerivedFrom niiri:9b79a74d8af6455c348a5ada6380936b .
 
-niiri:48a84fe52bfe8a9bc97d81d516e93eab
+niiri:096335e30681a87cc44956be7c2fd010
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0014" ;
-    prov:atLocation niiri:dcfa8004ef96dd2ad82d8c6d4d743e11 ;
+    prov:atLocation niiri:1108c3d99e6277aed8f925abd4ce55a4 ;
     prov:value "5.70337772369385"^^xsd:float ;
     nidm_equivalentZStatistic: "5.28674301747281"^^xsd:float ;
     nidm_pValueUncorrected: "6.22566831420812e-08"^^xsd:float ;
     nidm_pValueFWER: "0.011413186758684"^^xsd:float ;
     nidm_qValueFDR: "0.308612544684445"^^xsd:float .
 
-niiri:dcfa8004ef96dd2ad82d8c6d4d743e11
+niiri:1108c3d99e6277aed8f925abd4ce55a4
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0014" ;
     nidm_coordinateVector: "[56,-44,52]"^^xsd:string .
 
-niiri:48a84fe52bfe8a9bc97d81d516e93eab prov:wasDerivedFrom niiri:4768dfb4cd05c9ffe1d3d7d1f35cfe3d .
+niiri:096335e30681a87cc44956be7c2fd010 prov:wasDerivedFrom niiri:c2c282bcebcafee73ac596184605c302 .
 
-niiri:a42a2c3c5ac00250af7180012243e75e
+niiri:a3dbc64398559529658b7a5a0ef78d1e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0015" ;
-    prov:atLocation niiri:238916df0c0077e32bc3af02acb6ef43 ;
+    prov:atLocation niiri:023eb3a7010e9a8c9cb41ce2d7b56c70 ;
     prov:value "5.69516134262085"^^xsd:float ;
     nidm_equivalentZStatistic: "5.28011855642631"^^xsd:float ;
     nidm_pValueUncorrected: "6.45501619933597e-08"^^xsd:float ;
     nidm_pValueFWER: "0.0117816592148946"^^xsd:float ;
     nidm_qValueFDR: "0.308612544684445"^^xsd:float .
 
-niiri:238916df0c0077e32bc3af02acb6ef43
+niiri:023eb3a7010e9a8c9cb41ce2d7b56c70
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0015" ;
     nidm_coordinateVector: "[60,-36,54]"^^xsd:string .
 
-niiri:a42a2c3c5ac00250af7180012243e75e prov:wasDerivedFrom niiri:4768dfb4cd05c9ffe1d3d7d1f35cfe3d .
+niiri:a3dbc64398559529658b7a5a0ef78d1e prov:wasDerivedFrom niiri:c2c282bcebcafee73ac596184605c302 .
 
-niiri:082f64e2aa5b5b8cd247e40e766ca56c
+niiri:ae3818cc45d2c9fb41dffe82e4c2d818
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0016" ;
-    prov:atLocation niiri:10370a1f89214bbcbb792d11302cef5d ;
+    prov:atLocation niiri:133c50d19ae417bae4232fa6ae5d2b0b ;
     prov:value "5.68819808959961"^^xsd:float ;
     nidm_equivalentZStatistic: "5.27450168515333"^^xsd:float ;
     nidm_pValueUncorrected: "6.655864770444e-08"^^xsd:float ;
     nidm_pValueFWER: "0.0121028975026269"^^xsd:float ;
     nidm_qValueFDR: "0.308612544684445"^^xsd:float .
 
-niiri:10370a1f89214bbcbb792d11302cef5d
+niiri:133c50d19ae417bae4232fa6ae5d2b0b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0016" ;
     nidm_coordinateVector: "[18,16,4]"^^xsd:string .
 
-niiri:082f64e2aa5b5b8cd247e40e766ca56c prov:wasDerivedFrom niiri:a405d942872d5b85c1b4326d3a87b92c .
+niiri:ae3818cc45d2c9fb41dffe82e4c2d818 prov:wasDerivedFrom niiri:76b1ed7cd5606b2d502e4a5ee6dfe343 .
 
-niiri:3bc26b9b32bf0e6fe8f1737adfee300a
+niiri:d1aca860b0cc6a11b313c4acf1dc02e0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0017" ;
-    prov:atLocation niiri:babd90d36c8e8bfe59433ea16a67d1f6 ;
+    prov:atLocation niiri:fecb191253e64a6ef9b1108c7ab7b6bf ;
     prov:value "5.61174583435059"^^xsd:float ;
     nidm_equivalentZStatistic: "5.21266637309498"^^xsd:float ;
     nidm_pValueUncorrected: "9.30727468428927e-08"^^xsd:float ;
     nidm_pValueFWER: "0.0162336583380834"^^xsd:float ;
     nidm_qValueFDR: "0.380850485465036"^^xsd:float .
 
-niiri:babd90d36c8e8bfe59433ea16a67d1f6
+niiri:fecb191253e64a6ef9b1108c7ab7b6bf
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0017" ;
     nidm_coordinateVector: "[44,-70,50]"^^xsd:string .
 
-niiri:3bc26b9b32bf0e6fe8f1737adfee300a prov:wasDerivedFrom niiri:bd8460a11fb14617fc43ac91658b693e .
+niiri:d1aca860b0cc6a11b313c4acf1dc02e0 prov:wasDerivedFrom niiri:010ce656a5e597d871ca20ab1aa2a631 .
 
-niiri:6b27ae009371c8a2c5d7d3a5d1f0ace8
+niiri:bdf5c277bd5f8597a6d660daa5603065
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0018" ;
-    prov:atLocation niiri:ef6890d992247ecc9ee034c031a58cd2 ;
+    prov:atLocation niiri:347aa567ee2073ea9f5e876e0f70a34e ;
     prov:value "5.60917520523071"^^xsd:float ;
     nidm_equivalentZStatistic: "5.21058195491799"^^xsd:float ;
     nidm_pValueUncorrected: "9.41245997809759e-08"^^xsd:float ;
     nidm_pValueFWER: "0.0163938142285941"^^xsd:float ;
     nidm_qValueFDR: "0.380850485465036"^^xsd:float .
 
-niiri:ef6890d992247ecc9ee034c031a58cd2
+niiri:347aa567ee2073ea9f5e876e0f70a34e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0018" ;
     nidm_coordinateVector: "[-30,26,2]"^^xsd:string .
 
-niiri:6b27ae009371c8a2c5d7d3a5d1f0ace8 prov:wasDerivedFrom niiri:8e7d24425dd5859e85ca7c28c012c5cd .
+niiri:bdf5c277bd5f8597a6d660daa5603065 prov:wasDerivedFrom niiri:2083b75818d091b6724ed0adf40223ab .
 
-niiri:b04d3d3fe5c0a0c74423665bded90e49
+niiri:4356eedee0d987414ac03b8e6d290dff
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0019" ;
-    prov:atLocation niiri:f79eb9d2caa2df659c784dafdc0ef394 ;
+    prov:atLocation niiri:e4749d25f84cd00e691fa81d14d76866 ;
     prov:value "5.40964078903198"^^xsd:float ;
     nidm_equivalentZStatistic: "5.04774404642803"^^xsd:float ;
     nidm_pValueUncorrected: "2.23528758724889e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0346958937061391"^^xsd:float ;
     nidm_qValueFDR: "0.745804416705928"^^xsd:float .
 
-niiri:f79eb9d2caa2df659c784dafdc0ef394
+niiri:e4749d25f84cd00e691fa81d14d76866
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0019" ;
     nidm_coordinateVector: "[-54,-46,58]"^^xsd:string .
 
-niiri:b04d3d3fe5c0a0c74423665bded90e49 prov:wasDerivedFrom niiri:59f598a957aabf6559fffdd51d733944 .
+niiri:4356eedee0d987414ac03b8e6d290dff prov:wasDerivedFrom niiri:e8fd4bf9f34c220cd368e846c6651d35 .
 
-niiri:4b418090a3653aae03ff113b2f9fd399
+niiri:f6aeea95598409a388840e0dc81f791c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0020" ;
-    prov:atLocation niiri:2da14cbac6023c14727bb21b3cfada62 ;
+    prov:atLocation niiri:92870da8ac439dc467665d0abd4b7c66 ;
     prov:value "5.33153486251831"^^xsd:float ;
     nidm_equivalentZStatistic: "4.98344293282216"^^xsd:float ;
     nidm_pValueUncorrected: "3.12313708672463e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0461854110301809"^^xsd:float ;
     nidm_qValueFDR: "0.958749429114292"^^xsd:float .
 
-niiri:2da14cbac6023c14727bb21b3cfada62
+niiri:92870da8ac439dc467665d0abd4b7c66
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0020" ;
     nidm_coordinateVector: "[52,-48,48]"^^xsd:string .
 
-niiri:4b418090a3653aae03ff113b2f9fd399 prov:wasDerivedFrom niiri:3f6eaa65d9b555818ce062afbbcb140b .
+niiri:f6aeea95598409a388840e0dc81f791c prov:wasDerivedFrom niiri:4458d8f762604f7ee56c5d3e6ea96fca .
 
-niiri:1a2b7de790d155cd659f2b3cf1cee080
+niiri:5825ee7b2aaed90133518e138ec17012
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0021" ;
-    prov:atLocation niiri:109938df788cc89af85897914e12926f ;
+    prov:atLocation niiri:82709dcc930c91a7e1305d3dea811c97 ;
     prov:value "5.31841945648193"^^xsd:float ;
     nidm_equivalentZStatistic: "4.97261482231588"^^xsd:float ;
     nidm_pValueUncorrected: "3.30279114724163e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0484353441449864"^^xsd:float ;
     nidm_qValueFDR: "0.967916832880998"^^xsd:float .
 
-niiri:109938df788cc89af85897914e12926f
+niiri:82709dcc930c91a7e1305d3dea811c97
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0021" ;
     nidm_coordinateVector: "[-62,-38,48]"^^xsd:string .
 
-niiri:1a2b7de790d155cd659f2b3cf1cee080 prov:wasDerivedFrom niiri:608052d2152344776bc043455c610be4 .
+niiri:5825ee7b2aaed90133518e138ec17012 prov:wasDerivedFrom niiri:a2f1489aa082c9cb44338fd916006ecb .
 

--- a/spmexport/ex_spm_thr_voxelunct4/nidm.json
+++ b/spmexport/ex_spm_thr_voxelunct4/nidm.json
@@ -1,0 +1,7314 @@
+{
+  "prefix": {
+    "nidm": "http://purl.org/nidash/nidm#",
+    "niiri": "http://iri.nidash.org/",
+    "spm": "http://purl.org/nidash/spm#",
+    "neurolex": "http://neurolex.org/wiki/",
+    "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/",
+    "dct": "http://purl.org/dc/terms/",
+    "nfo": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#",
+    "dc": "http://purl.org/dc/elements/1.1/",
+    "dctype": "http://purl.org/dc/dcmitype/",
+    "obo": "http://purl.obolibrary.org/obo/",
+    "nidm_NIDMResults": "http://purl.org/nidash/nidm#NIDM_0000027",
+    "nidm_version": "http://purl.org/nidash/nidm#NIDM_0000127",
+    "nidm_spm_results_nidm": "http://purl.org/nidash/nidm#NIDM_0000168",
+    "nidm_softwareVersion": "http://purl.org/nidash/nidm#NIDM_0000122",
+    "nidm_NIDMResultsExport": "http://purl.org/nidash/nidm#NIDM_0000166"
+  },
+  "entity": {
+    "niiri:189896bede23f6c48d3a070d109b2e1a": {
+      "prov:type": [
+        {
+        "$": "prov:Bundle",
+        "type": "xsd:QName"
+        },
+        {
+        "$": "nidm_NIDMResults:",
+        "type": "xsd:QName"
+        }
+      ],
+      "prov:label": {
+        "$": "NIDM-Results",
+        "type": "xsd:string"
+      },
+      "nidm_version:": {
+        "$": "1.3.0",
+        "type": "xsd:string"
+      }
+    }
+  },
+  "activity": {
+    "niiri:18ff4e974aa8acb4e95128ad7d68d393": {
+      "prov:type": {
+        "$": "nidm_NIDMResultsExport:",
+        "type": "xsd:QName"
+      },
+      "prov:label": {
+        "$": "NIDM-Results export",
+        "type": "xsd:string"
+      }
+    }
+  },
+  "agent": {
+    "niiri:9997cb99dd0c128680679af0520a8123": {
+      "prov:type": [
+        {
+        "$": "nidm_spm_results_nidm:",
+        "type": "xsd:QName"
+        },
+        {
+        "$": "prov:SoftwareAgent",
+        "type": "xsd:QName"
+        }
+      ],
+      "prov:label": {
+        "$": "spm_results_nidm",
+        "type": "xsd:string"
+      },
+      "nidm_softwareVersion:": {
+        "$": "12.7057",
+        "type": "xsd:string"
+      }
+    }
+  },
+  "wasGeneratedBy": {
+    "_:wGB5": {
+      "prov:entity": "niiri:189896bede23f6c48d3a070d109b2e1a",
+      "prov:activity": "niiri:18ff4e974aa8acb4e95128ad7d68d393",
+      "prov:time": "2017-04-19T12:19:27"
+    }
+  },
+  "wasAssociatedWith": {
+    "_:wAW4": {
+      "prov:activity": "niiri:18ff4e974aa8acb4e95128ad7d68d393",
+      "prov:agent": "niiri:9997cb99dd0c128680679af0520a8123"
+    }
+  },
+  "bundle": {
+    "niiri:189896bede23f6c48d3a070d109b2e1a": {
+    "prefix": {
+        "nidm_softwareVersion": "http://purl.org/nidash/nidm#NIDM_0000122",
+        "nidm_CoordinateSpace": "http://purl.org/nidash/nidm#NIDM_0000016",
+        "nidm_voxelToWorldMapping": "http://purl.org/nidash/nidm#NIDM_0000132",
+        "nidm_voxelUnits": "http://purl.org/nidash/nidm#NIDM_0000133",
+        "nidm_voxelSize": "http://purl.org/nidash/nidm#NIDM_0000131",
+        "nidm_inWorldCoordinateSystem": "http://purl.org/nidash/nidm#NIDM_0000105",
+        "nidm_numberOfDimensions": "http://purl.org/nidash/nidm#NIDM_0000112",
+        "nidm_dimensionsInVoxels": "http://purl.org/nidash/nidm#NIDM_0000090",
+        "nlx_Imaginginstrument": "http://uri.neuinfo.org/nif/nifstd/birnlex_2094",
+        "nlx_Magneticresonanceimagingscanner": "http://uri.neuinfo.org/nif/nifstd/birnlex_2100",
+        "nidm_grandMeanScaling": "http://purl.org/nidash/nidm#NIDM_0000096",
+        "nidm_targetIntensity": "http://purl.org/nidash/nidm#NIDM_0000124",
+        "nidm_hasMRIProtocol": "http://purl.org/nidash/nidm#NIDM_0000172",
+        "nlx_FunctionalMRIprotocol": "http://uri.neuinfo.org/nif/nifstd/birnlex_2250",
+        "nidm_Data": "http://purl.org/nidash/nidm#NIDM_0000169",
+        "spm_DCTDriftModel": "http://purl.org/nidash/spm#SPM_0000002",
+        "spm_SPMsDriftCutoffPeriod": "http://purl.org/nidash/spm#SPM_0000001",
+        "nidm_hasDriftModel": "http://purl.org/nidash/nidm#NIDM_0000088",
+        "nidm_hasHRFBasis": "http://purl.org/nidash/nidm#NIDM_0000102",
+        "spm_SPMsCanonicalHRF": "http://purl.org/nidash/spm#SPM_0000004",
+        "nidm_DesignMatrix": "http://purl.org/nidash/nidm#NIDM_0000019",
+        "nidm_regressorNames": "http://purl.org/nidash/nidm#NIDM_0000021",
+        "nidm_hasErrorDependence": "http://purl.org/nidash/nidm#NIDM_0000100",
+        "obo_Toeplitzcovariancestructure": "http://purl.obolibrary.org/obo/STATO_0000357",
+        "nidm_dependenceMapWiseDependence": "http://purl.org/nidash/nidm#NIDM_0000089",
+        "nidm_ConstantParameter": "http://purl.org/nidash/nidm#NIDM_0000072",
+        "nidm_errorVarianceHomogeneous": "http://purl.org/nidash/nidm#NIDM_0000094",
+        "nidm_varianceMapWiseDependence": "http://purl.org/nidash/nidm#NIDM_0000126",
+        "nidm_IndependentParameter": "http://purl.org/nidash/nidm#NIDM_0000073",
+        "nidm_withEstimationMethod": "http://purl.org/nidash/nidm#NIDM_0000134",
+        "obo_generalizedleastsquaresestimation": "http://purl.obolibrary.org/obo/STATO_0000372",
+        "nidm_ErrorModel": "http://purl.org/nidash/nidm#NIDM_0000023",
+        "nidm_hasErrorDistribution": "http://purl.org/nidash/nidm#NIDM_0000101",
+        "obo_normaldistribution": "http://purl.obolibrary.org/obo/STATO_0000227",
+        "nidm_ModelParametersEstimation": "http://purl.org/nidash/nidm#NIDM_0000056",
+        "nidm_MaskMap": "http://purl.org/nidash/nidm#NIDM_0000054",
+        "nidm_isUserDefined": "http://purl.org/nidash/nidm#NIDM_0000106",
+        "nidm_inCoordinateSpace": "http://purl.org/nidash/nidm#NIDM_0000104",
+        "nidm_GrandMeanMap": "http://purl.org/nidash/nidm#NIDM_0000033",
+        "nidm_maskedMedian": "http://purl.org/nidash/nidm#NIDM_0000107",
+        "nidm_ParameterEstimateMap": "http://purl.org/nidash/nidm#NIDM_0000061",
+        "nidm_ResidualMeanSquaresMap": "http://purl.org/nidash/nidm#NIDM_0000066",
+        "nidm_ReselsPerVoxelMap": "http://purl.org/nidash/nidm#NIDM_0000144",
+        "obo_contrastweightmatrix": "http://purl.obolibrary.org/obo/STATO_0000323",
+        "nidm_statisticType": "http://purl.org/nidash/nidm#NIDM_0000123",
+        "obo_tstatistic": "http://purl.obolibrary.org/obo/STATO_0000176",
+        "nidm_contrastName": "http://purl.org/nidash/nidm#NIDM_0000085",
+        "nidm_ContrastEstimation": "http://purl.org/nidash/nidm#NIDM_0000001",
+        "nidm_StatisticMap": "http://purl.org/nidash/nidm#NIDM_0000076",
+        "nidm_errorDegreesOfFreedom": "http://purl.org/nidash/nidm#NIDM_0000093",
+        "nidm_effectDegreesOfFreedom": "http://purl.org/nidash/nidm#NIDM_0000091",
+        "nidm_ContrastMap": "http://purl.org/nidash/nidm#NIDM_0000002",
+        "nidm_ContrastStandardErrorMap": "http://purl.org/nidash/nidm#NIDM_0000013",
+        "obo_statistic": "http://purl.obolibrary.org/obo/STATO_0000039",
+        "nidm_PValueUncorrected": "http://purl.org/nidash/nidm#NIDM_0000160",
+        "obo_FWERadjustedpvalue": "http://purl.obolibrary.org/obo/OBI_0001265",
+        "nidm_HeightThreshold": "http://purl.org/nidash/nidm#NIDM_0000034",
+        "nidm_equivalentThreshold": "http://purl.org/nidash/nidm#NIDM_0000161",
+        "nidm_ExtentThreshold": "http://purl.org/nidash/nidm#NIDM_0000026",
+        "nidm_clusterSizeInVoxels": "http://purl.org/nidash/nidm#NIDM_0000084",
+        "nidm_clusterSizeInResels": "http://purl.org/nidash/nidm#NIDM_0000156",
+        "nidm_PeakDefinitionCriteria": "http://purl.org/nidash/nidm#NIDM_0000063",
+        "nidm_maxNumberOfPeaksPerCluster": "http://purl.org/nidash/nidm#NIDM_0000108",
+        "nidm_minDistanceBetweenPeaks": "http://purl.org/nidash/nidm#NIDM_0000109",
+        "nidm_ClusterDefinitionCriteria": "http://purl.org/nidash/nidm#NIDM_0000007",
+        "nidm_hasConnectivityCriterion": "http://purl.org/nidash/nidm#NIDM_0000099",
+        "nidm_voxel18connected": "http://purl.org/nidash/nidm#NIDM_0000128",
+        "nidm_Inference": "http://purl.org/nidash/nidm#NIDM_0000049",
+        "nidm_hasAlternativeHypothesis": "http://purl.org/nidash/nidm#NIDM_0000097",
+        "nidm_OneTailedTest": "http://purl.org/nidash/nidm#NIDM_0000060",
+        "nidm_SearchSpaceMaskMap": "http://purl.org/nidash/nidm#NIDM_0000068",
+        "nidm_searchVolumeInVoxels": "http://purl.org/nidash/nidm#NIDM_0000121",
+        "nidm_searchVolumeInUnits": "http://purl.org/nidash/nidm#NIDM_0000136",
+        "nidm_reselSizeInVoxels": "http://purl.org/nidash/nidm#NIDM_0000148",
+        "nidm_searchVolumeInResels": "http://purl.org/nidash/nidm#NIDM_0000149",
+        "spm_searchVolumeReselsGeometry": "http://purl.org/nidash/spm#SPM_0000010",
+        "nidm_noiseFWHMInVoxels": "http://purl.org/nidash/nidm#NIDM_0000159",
+        "nidm_noiseFWHMInUnits": "http://purl.org/nidash/nidm#NIDM_0000157",
+        "nidm_randomFieldStationarity": "http://purl.org/nidash/nidm#NIDM_0000120",
+        "nidm_expectedNumberOfVoxelsPerCluster": "http://purl.org/nidash/nidm#NIDM_0000143",
+        "nidm_expectedNumberOfClusters": "http://purl.org/nidash/nidm#NIDM_0000141",
+        "nidm_heightCriticalThresholdFWE05": "http://purl.org/nidash/nidm#NIDM_0000147",
+        "nidm_heightCriticalThresholdFDR05": "http://purl.org/nidash/nidm#NIDM_0000146",
+        "spm_smallestSignificantClusterSizeInVoxelsFWE05": "http://purl.org/nidash/spm#SPM_0000014",
+        "spm_smallestSignificantClusterSizeInVoxelsFDR05": "http://purl.org/nidash/spm#SPM_0000013",
+        "nidm_ExcursionSetMap": "http://purl.org/nidash/nidm#NIDM_0000025",
+        "nidm_numberOfSupraThresholdClusters": "http://purl.org/nidash/nidm#NIDM_0000111",
+        "nidm_pValue": "http://purl.org/nidash/nidm#NIDM_0000114",
+        "nidm_hasClusterLabelsMap": "http://purl.org/nidash/nidm#NIDM_0000098",
+        "nidm_hasMaximumIntensityProjection": "http://purl.org/nidash/nidm#NIDM_0000138",
+        "nidm_ClusterLabelsMap": "http://purl.org/nidash/nidm#NIDM_0000008",
+        "nidm_SupraThresholdCluster": "http://purl.org/nidash/nidm#NIDM_0000070",
+        "nidm_pValueUncorrected": "http://purl.org/nidash/nidm#NIDM_0000116",
+        "nidm_pValueFWER": "http://purl.org/nidash/nidm#NIDM_0000115",
+        "nidm_qValueFDR": "http://purl.org/nidash/nidm#NIDM_0000119",
+        "nidm_clusterLabelId": "http://purl.org/nidash/nidm#NIDM_0000082",
+        "nidm_Peak": "http://purl.org/nidash/nidm#NIDM_0000062",
+        "nidm_equivalentZStatistic": "http://purl.org/nidash/nidm#NIDM_0000092",
+        "nidm_Coordinate": "http://purl.org/nidash/nidm#NIDM_0000015",
+        "nidm_coordinateVector": "http://purl.org/nidash/nidm#NIDM_0000086"
+    },
+    "entity": {
+        "niiri:7281f1fb34adff5220f3261fb87667df": {
+            "prov:type": {
+                "$": "nidm_CoordinateSpace:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Coordinate space 1",
+                "type": "xsd:string"
+            },
+            "nidm_voxelToWorldMapping:": {
+                "$": "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]",
+                "type": "xsd:string"
+            },
+            "nidm_voxelUnits:": {
+                "$": "[\"mm\", \"mm\", \"mm\"]",
+                "type": "xsd:string"
+            },
+            "nidm_voxelSize:": {
+                "$": "[2, 2, 2]",
+                "type": "xsd:string"
+            },
+            "nidm_inWorldCoordinateSystem:": {
+                "$": "nidm_Ixi549CoordinateSystem:",
+                "type": "xsd:string"
+            },
+            "nidm_numberOfDimensions:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_dimensionsInVoxels:": {
+                "$": "[79,95,79]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6524bf7ddad1b51b7e6eccf056897312": {
+            "prov:type": [
+                {
+                "$": "prov:Collection",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Data:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Data",
+                "type": "xsd:string"
+            },
+            "nidm_grandMeanScaling:": {
+                "$": "true",
+                "type": "xsd:boolean"
+            },
+            "nidm_targetIntensity:": {
+                "$": "100",
+                "type": "xsd:float"
+            },
+            "nidm_hasMRIProtocol:": {
+                "$": "nlx_FunctionalMRIprotocol:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2fb1bfe37a87dba64d5a5d293590e187": {
+            "prov:type": {
+                "$": "spm_DCTDriftModel:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "SPM's DCT Drift Model",
+                "type": "xsd:string"
+            },
+            "spm_SPMsDriftCutoffPeriod:": {
+                "$": "128",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4731086ecff63edff2efe01371b545d8": {
+            "prov:type": {
+                "$": "nidm_DesignMatrix:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "DesignMatrix.csv",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "DesignMatrix.csv",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "text/csv",
+                "type": "xsd:string"
+            },
+            "dc:description": {
+                "$": "niiri:5ca4ac54eeaf6f1d9152a1bdf46710a6",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Design Matrix",
+                "type": "xsd:string"
+            },
+            "nidm_regressorNames:": {
+                "$": "[\"Sn(1) to*bf(1)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) constant\"]",
+                "type": "xsd:string"
+            },
+            "nidm_hasDriftModel:": {
+                "$": "niiri:2fb1bfe37a87dba64d5a5d293590e187",
+                "type": "xsd:string"
+            },
+            "nidm_hasHRFBasis:": {
+                "$": "spm_SPMsCanonicalHRF:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5ca4ac54eeaf6f1d9152a1bdf46710a6": {
+            "prov:type": {
+                "$": "dctype:Image",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "DesignMatrix.png",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "DesignMatrix.png",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/png",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:386bf6b77814cb710199234a256a021c": {
+            "prov:type": {
+                "$": "nidm_ErrorModel:",
+                "type": "xsd:QName"
+            },
+            "nidm_hasErrorDistribution:": {
+                "$": "obo_normaldistribution:",
+                "type": "xsd:string"
+            },
+            "nidm_hasErrorDependence:": {
+                "$": "obo_Toeplitzcovariancestructure:",
+                "type": "xsd:string"
+            },
+            "nidm_dependenceMapWiseDependence:": {
+                "$": "nidm_ConstantParameter:",
+                "type": "xsd:string"
+            },
+            "nidm_errorVarianceHomogeneous:": {
+                "$": "true",
+                "type": "xsd:boolean"
+            },
+            "nidm_varianceMapWiseDependence:": {
+                "$": "nidm_IndependentParameter:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9297aa85579b346a54833d2b1d149a50": {
+            "prov:type": {
+                "$": "nidm_MaskMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "Mask.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nidm_isUserDefined:": {
+                "$": "false",
+                "type": "xsd:boolean"
+            },
+            "nfo:fileName": {
+                "$": "Mask.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Mask",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:7281f1fb34adff5220f3261fb87667df",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:65afc11255961d055498d34a233f38eb": {
+            "prov:type": {
+                "$": "nidm_MaskMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "mask.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "36929e1f5f4143bd9cc818cd896a25f129961fab208c3a4438555f40444c08347b359142ee8c53ece6e8cca1627f49db0788a1fd3b9e2ecaef61999c6c6c67ac",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:da0199129aa114a6e34a67087f7a90ec": {
+            "prov:type": {
+                "$": "nidm_GrandMeanMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "GrandMean.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "GrandMean.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Grand Mean Map",
+                "type": "xsd:string"
+            },
+            "nidm_maskedMedian:": {
+                "$": "111.557487487793",
+                "type": "xsd:float"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:7281f1fb34adff5220f3261fb87667df",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "512157cc6bff89d9343a09b4068226eb3edd64a8cbcee861f06231767fae6f8d4819921182adebee083a9bf309afd65529ab04a92f0aa6b0038c8098550f6124",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a04b9105e94e89a3c8075e41a664542c": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0001.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0001.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 1",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:7281f1fb34adff5220f3261fb87667df",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d6633d601feae732247aa91489588cbb": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0001.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8db44c591befd8da54a7b7424f044499": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0002.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0002.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 2",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:7281f1fb34adff5220f3261fb87667df",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d6ae022ee50285e2c8fc24712ceb3996": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0002.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:cda4f59b5814df22c694a9beb62517cc": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ParameterEstimate_0003.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ParameterEstimate_0003.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Parameter Estimate Map 3",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:7281f1fb34adff5220f3261fb87667df",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1afcd7a91ab1ca3f7f51cc545792a500": {
+            "prov:type": {
+                "$": "nidm_ParameterEstimateMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "beta_0003.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ce15a9ed085ff2948353c419697255e2": {
+            "prov:type": {
+                "$": "nidm_ResidualMeanSquaresMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ResidualMeanSquares.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ResidualMeanSquares.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Residual Mean Squares Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:7281f1fb34adff5220f3261fb87667df",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "991abf563d795a43b1e2eef8643e57023f2e0b090b2031f05f839321fc0643df6f71d423486a1021519b6dc82f6b0f563e19f3fbd50cb16063bed54a0e192d3e",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c628a1191f9d4a477945f23e95b293e6": {
+            "prov:type": {
+                "$": "nidm_ResidualMeanSquaresMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "ResMS.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "40b28d03fcf9a2f60b11f10d7fb83bf3618b234fb5aedf09df644cb7cbb6aab8c9f468897c1078166d455a3d04a83f4e3bf762cfca0b4ea982d7a4e406849f18",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:76c6d153d35cc6d3973219ee9b3f2f15": {
+            "prov:type": {
+                "$": "nidm_ReselsPerVoxelMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ReselsPerVoxel.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ReselsPerVoxel.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Resels per Voxel Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:7281f1fb34adff5220f3261fb87667df",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "1a3f9216e145249ccc0b14b2bc337d6b38b81ad45e32768001fb22b35f0c2c0f3e2bce013b40c85f7dc0fc62723ac761ee7f7e1e6aff128a05f0ba7b8b8202a3",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d9195d9e6536b5b316d751beb2ce3627": {
+            "prov:type": {
+                "$": "nidm_ReselsPerVoxelMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "RPV.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "4f76663162857f6b38b2a45a63b15a23b2ca8b338c283b69c1e71f2ea2f43797d045a733cd14e845be9c12f8b8f84d3931c599a08e8f6d77e99fab46ad87ab8f",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b931aad8007041b3ad2e52d2af33806b": {
+            "prov:type": {
+                "$": "obo_contrastweightmatrix:",
+                "type": "xsd:QName"
+            },
+            "nidm_statisticType:": {
+                "$": "obo_tstatistic:",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast: tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "[1, 0, 0]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:23148787f3344748fde71183ebc7da43": {
+            "prov:type": {
+                "$": "nidm_StatisticMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "TStatistic.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "TStatistic.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "T-Statistic Map: tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "nidm_statisticType:": {
+                "$": "obo_tstatistic:",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "nidm_errorDegreesOfFreedom:": {
+                "$": "97.9999999998522",
+                "type": "xsd:float"
+            },
+            "nidm_effectDegreesOfFreedom:": {
+                "$": "1",
+                "type": "xsd:float"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:7281f1fb34adff5220f3261fb87667df",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "9e1714c2d86a050b38b4e10a4d2d23253a24c5e1d228ae16a9c3be8872739278505ac0729ecab54265a717e3a54f9f782d0ed72eea904e0d482a6072bb817bd4",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:130668736169c4cdfa7fd91d417d86a8": {
+            "prov:type": {
+                "$": "nidm_StatisticMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "spmT_0001.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "d288b1b0f117f64502555da13c5398dffa5bf5ff0b58951510e43d5388755bc185798802a92e98a07c7e313c6991066d2908f2a44aa5153ba23433da1335970f",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:011b48f84e70f8c3e98a300224c8a1c1": {
+            "prov:type": {
+                "$": "nidm_ContrastMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "Contrast.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "Contrast.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast Map: tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "nidm_contrastName:": {
+                "$": "tone counting vs baseline",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:7281f1fb34adff5220f3261fb87667df",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "fc5e2ad175243ee496db98f9b2e1b235c4c3bae1a8d7122ce461c897b537e40c49dfee5d6cf20f71c6a2bb9b5f0760fcb4ecd8fe2e9428910ef3d60d8f3c56a9",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c5041422daebd48592536bc76fa2d1b2": {
+            "prov:type": {
+                "$": "nidm_ContrastMap:",
+                "type": "xsd:QName"
+            },
+            "nfo:fileName": {
+                "$": "con_0001.nii",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "d4aa46b3603ba508578e39751262d528cf6d1ed2e722ec46f1cd8194c50591e46b229deb8cb4f72d1b7e0e2640f3e6604be7a335301c5c8357f453e5d0d4daf2",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a0b021c7d36be4a9f8aecb86143deef4": {
+            "prov:type": {
+                "$": "nidm_ContrastStandardErrorMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ContrastStandardError.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ContrastStandardError.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Contrast Standard Error Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:7281f1fb34adff5220f3261fb87667df",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "791d48f5d1adb15079a5289271ce0c4b95c56d69bfdb3e5d41b0d24eb538d3075e1cdd15502494b5a5a18c16eaa2153cb4847a996043fa48cdaf26e938a2576d",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2bc75bbda2f5267265d3e555991c4a20": {
+            "prov:type": [
+                {
+                "$": "nidm_HeightThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_statistic:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Height Threshold: T=4.000000)",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentThreshold:": [
+                {
+                "$": "niiri:2ba3915fe8a8233cd1decaccf893dfc6",
+                "type": "xsd:string"
+                },
+                {
+                "$": "niiri:f96c0a4477be91540adcc3de42e3bff1",
+                "type": "xsd:string"
+                }
+            ]
+        },
+        "niiri:2ba3915fe8a8233cd1decaccf893dfc6": {
+            "prov:type": [
+                {
+                "$": "nidm_HeightThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_PValueUncorrected:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Height Threshold: p<0.000061 (unc.)",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.14967978617154e-05",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f96c0a4477be91540adcc3de42e3bff1": {
+            "prov:type": [
+                {
+                "$": "nidm_HeightThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_FWERadjustedpvalue:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Height Threshold: p<0.982274 (FWE)",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "0.982273768856173",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:2943fbbdfc96906a3fd4051bd160e061": {
+            "prov:type": [
+                {
+                "$": "nidm_ExtentThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_statistic:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Extent Threshold: k>=0",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "0",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentThreshold:": [
+                {
+                "$": "niiri:7775696a22ed75b805453eb5b6b80ad7",
+                "type": "xsd:string"
+                },
+                {
+                "$": "niiri:b24450b6aba483c0fc1ba043cfb63970",
+                "type": "xsd:string"
+                }
+            ]
+        },
+        "niiri:7775696a22ed75b805453eb5b6b80ad7": {
+            "prov:type": [
+                {
+                "$": "nidm_ExtentThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "obo_FWERadjustedpvalue:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Extent Threshold",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b24450b6aba483c0fc1ba043cfb63970": {
+            "prov:type": [
+                {
+                "$": "nidm_ExtentThreshold:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_PValueUncorrected:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Extent Threshold",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "1",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0308135e8c28f665d33c547ac6714cf5": {
+            "prov:type": {
+                "$": "nidm_PeakDefinitionCriteria:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak Definition Criteria",
+                "type": "xsd:string"
+            },
+            "nidm_maxNumberOfPeaksPerCluster:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_minDistanceBetweenPeaks:": {
+                "$": "8",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a3c0f5b41e3541ca175be5a36b600ad4": {
+            "prov:type": {
+                "$": "nidm_ClusterDefinitionCriteria:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Cluster Connectivity Criterion: 18",
+                "type": "xsd:string"
+            },
+            "nidm_hasConnectivityCriterion:": {
+                "$": "nidm_voxel18connected:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:fea41c80a81d93e6e5d3ae10aaaca7c6": {
+            "prov:type": {
+                "$": "nidm_SearchSpaceMaskMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "SearchSpaceMask.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "SearchSpaceMask.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Search Space Mask Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:7281f1fb34adff5220f3261fb87667df",
+                "type": "xsd:string"
+            },
+            "nidm_searchVolumeInVoxels:": {
+                "$": "223057",
+                "type": "xsd:int"
+            },
+            "nidm_searchVolumeInUnits:": {
+                "$": "1784456",
+                "type": "xsd:float"
+            },
+            "nidm_reselSizeInVoxels:": {
+                "$": "65.5786964036542",
+                "type": "xsd:float"
+            },
+            "nidm_searchVolumeInResels:": {
+                "$": "3155.84193266257",
+                "type": "xsd:float"
+            },
+            "spm_searchVolumeReselsGeometry:": {
+                "$": "[6, 97.8140592306853, 965.938819261507, 3155.84193266257]",
+                "type": "xsd:string"
+            },
+            "nidm_noiseFWHMInVoxels:": {
+                "$": "[4.09118640605185, 4.0346308705955, 3.97291894351243]",
+                "type": "xsd:string"
+            },
+            "nidm_noiseFWHMInUnits:": {
+                "$": "[8.18237281210369, 8.069261741191, 7.94583788702486]",
+                "type": "xsd:string"
+            },
+            "nidm_randomFieldStationarity:": {
+                "$": "true",
+                "type": "xsd:boolean"
+            },
+            "nidm_expectedNumberOfVoxelsPerCluster:": {
+                "$": "3.56239836066169",
+                "type": "xsd:float"
+            },
+            "nidm_expectedNumberOfClusters:": {
+                "$": "4.03270975093222",
+                "type": "xsd:float"
+            },
+            "nidm_heightCriticalThresholdFWE05:": {
+                "$": "5.30963135104407",
+                "type": "xsd:float"
+            },
+            "nidm_heightCriticalThresholdFDR05:": {
+                "$": "5.26161956787109",
+                "type": "xsd:float"
+            },
+            "crypto:sha512": {
+                "$": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876",
+                "type": "xsd:string"
+            },
+            "spm_smallestSignificantClusterSizeInVoxelsFWE05:": {
+                "$": "48",
+                "type": "xsd:int"
+            },
+            "spm_smallestSignificantClusterSizeInVoxelsFDR05:": {
+                "$": "24",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:01e8d7706461319dc2f9f847acb9d9b6": {
+            "prov:type": {
+                "$": "nidm_ExcursionSetMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ExcursionSet.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ExcursionSet.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Excursion Set Map",
+                "type": "xsd:string"
+            },
+            "nidm_numberOfSupraThresholdClusters:": {
+                "$": "50",
+                "type": "xsd:int"
+            },
+            "nidm_pValue:": {
+                "$": "0",
+                "type": "xsd:float"
+            },
+            "nidm_hasClusterLabelsMap:": {
+                "$": "niiri:af1adaf3b31a04d6e71698c939ab4b78",
+                "type": "xsd:string"
+            },
+            "nidm_hasMaximumIntensityProjection:": {
+                "$": "niiri:9309bc37a685ef32c88ac516783d33c1",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:7281f1fb34adff5220f3261fb87667df",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "a38743559bef11977e156d91275f386fc5f6886442cb7de734c12bdac62fac0cee28c0084419d0258da02ccef31a25aeea212441e01eaf2e902f1acb60b073df",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:af1adaf3b31a04d6e71698c939ab4b78": {
+            "prov:type": {
+                "$": "nidm_ClusterLabelsMap:",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "ClusterLabels.nii.gz",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "ClusterLabels.nii.gz",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/nifti",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Cluster Labels Map",
+                "type": "xsd:string"
+            },
+            "nidm_inCoordinateSpace:": {
+                "$": "niiri:7281f1fb34adff5220f3261fb87667df",
+                "type": "xsd:string"
+            },
+            "crypto:sha512": {
+                "$": "0802849189145a669e184384d952b5a23ec1267712f265582c4e7211b3307cb6cc05e055d687ec7fb168c7c3abffd843f3013061000bcb817971544daf0c712b",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9309bc37a685ef32c88ac516783d33c1": {
+            "prov:type": {
+                "$": "dctype:Image",
+                "type": "xsd:QName"
+            },
+            "prov:location": {
+                "$": "MaximumIntensityProjection.png",
+                "type": "xsd:anyURI"
+            },
+            "nfo:fileName": {
+                "$": "MaximumIntensityProjection.png",
+                "type": "xsd:string"
+            },
+            "dct:format": {
+                "$": "image/png",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7205414c11fb33ad00f174ced75bedbf": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0001",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "449",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "6.84673567215009",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.32264875079833e-14",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "2.55018228756398e-13",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "1.05377479179972e-12",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "1",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:8f4713f29184830ccee1527aedd5043c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0002",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "159",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "2.42456786608433",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.47398502769769e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "9.97685856818364e-07",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "2.06165418974807e-06",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "2",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:6565811c2226598488a782fcfbe65641": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0003",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "348",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "5.30660136727891",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.2954082055035e-12",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "2.94202440187519e-11",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "9.11926025687937e-11",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "3",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:775519b5c1873bb910da7115bee920c0": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0004",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "817",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "12.4583141295025",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.12526026794101e-20",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "5.31315066985251e-19",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "4",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:0deac3c5a5a1925942b4c734669b80cc": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0005",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "224",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "3.41574340882321",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.98239151916056e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "2.00925386328876e-08",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "4.98239151916056e-08",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "5",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c20e67383ada8b9423453af31b5a55de": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0006",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "65",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.991175542738877",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000229583980927154",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.000925417095783976",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00114791990463577",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "6",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:23214e52c07fc432e44b14cfd9b05b8c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0007",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "24",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.365972508088201",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0133990055641975",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0526003902330785",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0478535913007054",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "7",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:63b9219b72b5b660f76b07f652b6ddab": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0008",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "101",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.54013430487118",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.31231548408092e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "5.29204741518408e-05",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "8.20197177550572e-05",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "8",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:b37dd2ff926a0dc9856b3d0532b1c0dd": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0009",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "121",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.84511139494468",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.11274981286496e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "1.255273773626e-05",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "2.22339272347497e-05",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "9",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:e9b24d9fcc87aa114863aac61da68dea": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0010",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "48",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.731945016176401",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.00106392992240541",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00428132943861648",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00409203816309772",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "10",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:7e536777241b4ecd7a6966f907894029": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0011",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "968",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "14.7608911595574",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "9.38808175052664e-23",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "4.69404087526332e-21",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "11",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f008be07086de77a22010a7f08caa22f": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0012",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "9",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.137239690533075",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.106178964707615",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.348311730935284",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.212357929415231",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "12",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:0b8006d59ae6d79e0e814aa87159321c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0013",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "14",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.21348396305145",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0492525133792869",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.180139512966202",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.123131283448217",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "13",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:6581a2a4fbc96915373d67e7edf695a9": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0014",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "69",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "1.05217096075358",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0001633569702971",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.000658554304862946",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000907538723872777",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "14",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:d1a419e3b8453b976a58dbdde542b8c4": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0015",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "55",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.838686997702127",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000555224209552174",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0022365532630918",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00252374640705533",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "15",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:9f5db5fa91c4f9045129661d86ff7c8f": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0016",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "50",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.762442725183751",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.000880826590546597",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00354581667270804",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00367011079394416",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "16",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:dc8fb82556a5fb25f9d253499774c9d3": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0017",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "19",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.289728235569826",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.024956761440693",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0957445447008427",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0779898795021655",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "17",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:65d11f313edff947dbe708fa2df7a47f": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0018",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "17",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.259230526562475",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0324891210881831",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.12279906400353",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0902475585782863",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "18",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:5e70ca2cffa7ec4b08a897a898eb5b28": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0019",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "21",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.320225944577176",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0193462362939225",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0750519967443879",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0644874543130751",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "19",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c77ff18164bd254c10834cf4198cc926": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0020",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "11",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.167737399540425",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.077023606911316",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.267003132503806",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.175053652071173",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "20",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:5ec4ec1a9ea7234dae961134341c413f": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0021",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "10",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.15248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0901918343067497",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.304912463578717",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.187899654805729",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "21",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:43dcb06f795f24225ca2e94a905a018a": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0022",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "7",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.106741981525725",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.150065723699571",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.454019221049343",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.267974506606377",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "22",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:63c6acd902a0987762c94921fa226068": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0023",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "10",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.15248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0901918343067497",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.304912463578717",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.187899654805729",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "23",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:5e9dd0483caa5eb1c58d3fce896ce441": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0024",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "6",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0914931270220502",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.180604370544184",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.517283138916719",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.301007284240307",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "24",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:a371619b98c52e0355b320d28edb7189": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0025",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "5",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0762442725183751",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.219683072090517",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.587664552082487",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.31383296012931",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "25",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:37cde807f5ec7a0a182032d2608a5010": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0026",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "8",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.1219908360294",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.125773864474947",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.397826391888126",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.232914563842494",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "26",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:6bb17b684d45a4f861c90fe5fbe07173": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0027",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "5",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0762442725183751",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.219683072090517",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.587664552082487",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.31383296012931",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "27",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:7560e53c1288bc92b5a4d846f27be2a2": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0028",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "11",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.167737399540425",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.077023606911316",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.267003132503806",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.175053652071173",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "28",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:6a1d4b90730b6f045c485c09e364158b": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0029",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "8",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.1219908360294",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.125773864474947",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.397826391888126",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.232914563842494",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "29",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:642f54df01178892acf81b69ba1cdd64": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0030",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "5",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0762442725183751",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.219683072090517",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.587664552082487",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.31383296012931",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "30",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:7004bd2e853e73ce41a764732d04d90f": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0031",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "16",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.2439816720588",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.037212501212752",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.139349875405945",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0979276347703999",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "31",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:44f3268a65a1bd0913070af57e7f8c22": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0032",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "17",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.259230526562475",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.0324891210881831",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.12279906400353",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0902475585782863",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "32",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:27e476ef788fe4fb3d8dcc031b399a81": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0033",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "6",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0914931270220502",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.180604370544184",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.517283138916719",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.301007284240307",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "33",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:ca4952c39685bacdd04c639d61f596dc": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0034",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.439209995767388",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.829872382543375",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.51070929740394",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "34",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:af2ac94d3f5ea60663d90097f8159f1d": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0035",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "5",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0762442725183751",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.219683072090517",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.587664552082487",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.31383296012931",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "35",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:d088c79195acad1ffe8fcf692ee20b14": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0036",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.595521713796185",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.909424019965657",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.595521713796185",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "36",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:9d84cb059aa001b080f641472d50dee9": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0037",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.595521713796185",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.909424019965657",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.595521713796185",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "37",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:51d1d5abbfa00532f6e6a2f6c7c0cf8f": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0038",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "5",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0762442725183751",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.219683072090517",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.587664552082487",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.31383296012931",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "38",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f39108df33a4d833661db62b9a0c407f": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0039",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0457465635110251",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.340226503435217",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.746409555850822",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.436187824916945",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "39",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:4b799f0cf87667a22d5d0bd894e1cf9f": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0040",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.439209995767388",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.829872382543375",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.51070929740394",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "40",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:418bd4d687fd48d9de96b297aa605a93": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0041",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.439209995767388",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.829872382543375",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.51070929740394",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "41",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:69987b67a58d47cf5fdd3f3dd0097df0": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0042",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0609954180147001",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.270880348129629",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.664583360945099",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.366054524499499",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "42",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:f0f2196eb8e713870fab0d351b7d0893": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0043",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.595521713796185",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.909424019965657",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.595521713796185",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "43",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:917a8294186d88d434a4bfc11da79880": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0044",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "4",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0609954180147001",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.270880348129629",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.664583360945099",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.366054524499499",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "44",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:2bf2abbcd31986ec01bd57d20b6711a8": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0045",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.595521713796185",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.909424019965657",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.595521713796185",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "45",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:ad8c7d04ce78559070db7b91d78cc57c": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0046",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "3",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0457465635110251",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.340226503435217",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.746409555850822",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.436187824916945",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "46",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:17c9ecb05e0c47b2a47ad52062e17b94": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0047",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.595521713796185",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.909424019965657",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.595521713796185",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "47",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:c5e4e1aa155896b26494489613f9ad95": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0048",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.595521713796185",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.909424019965657",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.595521713796185",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "48",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:b838a0239e573b6049362c413185e4cb": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0049",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "2",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.0304977090073501",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.439209995767388",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.829872382543375",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.51070929740394",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "49",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:e35bb4611d1d05c17b7964df5a12a385": {
+            "prov:type": {
+                "$": "nidm_SupraThresholdCluster:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Supra-Threshold Cluster: 0050",
+                "type": "xsd:string"
+            },
+            "nidm_clusterSizeInVoxels:": {
+                "$": "1",
+                "type": "xsd:int"
+            },
+            "nidm_clusterSizeInResels:": {
+                "$": "0.015248854503675",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "0.595521713796185",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.909424019965657",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.595521713796185",
+                "type": "xsd:float"
+            },
+            "nidm_clusterLabelId:": {
+                "$": "50",
+                "type": "xsd:int"
+            }
+        },
+        "niiri:96a59d90e155647137289214422e35d4": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0001",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b1d6c31f98bd6f43acc3b57cdc2c4cdc",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "7.92007970809937",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "6.94608360738412",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.87783122385099e-12",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "4.18813870695089e-07",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "2.27218233660389e-05",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b1d6c31f98bd6f43acc3b57cdc2c4cdc": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0001",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[46,16,24]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:488ce8b025057ec458509b3e364bc4e4": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0002",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:314d42742a9d56e3b3203381bc0b5e0c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.9243049621582",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.64313045489904",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.7158475814627e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.186190030417796",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.112174373202225",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:314d42742a9d56e3b3203381bc0b5e0c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0002",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[52,30,20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:54c35228f66c13680fd122cfa6cf904a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0003",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:fdaec965712432043bed4c8cf9c6c6e9",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.8244423866272",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.55839353511092",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.57731916020187e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.252878395148086",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.146027166584536",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:fdaec965712432043bed4c8cf9c6c6e9": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0003",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[56,18,8]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4c983fde4736cd2a3b8fecb492d20712": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0004",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:cf6e72eafb8fe970a74bb917f5df7698",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "7.11683940887451",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "6.37404871703245",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "9.20510334623259e-11",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "2.05325778424026e-05",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.000406703400889328",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:cf6e72eafb8fe970a74bb917f5df7698": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0004",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[34,-88,-2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:debfad6d4dfc9f7dcad235e472df64e9": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0005",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0a68cfc82c1a38bf1844a9db623df7b7",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.48292255401611",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.8992593141605",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.82568493656277e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.000407231755366277",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00361825878055109",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0a68cfc82c1a38bf1844a9db623df7b7": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0005",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[42,-72,-10]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1daadc92a3ffaa028128f1dd83dd2d87": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0006",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ac087376d1fcef018e5c722275dc0d44",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.31603479385376",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.77079466112137",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.94492849498107e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.000879943865776389",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00361825878055109",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ac087376d1fcef018e5c722275dc0d44": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0006",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[32,24,-4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ed544793a577f316b6d4f813d1d3bea0": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0007",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:3bd89cdd33454979cf7f28e75e1e6678",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.68819808959961",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.27450168515333",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.655864770444e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0121028975026269",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0152484334686785",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:3bd89cdd33454979cf7f28e75e1e6678": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0007",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[18,16,4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:3b3c0e5c0e0bda6412e915038db30c1e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0008",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:145cbb2d1fed72de625f99f542b7c4df",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.94056129455566",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.65687699571461",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.60521061320917e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.17684019308854",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.110770865806137",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:145cbb2d1fed72de625f99f542b7c4df": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0008",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[34,36,-12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f47f325cd640020f4d275a5e5637467d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0009",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7c14a6bf6f09d55caffa373e1993730f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.28007745742798",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.74292583422276",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.65272453897825e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00103782272796227",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00361825878055109",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7c14a6bf6f09d55caffa373e1993730f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0009",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[8,18,50]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:109800b79f33034388fb15fe6337d32d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0010",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0fc5d776108764b8b7c5222659219ffc",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.15222215652466",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.64328512810061",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.34178537356678e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00186069357054308",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00423674188371422",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0fc5d776108764b8b7c5222659219ffc": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0010",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-6,12,52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c873973223ffcbd2bc046af12b3cb084": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0011",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:038be17df65e5da54aa0117e3bdb0291",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.98517084121704",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.51181334779297",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.77577724747024e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00376326218366319",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0059418335926859",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:038be17df65e5da54aa0117e3bdb0291": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0011",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[8,32,38]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:8bbd28cf684609e9144a2f897eb1140e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0012",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c8a3baf174ad35060a06e3a29eac92dd",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.25127363204956",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.72055271981637",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.30890376104765e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0011841880966994",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00361825878055109",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c8a3baf174ad35060a06e3a29eac92dd": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0012",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[52,-32,42]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d86b751c0d22a9c191fbfb604d97f2cd": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0013",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d0256ff296dcef1d59eff26b64f34f75",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.70337772369385",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.28674301747281",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.22566831420812e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.011413186758684",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0152484334686785",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d0256ff296dcef1d59eff26b64f34f75": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0013",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[56,-44,52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d3d50cda890a097337dea07d5a4fe805": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0014",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:15787b1a2c249af12a69dbbc54246a2d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.69516134262085",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.28011855642631",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.45501619933597e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0117816592148946",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0152484334686785",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:15787b1a2c249af12a69dbbc54246a2d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0014",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[60,-36,54]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:149d3b765ad7fafbf9fbd3b50150b590": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0015",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f9928a5f1eece0dab107dcfe66af2b61",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.24752378463745",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.71763687476157",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.40078304300806e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00120468241369565",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00361825878055109",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f9928a5f1eece0dab107dcfe66af2b61": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0015",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[40,-62,50]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a3443b6ff5785b43971a8dafa4cf7790": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0016",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f843f4e9d6679b55e9c5724c953d5a02",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.61174583435059",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.21266637309498",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "9.30727468428927e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0162336583380834",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0188176838211989",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f843f4e9d6679b55e9c5724c953d5a02": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0016",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[44,-70,50]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f7f75f82ae4ccf8674d67ee6b3d6bdf5": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0017",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:f47724d9b1d024327623cf1e2e287528",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.15371799468994",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.64445580026639",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.285227171001e-09",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00184807786755337",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00423674188371422",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:f47724d9b1d024327623cf1e2e287528": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0017",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-28,-94,4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:162515024ff898dc13bff56500dd3eb1": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0018",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:44b68eb3c0dfabd2fe86365c8fcfd4bf",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "6.10109901428223",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.60320502193174",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.05212039080982e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00234682813060005",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.00455235302862474",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:44b68eb3c0dfabd2fe86365c8fcfd4bf": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0018",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[32,2,46]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0c87f6e52c8ca63d8178cb1e1cd2cf44": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0019",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:762280b48fb4648ea57c12e2180a549e",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.6086859703064",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.3736141683061",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.11031435759912e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.453877178455514",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.261209020216113",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:762280b48fb4648ea57c12e2180a549e": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0019",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[28,4,58]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4e70efe9f00c5d7acd1338d327fa18e6": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0020",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:9dacc3b34de0b0518738ac094b81cd18",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.98348569869995",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.51047970249337",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.78928538652201e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00378871596531738",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0059418335926859",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:9dacc3b34de0b0518738ac094b81cd18": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0020",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-52,0,38]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:23ee46ca8d3095632418f7819018d5cb": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0021",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c333edf1c6856225c10c102228f12592",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.98950004577637",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.69817956585148",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.31245304380023e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.151048137890434",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.101749935670058",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c333edf1c6856225c10c102228f12592": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0021",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-44,6,28]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:cb2a043df8fb2d544b2189a13c3ce527": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0022",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:765799a0de84190495361ce1c36bf628",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.55136632919312",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.32413626860189",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.65653129031207e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.518506646121902",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.283110032467297",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:765799a0de84190495361ce1c36bf628": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0022",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-48,8,20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:5b1ff8eefa78821ce44bbb392b06b97e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0023",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:69f53688d48730600e168061ff38a927",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.78093099594116",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.34909755317379",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.41969442155354e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.00844151822925698",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.012489227663654",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:69f53688d48730600e168061ff38a927": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0023",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-34,-2,52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9207951d54db56abf749d9e5e74d2b6e": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0024",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c8d9fdeaa9f06be2ac165988113456f2",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.60917520523071",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.21058195491799",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "9.41245997809759e-08",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0163938142285941",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0188176838211989",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c8d9fdeaa9f06be2ac165988113456f2": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0024",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-30,26,2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c53d89517ec403bef7219abc9030f05d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0025",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:50e5c64dc44fd1aa0ba0c6c251308e66",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.29189538955688",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.95068947481578",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.69755095430691e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.053302912325625",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0464966156430715",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:50e5c64dc44fd1aa0ba0c6c251308e66": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0025",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-12,34,16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:472b41edc6bbee67c33ad7504becf2e5": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0026",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ae0e674dc958653baadd67126d74577c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.28739595413208",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.94696656297749",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.76894592424293e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0541726709732473",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0464966156430715",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ae0e674dc958653baadd67126d74577c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0026",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-50,40,20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:678a272f3a215fe580cc243e51ca4901": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0027",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ec38211804f6ec8a7218bd9caabae7bf",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.40964078903198",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "5.04774404642803",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.23528758724889e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0346958937061391",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0368499246860334",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ec38211804f6ec8a7218bd9caabae7bf": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0027",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-54,-46,58]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:03230db640f45ee7e7b17d0bcfa81e0f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0028",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d82858e1629e476d7a3385ec1f576d72",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.31841945648193",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.97261482231588",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.30279114724163e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0484353441449864",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0464966156430715",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d82858e1629e476d7a3385ec1f576d72": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0028",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-62,-38,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c3e3e8c6beb75a2c98d2adca27e25de1": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0029",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:6feea062185f26004b99d522812cccf6",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.30699443817139",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.96317509467693",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.46750043123123e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0504786376455083",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0464966156430715",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:6feea062185f26004b99d522812cccf6": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0029",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[32,40,16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:1d7080d7ce698e17ddf3efae8dcdec05": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0030",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c2c900a8f6153cd09f2ea5cf6e202d15",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.5497465133667",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.32273570618355",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.7053150754347e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.520378392891944",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.283110032467297",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c2c900a8f6153cd09f2ea5cf6e202d15": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0030",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[40,46,12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:30c5de3d78e8750bd60110543a6d4e95": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0031",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e81909a8204f4543fa739fde9d159dbe",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.27030229568481",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.93281349716267",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.05267701952816e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0575990926145485",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0479288297151396",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e81909a8204f4543fa739fde9d159dbe": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0031",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[40,26,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:bd06c3d65d3e9933f6a3f8ef15e826f1": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0032",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d2f363694c05d0c16c22106097551ec6",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.2275915145874",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.89738468004472",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.85602978606003e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0670610253017228",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0515537977875989",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d2f363694c05d0c16c22106097551ec6": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0032",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[34,-86,12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:30c37a4e6d4b232771755d1748c76f58": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0033",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:e87c4862eab61d8f99a2b73c0996bedc",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.98287582397461",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.6925960462209",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.34879908808561e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.15433914065195",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.101749935670058",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:e87c4862eab61d8f99a2b73c0996bedc": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0033",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[26,-84,14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:6c2577b41582f50d831338802e4df7ad": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0034",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:54941ad1d26a7090edd080e406d9672f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.2253565788269",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.89552821543552",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.90210114501011e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0675937275056587",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0515537977875989",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:54941ad1d26a7090edd080e406d9672f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0034",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-60,8,20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d72c63855a1da4123aa2d2b91077aa04": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0035",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b8071a162bee188fb3f27c0adcc6011b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.19020795822144",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.86629814644752",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.68539714418392e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0765015651399961",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.055368089146651",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b8071a162bee188fb3f27c0adcc6011b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0035",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[48,28,-14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:ded48c88b009b45ce79c933455ae62b1": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0036",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0668dac472065a436c04ed87c6b48312",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "5.11790418624878",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.80597083243817",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.70011758244316e-07",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.0982924709915751",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.0681921715169792",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0668dac472065a436c04ed87c6b48312": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0036",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[62,-42,32]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:091096b37b35a35e14cf6256cdec88c2": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0037",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:38981ae85de58d330e1d76276b048fab",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.93343877792358",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.65085575575197",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.6528024058271e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.180887232162623",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.111052348606216",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:38981ae85de58d330e1d76276b048fab": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0037",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-58,-30,-18]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:307311b45e91bb80ed6c37ee9ce68670": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0038",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7c13987519a921c569ccd9f47a99be37",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.76414346694946",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.50698548813516",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.287756441539e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.301278778226174",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.172669007569286",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7c13987519a921c569ccd9f47a99be37": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0038",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-46,-66,-6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d6572346d31a2bcaf5575073d3264e49": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0039",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:7bb7c053f16458c5ac88a7b8c38c2df3",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.72232866287231",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.47122948835043",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.88855941602095e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.338512677882141",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.195288467872082",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:7bb7c053f16458c5ac88a7b8c38c2df3": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0039",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[58,-38,6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:940561c12adb90e459277d266bcf26a4": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0040",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:a3b66913a7d4f099d41a7e34a9aad13b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.70483255386353",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.45624265093732",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.17043099876224e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.354967306449537",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.203068312336819",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:a3b66913a7d4f099d41a7e34a9aad13b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0040",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-36,-74,-14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:be01e340dcb236d6f72f24c39660c369": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0041",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:48e06113c665fc04a60795b896d2d447",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.08770418167114",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.91804495668",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.46350297789166e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.955724279224547",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.813269333398153",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:48e06113c665fc04a60795b896d2d447": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0041",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-36,-68,-20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:76e00a2148bcf89400f71aed8ae6bb4f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0042",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:c9c45c8f7997274422ea8a368b4a5a18",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.66261720657349",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.42001914550306",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.93460785955246e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.396707240036217",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.226011723416334",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:c9c45c8f7997274422ea8a368b4a5a18": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0042",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[50,-48,62]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b1a1bba13244d909eb7f26c94d677fc4": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0043",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:cfd246dde4faa922a56924236cff1bd9",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.59621620178223",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.36286413267216",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.41853365035416e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.467637998233248",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.263154686545706",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:cfd246dde4faa922a56924236cff1bd9": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0043",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[16,-98,6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:88d3d44277a170d297f951135875f79d": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0044",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0eb0f37e7efb84a8ba951e6d317738aa",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.57891654968262",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.34793761600864",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "6.87118388575936e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.487021764768749",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.274069095631333",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0eb0f37e7efb84a8ba951e6d317738aa": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0044",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-60,-16,28]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b07acc6a2e3964eb9539a6d7b697a89f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0045",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:cac7d9ae81e5c1ad2405164496fb8fea",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.57099342346191",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.34109644800954",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "7.08867353027554e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.496004086968197",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.276784591562674",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:cac7d9ae81e5c1ad2405164496fb8fea": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0045",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-60,-50,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:c17bb40d7f9a065ed9e20283f08d832f": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0046",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b85ea683da3b35f328c636768ed1ddca",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.52660465240479",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.3027121900522",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "8.43599790589789e-06",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.547325139783002",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.296273869721501",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b85ea683da3b35f328c636768ed1ddca": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0046",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[16,14,62]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:e4746d1e59f58f3c65f5926f3a910408": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0047",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:bc0c487d20ed46595ec5f729ccaefa47",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.394446849823",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.18786093394641",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.40797984292673e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.702859796483929",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.416351033742128",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:bc0c487d20ed46595ec5f729ccaefa47": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0047",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-24,54,36]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:912ce2854ee45d7566ad2d5a9ffe063a": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0048",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b3e9065f593d58e675a1f1b518e286e9",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.37013816833496",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.16664310578498",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.54558935169247e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.730405153245217",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.44365024151901",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b3e9065f593d58e675a1f1b518e286e9": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0048",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-52,-62,52]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:d5ff6b492b936f7614cd983926d8d1d8": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0049",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:99d2ed1d9ad0c05f4ab3275060f6f1b3",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.34150457382202",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.14161364101519",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.72435463601239e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.761825497910085",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.479115128745269",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:99d2ed1d9ad0c05f4ab3275060f6f1b3": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0049",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[10,48,44]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:08c188bf3f47eb482ee56d1867b00173": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0050",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:23b7aa0c87723842565ef21f6cd4b6d7",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.32184886932373",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.12440912812688",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.85843849718204e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.782605982808509",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.502895583840395",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:23b7aa0c87723842565ef21f6cd4b6d7": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0050",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[10,24,24]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:37f058dfafc27db2e4a67b00c2c19b3b": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0051",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:cb2674b27a55a15c11356b077c23f96f",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.31582498550415",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.11913273798974",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.90150518718513e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.788829013385429",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.505811157403841",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:cb2674b27a55a15c11356b077c23f96f": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0051",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[36,54,6]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:0e467e20cc0f4bae2c75a2e53bb0c47c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0052",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:dcf7da4393edd644ef884de7aa33221c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.30655717849731",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.11101155082742",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "1.96964745459161e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.798260223882423",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.513996955111144",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:dcf7da4393edd644ef884de7aa33221c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0052",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-26,-92,32]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7346c6134f21e9c55bded49d811acfb6": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0053",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:5b38b31387f1f4d969275778c505f158",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.29490756988525",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.10079738778036",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.0586446986437e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.809857168354565",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.526259690094564",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:5b38b31387f1f4d969275778c505f158": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0053",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[30,42,4]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b407bae917b87023865024204198dbd0": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0054",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:424f8ba488562285d011591931afce31",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.24533367156982",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.05725918601008",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.4825985211363e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.855631833511506",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.591124172488423",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:424f8ba488562285d011591931afce31": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0054",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-18,-60,48]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a7defe617f206121c0d7cb04a6f72f08": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0055",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:879a2d4376625a7c15bed48a1afe84ff",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.22729349136353",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.04138628171284",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.65680735640483e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.870712357794855",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.603696486616006",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:879a2d4376625a7c15bed48a1afe84ff": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0055",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-20,-98,22]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9393a45c585430d7d331841bd135503c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0056",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:0bfbfc6068d71c869562de069b1a6dac",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.22682189941406",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.04097113688235",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.66151551338023e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.871094574055471",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.603696486616006",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:0bfbfc6068d71c869562de069b1a6dac": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0056",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-38,28,-12]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:fa8d8d73ed0cd84d17283368b810eeb9": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0057",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:88a381fc45f1118447ccea71efd9983b",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.22599840164185",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.04024618213588",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.66975618669063e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.871760516202526",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.603696486616006",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:88a381fc45f1118447ccea71efd9983b": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0057",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-36,-74,-34]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9691b9801790bca1d083f574dd41b296": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0058",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:531311d43904b7e17f8c8865edcfd5bf",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.22297620773315",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.03758535922196",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.70020985901898e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.874188238392237",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.603696486616006",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:531311d43904b7e17f8c8865edcfd5bf": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0058",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[38,42,30]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:13e98aff2c31b15268b3dea9959c495c": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0059",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:fc2e46d8aa4cc5b8c0bbb64269631760",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.20424270629883",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.02108217006528",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.89656955663187e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.888659424129494",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.625386565826961",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:fc2e46d8aa4cc5b8c0bbb64269631760": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0059",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[42,6,30]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:7b4db1c258dcb4190f46960d27c75552": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0060",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:4bab1f81849c7a74d149628cba9544aa",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.20391035079956",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.02078923241408",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "2.900174224163e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.888907080881232",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.625386565826961",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:4bab1f81849c7a74d149628cba9544aa": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0060",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[34,-54,-16]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:eb08ea7bd76ef2115f5513cf8044a2cf": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0061",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d7d52cbb1c476bffe993b70632831ff2",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.18721437454224",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "4.00606667297511",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.08691144208506e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.900934824371894",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.6506058568578",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d7d52cbb1c476bffe993b70632831ff2": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0061",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[12,-100,20]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2356612dab79bab4ff2c3251921c2981": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0062",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:b8745b5e296eeb89bc134806045f23be",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.17404651641846",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.99444589181498",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.24228638075574e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.909844421846994",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.669602324090354",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:b8745b5e296eeb89bc134806045f23be": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0062",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-40,-38,44]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:2cf649b070696a752113125b709baba3": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0063",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d3aa1c5c65ab980c6c3f0a8287b4ca8c",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.1575984954834",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.97991879787505",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.44694060671058e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.920254423392118",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.696012561232619",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d3aa1c5c65ab980c6c3f0a8287b4ca8c": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0063",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[40,44,28]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:321b79a80ec05c8592d93c1223873eb6": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0064",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:778c8ac49540c7ead25b8567022eca9d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.12145137786865",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.94794832362008",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "3.94119065879606e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.940339218142555",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.751110816447844",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:778c8ac49540c7ead25b8567022eca9d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0064",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-48,-72,2]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4e061a53d9dbe94531688c8bc9ccf986": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0065",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:ff83d5006e647b8e22be75b649373fe2",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.07333517074585",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.9052963692066",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.70549882543025e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.961337330645756",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.839886920372845",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:ff83d5006e647b8e22be75b649373fe2": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0065",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[20,-66,34]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:f1fbcfcac4253cdc329fd605b6a751fc": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0066",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d65701c98dd3217e20d935ade61b8f3d",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.05762767791748",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.89134919103145",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "4.98441713834286e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.966867400896655",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.870764578469458",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d65701c98dd3217e20d935ade61b8f3d": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0066",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-46,-56,14]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:b2808d6838f77aa021c934016cf8ee92": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0067",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:d4bb610116be7283da67989a1c4ffbdc",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.03719234466553",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.87318677164159",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.37107204765519e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.973166168280088",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.915311242761809",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:d4bb610116be7283da67989a1c4ffbdc": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0067",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-48,2,50]",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9f6687ae47f76bfbebf449dfbe37a197": {
+            "prov:type": {
+                "$": "nidm_Peak:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Peak: 0068",
+                "type": "xsd:string"
+            },
+            "prov:location": {
+                "$": "niiri:84087ba3e4fb886eb498efbf6852f831",
+                "type": "xsd:string"
+            },
+            "prov:value": {
+                "$": "4.0217924118042",
+                "type": "xsd:float"
+            },
+            "nidm_equivalentZStatistic:": {
+                "$": "3.85948683644491",
+                "type": "xsd:float"
+            },
+            "nidm_pValueUncorrected:": {
+                "$": "5.68126885931441e-05",
+                "type": "xsd:float"
+            },
+            "nidm_pValueFWER:": {
+                "$": "0.977286609355005",
+                "type": "xsd:float"
+            },
+            "nidm_qValueFDR:": {
+                "$": "0.947910679065814",
+                "type": "xsd:float"
+            }
+        },
+        "niiri:84087ba3e4fb886eb498efbf6852f831": {
+            "prov:type": [
+                {
+                "$": "prov:Location",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nidm_Coordinate:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "Coordinate: 0068",
+                "type": "xsd:string"
+            },
+            "nidm_coordinateVector:": {
+                "$": "[-36,-40,-36]",
+                "type": "xsd:string"
+            }
+        }
+    },
+    "activity": {
+        "niiri:29ba85768229f1858344545a78875dd5": {
+            "prov:type": {
+                "$": "nidm_ModelParametersEstimation:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Model parameters estimation",
+                "type": "xsd:string"
+            },
+            "nidm_withEstimationMethod:": {
+                "$": "obo_generalizedleastsquaresestimation:",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:4dff47b859ccc8145da60881ef3fcadc": {
+            "prov:type": {
+                "$": "nidm_ContrastEstimation:",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Contrast estimation",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:a587a25c633a14b3f1737b24594224a2": {
+            "prov:type": {
+                "$": "nidm_Inference:",
+                "type": "xsd:QName"
+            },
+            "nidm_hasAlternativeHypothesis:": {
+                "$": "nidm_OneTailedTest:",
+                "type": "xsd:string"
+            },
+            "prov:label": {
+                "$": "Inference",
+                "type": "xsd:string"
+            }
+        }
+    },
+    "agent": {
+        "niiri:002f4e58c54fcf1f391a012f055d564a": {
+            "prov:type": [
+                {
+                "$": "src_SPM:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "prov:SoftwareAgent",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "SPM",
+                "type": "xsd:string"
+            },
+            "nidm_softwareVersion:": {
+                "$": "12.6906",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:23a5f4fc75628be04559466d0d952b3c": {
+            "prov:type": [
+                {
+                "$": "nlx_Imaginginstrument:",
+                "type": "xsd:QName"
+                },
+                {
+                "$": "nlx_Magneticresonanceimagingscanner:",
+                "type": "xsd:QName"
+                }
+            ],
+            "prov:label": {
+                "$": "MRI Scanner",
+                "type": "xsd:string"
+            }
+        },
+        "niiri:9b463f2aa230e015f987241b0fc8a497": {
+            "prov:type": {
+                "$": "prov:Person",
+                "type": "xsd:QName"
+            },
+            "prov:label": {
+                "$": "Person",
+                "type": "xsd:string"
+            }
+        }
+    },
+    "wasGeneratedBy": {
+        "_:wGB20": {
+            "prov:entity": "niiri:9297aa85579b346a54833d2b1d149a50",
+            "prov:activity": "niiri:29ba85768229f1858344545a78875dd5"
+        },
+        "_:wGB22": {
+            "prov:entity": "niiri:da0199129aa114a6e34a67087f7a90ec",
+            "prov:activity": "niiri:29ba85768229f1858344545a78875dd5"
+        },
+        "_:wGB26": {
+            "prov:entity": "niiri:a04b9105e94e89a3c8075e41a664542c",
+            "prov:activity": "niiri:29ba85768229f1858344545a78875dd5"
+        },
+        "_:wGB30": {
+            "prov:entity": "niiri:8db44c591befd8da54a7b7424f044499",
+            "prov:activity": "niiri:29ba85768229f1858344545a78875dd5"
+        },
+        "_:wGB34": {
+            "prov:entity": "niiri:cda4f59b5814df22c694a9beb62517cc",
+            "prov:activity": "niiri:29ba85768229f1858344545a78875dd5"
+        },
+        "_:wGB38": {
+            "prov:entity": "niiri:ce15a9ed085ff2948353c419697255e2",
+            "prov:activity": "niiri:29ba85768229f1858344545a78875dd5"
+        },
+        "_:wGB42": {
+            "prov:entity": "niiri:76c6d153d35cc6d3973219ee9b3f2f15",
+            "prov:activity": "niiri:29ba85768229f1858344545a78875dd5"
+        },
+        "_:wGB56": {
+            "prov:entity": "niiri:23148787f3344748fde71183ebc7da43",
+            "prov:activity": "niiri:4dff47b859ccc8145da60881ef3fcadc"
+        },
+        "_:wGB60": {
+            "prov:entity": "niiri:011b48f84e70f8c3e98a300224c8a1c1",
+            "prov:activity": "niiri:4dff47b859ccc8145da60881ef3fcadc"
+        },
+        "_:wGB62": {
+            "prov:entity": "niiri:a0b021c7d36be4a9f8aecb86143deef4",
+            "prov:activity": "niiri:4dff47b859ccc8145da60881ef3fcadc"
+        },
+        "_:wGB81": {
+            "prov:entity": "niiri:fea41c80a81d93e6e5d3ae10aaaca7c6",
+            "prov:activity": "niiri:a587a25c633a14b3f1737b24594224a2"
+        },
+        "_:wGB85": {
+            "prov:entity": "niiri:01e8d7706461319dc2f9f847acb9d9b6",
+            "prov:activity": "niiri:a587a25c633a14b3f1737b24594224a2"
+        }
+    },
+    "used": {
+        "_:u14": {
+            "prov:activity": "niiri:29ba85768229f1858344545a78875dd5",
+            "prov:entity": "niiri:4731086ecff63edff2efe01371b545d8"
+        },
+        "_:u15": {
+            "prov:activity": "niiri:29ba85768229f1858344545a78875dd5",
+            "prov:entity": "niiri:6524bf7ddad1b51b7e6eccf056897312"
+        },
+        "_:u16": {
+            "prov:activity": "niiri:29ba85768229f1858344545a78875dd5",
+            "prov:entity": "niiri:386bf6b77814cb710199234a256a021c"
+        },
+        "_:u46": {
+            "prov:activity": "niiri:4dff47b859ccc8145da60881ef3fcadc",
+            "prov:entity": "niiri:9297aa85579b346a54833d2b1d149a50"
+        },
+        "_:u47": {
+            "prov:activity": "niiri:4dff47b859ccc8145da60881ef3fcadc",
+            "prov:entity": "niiri:ce15a9ed085ff2948353c419697255e2"
+        },
+        "_:u48": {
+            "prov:activity": "niiri:4dff47b859ccc8145da60881ef3fcadc",
+            "prov:entity": "niiri:4731086ecff63edff2efe01371b545d8"
+        },
+        "_:u49": {
+            "prov:activity": "niiri:4dff47b859ccc8145da60881ef3fcadc",
+            "prov:entity": "niiri:b931aad8007041b3ad2e52d2af33806b"
+        },
+        "_:u50": {
+            "prov:activity": "niiri:4dff47b859ccc8145da60881ef3fcadc",
+            "prov:entity": "niiri:a04b9105e94e89a3c8075e41a664542c"
+        },
+        "_:u51": {
+            "prov:activity": "niiri:4dff47b859ccc8145da60881ef3fcadc",
+            "prov:entity": "niiri:8db44c591befd8da54a7b7424f044499"
+        },
+        "_:u52": {
+            "prov:activity": "niiri:4dff47b859ccc8145da60881ef3fcadc",
+            "prov:entity": "niiri:cda4f59b5814df22c694a9beb62517cc"
+        },
+        "_:u73": {
+            "prov:activity": "niiri:a587a25c633a14b3f1737b24594224a2",
+            "prov:entity": "niiri:2bc75bbda2f5267265d3e555991c4a20"
+        },
+        "_:u74": {
+            "prov:activity": "niiri:a587a25c633a14b3f1737b24594224a2",
+            "prov:entity": "niiri:2943fbbdfc96906a3fd4051bd160e061"
+        },
+        "_:u75": {
+            "prov:activity": "niiri:a587a25c633a14b3f1737b24594224a2",
+            "prov:entity": "niiri:23148787f3344748fde71183ebc7da43"
+        },
+        "_:u76": {
+            "prov:activity": "niiri:a587a25c633a14b3f1737b24594224a2",
+            "prov:entity": "niiri:76c6d153d35cc6d3973219ee9b3f2f15"
+        },
+        "_:u77": {
+            "prov:activity": "niiri:a587a25c633a14b3f1737b24594224a2",
+            "prov:entity": "niiri:9297aa85579b346a54833d2b1d149a50"
+        },
+        "_:u78": {
+            "prov:activity": "niiri:a587a25c633a14b3f1737b24594224a2",
+            "prov:entity": "niiri:0308135e8c28f665d33c547ac6714cf5"
+        },
+        "_:u79": {
+            "prov:activity": "niiri:a587a25c633a14b3f1737b24594224a2",
+            "prov:entity": "niiri:a3c0f5b41e3541ca175be5a36b600ad4"
+        }
+    },
+    "wasDerivedFrom": {
+        "_:wDF19": {
+            "prov:generatedEntity": "niiri:9297aa85579b346a54833d2b1d149a50",
+            "prov:usedEntity": "niiri:65afc11255961d055498d34a233f38eb"
+        },
+        "_:wDF25": {
+            "prov:generatedEntity": "niiri:a04b9105e94e89a3c8075e41a664542c",
+            "prov:usedEntity": "niiri:d6633d601feae732247aa91489588cbb"
+        },
+        "_:wDF29": {
+            "prov:generatedEntity": "niiri:8db44c591befd8da54a7b7424f044499",
+            "prov:usedEntity": "niiri:d6ae022ee50285e2c8fc24712ceb3996"
+        },
+        "_:wDF33": {
+            "prov:generatedEntity": "niiri:cda4f59b5814df22c694a9beb62517cc",
+            "prov:usedEntity": "niiri:1afcd7a91ab1ca3f7f51cc545792a500"
+        },
+        "_:wDF37": {
+            "prov:generatedEntity": "niiri:ce15a9ed085ff2948353c419697255e2",
+            "prov:usedEntity": "niiri:c628a1191f9d4a477945f23e95b293e6"
+        },
+        "_:wDF41": {
+            "prov:generatedEntity": "niiri:76c6d153d35cc6d3973219ee9b3f2f15",
+            "prov:usedEntity": "niiri:d9195d9e6536b5b316d751beb2ce3627"
+        },
+        "_:wDF55": {
+            "prov:generatedEntity": "niiri:23148787f3344748fde71183ebc7da43",
+            "prov:usedEntity": "niiri:130668736169c4cdfa7fd91d417d86a8"
+        },
+        "_:wDF59": {
+            "prov:generatedEntity": "niiri:011b48f84e70f8c3e98a300224c8a1c1",
+            "prov:usedEntity": "niiri:c5041422daebd48592536bc76fa2d1b2"
+        },
+        "_:wDF87": {
+            "prov:generatedEntity": "niiri:7205414c11fb33ad00f174ced75bedbf",
+            "prov:usedEntity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
+        },
+        "_:wDF89": {
+            "prov:generatedEntity": "niiri:8f4713f29184830ccee1527aedd5043c",
+            "prov:usedEntity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
+        },
+        "_:wDF91": {
+            "prov:generatedEntity": "niiri:6565811c2226598488a782fcfbe65641",
+            "prov:usedEntity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
+        },
+        "_:wDF93": {
+            "prov:generatedEntity": "niiri:775519b5c1873bb910da7115bee920c0",
+            "prov:usedEntity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
+        },
+        "_:wDF95": {
+            "prov:generatedEntity": "niiri:0deac3c5a5a1925942b4c734669b80cc",
+            "prov:usedEntity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
+        },
+        "_:wDF97": {
+            "prov:generatedEntity": "niiri:c20e67383ada8b9423453af31b5a55de",
+            "prov:usedEntity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
+        },
+        "_:wDF99": {
+            "prov:generatedEntity": "niiri:23214e52c07fc432e44b14cfd9b05b8c",
+            "prov:usedEntity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
+        },
+        "_:wDF101": {
+            "prov:generatedEntity": "niiri:63b9219b72b5b660f76b07f652b6ddab",
+            "prov:usedEntity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
+        },
+        "_:wDF103": {
+            "prov:generatedEntity": "niiri:b37dd2ff926a0dc9856b3d0532b1c0dd",
+            "prov:usedEntity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
+        },
+        "_:wDF105": {
+            "prov:generatedEntity": "niiri:e9b24d9fcc87aa114863aac61da68dea",
+            "prov:usedEntity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
+        },
+        "_:wDF107": {
+            "prov:generatedEntity": "niiri:7e536777241b4ecd7a6966f907894029",
+            "prov:usedEntity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
+        },
+        "_:wDF109": {
+            "prov:generatedEntity": "niiri:f008be07086de77a22010a7f08caa22f",
+            "prov:usedEntity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
+        },
+        "_:wDF111": {
+            "prov:generatedEntity": "niiri:0b8006d59ae6d79e0e814aa87159321c",
+            "prov:usedEntity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
+        },
+        "_:wDF113": {
+            "prov:generatedEntity": "niiri:6581a2a4fbc96915373d67e7edf695a9",
+            "prov:usedEntity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
+        },
+        "_:wDF115": {
+            "prov:generatedEntity": "niiri:d1a419e3b8453b976a58dbdde542b8c4",
+            "prov:usedEntity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
+        },
+        "_:wDF117": {
+            "prov:generatedEntity": "niiri:9f5db5fa91c4f9045129661d86ff7c8f",
+            "prov:usedEntity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
+        },
+        "_:wDF119": {
+            "prov:generatedEntity": "niiri:dc8fb82556a5fb25f9d253499774c9d3",
+            "prov:usedEntity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
+        },
+        "_:wDF121": {
+            "prov:generatedEntity": "niiri:65d11f313edff947dbe708fa2df7a47f",
+            "prov:usedEntity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
+        },
+        "_:wDF123": {
+            "prov:generatedEntity": "niiri:5e70ca2cffa7ec4b08a897a898eb5b28",
+            "prov:usedEntity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
+        },
+        "_:wDF125": {
+            "prov:generatedEntity": "niiri:c77ff18164bd254c10834cf4198cc926",
+            "prov:usedEntity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
+        },
+        "_:wDF127": {
+            "prov:generatedEntity": "niiri:5ec4ec1a9ea7234dae961134341c413f",
+            "prov:usedEntity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
+        },
+        "_:wDF129": {
+            "prov:generatedEntity": "niiri:43dcb06f795f24225ca2e94a905a018a",
+            "prov:usedEntity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
+        },
+        "_:wDF131": {
+            "prov:generatedEntity": "niiri:63c6acd902a0987762c94921fa226068",
+            "prov:usedEntity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
+        },
+        "_:wDF133": {
+            "prov:generatedEntity": "niiri:5e9dd0483caa5eb1c58d3fce896ce441",
+            "prov:usedEntity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
+        },
+        "_:wDF135": {
+            "prov:generatedEntity": "niiri:a371619b98c52e0355b320d28edb7189",
+            "prov:usedEntity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
+        },
+        "_:wDF137": {
+            "prov:generatedEntity": "niiri:37cde807f5ec7a0a182032d2608a5010",
+            "prov:usedEntity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
+        },
+        "_:wDF139": {
+            "prov:generatedEntity": "niiri:6bb17b684d45a4f861c90fe5fbe07173",
+            "prov:usedEntity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
+        },
+        "_:wDF141": {
+            "prov:generatedEntity": "niiri:7560e53c1288bc92b5a4d846f27be2a2",
+            "prov:usedEntity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
+        },
+        "_:wDF143": {
+            "prov:generatedEntity": "niiri:6a1d4b90730b6f045c485c09e364158b",
+            "prov:usedEntity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
+        },
+        "_:wDF145": {
+            "prov:generatedEntity": "niiri:642f54df01178892acf81b69ba1cdd64",
+            "prov:usedEntity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
+        },
+        "_:wDF147": {
+            "prov:generatedEntity": "niiri:7004bd2e853e73ce41a764732d04d90f",
+            "prov:usedEntity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
+        },
+        "_:wDF149": {
+            "prov:generatedEntity": "niiri:44f3268a65a1bd0913070af57e7f8c22",
+            "prov:usedEntity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
+        },
+        "_:wDF151": {
+            "prov:generatedEntity": "niiri:27e476ef788fe4fb3d8dcc031b399a81",
+            "prov:usedEntity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
+        },
+        "_:wDF153": {
+            "prov:generatedEntity": "niiri:ca4952c39685bacdd04c639d61f596dc",
+            "prov:usedEntity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
+        },
+        "_:wDF155": {
+            "prov:generatedEntity": "niiri:af2ac94d3f5ea60663d90097f8159f1d",
+            "prov:usedEntity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
+        },
+        "_:wDF157": {
+            "prov:generatedEntity": "niiri:d088c79195acad1ffe8fcf692ee20b14",
+            "prov:usedEntity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
+        },
+        "_:wDF159": {
+            "prov:generatedEntity": "niiri:9d84cb059aa001b080f641472d50dee9",
+            "prov:usedEntity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
+        },
+        "_:wDF161": {
+            "prov:generatedEntity": "niiri:51d1d5abbfa00532f6e6a2f6c7c0cf8f",
+            "prov:usedEntity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
+        },
+        "_:wDF163": {
+            "prov:generatedEntity": "niiri:f39108df33a4d833661db62b9a0c407f",
+            "prov:usedEntity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
+        },
+        "_:wDF165": {
+            "prov:generatedEntity": "niiri:4b799f0cf87667a22d5d0bd894e1cf9f",
+            "prov:usedEntity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
+        },
+        "_:wDF167": {
+            "prov:generatedEntity": "niiri:418bd4d687fd48d9de96b297aa605a93",
+            "prov:usedEntity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
+        },
+        "_:wDF169": {
+            "prov:generatedEntity": "niiri:69987b67a58d47cf5fdd3f3dd0097df0",
+            "prov:usedEntity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
+        },
+        "_:wDF171": {
+            "prov:generatedEntity": "niiri:f0f2196eb8e713870fab0d351b7d0893",
+            "prov:usedEntity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
+        },
+        "_:wDF173": {
+            "prov:generatedEntity": "niiri:917a8294186d88d434a4bfc11da79880",
+            "prov:usedEntity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
+        },
+        "_:wDF175": {
+            "prov:generatedEntity": "niiri:2bf2abbcd31986ec01bd57d20b6711a8",
+            "prov:usedEntity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
+        },
+        "_:wDF177": {
+            "prov:generatedEntity": "niiri:ad8c7d04ce78559070db7b91d78cc57c",
+            "prov:usedEntity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
+        },
+        "_:wDF179": {
+            "prov:generatedEntity": "niiri:17c9ecb05e0c47b2a47ad52062e17b94",
+            "prov:usedEntity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
+        },
+        "_:wDF181": {
+            "prov:generatedEntity": "niiri:c5e4e1aa155896b26494489613f9ad95",
+            "prov:usedEntity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
+        },
+        "_:wDF183": {
+            "prov:generatedEntity": "niiri:b838a0239e573b6049362c413185e4cb",
+            "prov:usedEntity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
+        },
+        "_:wDF185": {
+            "prov:generatedEntity": "niiri:e35bb4611d1d05c17b7964df5a12a385",
+            "prov:usedEntity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
+        },
+        "_:wDF188": {
+            "prov:generatedEntity": "niiri:96a59d90e155647137289214422e35d4",
+            "prov:usedEntity": "niiri:7205414c11fb33ad00f174ced75bedbf"
+        },
+        "_:wDF191": {
+            "prov:generatedEntity": "niiri:488ce8b025057ec458509b3e364bc4e4",
+            "prov:usedEntity": "niiri:7205414c11fb33ad00f174ced75bedbf"
+        },
+        "_:wDF194": {
+            "prov:generatedEntity": "niiri:54c35228f66c13680fd122cfa6cf904a",
+            "prov:usedEntity": "niiri:7205414c11fb33ad00f174ced75bedbf"
+        },
+        "_:wDF197": {
+            "prov:generatedEntity": "niiri:4c983fde4736cd2a3b8fecb492d20712",
+            "prov:usedEntity": "niiri:8f4713f29184830ccee1527aedd5043c"
+        },
+        "_:wDF200": {
+            "prov:generatedEntity": "niiri:debfad6d4dfc9f7dcad235e472df64e9",
+            "prov:usedEntity": "niiri:8f4713f29184830ccee1527aedd5043c"
+        },
+        "_:wDF203": {
+            "prov:generatedEntity": "niiri:1daadc92a3ffaa028128f1dd83dd2d87",
+            "prov:usedEntity": "niiri:6565811c2226598488a782fcfbe65641"
+        },
+        "_:wDF206": {
+            "prov:generatedEntity": "niiri:ed544793a577f316b6d4f813d1d3bea0",
+            "prov:usedEntity": "niiri:6565811c2226598488a782fcfbe65641"
+        },
+        "_:wDF209": {
+            "prov:generatedEntity": "niiri:3b3c0e5c0e0bda6412e915038db30c1e",
+            "prov:usedEntity": "niiri:6565811c2226598488a782fcfbe65641"
+        },
+        "_:wDF212": {
+            "prov:generatedEntity": "niiri:f47f325cd640020f4d275a5e5637467d",
+            "prov:usedEntity": "niiri:775519b5c1873bb910da7115bee920c0"
+        },
+        "_:wDF215": {
+            "prov:generatedEntity": "niiri:109800b79f33034388fb15fe6337d32d",
+            "prov:usedEntity": "niiri:775519b5c1873bb910da7115bee920c0"
+        },
+        "_:wDF218": {
+            "prov:generatedEntity": "niiri:c873973223ffcbd2bc046af12b3cb084",
+            "prov:usedEntity": "niiri:775519b5c1873bb910da7115bee920c0"
+        },
+        "_:wDF221": {
+            "prov:generatedEntity": "niiri:8bbd28cf684609e9144a2f897eb1140e",
+            "prov:usedEntity": "niiri:0deac3c5a5a1925942b4c734669b80cc"
+        },
+        "_:wDF224": {
+            "prov:generatedEntity": "niiri:d86b751c0d22a9c191fbfb604d97f2cd",
+            "prov:usedEntity": "niiri:0deac3c5a5a1925942b4c734669b80cc"
+        },
+        "_:wDF227": {
+            "prov:generatedEntity": "niiri:d3d50cda890a097337dea07d5a4fe805",
+            "prov:usedEntity": "niiri:0deac3c5a5a1925942b4c734669b80cc"
+        },
+        "_:wDF230": {
+            "prov:generatedEntity": "niiri:149d3b765ad7fafbf9fbd3b50150b590",
+            "prov:usedEntity": "niiri:c20e67383ada8b9423453af31b5a55de"
+        },
+        "_:wDF233": {
+            "prov:generatedEntity": "niiri:a3443b6ff5785b43971a8dafa4cf7790",
+            "prov:usedEntity": "niiri:c20e67383ada8b9423453af31b5a55de"
+        },
+        "_:wDF236": {
+            "prov:generatedEntity": "niiri:f7f75f82ae4ccf8674d67ee6b3d6bdf5",
+            "prov:usedEntity": "niiri:23214e52c07fc432e44b14cfd9b05b8c"
+        },
+        "_:wDF239": {
+            "prov:generatedEntity": "niiri:162515024ff898dc13bff56500dd3eb1",
+            "prov:usedEntity": "niiri:63b9219b72b5b660f76b07f652b6ddab"
+        },
+        "_:wDF242": {
+            "prov:generatedEntity": "niiri:0c87f6e52c8ca63d8178cb1e1cd2cf44",
+            "prov:usedEntity": "niiri:63b9219b72b5b660f76b07f652b6ddab"
+        },
+        "_:wDF245": {
+            "prov:generatedEntity": "niiri:4e70efe9f00c5d7acd1338d327fa18e6",
+            "prov:usedEntity": "niiri:b37dd2ff926a0dc9856b3d0532b1c0dd"
+        },
+        "_:wDF248": {
+            "prov:generatedEntity": "niiri:23ee46ca8d3095632418f7819018d5cb",
+            "prov:usedEntity": "niiri:b37dd2ff926a0dc9856b3d0532b1c0dd"
+        },
+        "_:wDF251": {
+            "prov:generatedEntity": "niiri:cb2a043df8fb2d544b2189a13c3ce527",
+            "prov:usedEntity": "niiri:b37dd2ff926a0dc9856b3d0532b1c0dd"
+        },
+        "_:wDF254": {
+            "prov:generatedEntity": "niiri:5b1ff8eefa78821ce44bbb392b06b97e",
+            "prov:usedEntity": "niiri:e9b24d9fcc87aa114863aac61da68dea"
+        },
+        "_:wDF257": {
+            "prov:generatedEntity": "niiri:9207951d54db56abf749d9e5e74d2b6e",
+            "prov:usedEntity": "niiri:7e536777241b4ecd7a6966f907894029"
+        },
+        "_:wDF260": {
+            "prov:generatedEntity": "niiri:c53d89517ec403bef7219abc9030f05d",
+            "prov:usedEntity": "niiri:7e536777241b4ecd7a6966f907894029"
+        },
+        "_:wDF263": {
+            "prov:generatedEntity": "niiri:472b41edc6bbee67c33ad7504becf2e5",
+            "prov:usedEntity": "niiri:7e536777241b4ecd7a6966f907894029"
+        },
+        "_:wDF266": {
+            "prov:generatedEntity": "niiri:678a272f3a215fe580cc243e51ca4901",
+            "prov:usedEntity": "niiri:f008be07086de77a22010a7f08caa22f"
+        },
+        "_:wDF269": {
+            "prov:generatedEntity": "niiri:03230db640f45ee7e7b17d0bcfa81e0f",
+            "prov:usedEntity": "niiri:0b8006d59ae6d79e0e814aa87159321c"
+        },
+        "_:wDF272": {
+            "prov:generatedEntity": "niiri:c3e3e8c6beb75a2c98d2adca27e25de1",
+            "prov:usedEntity": "niiri:6581a2a4fbc96915373d67e7edf695a9"
+        },
+        "_:wDF275": {
+            "prov:generatedEntity": "niiri:1d7080d7ce698e17ddf3efae8dcdec05",
+            "prov:usedEntity": "niiri:6581a2a4fbc96915373d67e7edf695a9"
+        },
+        "_:wDF278": {
+            "prov:generatedEntity": "niiri:30c5de3d78e8750bd60110543a6d4e95",
+            "prov:usedEntity": "niiri:d1a419e3b8453b976a58dbdde542b8c4"
+        },
+        "_:wDF281": {
+            "prov:generatedEntity": "niiri:bd06c3d65d3e9933f6a3f8ef15e826f1",
+            "prov:usedEntity": "niiri:9f5db5fa91c4f9045129661d86ff7c8f"
+        },
+        "_:wDF284": {
+            "prov:generatedEntity": "niiri:30c37a4e6d4b232771755d1748c76f58",
+            "prov:usedEntity": "niiri:9f5db5fa91c4f9045129661d86ff7c8f"
+        },
+        "_:wDF287": {
+            "prov:generatedEntity": "niiri:6c2577b41582f50d831338802e4df7ad",
+            "prov:usedEntity": "niiri:dc8fb82556a5fb25f9d253499774c9d3"
+        },
+        "_:wDF290": {
+            "prov:generatedEntity": "niiri:d72c63855a1da4123aa2d2b91077aa04",
+            "prov:usedEntity": "niiri:65d11f313edff947dbe708fa2df7a47f"
+        },
+        "_:wDF293": {
+            "prov:generatedEntity": "niiri:ded48c88b009b45ce79c933455ae62b1",
+            "prov:usedEntity": "niiri:5e70ca2cffa7ec4b08a897a898eb5b28"
+        },
+        "_:wDF296": {
+            "prov:generatedEntity": "niiri:091096b37b35a35e14cf6256cdec88c2",
+            "prov:usedEntity": "niiri:c77ff18164bd254c10834cf4198cc926"
+        },
+        "_:wDF299": {
+            "prov:generatedEntity": "niiri:307311b45e91bb80ed6c37ee9ce68670",
+            "prov:usedEntity": "niiri:5ec4ec1a9ea7234dae961134341c413f"
+        },
+        "_:wDF302": {
+            "prov:generatedEntity": "niiri:d6572346d31a2bcaf5575073d3264e49",
+            "prov:usedEntity": "niiri:43dcb06f795f24225ca2e94a905a018a"
+        },
+        "_:wDF305": {
+            "prov:generatedEntity": "niiri:940561c12adb90e459277d266bcf26a4",
+            "prov:usedEntity": "niiri:63c6acd902a0987762c94921fa226068"
+        },
+        "_:wDF308": {
+            "prov:generatedEntity": "niiri:be01e340dcb236d6f72f24c39660c369",
+            "prov:usedEntity": "niiri:63c6acd902a0987762c94921fa226068"
+        },
+        "_:wDF311": {
+            "prov:generatedEntity": "niiri:76e00a2148bcf89400f71aed8ae6bb4f",
+            "prov:usedEntity": "niiri:5e9dd0483caa5eb1c58d3fce896ce441"
+        },
+        "_:wDF314": {
+            "prov:generatedEntity": "niiri:b1a1bba13244d909eb7f26c94d677fc4",
+            "prov:usedEntity": "niiri:a371619b98c52e0355b320d28edb7189"
+        },
+        "_:wDF317": {
+            "prov:generatedEntity": "niiri:88d3d44277a170d297f951135875f79d",
+            "prov:usedEntity": "niiri:37cde807f5ec7a0a182032d2608a5010"
+        },
+        "_:wDF320": {
+            "prov:generatedEntity": "niiri:b07acc6a2e3964eb9539a6d7b697a89f",
+            "prov:usedEntity": "niiri:6bb17b684d45a4f861c90fe5fbe07173"
+        },
+        "_:wDF323": {
+            "prov:generatedEntity": "niiri:c17bb40d7f9a065ed9e20283f08d832f",
+            "prov:usedEntity": "niiri:7560e53c1288bc92b5a4d846f27be2a2"
+        },
+        "_:wDF326": {
+            "prov:generatedEntity": "niiri:e4746d1e59f58f3c65f5926f3a910408",
+            "prov:usedEntity": "niiri:6a1d4b90730b6f045c485c09e364158b"
+        },
+        "_:wDF329": {
+            "prov:generatedEntity": "niiri:912ce2854ee45d7566ad2d5a9ffe063a",
+            "prov:usedEntity": "niiri:642f54df01178892acf81b69ba1cdd64"
+        },
+        "_:wDF332": {
+            "prov:generatedEntity": "niiri:d5ff6b492b936f7614cd983926d8d1d8",
+            "prov:usedEntity": "niiri:7004bd2e853e73ce41a764732d04d90f"
+        },
+        "_:wDF335": {
+            "prov:generatedEntity": "niiri:08c188bf3f47eb482ee56d1867b00173",
+            "prov:usedEntity": "niiri:44f3268a65a1bd0913070af57e7f8c22"
+        },
+        "_:wDF338": {
+            "prov:generatedEntity": "niiri:37f058dfafc27db2e4a67b00c2c19b3b",
+            "prov:usedEntity": "niiri:27e476ef788fe4fb3d8dcc031b399a81"
+        },
+        "_:wDF341": {
+            "prov:generatedEntity": "niiri:0e467e20cc0f4bae2c75a2e53bb0c47c",
+            "prov:usedEntity": "niiri:ca4952c39685bacdd04c639d61f596dc"
+        },
+        "_:wDF344": {
+            "prov:generatedEntity": "niiri:7346c6134f21e9c55bded49d811acfb6",
+            "prov:usedEntity": "niiri:af2ac94d3f5ea60663d90097f8159f1d"
+        },
+        "_:wDF347": {
+            "prov:generatedEntity": "niiri:b407bae917b87023865024204198dbd0",
+            "prov:usedEntity": "niiri:d088c79195acad1ffe8fcf692ee20b14"
+        },
+        "_:wDF350": {
+            "prov:generatedEntity": "niiri:a7defe617f206121c0d7cb04a6f72f08",
+            "prov:usedEntity": "niiri:9d84cb059aa001b080f641472d50dee9"
+        },
+        "_:wDF353": {
+            "prov:generatedEntity": "niiri:9393a45c585430d7d331841bd135503c",
+            "prov:usedEntity": "niiri:51d1d5abbfa00532f6e6a2f6c7c0cf8f"
+        },
+        "_:wDF356": {
+            "prov:generatedEntity": "niiri:fa8d8d73ed0cd84d17283368b810eeb9",
+            "prov:usedEntity": "niiri:f39108df33a4d833661db62b9a0c407f"
+        },
+        "_:wDF359": {
+            "prov:generatedEntity": "niiri:9691b9801790bca1d083f574dd41b296",
+            "prov:usedEntity": "niiri:4b799f0cf87667a22d5d0bd894e1cf9f"
+        },
+        "_:wDF362": {
+            "prov:generatedEntity": "niiri:13e98aff2c31b15268b3dea9959c495c",
+            "prov:usedEntity": "niiri:418bd4d687fd48d9de96b297aa605a93"
+        },
+        "_:wDF365": {
+            "prov:generatedEntity": "niiri:7b4db1c258dcb4190f46960d27c75552",
+            "prov:usedEntity": "niiri:69987b67a58d47cf5fdd3f3dd0097df0"
+        },
+        "_:wDF368": {
+            "prov:generatedEntity": "niiri:eb08ea7bd76ef2115f5513cf8044a2cf",
+            "prov:usedEntity": "niiri:f0f2196eb8e713870fab0d351b7d0893"
+        },
+        "_:wDF371": {
+            "prov:generatedEntity": "niiri:2356612dab79bab4ff2c3251921c2981",
+            "prov:usedEntity": "niiri:917a8294186d88d434a4bfc11da79880"
+        },
+        "_:wDF374": {
+            "prov:generatedEntity": "niiri:2cf649b070696a752113125b709baba3",
+            "prov:usedEntity": "niiri:2bf2abbcd31986ec01bd57d20b6711a8"
+        },
+        "_:wDF377": {
+            "prov:generatedEntity": "niiri:321b79a80ec05c8592d93c1223873eb6",
+            "prov:usedEntity": "niiri:ad8c7d04ce78559070db7b91d78cc57c"
+        },
+        "_:wDF380": {
+            "prov:generatedEntity": "niiri:4e061a53d9dbe94531688c8bc9ccf986",
+            "prov:usedEntity": "niiri:17c9ecb05e0c47b2a47ad52062e17b94"
+        },
+        "_:wDF383": {
+            "prov:generatedEntity": "niiri:f1fbcfcac4253cdc329fd605b6a751fc",
+            "prov:usedEntity": "niiri:c5e4e1aa155896b26494489613f9ad95"
+        },
+        "_:wDF386": {
+            "prov:generatedEntity": "niiri:b2808d6838f77aa021c934016cf8ee92",
+            "prov:usedEntity": "niiri:b838a0239e573b6049362c413185e4cb"
+        },
+        "_:wDF389": {
+            "prov:generatedEntity": "niiri:9f6687ae47f76bfbebf449dfbe37a197",
+            "prov:usedEntity": "niiri:e35bb4611d1d05c17b7964df5a12a385"
+        }
+    },
+    "wasAttributedTo": {
+        "_:wAT6": {
+            "prov:entity": "niiri:6524bf7ddad1b51b7e6eccf056897312",
+            "prov:agent": "niiri:23a5f4fc75628be04559466d0d952b3c"
+        },
+        "_:wAT7": {
+            "prov:entity": "niiri:6524bf7ddad1b51b7e6eccf056897312",
+            "prov:agent": "niiri:9b463f2aa230e015f987241b0fc8a497"
+        }
+    },
+    "wasAssociatedWith": {
+        "_:wAW13": {
+            "prov:activity": "niiri:29ba85768229f1858344545a78875dd5",
+            "prov:agent": "niiri:002f4e58c54fcf1f391a012f055d564a"
+        },
+        "_:wAW45": {
+            "prov:activity": "niiri:4dff47b859ccc8145da60881ef3fcadc",
+            "prov:agent": "niiri:002f4e58c54fcf1f391a012f055d564a"
+        },
+        "_:wAW72": {
+            "prov:activity": "niiri:a587a25c633a14b3f1737b24594224a2",
+            "prov:agent": "niiri:002f4e58c54fcf1f391a012f055d564a"
+        }
+    }
+    }
+  }
+}

--- a/spmexport/ex_spm_thr_voxelunct4/nidm.jsonld
+++ b/spmexport/ex_spm_thr_voxelunct4/nidm.jsonld
@@ -7,7 +7,7 @@
       "niiri": "http://iri.nidash.org/",
       "spm": "http://purl.org/nidash/spm#",
       "neurolex": "http://neurolex.org/wiki/",
-      "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#",
+      "crypto": "http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/",
       "dct": "http://purl.org/dc/terms/",
       "nfo": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#",
       "dc": "http://purl.org/dc/elements/1.1/",
@@ -22,32 +22,32 @@
   ],
   "@graph": [
     {
-      "@id": "niiri:d10494a81e870375372c9189f6ca7f37",
-      "@type": ["prov:Entity","prov:Bundle","nidm_NIDMResults:"],
+      "@id": "niiri:189896bede23f6c48d3a070d109b2e1a",
+      "@type": ["prov:Entity","prov:Bundle","nidm_NIDMResults"],
       "rdfs:label": "NIDM-Results",
-      "nidm_version:": {"@type": "xsd:string", "@value": "1.3.0"}
+      "nidm_version": {"@type": "xsd:string", "@value": "1.3.0"}
     },
     {
-      "@id": "niiri:ff659f42f1df9ff3981edcd4db9a795a",
-      "@type": ["prov:Agent","nidm_spm_results_nidm:","prov:SoftwareAgent"],
+      "@id": "niiri:9997cb99dd0c128680679af0520a8123",
+      "@type": ["prov:Agent","nidm_spm_results_nidm","prov:SoftwareAgent"],
       "rdfs:label": "spm_results_nidm",
-      "nidm_softwareVersion:": {"@type": "xsd:string", "@value": "12.6903"}
+      "nidm_softwareVersion": {"@type": "xsd:string", "@value": "12.7057"}
     },
     {
-      "@id": "niiri:ff094f0495094247c0303e6b19c7b116",
-      "@type": ["prov:Activity","nidm_NIDMResultsExport:"],
+      "@id": "niiri:18ff4e974aa8acb4e95128ad7d68d393",
+      "@type": ["prov:Activity","nidm_NIDMResultsExport"],
       "rdfs:label": "NIDM-Results export"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:ff094f0495094247c0303e6b19c7b116",
-      "agent": "niiri:ff659f42f1df9ff3981edcd4db9a795a"
+      "activity_associated": "niiri:18ff4e974aa8acb4e95128ad7d68d393",
+      "agent": "niiri:9997cb99dd0c128680679af0520a8123"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:d10494a81e870375372c9189f6ca7f37",
-      "activity": "niiri:ff094f0495094247c0303e6b19c7b116",
-      "atTime": "2016-12-07T16:10:09"
+      "entity_generated": "niiri:189896bede23f6c48d3a070d109b2e1a",
+      "activity": "niiri:18ff4e974aa8acb4e95128ad7d68d393",
+      "atTime": "2017-04-19T12:19:27"
     }
   ]
 },
@@ -158,572 +158,572 @@
       "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
     }
   ],
-  "@id": "niiri:d10494a81e870375372c9189f6ca7f37",
+  "@id": "niiri:189896bede23f6c48d3a070d109b2e1a",
   "@graph": [
     {
-      "@id": "niiri:c208e9d9cb32439be7a7b44d2c921772",
-      "@type": ["prov:Agent","src_SPM:","prov:SoftwareAgent"],
+      "@id": "niiri:002f4e58c54fcf1f391a012f055d564a",
+      "@type": ["prov:Agent","src_SPM","prov:SoftwareAgent"],
       "rdfs:label": "SPM",
-      "nidm_softwareVersion:": {"@type": "xsd:string", "@value": "12.12.2"}
+      "nidm_softwareVersion": {"@type": "xsd:string", "@value": "12.6906"}
     },
     {
-      "@id": "niiri:5545f55e2dd1b9010b79b506d70b6d15",
-      "@type": ["prov:Entity","nidm_CoordinateSpace:"],
+      "@id": "niiri:7281f1fb34adff5220f3261fb87667df",
+      "@type": ["prov:Entity","nidm_CoordinateSpace"],
       "rdfs:label": "Coordinate space 1",
-      "nidm_voxelToWorldMapping:": {"@type": "xsd:string", "@value": "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"},
-      "nidm_voxelUnits:": {"@type": "xsd:string", "@value": "[\"mm\", \"mm\", \"mm\"]"},
-      "nidm_voxelSize:": {"@type": "xsd:string", "@value": "[2, 2, 2]"},
-      "nidm_inWorldCoordinateSystem:": {"@id": "nidm_Ixi549CoordinateSystem:"},
-      "nidm_numberOfDimensions:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_dimensionsInVoxels:": {"@type": "xsd:string", "@value": "[79,95,79]"}
+      "nidm_voxelToWorldMapping": {"@type": "xsd:string", "@value": "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"},
+      "nidm_voxelUnits": {"@type": "xsd:string", "@value": "[\"mm\", \"mm\", \"mm\"]"},
+      "nidm_voxelSize": {"@type": "xsd:string", "@value": "[2, 2, 2]"},
+      "nidm_inWorldCoordinateSystem": {"@id": "nidm_Ixi549CoordinateSystem"},
+      "nidm_numberOfDimensions": {"@type": "xsd:int", "@value": "3"},
+      "nidm_dimensionsInVoxels": {"@type": "xsd:string", "@value": "[79,95,79]"}
     },
     {
-      "@id": "niiri:bf3ff8bc715b391003c28ba185dce637",
-      "@type": ["prov:Agent","nlx_Imaginginstrument:","nlx_Magneticresonanceimagingscanner:"],
+      "@id": "niiri:23a5f4fc75628be04559466d0d952b3c",
+      "@type": ["prov:Agent","nlx_Imaginginstrument","nlx_Magneticresonanceimagingscanner"],
       "rdfs:label": "MRI Scanner"
     },
     {
-      "@id": "niiri:61421aecf99ca3761fedab9ddf8f66e7",
+      "@id": "niiri:9b463f2aa230e015f987241b0fc8a497",
       "@type": ["prov:Agent","prov:Person"],
       "rdfs:label": "Person"
     },
     {
-      "@id": "niiri:6c8c79ef5f06c6c4b2b646901ce80405",
-      "@type": ["prov:Entity","prov:Collection","nidm_Data:"],
+      "@id": "niiri:6524bf7ddad1b51b7e6eccf056897312",
+      "@type": ["prov:Entity","prov:Collection","nidm_Data"],
       "rdfs:label": "Data",
-      "nidm_grandMeanScaling:": {"@type": "xsd:boolean", "@value": "true"},
-      "nidm_targetIntensity:": {"@type": "xsd:float", "@value": "100"},
-      "nidm_hasMRIProtocol:": {"@id": "nlx_FunctionalMRIprotocol:"}
+      "nidm_grandMeanScaling": {"@type": "xsd:boolean", "@value": "true"},
+      "nidm_targetIntensity": {"@type": "xsd:float", "@value": "100"},
+      "nidm_hasMRIProtocol": {"@id": "nlx_FunctionalMRIprotocol"}
     },
     {
       "@type": "prov:Attribution",
-      "entity_attributed": "niiri:6c8c79ef5f06c6c4b2b646901ce80405",
-      "agent": "niiri:bf3ff8bc715b391003c28ba185dce637"
+      "entity_attributed": "niiri:6524bf7ddad1b51b7e6eccf056897312",
+      "agent": "niiri:23a5f4fc75628be04559466d0d952b3c"
     },
     {
       "@type": "prov:Attribution",
-      "entity_attributed": "niiri:6c8c79ef5f06c6c4b2b646901ce80405",
-      "agent": "niiri:61421aecf99ca3761fedab9ddf8f66e7"
+      "entity_attributed": "niiri:6524bf7ddad1b51b7e6eccf056897312",
+      "agent": "niiri:9b463f2aa230e015f987241b0fc8a497"
     },
     {
-      "@id": "niiri:59a00422bd2b1358c5f2ec1a384f7c03",
-      "@type": ["prov:Entity","spm_DCTDriftModel:"],
+      "@id": "niiri:2fb1bfe37a87dba64d5a5d293590e187",
+      "@type": ["prov:Entity","spm_DCTDriftModel"],
       "rdfs:label": "SPM's DCT Drift Model",
-      "spm_SPMsDriftCutoffPeriod:": {"@type": "xsd:float", "@value": "128"}
+      "spm_SPMsDriftCutoffPeriod": {"@type": "xsd:float", "@value": "128"}
     },
     {
-      "@id": "niiri:b886da30ef5cdaf4572037256a840167",
-      "@type": ["prov:Entity","nidm_DesignMatrix:"],
+      "@id": "niiri:4731086ecff63edff2efe01371b545d8",
+      "@type": ["prov:Entity","nidm_DesignMatrix"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "DesignMatrix.csv"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "DesignMatrix.csv"},
       "dct:format": {"@type": "xsd:string", "@value": "text/csv"},
-      "dc:description": {"@id": "niiri:b4975d35fae6906cfcdc386dab48dbdb"},
+      "dc:description": {"@id": "niiri:5ca4ac54eeaf6f1d9152a1bdf46710a6"},
       "rdfs:label": "Design Matrix",
-      "nidm_regressorNames:": {"@type": "xsd:string", "@value": "[\"Sn(1) to*bf(1)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) constant\"]"},
-      "nidm_hasDriftModel:": {"@id": "niiri:59a00422bd2b1358c5f2ec1a384f7c03"},
-      "nidm_hasHRFBasis:": {"@id": "spm_SPMsCanonicalHRF:"}
+      "nidm_regressorNames": {"@type": "xsd:string", "@value": "[\"Sn(1) to*bf(1)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) constant\"]"},
+      "nidm_hasDriftModel": {"@id": "niiri:2fb1bfe37a87dba64d5a5d293590e187"},
+      "nidm_hasHRFBasis": {"@id": "spm_SPMsCanonicalHRF"}
     },
     {
-      "@id": "niiri:b4975d35fae6906cfcdc386dab48dbdb",
+      "@id": "niiri:5ca4ac54eeaf6f1d9152a1bdf46710a6",
       "@type": ["prov:Entity","dctype:Image"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "DesignMatrix.png"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "DesignMatrix.png"},
       "dct:format": {"@type": "xsd:string", "@value": "image/png"}
     },
     {
-      "@id": "niiri:60943f0fe63a407e4460f1fb2c885915",
-      "@type": ["prov:Entity","nidm_ErrorModel:"],
-      "nidm_hasErrorDistribution:": {"@id": "obo_normaldistribution:"},
-      "nidm_hasErrorDependence:": {"@id": "obo_Toeplitzcovariancestructure:"},
-      "nidm_dependenceMapWiseDependence:": {"@id": "nidm_ConstantParameter:"},
-      "nidm_errorVarianceHomogeneous:": {"@type": "xsd:boolean", "@value": "true"},
-      "nidm_varianceMapWiseDependence:": {"@id": "nidm_IndependentParameter:"}
+      "@id": "niiri:386bf6b77814cb710199234a256a021c",
+      "@type": ["prov:Entity","nidm_ErrorModel"],
+      "nidm_hasErrorDistribution": {"@id": "obo_normaldistribution"},
+      "nidm_hasErrorDependence": {"@id": "obo_Toeplitzcovariancestructure"},
+      "nidm_dependenceMapWiseDependence": {"@id": "nidm_ConstantParameter"},
+      "nidm_errorVarianceHomogeneous": {"@type": "xsd:boolean", "@value": "true"},
+      "nidm_varianceMapWiseDependence": {"@id": "nidm_IndependentParameter"}
     },
     {
-      "@id": "niiri:47818adb47796fd14341054ef89b678b",
-      "@type": ["prov:Activity","nidm_ModelParametersEstimation:"],
+      "@id": "niiri:29ba85768229f1858344545a78875dd5",
+      "@type": ["prov:Activity","nidm_ModelParametersEstimation"],
       "rdfs:label": "Model parameters estimation",
-      "nidm_withEstimationMethod:": {"@id": "obo_generalizedleastsquaresestimation:"}
+      "nidm_withEstimationMethod": {"@id": "obo_generalizedleastsquaresestimation"}
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:47818adb47796fd14341054ef89b678b",
-      "agent": "niiri:c208e9d9cb32439be7a7b44d2c921772"
+      "activity_associated": "niiri:29ba85768229f1858344545a78875dd5",
+      "agent": "niiri:002f4e58c54fcf1f391a012f055d564a"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:47818adb47796fd14341054ef89b678b",
-      "entity": "niiri:b886da30ef5cdaf4572037256a840167"
+      "activity_using": "niiri:29ba85768229f1858344545a78875dd5",
+      "entity": "niiri:4731086ecff63edff2efe01371b545d8"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:47818adb47796fd14341054ef89b678b",
-      "entity": "niiri:6c8c79ef5f06c6c4b2b646901ce80405"
+      "activity_using": "niiri:29ba85768229f1858344545a78875dd5",
+      "entity": "niiri:6524bf7ddad1b51b7e6eccf056897312"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:47818adb47796fd14341054ef89b678b",
-      "entity": "niiri:60943f0fe63a407e4460f1fb2c885915"
+      "activity_using": "niiri:29ba85768229f1858344545a78875dd5",
+      "entity": "niiri:386bf6b77814cb710199234a256a021c"
     },
     {
-      "@id": "niiri:846a7a5fd2e3481706867026e8b26c7d",
-      "@type": ["prov:Entity","nidm_MaskMap:"],
+      "@id": "niiri:9297aa85579b346a54833d2b1d149a50",
+      "@type": ["prov:Entity","nidm_MaskMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "Mask.nii.gz"},
-      "nidm_isUserDefined:": {"@type": "xsd:boolean", "@value": "false"},
+      "nidm_isUserDefined": {"@type": "xsd:boolean", "@value": "false"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "Mask.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Mask",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:5545f55e2dd1b9010b79b506d70b6d15"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:7281f1fb34adff5220f3261fb87667df"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876"}
     },
     {
-      "@id": "niiri:d8069ae7247e425967d7c1d1adef43e0",
-      "@type": ["prov:Entity","nidm_MaskMap:"],
+      "@id": "niiri:65afc11255961d055498d34a233f38eb",
+      "@type": ["prov:Entity","nidm_MaskMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "mask.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "36929e1f5f4143bd9cc818cd896a25f129961fab208c3a4438555f40444c08347b359142ee8c53ece6e8cca1627f49db0788a1fd3b9e2ecaef61999c6c6c67ac"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:846a7a5fd2e3481706867026e8b26c7d",
-      "entity": "niiri:d8069ae7247e425967d7c1d1adef43e0"
+      "entity_derived": "niiri:9297aa85579b346a54833d2b1d149a50",
+      "entity": "niiri:65afc11255961d055498d34a233f38eb"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:846a7a5fd2e3481706867026e8b26c7d",
-      "activity": "niiri:47818adb47796fd14341054ef89b678b"
+      "entity_generated": "niiri:9297aa85579b346a54833d2b1d149a50",
+      "activity": "niiri:29ba85768229f1858344545a78875dd5"
     },
     {
-      "@id": "niiri:59c5c85881ca09e29d5f1ccc9a03478d",
-      "@type": ["prov:Entity","nidm_GrandMeanMap:"],
+      "@id": "niiri:da0199129aa114a6e34a67087f7a90ec",
+      "@type": ["prov:Entity","nidm_GrandMeanMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "GrandMean.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "GrandMean.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Grand Mean Map",
-      "nidm_maskedMedian:": {"@type": "xsd:float", "@value": "111.557487487793"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:5545f55e2dd1b9010b79b506d70b6d15"},
+      "nidm_maskedMedian": {"@type": "xsd:float", "@value": "111.557487487793"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:7281f1fb34adff5220f3261fb87667df"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "512157cc6bff89d9343a09b4068226eb3edd64a8cbcee861f06231767fae6f8d4819921182adebee083a9bf309afd65529ab04a92f0aa6b0038c8098550f6124"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:59c5c85881ca09e29d5f1ccc9a03478d",
-      "activity": "niiri:47818adb47796fd14341054ef89b678b"
+      "entity_generated": "niiri:da0199129aa114a6e34a67087f7a90ec",
+      "activity": "niiri:29ba85768229f1858344545a78875dd5"
     },
     {
-      "@id": "niiri:057cca9a08df9f609713fa51a2b82777",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:a04b9105e94e89a3c8075e41a664542c",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0001.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0001.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 1",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:5545f55e2dd1b9010b79b506d70b6d15"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:7281f1fb34adff5220f3261fb87667df"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd"}
     },
     {
-      "@id": "niiri:2027ebeb9d31b20197daf9228267563c",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:d6633d601feae732247aa91489588cbb",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0001.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:057cca9a08df9f609713fa51a2b82777",
-      "entity": "niiri:2027ebeb9d31b20197daf9228267563c"
+      "entity_derived": "niiri:a04b9105e94e89a3c8075e41a664542c",
+      "entity": "niiri:d6633d601feae732247aa91489588cbb"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:057cca9a08df9f609713fa51a2b82777",
-      "activity": "niiri:47818adb47796fd14341054ef89b678b"
+      "entity_generated": "niiri:a04b9105e94e89a3c8075e41a664542c",
+      "activity": "niiri:29ba85768229f1858344545a78875dd5"
     },
     {
-      "@id": "niiri:30f5079ccbe0c219f133f34e6c4fe0b6",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:8db44c591befd8da54a7b7424f044499",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0002.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0002.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 2",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:5545f55e2dd1b9010b79b506d70b6d15"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:7281f1fb34adff5220f3261fb87667df"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c"}
     },
     {
-      "@id": "niiri:18dd5cb4231230239ab91400d41df7d6",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:d6ae022ee50285e2c8fc24712ceb3996",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0002.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:30f5079ccbe0c219f133f34e6c4fe0b6",
-      "entity": "niiri:18dd5cb4231230239ab91400d41df7d6"
+      "entity_derived": "niiri:8db44c591befd8da54a7b7424f044499",
+      "entity": "niiri:d6ae022ee50285e2c8fc24712ceb3996"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:30f5079ccbe0c219f133f34e6c4fe0b6",
-      "activity": "niiri:47818adb47796fd14341054ef89b678b"
+      "entity_generated": "niiri:8db44c591befd8da54a7b7424f044499",
+      "activity": "niiri:29ba85768229f1858344545a78875dd5"
     },
     {
-      "@id": "niiri:c2e336373051539a367062441de85d31",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:cda4f59b5814df22c694a9beb62517cc",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ParameterEstimate_0003.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ParameterEstimate_0003.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Parameter Estimate Map 3",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:5545f55e2dd1b9010b79b506d70b6d15"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:7281f1fb34adff5220f3261fb87667df"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373"}
     },
     {
-      "@id": "niiri:3e4c25d18bc598d8a3251e550ae744d0",
-      "@type": ["prov:Entity","nidm_ParameterEstimateMap:"],
+      "@id": "niiri:1afcd7a91ab1ca3f7f51cc545792a500",
+      "@type": ["prov:Entity","nidm_ParameterEstimateMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "beta_0003.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c2e336373051539a367062441de85d31",
-      "entity": "niiri:3e4c25d18bc598d8a3251e550ae744d0"
+      "entity_derived": "niiri:cda4f59b5814df22c694a9beb62517cc",
+      "entity": "niiri:1afcd7a91ab1ca3f7f51cc545792a500"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:c2e336373051539a367062441de85d31",
-      "activity": "niiri:47818adb47796fd14341054ef89b678b"
+      "entity_generated": "niiri:cda4f59b5814df22c694a9beb62517cc",
+      "activity": "niiri:29ba85768229f1858344545a78875dd5"
     },
     {
-      "@id": "niiri:6d6a7fa36dc6a44086cf6a31b5867762",
-      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap:"],
+      "@id": "niiri:ce15a9ed085ff2948353c419697255e2",
+      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ResidualMeanSquares.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ResidualMeanSquares.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Residual Mean Squares Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:5545f55e2dd1b9010b79b506d70b6d15"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:7281f1fb34adff5220f3261fb87667df"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "991abf563d795a43b1e2eef8643e57023f2e0b090b2031f05f839321fc0643df6f71d423486a1021519b6dc82f6b0f563e19f3fbd50cb16063bed54a0e192d3e"}
     },
     {
-      "@id": "niiri:959c72679a23583975a747451d5992a2",
-      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap:"],
+      "@id": "niiri:c628a1191f9d4a477945f23e95b293e6",
+      "@type": ["prov:Entity","nidm_ResidualMeanSquaresMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "ResMS.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "40b28d03fcf9a2f60b11f10d7fb83bf3618b234fb5aedf09df644cb7cbb6aab8c9f468897c1078166d455a3d04a83f4e3bf762cfca0b4ea982d7a4e406849f18"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6d6a7fa36dc6a44086cf6a31b5867762",
-      "entity": "niiri:959c72679a23583975a747451d5992a2"
+      "entity_derived": "niiri:ce15a9ed085ff2948353c419697255e2",
+      "entity": "niiri:c628a1191f9d4a477945f23e95b293e6"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:6d6a7fa36dc6a44086cf6a31b5867762",
-      "activity": "niiri:47818adb47796fd14341054ef89b678b"
+      "entity_generated": "niiri:ce15a9ed085ff2948353c419697255e2",
+      "activity": "niiri:29ba85768229f1858344545a78875dd5"
     },
     {
-      "@id": "niiri:34492567d7743546554a67338e951884",
-      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap:"],
+      "@id": "niiri:76c6d153d35cc6d3973219ee9b3f2f15",
+      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ReselsPerVoxel.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ReselsPerVoxel.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Resels per Voxel Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:5545f55e2dd1b9010b79b506d70b6d15"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:7281f1fb34adff5220f3261fb87667df"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "1a3f9216e145249ccc0b14b2bc337d6b38b81ad45e32768001fb22b35f0c2c0f3e2bce013b40c85f7dc0fc62723ac761ee7f7e1e6aff128a05f0ba7b8b8202a3"}
     },
     {
-      "@id": "niiri:472121f90faabc500aa266e106c755d1",
-      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap:"],
+      "@id": "niiri:d9195d9e6536b5b316d751beb2ce3627",
+      "@type": ["prov:Entity","nidm_ReselsPerVoxelMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "RPV.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "4f76663162857f6b38b2a45a63b15a23b2ca8b338c283b69c1e71f2ea2f43797d045a733cd14e845be9c12f8b8f84d3931c599a08e8f6d77e99fab46ad87ab8f"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:34492567d7743546554a67338e951884",
-      "entity": "niiri:472121f90faabc500aa266e106c755d1"
+      "entity_derived": "niiri:76c6d153d35cc6d3973219ee9b3f2f15",
+      "entity": "niiri:d9195d9e6536b5b316d751beb2ce3627"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:34492567d7743546554a67338e951884",
-      "activity": "niiri:47818adb47796fd14341054ef89b678b"
+      "entity_generated": "niiri:76c6d153d35cc6d3973219ee9b3f2f15",
+      "activity": "niiri:29ba85768229f1858344545a78875dd5"
     },
     {
-      "@id": "niiri:a63673e5a46f5dceec53b5209f36d606",
-      "@type": ["prov:Entity","obo_contrastweightmatrix:"],
-      "nidm_statisticType:": {"@id": "obo_tstatistic:"},
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
+      "@id": "niiri:b931aad8007041b3ad2e52d2af33806b",
+      "@type": ["prov:Entity","obo_contrastweightmatrix"],
+      "nidm_statisticType": {"@id": "obo_tstatistic"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
       "rdfs:label": "Contrast: tone counting vs baseline",
       "prov:value": {"@type": "xsd:string", "@value": "[1, 0, 0]"}
     },
     {
-      "@id": "niiri:35c7eba70163dd4b70439861d7f9877c",
-      "@type": ["prov:Activity","nidm_ContrastEstimation:"],
+      "@id": "niiri:4dff47b859ccc8145da60881ef3fcadc",
+      "@type": ["prov:Activity","nidm_ContrastEstimation"],
       "rdfs:label": "Contrast estimation"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:35c7eba70163dd4b70439861d7f9877c",
-      "agent": "niiri:c208e9d9cb32439be7a7b44d2c921772"
+      "activity_associated": "niiri:4dff47b859ccc8145da60881ef3fcadc",
+      "agent": "niiri:002f4e58c54fcf1f391a012f055d564a"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:35c7eba70163dd4b70439861d7f9877c",
-      "entity": "niiri:846a7a5fd2e3481706867026e8b26c7d"
+      "activity_using": "niiri:4dff47b859ccc8145da60881ef3fcadc",
+      "entity": "niiri:9297aa85579b346a54833d2b1d149a50"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:35c7eba70163dd4b70439861d7f9877c",
-      "entity": "niiri:6d6a7fa36dc6a44086cf6a31b5867762"
+      "activity_using": "niiri:4dff47b859ccc8145da60881ef3fcadc",
+      "entity": "niiri:ce15a9ed085ff2948353c419697255e2"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:35c7eba70163dd4b70439861d7f9877c",
-      "entity": "niiri:b886da30ef5cdaf4572037256a840167"
+      "activity_using": "niiri:4dff47b859ccc8145da60881ef3fcadc",
+      "entity": "niiri:4731086ecff63edff2efe01371b545d8"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:35c7eba70163dd4b70439861d7f9877c",
-      "entity": "niiri:a63673e5a46f5dceec53b5209f36d606"
+      "activity_using": "niiri:4dff47b859ccc8145da60881ef3fcadc",
+      "entity": "niiri:b931aad8007041b3ad2e52d2af33806b"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:35c7eba70163dd4b70439861d7f9877c",
-      "entity": "niiri:057cca9a08df9f609713fa51a2b82777"
+      "activity_using": "niiri:4dff47b859ccc8145da60881ef3fcadc",
+      "entity": "niiri:a04b9105e94e89a3c8075e41a664542c"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:35c7eba70163dd4b70439861d7f9877c",
-      "entity": "niiri:30f5079ccbe0c219f133f34e6c4fe0b6"
+      "activity_using": "niiri:4dff47b859ccc8145da60881ef3fcadc",
+      "entity": "niiri:8db44c591befd8da54a7b7424f044499"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:35c7eba70163dd4b70439861d7f9877c",
-      "entity": "niiri:c2e336373051539a367062441de85d31"
+      "activity_using": "niiri:4dff47b859ccc8145da60881ef3fcadc",
+      "entity": "niiri:cda4f59b5814df22c694a9beb62517cc"
     },
     {
-      "@id": "niiri:005a761addf8440e95437a913ccc9361",
-      "@type": ["prov:Entity","nidm_StatisticMap:"],
+      "@id": "niiri:23148787f3344748fde71183ebc7da43",
+      "@type": ["prov:Entity","nidm_StatisticMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "TStatistic.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "TStatistic.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "T-Statistic Map: tone counting vs baseline",
-      "nidm_statisticType:": {"@id": "obo_tstatistic:"},
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
-      "nidm_errorDegreesOfFreedom:": {"@type": "xsd:float", "@value": "97.9999999998522"},
-      "nidm_effectDegreesOfFreedom:": {"@type": "xsd:float", "@value": "1"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:5545f55e2dd1b9010b79b506d70b6d15"},
+      "nidm_statisticType": {"@id": "obo_tstatistic"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
+      "nidm_errorDegreesOfFreedom": {"@type": "xsd:float", "@value": "97.9999999998522"},
+      "nidm_effectDegreesOfFreedom": {"@type": "xsd:float", "@value": "1"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:7281f1fb34adff5220f3261fb87667df"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "9e1714c2d86a050b38b4e10a4d2d23253a24c5e1d228ae16a9c3be8872739278505ac0729ecab54265a717e3a54f9f782d0ed72eea904e0d482a6072bb817bd4"}
     },
     {
-      "@id": "niiri:c1d2c069631a2b218d0e3b760c38281a",
-      "@type": ["prov:Entity","nidm_StatisticMap:"],
+      "@id": "niiri:130668736169c4cdfa7fd91d417d86a8",
+      "@type": ["prov:Entity","nidm_StatisticMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "spmT_0001.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "d288b1b0f117f64502555da13c5398dffa5bf5ff0b58951510e43d5388755bc185798802a92e98a07c7e313c6991066d2908f2a44aa5153ba23433da1335970f"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:005a761addf8440e95437a913ccc9361",
-      "entity": "niiri:c1d2c069631a2b218d0e3b760c38281a"
+      "entity_derived": "niiri:23148787f3344748fde71183ebc7da43",
+      "entity": "niiri:130668736169c4cdfa7fd91d417d86a8"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:005a761addf8440e95437a913ccc9361",
-      "activity": "niiri:35c7eba70163dd4b70439861d7f9877c"
+      "entity_generated": "niiri:23148787f3344748fde71183ebc7da43",
+      "activity": "niiri:4dff47b859ccc8145da60881ef3fcadc"
     },
     {
-      "@id": "niiri:29ee40bc1d63e556b25a129e3278916e",
-      "@type": ["prov:Entity","nidm_ContrastMap:"],
+      "@id": "niiri:011b48f84e70f8c3e98a300224c8a1c1",
+      "@type": ["prov:Entity","nidm_ContrastMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "Contrast.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "Contrast.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Contrast Map: tone counting vs baseline",
-      "nidm_contrastName:": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:5545f55e2dd1b9010b79b506d70b6d15"},
+      "nidm_contrastName": {"@type": "xsd:string", "@value": "tone counting vs baseline"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:7281f1fb34adff5220f3261fb87667df"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "fc5e2ad175243ee496db98f9b2e1b235c4c3bae1a8d7122ce461c897b537e40c49dfee5d6cf20f71c6a2bb9b5f0760fcb4ecd8fe2e9428910ef3d60d8f3c56a9"}
     },
     {
-      "@id": "niiri:f53f77a3a1877600544e0c3e41134d22",
-      "@type": ["prov:Entity","nidm_ContrastMap:"],
+      "@id": "niiri:c5041422daebd48592536bc76fa2d1b2",
+      "@type": ["prov:Entity","nidm_ContrastMap"],
       "nfo:fileName": {"@type": "xsd:string", "@value": "con_0001.nii"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "d4aa46b3603ba508578e39751262d528cf6d1ed2e722ec46f1cd8194c50591e46b229deb8cb4f72d1b7e0e2640f3e6604be7a335301c5c8357f453e5d0d4daf2"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:29ee40bc1d63e556b25a129e3278916e",
-      "entity": "niiri:f53f77a3a1877600544e0c3e41134d22"
+      "entity_derived": "niiri:011b48f84e70f8c3e98a300224c8a1c1",
+      "entity": "niiri:c5041422daebd48592536bc76fa2d1b2"
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:29ee40bc1d63e556b25a129e3278916e",
-      "activity": "niiri:35c7eba70163dd4b70439861d7f9877c"
+      "entity_generated": "niiri:011b48f84e70f8c3e98a300224c8a1c1",
+      "activity": "niiri:4dff47b859ccc8145da60881ef3fcadc"
     },
     {
-      "@id": "niiri:bfd6482c20b0fb3800c79c63e8901d91",
-      "@type": ["prov:Entity","nidm_ContrastStandardErrorMap:"],
+      "@id": "niiri:a0b021c7d36be4a9f8aecb86143deef4",
+      "@type": ["prov:Entity","nidm_ContrastStandardErrorMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ContrastStandardError.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ContrastStandardError.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Contrast Standard Error Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:5545f55e2dd1b9010b79b506d70b6d15"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:7281f1fb34adff5220f3261fb87667df"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "791d48f5d1adb15079a5289271ce0c4b95c56d69bfdb3e5d41b0d24eb538d3075e1cdd15502494b5a5a18c16eaa2153cb4847a996043fa48cdaf26e938a2576d"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:bfd6482c20b0fb3800c79c63e8901d91",
-      "activity": "niiri:35c7eba70163dd4b70439861d7f9877c"
+      "entity_generated": "niiri:a0b021c7d36be4a9f8aecb86143deef4",
+      "activity": "niiri:4dff47b859ccc8145da60881ef3fcadc"
     },
     {
-      "@id": "niiri:47456ce2ef17b7cd1d7311aa87384430",
-      "@type": ["prov:Entity","nidm_HeightThreshold:","obo_statistic:"],
+      "@id": "niiri:2bc75bbda2f5267265d3e555991c4a20",
+      "@type": ["prov:Entity","nidm_HeightThreshold","obo_statistic"],
       "rdfs:label": "Height Threshold: T=4.000000)",
       "prov:value": {"@type": "xsd:float", "@value": "4"},
-      "nidm_equivalentThreshold:": [{"@id": "niiri:d7c3dac965ebf71e3c0385c736eb15fc"},{"@id": "niiri:f8480c367edce0f95a718f1b492a2aca"}]
+      "nidm_equivalentThreshold": [{"@id": "niiri:2ba3915fe8a8233cd1decaccf893dfc6"},{"@id": "niiri:f96c0a4477be91540adcc3de42e3bff1"}]
     },
     {
-      "@id": "niiri:d7c3dac965ebf71e3c0385c736eb15fc",
-      "@type": ["prov:Entity","nidm_HeightThreshold:","nidm_PValueUncorrected:"],
-      "rdfs:label": "Height Threshold",
+      "@id": "niiri:2ba3915fe8a8233cd1decaccf893dfc6",
+      "@type": ["prov:Entity","nidm_HeightThreshold","nidm_PValueUncorrected"],
+      "rdfs:label": "Height Threshold: p<0.000061 (unc.)",
       "prov:value": {"@type": "xsd:float", "@value": "6.14967978617154e-05"}
     },
     {
-      "@id": "niiri:f8480c367edce0f95a718f1b492a2aca",
-      "@type": ["prov:Entity","nidm_HeightThreshold:","obo_FWERadjustedpvalue:"],
-      "rdfs:label": "Height Threshold",
+      "@id": "niiri:f96c0a4477be91540adcc3de42e3bff1",
+      "@type": ["prov:Entity","nidm_HeightThreshold","obo_FWERadjustedpvalue"],
+      "rdfs:label": "Height Threshold: p<0.982274 (FWE)",
       "prov:value": {"@type": "xsd:float", "@value": "0.982273768856173"}
     },
     {
-      "@id": "niiri:595081c81f8719333d05016c9a34a07b",
-      "@type": ["prov:Entity","nidm_ExtentThreshold:","obo_statistic:"],
+      "@id": "niiri:2943fbbdfc96906a3fd4051bd160e061",
+      "@type": ["prov:Entity","nidm_ExtentThreshold","obo_statistic"],
       "rdfs:label": "Extent Threshold: k>=0",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "0"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0"},
-      "nidm_equivalentThreshold:": [{"@id": "niiri:feb69f9468a1e9175df97e2d3ad800ac"},{"@id": "niiri:54a732e5725b44b8b774b00e1e09a5d9"}]
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "0"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0"},
+      "nidm_equivalentThreshold": [{"@id": "niiri:7775696a22ed75b805453eb5b6b80ad7"},{"@id": "niiri:b24450b6aba483c0fc1ba043cfb63970"}]
     },
     {
-      "@id": "niiri:feb69f9468a1e9175df97e2d3ad800ac",
-      "@type": ["prov:Entity","nidm_ExtentThreshold:","obo_FWERadjustedpvalue:"],
+      "@id": "niiri:7775696a22ed75b805453eb5b6b80ad7",
+      "@type": ["prov:Entity","nidm_ExtentThreshold","obo_FWERadjustedpvalue"],
       "rdfs:label": "Extent Threshold",
       "prov:value": {"@type": "xsd:float", "@value": "1"}
     },
     {
-      "@id": "niiri:54a732e5725b44b8b774b00e1e09a5d9",
-      "@type": ["prov:Entity","nidm_ExtentThreshold:","nidm_PValueUncorrected:"],
+      "@id": "niiri:b24450b6aba483c0fc1ba043cfb63970",
+      "@type": ["prov:Entity","nidm_ExtentThreshold","nidm_PValueUncorrected"],
       "rdfs:label": "Extent Threshold",
       "prov:value": {"@type": "xsd:float", "@value": "1"}
     },
     {
-      "@id": "niiri:1b06cd810a1935127442fc3eb55e0e6a",
-      "@type": ["prov:Entity","nidm_PeakDefinitionCriteria:"],
+      "@id": "niiri:0308135e8c28f665d33c547ac6714cf5",
+      "@type": ["prov:Entity","nidm_PeakDefinitionCriteria"],
       "rdfs:label": "Peak Definition Criteria",
-      "nidm_maxNumberOfPeaksPerCluster:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_minDistanceBetweenPeaks:": {"@type": "xsd:float", "@value": "8"}
+      "nidm_maxNumberOfPeaksPerCluster": {"@type": "xsd:int", "@value": "3"},
+      "nidm_minDistanceBetweenPeaks": {"@type": "xsd:float", "@value": "8"}
     },
     {
-      "@id": "niiri:44cc1dd0b9215186b40b5c6b996b4011",
-      "@type": ["prov:Entity","nidm_ClusterDefinitionCriteria:"],
+      "@id": "niiri:a3c0f5b41e3541ca175be5a36b600ad4",
+      "@type": ["prov:Entity","nidm_ClusterDefinitionCriteria"],
       "rdfs:label": "Cluster Connectivity Criterion: 18",
-      "nidm_hasConnectivityCriterion:": {"@id": "nidm_voxel18connected:"}
+      "nidm_hasConnectivityCriterion": {"@id": "nidm_voxel18connected"}
     },
     {
-      "@id": "niiri:9e1edd1ab6c94a52fa0c8c77440391da",
-      "@type": ["prov:Activity","nidm_Inference:"],
-      "nidm_hasAlternativeHypothesis:": {"@id": "nidm_OneTailedTest:"},
+      "@id": "niiri:a587a25c633a14b3f1737b24594224a2",
+      "@type": ["prov:Activity","nidm_Inference"],
+      "nidm_hasAlternativeHypothesis": {"@id": "nidm_OneTailedTest"},
       "rdfs:label": "Inference"
     },
     {
       "@type": "prov:Association",
-      "activity_associated": "niiri:9e1edd1ab6c94a52fa0c8c77440391da",
-      "agent": "niiri:c208e9d9cb32439be7a7b44d2c921772"
+      "activity_associated": "niiri:a587a25c633a14b3f1737b24594224a2",
+      "agent": "niiri:002f4e58c54fcf1f391a012f055d564a"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:9e1edd1ab6c94a52fa0c8c77440391da",
-      "entity": "niiri:47456ce2ef17b7cd1d7311aa87384430"
+      "activity_using": "niiri:a587a25c633a14b3f1737b24594224a2",
+      "entity": "niiri:2bc75bbda2f5267265d3e555991c4a20"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:9e1edd1ab6c94a52fa0c8c77440391da",
-      "entity": "niiri:595081c81f8719333d05016c9a34a07b"
+      "activity_using": "niiri:a587a25c633a14b3f1737b24594224a2",
+      "entity": "niiri:2943fbbdfc96906a3fd4051bd160e061"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:9e1edd1ab6c94a52fa0c8c77440391da",
-      "entity": "niiri:005a761addf8440e95437a913ccc9361"
+      "activity_using": "niiri:a587a25c633a14b3f1737b24594224a2",
+      "entity": "niiri:23148787f3344748fde71183ebc7da43"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:9e1edd1ab6c94a52fa0c8c77440391da",
-      "entity": "niiri:34492567d7743546554a67338e951884"
+      "activity_using": "niiri:a587a25c633a14b3f1737b24594224a2",
+      "entity": "niiri:76c6d153d35cc6d3973219ee9b3f2f15"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:9e1edd1ab6c94a52fa0c8c77440391da",
-      "entity": "niiri:846a7a5fd2e3481706867026e8b26c7d"
+      "activity_using": "niiri:a587a25c633a14b3f1737b24594224a2",
+      "entity": "niiri:9297aa85579b346a54833d2b1d149a50"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:9e1edd1ab6c94a52fa0c8c77440391da",
-      "entity": "niiri:1b06cd810a1935127442fc3eb55e0e6a"
+      "activity_using": "niiri:a587a25c633a14b3f1737b24594224a2",
+      "entity": "niiri:0308135e8c28f665d33c547ac6714cf5"
     },
     {
       "@type": "prov:Usage",
-      "activity_using": "niiri:9e1edd1ab6c94a52fa0c8c77440391da",
-      "entity": "niiri:44cc1dd0b9215186b40b5c6b996b4011"
+      "activity_using": "niiri:a587a25c633a14b3f1737b24594224a2",
+      "entity": "niiri:a3c0f5b41e3541ca175be5a36b600ad4"
     },
     {
-      "@id": "niiri:490d98a60df558fd19f8da510e5ddd78",
-      "@type": ["prov:Entity","nidm_SearchSpaceMaskMap:"],
+      "@id": "niiri:fea41c80a81d93e6e5d3ae10aaaca7c6",
+      "@type": ["prov:Entity","nidm_SearchSpaceMaskMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "SearchSpaceMask.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "SearchSpaceMask.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Search Space Mask Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:5545f55e2dd1b9010b79b506d70b6d15"},
-      "nidm_searchVolumeInVoxels:": {"@type": "xsd:int", "@value": "223057"},
-      "nidm_searchVolumeInUnits:": {"@type": "xsd:float", "@value": "1784456"},
-      "nidm_reselSizeInVoxels:": {"@type": "xsd:float", "@value": "65.5786964036542"},
-      "nidm_searchVolumeInResels:": {"@type": "xsd:float", "@value": "3155.84193266257"},
-      "spm_searchVolumeReselsGeometry:": {"@type": "xsd:string", "@value": "[6, 97.8140592306853, 965.938819261507, 3155.84193266257]"},
-      "nidm_noiseFWHMInVoxels:": {"@type": "xsd:string", "@value": "[4.09118640605185, 4.0346308705955, 3.97291894351243]"},
-      "nidm_noiseFWHMInUnits:": {"@type": "xsd:string", "@value": "[8.18237281210369, 8.069261741191, 7.94583788702486]"},
-      "nidm_randomFieldStationarity:": {"@type": "xsd:boolean", "@value": "true"},
-      "nidm_expectedNumberOfVoxelsPerCluster:": {"@type": "xsd:float", "@value": "3.56239836066169"},
-      "nidm_expectedNumberOfClusters:": {"@type": "xsd:float", "@value": "4.03270975093222"},
-      "nidm_heightCriticalThresholdFWE05:": {"@type": "xsd:float", "@value": "5.30963135104407"},
-      "nidm_heightCriticalThresholdFDR05:": {"@type": "xsd:float", "@value": "5.26161956787109"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:7281f1fb34adff5220f3261fb87667df"},
+      "nidm_searchVolumeInVoxels": {"@type": "xsd:int", "@value": "223057"},
+      "nidm_searchVolumeInUnits": {"@type": "xsd:float", "@value": "1784456"},
+      "nidm_reselSizeInVoxels": {"@type": "xsd:float", "@value": "65.5786964036542"},
+      "nidm_searchVolumeInResels": {"@type": "xsd:float", "@value": "3155.84193266257"},
+      "spm_searchVolumeReselsGeometry": {"@type": "xsd:string", "@value": "[6, 97.8140592306853, 965.938819261507, 3155.84193266257]"},
+      "nidm_noiseFWHMInVoxels": {"@type": "xsd:string", "@value": "[4.09118640605185, 4.0346308705955, 3.97291894351243]"},
+      "nidm_noiseFWHMInUnits": {"@type": "xsd:string", "@value": "[8.18237281210369, 8.069261741191, 7.94583788702486]"},
+      "nidm_randomFieldStationarity": {"@type": "xsd:boolean", "@value": "true"},
+      "nidm_expectedNumberOfVoxelsPerCluster": {"@type": "xsd:float", "@value": "3.56239836066169"},
+      "nidm_expectedNumberOfClusters": {"@type": "xsd:float", "@value": "4.03270975093222"},
+      "nidm_heightCriticalThresholdFWE05": {"@type": "xsd:float", "@value": "5.30963135104407"},
+      "nidm_heightCriticalThresholdFDR05": {"@type": "xsd:float", "@value": "5.26161956787109"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876"},
-      "spm_smallestSignificantClusterSizeInVoxelsFWE05:": {"@type": "xsd:int", "@value": "48"},
-      "spm_smallestSignificantClusterSizeInVoxelsFDR05:": {"@type": "xsd:int", "@value": "24"}
+      "spm_smallestSignificantClusterSizeInVoxelsFWE05": {"@type": "xsd:int", "@value": "48"},
+      "spm_smallestSignificantClusterSizeInVoxelsFDR05": {"@type": "xsd:int", "@value": "24"}
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:490d98a60df558fd19f8da510e5ddd78",
-      "activity": "niiri:9e1edd1ab6c94a52fa0c8c77440391da"
+      "entity_generated": "niiri:fea41c80a81d93e6e5d3ae10aaaca7c6",
+      "activity": "niiri:a587a25c633a14b3f1737b24594224a2"
     },
     {
-      "@id": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8",
-      "@type": ["prov:Entity","nidm_ExcursionSetMap:"],
+      "@id": "niiri:01e8d7706461319dc2f9f847acb9d9b6",
+      "@type": ["prov:Entity","nidm_ExcursionSetMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ExcursionSet.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ExcursionSet.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Excursion Set Map",
-      "nidm_numberOfSupraThresholdClusters:": {"@type": "xsd:int", "@value": "50"},
-      "nidm_pValue:": {"@type": "xsd:float", "@value": "0"},
-      "nidm_hasClusterLabelsMap:": {"@id": "niiri:c0460e253ef0222ac9a8875873636259"},
-      "nidm_hasMaximumIntensityProjection:": {"@id": "niiri:d9ad87418744b82ac48223bedf3b9e48"},
-      "nidm_inCoordinateSpace:": {"@id": "niiri:5545f55e2dd1b9010b79b506d70b6d15"},
+      "nidm_numberOfSupraThresholdClusters": {"@type": "xsd:int", "@value": "50"},
+      "nidm_pValue": {"@type": "xsd:float", "@value": "0"},
+      "nidm_hasClusterLabelsMap": {"@id": "niiri:af1adaf3b31a04d6e71698c939ab4b78"},
+      "nidm_hasMaximumIntensityProjection": {"@id": "niiri:9309bc37a685ef32c88ac516783d33c1"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:7281f1fb34adff5220f3261fb87667df"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "a38743559bef11977e156d91275f386fc5f6886442cb7de734c12bdac62fac0cee28c0084419d0258da02ccef31a25aeea212441e01eaf2e902f1acb60b073df"}
     },
     {
-      "@id": "niiri:c0460e253ef0222ac9a8875873636259",
-      "@type": ["prov:Entity","nidm_ClusterLabelsMap:"],
+      "@id": "niiri:af1adaf3b31a04d6e71698c939ab4b78",
+      "@type": ["prov:Entity","nidm_ClusterLabelsMap"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "ClusterLabels.nii.gz"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "ClusterLabels.nii.gz"},
       "dct:format": {"@type": "xsd:string", "@value": "image/nifti"},
       "rdfs:label": "Cluster Labels Map",
-      "nidm_inCoordinateSpace:": {"@id": "niiri:5545f55e2dd1b9010b79b506d70b6d15"},
+      "nidm_inCoordinateSpace": {"@id": "niiri:7281f1fb34adff5220f3261fb87667df"},
       "crypto:sha512": {"@type": "xsd:string", "@value": "0802849189145a669e184384d952b5a23ec1267712f265582c4e7211b3307cb6cc05e055d687ec7fb168c7c3abffd843f3013061000bcb817971544daf0c712b"}
     },
     {
-      "@id": "niiri:d9ad87418744b82ac48223bedf3b9e48",
+      "@id": "niiri:9309bc37a685ef32c88ac516783d33c1",
       "@type": ["prov:Entity","dctype:Image"],
       "prov:atLocation": {"@type": "xsd:anyURI", "@value": "MaximumIntensityProjection.png"},
       "nfo:fileName": {"@type": "xsd:string", "@value": "MaximumIntensityProjection.png"},
@@ -731,2304 +731,2304 @@
     },
     {
       "@type": "prov:Generation",
-      "entity_generated": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8",
-      "activity": "niiri:9e1edd1ab6c94a52fa0c8c77440391da"
+      "entity_generated": "niiri:01e8d7706461319dc2f9f847acb9d9b6",
+      "activity": "niiri:a587a25c633a14b3f1737b24594224a2"
     },
     {
-      "@id": "niiri:094d7334d70e893686eb679e848c9ea4",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:7205414c11fb33ad00f174ced75bedbf",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0001",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "449"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "6.84673567215009"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.32264875079833e-14"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "2.55018228756398e-13"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "1.05377479179972e-12"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "1"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "449"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "6.84673567215009"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.32264875079833e-14"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "2.55018228756398e-13"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "1.05377479179972e-12"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "1"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:094d7334d70e893686eb679e848c9ea4",
-      "entity": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8"
+      "entity_derived": "niiri:7205414c11fb33ad00f174ced75bedbf",
+      "entity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
     },
     {
-      "@id": "niiri:f3d3c07e06847367de29b57d78ad4c4d",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:8f4713f29184830ccee1527aedd5043c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0002",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "159"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "2.42456786608433"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.47398502769769e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "9.97685856818364e-07"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "2.06165418974807e-06"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "2"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "159"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "2.42456786608433"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.47398502769769e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "9.97685856818364e-07"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "2.06165418974807e-06"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "2"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f3d3c07e06847367de29b57d78ad4c4d",
-      "entity": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8"
+      "entity_derived": "niiri:8f4713f29184830ccee1527aedd5043c",
+      "entity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
     },
     {
-      "@id": "niiri:0b25583a911e871428e848d5f39ad760",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:6565811c2226598488a782fcfbe65641",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0003",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "348"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "5.30660136727891"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.2954082055035e-12"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "2.94202440187519e-11"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "9.11926025687937e-11"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "3"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "348"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "5.30660136727891"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.2954082055035e-12"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "2.94202440187519e-11"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "9.11926025687937e-11"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "3"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0b25583a911e871428e848d5f39ad760",
-      "entity": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8"
+      "entity_derived": "niiri:6565811c2226598488a782fcfbe65641",
+      "entity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
     },
     {
-      "@id": "niiri:eb6931b2d74447879ba47c6442079649",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:775519b5c1873bb910da7115bee920c0",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0004",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "817"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "12.4583141295025"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.12526026794101e-20"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "5.31315066985251e-19"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "4"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "817"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "12.4583141295025"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.12526026794101e-20"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "5.31315066985251e-19"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "4"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:eb6931b2d74447879ba47c6442079649",
-      "entity": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8"
+      "entity_derived": "niiri:775519b5c1873bb910da7115bee920c0",
+      "entity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
     },
     {
-      "@id": "niiri:44faa3b6b4970674a664a3584aeafbd7",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:0deac3c5a5a1925942b4c734669b80cc",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0005",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "224"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "3.41574340882321"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.98239151916056e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "2.00925386328876e-08"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "4.98239151916056e-08"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "5"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "224"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "3.41574340882321"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.98239151916056e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "2.00925386328876e-08"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "4.98239151916056e-08"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "5"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:44faa3b6b4970674a664a3584aeafbd7",
-      "entity": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8"
+      "entity_derived": "niiri:0deac3c5a5a1925942b4c734669b80cc",
+      "entity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
     },
     {
-      "@id": "niiri:04a5b76be470d6bad89f3870fda12c8f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c20e67383ada8b9423453af31b5a55de",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0006",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "65"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.991175542738877"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000229583980927154"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.000925417095783976"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00114791990463577"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "6"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "65"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.991175542738877"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000229583980927154"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.000925417095783976"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00114791990463577"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "6"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:04a5b76be470d6bad89f3870fda12c8f",
-      "entity": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8"
+      "entity_derived": "niiri:c20e67383ada8b9423453af31b5a55de",
+      "entity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
     },
     {
-      "@id": "niiri:791b0e754efbbb51618cea3a14b3b0e6",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:23214e52c07fc432e44b14cfd9b05b8c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0007",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "24"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.365972508088201"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0133990055641975"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0526003902330785"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0478535913007054"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "7"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "24"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.365972508088201"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0133990055641975"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0526003902330785"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0478535913007054"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "7"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:791b0e754efbbb51618cea3a14b3b0e6",
-      "entity": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8"
+      "entity_derived": "niiri:23214e52c07fc432e44b14cfd9b05b8c",
+      "entity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
     },
     {
-      "@id": "niiri:7e9854c772fccbc9dd667ccaf963d0ad",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:63b9219b72b5b660f76b07f652b6ddab",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0008",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "101"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.54013430487118"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.31231548408092e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "5.29204741518408e-05"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "8.20197177550572e-05"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "8"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "101"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.54013430487118"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.31231548408092e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "5.29204741518408e-05"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "8.20197177550572e-05"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "8"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7e9854c772fccbc9dd667ccaf963d0ad",
-      "entity": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8"
+      "entity_derived": "niiri:63b9219b72b5b660f76b07f652b6ddab",
+      "entity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
     },
     {
-      "@id": "niiri:e72ed1be72500e0e5102f29f0ac13651",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:b37dd2ff926a0dc9856b3d0532b1c0dd",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0009",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "121"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.84511139494468"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.11274981286496e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "1.255273773626e-05"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "2.22339272347497e-05"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "9"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "121"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.84511139494468"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.11274981286496e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "1.255273773626e-05"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "2.22339272347497e-05"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "9"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e72ed1be72500e0e5102f29f0ac13651",
-      "entity": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8"
+      "entity_derived": "niiri:b37dd2ff926a0dc9856b3d0532b1c0dd",
+      "entity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
     },
     {
-      "@id": "niiri:1ec5bcf3d27a79e3a649cf72f09cc3e2",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:e9b24d9fcc87aa114863aac61da68dea",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0010",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "48"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.731945016176401"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.00106392992240541"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00428132943861648"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00409203816309772"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "10"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "48"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.731945016176401"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.00106392992240541"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00428132943861648"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00409203816309772"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "10"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1ec5bcf3d27a79e3a649cf72f09cc3e2",
-      "entity": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8"
+      "entity_derived": "niiri:e9b24d9fcc87aa114863aac61da68dea",
+      "entity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
     },
     {
-      "@id": "niiri:9d57dfc9c26a3b26ff08bc8602cb7238",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:7e536777241b4ecd7a6966f907894029",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0011",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "968"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "14.7608911595574"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "9.38808175052664e-23"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "4.69404087526332e-21"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "11"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "968"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "14.7608911595574"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "9.38808175052664e-23"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "4.69404087526332e-21"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "11"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9d57dfc9c26a3b26ff08bc8602cb7238",
-      "entity": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8"
+      "entity_derived": "niiri:7e536777241b4ecd7a6966f907894029",
+      "entity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
     },
     {
-      "@id": "niiri:56b434cc0204499fc97e08dac52bab86",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f008be07086de77a22010a7f08caa22f",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0012",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "9"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.137239690533075"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.106178964707615"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.348311730935284"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.212357929415231"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "12"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "9"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.137239690533075"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.106178964707615"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.348311730935284"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.212357929415231"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "12"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:56b434cc0204499fc97e08dac52bab86",
-      "entity": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8"
+      "entity_derived": "niiri:f008be07086de77a22010a7f08caa22f",
+      "entity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
     },
     {
-      "@id": "niiri:eb4c4ce00fca97f5c6e779fced2198a7",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:0b8006d59ae6d79e0e814aa87159321c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0013",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "14"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.21348396305145"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0492525133792869"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.180139512966202"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.123131283448217"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "13"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "14"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.21348396305145"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0492525133792869"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.180139512966202"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.123131283448217"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "13"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:eb4c4ce00fca97f5c6e779fced2198a7",
-      "entity": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8"
+      "entity_derived": "niiri:0b8006d59ae6d79e0e814aa87159321c",
+      "entity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
     },
     {
-      "@id": "niiri:de8927fdf14192632eecaa3636f2e9e3",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:6581a2a4fbc96915373d67e7edf695a9",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0014",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "69"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "1.05217096075358"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0001633569702971"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.000658554304862946"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000907538723872777"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "14"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "69"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "1.05217096075358"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0001633569702971"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.000658554304862946"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000907538723872777"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "14"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:de8927fdf14192632eecaa3636f2e9e3",
-      "entity": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8"
+      "entity_derived": "niiri:6581a2a4fbc96915373d67e7edf695a9",
+      "entity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
     },
     {
-      "@id": "niiri:21c83646c5b8900bb66ac4bdc408bd17",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:d1a419e3b8453b976a58dbdde542b8c4",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0015",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "55"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.838686997702127"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000555224209552174"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0022365532630918"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00252374640705533"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "15"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "55"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.838686997702127"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000555224209552174"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0022365532630918"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00252374640705533"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "15"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:21c83646c5b8900bb66ac4bdc408bd17",
-      "entity": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8"
+      "entity_derived": "niiri:d1a419e3b8453b976a58dbdde542b8c4",
+      "entity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
     },
     {
-      "@id": "niiri:39b00e4afb3679693ccf462cccc76f45",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:9f5db5fa91c4f9045129661d86ff7c8f",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0016",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "50"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.762442725183751"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.000880826590546597"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00354581667270804"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00367011079394416"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "16"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "50"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.762442725183751"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.000880826590546597"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00354581667270804"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00367011079394416"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "16"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:39b00e4afb3679693ccf462cccc76f45",
-      "entity": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8"
+      "entity_derived": "niiri:9f5db5fa91c4f9045129661d86ff7c8f",
+      "entity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
     },
     {
-      "@id": "niiri:1b13213ccbcda957315f11cacbe52f8e",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:dc8fb82556a5fb25f9d253499774c9d3",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0017",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "19"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.289728235569826"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.024956761440693"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0957445447008427"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0779898795021655"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "17"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "19"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.289728235569826"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.024956761440693"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0957445447008427"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0779898795021655"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "17"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1b13213ccbcda957315f11cacbe52f8e",
-      "entity": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8"
+      "entity_derived": "niiri:dc8fb82556a5fb25f9d253499774c9d3",
+      "entity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
     },
     {
-      "@id": "niiri:57a4b5c4432a4efdb2afe166bc8a8d40",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:65d11f313edff947dbe708fa2df7a47f",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0018",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "17"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.259230526562475"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0324891210881831"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.12279906400353"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0902475585782863"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "18"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "17"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.259230526562475"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0324891210881831"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.12279906400353"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0902475585782863"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "18"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:57a4b5c4432a4efdb2afe166bc8a8d40",
-      "entity": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8"
+      "entity_derived": "niiri:65d11f313edff947dbe708fa2df7a47f",
+      "entity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
     },
     {
-      "@id": "niiri:1fc9da3e6287c03753ee90c1a5abc45f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:5e70ca2cffa7ec4b08a897a898eb5b28",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0019",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "21"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.320225944577176"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0193462362939225"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0750519967443879"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0644874543130751"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "19"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "21"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.320225944577176"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0193462362939225"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0750519967443879"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0644874543130751"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "19"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1fc9da3e6287c03753ee90c1a5abc45f",
-      "entity": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8"
+      "entity_derived": "niiri:5e70ca2cffa7ec4b08a897a898eb5b28",
+      "entity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
     },
     {
-      "@id": "niiri:a87ac34d0b2aa71a22f631bee6f5d009",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c77ff18164bd254c10834cf4198cc926",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0020",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "11"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.167737399540425"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.077023606911316"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.267003132503806"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.175053652071173"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "20"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "11"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.167737399540425"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.077023606911316"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.267003132503806"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.175053652071173"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "20"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a87ac34d0b2aa71a22f631bee6f5d009",
-      "entity": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8"
+      "entity_derived": "niiri:c77ff18164bd254c10834cf4198cc926",
+      "entity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
     },
     {
-      "@id": "niiri:d6ac21365d2405aa9644fdebf0cc6ef4",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:5ec4ec1a9ea7234dae961134341c413f",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0021",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "10"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.15248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0901918343067497"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.304912463578717"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.187899654805729"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "21"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "10"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.15248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0901918343067497"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.304912463578717"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.187899654805729"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "21"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d6ac21365d2405aa9644fdebf0cc6ef4",
-      "entity": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8"
+      "entity_derived": "niiri:5ec4ec1a9ea7234dae961134341c413f",
+      "entity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
     },
     {
-      "@id": "niiri:1538a072d6986b630537b29066fec5db",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:43dcb06f795f24225ca2e94a905a018a",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0022",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "7"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.106741981525725"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.150065723699571"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.454019221049343"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.267974506606377"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "22"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "7"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.106741981525725"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.150065723699571"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.454019221049343"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.267974506606377"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "22"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1538a072d6986b630537b29066fec5db",
-      "entity": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8"
+      "entity_derived": "niiri:43dcb06f795f24225ca2e94a905a018a",
+      "entity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
     },
     {
-      "@id": "niiri:b1a9ed0ce88ddf57f1afa2ab051d9094",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:63c6acd902a0987762c94921fa226068",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0023",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "10"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.15248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0901918343067497"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.304912463578717"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.187899654805729"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "23"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "10"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.15248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0901918343067497"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.304912463578717"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.187899654805729"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "23"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b1a9ed0ce88ddf57f1afa2ab051d9094",
-      "entity": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8"
+      "entity_derived": "niiri:63c6acd902a0987762c94921fa226068",
+      "entity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
     },
     {
-      "@id": "niiri:a820061ecf406d69716300c9fedb0d02",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:5e9dd0483caa5eb1c58d3fce896ce441",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0024",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "6"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0914931270220502"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.180604370544184"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.517283138916719"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.301007284240307"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "24"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "6"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0914931270220502"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.180604370544184"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.517283138916719"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.301007284240307"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "24"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a820061ecf406d69716300c9fedb0d02",
-      "entity": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8"
+      "entity_derived": "niiri:5e9dd0483caa5eb1c58d3fce896ce441",
+      "entity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
     },
     {
-      "@id": "niiri:1c89663261d7fe599621a515c41412ef",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:a371619b98c52e0355b320d28edb7189",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0025",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "5"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0762442725183751"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.219683072090517"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.587664552082487"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.31383296012931"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "25"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "5"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0762442725183751"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.219683072090517"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.587664552082487"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.31383296012931"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "25"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1c89663261d7fe599621a515c41412ef",
-      "entity": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8"
+      "entity_derived": "niiri:a371619b98c52e0355b320d28edb7189",
+      "entity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
     },
     {
-      "@id": "niiri:347c2f752b33682df28dbb3618ca4959",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:37cde807f5ec7a0a182032d2608a5010",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0026",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "8"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.1219908360294"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.125773864474947"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.397826391888126"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.232914563842494"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "26"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "8"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.1219908360294"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.125773864474947"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.397826391888126"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.232914563842494"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "26"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:347c2f752b33682df28dbb3618ca4959",
-      "entity": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8"
+      "entity_derived": "niiri:37cde807f5ec7a0a182032d2608a5010",
+      "entity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
     },
     {
-      "@id": "niiri:b06c1cefe3c12fe41b07e749646c1006",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:6bb17b684d45a4f861c90fe5fbe07173",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0027",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "5"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0762442725183751"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.219683072090517"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.587664552082487"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.31383296012931"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "27"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "5"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0762442725183751"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.219683072090517"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.587664552082487"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.31383296012931"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "27"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b06c1cefe3c12fe41b07e749646c1006",
-      "entity": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8"
+      "entity_derived": "niiri:6bb17b684d45a4f861c90fe5fbe07173",
+      "entity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
     },
     {
-      "@id": "niiri:9ac56d5858e1280575cd8c2eaac3bf9f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:7560e53c1288bc92b5a4d846f27be2a2",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0028",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "11"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.167737399540425"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.077023606911316"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.267003132503806"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.175053652071173"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "28"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "11"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.167737399540425"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.077023606911316"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.267003132503806"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.175053652071173"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "28"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9ac56d5858e1280575cd8c2eaac3bf9f",
-      "entity": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8"
+      "entity_derived": "niiri:7560e53c1288bc92b5a4d846f27be2a2",
+      "entity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
     },
     {
-      "@id": "niiri:c1038d6173e201e6db5e15170fe9c504",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:6a1d4b90730b6f045c485c09e364158b",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0029",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "8"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.1219908360294"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.125773864474947"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.397826391888126"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.232914563842494"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "29"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "8"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.1219908360294"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.125773864474947"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.397826391888126"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.232914563842494"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "29"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c1038d6173e201e6db5e15170fe9c504",
-      "entity": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8"
+      "entity_derived": "niiri:6a1d4b90730b6f045c485c09e364158b",
+      "entity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
     },
     {
-      "@id": "niiri:10fb1def343c16cea3ed7ca34f95f4a5",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:642f54df01178892acf81b69ba1cdd64",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0030",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "5"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0762442725183751"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.219683072090517"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.587664552082487"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.31383296012931"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "30"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "5"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0762442725183751"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.219683072090517"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.587664552082487"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.31383296012931"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "30"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:10fb1def343c16cea3ed7ca34f95f4a5",
-      "entity": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8"
+      "entity_derived": "niiri:642f54df01178892acf81b69ba1cdd64",
+      "entity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
     },
     {
-      "@id": "niiri:05b9a5f65294a59f709d2874ee06eb74",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:7004bd2e853e73ce41a764732d04d90f",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0031",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "16"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.2439816720588"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.037212501212752"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.139349875405945"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0979276347703999"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "31"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "16"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.2439816720588"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.037212501212752"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.139349875405945"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0979276347703999"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "31"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:05b9a5f65294a59f709d2874ee06eb74",
-      "entity": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8"
+      "entity_derived": "niiri:7004bd2e853e73ce41a764732d04d90f",
+      "entity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
     },
     {
-      "@id": "niiri:6e7ba611211b14c42b46c20448bed1da",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:44f3268a65a1bd0913070af57e7f8c22",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0032",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "17"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.259230526562475"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.0324891210881831"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.12279906400353"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0902475585782863"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "32"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "17"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.259230526562475"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.0324891210881831"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.12279906400353"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0902475585782863"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "32"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6e7ba611211b14c42b46c20448bed1da",
-      "entity": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8"
+      "entity_derived": "niiri:44f3268a65a1bd0913070af57e7f8c22",
+      "entity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
     },
     {
-      "@id": "niiri:b460f1f0b03e40e2ef4befc4665227a8",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:27e476ef788fe4fb3d8dcc031b399a81",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0033",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "6"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0914931270220502"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.180604370544184"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.517283138916719"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.301007284240307"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "33"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "6"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0914931270220502"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.180604370544184"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.517283138916719"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.301007284240307"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "33"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b460f1f0b03e40e2ef4befc4665227a8",
-      "entity": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8"
+      "entity_derived": "niiri:27e476ef788fe4fb3d8dcc031b399a81",
+      "entity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
     },
     {
-      "@id": "niiri:054b7672bba8ed55d6c9d550e674f600",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:ca4952c39685bacdd04c639d61f596dc",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0034",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.439209995767388"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.829872382543375"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.51070929740394"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "34"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.439209995767388"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.829872382543375"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.51070929740394"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "34"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:054b7672bba8ed55d6c9d550e674f600",
-      "entity": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8"
+      "entity_derived": "niiri:ca4952c39685bacdd04c639d61f596dc",
+      "entity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
     },
     {
-      "@id": "niiri:5c380d0f5b0d102daa46b5ee765401d0",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:af2ac94d3f5ea60663d90097f8159f1d",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0035",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "5"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0762442725183751"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.219683072090517"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.587664552082487"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.31383296012931"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "35"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "5"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0762442725183751"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.219683072090517"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.587664552082487"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.31383296012931"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "35"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5c380d0f5b0d102daa46b5ee765401d0",
-      "entity": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8"
+      "entity_derived": "niiri:af2ac94d3f5ea60663d90097f8159f1d",
+      "entity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
     },
     {
-      "@id": "niiri:ff57ed710046587ca6241d3e59018019",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:d088c79195acad1ffe8fcf692ee20b14",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0036",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.595521713796185"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.909424019965657"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.595521713796185"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "36"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.595521713796185"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.909424019965657"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.595521713796185"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "36"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ff57ed710046587ca6241d3e59018019",
-      "entity": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8"
+      "entity_derived": "niiri:d088c79195acad1ffe8fcf692ee20b14",
+      "entity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
     },
     {
-      "@id": "niiri:8d2f0fd2c9e7d0b8208eb1fc4b198d3a",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:9d84cb059aa001b080f641472d50dee9",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0037",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.595521713796185"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.909424019965657"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.595521713796185"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "37"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.595521713796185"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.909424019965657"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.595521713796185"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "37"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8d2f0fd2c9e7d0b8208eb1fc4b198d3a",
-      "entity": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8"
+      "entity_derived": "niiri:9d84cb059aa001b080f641472d50dee9",
+      "entity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
     },
     {
-      "@id": "niiri:684e846c172afe6d05d5ae78e91a66ab",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:51d1d5abbfa00532f6e6a2f6c7c0cf8f",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0038",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "5"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0762442725183751"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.219683072090517"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.587664552082487"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.31383296012931"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "38"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "5"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0762442725183751"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.219683072090517"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.587664552082487"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.31383296012931"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "38"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:684e846c172afe6d05d5ae78e91a66ab",
-      "entity": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8"
+      "entity_derived": "niiri:51d1d5abbfa00532f6e6a2f6c7c0cf8f",
+      "entity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
     },
     {
-      "@id": "niiri:e41c1ae17d421ba7f943954ecb82266f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f39108df33a4d833661db62b9a0c407f",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0039",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0457465635110251"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.340226503435217"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.746409555850822"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.436187824916945"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "39"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0457465635110251"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.340226503435217"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.746409555850822"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.436187824916945"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "39"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e41c1ae17d421ba7f943954ecb82266f",
-      "entity": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8"
+      "entity_derived": "niiri:f39108df33a4d833661db62b9a0c407f",
+      "entity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
     },
     {
-      "@id": "niiri:6ebbb8b1cbde12076fc5d4ef4e85955c",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:4b799f0cf87667a22d5d0bd894e1cf9f",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0040",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.439209995767388"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.829872382543375"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.51070929740394"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "40"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.439209995767388"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.829872382543375"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.51070929740394"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "40"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6ebbb8b1cbde12076fc5d4ef4e85955c",
-      "entity": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8"
+      "entity_derived": "niiri:4b799f0cf87667a22d5d0bd894e1cf9f",
+      "entity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
     },
     {
-      "@id": "niiri:370b2cb6de898bd071b9e171bc29995b",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:418bd4d687fd48d9de96b297aa605a93",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0041",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.439209995767388"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.829872382543375"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.51070929740394"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "41"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.439209995767388"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.829872382543375"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.51070929740394"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "41"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:370b2cb6de898bd071b9e171bc29995b",
-      "entity": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8"
+      "entity_derived": "niiri:418bd4d687fd48d9de96b297aa605a93",
+      "entity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
     },
     {
-      "@id": "niiri:24a35ffc9e3360be3e77ac0bdf6162e1",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:69987b67a58d47cf5fdd3f3dd0097df0",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0042",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0609954180147001"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.270880348129629"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.664583360945099"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.366054524499499"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "42"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0609954180147001"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.270880348129629"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.664583360945099"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.366054524499499"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "42"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:24a35ffc9e3360be3e77ac0bdf6162e1",
-      "entity": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8"
+      "entity_derived": "niiri:69987b67a58d47cf5fdd3f3dd0097df0",
+      "entity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
     },
     {
-      "@id": "niiri:938df04c7b599a7c74931290216cc187",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:f0f2196eb8e713870fab0d351b7d0893",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0043",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.595521713796185"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.909424019965657"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.595521713796185"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "43"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.595521713796185"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.909424019965657"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.595521713796185"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "43"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:938df04c7b599a7c74931290216cc187",
-      "entity": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8"
+      "entity_derived": "niiri:f0f2196eb8e713870fab0d351b7d0893",
+      "entity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
     },
     {
-      "@id": "niiri:d9d050f643bc5856b77ef6ab7839c73f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:917a8294186d88d434a4bfc11da79880",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0044",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "4"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0609954180147001"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.270880348129629"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.664583360945099"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.366054524499499"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "44"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "4"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0609954180147001"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.270880348129629"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.664583360945099"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.366054524499499"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "44"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d9d050f643bc5856b77ef6ab7839c73f",
-      "entity": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8"
+      "entity_derived": "niiri:917a8294186d88d434a4bfc11da79880",
+      "entity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
     },
     {
-      "@id": "niiri:e6891860aa8b247560dff60407d6186f",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:2bf2abbcd31986ec01bd57d20b6711a8",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0045",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.595521713796185"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.909424019965657"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.595521713796185"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "45"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.595521713796185"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.909424019965657"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.595521713796185"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "45"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e6891860aa8b247560dff60407d6186f",
-      "entity": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8"
+      "entity_derived": "niiri:2bf2abbcd31986ec01bd57d20b6711a8",
+      "entity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
     },
     {
-      "@id": "niiri:e70320e383167eb84eda35bf9e7b0fdd",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:ad8c7d04ce78559070db7b91d78cc57c",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0046",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "3"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0457465635110251"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.340226503435217"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.746409555850822"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.436187824916945"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "46"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "3"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0457465635110251"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.340226503435217"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.746409555850822"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.436187824916945"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "46"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e70320e383167eb84eda35bf9e7b0fdd",
-      "entity": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8"
+      "entity_derived": "niiri:ad8c7d04ce78559070db7b91d78cc57c",
+      "entity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
     },
     {
-      "@id": "niiri:11f8c2ae0641d8825a111d78d6676ecf",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:17c9ecb05e0c47b2a47ad52062e17b94",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0047",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.595521713796185"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.909424019965657"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.595521713796185"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "47"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.595521713796185"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.909424019965657"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.595521713796185"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "47"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:11f8c2ae0641d8825a111d78d6676ecf",
-      "entity": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8"
+      "entity_derived": "niiri:17c9ecb05e0c47b2a47ad52062e17b94",
+      "entity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
     },
     {
-      "@id": "niiri:dad011c7f4403d3ac70b748845e3c867",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:c5e4e1aa155896b26494489613f9ad95",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0048",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.595521713796185"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.909424019965657"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.595521713796185"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "48"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.595521713796185"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.909424019965657"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.595521713796185"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "48"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:dad011c7f4403d3ac70b748845e3c867",
-      "entity": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8"
+      "entity_derived": "niiri:c5e4e1aa155896b26494489613f9ad95",
+      "entity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
     },
     {
-      "@id": "niiri:d530532271fa470308bd3bf1b9d79611",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:b838a0239e573b6049362c413185e4cb",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0049",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "2"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.0304977090073501"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.439209995767388"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.829872382543375"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.51070929740394"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "49"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "2"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.0304977090073501"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.439209995767388"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.829872382543375"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.51070929740394"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "49"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d530532271fa470308bd3bf1b9d79611",
-      "entity": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8"
+      "entity_derived": "niiri:b838a0239e573b6049362c413185e4cb",
+      "entity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
     },
     {
-      "@id": "niiri:e9bc012a60857c8c9c65fa0b8468ac39",
-      "@type": ["prov:Entity","nidm_SupraThresholdCluster:"],
+      "@id": "niiri:e35bb4611d1d05c17b7964df5a12a385",
+      "@type": ["prov:Entity","nidm_SupraThresholdCluster"],
       "rdfs:label": "Supra-Threshold Cluster: 0050",
-      "nidm_clusterSizeInVoxels:": {"@type": "xsd:int", "@value": "1"},
-      "nidm_clusterSizeInResels:": {"@type": "xsd:float", "@value": "0.015248854503675"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "0.595521713796185"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.909424019965657"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.595521713796185"},
-      "nidm_clusterLabelId:": {"@type": "xsd:int", "@value": "50"}
+      "nidm_clusterSizeInVoxels": {"@type": "xsd:int", "@value": "1"},
+      "nidm_clusterSizeInResels": {"@type": "xsd:float", "@value": "0.015248854503675"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "0.595521713796185"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.909424019965657"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.595521713796185"},
+      "nidm_clusterLabelId": {"@type": "xsd:int", "@value": "50"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e9bc012a60857c8c9c65fa0b8468ac39",
-      "entity": "niiri:8c9e982b5e5acb0cf016de26a88d4eb8"
+      "entity_derived": "niiri:e35bb4611d1d05c17b7964df5a12a385",
+      "entity": "niiri:01e8d7706461319dc2f9f847acb9d9b6"
     },
     {
-      "@id": "niiri:c768c5e94b4ac7daec697b06ee3c2438",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:96a59d90e155647137289214422e35d4",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0001",
-      "prov:atLocation": {"@id": "niiri:47e29259ce8e8c6a4fd52e2776a6b292"},
+      "prov:atLocation": {"@id": "niiri:b1d6c31f98bd6f43acc3b57cdc2c4cdc"},
       "prov:value": {"@type": "xsd:float", "@value": "7.92007970809937"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "6.94608360738412"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.87783122385099e-12"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "4.18813870695089e-07"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "2.27218233660389e-05"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "6.94608360738412"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.87783122385099e-12"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "4.18813870695089e-07"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "2.27218233660389e-05"}
     },
     {
-      "@id": "niiri:47e29259ce8e8c6a4fd52e2776a6b292",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b1d6c31f98bd6f43acc3b57cdc2c4cdc",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0001",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[46,16,24]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[46,16,24]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c768c5e94b4ac7daec697b06ee3c2438",
-      "entity": "niiri:094d7334d70e893686eb679e848c9ea4"
+      "entity_derived": "niiri:96a59d90e155647137289214422e35d4",
+      "entity": "niiri:7205414c11fb33ad00f174ced75bedbf"
     },
     {
-      "@id": "niiri:c3424664b8c3bb4c791a246d7467e3e8",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:488ce8b025057ec458509b3e364bc4e4",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0002",
-      "prov:atLocation": {"@id": "niiri:7e991cf30cd9edf203a3783b88d3ed56"},
+      "prov:atLocation": {"@id": "niiri:314d42742a9d56e3b3203381bc0b5e0c"},
       "prov:value": {"@type": "xsd:float", "@value": "4.9243049621582"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.64313045489904"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.7158475814627e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.186190030417796"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.112174373202225"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.64313045489904"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.7158475814627e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.186190030417796"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.112174373202225"}
     },
     {
-      "@id": "niiri:7e991cf30cd9edf203a3783b88d3ed56",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:314d42742a9d56e3b3203381bc0b5e0c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0002",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[52,30,20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[52,30,20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:c3424664b8c3bb4c791a246d7467e3e8",
-      "entity": "niiri:094d7334d70e893686eb679e848c9ea4"
+      "entity_derived": "niiri:488ce8b025057ec458509b3e364bc4e4",
+      "entity": "niiri:7205414c11fb33ad00f174ced75bedbf"
     },
     {
-      "@id": "niiri:484cb2552d61cb8a2ce07026897b06db",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:54c35228f66c13680fd122cfa6cf904a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0003",
-      "prov:atLocation": {"@id": "niiri:240754b068754ce703bace05b29d61b1"},
+      "prov:atLocation": {"@id": "niiri:fdaec965712432043bed4c8cf9c6c6e9"},
       "prov:value": {"@type": "xsd:float", "@value": "4.8244423866272"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.55839353511092"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.57731916020187e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.252878395148086"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.146027166584536"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.55839353511092"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.57731916020187e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.252878395148086"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.146027166584536"}
     },
     {
-      "@id": "niiri:240754b068754ce703bace05b29d61b1",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:fdaec965712432043bed4c8cf9c6c6e9",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0003",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[56,18,8]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[56,18,8]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:484cb2552d61cb8a2ce07026897b06db",
-      "entity": "niiri:094d7334d70e893686eb679e848c9ea4"
+      "entity_derived": "niiri:54c35228f66c13680fd122cfa6cf904a",
+      "entity": "niiri:7205414c11fb33ad00f174ced75bedbf"
     },
     {
-      "@id": "niiri:68b721a19f4347ceb128a62ee28405da",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:4c983fde4736cd2a3b8fecb492d20712",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0004",
-      "prov:atLocation": {"@id": "niiri:f0829a717047580042885b96f23dff6f"},
+      "prov:atLocation": {"@id": "niiri:cf6e72eafb8fe970a74bb917f5df7698"},
       "prov:value": {"@type": "xsd:float", "@value": "7.11683940887451"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "6.37404871703245"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "9.20510334623259e-11"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "2.05325778424026e-05"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.000406703400889328"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "6.37404871703245"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "9.20510334623259e-11"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "2.05325778424026e-05"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.000406703400889328"}
     },
     {
-      "@id": "niiri:f0829a717047580042885b96f23dff6f",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:cf6e72eafb8fe970a74bb917f5df7698",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0004",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[34,-88,-2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[34,-88,-2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:68b721a19f4347ceb128a62ee28405da",
-      "entity": "niiri:f3d3c07e06847367de29b57d78ad4c4d"
+      "entity_derived": "niiri:4c983fde4736cd2a3b8fecb492d20712",
+      "entity": "niiri:8f4713f29184830ccee1527aedd5043c"
     },
     {
-      "@id": "niiri:0b2074f3517599375a04ea7322473e51",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:debfad6d4dfc9f7dcad235e472df64e9",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0005",
-      "prov:atLocation": {"@id": "niiri:a4af8d1a69e7e55105c45de053c1df15"},
+      "prov:atLocation": {"@id": "niiri:0a68cfc82c1a38bf1844a9db623df7b7"},
       "prov:value": {"@type": "xsd:float", "@value": "6.48292255401611"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.8992593141605"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.82568493656277e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.000407231755366277"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00361825878055109"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.8992593141605"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.82568493656277e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.000407231755366277"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00361825878055109"}
     },
     {
-      "@id": "niiri:a4af8d1a69e7e55105c45de053c1df15",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0a68cfc82c1a38bf1844a9db623df7b7",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0005",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[42,-72,-10]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[42,-72,-10]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0b2074f3517599375a04ea7322473e51",
-      "entity": "niiri:f3d3c07e06847367de29b57d78ad4c4d"
+      "entity_derived": "niiri:debfad6d4dfc9f7dcad235e472df64e9",
+      "entity": "niiri:8f4713f29184830ccee1527aedd5043c"
     },
     {
-      "@id": "niiri:de8b4c2dc3ece9933bff59347ae01471",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:1daadc92a3ffaa028128f1dd83dd2d87",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0006",
-      "prov:atLocation": {"@id": "niiri:a4cb97dd656bd25b8300336959764df2"},
+      "prov:atLocation": {"@id": "niiri:ac087376d1fcef018e5c722275dc0d44"},
       "prov:value": {"@type": "xsd:float", "@value": "6.31603479385376"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.77079466112137"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.94492849498107e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.000879943865776389"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00361825878055109"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.77079466112137"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.94492849498107e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.000879943865776389"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00361825878055109"}
     },
     {
-      "@id": "niiri:a4cb97dd656bd25b8300336959764df2",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ac087376d1fcef018e5c722275dc0d44",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0006",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[32,24,-4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[32,24,-4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:de8b4c2dc3ece9933bff59347ae01471",
-      "entity": "niiri:0b25583a911e871428e848d5f39ad760"
+      "entity_derived": "niiri:1daadc92a3ffaa028128f1dd83dd2d87",
+      "entity": "niiri:6565811c2226598488a782fcfbe65641"
     },
     {
-      "@id": "niiri:79ef8031365056f841857e59a734570d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ed544793a577f316b6d4f813d1d3bea0",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0007",
-      "prov:atLocation": {"@id": "niiri:2bb367cc2a93e698a93b159483545de9"},
+      "prov:atLocation": {"@id": "niiri:3bd89cdd33454979cf7f28e75e1e6678"},
       "prov:value": {"@type": "xsd:float", "@value": "5.68819808959961"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.27450168515333"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.655864770444e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0121028975026269"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0152484334686785"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.27450168515333"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.655864770444e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0121028975026269"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0152484334686785"}
     },
     {
-      "@id": "niiri:2bb367cc2a93e698a93b159483545de9",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:3bd89cdd33454979cf7f28e75e1e6678",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0007",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[18,16,4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[18,16,4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:79ef8031365056f841857e59a734570d",
-      "entity": "niiri:0b25583a911e871428e848d5f39ad760"
+      "entity_derived": "niiri:ed544793a577f316b6d4f813d1d3bea0",
+      "entity": "niiri:6565811c2226598488a782fcfbe65641"
     },
     {
-      "@id": "niiri:f9cb927d23687de90e6d43b303fff7bc",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:3b3c0e5c0e0bda6412e915038db30c1e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0008",
-      "prov:atLocation": {"@id": "niiri:99ca24af8fbb485d77ba9a1884d088f8"},
+      "prov:atLocation": {"@id": "niiri:145cbb2d1fed72de625f99f542b7c4df"},
       "prov:value": {"@type": "xsd:float", "@value": "4.94056129455566"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.65687699571461"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.60521061320917e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.17684019308854"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.110770865806137"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.65687699571461"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.60521061320917e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.17684019308854"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.110770865806137"}
     },
     {
-      "@id": "niiri:99ca24af8fbb485d77ba9a1884d088f8",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:145cbb2d1fed72de625f99f542b7c4df",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0008",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[34,36,-12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[34,36,-12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f9cb927d23687de90e6d43b303fff7bc",
-      "entity": "niiri:0b25583a911e871428e848d5f39ad760"
+      "entity_derived": "niiri:3b3c0e5c0e0bda6412e915038db30c1e",
+      "entity": "niiri:6565811c2226598488a782fcfbe65641"
     },
     {
-      "@id": "niiri:1ade9597332dc8c8f2133dd00470e2d9",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f47f325cd640020f4d275a5e5637467d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0009",
-      "prov:atLocation": {"@id": "niiri:51a7361e803d710ffd23bba12de1ed31"},
+      "prov:atLocation": {"@id": "niiri:7c14a6bf6f09d55caffa373e1993730f"},
       "prov:value": {"@type": "xsd:float", "@value": "6.28007745742798"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.74292583422276"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.65272453897825e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00103782272796227"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00361825878055109"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.74292583422276"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.65272453897825e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00103782272796227"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00361825878055109"}
     },
     {
-      "@id": "niiri:51a7361e803d710ffd23bba12de1ed31",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7c14a6bf6f09d55caffa373e1993730f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0009",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[8,18,50]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[8,18,50]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1ade9597332dc8c8f2133dd00470e2d9",
-      "entity": "niiri:eb6931b2d74447879ba47c6442079649"
+      "entity_derived": "niiri:f47f325cd640020f4d275a5e5637467d",
+      "entity": "niiri:775519b5c1873bb910da7115bee920c0"
     },
     {
-      "@id": "niiri:a0c45cf332e75ca2c2f3a833a4ed4169",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:109800b79f33034388fb15fe6337d32d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0010",
-      "prov:atLocation": {"@id": "niiri:187f409e451cc1c017a1d36a9bbee780"},
+      "prov:atLocation": {"@id": "niiri:0fc5d776108764b8b7c5222659219ffc"},
       "prov:value": {"@type": "xsd:float", "@value": "6.15222215652466"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.64328512810061"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.34178537356678e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00186069357054308"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00423674188371422"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.64328512810061"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.34178537356678e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00186069357054308"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00423674188371422"}
     },
     {
-      "@id": "niiri:187f409e451cc1c017a1d36a9bbee780",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0fc5d776108764b8b7c5222659219ffc",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0010",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-6,12,52]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-6,12,52]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a0c45cf332e75ca2c2f3a833a4ed4169",
-      "entity": "niiri:eb6931b2d74447879ba47c6442079649"
+      "entity_derived": "niiri:109800b79f33034388fb15fe6337d32d",
+      "entity": "niiri:775519b5c1873bb910da7115bee920c0"
     },
     {
-      "@id": "niiri:e8b7520b9c945e406f84bd1f7c1b0641",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c873973223ffcbd2bc046af12b3cb084",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0011",
-      "prov:atLocation": {"@id": "niiri:da6e712baad49ecbe62e5180160f3d03"},
+      "prov:atLocation": {"@id": "niiri:038be17df65e5da54aa0117e3bdb0291"},
       "prov:value": {"@type": "xsd:float", "@value": "5.98517084121704"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.51181334779297"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.77577724747024e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00376326218366319"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0059418335926859"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.51181334779297"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.77577724747024e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00376326218366319"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0059418335926859"}
     },
     {
-      "@id": "niiri:da6e712baad49ecbe62e5180160f3d03",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:038be17df65e5da54aa0117e3bdb0291",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0011",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[8,32,38]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[8,32,38]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e8b7520b9c945e406f84bd1f7c1b0641",
-      "entity": "niiri:eb6931b2d74447879ba47c6442079649"
+      "entity_derived": "niiri:c873973223ffcbd2bc046af12b3cb084",
+      "entity": "niiri:775519b5c1873bb910da7115bee920c0"
     },
     {
-      "@id": "niiri:b916060f302c7d26db4c78e71d433c40",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:8bbd28cf684609e9144a2f897eb1140e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0012",
-      "prov:atLocation": {"@id": "niiri:ae1f416ec1bea5962fa3881f3e327217"},
+      "prov:atLocation": {"@id": "niiri:c8a3baf174ad35060a06e3a29eac92dd"},
       "prov:value": {"@type": "xsd:float", "@value": "6.25127363204956"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.72055271981637"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.30890376104765e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0011841880966994"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00361825878055109"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.72055271981637"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.30890376104765e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0011841880966994"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00361825878055109"}
     },
     {
-      "@id": "niiri:ae1f416ec1bea5962fa3881f3e327217",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c8a3baf174ad35060a06e3a29eac92dd",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0012",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[52,-32,42]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[52,-32,42]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b916060f302c7d26db4c78e71d433c40",
-      "entity": "niiri:44faa3b6b4970674a664a3584aeafbd7"
+      "entity_derived": "niiri:8bbd28cf684609e9144a2f897eb1140e",
+      "entity": "niiri:0deac3c5a5a1925942b4c734669b80cc"
     },
     {
-      "@id": "niiri:6774f189de49ba868e9ed4a33e736e3a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d86b751c0d22a9c191fbfb604d97f2cd",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0013",
-      "prov:atLocation": {"@id": "niiri:8b5b1b9ab7e72d126bdbb773e7d191db"},
+      "prov:atLocation": {"@id": "niiri:d0256ff296dcef1d59eff26b64f34f75"},
       "prov:value": {"@type": "xsd:float", "@value": "5.70337772369385"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.28674301747281"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.22566831420812e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.011413186758684"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0152484334686785"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.28674301747281"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.22566831420812e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.011413186758684"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0152484334686785"}
     },
     {
-      "@id": "niiri:8b5b1b9ab7e72d126bdbb773e7d191db",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d0256ff296dcef1d59eff26b64f34f75",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0013",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[56,-44,52]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[56,-44,52]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6774f189de49ba868e9ed4a33e736e3a",
-      "entity": "niiri:44faa3b6b4970674a664a3584aeafbd7"
+      "entity_derived": "niiri:d86b751c0d22a9c191fbfb604d97f2cd",
+      "entity": "niiri:0deac3c5a5a1925942b4c734669b80cc"
     },
     {
-      "@id": "niiri:a14ba879243e009dfeea6e7e9de68793",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d3d50cda890a097337dea07d5a4fe805",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0014",
-      "prov:atLocation": {"@id": "niiri:d2838cd94edf23abc800adb3366498e0"},
+      "prov:atLocation": {"@id": "niiri:15787b1a2c249af12a69dbbc54246a2d"},
       "prov:value": {"@type": "xsd:float", "@value": "5.69516134262085"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.28011855642631"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.45501619933597e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0117816592148946"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0152484334686785"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.28011855642631"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.45501619933597e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0117816592148946"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0152484334686785"}
     },
     {
-      "@id": "niiri:d2838cd94edf23abc800adb3366498e0",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:15787b1a2c249af12a69dbbc54246a2d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0014",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[60,-36,54]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[60,-36,54]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a14ba879243e009dfeea6e7e9de68793",
-      "entity": "niiri:44faa3b6b4970674a664a3584aeafbd7"
+      "entity_derived": "niiri:d3d50cda890a097337dea07d5a4fe805",
+      "entity": "niiri:0deac3c5a5a1925942b4c734669b80cc"
     },
     {
-      "@id": "niiri:1a312401e61f334882e72fdd05ad141d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:149d3b765ad7fafbf9fbd3b50150b590",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0015",
-      "prov:atLocation": {"@id": "niiri:57a7ac2af98fcf32e7886a9b99f58609"},
+      "prov:atLocation": {"@id": "niiri:f9928a5f1eece0dab107dcfe66af2b61"},
       "prov:value": {"@type": "xsd:float", "@value": "6.24752378463745"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.71763687476157"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.40078304300806e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00120468241369565"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00361825878055109"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.71763687476157"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.40078304300806e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00120468241369565"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00361825878055109"}
     },
     {
-      "@id": "niiri:57a7ac2af98fcf32e7886a9b99f58609",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f9928a5f1eece0dab107dcfe66af2b61",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0015",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[40,-62,50]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[40,-62,50]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1a312401e61f334882e72fdd05ad141d",
-      "entity": "niiri:04a5b76be470d6bad89f3870fda12c8f"
+      "entity_derived": "niiri:149d3b765ad7fafbf9fbd3b50150b590",
+      "entity": "niiri:c20e67383ada8b9423453af31b5a55de"
     },
     {
-      "@id": "niiri:4c36010a81e59e88ca1d89848f0fe3c3",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a3443b6ff5785b43971a8dafa4cf7790",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0016",
-      "prov:atLocation": {"@id": "niiri:84571886b0e80a9ceaf77b0ca2ca4778"},
+      "prov:atLocation": {"@id": "niiri:f843f4e9d6679b55e9c5724c953d5a02"},
       "prov:value": {"@type": "xsd:float", "@value": "5.61174583435059"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.21266637309498"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "9.30727468428927e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0162336583380834"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0188176838211989"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.21266637309498"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "9.30727468428927e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0162336583380834"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0188176838211989"}
     },
     {
-      "@id": "niiri:84571886b0e80a9ceaf77b0ca2ca4778",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f843f4e9d6679b55e9c5724c953d5a02",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0016",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[44,-70,50]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[44,-70,50]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:4c36010a81e59e88ca1d89848f0fe3c3",
-      "entity": "niiri:04a5b76be470d6bad89f3870fda12c8f"
+      "entity_derived": "niiri:a3443b6ff5785b43971a8dafa4cf7790",
+      "entity": "niiri:c20e67383ada8b9423453af31b5a55de"
     },
     {
-      "@id": "niiri:7217bc844dd9995641b325df774d186a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f7f75f82ae4ccf8674d67ee6b3d6bdf5",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0017",
-      "prov:atLocation": {"@id": "niiri:3ecfe0bd50e8eab291e4ee47387017cf"},
+      "prov:atLocation": {"@id": "niiri:f47724d9b1d024327623cf1e2e287528"},
       "prov:value": {"@type": "xsd:float", "@value": "6.15371799468994"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.64445580026639"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.285227171001e-09"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00184807786755337"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00423674188371422"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.64445580026639"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.285227171001e-09"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00184807786755337"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00423674188371422"}
     },
     {
-      "@id": "niiri:3ecfe0bd50e8eab291e4ee47387017cf",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:f47724d9b1d024327623cf1e2e287528",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0017",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-28,-94,4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-28,-94,4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7217bc844dd9995641b325df774d186a",
-      "entity": "niiri:791b0e754efbbb51618cea3a14b3b0e6"
+      "entity_derived": "niiri:f7f75f82ae4ccf8674d67ee6b3d6bdf5",
+      "entity": "niiri:23214e52c07fc432e44b14cfd9b05b8c"
     },
     {
-      "@id": "niiri:a56ef2aacb65354f43e2246a163f99d2",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:162515024ff898dc13bff56500dd3eb1",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0018",
-      "prov:atLocation": {"@id": "niiri:7caceee5203021dc995dc7430ce890bd"},
+      "prov:atLocation": {"@id": "niiri:44b68eb3c0dfabd2fe86365c8fcfd4bf"},
       "prov:value": {"@type": "xsd:float", "@value": "6.10109901428223"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.60320502193174"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.05212039080982e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00234682813060005"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.00455235302862474"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.60320502193174"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.05212039080982e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00234682813060005"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.00455235302862474"}
     },
     {
-      "@id": "niiri:7caceee5203021dc995dc7430ce890bd",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:44b68eb3c0dfabd2fe86365c8fcfd4bf",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0018",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[32,2,46]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[32,2,46]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:a56ef2aacb65354f43e2246a163f99d2",
-      "entity": "niiri:7e9854c772fccbc9dd667ccaf963d0ad"
+      "entity_derived": "niiri:162515024ff898dc13bff56500dd3eb1",
+      "entity": "niiri:63b9219b72b5b660f76b07f652b6ddab"
     },
     {
-      "@id": "niiri:965e3b440ac1070cf024adbdc4e93a8f",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0c87f6e52c8ca63d8178cb1e1cd2cf44",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0019",
-      "prov:atLocation": {"@id": "niiri:1adab910db39dd31432645320b5aa2ac"},
+      "prov:atLocation": {"@id": "niiri:762280b48fb4648ea57c12e2180a549e"},
       "prov:value": {"@type": "xsd:float", "@value": "4.6086859703064"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.3736141683061"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.11031435759912e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.453877178455514"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.261209020216113"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.3736141683061"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.11031435759912e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.453877178455514"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.261209020216113"}
     },
     {
-      "@id": "niiri:1adab910db39dd31432645320b5aa2ac",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:762280b48fb4648ea57c12e2180a549e",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0019",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[28,4,58]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[28,4,58]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:965e3b440ac1070cf024adbdc4e93a8f",
-      "entity": "niiri:7e9854c772fccbc9dd667ccaf963d0ad"
+      "entity_derived": "niiri:0c87f6e52c8ca63d8178cb1e1cd2cf44",
+      "entity": "niiri:63b9219b72b5b660f76b07f652b6ddab"
     },
     {
-      "@id": "niiri:481059c0065fdbec18002f2fc95288a4",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:4e70efe9f00c5d7acd1338d327fa18e6",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0020",
-      "prov:atLocation": {"@id": "niiri:77149dc00fea4411f41bb0ee1fc87de6"},
+      "prov:atLocation": {"@id": "niiri:9dacc3b34de0b0518738ac094b81cd18"},
       "prov:value": {"@type": "xsd:float", "@value": "5.98348569869995"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.51047970249337"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.78928538652201e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00378871596531738"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0059418335926859"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.51047970249337"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.78928538652201e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00378871596531738"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0059418335926859"}
     },
     {
-      "@id": "niiri:77149dc00fea4411f41bb0ee1fc87de6",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:9dacc3b34de0b0518738ac094b81cd18",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0020",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-52,0,38]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-52,0,38]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:481059c0065fdbec18002f2fc95288a4",
-      "entity": "niiri:e72ed1be72500e0e5102f29f0ac13651"
+      "entity_derived": "niiri:4e70efe9f00c5d7acd1338d327fa18e6",
+      "entity": "niiri:b37dd2ff926a0dc9856b3d0532b1c0dd"
     },
     {
-      "@id": "niiri:7182caed118b691f7e4be6a5f6d4ccde",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:23ee46ca8d3095632418f7819018d5cb",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0021",
-      "prov:atLocation": {"@id": "niiri:28289344d3de88a2173f87e4d0f5b40f"},
+      "prov:atLocation": {"@id": "niiri:c333edf1c6856225c10c102228f12592"},
       "prov:value": {"@type": "xsd:float", "@value": "4.98950004577637"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.69817956585148"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.31245304380023e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.151048137890434"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.101749935670058"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.69817956585148"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.31245304380023e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.151048137890434"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.101749935670058"}
     },
     {
-      "@id": "niiri:28289344d3de88a2173f87e4d0f5b40f",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c333edf1c6856225c10c102228f12592",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0021",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-44,6,28]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-44,6,28]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7182caed118b691f7e4be6a5f6d4ccde",
-      "entity": "niiri:e72ed1be72500e0e5102f29f0ac13651"
+      "entity_derived": "niiri:23ee46ca8d3095632418f7819018d5cb",
+      "entity": "niiri:b37dd2ff926a0dc9856b3d0532b1c0dd"
     },
     {
-      "@id": "niiri:419086b1092b835bfb16c4757c0b3f97",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:cb2a043df8fb2d544b2189a13c3ce527",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0022",
-      "prov:atLocation": {"@id": "niiri:18eb151e45b5f13c9e63d0879162cbf1"},
+      "prov:atLocation": {"@id": "niiri:765799a0de84190495361ce1c36bf628"},
       "prov:value": {"@type": "xsd:float", "@value": "4.55136632919312"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.32413626860189"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.65653129031207e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.518506646121902"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.283110032467297"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.32413626860189"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.65653129031207e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.518506646121902"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.283110032467297"}
     },
     {
-      "@id": "niiri:18eb151e45b5f13c9e63d0879162cbf1",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:765799a0de84190495361ce1c36bf628",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0022",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-48,8,20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-48,8,20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:419086b1092b835bfb16c4757c0b3f97",
-      "entity": "niiri:e72ed1be72500e0e5102f29f0ac13651"
+      "entity_derived": "niiri:cb2a043df8fb2d544b2189a13c3ce527",
+      "entity": "niiri:b37dd2ff926a0dc9856b3d0532b1c0dd"
     },
     {
-      "@id": "niiri:5477208d3ba5dc776fba5dbcef7e15f4",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:5b1ff8eefa78821ce44bbb392b06b97e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0023",
-      "prov:atLocation": {"@id": "niiri:f046b6951bc88aa55d13f3af2aa05969"},
+      "prov:atLocation": {"@id": "niiri:69f53688d48730600e168061ff38a927"},
       "prov:value": {"@type": "xsd:float", "@value": "5.78093099594116"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.34909755317379"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.41969442155354e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.00844151822925698"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.012489227663654"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.34909755317379"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.41969442155354e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.00844151822925698"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.012489227663654"}
     },
     {
-      "@id": "niiri:f046b6951bc88aa55d13f3af2aa05969",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:69f53688d48730600e168061ff38a927",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0023",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-34,-2,52]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-34,-2,52]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5477208d3ba5dc776fba5dbcef7e15f4",
-      "entity": "niiri:1ec5bcf3d27a79e3a649cf72f09cc3e2"
+      "entity_derived": "niiri:5b1ff8eefa78821ce44bbb392b06b97e",
+      "entity": "niiri:e9b24d9fcc87aa114863aac61da68dea"
     },
     {
-      "@id": "niiri:1b7453a2c89d42ad13ebb49651230b76",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:9207951d54db56abf749d9e5e74d2b6e",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0024",
-      "prov:atLocation": {"@id": "niiri:1c1feffd1a6c7c6ee90eadced0bd6f00"},
+      "prov:atLocation": {"@id": "niiri:c8d9fdeaa9f06be2ac165988113456f2"},
       "prov:value": {"@type": "xsd:float", "@value": "5.60917520523071"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.21058195491799"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "9.41245997809759e-08"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0163938142285941"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0188176838211989"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.21058195491799"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "9.41245997809759e-08"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0163938142285941"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0188176838211989"}
     },
     {
-      "@id": "niiri:1c1feffd1a6c7c6ee90eadced0bd6f00",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c8d9fdeaa9f06be2ac165988113456f2",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0024",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-30,26,2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-30,26,2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1b7453a2c89d42ad13ebb49651230b76",
-      "entity": "niiri:9d57dfc9c26a3b26ff08bc8602cb7238"
+      "entity_derived": "niiri:9207951d54db56abf749d9e5e74d2b6e",
+      "entity": "niiri:7e536777241b4ecd7a6966f907894029"
     },
     {
-      "@id": "niiri:7a5820ea4e18cdb9e8ef3308c490a126",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c53d89517ec403bef7219abc9030f05d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0025",
-      "prov:atLocation": {"@id": "niiri:46cbe56a773883af47259380fee679d9"},
+      "prov:atLocation": {"@id": "niiri:50e5c64dc44fd1aa0ba0c6c251308e66"},
       "prov:value": {"@type": "xsd:float", "@value": "5.29189538955688"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.95068947481578"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.69755095430691e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.053302912325625"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0464966156430715"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.95068947481578"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.69755095430691e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.053302912325625"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0464966156430715"}
     },
     {
-      "@id": "niiri:46cbe56a773883af47259380fee679d9",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:50e5c64dc44fd1aa0ba0c6c251308e66",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0025",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-12,34,16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-12,34,16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:7a5820ea4e18cdb9e8ef3308c490a126",
-      "entity": "niiri:9d57dfc9c26a3b26ff08bc8602cb7238"
+      "entity_derived": "niiri:c53d89517ec403bef7219abc9030f05d",
+      "entity": "niiri:7e536777241b4ecd7a6966f907894029"
     },
     {
-      "@id": "niiri:62591a941cfe01f122073b6443c6d233",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:472b41edc6bbee67c33ad7504becf2e5",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0026",
-      "prov:atLocation": {"@id": "niiri:45da15b622b7b1dea01b550479b48924"},
+      "prov:atLocation": {"@id": "niiri:ae0e674dc958653baadd67126d74577c"},
       "prov:value": {"@type": "xsd:float", "@value": "5.28739595413208"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.94696656297749"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.76894592424293e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0541726709732473"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0464966156430715"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.94696656297749"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.76894592424293e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0541726709732473"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0464966156430715"}
     },
     {
-      "@id": "niiri:45da15b622b7b1dea01b550479b48924",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ae0e674dc958653baadd67126d74577c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0026",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-50,40,20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-50,40,20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:62591a941cfe01f122073b6443c6d233",
-      "entity": "niiri:9d57dfc9c26a3b26ff08bc8602cb7238"
+      "entity_derived": "niiri:472b41edc6bbee67c33ad7504becf2e5",
+      "entity": "niiri:7e536777241b4ecd7a6966f907894029"
     },
     {
-      "@id": "niiri:01271fb32ff38f979f82b302ae0adc45",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:678a272f3a215fe580cc243e51ca4901",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0027",
-      "prov:atLocation": {"@id": "niiri:6af0d172ac82895d7713e1d877c68ceb"},
+      "prov:atLocation": {"@id": "niiri:ec38211804f6ec8a7218bd9caabae7bf"},
       "prov:value": {"@type": "xsd:float", "@value": "5.40964078903198"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "5.04774404642803"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.23528758724889e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0346958937061391"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0368499246860334"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "5.04774404642803"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.23528758724889e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0346958937061391"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0368499246860334"}
     },
     {
-      "@id": "niiri:6af0d172ac82895d7713e1d877c68ceb",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ec38211804f6ec8a7218bd9caabae7bf",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0027",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-54,-46,58]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-54,-46,58]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:01271fb32ff38f979f82b302ae0adc45",
-      "entity": "niiri:56b434cc0204499fc97e08dac52bab86"
+      "entity_derived": "niiri:678a272f3a215fe580cc243e51ca4901",
+      "entity": "niiri:f008be07086de77a22010a7f08caa22f"
     },
     {
-      "@id": "niiri:feee544c48f7b87fa15c5e6e72e32ec4",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:03230db640f45ee7e7b17d0bcfa81e0f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0028",
-      "prov:atLocation": {"@id": "niiri:c02e77056ffe36164f3bb0cefbac5257"},
+      "prov:atLocation": {"@id": "niiri:d82858e1629e476d7a3385ec1f576d72"},
       "prov:value": {"@type": "xsd:float", "@value": "5.31841945648193"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.97261482231588"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.30279114724163e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0484353441449864"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0464966156430715"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.97261482231588"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.30279114724163e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0484353441449864"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0464966156430715"}
     },
     {
-      "@id": "niiri:c02e77056ffe36164f3bb0cefbac5257",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d82858e1629e476d7a3385ec1f576d72",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0028",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-62,-38,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-62,-38,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:feee544c48f7b87fa15c5e6e72e32ec4",
-      "entity": "niiri:eb4c4ce00fca97f5c6e779fced2198a7"
+      "entity_derived": "niiri:03230db640f45ee7e7b17d0bcfa81e0f",
+      "entity": "niiri:0b8006d59ae6d79e0e814aa87159321c"
     },
     {
-      "@id": "niiri:2cd8a588ad343d77317a0761e1a88bd1",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c3e3e8c6beb75a2c98d2adca27e25de1",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0029",
-      "prov:atLocation": {"@id": "niiri:a517244f5dc7dd2cddd5829502e86cb7"},
+      "prov:atLocation": {"@id": "niiri:6feea062185f26004b99d522812cccf6"},
       "prov:value": {"@type": "xsd:float", "@value": "5.30699443817139"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.96317509467693"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.46750043123123e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0504786376455083"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0464966156430715"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.96317509467693"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.46750043123123e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0504786376455083"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0464966156430715"}
     },
     {
-      "@id": "niiri:a517244f5dc7dd2cddd5829502e86cb7",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:6feea062185f26004b99d522812cccf6",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0029",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[32,40,16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[32,40,16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2cd8a588ad343d77317a0761e1a88bd1",
-      "entity": "niiri:de8927fdf14192632eecaa3636f2e9e3"
+      "entity_derived": "niiri:c3e3e8c6beb75a2c98d2adca27e25de1",
+      "entity": "niiri:6581a2a4fbc96915373d67e7edf695a9"
     },
     {
-      "@id": "niiri:16fe3e1d9a8be07f0168b7cd709a6e8b",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:1d7080d7ce698e17ddf3efae8dcdec05",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0030",
-      "prov:atLocation": {"@id": "niiri:2681ea7a0888ffec52fec625bbd74f8f"},
+      "prov:atLocation": {"@id": "niiri:c2c900a8f6153cd09f2ea5cf6e202d15"},
       "prov:value": {"@type": "xsd:float", "@value": "4.5497465133667"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.32273570618355"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.7053150754347e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.520378392891944"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.283110032467297"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.32273570618355"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.7053150754347e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.520378392891944"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.283110032467297"}
     },
     {
-      "@id": "niiri:2681ea7a0888ffec52fec625bbd74f8f",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c2c900a8f6153cd09f2ea5cf6e202d15",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0030",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[40,46,12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[40,46,12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:16fe3e1d9a8be07f0168b7cd709a6e8b",
-      "entity": "niiri:de8927fdf14192632eecaa3636f2e9e3"
+      "entity_derived": "niiri:1d7080d7ce698e17ddf3efae8dcdec05",
+      "entity": "niiri:6581a2a4fbc96915373d67e7edf695a9"
     },
     {
-      "@id": "niiri:cd2bd8a74f69bca8016b048323bd1f27",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:30c5de3d78e8750bd60110543a6d4e95",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0031",
-      "prov:atLocation": {"@id": "niiri:e45104bae002e3c072793fcc49f0c0e3"},
+      "prov:atLocation": {"@id": "niiri:e81909a8204f4543fa739fde9d159dbe"},
       "prov:value": {"@type": "xsd:float", "@value": "5.27030229568481"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.93281349716267"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.05267701952816e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0575990926145485"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0479288297151396"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.93281349716267"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.05267701952816e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0575990926145485"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0479288297151396"}
     },
     {
-      "@id": "niiri:e45104bae002e3c072793fcc49f0c0e3",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e81909a8204f4543fa739fde9d159dbe",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0031",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[40,26,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[40,26,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:cd2bd8a74f69bca8016b048323bd1f27",
-      "entity": "niiri:21c83646c5b8900bb66ac4bdc408bd17"
+      "entity_derived": "niiri:30c5de3d78e8750bd60110543a6d4e95",
+      "entity": "niiri:d1a419e3b8453b976a58dbdde542b8c4"
     },
     {
-      "@id": "niiri:82f6dea1ea01c9ca931fd1c5273288f8",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:bd06c3d65d3e9933f6a3f8ef15e826f1",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0032",
-      "prov:atLocation": {"@id": "niiri:9dbc5dd1732c9addc6d888459fec8f23"},
+      "prov:atLocation": {"@id": "niiri:d2f363694c05d0c16c22106097551ec6"},
       "prov:value": {"@type": "xsd:float", "@value": "5.2275915145874"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.89738468004472"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.85602978606003e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0670610253017228"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0515537977875989"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.89738468004472"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.85602978606003e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0670610253017228"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0515537977875989"}
     },
     {
-      "@id": "niiri:9dbc5dd1732c9addc6d888459fec8f23",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d2f363694c05d0c16c22106097551ec6",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0032",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[34,-86,12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[34,-86,12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:82f6dea1ea01c9ca931fd1c5273288f8",
-      "entity": "niiri:39b00e4afb3679693ccf462cccc76f45"
+      "entity_derived": "niiri:bd06c3d65d3e9933f6a3f8ef15e826f1",
+      "entity": "niiri:9f5db5fa91c4f9045129661d86ff7c8f"
     },
     {
-      "@id": "niiri:e9cb78593ccfdc6b85c4329aff99c816",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:30c37a4e6d4b232771755d1748c76f58",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0033",
-      "prov:atLocation": {"@id": "niiri:d07b7e8a86e8bed5365664e2ac90a736"},
+      "prov:atLocation": {"@id": "niiri:e87c4862eab61d8f99a2b73c0996bedc"},
       "prov:value": {"@type": "xsd:float", "@value": "4.98287582397461"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.6925960462209"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.34879908808561e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.15433914065195"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.101749935670058"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.6925960462209"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.34879908808561e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.15433914065195"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.101749935670058"}
     },
     {
-      "@id": "niiri:d07b7e8a86e8bed5365664e2ac90a736",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:e87c4862eab61d8f99a2b73c0996bedc",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0033",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[26,-84,14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[26,-84,14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e9cb78593ccfdc6b85c4329aff99c816",
-      "entity": "niiri:39b00e4afb3679693ccf462cccc76f45"
+      "entity_derived": "niiri:30c37a4e6d4b232771755d1748c76f58",
+      "entity": "niiri:9f5db5fa91c4f9045129661d86ff7c8f"
     },
     {
-      "@id": "niiri:2919a8386376bfa5b280217dee994a19",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:6c2577b41582f50d831338802e4df7ad",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0034",
-      "prov:atLocation": {"@id": "niiri:09fe2bf32e5710410a835b828d2bbeee"},
+      "prov:atLocation": {"@id": "niiri:54941ad1d26a7090edd080e406d9672f"},
       "prov:value": {"@type": "xsd:float", "@value": "5.2253565788269"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.89552821543552"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.90210114501011e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0675937275056587"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0515537977875989"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.89552821543552"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.90210114501011e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0675937275056587"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0515537977875989"}
     },
     {
-      "@id": "niiri:09fe2bf32e5710410a835b828d2bbeee",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:54941ad1d26a7090edd080e406d9672f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0034",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-60,8,20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-60,8,20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2919a8386376bfa5b280217dee994a19",
-      "entity": "niiri:1b13213ccbcda957315f11cacbe52f8e"
+      "entity_derived": "niiri:6c2577b41582f50d831338802e4df7ad",
+      "entity": "niiri:dc8fb82556a5fb25f9d253499774c9d3"
     },
     {
-      "@id": "niiri:efc48200b02f87e9d994e4dca9eaed8f",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d72c63855a1da4123aa2d2b91077aa04",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0035",
-      "prov:atLocation": {"@id": "niiri:db121161d5febd4f1772ea57224511f9"},
+      "prov:atLocation": {"@id": "niiri:b8071a162bee188fb3f27c0adcc6011b"},
       "prov:value": {"@type": "xsd:float", "@value": "5.19020795822144"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.86629814644752"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.68539714418392e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0765015651399961"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.055368089146651"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.86629814644752"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.68539714418392e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0765015651399961"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.055368089146651"}
     },
     {
-      "@id": "niiri:db121161d5febd4f1772ea57224511f9",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b8071a162bee188fb3f27c0adcc6011b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0035",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[48,28,-14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[48,28,-14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:efc48200b02f87e9d994e4dca9eaed8f",
-      "entity": "niiri:57a4b5c4432a4efdb2afe166bc8a8d40"
+      "entity_derived": "niiri:d72c63855a1da4123aa2d2b91077aa04",
+      "entity": "niiri:65d11f313edff947dbe708fa2df7a47f"
     },
     {
-      "@id": "niiri:9e8be857380c831e3b481f1846f588ff",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:ded48c88b009b45ce79c933455ae62b1",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0036",
-      "prov:atLocation": {"@id": "niiri:21a0fec44f230732d41a886639a0a057"},
+      "prov:atLocation": {"@id": "niiri:0668dac472065a436c04ed87c6b48312"},
       "prov:value": {"@type": "xsd:float", "@value": "5.11790418624878"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.80597083243817"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.70011758244316e-07"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.0982924709915751"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.0681921715169792"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.80597083243817"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.70011758244316e-07"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.0982924709915751"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.0681921715169792"}
     },
     {
-      "@id": "niiri:21a0fec44f230732d41a886639a0a057",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0668dac472065a436c04ed87c6b48312",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0036",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[62,-42,32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[62,-42,32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9e8be857380c831e3b481f1846f588ff",
-      "entity": "niiri:1fc9da3e6287c03753ee90c1a5abc45f"
+      "entity_derived": "niiri:ded48c88b009b45ce79c933455ae62b1",
+      "entity": "niiri:5e70ca2cffa7ec4b08a897a898eb5b28"
     },
     {
-      "@id": "niiri:0e9fb00bf160881635a28a8a9d2a9a36",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:091096b37b35a35e14cf6256cdec88c2",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0037",
-      "prov:atLocation": {"@id": "niiri:84b397b0fdfa7246378bf98174954570"},
+      "prov:atLocation": {"@id": "niiri:38981ae85de58d330e1d76276b048fab"},
       "prov:value": {"@type": "xsd:float", "@value": "4.93343877792358"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.65085575575197"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.6528024058271e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.180887232162623"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.111052348606216"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.65085575575197"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.6528024058271e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.180887232162623"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.111052348606216"}
     },
     {
-      "@id": "niiri:84b397b0fdfa7246378bf98174954570",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:38981ae85de58d330e1d76276b048fab",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0037",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-58,-30,-18]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-58,-30,-18]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:0e9fb00bf160881635a28a8a9d2a9a36",
-      "entity": "niiri:a87ac34d0b2aa71a22f631bee6f5d009"
+      "entity_derived": "niiri:091096b37b35a35e14cf6256cdec88c2",
+      "entity": "niiri:c77ff18164bd254c10834cf4198cc926"
     },
     {
-      "@id": "niiri:ece2f29d2544b2b5adb4c4302c48158d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:307311b45e91bb80ed6c37ee9ce68670",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0038",
-      "prov:atLocation": {"@id": "niiri:64b53fb57d19b8db6f92cd3604b7f506"},
+      "prov:atLocation": {"@id": "niiri:7c13987519a921c569ccd9f47a99be37"},
       "prov:value": {"@type": "xsd:float", "@value": "4.76414346694946"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.50698548813516"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.287756441539e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.301278778226174"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.172669007569286"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.50698548813516"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.287756441539e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.301278778226174"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.172669007569286"}
     },
     {
-      "@id": "niiri:64b53fb57d19b8db6f92cd3604b7f506",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7c13987519a921c569ccd9f47a99be37",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0038",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-46,-66,-6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-46,-66,-6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ece2f29d2544b2b5adb4c4302c48158d",
-      "entity": "niiri:d6ac21365d2405aa9644fdebf0cc6ef4"
+      "entity_derived": "niiri:307311b45e91bb80ed6c37ee9ce68670",
+      "entity": "niiri:5ec4ec1a9ea7234dae961134341c413f"
     },
     {
-      "@id": "niiri:ad191794f5a56de3f14465569de72ca9",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d6572346d31a2bcaf5575073d3264e49",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0039",
-      "prov:atLocation": {"@id": "niiri:079591d592eef8662fdc1b2f8598fb6e"},
+      "prov:atLocation": {"@id": "niiri:7bb7c053f16458c5ac88a7b8c38c2df3"},
       "prov:value": {"@type": "xsd:float", "@value": "4.72232866287231"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.47122948835043"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.88855941602095e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.338512677882141"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.195288467872082"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.47122948835043"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.88855941602095e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.338512677882141"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.195288467872082"}
     },
     {
-      "@id": "niiri:079591d592eef8662fdc1b2f8598fb6e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:7bb7c053f16458c5ac88a7b8c38c2df3",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0039",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[58,-38,6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[58,-38,6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ad191794f5a56de3f14465569de72ca9",
-      "entity": "niiri:1538a072d6986b630537b29066fec5db"
+      "entity_derived": "niiri:d6572346d31a2bcaf5575073d3264e49",
+      "entity": "niiri:43dcb06f795f24225ca2e94a905a018a"
     },
     {
-      "@id": "niiri:f7c2f2bee1030ef081a7a1e40430746e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:940561c12adb90e459277d266bcf26a4",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0040",
-      "prov:atLocation": {"@id": "niiri:8f7e2a36a3eef5a7b15cd88b2c0a7228"},
+      "prov:atLocation": {"@id": "niiri:a3b66913a7d4f099d41a7e34a9aad13b"},
       "prov:value": {"@type": "xsd:float", "@value": "4.70483255386353"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.45624265093732"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.17043099876224e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.354967306449537"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.203068312336819"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.45624265093732"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.17043099876224e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.354967306449537"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.203068312336819"}
     },
     {
-      "@id": "niiri:8f7e2a36a3eef5a7b15cd88b2c0a7228",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:a3b66913a7d4f099d41a7e34a9aad13b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0040",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-36,-74,-14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-36,-74,-14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f7c2f2bee1030ef081a7a1e40430746e",
-      "entity": "niiri:b1a9ed0ce88ddf57f1afa2ab051d9094"
+      "entity_derived": "niiri:940561c12adb90e459277d266bcf26a4",
+      "entity": "niiri:63c6acd902a0987762c94921fa226068"
     },
     {
-      "@id": "niiri:bf1f78e2177ca62a3887166040cdb1c0",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:be01e340dcb236d6f72f24c39660c369",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0041",
-      "prov:atLocation": {"@id": "niiri:7c936836f1f0ac9f2e5efe19153a6775"},
+      "prov:atLocation": {"@id": "niiri:48e06113c665fc04a60795b896d2d447"},
       "prov:value": {"@type": "xsd:float", "@value": "4.08770418167114"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.91804495668"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.46350297789166e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.955724279224547"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.813269333398153"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.91804495668"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.46350297789166e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.955724279224547"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.813269333398153"}
     },
     {
-      "@id": "niiri:7c936836f1f0ac9f2e5efe19153a6775",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:48e06113c665fc04a60795b896d2d447",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0041",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-36,-68,-20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-36,-68,-20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:bf1f78e2177ca62a3887166040cdb1c0",
-      "entity": "niiri:b1a9ed0ce88ddf57f1afa2ab051d9094"
+      "entity_derived": "niiri:be01e340dcb236d6f72f24c39660c369",
+      "entity": "niiri:63c6acd902a0987762c94921fa226068"
     },
     {
-      "@id": "niiri:6dfe48d8d03058f3dc8cf56c358d4f70",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:76e00a2148bcf89400f71aed8ae6bb4f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0042",
-      "prov:atLocation": {"@id": "niiri:3b72ed66afebb8c2f7319703a570218a"},
+      "prov:atLocation": {"@id": "niiri:c9c45c8f7997274422ea8a368b4a5a18"},
       "prov:value": {"@type": "xsd:float", "@value": "4.66261720657349"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.42001914550306"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.93460785955246e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.396707240036217"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.226011723416334"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.42001914550306"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.93460785955246e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.396707240036217"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.226011723416334"}
     },
     {
-      "@id": "niiri:3b72ed66afebb8c2f7319703a570218a",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:c9c45c8f7997274422ea8a368b4a5a18",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0042",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[50,-48,62]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[50,-48,62]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6dfe48d8d03058f3dc8cf56c358d4f70",
-      "entity": "niiri:a820061ecf406d69716300c9fedb0d02"
+      "entity_derived": "niiri:76e00a2148bcf89400f71aed8ae6bb4f",
+      "entity": "niiri:5e9dd0483caa5eb1c58d3fce896ce441"
     },
     {
-      "@id": "niiri:16a2542b0f2bdf2b657722e3fd519a49",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b1a1bba13244d909eb7f26c94d677fc4",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0043",
-      "prov:atLocation": {"@id": "niiri:64e50a631faf9a6012603f90fe38f1a9"},
+      "prov:atLocation": {"@id": "niiri:cfd246dde4faa922a56924236cff1bd9"},
       "prov:value": {"@type": "xsd:float", "@value": "4.59621620178223"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.36286413267216"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.41853365035416e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.467637998233248"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.263154686545706"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.36286413267216"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.41853365035416e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.467637998233248"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.263154686545706"}
     },
     {
-      "@id": "niiri:64e50a631faf9a6012603f90fe38f1a9",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:cfd246dde4faa922a56924236cff1bd9",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0043",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[16,-98,6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[16,-98,6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:16a2542b0f2bdf2b657722e3fd519a49",
-      "entity": "niiri:1c89663261d7fe599621a515c41412ef"
+      "entity_derived": "niiri:b1a1bba13244d909eb7f26c94d677fc4",
+      "entity": "niiri:a371619b98c52e0355b320d28edb7189"
     },
     {
-      "@id": "niiri:9c2e5a1af29bfe0513915f2f1b0370c8",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:88d3d44277a170d297f951135875f79d",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0044",
-      "prov:atLocation": {"@id": "niiri:9e968798b12cede38312a0fd897d5c82"},
+      "prov:atLocation": {"@id": "niiri:0eb0f37e7efb84a8ba951e6d317738aa"},
       "prov:value": {"@type": "xsd:float", "@value": "4.57891654968262"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.34793761600864"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "6.87118388575936e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.487021764768749"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.274069095631333"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.34793761600864"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "6.87118388575936e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.487021764768749"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.274069095631333"}
     },
     {
-      "@id": "niiri:9e968798b12cede38312a0fd897d5c82",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0eb0f37e7efb84a8ba951e6d317738aa",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0044",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-60,-16,28]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-60,-16,28]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:9c2e5a1af29bfe0513915f2f1b0370c8",
-      "entity": "niiri:347c2f752b33682df28dbb3618ca4959"
+      "entity_derived": "niiri:88d3d44277a170d297f951135875f79d",
+      "entity": "niiri:37cde807f5ec7a0a182032d2608a5010"
     },
     {
-      "@id": "niiri:ad748b8ab42bed324e1a1a7bf31e81c7",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b07acc6a2e3964eb9539a6d7b697a89f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0045",
-      "prov:atLocation": {"@id": "niiri:f7bf4618687b6c2da668155664548dc8"},
+      "prov:atLocation": {"@id": "niiri:cac7d9ae81e5c1ad2405164496fb8fea"},
       "prov:value": {"@type": "xsd:float", "@value": "4.57099342346191"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.34109644800954"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "7.08867353027554e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.496004086968197"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.276784591562674"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.34109644800954"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "7.08867353027554e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.496004086968197"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.276784591562674"}
     },
     {
-      "@id": "niiri:f7bf4618687b6c2da668155664548dc8",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:cac7d9ae81e5c1ad2405164496fb8fea",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0045",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-60,-50,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-60,-50,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:ad748b8ab42bed324e1a1a7bf31e81c7",
-      "entity": "niiri:b06c1cefe3c12fe41b07e749646c1006"
+      "entity_derived": "niiri:b07acc6a2e3964eb9539a6d7b697a89f",
+      "entity": "niiri:6bb17b684d45a4f861c90fe5fbe07173"
     },
     {
-      "@id": "niiri:87f0797a3fbc74b3d3f0e046d44f3edb",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:c17bb40d7f9a065ed9e20283f08d832f",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0046",
-      "prov:atLocation": {"@id": "niiri:21ef8b051e4e3281c6ee0d3fb2f9b88f"},
+      "prov:atLocation": {"@id": "niiri:b85ea683da3b35f328c636768ed1ddca"},
       "prov:value": {"@type": "xsd:float", "@value": "4.52660465240479"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.3027121900522"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "8.43599790589789e-06"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.547325139783002"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.296273869721501"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.3027121900522"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "8.43599790589789e-06"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.547325139783002"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.296273869721501"}
     },
     {
-      "@id": "niiri:21ef8b051e4e3281c6ee0d3fb2f9b88f",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b85ea683da3b35f328c636768ed1ddca",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0046",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[16,14,62]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[16,14,62]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:87f0797a3fbc74b3d3f0e046d44f3edb",
-      "entity": "niiri:9ac56d5858e1280575cd8c2eaac3bf9f"
+      "entity_derived": "niiri:c17bb40d7f9a065ed9e20283f08d832f",
+      "entity": "niiri:7560e53c1288bc92b5a4d846f27be2a2"
     },
     {
-      "@id": "niiri:5cd038458d4de4d29cb3286e76d05a5a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:e4746d1e59f58f3c65f5926f3a910408",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0047",
-      "prov:atLocation": {"@id": "niiri:f43581527926708c33116bc8053e24aa"},
+      "prov:atLocation": {"@id": "niiri:bc0c487d20ed46595ec5f729ccaefa47"},
       "prov:value": {"@type": "xsd:float", "@value": "4.394446849823"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.18786093394641"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.40797984292673e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.702859796483929"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.416351033742128"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.18786093394641"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.40797984292673e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.702859796483929"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.416351033742128"}
     },
     {
-      "@id": "niiri:f43581527926708c33116bc8053e24aa",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:bc0c487d20ed46595ec5f729ccaefa47",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0047",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-24,54,36]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-24,54,36]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5cd038458d4de4d29cb3286e76d05a5a",
-      "entity": "niiri:c1038d6173e201e6db5e15170fe9c504"
+      "entity_derived": "niiri:e4746d1e59f58f3c65f5926f3a910408",
+      "entity": "niiri:6a1d4b90730b6f045c485c09e364158b"
     },
     {
-      "@id": "niiri:2b40957f767e7304c0ba8b61141724a9",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:912ce2854ee45d7566ad2d5a9ffe063a",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0048",
-      "prov:atLocation": {"@id": "niiri:3f8d7235207683b5a8ebc52a70306ee6"},
+      "prov:atLocation": {"@id": "niiri:b3e9065f593d58e675a1f1b518e286e9"},
       "prov:value": {"@type": "xsd:float", "@value": "4.37013816833496"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.16664310578498"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.54558935169247e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.730405153245217"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.44365024151901"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.16664310578498"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.54558935169247e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.730405153245217"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.44365024151901"}
     },
     {
-      "@id": "niiri:3f8d7235207683b5a8ebc52a70306ee6",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b3e9065f593d58e675a1f1b518e286e9",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0048",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-52,-62,52]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-52,-62,52]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2b40957f767e7304c0ba8b61141724a9",
-      "entity": "niiri:10fb1def343c16cea3ed7ca34f95f4a5"
+      "entity_derived": "niiri:912ce2854ee45d7566ad2d5a9ffe063a",
+      "entity": "niiri:642f54df01178892acf81b69ba1cdd64"
     },
     {
-      "@id": "niiri:88b8850eb11486e6b61936caf3ea974e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:d5ff6b492b936f7614cd983926d8d1d8",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0049",
-      "prov:atLocation": {"@id": "niiri:ef168860f61bc4ac516efed9971c6415"},
+      "prov:atLocation": {"@id": "niiri:99d2ed1d9ad0c05f4ab3275060f6f1b3"},
       "prov:value": {"@type": "xsd:float", "@value": "4.34150457382202"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.14161364101519"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.72435463601239e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.761825497910085"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.479115128745269"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.14161364101519"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.72435463601239e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.761825497910085"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.479115128745269"}
     },
     {
-      "@id": "niiri:ef168860f61bc4ac516efed9971c6415",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:99d2ed1d9ad0c05f4ab3275060f6f1b3",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0049",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[10,48,44]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[10,48,44]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:88b8850eb11486e6b61936caf3ea974e",
-      "entity": "niiri:05b9a5f65294a59f709d2874ee06eb74"
+      "entity_derived": "niiri:d5ff6b492b936f7614cd983926d8d1d8",
+      "entity": "niiri:7004bd2e853e73ce41a764732d04d90f"
     },
     {
-      "@id": "niiri:5ebfc4096d3bd75e930dc2fadc89cf1d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:08c188bf3f47eb482ee56d1867b00173",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0050",
-      "prov:atLocation": {"@id": "niiri:47d6563ec7640ec7362e769a89f072e9"},
+      "prov:atLocation": {"@id": "niiri:23b7aa0c87723842565ef21f6cd4b6d7"},
       "prov:value": {"@type": "xsd:float", "@value": "4.32184886932373"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.12440912812688"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.85843849718204e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.782605982808509"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.502895583840395"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.12440912812688"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.85843849718204e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.782605982808509"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.502895583840395"}
     },
     {
-      "@id": "niiri:47d6563ec7640ec7362e769a89f072e9",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:23b7aa0c87723842565ef21f6cd4b6d7",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0050",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[10,24,24]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[10,24,24]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:5ebfc4096d3bd75e930dc2fadc89cf1d",
-      "entity": "niiri:6e7ba611211b14c42b46c20448bed1da"
+      "entity_derived": "niiri:08c188bf3f47eb482ee56d1867b00173",
+      "entity": "niiri:44f3268a65a1bd0913070af57e7f8c22"
     },
     {
-      "@id": "niiri:1bb45e1e314341bb67efc1d0e62baf1d",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:37f058dfafc27db2e4a67b00c2c19b3b",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0051",
-      "prov:atLocation": {"@id": "niiri:7b1d03dadac03483dcb17fdc2dd24ed0"},
+      "prov:atLocation": {"@id": "niiri:cb2674b27a55a15c11356b077c23f96f"},
       "prov:value": {"@type": "xsd:float", "@value": "4.31582498550415"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.11913273798974"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.90150518718513e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.788829013385429"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.505811157403841"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.11913273798974"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.90150518718513e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.788829013385429"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.505811157403841"}
     },
     {
-      "@id": "niiri:7b1d03dadac03483dcb17fdc2dd24ed0",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:cb2674b27a55a15c11356b077c23f96f",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0051",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[36,54,6]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[36,54,6]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:1bb45e1e314341bb67efc1d0e62baf1d",
-      "entity": "niiri:b460f1f0b03e40e2ef4befc4665227a8"
+      "entity_derived": "niiri:37f058dfafc27db2e4a67b00c2c19b3b",
+      "entity": "niiri:27e476ef788fe4fb3d8dcc031b399a81"
     },
     {
-      "@id": "niiri:b7bec33c2907aa625911f7a53a2746bb",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:0e467e20cc0f4bae2c75a2e53bb0c47c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0052",
-      "prov:atLocation": {"@id": "niiri:00b55ff454e211ee5cc909f007d669fc"},
+      "prov:atLocation": {"@id": "niiri:dcf7da4393edd644ef884de7aa33221c"},
       "prov:value": {"@type": "xsd:float", "@value": "4.30655717849731"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.11101155082742"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "1.96964745459161e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.798260223882423"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.513996955111144"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.11101155082742"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "1.96964745459161e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.798260223882423"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.513996955111144"}
     },
     {
-      "@id": "niiri:00b55ff454e211ee5cc909f007d669fc",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:dcf7da4393edd644ef884de7aa33221c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0052",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-26,-92,32]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-26,-92,32]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:b7bec33c2907aa625911f7a53a2746bb",
-      "entity": "niiri:054b7672bba8ed55d6c9d550e674f600"
+      "entity_derived": "niiri:0e467e20cc0f4bae2c75a2e53bb0c47c",
+      "entity": "niiri:ca4952c39685bacdd04c639d61f596dc"
     },
     {
-      "@id": "niiri:59e980fb3cd9d3cc55969c08b0153d37",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:7346c6134f21e9c55bded49d811acfb6",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0053",
-      "prov:atLocation": {"@id": "niiri:5216ed4db9504a6f9fb09d8681723d20"},
+      "prov:atLocation": {"@id": "niiri:5b38b31387f1f4d969275778c505f158"},
       "prov:value": {"@type": "xsd:float", "@value": "4.29490756988525"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.10079738778036"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.0586446986437e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.809857168354565"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.526259690094564"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.10079738778036"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.0586446986437e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.809857168354565"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.526259690094564"}
     },
     {
-      "@id": "niiri:5216ed4db9504a6f9fb09d8681723d20",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:5b38b31387f1f4d969275778c505f158",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0053",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[30,42,4]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[30,42,4]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:59e980fb3cd9d3cc55969c08b0153d37",
-      "entity": "niiri:5c380d0f5b0d102daa46b5ee765401d0"
+      "entity_derived": "niiri:7346c6134f21e9c55bded49d811acfb6",
+      "entity": "niiri:af2ac94d3f5ea60663d90097f8159f1d"
     },
     {
-      "@id": "niiri:096769922bba475a73cd4cc353cf2b59",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b407bae917b87023865024204198dbd0",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0054",
-      "prov:atLocation": {"@id": "niiri:3eccb5877e5d71d252f2f0a9144a7855"},
+      "prov:atLocation": {"@id": "niiri:424f8ba488562285d011591931afce31"},
       "prov:value": {"@type": "xsd:float", "@value": "4.24533367156982"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.05725918601008"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.4825985211363e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.855631833511506"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.591124172488423"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.05725918601008"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.4825985211363e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.855631833511506"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.591124172488423"}
     },
     {
-      "@id": "niiri:3eccb5877e5d71d252f2f0a9144a7855",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:424f8ba488562285d011591931afce31",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0054",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-18,-60,48]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-18,-60,48]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:096769922bba475a73cd4cc353cf2b59",
-      "entity": "niiri:ff57ed710046587ca6241d3e59018019"
+      "entity_derived": "niiri:b407bae917b87023865024204198dbd0",
+      "entity": "niiri:d088c79195acad1ffe8fcf692ee20b14"
     },
     {
-      "@id": "niiri:d95825d7132ddf011f7472f90f6a96f5",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:a7defe617f206121c0d7cb04a6f72f08",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0055",
-      "prov:atLocation": {"@id": "niiri:777ae15f4c84152f8125dcb661c144ae"},
+      "prov:atLocation": {"@id": "niiri:879a2d4376625a7c15bed48a1afe84ff"},
       "prov:value": {"@type": "xsd:float", "@value": "4.22729349136353"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.04138628171284"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.65680735640483e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.870712357794855"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.603696486616006"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.04138628171284"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.65680735640483e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.870712357794855"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.603696486616006"}
     },
     {
-      "@id": "niiri:777ae15f4c84152f8125dcb661c144ae",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:879a2d4376625a7c15bed48a1afe84ff",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0055",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-20,-98,22]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-20,-98,22]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:d95825d7132ddf011f7472f90f6a96f5",
-      "entity": "niiri:8d2f0fd2c9e7d0b8208eb1fc4b198d3a"
+      "entity_derived": "niiri:a7defe617f206121c0d7cb04a6f72f08",
+      "entity": "niiri:9d84cb059aa001b080f641472d50dee9"
     },
     {
-      "@id": "niiri:f2a8ce3a8908185b4de88a2556925fd2",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:9393a45c585430d7d331841bd135503c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0056",
-      "prov:atLocation": {"@id": "niiri:bdb865d7b60944d22ea37944fab3aa53"},
+      "prov:atLocation": {"@id": "niiri:0bfbfc6068d71c869562de069b1a6dac"},
       "prov:value": {"@type": "xsd:float", "@value": "4.22682189941406"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.04097113688235"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.66151551338023e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.871094574055471"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.603696486616006"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.04097113688235"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.66151551338023e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.871094574055471"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.603696486616006"}
     },
     {
-      "@id": "niiri:bdb865d7b60944d22ea37944fab3aa53",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:0bfbfc6068d71c869562de069b1a6dac",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0056",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-38,28,-12]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-38,28,-12]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:f2a8ce3a8908185b4de88a2556925fd2",
-      "entity": "niiri:684e846c172afe6d05d5ae78e91a66ab"
+      "entity_derived": "niiri:9393a45c585430d7d331841bd135503c",
+      "entity": "niiri:51d1d5abbfa00532f6e6a2f6c7c0cf8f"
     },
     {
-      "@id": "niiri:3c0ab7db2b58f664c1fc502cfb68c54a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:fa8d8d73ed0cd84d17283368b810eeb9",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0057",
-      "prov:atLocation": {"@id": "niiri:60c35260b456d77c368377edd30808ff"},
+      "prov:atLocation": {"@id": "niiri:88a381fc45f1118447ccea71efd9983b"},
       "prov:value": {"@type": "xsd:float", "@value": "4.22599840164185"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.04024618213588"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.66975618669063e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.871760516202526"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.603696486616006"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.04024618213588"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.66975618669063e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.871760516202526"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.603696486616006"}
     },
     {
-      "@id": "niiri:60c35260b456d77c368377edd30808ff",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:88a381fc45f1118447ccea71efd9983b",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0057",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-36,-74,-34]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-36,-74,-34]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:3c0ab7db2b58f664c1fc502cfb68c54a",
-      "entity": "niiri:e41c1ae17d421ba7f943954ecb82266f"
+      "entity_derived": "niiri:fa8d8d73ed0cd84d17283368b810eeb9",
+      "entity": "niiri:f39108df33a4d833661db62b9a0c407f"
     },
     {
-      "@id": "niiri:2a44618f3a55e01df9a317699d96e405",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:9691b9801790bca1d083f574dd41b296",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0058",
-      "prov:atLocation": {"@id": "niiri:1c540ec4a19d6207070aef71e3777d46"},
+      "prov:atLocation": {"@id": "niiri:531311d43904b7e17f8c8865edcfd5bf"},
       "prov:value": {"@type": "xsd:float", "@value": "4.22297620773315"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.03758535922196"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.70020985901898e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.874188238392237"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.603696486616006"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.03758535922196"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.70020985901898e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.874188238392237"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.603696486616006"}
     },
     {
-      "@id": "niiri:1c540ec4a19d6207070aef71e3777d46",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:531311d43904b7e17f8c8865edcfd5bf",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0058",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[38,42,30]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[38,42,30]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2a44618f3a55e01df9a317699d96e405",
-      "entity": "niiri:6ebbb8b1cbde12076fc5d4ef4e85955c"
+      "entity_derived": "niiri:9691b9801790bca1d083f574dd41b296",
+      "entity": "niiri:4b799f0cf87667a22d5d0bd894e1cf9f"
     },
     {
-      "@id": "niiri:238e2f4cc87b28d58b45c565a385b7f3",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:13e98aff2c31b15268b3dea9959c495c",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0059",
-      "prov:atLocation": {"@id": "niiri:e74932d7b348b8f07eb045414481614d"},
+      "prov:atLocation": {"@id": "niiri:fc2e46d8aa4cc5b8c0bbb64269631760"},
       "prov:value": {"@type": "xsd:float", "@value": "4.20424270629883"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.02108217006528"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.89656955663187e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.888659424129494"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.625386565826961"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.02108217006528"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.89656955663187e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.888659424129494"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.625386565826961"}
     },
     {
-      "@id": "niiri:e74932d7b348b8f07eb045414481614d",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:fc2e46d8aa4cc5b8c0bbb64269631760",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0059",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[42,6,30]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[42,6,30]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:238e2f4cc87b28d58b45c565a385b7f3",
-      "entity": "niiri:370b2cb6de898bd071b9e171bc29995b"
+      "entity_derived": "niiri:13e98aff2c31b15268b3dea9959c495c",
+      "entity": "niiri:418bd4d687fd48d9de96b297aa605a93"
     },
     {
-      "@id": "niiri:e2de74ebddd49fa6d36a19d7ceeb23e3",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:7b4db1c258dcb4190f46960d27c75552",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0060",
-      "prov:atLocation": {"@id": "niiri:ca79585150f724d668d25bf27931b814"},
+      "prov:atLocation": {"@id": "niiri:4bab1f81849c7a74d149628cba9544aa"},
       "prov:value": {"@type": "xsd:float", "@value": "4.20391035079956"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.02078923241408"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "2.900174224163e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.888907080881232"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.625386565826961"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.02078923241408"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "2.900174224163e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.888907080881232"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.625386565826961"}
     },
     {
-      "@id": "niiri:ca79585150f724d668d25bf27931b814",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:4bab1f81849c7a74d149628cba9544aa",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0060",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[34,-54,-16]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[34,-54,-16]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:e2de74ebddd49fa6d36a19d7ceeb23e3",
-      "entity": "niiri:24a35ffc9e3360be3e77ac0bdf6162e1"
+      "entity_derived": "niiri:7b4db1c258dcb4190f46960d27c75552",
+      "entity": "niiri:69987b67a58d47cf5fdd3f3dd0097df0"
     },
     {
-      "@id": "niiri:2abec1b9274eb16400b110d9b052105e",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:eb08ea7bd76ef2115f5513cf8044a2cf",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0061",
-      "prov:atLocation": {"@id": "niiri:eeeb727512a86307e973d1d18d9d2908"},
+      "prov:atLocation": {"@id": "niiri:d7d52cbb1c476bffe993b70632831ff2"},
       "prov:value": {"@type": "xsd:float", "@value": "4.18721437454224"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "4.00606667297511"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.08691144208506e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.900934824371894"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.6506058568578"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "4.00606667297511"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.08691144208506e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.900934824371894"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.6506058568578"}
     },
     {
-      "@id": "niiri:eeeb727512a86307e973d1d18d9d2908",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d7d52cbb1c476bffe993b70632831ff2",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0061",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[12,-100,20]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[12,-100,20]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2abec1b9274eb16400b110d9b052105e",
-      "entity": "niiri:938df04c7b599a7c74931290216cc187"
+      "entity_derived": "niiri:eb08ea7bd76ef2115f5513cf8044a2cf",
+      "entity": "niiri:f0f2196eb8e713870fab0d351b7d0893"
     },
     {
-      "@id": "niiri:58b48283047cd6205c93dce88e4d334a",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:2356612dab79bab4ff2c3251921c2981",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0062",
-      "prov:atLocation": {"@id": "niiri:c9c4e7b200c2534ad97e3c43dc09088e"},
+      "prov:atLocation": {"@id": "niiri:b8745b5e296eeb89bc134806045f23be"},
       "prov:value": {"@type": "xsd:float", "@value": "4.17404651641846"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.99444589181498"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.24228638075574e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.909844421846994"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.669602324090354"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.99444589181498"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.24228638075574e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.909844421846994"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.669602324090354"}
     },
     {
-      "@id": "niiri:c9c4e7b200c2534ad97e3c43dc09088e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:b8745b5e296eeb89bc134806045f23be",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0062",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-40,-38,44]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-40,-38,44]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:58b48283047cd6205c93dce88e4d334a",
-      "entity": "niiri:d9d050f643bc5856b77ef6ab7839c73f"
+      "entity_derived": "niiri:2356612dab79bab4ff2c3251921c2981",
+      "entity": "niiri:917a8294186d88d434a4bfc11da79880"
     },
     {
-      "@id": "niiri:8f67354bb7a7f6da0a5471bdd4560f76",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:2cf649b070696a752113125b709baba3",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0063",
-      "prov:atLocation": {"@id": "niiri:6a4e0d9194dfc9d9273487e854ca3c39"},
+      "prov:atLocation": {"@id": "niiri:d3aa1c5c65ab980c6c3f0a8287b4ca8c"},
       "prov:value": {"@type": "xsd:float", "@value": "4.1575984954834"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.97991879787505"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.44694060671058e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.920254423392118"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.696012561232619"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.97991879787505"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.44694060671058e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.920254423392118"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.696012561232619"}
     },
     {
-      "@id": "niiri:6a4e0d9194dfc9d9273487e854ca3c39",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d3aa1c5c65ab980c6c3f0a8287b4ca8c",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0063",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[40,44,28]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[40,44,28]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:8f67354bb7a7f6da0a5471bdd4560f76",
-      "entity": "niiri:e6891860aa8b247560dff60407d6186f"
+      "entity_derived": "niiri:2cf649b070696a752113125b709baba3",
+      "entity": "niiri:2bf2abbcd31986ec01bd57d20b6711a8"
     },
     {
-      "@id": "niiri:fe4bebfe28418d49a7513f9d90b851c0",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:321b79a80ec05c8592d93c1223873eb6",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0064",
-      "prov:atLocation": {"@id": "niiri:1bcf091c7d5f7cd062929b308c1a661c"},
+      "prov:atLocation": {"@id": "niiri:778c8ac49540c7ead25b8567022eca9d"},
       "prov:value": {"@type": "xsd:float", "@value": "4.12145137786865"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.94794832362008"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "3.94119065879606e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.940339218142555"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.751110816447844"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.94794832362008"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "3.94119065879606e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.940339218142555"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.751110816447844"}
     },
     {
-      "@id": "niiri:1bcf091c7d5f7cd062929b308c1a661c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:778c8ac49540c7ead25b8567022eca9d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0064",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-48,-72,2]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-48,-72,2]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:fe4bebfe28418d49a7513f9d90b851c0",
-      "entity": "niiri:e70320e383167eb84eda35bf9e7b0fdd"
+      "entity_derived": "niiri:321b79a80ec05c8592d93c1223873eb6",
+      "entity": "niiri:ad8c7d04ce78559070db7b91d78cc57c"
     },
     {
-      "@id": "niiri:6f049a707887307544120045acf0b1cb",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:4e061a53d9dbe94531688c8bc9ccf986",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0065",
-      "prov:atLocation": {"@id": "niiri:3d7cd35e13ba11df83a274b563d9bce5"},
+      "prov:atLocation": {"@id": "niiri:ff83d5006e647b8e22be75b649373fe2"},
       "prov:value": {"@type": "xsd:float", "@value": "4.07333517074585"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.9052963692066"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.70549882543025e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.961337330645756"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.839886920372845"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.9052963692066"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.70549882543025e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.961337330645756"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.839886920372845"}
     },
     {
-      "@id": "niiri:3d7cd35e13ba11df83a274b563d9bce5",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:ff83d5006e647b8e22be75b649373fe2",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0065",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[20,-66,34]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[20,-66,34]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6f049a707887307544120045acf0b1cb",
-      "entity": "niiri:11f8c2ae0641d8825a111d78d6676ecf"
+      "entity_derived": "niiri:4e061a53d9dbe94531688c8bc9ccf986",
+      "entity": "niiri:17c9ecb05e0c47b2a47ad52062e17b94"
     },
     {
-      "@id": "niiri:2bf3483f6b5609b304bb41e17d7d49a3",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:f1fbcfcac4253cdc329fd605b6a751fc",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0066",
-      "prov:atLocation": {"@id": "niiri:b1f0483d37409edeaf0a0183e618358c"},
+      "prov:atLocation": {"@id": "niiri:d65701c98dd3217e20d935ade61b8f3d"},
       "prov:value": {"@type": "xsd:float", "@value": "4.05762767791748"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.89134919103145"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "4.98441713834286e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.966867400896655"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.870764578469458"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.89134919103145"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "4.98441713834286e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.966867400896655"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.870764578469458"}
     },
     {
-      "@id": "niiri:b1f0483d37409edeaf0a0183e618358c",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d65701c98dd3217e20d935ade61b8f3d",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0066",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-46,-56,14]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-46,-56,14]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:2bf3483f6b5609b304bb41e17d7d49a3",
-      "entity": "niiri:dad011c7f4403d3ac70b748845e3c867"
+      "entity_derived": "niiri:f1fbcfcac4253cdc329fd605b6a751fc",
+      "entity": "niiri:c5e4e1aa155896b26494489613f9ad95"
     },
     {
-      "@id": "niiri:117fbd87a54678bbfc2298a8b5e8d728",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:b2808d6838f77aa021c934016cf8ee92",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0067",
-      "prov:atLocation": {"@id": "niiri:1a04baac425986a29538317e8056a88e"},
+      "prov:atLocation": {"@id": "niiri:d4bb610116be7283da67989a1c4ffbdc"},
       "prov:value": {"@type": "xsd:float", "@value": "4.03719234466553"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.87318677164159"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.37107204765519e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.973166168280088"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.915311242761809"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.87318677164159"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.37107204765519e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.973166168280088"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.915311242761809"}
     },
     {
-      "@id": "niiri:1a04baac425986a29538317e8056a88e",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:d4bb610116be7283da67989a1c4ffbdc",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0067",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-48,2,50]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-48,2,50]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:117fbd87a54678bbfc2298a8b5e8d728",
-      "entity": "niiri:d530532271fa470308bd3bf1b9d79611"
+      "entity_derived": "niiri:b2808d6838f77aa021c934016cf8ee92",
+      "entity": "niiri:b838a0239e573b6049362c413185e4cb"
     },
     {
-      "@id": "niiri:6721e303016a7926d4a49e762e8619dd",
-      "@type": ["prov:Entity","nidm_Peak:"],
+      "@id": "niiri:9f6687ae47f76bfbebf449dfbe37a197",
+      "@type": ["prov:Entity","nidm_Peak"],
       "rdfs:label": "Peak: 0068",
-      "prov:atLocation": {"@id": "niiri:1bb58b5df703fd67057d0e427e0d1d73"},
+      "prov:atLocation": {"@id": "niiri:84087ba3e4fb886eb498efbf6852f831"},
       "prov:value": {"@type": "xsd:float", "@value": "4.0217924118042"},
-      "nidm_equivalentZStatistic:": {"@type": "xsd:float", "@value": "3.85948683644491"},
-      "nidm_pValueUncorrected:": {"@type": "xsd:float", "@value": "5.68126885931441e-05"},
-      "nidm_pValueFWER:": {"@type": "xsd:float", "@value": "0.977286609355005"},
-      "nidm_qValueFDR:": {"@type": "xsd:float", "@value": "0.947910679065814"}
+      "nidm_equivalentZStatistic": {"@type": "xsd:float", "@value": "3.85948683644491"},
+      "nidm_pValueUncorrected": {"@type": "xsd:float", "@value": "5.68126885931441e-05"},
+      "nidm_pValueFWER": {"@type": "xsd:float", "@value": "0.977286609355005"},
+      "nidm_qValueFDR": {"@type": "xsd:float", "@value": "0.947910679065814"}
     },
     {
-      "@id": "niiri:1bb58b5df703fd67057d0e427e0d1d73",
-      "@type": ["prov:Entity","prov:Location","nidm_Coordinate:"],
+      "@id": "niiri:84087ba3e4fb886eb498efbf6852f831",
+      "@type": ["prov:Entity","prov:Location","nidm_Coordinate"],
       "rdfs:label": "Coordinate: 0068",
-      "nidm_coordinateVector:": {"@type": "xsd:string", "@value": "[-36,-40,-36]"}
+      "nidm_coordinateVector": {"@type": "xsd:string", "@value": "[-36,-40,-36]"}
     },
     {
       "@type": "prov:Derivation",
-      "entity_derived": "niiri:6721e303016a7926d4a49e762e8619dd",
-      "entity": "niiri:e9bc012a60857c8c9c65fa0b8468ac39"
+      "entity_derived": "niiri:9f6687ae47f76bfbebf449dfbe37a197",
+      "entity": "niiri:e35bb4611d1d05c17b7964df5a12a385"
     }
   ]
 }

--- a/spmexport/ex_spm_thr_voxelunct4/nidm.ttl
+++ b/spmexport/ex_spm_thr_voxelunct4/nidm.ttl
@@ -4,7 +4,7 @@
 @prefix niiri: <http://iri.nidash.org/> .
 @prefix spm: <http://purl.org/nidash/spm#> .
 @prefix neurolex: <http://neurolex.org/wiki/> .
-@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions#> .
+@prefix crypto: <http://id.loc.gov/vocabulary/preservation/cryptographicHashFunctions/> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
@@ -17,27 +17,27 @@
 @prefix nidm_NIDMResultsExport: <http://purl.org/nidash/nidm#NIDM_0000166> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-niiri:d10494a81e870375372c9189f6ca7f37
+niiri:189896bede23f6c48d3a070d109b2e1a
   a prov:Entity, prov:Bundle, nidm_NIDMResults: ; 
   rdfs:label "NIDM-Results" ;
   nidm_version: "1.3.0"^^xsd:string .
 
-niiri:ff659f42f1df9ff3981edcd4db9a795a
+niiri:9997cb99dd0c128680679af0520a8123
   a prov:Agent, nidm_spm_results_nidm:, prov:SoftwareAgent ; 
   rdfs:label "spm_results_nidm" ;
-  nidm_softwareVersion: "12.6903"^^xsd:string .
+  nidm_softwareVersion: "12.7057"^^xsd:string .
 
-niiri:ff094f0495094247c0303e6b19c7b116
+niiri:18ff4e974aa8acb4e95128ad7d68d393
   a prov:Activity, nidm_NIDMResultsExport: ; 
   rdfs:label "NIDM-Results export" .
 
-niiri:ff094f0495094247c0303e6b19c7b116 prov:wasAssociatedWith niiri:ff659f42f1df9ff3981edcd4db9a795a .
+niiri:18ff4e974aa8acb4e95128ad7d68d393 prov:wasAssociatedWith niiri:9997cb99dd0c128680679af0520a8123 .
 
 _:blank5 a prov:Generation .
 
-niiri:d10494a81e870375372c9189f6ca7f37 prov:qualifiedGeneration _:blank5 .
+niiri:189896bede23f6c48d3a070d109b2e1a prov:qualifiedGeneration _:blank5 .
 
-_:blank5 prov:atTime "2016-12-07T16:10:09"^^xsd:dateTime .
+_:blank5 prov:atTime "2017-04-19T12:19:27"^^xsd:dateTime .
 
 @prefix nidm_Ixi549CoordinateSystem: <http://purl.org/nidash/nidm#NIDM_0000050> .
 @prefix src_SPM: <http://scicrunch.org/resolver/SCR_007037> .
@@ -142,12 +142,12 @@ _:blank5 prov:atTime "2016-12-07T16:10:09"^^xsd:dateTime .
 @prefix nidm_Coordinate: <http://purl.org/nidash/nidm#NIDM_0000015> .
 @prefix nidm_coordinateVector: <http://purl.org/nidash/nidm#NIDM_0000086> .
 
-niiri:c208e9d9cb32439be7a7b44d2c921772
+niiri:002f4e58c54fcf1f391a012f055d564a
     a prov:Agent, src_SPM:, prov:SoftwareAgent ; 
     rdfs:label "SPM" ;
-    nidm_softwareVersion: "12.12.2"^^xsd:string .
+    nidm_softwareVersion: "12.6906"^^xsd:string .
 
-niiri:5545f55e2dd1b9010b79b506d70b6d15
+niiri:7281f1fb34adff5220f3261fb87667df
     a prov:Entity, nidm_CoordinateSpace: ; 
     rdfs:label "Coordinate space 1" ;
     nidm_voxelToWorldMapping: "[[-2, 0, 0, 78],[0, 2, 0, -112],[0, 0, 2, -70],[0, 0, 0, 1]]"^^xsd:string ;
@@ -157,48 +157,48 @@ niiri:5545f55e2dd1b9010b79b506d70b6d15
     nidm_numberOfDimensions: "3"^^xsd:int ;
     nidm_dimensionsInVoxels: "[79,95,79]"^^xsd:string .
 
-niiri:bf3ff8bc715b391003c28ba185dce637
+niiri:23a5f4fc75628be04559466d0d952b3c
     a prov:Agent, nlx_Imaginginstrument:, nlx_Magneticresonanceimagingscanner: ; 
     rdfs:label "MRI Scanner" .
 
-niiri:61421aecf99ca3761fedab9ddf8f66e7
+niiri:9b463f2aa230e015f987241b0fc8a497
     a prov:Agent, prov:Person ; 
     rdfs:label "Person" .
 
-niiri:6c8c79ef5f06c6c4b2b646901ce80405
+niiri:6524bf7ddad1b51b7e6eccf056897312
     a prov:Entity, prov:Collection, nidm_Data: ; 
     rdfs:label "Data" ;
     nidm_grandMeanScaling: "true"^^xsd:boolean ;
     nidm_targetIntensity: "100"^^xsd:float ;
     nidm_hasMRIProtocol: nlx_FunctionalMRIprotocol: .
 
-niiri:6c8c79ef5f06c6c4b2b646901ce80405 prov:wasAttributedTo niiri:bf3ff8bc715b391003c28ba185dce637 .
+niiri:6524bf7ddad1b51b7e6eccf056897312 prov:wasAttributedTo niiri:23a5f4fc75628be04559466d0d952b3c .
 
-niiri:6c8c79ef5f06c6c4b2b646901ce80405 prov:wasAttributedTo niiri:61421aecf99ca3761fedab9ddf8f66e7 .
+niiri:6524bf7ddad1b51b7e6eccf056897312 prov:wasAttributedTo niiri:9b463f2aa230e015f987241b0fc8a497 .
 
-niiri:59a00422bd2b1358c5f2ec1a384f7c03
+niiri:2fb1bfe37a87dba64d5a5d293590e187
     a prov:Entity, spm_DCTDriftModel: ; 
     rdfs:label "SPM's DCT Drift Model" ;
     spm_SPMsDriftCutoffPeriod: "128"^^xsd:float .
 
-niiri:b886da30ef5cdaf4572037256a840167
+niiri:4731086ecff63edff2efe01371b545d8
     a prov:Entity, nidm_DesignMatrix: ; 
     prov:atLocation "DesignMatrix.csv"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.csv"^^xsd:string ;
     dct:format "text/csv"^^xsd:string ;
-    dc:description niiri:b4975d35fae6906cfcdc386dab48dbdb ;
+    dc:description niiri:5ca4ac54eeaf6f1d9152a1bdf46710a6 ;
     rdfs:label "Design Matrix" ;
     nidm_regressorNames: "[\"Sn(1) to*bf(1)\", \"Sn(1) \ntask001 co*bf(1)\", \"Sn(1) constant\"]"^^xsd:string ;
-    nidm_hasDriftModel: niiri:59a00422bd2b1358c5f2ec1a384f7c03 ;
+    nidm_hasDriftModel: niiri:2fb1bfe37a87dba64d5a5d293590e187 ;
     nidm_hasHRFBasis: spm_SPMsCanonicalHRF: .
 
-niiri:b4975d35fae6906cfcdc386dab48dbdb
+niiri:5ca4ac54eeaf6f1d9152a1bdf46710a6
     a prov:Entity, dctype:Image ; 
     prov:atLocation "DesignMatrix.png"^^xsd:anyURI ;
     nfo:fileName "DesignMatrix.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:60943f0fe63a407e4460f1fb2c885915
+niiri:386bf6b77814cb710199234a256a021c
     a prov:Entity, nidm_ErrorModel: ; 
     nidm_hasErrorDistribution: obo_normaldistribution: ;
     nidm_hasErrorDependence: obo_Toeplitzcovariancestructure: ;
@@ -206,174 +206,174 @@ niiri:60943f0fe63a407e4460f1fb2c885915
     nidm_errorVarianceHomogeneous: "true"^^xsd:boolean ;
     nidm_varianceMapWiseDependence: nidm_IndependentParameter: .
 
-niiri:47818adb47796fd14341054ef89b678b
+niiri:29ba85768229f1858344545a78875dd5
     a prov:Activity, nidm_ModelParametersEstimation: ; 
     rdfs:label "Model parameters estimation" ;
     nidm_withEstimationMethod: obo_generalizedleastsquaresestimation: .
 
-niiri:47818adb47796fd14341054ef89b678b prov:wasAssociatedWith niiri:c208e9d9cb32439be7a7b44d2c921772 .
+niiri:29ba85768229f1858344545a78875dd5 prov:wasAssociatedWith niiri:002f4e58c54fcf1f391a012f055d564a .
 
-niiri:47818adb47796fd14341054ef89b678b prov:used niiri:b886da30ef5cdaf4572037256a840167 .
+niiri:29ba85768229f1858344545a78875dd5 prov:used niiri:4731086ecff63edff2efe01371b545d8 .
 
-niiri:47818adb47796fd14341054ef89b678b prov:used niiri:6c8c79ef5f06c6c4b2b646901ce80405 .
+niiri:29ba85768229f1858344545a78875dd5 prov:used niiri:6524bf7ddad1b51b7e6eccf056897312 .
 
-niiri:47818adb47796fd14341054ef89b678b prov:used niiri:60943f0fe63a407e4460f1fb2c885915 .
+niiri:29ba85768229f1858344545a78875dd5 prov:used niiri:386bf6b77814cb710199234a256a021c .
 
-niiri:846a7a5fd2e3481706867026e8b26c7d
+niiri:9297aa85579b346a54833d2b1d149a50
     a prov:Entity, nidm_MaskMap: ; 
     prov:atLocation "Mask.nii.gz"^^xsd:anyURI ;
     nidm_isUserDefined: "false"^^xsd:boolean ;
     nfo:fileName "Mask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Mask" ;
-    nidm_inCoordinateSpace: niiri:5545f55e2dd1b9010b79b506d70b6d15 ;
+    nidm_inCoordinateSpace: niiri:7281f1fb34adff5220f3261fb87667df ;
     crypto:sha512 "dc7dd2f8485039d7bcf7f41d9f8e3d35045cd3d0dd9ae34a2b945d4fcd87a396b4336b01f6a027797761b08a05d1c51c83c0a7e61d9fbd4d165526741a36c876"^^xsd:string .
 
-niiri:d8069ae7247e425967d7c1d1adef43e0
+niiri:65afc11255961d055498d34a233f38eb
     a prov:Entity, nidm_MaskMap: ; 
     nfo:fileName "mask.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "36929e1f5f4143bd9cc818cd896a25f129961fab208c3a4438555f40444c08347b359142ee8c53ece6e8cca1627f49db0788a1fd3b9e2ecaef61999c6c6c67ac"^^xsd:string .
 
-niiri:846a7a5fd2e3481706867026e8b26c7d prov:wasDerivedFrom niiri:d8069ae7247e425967d7c1d1adef43e0 .
+niiri:9297aa85579b346a54833d2b1d149a50 prov:wasDerivedFrom niiri:65afc11255961d055498d34a233f38eb .
 
-niiri:846a7a5fd2e3481706867026e8b26c7d prov:wasGeneratedBy niiri:47818adb47796fd14341054ef89b678b .
+niiri:9297aa85579b346a54833d2b1d149a50 prov:wasGeneratedBy niiri:29ba85768229f1858344545a78875dd5 .
 
-niiri:59c5c85881ca09e29d5f1ccc9a03478d
+niiri:da0199129aa114a6e34a67087f7a90ec
     a prov:Entity, nidm_GrandMeanMap: ; 
     prov:atLocation "GrandMean.nii.gz"^^xsd:anyURI ;
     nfo:fileName "GrandMean.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Grand Mean Map" ;
     nidm_maskedMedian: "111.557487487793"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:5545f55e2dd1b9010b79b506d70b6d15 ;
+    nidm_inCoordinateSpace: niiri:7281f1fb34adff5220f3261fb87667df ;
     crypto:sha512 "512157cc6bff89d9343a09b4068226eb3edd64a8cbcee861f06231767fae6f8d4819921182adebee083a9bf309afd65529ab04a92f0aa6b0038c8098550f6124"^^xsd:string .
 
-niiri:59c5c85881ca09e29d5f1ccc9a03478d prov:wasGeneratedBy niiri:47818adb47796fd14341054ef89b678b .
+niiri:da0199129aa114a6e34a67087f7a90ec prov:wasGeneratedBy niiri:29ba85768229f1858344545a78875dd5 .
 
-niiri:057cca9a08df9f609713fa51a2b82777
+niiri:a04b9105e94e89a3c8075e41a664542c
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0001.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0001.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 1" ;
-    nidm_inCoordinateSpace: niiri:5545f55e2dd1b9010b79b506d70b6d15 ;
+    nidm_inCoordinateSpace: niiri:7281f1fb34adff5220f3261fb87667df ;
     crypto:sha512 "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd"^^xsd:string .
 
-niiri:2027ebeb9d31b20197daf9228267563c
+niiri:d6633d601feae732247aa91489588cbb
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "33b5c8e91109d1de8c439ebce8a6d7477a62ec35e0143b28cf433f3c6f0d146e117c874fda76fc9ace6a55c7a9798630dcca397976d597f35c008cb8167689bd"^^xsd:string .
 
-niiri:057cca9a08df9f609713fa51a2b82777 prov:wasDerivedFrom niiri:2027ebeb9d31b20197daf9228267563c .
+niiri:a04b9105e94e89a3c8075e41a664542c prov:wasDerivedFrom niiri:d6633d601feae732247aa91489588cbb .
 
-niiri:057cca9a08df9f609713fa51a2b82777 prov:wasGeneratedBy niiri:47818adb47796fd14341054ef89b678b .
+niiri:a04b9105e94e89a3c8075e41a664542c prov:wasGeneratedBy niiri:29ba85768229f1858344545a78875dd5 .
 
-niiri:30f5079ccbe0c219f133f34e6c4fe0b6
+niiri:8db44c591befd8da54a7b7424f044499
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0002.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0002.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 2" ;
-    nidm_inCoordinateSpace: niiri:5545f55e2dd1b9010b79b506d70b6d15 ;
+    nidm_inCoordinateSpace: niiri:7281f1fb34adff5220f3261fb87667df ;
     crypto:sha512 "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c"^^xsd:string .
 
-niiri:18dd5cb4231230239ab91400d41df7d6
+niiri:d6ae022ee50285e2c8fc24712ceb3996
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0002.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "bf26043362f278f8e26e5b044ecb8c0585e77fc408cd09aebafc47f68df766af2c074db1c28979227881e394d2ca2902de94f8c4b934cd315a35826d11ea033c"^^xsd:string .
 
-niiri:30f5079ccbe0c219f133f34e6c4fe0b6 prov:wasDerivedFrom niiri:18dd5cb4231230239ab91400d41df7d6 .
+niiri:8db44c591befd8da54a7b7424f044499 prov:wasDerivedFrom niiri:d6ae022ee50285e2c8fc24712ceb3996 .
 
-niiri:30f5079ccbe0c219f133f34e6c4fe0b6 prov:wasGeneratedBy niiri:47818adb47796fd14341054ef89b678b .
+niiri:8db44c591befd8da54a7b7424f044499 prov:wasGeneratedBy niiri:29ba85768229f1858344545a78875dd5 .
 
-niiri:c2e336373051539a367062441de85d31
+niiri:cda4f59b5814df22c694a9beb62517cc
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     prov:atLocation "ParameterEstimate_0003.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0003.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Parameter Estimate Map 3" ;
-    nidm_inCoordinateSpace: niiri:5545f55e2dd1b9010b79b506d70b6d15 ;
+    nidm_inCoordinateSpace: niiri:7281f1fb34adff5220f3261fb87667df ;
     crypto:sha512 "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373"^^xsd:string .
 
-niiri:3e4c25d18bc598d8a3251e550ae744d0
+niiri:1afcd7a91ab1ca3f7f51cc545792a500
     a prov:Entity, nidm_ParameterEstimateMap: ; 
     nfo:fileName "beta_0003.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "83f5c6c500382cc96a537f570a7559ae83153716c390d7acee41c9668b8e31007c85e354ff43ed7a0430c627847ad48a1972222eec7bf7b1f7722f8778357373"^^xsd:string .
 
-niiri:c2e336373051539a367062441de85d31 prov:wasDerivedFrom niiri:3e4c25d18bc598d8a3251e550ae744d0 .
+niiri:cda4f59b5814df22c694a9beb62517cc prov:wasDerivedFrom niiri:1afcd7a91ab1ca3f7f51cc545792a500 .
 
-niiri:c2e336373051539a367062441de85d31 prov:wasGeneratedBy niiri:47818adb47796fd14341054ef89b678b .
+niiri:cda4f59b5814df22c694a9beb62517cc prov:wasGeneratedBy niiri:29ba85768229f1858344545a78875dd5 .
 
-niiri:6d6a7fa36dc6a44086cf6a31b5867762
+niiri:ce15a9ed085ff2948353c419697255e2
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     prov:atLocation "ResidualMeanSquares.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ResidualMeanSquares.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Residual Mean Squares Map" ;
-    nidm_inCoordinateSpace: niiri:5545f55e2dd1b9010b79b506d70b6d15 ;
+    nidm_inCoordinateSpace: niiri:7281f1fb34adff5220f3261fb87667df ;
     crypto:sha512 "991abf563d795a43b1e2eef8643e57023f2e0b090b2031f05f839321fc0643df6f71d423486a1021519b6dc82f6b0f563e19f3fbd50cb16063bed54a0e192d3e"^^xsd:string .
 
-niiri:959c72679a23583975a747451d5992a2
+niiri:c628a1191f9d4a477945f23e95b293e6
     a prov:Entity, nidm_ResidualMeanSquaresMap: ; 
     nfo:fileName "ResMS.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "40b28d03fcf9a2f60b11f10d7fb83bf3618b234fb5aedf09df644cb7cbb6aab8c9f468897c1078166d455a3d04a83f4e3bf762cfca0b4ea982d7a4e406849f18"^^xsd:string .
 
-niiri:6d6a7fa36dc6a44086cf6a31b5867762 prov:wasDerivedFrom niiri:959c72679a23583975a747451d5992a2 .
+niiri:ce15a9ed085ff2948353c419697255e2 prov:wasDerivedFrom niiri:c628a1191f9d4a477945f23e95b293e6 .
 
-niiri:6d6a7fa36dc6a44086cf6a31b5867762 prov:wasGeneratedBy niiri:47818adb47796fd14341054ef89b678b .
+niiri:ce15a9ed085ff2948353c419697255e2 prov:wasGeneratedBy niiri:29ba85768229f1858344545a78875dd5 .
 
-niiri:34492567d7743546554a67338e951884
+niiri:76c6d153d35cc6d3973219ee9b3f2f15
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     prov:atLocation "ReselsPerVoxel.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ReselsPerVoxel.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Resels per Voxel Map" ;
-    nidm_inCoordinateSpace: niiri:5545f55e2dd1b9010b79b506d70b6d15 ;
+    nidm_inCoordinateSpace: niiri:7281f1fb34adff5220f3261fb87667df ;
     crypto:sha512 "1a3f9216e145249ccc0b14b2bc337d6b38b81ad45e32768001fb22b35f0c2c0f3e2bce013b40c85f7dc0fc62723ac761ee7f7e1e6aff128a05f0ba7b8b8202a3"^^xsd:string .
 
-niiri:472121f90faabc500aa266e106c755d1
+niiri:d9195d9e6536b5b316d751beb2ce3627
     a prov:Entity, nidm_ReselsPerVoxelMap: ; 
     nfo:fileName "RPV.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "4f76663162857f6b38b2a45a63b15a23b2ca8b338c283b69c1e71f2ea2f43797d045a733cd14e845be9c12f8b8f84d3931c599a08e8f6d77e99fab46ad87ab8f"^^xsd:string .
 
-niiri:34492567d7743546554a67338e951884 prov:wasDerivedFrom niiri:472121f90faabc500aa266e106c755d1 .
+niiri:76c6d153d35cc6d3973219ee9b3f2f15 prov:wasDerivedFrom niiri:d9195d9e6536b5b316d751beb2ce3627 .
 
-niiri:34492567d7743546554a67338e951884 prov:wasGeneratedBy niiri:47818adb47796fd14341054ef89b678b .
+niiri:76c6d153d35cc6d3973219ee9b3f2f15 prov:wasGeneratedBy niiri:29ba85768229f1858344545a78875dd5 .
 
-niiri:a63673e5a46f5dceec53b5209f36d606
+niiri:b931aad8007041b3ad2e52d2af33806b
     a prov:Entity, obo_contrastweightmatrix: ; 
     nidm_statisticType: obo_tstatistic: ;
     nidm_contrastName: "tone counting vs baseline"^^xsd:string ;
     rdfs:label "Contrast: tone counting vs baseline" ;
     prov:value "[1, 0, 0]"^^xsd:string .
 
-niiri:35c7eba70163dd4b70439861d7f9877c
+niiri:4dff47b859ccc8145da60881ef3fcadc
     a prov:Activity, nidm_ContrastEstimation: ; 
     rdfs:label "Contrast estimation" .
 
-niiri:35c7eba70163dd4b70439861d7f9877c prov:wasAssociatedWith niiri:c208e9d9cb32439be7a7b44d2c921772 .
+niiri:4dff47b859ccc8145da60881ef3fcadc prov:wasAssociatedWith niiri:002f4e58c54fcf1f391a012f055d564a .
 
-niiri:35c7eba70163dd4b70439861d7f9877c prov:used niiri:846a7a5fd2e3481706867026e8b26c7d .
+niiri:4dff47b859ccc8145da60881ef3fcadc prov:used niiri:9297aa85579b346a54833d2b1d149a50 .
 
-niiri:35c7eba70163dd4b70439861d7f9877c prov:used niiri:6d6a7fa36dc6a44086cf6a31b5867762 .
+niiri:4dff47b859ccc8145da60881ef3fcadc prov:used niiri:ce15a9ed085ff2948353c419697255e2 .
 
-niiri:35c7eba70163dd4b70439861d7f9877c prov:used niiri:b886da30ef5cdaf4572037256a840167 .
+niiri:4dff47b859ccc8145da60881ef3fcadc prov:used niiri:4731086ecff63edff2efe01371b545d8 .
 
-niiri:35c7eba70163dd4b70439861d7f9877c prov:used niiri:a63673e5a46f5dceec53b5209f36d606 .
+niiri:4dff47b859ccc8145da60881ef3fcadc prov:used niiri:b931aad8007041b3ad2e52d2af33806b .
 
-niiri:35c7eba70163dd4b70439861d7f9877c prov:used niiri:057cca9a08df9f609713fa51a2b82777 .
+niiri:4dff47b859ccc8145da60881ef3fcadc prov:used niiri:a04b9105e94e89a3c8075e41a664542c .
 
-niiri:35c7eba70163dd4b70439861d7f9877c prov:used niiri:30f5079ccbe0c219f133f34e6c4fe0b6 .
+niiri:4dff47b859ccc8145da60881ef3fcadc prov:used niiri:8db44c591befd8da54a7b7424f044499 .
 
-niiri:35c7eba70163dd4b70439861d7f9877c prov:used niiri:c2e336373051539a367062441de85d31 .
+niiri:4dff47b859ccc8145da60881ef3fcadc prov:used niiri:cda4f59b5814df22c694a9beb62517cc .
 
-niiri:005a761addf8440e95437a913ccc9361
+niiri:23148787f3344748fde71183ebc7da43
     a prov:Entity, nidm_StatisticMap: ; 
     prov:atLocation "TStatistic.nii.gz"^^xsd:anyURI ;
     nfo:fileName "TStatistic.nii.gz"^^xsd:string ;
@@ -383,124 +383,124 @@ niiri:005a761addf8440e95437a913ccc9361
     nidm_contrastName: "tone counting vs baseline"^^xsd:string ;
     nidm_errorDegreesOfFreedom: "97.9999999998522"^^xsd:float ;
     nidm_effectDegreesOfFreedom: "1"^^xsd:float ;
-    nidm_inCoordinateSpace: niiri:5545f55e2dd1b9010b79b506d70b6d15 ;
+    nidm_inCoordinateSpace: niiri:7281f1fb34adff5220f3261fb87667df ;
     crypto:sha512 "9e1714c2d86a050b38b4e10a4d2d23253a24c5e1d228ae16a9c3be8872739278505ac0729ecab54265a717e3a54f9f782d0ed72eea904e0d482a6072bb817bd4"^^xsd:string .
 
-niiri:c1d2c069631a2b218d0e3b760c38281a
+niiri:130668736169c4cdfa7fd91d417d86a8
     a prov:Entity, nidm_StatisticMap: ; 
     nfo:fileName "spmT_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "d288b1b0f117f64502555da13c5398dffa5bf5ff0b58951510e43d5388755bc185798802a92e98a07c7e313c6991066d2908f2a44aa5153ba23433da1335970f"^^xsd:string .
 
-niiri:005a761addf8440e95437a913ccc9361 prov:wasDerivedFrom niiri:c1d2c069631a2b218d0e3b760c38281a .
+niiri:23148787f3344748fde71183ebc7da43 prov:wasDerivedFrom niiri:130668736169c4cdfa7fd91d417d86a8 .
 
-niiri:005a761addf8440e95437a913ccc9361 prov:wasGeneratedBy niiri:35c7eba70163dd4b70439861d7f9877c .
+niiri:23148787f3344748fde71183ebc7da43 prov:wasGeneratedBy niiri:4dff47b859ccc8145da60881ef3fcadc .
 
-niiri:29ee40bc1d63e556b25a129e3278916e
+niiri:011b48f84e70f8c3e98a300224c8a1c1
     a prov:Entity, nidm_ContrastMap: ; 
     prov:atLocation "Contrast.nii.gz"^^xsd:anyURI ;
     nfo:fileName "Contrast.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Map: tone counting vs baseline" ;
     nidm_contrastName: "tone counting vs baseline"^^xsd:string ;
-    nidm_inCoordinateSpace: niiri:5545f55e2dd1b9010b79b506d70b6d15 ;
+    nidm_inCoordinateSpace: niiri:7281f1fb34adff5220f3261fb87667df ;
     crypto:sha512 "fc5e2ad175243ee496db98f9b2e1b235c4c3bae1a8d7122ce461c897b537e40c49dfee5d6cf20f71c6a2bb9b5f0760fcb4ecd8fe2e9428910ef3d60d8f3c56a9"^^xsd:string .
 
-niiri:f53f77a3a1877600544e0c3e41134d22
+niiri:c5041422daebd48592536bc76fa2d1b2
     a prov:Entity, nidm_ContrastMap: ; 
     nfo:fileName "con_0001.nii"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     crypto:sha512 "d4aa46b3603ba508578e39751262d528cf6d1ed2e722ec46f1cd8194c50591e46b229deb8cb4f72d1b7e0e2640f3e6604be7a335301c5c8357f453e5d0d4daf2"^^xsd:string .
 
-niiri:29ee40bc1d63e556b25a129e3278916e prov:wasDerivedFrom niiri:f53f77a3a1877600544e0c3e41134d22 .
+niiri:011b48f84e70f8c3e98a300224c8a1c1 prov:wasDerivedFrom niiri:c5041422daebd48592536bc76fa2d1b2 .
 
-niiri:29ee40bc1d63e556b25a129e3278916e prov:wasGeneratedBy niiri:35c7eba70163dd4b70439861d7f9877c .
+niiri:011b48f84e70f8c3e98a300224c8a1c1 prov:wasGeneratedBy niiri:4dff47b859ccc8145da60881ef3fcadc .
 
-niiri:bfd6482c20b0fb3800c79c63e8901d91
+niiri:a0b021c7d36be4a9f8aecb86143deef4
     a prov:Entity, nidm_ContrastStandardErrorMap: ; 
     prov:atLocation "ContrastStandardError.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ContrastStandardError.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Contrast Standard Error Map" ;
-    nidm_inCoordinateSpace: niiri:5545f55e2dd1b9010b79b506d70b6d15 ;
+    nidm_inCoordinateSpace: niiri:7281f1fb34adff5220f3261fb87667df ;
     crypto:sha512 "791d48f5d1adb15079a5289271ce0c4b95c56d69bfdb3e5d41b0d24eb538d3075e1cdd15502494b5a5a18c16eaa2153cb4847a996043fa48cdaf26e938a2576d"^^xsd:string .
 
-niiri:bfd6482c20b0fb3800c79c63e8901d91 prov:wasGeneratedBy niiri:35c7eba70163dd4b70439861d7f9877c .
+niiri:a0b021c7d36be4a9f8aecb86143deef4 prov:wasGeneratedBy niiri:4dff47b859ccc8145da60881ef3fcadc .
 
-niiri:47456ce2ef17b7cd1d7311aa87384430
+niiri:2bc75bbda2f5267265d3e555991c4a20
     a prov:Entity, nidm_HeightThreshold:, obo_statistic: ; 
     rdfs:label "Height Threshold: T=4.000000)" ;
     prov:value "4"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:d7c3dac965ebf71e3c0385c736eb15fc ;
-    nidm_equivalentThreshold: niiri:f8480c367edce0f95a718f1b492a2aca .
+    nidm_equivalentThreshold: niiri:2ba3915fe8a8233cd1decaccf893dfc6 ;
+    nidm_equivalentThreshold: niiri:f96c0a4477be91540adcc3de42e3bff1 .
 
-niiri:d7c3dac965ebf71e3c0385c736eb15fc
+niiri:2ba3915fe8a8233cd1decaccf893dfc6
     a prov:Entity, nidm_HeightThreshold:, nidm_PValueUncorrected: ; 
-    rdfs:label "Height Threshold" ;
+    rdfs:label "Height Threshold: p<0.000061 (unc.)" ;
     prov:value "6.14967978617154e-05"^^xsd:float .
 
-niiri:f8480c367edce0f95a718f1b492a2aca
+niiri:f96c0a4477be91540adcc3de42e3bff1
     a prov:Entity, nidm_HeightThreshold:, obo_FWERadjustedpvalue: ; 
-    rdfs:label "Height Threshold" ;
+    rdfs:label "Height Threshold: p<0.982274 (FWE)" ;
     prov:value "0.982273768856173"^^xsd:float .
 
-niiri:595081c81f8719333d05016c9a34a07b
+niiri:2943fbbdfc96906a3fd4051bd160e061
     a prov:Entity, nidm_ExtentThreshold:, obo_statistic: ; 
     rdfs:label "Extent Threshold: k>=0" ;
     nidm_clusterSizeInVoxels: "0"^^xsd:int ;
     nidm_clusterSizeInResels: "0"^^xsd:float ;
-    nidm_equivalentThreshold: niiri:feb69f9468a1e9175df97e2d3ad800ac ;
-    nidm_equivalentThreshold: niiri:54a732e5725b44b8b774b00e1e09a5d9 .
+    nidm_equivalentThreshold: niiri:7775696a22ed75b805453eb5b6b80ad7 ;
+    nidm_equivalentThreshold: niiri:b24450b6aba483c0fc1ba043cfb63970 .
 
-niiri:feb69f9468a1e9175df97e2d3ad800ac
+niiri:7775696a22ed75b805453eb5b6b80ad7
     a prov:Entity, nidm_ExtentThreshold:, obo_FWERadjustedpvalue: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:54a732e5725b44b8b774b00e1e09a5d9
+niiri:b24450b6aba483c0fc1ba043cfb63970
     a prov:Entity, nidm_ExtentThreshold:, nidm_PValueUncorrected: ; 
     rdfs:label "Extent Threshold" ;
     prov:value "1"^^xsd:float .
 
-niiri:1b06cd810a1935127442fc3eb55e0e6a
+niiri:0308135e8c28f665d33c547ac6714cf5
     a prov:Entity, nidm_PeakDefinitionCriteria: ; 
     rdfs:label "Peak Definition Criteria" ;
     nidm_maxNumberOfPeaksPerCluster: "3"^^xsd:int ;
     nidm_minDistanceBetweenPeaks: "8"^^xsd:float .
 
-niiri:44cc1dd0b9215186b40b5c6b996b4011
+niiri:a3c0f5b41e3541ca175be5a36b600ad4
     a prov:Entity, nidm_ClusterDefinitionCriteria: ; 
     rdfs:label "Cluster Connectivity Criterion: 18" ;
     nidm_hasConnectivityCriterion: nidm_voxel18connected: .
 
-niiri:9e1edd1ab6c94a52fa0c8c77440391da
+niiri:a587a25c633a14b3f1737b24594224a2
     a prov:Activity, nidm_Inference: ; 
     nidm_hasAlternativeHypothesis: nidm_OneTailedTest: ;
     rdfs:label "Inference" .
 
-niiri:9e1edd1ab6c94a52fa0c8c77440391da prov:wasAssociatedWith niiri:c208e9d9cb32439be7a7b44d2c921772 .
+niiri:a587a25c633a14b3f1737b24594224a2 prov:wasAssociatedWith niiri:002f4e58c54fcf1f391a012f055d564a .
 
-niiri:9e1edd1ab6c94a52fa0c8c77440391da prov:used niiri:47456ce2ef17b7cd1d7311aa87384430 .
+niiri:a587a25c633a14b3f1737b24594224a2 prov:used niiri:2bc75bbda2f5267265d3e555991c4a20 .
 
-niiri:9e1edd1ab6c94a52fa0c8c77440391da prov:used niiri:595081c81f8719333d05016c9a34a07b .
+niiri:a587a25c633a14b3f1737b24594224a2 prov:used niiri:2943fbbdfc96906a3fd4051bd160e061 .
 
-niiri:9e1edd1ab6c94a52fa0c8c77440391da prov:used niiri:005a761addf8440e95437a913ccc9361 .
+niiri:a587a25c633a14b3f1737b24594224a2 prov:used niiri:23148787f3344748fde71183ebc7da43 .
 
-niiri:9e1edd1ab6c94a52fa0c8c77440391da prov:used niiri:34492567d7743546554a67338e951884 .
+niiri:a587a25c633a14b3f1737b24594224a2 prov:used niiri:76c6d153d35cc6d3973219ee9b3f2f15 .
 
-niiri:9e1edd1ab6c94a52fa0c8c77440391da prov:used niiri:846a7a5fd2e3481706867026e8b26c7d .
+niiri:a587a25c633a14b3f1737b24594224a2 prov:used niiri:9297aa85579b346a54833d2b1d149a50 .
 
-niiri:9e1edd1ab6c94a52fa0c8c77440391da prov:used niiri:1b06cd810a1935127442fc3eb55e0e6a .
+niiri:a587a25c633a14b3f1737b24594224a2 prov:used niiri:0308135e8c28f665d33c547ac6714cf5 .
 
-niiri:9e1edd1ab6c94a52fa0c8c77440391da prov:used niiri:44cc1dd0b9215186b40b5c6b996b4011 .
+niiri:a587a25c633a14b3f1737b24594224a2 prov:used niiri:a3c0f5b41e3541ca175be5a36b600ad4 .
 
-niiri:490d98a60df558fd19f8da510e5ddd78
+niiri:fea41c80a81d93e6e5d3ae10aaaca7c6
     a prov:Entity, nidm_SearchSpaceMaskMap: ; 
     prov:atLocation "SearchSpaceMask.nii.gz"^^xsd:anyURI ;
     nfo:fileName "SearchSpaceMask.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Search Space Mask Map" ;
-    nidm_inCoordinateSpace: niiri:5545f55e2dd1b9010b79b506d70b6d15 ;
+    nidm_inCoordinateSpace: niiri:7281f1fb34adff5220f3261fb87667df ;
     nidm_searchVolumeInVoxels: "223057"^^xsd:int ;
     nidm_searchVolumeInUnits: "1784456"^^xsd:float ;
     nidm_reselSizeInVoxels: "65.5786964036542"^^xsd:float ;
@@ -517,9 +517,9 @@ niiri:490d98a60df558fd19f8da510e5ddd78
     spm_smallestSignificantClusterSizeInVoxelsFWE05: "48"^^xsd:int ;
     spm_smallestSignificantClusterSizeInVoxelsFDR05: "24"^^xsd:int .
 
-niiri:490d98a60df558fd19f8da510e5ddd78 prov:wasGeneratedBy niiri:9e1edd1ab6c94a52fa0c8c77440391da .
+niiri:fea41c80a81d93e6e5d3ae10aaaca7c6 prov:wasGeneratedBy niiri:a587a25c633a14b3f1737b24594224a2 .
 
-niiri:8c9e982b5e5acb0cf016de26a88d4eb8
+niiri:01e8d7706461319dc2f9f847acb9d9b6
     a prov:Entity, nidm_ExcursionSetMap: ; 
     prov:atLocation "ExcursionSet.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ExcursionSet.nii.gz"^^xsd:string ;
@@ -527,29 +527,29 @@ niiri:8c9e982b5e5acb0cf016de26a88d4eb8
     rdfs:label "Excursion Set Map" ;
     nidm_numberOfSupraThresholdClusters: "50"^^xsd:int ;
     nidm_pValue: "0"^^xsd:float ;
-    nidm_hasClusterLabelsMap: niiri:c0460e253ef0222ac9a8875873636259 ;
-    nidm_hasMaximumIntensityProjection: niiri:d9ad87418744b82ac48223bedf3b9e48 ;
-    nidm_inCoordinateSpace: niiri:5545f55e2dd1b9010b79b506d70b6d15 ;
+    nidm_hasClusterLabelsMap: niiri:af1adaf3b31a04d6e71698c939ab4b78 ;
+    nidm_hasMaximumIntensityProjection: niiri:9309bc37a685ef32c88ac516783d33c1 ;
+    nidm_inCoordinateSpace: niiri:7281f1fb34adff5220f3261fb87667df ;
     crypto:sha512 "a38743559bef11977e156d91275f386fc5f6886442cb7de734c12bdac62fac0cee28c0084419d0258da02ccef31a25aeea212441e01eaf2e902f1acb60b073df"^^xsd:string .
 
-niiri:c0460e253ef0222ac9a8875873636259
+niiri:af1adaf3b31a04d6e71698c939ab4b78
     a prov:Entity, nidm_ClusterLabelsMap: ; 
     prov:atLocation "ClusterLabels.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ClusterLabels.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string ;
     rdfs:label "Cluster Labels Map" ;
-    nidm_inCoordinateSpace: niiri:5545f55e2dd1b9010b79b506d70b6d15 ;
+    nidm_inCoordinateSpace: niiri:7281f1fb34adff5220f3261fb87667df ;
     crypto:sha512 "0802849189145a669e184384d952b5a23ec1267712f265582c4e7211b3307cb6cc05e055d687ec7fb168c7c3abffd843f3013061000bcb817971544daf0c712b"^^xsd:string .
 
-niiri:d9ad87418744b82ac48223bedf3b9e48
+niiri:9309bc37a685ef32c88ac516783d33c1
     a prov:Entity, dctype:Image ; 
     prov:atLocation "MaximumIntensityProjection.png"^^xsd:anyURI ;
     nfo:fileName "MaximumIntensityProjection.png"^^xsd:string ;
     dct:format "image/png"^^xsd:string .
 
-niiri:8c9e982b5e5acb0cf016de26a88d4eb8 prov:wasGeneratedBy niiri:9e1edd1ab6c94a52fa0c8c77440391da .
+niiri:01e8d7706461319dc2f9f847acb9d9b6 prov:wasGeneratedBy niiri:a587a25c633a14b3f1737b24594224a2 .
 
-niiri:094d7334d70e893686eb679e848c9ea4
+niiri:7205414c11fb33ad00f174ced75bedbf
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0001" ;
     nidm_clusterSizeInVoxels: "449"^^xsd:int ;
@@ -559,9 +559,9 @@ niiri:094d7334d70e893686eb679e848c9ea4
     nidm_qValueFDR: "1.05377479179972e-12"^^xsd:float ;
     nidm_clusterLabelId: "1"^^xsd:int .
 
-niiri:094d7334d70e893686eb679e848c9ea4 prov:wasDerivedFrom niiri:8c9e982b5e5acb0cf016de26a88d4eb8 .
+niiri:7205414c11fb33ad00f174ced75bedbf prov:wasDerivedFrom niiri:01e8d7706461319dc2f9f847acb9d9b6 .
 
-niiri:f3d3c07e06847367de29b57d78ad4c4d
+niiri:8f4713f29184830ccee1527aedd5043c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0002" ;
     nidm_clusterSizeInVoxels: "159"^^xsd:int ;
@@ -571,9 +571,9 @@ niiri:f3d3c07e06847367de29b57d78ad4c4d
     nidm_qValueFDR: "2.06165418974807e-06"^^xsd:float ;
     nidm_clusterLabelId: "2"^^xsd:int .
 
-niiri:f3d3c07e06847367de29b57d78ad4c4d prov:wasDerivedFrom niiri:8c9e982b5e5acb0cf016de26a88d4eb8 .
+niiri:8f4713f29184830ccee1527aedd5043c prov:wasDerivedFrom niiri:01e8d7706461319dc2f9f847acb9d9b6 .
 
-niiri:0b25583a911e871428e848d5f39ad760
+niiri:6565811c2226598488a782fcfbe65641
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0003" ;
     nidm_clusterSizeInVoxels: "348"^^xsd:int ;
@@ -583,9 +583,9 @@ niiri:0b25583a911e871428e848d5f39ad760
     nidm_qValueFDR: "9.11926025687937e-11"^^xsd:float ;
     nidm_clusterLabelId: "3"^^xsd:int .
 
-niiri:0b25583a911e871428e848d5f39ad760 prov:wasDerivedFrom niiri:8c9e982b5e5acb0cf016de26a88d4eb8 .
+niiri:6565811c2226598488a782fcfbe65641 prov:wasDerivedFrom niiri:01e8d7706461319dc2f9f847acb9d9b6 .
 
-niiri:eb6931b2d74447879ba47c6442079649
+niiri:775519b5c1873bb910da7115bee920c0
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0004" ;
     nidm_clusterSizeInVoxels: "817"^^xsd:int ;
@@ -595,9 +595,9 @@ niiri:eb6931b2d74447879ba47c6442079649
     nidm_qValueFDR: "5.31315066985251e-19"^^xsd:float ;
     nidm_clusterLabelId: "4"^^xsd:int .
 
-niiri:eb6931b2d74447879ba47c6442079649 prov:wasDerivedFrom niiri:8c9e982b5e5acb0cf016de26a88d4eb8 .
+niiri:775519b5c1873bb910da7115bee920c0 prov:wasDerivedFrom niiri:01e8d7706461319dc2f9f847acb9d9b6 .
 
-niiri:44faa3b6b4970674a664a3584aeafbd7
+niiri:0deac3c5a5a1925942b4c734669b80cc
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0005" ;
     nidm_clusterSizeInVoxels: "224"^^xsd:int ;
@@ -607,9 +607,9 @@ niiri:44faa3b6b4970674a664a3584aeafbd7
     nidm_qValueFDR: "4.98239151916056e-08"^^xsd:float ;
     nidm_clusterLabelId: "5"^^xsd:int .
 
-niiri:44faa3b6b4970674a664a3584aeafbd7 prov:wasDerivedFrom niiri:8c9e982b5e5acb0cf016de26a88d4eb8 .
+niiri:0deac3c5a5a1925942b4c734669b80cc prov:wasDerivedFrom niiri:01e8d7706461319dc2f9f847acb9d9b6 .
 
-niiri:04a5b76be470d6bad89f3870fda12c8f
+niiri:c20e67383ada8b9423453af31b5a55de
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0006" ;
     nidm_clusterSizeInVoxels: "65"^^xsd:int ;
@@ -619,9 +619,9 @@ niiri:04a5b76be470d6bad89f3870fda12c8f
     nidm_qValueFDR: "0.00114791990463577"^^xsd:float ;
     nidm_clusterLabelId: "6"^^xsd:int .
 
-niiri:04a5b76be470d6bad89f3870fda12c8f prov:wasDerivedFrom niiri:8c9e982b5e5acb0cf016de26a88d4eb8 .
+niiri:c20e67383ada8b9423453af31b5a55de prov:wasDerivedFrom niiri:01e8d7706461319dc2f9f847acb9d9b6 .
 
-niiri:791b0e754efbbb51618cea3a14b3b0e6
+niiri:23214e52c07fc432e44b14cfd9b05b8c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0007" ;
     nidm_clusterSizeInVoxels: "24"^^xsd:int ;
@@ -631,9 +631,9 @@ niiri:791b0e754efbbb51618cea3a14b3b0e6
     nidm_qValueFDR: "0.0478535913007054"^^xsd:float ;
     nidm_clusterLabelId: "7"^^xsd:int .
 
-niiri:791b0e754efbbb51618cea3a14b3b0e6 prov:wasDerivedFrom niiri:8c9e982b5e5acb0cf016de26a88d4eb8 .
+niiri:23214e52c07fc432e44b14cfd9b05b8c prov:wasDerivedFrom niiri:01e8d7706461319dc2f9f847acb9d9b6 .
 
-niiri:7e9854c772fccbc9dd667ccaf963d0ad
+niiri:63b9219b72b5b660f76b07f652b6ddab
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0008" ;
     nidm_clusterSizeInVoxels: "101"^^xsd:int ;
@@ -643,9 +643,9 @@ niiri:7e9854c772fccbc9dd667ccaf963d0ad
     nidm_qValueFDR: "8.20197177550572e-05"^^xsd:float ;
     nidm_clusterLabelId: "8"^^xsd:int .
 
-niiri:7e9854c772fccbc9dd667ccaf963d0ad prov:wasDerivedFrom niiri:8c9e982b5e5acb0cf016de26a88d4eb8 .
+niiri:63b9219b72b5b660f76b07f652b6ddab prov:wasDerivedFrom niiri:01e8d7706461319dc2f9f847acb9d9b6 .
 
-niiri:e72ed1be72500e0e5102f29f0ac13651
+niiri:b37dd2ff926a0dc9856b3d0532b1c0dd
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0009" ;
     nidm_clusterSizeInVoxels: "121"^^xsd:int ;
@@ -655,9 +655,9 @@ niiri:e72ed1be72500e0e5102f29f0ac13651
     nidm_qValueFDR: "2.22339272347497e-05"^^xsd:float ;
     nidm_clusterLabelId: "9"^^xsd:int .
 
-niiri:e72ed1be72500e0e5102f29f0ac13651 prov:wasDerivedFrom niiri:8c9e982b5e5acb0cf016de26a88d4eb8 .
+niiri:b37dd2ff926a0dc9856b3d0532b1c0dd prov:wasDerivedFrom niiri:01e8d7706461319dc2f9f847acb9d9b6 .
 
-niiri:1ec5bcf3d27a79e3a649cf72f09cc3e2
+niiri:e9b24d9fcc87aa114863aac61da68dea
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0010" ;
     nidm_clusterSizeInVoxels: "48"^^xsd:int ;
@@ -667,9 +667,9 @@ niiri:1ec5bcf3d27a79e3a649cf72f09cc3e2
     nidm_qValueFDR: "0.00409203816309772"^^xsd:float ;
     nidm_clusterLabelId: "10"^^xsd:int .
 
-niiri:1ec5bcf3d27a79e3a649cf72f09cc3e2 prov:wasDerivedFrom niiri:8c9e982b5e5acb0cf016de26a88d4eb8 .
+niiri:e9b24d9fcc87aa114863aac61da68dea prov:wasDerivedFrom niiri:01e8d7706461319dc2f9f847acb9d9b6 .
 
-niiri:9d57dfc9c26a3b26ff08bc8602cb7238
+niiri:7e536777241b4ecd7a6966f907894029
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0011" ;
     nidm_clusterSizeInVoxels: "968"^^xsd:int ;
@@ -679,9 +679,9 @@ niiri:9d57dfc9c26a3b26ff08bc8602cb7238
     nidm_qValueFDR: "4.69404087526332e-21"^^xsd:float ;
     nidm_clusterLabelId: "11"^^xsd:int .
 
-niiri:9d57dfc9c26a3b26ff08bc8602cb7238 prov:wasDerivedFrom niiri:8c9e982b5e5acb0cf016de26a88d4eb8 .
+niiri:7e536777241b4ecd7a6966f907894029 prov:wasDerivedFrom niiri:01e8d7706461319dc2f9f847acb9d9b6 .
 
-niiri:56b434cc0204499fc97e08dac52bab86
+niiri:f008be07086de77a22010a7f08caa22f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0012" ;
     nidm_clusterSizeInVoxels: "9"^^xsd:int ;
@@ -691,9 +691,9 @@ niiri:56b434cc0204499fc97e08dac52bab86
     nidm_qValueFDR: "0.212357929415231"^^xsd:float ;
     nidm_clusterLabelId: "12"^^xsd:int .
 
-niiri:56b434cc0204499fc97e08dac52bab86 prov:wasDerivedFrom niiri:8c9e982b5e5acb0cf016de26a88d4eb8 .
+niiri:f008be07086de77a22010a7f08caa22f prov:wasDerivedFrom niiri:01e8d7706461319dc2f9f847acb9d9b6 .
 
-niiri:eb4c4ce00fca97f5c6e779fced2198a7
+niiri:0b8006d59ae6d79e0e814aa87159321c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0013" ;
     nidm_clusterSizeInVoxels: "14"^^xsd:int ;
@@ -703,9 +703,9 @@ niiri:eb4c4ce00fca97f5c6e779fced2198a7
     nidm_qValueFDR: "0.123131283448217"^^xsd:float ;
     nidm_clusterLabelId: "13"^^xsd:int .
 
-niiri:eb4c4ce00fca97f5c6e779fced2198a7 prov:wasDerivedFrom niiri:8c9e982b5e5acb0cf016de26a88d4eb8 .
+niiri:0b8006d59ae6d79e0e814aa87159321c prov:wasDerivedFrom niiri:01e8d7706461319dc2f9f847acb9d9b6 .
 
-niiri:de8927fdf14192632eecaa3636f2e9e3
+niiri:6581a2a4fbc96915373d67e7edf695a9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0014" ;
     nidm_clusterSizeInVoxels: "69"^^xsd:int ;
@@ -715,9 +715,9 @@ niiri:de8927fdf14192632eecaa3636f2e9e3
     nidm_qValueFDR: "0.000907538723872777"^^xsd:float ;
     nidm_clusterLabelId: "14"^^xsd:int .
 
-niiri:de8927fdf14192632eecaa3636f2e9e3 prov:wasDerivedFrom niiri:8c9e982b5e5acb0cf016de26a88d4eb8 .
+niiri:6581a2a4fbc96915373d67e7edf695a9 prov:wasDerivedFrom niiri:01e8d7706461319dc2f9f847acb9d9b6 .
 
-niiri:21c83646c5b8900bb66ac4bdc408bd17
+niiri:d1a419e3b8453b976a58dbdde542b8c4
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0015" ;
     nidm_clusterSizeInVoxels: "55"^^xsd:int ;
@@ -727,9 +727,9 @@ niiri:21c83646c5b8900bb66ac4bdc408bd17
     nidm_qValueFDR: "0.00252374640705533"^^xsd:float ;
     nidm_clusterLabelId: "15"^^xsd:int .
 
-niiri:21c83646c5b8900bb66ac4bdc408bd17 prov:wasDerivedFrom niiri:8c9e982b5e5acb0cf016de26a88d4eb8 .
+niiri:d1a419e3b8453b976a58dbdde542b8c4 prov:wasDerivedFrom niiri:01e8d7706461319dc2f9f847acb9d9b6 .
 
-niiri:39b00e4afb3679693ccf462cccc76f45
+niiri:9f5db5fa91c4f9045129661d86ff7c8f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0016" ;
     nidm_clusterSizeInVoxels: "50"^^xsd:int ;
@@ -739,9 +739,9 @@ niiri:39b00e4afb3679693ccf462cccc76f45
     nidm_qValueFDR: "0.00367011079394416"^^xsd:float ;
     nidm_clusterLabelId: "16"^^xsd:int .
 
-niiri:39b00e4afb3679693ccf462cccc76f45 prov:wasDerivedFrom niiri:8c9e982b5e5acb0cf016de26a88d4eb8 .
+niiri:9f5db5fa91c4f9045129661d86ff7c8f prov:wasDerivedFrom niiri:01e8d7706461319dc2f9f847acb9d9b6 .
 
-niiri:1b13213ccbcda957315f11cacbe52f8e
+niiri:dc8fb82556a5fb25f9d253499774c9d3
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0017" ;
     nidm_clusterSizeInVoxels: "19"^^xsd:int ;
@@ -751,9 +751,9 @@ niiri:1b13213ccbcda957315f11cacbe52f8e
     nidm_qValueFDR: "0.0779898795021655"^^xsd:float ;
     nidm_clusterLabelId: "17"^^xsd:int .
 
-niiri:1b13213ccbcda957315f11cacbe52f8e prov:wasDerivedFrom niiri:8c9e982b5e5acb0cf016de26a88d4eb8 .
+niiri:dc8fb82556a5fb25f9d253499774c9d3 prov:wasDerivedFrom niiri:01e8d7706461319dc2f9f847acb9d9b6 .
 
-niiri:57a4b5c4432a4efdb2afe166bc8a8d40
+niiri:65d11f313edff947dbe708fa2df7a47f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0018" ;
     nidm_clusterSizeInVoxels: "17"^^xsd:int ;
@@ -763,9 +763,9 @@ niiri:57a4b5c4432a4efdb2afe166bc8a8d40
     nidm_qValueFDR: "0.0902475585782863"^^xsd:float ;
     nidm_clusterLabelId: "18"^^xsd:int .
 
-niiri:57a4b5c4432a4efdb2afe166bc8a8d40 prov:wasDerivedFrom niiri:8c9e982b5e5acb0cf016de26a88d4eb8 .
+niiri:65d11f313edff947dbe708fa2df7a47f prov:wasDerivedFrom niiri:01e8d7706461319dc2f9f847acb9d9b6 .
 
-niiri:1fc9da3e6287c03753ee90c1a5abc45f
+niiri:5e70ca2cffa7ec4b08a897a898eb5b28
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0019" ;
     nidm_clusterSizeInVoxels: "21"^^xsd:int ;
@@ -775,9 +775,9 @@ niiri:1fc9da3e6287c03753ee90c1a5abc45f
     nidm_qValueFDR: "0.0644874543130751"^^xsd:float ;
     nidm_clusterLabelId: "19"^^xsd:int .
 
-niiri:1fc9da3e6287c03753ee90c1a5abc45f prov:wasDerivedFrom niiri:8c9e982b5e5acb0cf016de26a88d4eb8 .
+niiri:5e70ca2cffa7ec4b08a897a898eb5b28 prov:wasDerivedFrom niiri:01e8d7706461319dc2f9f847acb9d9b6 .
 
-niiri:a87ac34d0b2aa71a22f631bee6f5d009
+niiri:c77ff18164bd254c10834cf4198cc926
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0020" ;
     nidm_clusterSizeInVoxels: "11"^^xsd:int ;
@@ -787,9 +787,9 @@ niiri:a87ac34d0b2aa71a22f631bee6f5d009
     nidm_qValueFDR: "0.175053652071173"^^xsd:float ;
     nidm_clusterLabelId: "20"^^xsd:int .
 
-niiri:a87ac34d0b2aa71a22f631bee6f5d009 prov:wasDerivedFrom niiri:8c9e982b5e5acb0cf016de26a88d4eb8 .
+niiri:c77ff18164bd254c10834cf4198cc926 prov:wasDerivedFrom niiri:01e8d7706461319dc2f9f847acb9d9b6 .
 
-niiri:d6ac21365d2405aa9644fdebf0cc6ef4
+niiri:5ec4ec1a9ea7234dae961134341c413f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0021" ;
     nidm_clusterSizeInVoxels: "10"^^xsd:int ;
@@ -799,9 +799,9 @@ niiri:d6ac21365d2405aa9644fdebf0cc6ef4
     nidm_qValueFDR: "0.187899654805729"^^xsd:float ;
     nidm_clusterLabelId: "21"^^xsd:int .
 
-niiri:d6ac21365d2405aa9644fdebf0cc6ef4 prov:wasDerivedFrom niiri:8c9e982b5e5acb0cf016de26a88d4eb8 .
+niiri:5ec4ec1a9ea7234dae961134341c413f prov:wasDerivedFrom niiri:01e8d7706461319dc2f9f847acb9d9b6 .
 
-niiri:1538a072d6986b630537b29066fec5db
+niiri:43dcb06f795f24225ca2e94a905a018a
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0022" ;
     nidm_clusterSizeInVoxels: "7"^^xsd:int ;
@@ -811,9 +811,9 @@ niiri:1538a072d6986b630537b29066fec5db
     nidm_qValueFDR: "0.267974506606377"^^xsd:float ;
     nidm_clusterLabelId: "22"^^xsd:int .
 
-niiri:1538a072d6986b630537b29066fec5db prov:wasDerivedFrom niiri:8c9e982b5e5acb0cf016de26a88d4eb8 .
+niiri:43dcb06f795f24225ca2e94a905a018a prov:wasDerivedFrom niiri:01e8d7706461319dc2f9f847acb9d9b6 .
 
-niiri:b1a9ed0ce88ddf57f1afa2ab051d9094
+niiri:63c6acd902a0987762c94921fa226068
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0023" ;
     nidm_clusterSizeInVoxels: "10"^^xsd:int ;
@@ -823,9 +823,9 @@ niiri:b1a9ed0ce88ddf57f1afa2ab051d9094
     nidm_qValueFDR: "0.187899654805729"^^xsd:float ;
     nidm_clusterLabelId: "23"^^xsd:int .
 
-niiri:b1a9ed0ce88ddf57f1afa2ab051d9094 prov:wasDerivedFrom niiri:8c9e982b5e5acb0cf016de26a88d4eb8 .
+niiri:63c6acd902a0987762c94921fa226068 prov:wasDerivedFrom niiri:01e8d7706461319dc2f9f847acb9d9b6 .
 
-niiri:a820061ecf406d69716300c9fedb0d02
+niiri:5e9dd0483caa5eb1c58d3fce896ce441
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0024" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -835,9 +835,9 @@ niiri:a820061ecf406d69716300c9fedb0d02
     nidm_qValueFDR: "0.301007284240307"^^xsd:float ;
     nidm_clusterLabelId: "24"^^xsd:int .
 
-niiri:a820061ecf406d69716300c9fedb0d02 prov:wasDerivedFrom niiri:8c9e982b5e5acb0cf016de26a88d4eb8 .
+niiri:5e9dd0483caa5eb1c58d3fce896ce441 prov:wasDerivedFrom niiri:01e8d7706461319dc2f9f847acb9d9b6 .
 
-niiri:1c89663261d7fe599621a515c41412ef
+niiri:a371619b98c52e0355b320d28edb7189
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0025" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -847,9 +847,9 @@ niiri:1c89663261d7fe599621a515c41412ef
     nidm_qValueFDR: "0.31383296012931"^^xsd:float ;
     nidm_clusterLabelId: "25"^^xsd:int .
 
-niiri:1c89663261d7fe599621a515c41412ef prov:wasDerivedFrom niiri:8c9e982b5e5acb0cf016de26a88d4eb8 .
+niiri:a371619b98c52e0355b320d28edb7189 prov:wasDerivedFrom niiri:01e8d7706461319dc2f9f847acb9d9b6 .
 
-niiri:347c2f752b33682df28dbb3618ca4959
+niiri:37cde807f5ec7a0a182032d2608a5010
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0026" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -859,9 +859,9 @@ niiri:347c2f752b33682df28dbb3618ca4959
     nidm_qValueFDR: "0.232914563842494"^^xsd:float ;
     nidm_clusterLabelId: "26"^^xsd:int .
 
-niiri:347c2f752b33682df28dbb3618ca4959 prov:wasDerivedFrom niiri:8c9e982b5e5acb0cf016de26a88d4eb8 .
+niiri:37cde807f5ec7a0a182032d2608a5010 prov:wasDerivedFrom niiri:01e8d7706461319dc2f9f847acb9d9b6 .
 
-niiri:b06c1cefe3c12fe41b07e749646c1006
+niiri:6bb17b684d45a4f861c90fe5fbe07173
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0027" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -871,9 +871,9 @@ niiri:b06c1cefe3c12fe41b07e749646c1006
     nidm_qValueFDR: "0.31383296012931"^^xsd:float ;
     nidm_clusterLabelId: "27"^^xsd:int .
 
-niiri:b06c1cefe3c12fe41b07e749646c1006 prov:wasDerivedFrom niiri:8c9e982b5e5acb0cf016de26a88d4eb8 .
+niiri:6bb17b684d45a4f861c90fe5fbe07173 prov:wasDerivedFrom niiri:01e8d7706461319dc2f9f847acb9d9b6 .
 
-niiri:9ac56d5858e1280575cd8c2eaac3bf9f
+niiri:7560e53c1288bc92b5a4d846f27be2a2
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0028" ;
     nidm_clusterSizeInVoxels: "11"^^xsd:int ;
@@ -883,9 +883,9 @@ niiri:9ac56d5858e1280575cd8c2eaac3bf9f
     nidm_qValueFDR: "0.175053652071173"^^xsd:float ;
     nidm_clusterLabelId: "28"^^xsd:int .
 
-niiri:9ac56d5858e1280575cd8c2eaac3bf9f prov:wasDerivedFrom niiri:8c9e982b5e5acb0cf016de26a88d4eb8 .
+niiri:7560e53c1288bc92b5a4d846f27be2a2 prov:wasDerivedFrom niiri:01e8d7706461319dc2f9f847acb9d9b6 .
 
-niiri:c1038d6173e201e6db5e15170fe9c504
+niiri:6a1d4b90730b6f045c485c09e364158b
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0029" ;
     nidm_clusterSizeInVoxels: "8"^^xsd:int ;
@@ -895,9 +895,9 @@ niiri:c1038d6173e201e6db5e15170fe9c504
     nidm_qValueFDR: "0.232914563842494"^^xsd:float ;
     nidm_clusterLabelId: "29"^^xsd:int .
 
-niiri:c1038d6173e201e6db5e15170fe9c504 prov:wasDerivedFrom niiri:8c9e982b5e5acb0cf016de26a88d4eb8 .
+niiri:6a1d4b90730b6f045c485c09e364158b prov:wasDerivedFrom niiri:01e8d7706461319dc2f9f847acb9d9b6 .
 
-niiri:10fb1def343c16cea3ed7ca34f95f4a5
+niiri:642f54df01178892acf81b69ba1cdd64
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0030" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -907,9 +907,9 @@ niiri:10fb1def343c16cea3ed7ca34f95f4a5
     nidm_qValueFDR: "0.31383296012931"^^xsd:float ;
     nidm_clusterLabelId: "30"^^xsd:int .
 
-niiri:10fb1def343c16cea3ed7ca34f95f4a5 prov:wasDerivedFrom niiri:8c9e982b5e5acb0cf016de26a88d4eb8 .
+niiri:642f54df01178892acf81b69ba1cdd64 prov:wasDerivedFrom niiri:01e8d7706461319dc2f9f847acb9d9b6 .
 
-niiri:05b9a5f65294a59f709d2874ee06eb74
+niiri:7004bd2e853e73ce41a764732d04d90f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0031" ;
     nidm_clusterSizeInVoxels: "16"^^xsd:int ;
@@ -919,9 +919,9 @@ niiri:05b9a5f65294a59f709d2874ee06eb74
     nidm_qValueFDR: "0.0979276347703999"^^xsd:float ;
     nidm_clusterLabelId: "31"^^xsd:int .
 
-niiri:05b9a5f65294a59f709d2874ee06eb74 prov:wasDerivedFrom niiri:8c9e982b5e5acb0cf016de26a88d4eb8 .
+niiri:7004bd2e853e73ce41a764732d04d90f prov:wasDerivedFrom niiri:01e8d7706461319dc2f9f847acb9d9b6 .
 
-niiri:6e7ba611211b14c42b46c20448bed1da
+niiri:44f3268a65a1bd0913070af57e7f8c22
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0032" ;
     nidm_clusterSizeInVoxels: "17"^^xsd:int ;
@@ -931,9 +931,9 @@ niiri:6e7ba611211b14c42b46c20448bed1da
     nidm_qValueFDR: "0.0902475585782863"^^xsd:float ;
     nidm_clusterLabelId: "32"^^xsd:int .
 
-niiri:6e7ba611211b14c42b46c20448bed1da prov:wasDerivedFrom niiri:8c9e982b5e5acb0cf016de26a88d4eb8 .
+niiri:44f3268a65a1bd0913070af57e7f8c22 prov:wasDerivedFrom niiri:01e8d7706461319dc2f9f847acb9d9b6 .
 
-niiri:b460f1f0b03e40e2ef4befc4665227a8
+niiri:27e476ef788fe4fb3d8dcc031b399a81
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0033" ;
     nidm_clusterSizeInVoxels: "6"^^xsd:int ;
@@ -943,9 +943,9 @@ niiri:b460f1f0b03e40e2ef4befc4665227a8
     nidm_qValueFDR: "0.301007284240307"^^xsd:float ;
     nidm_clusterLabelId: "33"^^xsd:int .
 
-niiri:b460f1f0b03e40e2ef4befc4665227a8 prov:wasDerivedFrom niiri:8c9e982b5e5acb0cf016de26a88d4eb8 .
+niiri:27e476ef788fe4fb3d8dcc031b399a81 prov:wasDerivedFrom niiri:01e8d7706461319dc2f9f847acb9d9b6 .
 
-niiri:054b7672bba8ed55d6c9d550e674f600
+niiri:ca4952c39685bacdd04c639d61f596dc
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0034" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -955,9 +955,9 @@ niiri:054b7672bba8ed55d6c9d550e674f600
     nidm_qValueFDR: "0.51070929740394"^^xsd:float ;
     nidm_clusterLabelId: "34"^^xsd:int .
 
-niiri:054b7672bba8ed55d6c9d550e674f600 prov:wasDerivedFrom niiri:8c9e982b5e5acb0cf016de26a88d4eb8 .
+niiri:ca4952c39685bacdd04c639d61f596dc prov:wasDerivedFrom niiri:01e8d7706461319dc2f9f847acb9d9b6 .
 
-niiri:5c380d0f5b0d102daa46b5ee765401d0
+niiri:af2ac94d3f5ea60663d90097f8159f1d
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0035" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -967,9 +967,9 @@ niiri:5c380d0f5b0d102daa46b5ee765401d0
     nidm_qValueFDR: "0.31383296012931"^^xsd:float ;
     nidm_clusterLabelId: "35"^^xsd:int .
 
-niiri:5c380d0f5b0d102daa46b5ee765401d0 prov:wasDerivedFrom niiri:8c9e982b5e5acb0cf016de26a88d4eb8 .
+niiri:af2ac94d3f5ea60663d90097f8159f1d prov:wasDerivedFrom niiri:01e8d7706461319dc2f9f847acb9d9b6 .
 
-niiri:ff57ed710046587ca6241d3e59018019
+niiri:d088c79195acad1ffe8fcf692ee20b14
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0036" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -979,9 +979,9 @@ niiri:ff57ed710046587ca6241d3e59018019
     nidm_qValueFDR: "0.595521713796185"^^xsd:float ;
     nidm_clusterLabelId: "36"^^xsd:int .
 
-niiri:ff57ed710046587ca6241d3e59018019 prov:wasDerivedFrom niiri:8c9e982b5e5acb0cf016de26a88d4eb8 .
+niiri:d088c79195acad1ffe8fcf692ee20b14 prov:wasDerivedFrom niiri:01e8d7706461319dc2f9f847acb9d9b6 .
 
-niiri:8d2f0fd2c9e7d0b8208eb1fc4b198d3a
+niiri:9d84cb059aa001b080f641472d50dee9
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0037" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -991,9 +991,9 @@ niiri:8d2f0fd2c9e7d0b8208eb1fc4b198d3a
     nidm_qValueFDR: "0.595521713796185"^^xsd:float ;
     nidm_clusterLabelId: "37"^^xsd:int .
 
-niiri:8d2f0fd2c9e7d0b8208eb1fc4b198d3a prov:wasDerivedFrom niiri:8c9e982b5e5acb0cf016de26a88d4eb8 .
+niiri:9d84cb059aa001b080f641472d50dee9 prov:wasDerivedFrom niiri:01e8d7706461319dc2f9f847acb9d9b6 .
 
-niiri:684e846c172afe6d05d5ae78e91a66ab
+niiri:51d1d5abbfa00532f6e6a2f6c7c0cf8f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0038" ;
     nidm_clusterSizeInVoxels: "5"^^xsd:int ;
@@ -1003,9 +1003,9 @@ niiri:684e846c172afe6d05d5ae78e91a66ab
     nidm_qValueFDR: "0.31383296012931"^^xsd:float ;
     nidm_clusterLabelId: "38"^^xsd:int .
 
-niiri:684e846c172afe6d05d5ae78e91a66ab prov:wasDerivedFrom niiri:8c9e982b5e5acb0cf016de26a88d4eb8 .
+niiri:51d1d5abbfa00532f6e6a2f6c7c0cf8f prov:wasDerivedFrom niiri:01e8d7706461319dc2f9f847acb9d9b6 .
 
-niiri:e41c1ae17d421ba7f943954ecb82266f
+niiri:f39108df33a4d833661db62b9a0c407f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0039" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1015,9 +1015,9 @@ niiri:e41c1ae17d421ba7f943954ecb82266f
     nidm_qValueFDR: "0.436187824916945"^^xsd:float ;
     nidm_clusterLabelId: "39"^^xsd:int .
 
-niiri:e41c1ae17d421ba7f943954ecb82266f prov:wasDerivedFrom niiri:8c9e982b5e5acb0cf016de26a88d4eb8 .
+niiri:f39108df33a4d833661db62b9a0c407f prov:wasDerivedFrom niiri:01e8d7706461319dc2f9f847acb9d9b6 .
 
-niiri:6ebbb8b1cbde12076fc5d4ef4e85955c
+niiri:4b799f0cf87667a22d5d0bd894e1cf9f
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0040" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1027,9 +1027,9 @@ niiri:6ebbb8b1cbde12076fc5d4ef4e85955c
     nidm_qValueFDR: "0.51070929740394"^^xsd:float ;
     nidm_clusterLabelId: "40"^^xsd:int .
 
-niiri:6ebbb8b1cbde12076fc5d4ef4e85955c prov:wasDerivedFrom niiri:8c9e982b5e5acb0cf016de26a88d4eb8 .
+niiri:4b799f0cf87667a22d5d0bd894e1cf9f prov:wasDerivedFrom niiri:01e8d7706461319dc2f9f847acb9d9b6 .
 
-niiri:370b2cb6de898bd071b9e171bc29995b
+niiri:418bd4d687fd48d9de96b297aa605a93
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0041" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1039,9 +1039,9 @@ niiri:370b2cb6de898bd071b9e171bc29995b
     nidm_qValueFDR: "0.51070929740394"^^xsd:float ;
     nidm_clusterLabelId: "41"^^xsd:int .
 
-niiri:370b2cb6de898bd071b9e171bc29995b prov:wasDerivedFrom niiri:8c9e982b5e5acb0cf016de26a88d4eb8 .
+niiri:418bd4d687fd48d9de96b297aa605a93 prov:wasDerivedFrom niiri:01e8d7706461319dc2f9f847acb9d9b6 .
 
-niiri:24a35ffc9e3360be3e77ac0bdf6162e1
+niiri:69987b67a58d47cf5fdd3f3dd0097df0
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0042" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1051,9 +1051,9 @@ niiri:24a35ffc9e3360be3e77ac0bdf6162e1
     nidm_qValueFDR: "0.366054524499499"^^xsd:float ;
     nidm_clusterLabelId: "42"^^xsd:int .
 
-niiri:24a35ffc9e3360be3e77ac0bdf6162e1 prov:wasDerivedFrom niiri:8c9e982b5e5acb0cf016de26a88d4eb8 .
+niiri:69987b67a58d47cf5fdd3f3dd0097df0 prov:wasDerivedFrom niiri:01e8d7706461319dc2f9f847acb9d9b6 .
 
-niiri:938df04c7b599a7c74931290216cc187
+niiri:f0f2196eb8e713870fab0d351b7d0893
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0043" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1063,9 +1063,9 @@ niiri:938df04c7b599a7c74931290216cc187
     nidm_qValueFDR: "0.595521713796185"^^xsd:float ;
     nidm_clusterLabelId: "43"^^xsd:int .
 
-niiri:938df04c7b599a7c74931290216cc187 prov:wasDerivedFrom niiri:8c9e982b5e5acb0cf016de26a88d4eb8 .
+niiri:f0f2196eb8e713870fab0d351b7d0893 prov:wasDerivedFrom niiri:01e8d7706461319dc2f9f847acb9d9b6 .
 
-niiri:d9d050f643bc5856b77ef6ab7839c73f
+niiri:917a8294186d88d434a4bfc11da79880
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0044" ;
     nidm_clusterSizeInVoxels: "4"^^xsd:int ;
@@ -1075,9 +1075,9 @@ niiri:d9d050f643bc5856b77ef6ab7839c73f
     nidm_qValueFDR: "0.366054524499499"^^xsd:float ;
     nidm_clusterLabelId: "44"^^xsd:int .
 
-niiri:d9d050f643bc5856b77ef6ab7839c73f prov:wasDerivedFrom niiri:8c9e982b5e5acb0cf016de26a88d4eb8 .
+niiri:917a8294186d88d434a4bfc11da79880 prov:wasDerivedFrom niiri:01e8d7706461319dc2f9f847acb9d9b6 .
 
-niiri:e6891860aa8b247560dff60407d6186f
+niiri:2bf2abbcd31986ec01bd57d20b6711a8
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0045" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1087,9 +1087,9 @@ niiri:e6891860aa8b247560dff60407d6186f
     nidm_qValueFDR: "0.595521713796185"^^xsd:float ;
     nidm_clusterLabelId: "45"^^xsd:int .
 
-niiri:e6891860aa8b247560dff60407d6186f prov:wasDerivedFrom niiri:8c9e982b5e5acb0cf016de26a88d4eb8 .
+niiri:2bf2abbcd31986ec01bd57d20b6711a8 prov:wasDerivedFrom niiri:01e8d7706461319dc2f9f847acb9d9b6 .
 
-niiri:e70320e383167eb84eda35bf9e7b0fdd
+niiri:ad8c7d04ce78559070db7b91d78cc57c
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0046" ;
     nidm_clusterSizeInVoxels: "3"^^xsd:int ;
@@ -1099,9 +1099,9 @@ niiri:e70320e383167eb84eda35bf9e7b0fdd
     nidm_qValueFDR: "0.436187824916945"^^xsd:float ;
     nidm_clusterLabelId: "46"^^xsd:int .
 
-niiri:e70320e383167eb84eda35bf9e7b0fdd prov:wasDerivedFrom niiri:8c9e982b5e5acb0cf016de26a88d4eb8 .
+niiri:ad8c7d04ce78559070db7b91d78cc57c prov:wasDerivedFrom niiri:01e8d7706461319dc2f9f847acb9d9b6 .
 
-niiri:11f8c2ae0641d8825a111d78d6676ecf
+niiri:17c9ecb05e0c47b2a47ad52062e17b94
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0047" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1111,9 +1111,9 @@ niiri:11f8c2ae0641d8825a111d78d6676ecf
     nidm_qValueFDR: "0.595521713796185"^^xsd:float ;
     nidm_clusterLabelId: "47"^^xsd:int .
 
-niiri:11f8c2ae0641d8825a111d78d6676ecf prov:wasDerivedFrom niiri:8c9e982b5e5acb0cf016de26a88d4eb8 .
+niiri:17c9ecb05e0c47b2a47ad52062e17b94 prov:wasDerivedFrom niiri:01e8d7706461319dc2f9f847acb9d9b6 .
 
-niiri:dad011c7f4403d3ac70b748845e3c867
+niiri:c5e4e1aa155896b26494489613f9ad95
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0048" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1123,9 +1123,9 @@ niiri:dad011c7f4403d3ac70b748845e3c867
     nidm_qValueFDR: "0.595521713796185"^^xsd:float ;
     nidm_clusterLabelId: "48"^^xsd:int .
 
-niiri:dad011c7f4403d3ac70b748845e3c867 prov:wasDerivedFrom niiri:8c9e982b5e5acb0cf016de26a88d4eb8 .
+niiri:c5e4e1aa155896b26494489613f9ad95 prov:wasDerivedFrom niiri:01e8d7706461319dc2f9f847acb9d9b6 .
 
-niiri:d530532271fa470308bd3bf1b9d79611
+niiri:b838a0239e573b6049362c413185e4cb
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0049" ;
     nidm_clusterSizeInVoxels: "2"^^xsd:int ;
@@ -1135,9 +1135,9 @@ niiri:d530532271fa470308bd3bf1b9d79611
     nidm_qValueFDR: "0.51070929740394"^^xsd:float ;
     nidm_clusterLabelId: "49"^^xsd:int .
 
-niiri:d530532271fa470308bd3bf1b9d79611 prov:wasDerivedFrom niiri:8c9e982b5e5acb0cf016de26a88d4eb8 .
+niiri:b838a0239e573b6049362c413185e4cb prov:wasDerivedFrom niiri:01e8d7706461319dc2f9f847acb9d9b6 .
 
-niiri:e9bc012a60857c8c9c65fa0b8468ac39
+niiri:e35bb4611d1d05c17b7964df5a12a385
     a prov:Entity, nidm_SupraThresholdCluster: ; 
     rdfs:label "Supra-Threshold Cluster: 0050" ;
     nidm_clusterSizeInVoxels: "1"^^xsd:int ;
@@ -1147,1161 +1147,1161 @@ niiri:e9bc012a60857c8c9c65fa0b8468ac39
     nidm_qValueFDR: "0.595521713796185"^^xsd:float ;
     nidm_clusterLabelId: "50"^^xsd:int .
 
-niiri:e9bc012a60857c8c9c65fa0b8468ac39 prov:wasDerivedFrom niiri:8c9e982b5e5acb0cf016de26a88d4eb8 .
+niiri:e35bb4611d1d05c17b7964df5a12a385 prov:wasDerivedFrom niiri:01e8d7706461319dc2f9f847acb9d9b6 .
 
-niiri:c768c5e94b4ac7daec697b06ee3c2438
+niiri:96a59d90e155647137289214422e35d4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0001" ;
-    prov:atLocation niiri:47e29259ce8e8c6a4fd52e2776a6b292 ;
+    prov:atLocation niiri:b1d6c31f98bd6f43acc3b57cdc2c4cdc ;
     prov:value "7.92007970809937"^^xsd:float ;
     nidm_equivalentZStatistic: "6.94608360738412"^^xsd:float ;
     nidm_pValueUncorrected: "1.87783122385099e-12"^^xsd:float ;
     nidm_pValueFWER: "4.18813870695089e-07"^^xsd:float ;
     nidm_qValueFDR: "2.27218233660389e-05"^^xsd:float .
 
-niiri:47e29259ce8e8c6a4fd52e2776a6b292
+niiri:b1d6c31f98bd6f43acc3b57cdc2c4cdc
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0001" ;
     nidm_coordinateVector: "[46,16,24]"^^xsd:string .
 
-niiri:c768c5e94b4ac7daec697b06ee3c2438 prov:wasDerivedFrom niiri:094d7334d70e893686eb679e848c9ea4 .
+niiri:96a59d90e155647137289214422e35d4 prov:wasDerivedFrom niiri:7205414c11fb33ad00f174ced75bedbf .
 
-niiri:c3424664b8c3bb4c791a246d7467e3e8
+niiri:488ce8b025057ec458509b3e364bc4e4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0002" ;
-    prov:atLocation niiri:7e991cf30cd9edf203a3783b88d3ed56 ;
+    prov:atLocation niiri:314d42742a9d56e3b3203381bc0b5e0c ;
     prov:value "4.9243049621582"^^xsd:float ;
     nidm_equivalentZStatistic: "4.64313045489904"^^xsd:float ;
     nidm_pValueUncorrected: "1.7158475814627e-06"^^xsd:float ;
     nidm_pValueFWER: "0.186190030417796"^^xsd:float ;
     nidm_qValueFDR: "0.112174373202225"^^xsd:float .
 
-niiri:7e991cf30cd9edf203a3783b88d3ed56
+niiri:314d42742a9d56e3b3203381bc0b5e0c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0002" ;
     nidm_coordinateVector: "[52,30,20]"^^xsd:string .
 
-niiri:c3424664b8c3bb4c791a246d7467e3e8 prov:wasDerivedFrom niiri:094d7334d70e893686eb679e848c9ea4 .
+niiri:488ce8b025057ec458509b3e364bc4e4 prov:wasDerivedFrom niiri:7205414c11fb33ad00f174ced75bedbf .
 
-niiri:484cb2552d61cb8a2ce07026897b06db
+niiri:54c35228f66c13680fd122cfa6cf904a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0003" ;
-    prov:atLocation niiri:240754b068754ce703bace05b29d61b1 ;
+    prov:atLocation niiri:fdaec965712432043bed4c8cf9c6c6e9 ;
     prov:value "4.8244423866272"^^xsd:float ;
     nidm_equivalentZStatistic: "4.55839353511092"^^xsd:float ;
     nidm_pValueUncorrected: "2.57731916020187e-06"^^xsd:float ;
     nidm_pValueFWER: "0.252878395148086"^^xsd:float ;
     nidm_qValueFDR: "0.146027166584536"^^xsd:float .
 
-niiri:240754b068754ce703bace05b29d61b1
+niiri:fdaec965712432043bed4c8cf9c6c6e9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0003" ;
     nidm_coordinateVector: "[56,18,8]"^^xsd:string .
 
-niiri:484cb2552d61cb8a2ce07026897b06db prov:wasDerivedFrom niiri:094d7334d70e893686eb679e848c9ea4 .
+niiri:54c35228f66c13680fd122cfa6cf904a prov:wasDerivedFrom niiri:7205414c11fb33ad00f174ced75bedbf .
 
-niiri:68b721a19f4347ceb128a62ee28405da
+niiri:4c983fde4736cd2a3b8fecb492d20712
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0004" ;
-    prov:atLocation niiri:f0829a717047580042885b96f23dff6f ;
+    prov:atLocation niiri:cf6e72eafb8fe970a74bb917f5df7698 ;
     prov:value "7.11683940887451"^^xsd:float ;
     nidm_equivalentZStatistic: "6.37404871703245"^^xsd:float ;
     nidm_pValueUncorrected: "9.20510334623259e-11"^^xsd:float ;
     nidm_pValueFWER: "2.05325778424026e-05"^^xsd:float ;
     nidm_qValueFDR: "0.000406703400889328"^^xsd:float .
 
-niiri:f0829a717047580042885b96f23dff6f
+niiri:cf6e72eafb8fe970a74bb917f5df7698
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0004" ;
     nidm_coordinateVector: "[34,-88,-2]"^^xsd:string .
 
-niiri:68b721a19f4347ceb128a62ee28405da prov:wasDerivedFrom niiri:f3d3c07e06847367de29b57d78ad4c4d .
+niiri:4c983fde4736cd2a3b8fecb492d20712 prov:wasDerivedFrom niiri:8f4713f29184830ccee1527aedd5043c .
 
-niiri:0b2074f3517599375a04ea7322473e51
+niiri:debfad6d4dfc9f7dcad235e472df64e9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0005" ;
-    prov:atLocation niiri:a4af8d1a69e7e55105c45de053c1df15 ;
+    prov:atLocation niiri:0a68cfc82c1a38bf1844a9db623df7b7 ;
     prov:value "6.48292255401611"^^xsd:float ;
     nidm_equivalentZStatistic: "5.8992593141605"^^xsd:float ;
     nidm_pValueUncorrected: "1.82568493656277e-09"^^xsd:float ;
     nidm_pValueFWER: "0.000407231755366277"^^xsd:float ;
     nidm_qValueFDR: "0.00361825878055109"^^xsd:float .
 
-niiri:a4af8d1a69e7e55105c45de053c1df15
+niiri:0a68cfc82c1a38bf1844a9db623df7b7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0005" ;
     nidm_coordinateVector: "[42,-72,-10]"^^xsd:string .
 
-niiri:0b2074f3517599375a04ea7322473e51 prov:wasDerivedFrom niiri:f3d3c07e06847367de29b57d78ad4c4d .
+niiri:debfad6d4dfc9f7dcad235e472df64e9 prov:wasDerivedFrom niiri:8f4713f29184830ccee1527aedd5043c .
 
-niiri:de8b4c2dc3ece9933bff59347ae01471
+niiri:1daadc92a3ffaa028128f1dd83dd2d87
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0006" ;
-    prov:atLocation niiri:a4cb97dd656bd25b8300336959764df2 ;
+    prov:atLocation niiri:ac087376d1fcef018e5c722275dc0d44 ;
     prov:value "6.31603479385376"^^xsd:float ;
     nidm_equivalentZStatistic: "5.77079466112137"^^xsd:float ;
     nidm_pValueUncorrected: "3.94492849498107e-09"^^xsd:float ;
     nidm_pValueFWER: "0.000879943865776389"^^xsd:float ;
     nidm_qValueFDR: "0.00361825878055109"^^xsd:float .
 
-niiri:a4cb97dd656bd25b8300336959764df2
+niiri:ac087376d1fcef018e5c722275dc0d44
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0006" ;
     nidm_coordinateVector: "[32,24,-4]"^^xsd:string .
 
-niiri:de8b4c2dc3ece9933bff59347ae01471 prov:wasDerivedFrom niiri:0b25583a911e871428e848d5f39ad760 .
+niiri:1daadc92a3ffaa028128f1dd83dd2d87 prov:wasDerivedFrom niiri:6565811c2226598488a782fcfbe65641 .
 
-niiri:79ef8031365056f841857e59a734570d
+niiri:ed544793a577f316b6d4f813d1d3bea0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0007" ;
-    prov:atLocation niiri:2bb367cc2a93e698a93b159483545de9 ;
+    prov:atLocation niiri:3bd89cdd33454979cf7f28e75e1e6678 ;
     prov:value "5.68819808959961"^^xsd:float ;
     nidm_equivalentZStatistic: "5.27450168515333"^^xsd:float ;
     nidm_pValueUncorrected: "6.655864770444e-08"^^xsd:float ;
     nidm_pValueFWER: "0.0121028975026269"^^xsd:float ;
     nidm_qValueFDR: "0.0152484334686785"^^xsd:float .
 
-niiri:2bb367cc2a93e698a93b159483545de9
+niiri:3bd89cdd33454979cf7f28e75e1e6678
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0007" ;
     nidm_coordinateVector: "[18,16,4]"^^xsd:string .
 
-niiri:79ef8031365056f841857e59a734570d prov:wasDerivedFrom niiri:0b25583a911e871428e848d5f39ad760 .
+niiri:ed544793a577f316b6d4f813d1d3bea0 prov:wasDerivedFrom niiri:6565811c2226598488a782fcfbe65641 .
 
-niiri:f9cb927d23687de90e6d43b303fff7bc
+niiri:3b3c0e5c0e0bda6412e915038db30c1e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0008" ;
-    prov:atLocation niiri:99ca24af8fbb485d77ba9a1884d088f8 ;
+    prov:atLocation niiri:145cbb2d1fed72de625f99f542b7c4df ;
     prov:value "4.94056129455566"^^xsd:float ;
     nidm_equivalentZStatistic: "4.65687699571461"^^xsd:float ;
     nidm_pValueUncorrected: "1.60521061320917e-06"^^xsd:float ;
     nidm_pValueFWER: "0.17684019308854"^^xsd:float ;
     nidm_qValueFDR: "0.110770865806137"^^xsd:float .
 
-niiri:99ca24af8fbb485d77ba9a1884d088f8
+niiri:145cbb2d1fed72de625f99f542b7c4df
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0008" ;
     nidm_coordinateVector: "[34,36,-12]"^^xsd:string .
 
-niiri:f9cb927d23687de90e6d43b303fff7bc prov:wasDerivedFrom niiri:0b25583a911e871428e848d5f39ad760 .
+niiri:3b3c0e5c0e0bda6412e915038db30c1e prov:wasDerivedFrom niiri:6565811c2226598488a782fcfbe65641 .
 
-niiri:1ade9597332dc8c8f2133dd00470e2d9
+niiri:f47f325cd640020f4d275a5e5637467d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0009" ;
-    prov:atLocation niiri:51a7361e803d710ffd23bba12de1ed31 ;
+    prov:atLocation niiri:7c14a6bf6f09d55caffa373e1993730f ;
     prov:value "6.28007745742798"^^xsd:float ;
     nidm_equivalentZStatistic: "5.74292583422276"^^xsd:float ;
     nidm_pValueUncorrected: "4.65272453897825e-09"^^xsd:float ;
     nidm_pValueFWER: "0.00103782272796227"^^xsd:float ;
     nidm_qValueFDR: "0.00361825878055109"^^xsd:float .
 
-niiri:51a7361e803d710ffd23bba12de1ed31
+niiri:7c14a6bf6f09d55caffa373e1993730f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0009" ;
     nidm_coordinateVector: "[8,18,50]"^^xsd:string .
 
-niiri:1ade9597332dc8c8f2133dd00470e2d9 prov:wasDerivedFrom niiri:eb6931b2d74447879ba47c6442079649 .
+niiri:f47f325cd640020f4d275a5e5637467d prov:wasDerivedFrom niiri:775519b5c1873bb910da7115bee920c0 .
 
-niiri:a0c45cf332e75ca2c2f3a833a4ed4169
+niiri:109800b79f33034388fb15fe6337d32d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0010" ;
-    prov:atLocation niiri:187f409e451cc1c017a1d36a9bbee780 ;
+    prov:atLocation niiri:0fc5d776108764b8b7c5222659219ffc ;
     prov:value "6.15222215652466"^^xsd:float ;
     nidm_equivalentZStatistic: "5.64328512810061"^^xsd:float ;
     nidm_pValueUncorrected: "8.34178537356678e-09"^^xsd:float ;
     nidm_pValueFWER: "0.00186069357054308"^^xsd:float ;
     nidm_qValueFDR: "0.00423674188371422"^^xsd:float .
 
-niiri:187f409e451cc1c017a1d36a9bbee780
+niiri:0fc5d776108764b8b7c5222659219ffc
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0010" ;
     nidm_coordinateVector: "[-6,12,52]"^^xsd:string .
 
-niiri:a0c45cf332e75ca2c2f3a833a4ed4169 prov:wasDerivedFrom niiri:eb6931b2d74447879ba47c6442079649 .
+niiri:109800b79f33034388fb15fe6337d32d prov:wasDerivedFrom niiri:775519b5c1873bb910da7115bee920c0 .
 
-niiri:e8b7520b9c945e406f84bd1f7c1b0641
+niiri:c873973223ffcbd2bc046af12b3cb084
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0011" ;
-    prov:atLocation niiri:da6e712baad49ecbe62e5180160f3d03 ;
+    prov:atLocation niiri:038be17df65e5da54aa0117e3bdb0291 ;
     prov:value "5.98517084121704"^^xsd:float ;
     nidm_equivalentZStatistic: "5.51181334779297"^^xsd:float ;
     nidm_pValueUncorrected: "1.77577724747024e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00376326218366319"^^xsd:float ;
     nidm_qValueFDR: "0.0059418335926859"^^xsd:float .
 
-niiri:da6e712baad49ecbe62e5180160f3d03
+niiri:038be17df65e5da54aa0117e3bdb0291
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0011" ;
     nidm_coordinateVector: "[8,32,38]"^^xsd:string .
 
-niiri:e8b7520b9c945e406f84bd1f7c1b0641 prov:wasDerivedFrom niiri:eb6931b2d74447879ba47c6442079649 .
+niiri:c873973223ffcbd2bc046af12b3cb084 prov:wasDerivedFrom niiri:775519b5c1873bb910da7115bee920c0 .
 
-niiri:b916060f302c7d26db4c78e71d433c40
+niiri:8bbd28cf684609e9144a2f897eb1140e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0012" ;
-    prov:atLocation niiri:ae1f416ec1bea5962fa3881f3e327217 ;
+    prov:atLocation niiri:c8a3baf174ad35060a06e3a29eac92dd ;
     prov:value "6.25127363204956"^^xsd:float ;
     nidm_equivalentZStatistic: "5.72055271981637"^^xsd:float ;
     nidm_pValueUncorrected: "5.30890376104765e-09"^^xsd:float ;
     nidm_pValueFWER: "0.0011841880966994"^^xsd:float ;
     nidm_qValueFDR: "0.00361825878055109"^^xsd:float .
 
-niiri:ae1f416ec1bea5962fa3881f3e327217
+niiri:c8a3baf174ad35060a06e3a29eac92dd
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0012" ;
     nidm_coordinateVector: "[52,-32,42]"^^xsd:string .
 
-niiri:b916060f302c7d26db4c78e71d433c40 prov:wasDerivedFrom niiri:44faa3b6b4970674a664a3584aeafbd7 .
+niiri:8bbd28cf684609e9144a2f897eb1140e prov:wasDerivedFrom niiri:0deac3c5a5a1925942b4c734669b80cc .
 
-niiri:6774f189de49ba868e9ed4a33e736e3a
+niiri:d86b751c0d22a9c191fbfb604d97f2cd
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0013" ;
-    prov:atLocation niiri:8b5b1b9ab7e72d126bdbb773e7d191db ;
+    prov:atLocation niiri:d0256ff296dcef1d59eff26b64f34f75 ;
     prov:value "5.70337772369385"^^xsd:float ;
     nidm_equivalentZStatistic: "5.28674301747281"^^xsd:float ;
     nidm_pValueUncorrected: "6.22566831420812e-08"^^xsd:float ;
     nidm_pValueFWER: "0.011413186758684"^^xsd:float ;
     nidm_qValueFDR: "0.0152484334686785"^^xsd:float .
 
-niiri:8b5b1b9ab7e72d126bdbb773e7d191db
+niiri:d0256ff296dcef1d59eff26b64f34f75
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0013" ;
     nidm_coordinateVector: "[56,-44,52]"^^xsd:string .
 
-niiri:6774f189de49ba868e9ed4a33e736e3a prov:wasDerivedFrom niiri:44faa3b6b4970674a664a3584aeafbd7 .
+niiri:d86b751c0d22a9c191fbfb604d97f2cd prov:wasDerivedFrom niiri:0deac3c5a5a1925942b4c734669b80cc .
 
-niiri:a14ba879243e009dfeea6e7e9de68793
+niiri:d3d50cda890a097337dea07d5a4fe805
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0014" ;
-    prov:atLocation niiri:d2838cd94edf23abc800adb3366498e0 ;
+    prov:atLocation niiri:15787b1a2c249af12a69dbbc54246a2d ;
     prov:value "5.69516134262085"^^xsd:float ;
     nidm_equivalentZStatistic: "5.28011855642631"^^xsd:float ;
     nidm_pValueUncorrected: "6.45501619933597e-08"^^xsd:float ;
     nidm_pValueFWER: "0.0117816592148946"^^xsd:float ;
     nidm_qValueFDR: "0.0152484334686785"^^xsd:float .
 
-niiri:d2838cd94edf23abc800adb3366498e0
+niiri:15787b1a2c249af12a69dbbc54246a2d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0014" ;
     nidm_coordinateVector: "[60,-36,54]"^^xsd:string .
 
-niiri:a14ba879243e009dfeea6e7e9de68793 prov:wasDerivedFrom niiri:44faa3b6b4970674a664a3584aeafbd7 .
+niiri:d3d50cda890a097337dea07d5a4fe805 prov:wasDerivedFrom niiri:0deac3c5a5a1925942b4c734669b80cc .
 
-niiri:1a312401e61f334882e72fdd05ad141d
+niiri:149d3b765ad7fafbf9fbd3b50150b590
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0015" ;
-    prov:atLocation niiri:57a7ac2af98fcf32e7886a9b99f58609 ;
+    prov:atLocation niiri:f9928a5f1eece0dab107dcfe66af2b61 ;
     prov:value "6.24752378463745"^^xsd:float ;
     nidm_equivalentZStatistic: "5.71763687476157"^^xsd:float ;
     nidm_pValueUncorrected: "5.40078304300806e-09"^^xsd:float ;
     nidm_pValueFWER: "0.00120468241369565"^^xsd:float ;
     nidm_qValueFDR: "0.00361825878055109"^^xsd:float .
 
-niiri:57a7ac2af98fcf32e7886a9b99f58609
+niiri:f9928a5f1eece0dab107dcfe66af2b61
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0015" ;
     nidm_coordinateVector: "[40,-62,50]"^^xsd:string .
 
-niiri:1a312401e61f334882e72fdd05ad141d prov:wasDerivedFrom niiri:04a5b76be470d6bad89f3870fda12c8f .
+niiri:149d3b765ad7fafbf9fbd3b50150b590 prov:wasDerivedFrom niiri:c20e67383ada8b9423453af31b5a55de .
 
-niiri:4c36010a81e59e88ca1d89848f0fe3c3
+niiri:a3443b6ff5785b43971a8dafa4cf7790
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0016" ;
-    prov:atLocation niiri:84571886b0e80a9ceaf77b0ca2ca4778 ;
+    prov:atLocation niiri:f843f4e9d6679b55e9c5724c953d5a02 ;
     prov:value "5.61174583435059"^^xsd:float ;
     nidm_equivalentZStatistic: "5.21266637309498"^^xsd:float ;
     nidm_pValueUncorrected: "9.30727468428927e-08"^^xsd:float ;
     nidm_pValueFWER: "0.0162336583380834"^^xsd:float ;
     nidm_qValueFDR: "0.0188176838211989"^^xsd:float .
 
-niiri:84571886b0e80a9ceaf77b0ca2ca4778
+niiri:f843f4e9d6679b55e9c5724c953d5a02
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0016" ;
     nidm_coordinateVector: "[44,-70,50]"^^xsd:string .
 
-niiri:4c36010a81e59e88ca1d89848f0fe3c3 prov:wasDerivedFrom niiri:04a5b76be470d6bad89f3870fda12c8f .
+niiri:a3443b6ff5785b43971a8dafa4cf7790 prov:wasDerivedFrom niiri:c20e67383ada8b9423453af31b5a55de .
 
-niiri:7217bc844dd9995641b325df774d186a
+niiri:f7f75f82ae4ccf8674d67ee6b3d6bdf5
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0017" ;
-    prov:atLocation niiri:3ecfe0bd50e8eab291e4ee47387017cf ;
+    prov:atLocation niiri:f47724d9b1d024327623cf1e2e287528 ;
     prov:value "6.15371799468994"^^xsd:float ;
     nidm_equivalentZStatistic: "5.64445580026639"^^xsd:float ;
     nidm_pValueUncorrected: "8.285227171001e-09"^^xsd:float ;
     nidm_pValueFWER: "0.00184807786755337"^^xsd:float ;
     nidm_qValueFDR: "0.00423674188371422"^^xsd:float .
 
-niiri:3ecfe0bd50e8eab291e4ee47387017cf
+niiri:f47724d9b1d024327623cf1e2e287528
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0017" ;
     nidm_coordinateVector: "[-28,-94,4]"^^xsd:string .
 
-niiri:7217bc844dd9995641b325df774d186a prov:wasDerivedFrom niiri:791b0e754efbbb51618cea3a14b3b0e6 .
+niiri:f7f75f82ae4ccf8674d67ee6b3d6bdf5 prov:wasDerivedFrom niiri:23214e52c07fc432e44b14cfd9b05b8c .
 
-niiri:a56ef2aacb65354f43e2246a163f99d2
+niiri:162515024ff898dc13bff56500dd3eb1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0018" ;
-    prov:atLocation niiri:7caceee5203021dc995dc7430ce890bd ;
+    prov:atLocation niiri:44b68eb3c0dfabd2fe86365c8fcfd4bf ;
     prov:value "6.10109901428223"^^xsd:float ;
     nidm_equivalentZStatistic: "5.60320502193174"^^xsd:float ;
     nidm_pValueUncorrected: "1.05212039080982e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00234682813060005"^^xsd:float ;
     nidm_qValueFDR: "0.00455235302862474"^^xsd:float .
 
-niiri:7caceee5203021dc995dc7430ce890bd
+niiri:44b68eb3c0dfabd2fe86365c8fcfd4bf
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0018" ;
     nidm_coordinateVector: "[32,2,46]"^^xsd:string .
 
-niiri:a56ef2aacb65354f43e2246a163f99d2 prov:wasDerivedFrom niiri:7e9854c772fccbc9dd667ccaf963d0ad .
+niiri:162515024ff898dc13bff56500dd3eb1 prov:wasDerivedFrom niiri:63b9219b72b5b660f76b07f652b6ddab .
 
-niiri:965e3b440ac1070cf024adbdc4e93a8f
+niiri:0c87f6e52c8ca63d8178cb1e1cd2cf44
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0019" ;
-    prov:atLocation niiri:1adab910db39dd31432645320b5aa2ac ;
+    prov:atLocation niiri:762280b48fb4648ea57c12e2180a549e ;
     prov:value "4.6086859703064"^^xsd:float ;
     nidm_equivalentZStatistic: "4.3736141683061"^^xsd:float ;
     nidm_pValueUncorrected: "6.11031435759912e-06"^^xsd:float ;
     nidm_pValueFWER: "0.453877178455514"^^xsd:float ;
     nidm_qValueFDR: "0.261209020216113"^^xsd:float .
 
-niiri:1adab910db39dd31432645320b5aa2ac
+niiri:762280b48fb4648ea57c12e2180a549e
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0019" ;
     nidm_coordinateVector: "[28,4,58]"^^xsd:string .
 
-niiri:965e3b440ac1070cf024adbdc4e93a8f prov:wasDerivedFrom niiri:7e9854c772fccbc9dd667ccaf963d0ad .
+niiri:0c87f6e52c8ca63d8178cb1e1cd2cf44 prov:wasDerivedFrom niiri:63b9219b72b5b660f76b07f652b6ddab .
 
-niiri:481059c0065fdbec18002f2fc95288a4
+niiri:4e70efe9f00c5d7acd1338d327fa18e6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0020" ;
-    prov:atLocation niiri:77149dc00fea4411f41bb0ee1fc87de6 ;
+    prov:atLocation niiri:9dacc3b34de0b0518738ac094b81cd18 ;
     prov:value "5.98348569869995"^^xsd:float ;
     nidm_equivalentZStatistic: "5.51047970249337"^^xsd:float ;
     nidm_pValueUncorrected: "1.78928538652201e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00378871596531738"^^xsd:float ;
     nidm_qValueFDR: "0.0059418335926859"^^xsd:float .
 
-niiri:77149dc00fea4411f41bb0ee1fc87de6
+niiri:9dacc3b34de0b0518738ac094b81cd18
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0020" ;
     nidm_coordinateVector: "[-52,0,38]"^^xsd:string .
 
-niiri:481059c0065fdbec18002f2fc95288a4 prov:wasDerivedFrom niiri:e72ed1be72500e0e5102f29f0ac13651 .
+niiri:4e70efe9f00c5d7acd1338d327fa18e6 prov:wasDerivedFrom niiri:b37dd2ff926a0dc9856b3d0532b1c0dd .
 
-niiri:7182caed118b691f7e4be6a5f6d4ccde
+niiri:23ee46ca8d3095632418f7819018d5cb
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0021" ;
-    prov:atLocation niiri:28289344d3de88a2173f87e4d0f5b40f ;
+    prov:atLocation niiri:c333edf1c6856225c10c102228f12592 ;
     prov:value "4.98950004577637"^^xsd:float ;
     nidm_equivalentZStatistic: "4.69817956585148"^^xsd:float ;
     nidm_pValueUncorrected: "1.31245304380023e-06"^^xsd:float ;
     nidm_pValueFWER: "0.151048137890434"^^xsd:float ;
     nidm_qValueFDR: "0.101749935670058"^^xsd:float .
 
-niiri:28289344d3de88a2173f87e4d0f5b40f
+niiri:c333edf1c6856225c10c102228f12592
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0021" ;
     nidm_coordinateVector: "[-44,6,28]"^^xsd:string .
 
-niiri:7182caed118b691f7e4be6a5f6d4ccde prov:wasDerivedFrom niiri:e72ed1be72500e0e5102f29f0ac13651 .
+niiri:23ee46ca8d3095632418f7819018d5cb prov:wasDerivedFrom niiri:b37dd2ff926a0dc9856b3d0532b1c0dd .
 
-niiri:419086b1092b835bfb16c4757c0b3f97
+niiri:cb2a043df8fb2d544b2189a13c3ce527
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0022" ;
-    prov:atLocation niiri:18eb151e45b5f13c9e63d0879162cbf1 ;
+    prov:atLocation niiri:765799a0de84190495361ce1c36bf628 ;
     prov:value "4.55136632919312"^^xsd:float ;
     nidm_equivalentZStatistic: "4.32413626860189"^^xsd:float ;
     nidm_pValueUncorrected: "7.65653129031207e-06"^^xsd:float ;
     nidm_pValueFWER: "0.518506646121902"^^xsd:float ;
     nidm_qValueFDR: "0.283110032467297"^^xsd:float .
 
-niiri:18eb151e45b5f13c9e63d0879162cbf1
+niiri:765799a0de84190495361ce1c36bf628
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0022" ;
     nidm_coordinateVector: "[-48,8,20]"^^xsd:string .
 
-niiri:419086b1092b835bfb16c4757c0b3f97 prov:wasDerivedFrom niiri:e72ed1be72500e0e5102f29f0ac13651 .
+niiri:cb2a043df8fb2d544b2189a13c3ce527 prov:wasDerivedFrom niiri:b37dd2ff926a0dc9856b3d0532b1c0dd .
 
-niiri:5477208d3ba5dc776fba5dbcef7e15f4
+niiri:5b1ff8eefa78821ce44bbb392b06b97e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0023" ;
-    prov:atLocation niiri:f046b6951bc88aa55d13f3af2aa05969 ;
+    prov:atLocation niiri:69f53688d48730600e168061ff38a927 ;
     prov:value "5.78093099594116"^^xsd:float ;
     nidm_equivalentZStatistic: "5.34909755317379"^^xsd:float ;
     nidm_pValueUncorrected: "4.41969442155354e-08"^^xsd:float ;
     nidm_pValueFWER: "0.00844151822925698"^^xsd:float ;
     nidm_qValueFDR: "0.012489227663654"^^xsd:float .
 
-niiri:f046b6951bc88aa55d13f3af2aa05969
+niiri:69f53688d48730600e168061ff38a927
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0023" ;
     nidm_coordinateVector: "[-34,-2,52]"^^xsd:string .
 
-niiri:5477208d3ba5dc776fba5dbcef7e15f4 prov:wasDerivedFrom niiri:1ec5bcf3d27a79e3a649cf72f09cc3e2 .
+niiri:5b1ff8eefa78821ce44bbb392b06b97e prov:wasDerivedFrom niiri:e9b24d9fcc87aa114863aac61da68dea .
 
-niiri:1b7453a2c89d42ad13ebb49651230b76
+niiri:9207951d54db56abf749d9e5e74d2b6e
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0024" ;
-    prov:atLocation niiri:1c1feffd1a6c7c6ee90eadced0bd6f00 ;
+    prov:atLocation niiri:c8d9fdeaa9f06be2ac165988113456f2 ;
     prov:value "5.60917520523071"^^xsd:float ;
     nidm_equivalentZStatistic: "5.21058195491799"^^xsd:float ;
     nidm_pValueUncorrected: "9.41245997809759e-08"^^xsd:float ;
     nidm_pValueFWER: "0.0163938142285941"^^xsd:float ;
     nidm_qValueFDR: "0.0188176838211989"^^xsd:float .
 
-niiri:1c1feffd1a6c7c6ee90eadced0bd6f00
+niiri:c8d9fdeaa9f06be2ac165988113456f2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0024" ;
     nidm_coordinateVector: "[-30,26,2]"^^xsd:string .
 
-niiri:1b7453a2c89d42ad13ebb49651230b76 prov:wasDerivedFrom niiri:9d57dfc9c26a3b26ff08bc8602cb7238 .
+niiri:9207951d54db56abf749d9e5e74d2b6e prov:wasDerivedFrom niiri:7e536777241b4ecd7a6966f907894029 .
 
-niiri:7a5820ea4e18cdb9e8ef3308c490a126
+niiri:c53d89517ec403bef7219abc9030f05d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0025" ;
-    prov:atLocation niiri:46cbe56a773883af47259380fee679d9 ;
+    prov:atLocation niiri:50e5c64dc44fd1aa0ba0c6c251308e66 ;
     prov:value "5.29189538955688"^^xsd:float ;
     nidm_equivalentZStatistic: "4.95068947481578"^^xsd:float ;
     nidm_pValueUncorrected: "3.69755095430691e-07"^^xsd:float ;
     nidm_pValueFWER: "0.053302912325625"^^xsd:float ;
     nidm_qValueFDR: "0.0464966156430715"^^xsd:float .
 
-niiri:46cbe56a773883af47259380fee679d9
+niiri:50e5c64dc44fd1aa0ba0c6c251308e66
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0025" ;
     nidm_coordinateVector: "[-12,34,16]"^^xsd:string .
 
-niiri:7a5820ea4e18cdb9e8ef3308c490a126 prov:wasDerivedFrom niiri:9d57dfc9c26a3b26ff08bc8602cb7238 .
+niiri:c53d89517ec403bef7219abc9030f05d prov:wasDerivedFrom niiri:7e536777241b4ecd7a6966f907894029 .
 
-niiri:62591a941cfe01f122073b6443c6d233
+niiri:472b41edc6bbee67c33ad7504becf2e5
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0026" ;
-    prov:atLocation niiri:45da15b622b7b1dea01b550479b48924 ;
+    prov:atLocation niiri:ae0e674dc958653baadd67126d74577c ;
     prov:value "5.28739595413208"^^xsd:float ;
     nidm_equivalentZStatistic: "4.94696656297749"^^xsd:float ;
     nidm_pValueUncorrected: "3.76894592424293e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0541726709732473"^^xsd:float ;
     nidm_qValueFDR: "0.0464966156430715"^^xsd:float .
 
-niiri:45da15b622b7b1dea01b550479b48924
+niiri:ae0e674dc958653baadd67126d74577c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0026" ;
     nidm_coordinateVector: "[-50,40,20]"^^xsd:string .
 
-niiri:62591a941cfe01f122073b6443c6d233 prov:wasDerivedFrom niiri:9d57dfc9c26a3b26ff08bc8602cb7238 .
+niiri:472b41edc6bbee67c33ad7504becf2e5 prov:wasDerivedFrom niiri:7e536777241b4ecd7a6966f907894029 .
 
-niiri:01271fb32ff38f979f82b302ae0adc45
+niiri:678a272f3a215fe580cc243e51ca4901
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0027" ;
-    prov:atLocation niiri:6af0d172ac82895d7713e1d877c68ceb ;
+    prov:atLocation niiri:ec38211804f6ec8a7218bd9caabae7bf ;
     prov:value "5.40964078903198"^^xsd:float ;
     nidm_equivalentZStatistic: "5.04774404642803"^^xsd:float ;
     nidm_pValueUncorrected: "2.23528758724889e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0346958937061391"^^xsd:float ;
     nidm_qValueFDR: "0.0368499246860334"^^xsd:float .
 
-niiri:6af0d172ac82895d7713e1d877c68ceb
+niiri:ec38211804f6ec8a7218bd9caabae7bf
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0027" ;
     nidm_coordinateVector: "[-54,-46,58]"^^xsd:string .
 
-niiri:01271fb32ff38f979f82b302ae0adc45 prov:wasDerivedFrom niiri:56b434cc0204499fc97e08dac52bab86 .
+niiri:678a272f3a215fe580cc243e51ca4901 prov:wasDerivedFrom niiri:f008be07086de77a22010a7f08caa22f .
 
-niiri:feee544c48f7b87fa15c5e6e72e32ec4
+niiri:03230db640f45ee7e7b17d0bcfa81e0f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0028" ;
-    prov:atLocation niiri:c02e77056ffe36164f3bb0cefbac5257 ;
+    prov:atLocation niiri:d82858e1629e476d7a3385ec1f576d72 ;
     prov:value "5.31841945648193"^^xsd:float ;
     nidm_equivalentZStatistic: "4.97261482231588"^^xsd:float ;
     nidm_pValueUncorrected: "3.30279114724163e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0484353441449864"^^xsd:float ;
     nidm_qValueFDR: "0.0464966156430715"^^xsd:float .
 
-niiri:c02e77056ffe36164f3bb0cefbac5257
+niiri:d82858e1629e476d7a3385ec1f576d72
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0028" ;
     nidm_coordinateVector: "[-62,-38,48]"^^xsd:string .
 
-niiri:feee544c48f7b87fa15c5e6e72e32ec4 prov:wasDerivedFrom niiri:eb4c4ce00fca97f5c6e779fced2198a7 .
+niiri:03230db640f45ee7e7b17d0bcfa81e0f prov:wasDerivedFrom niiri:0b8006d59ae6d79e0e814aa87159321c .
 
-niiri:2cd8a588ad343d77317a0761e1a88bd1
+niiri:c3e3e8c6beb75a2c98d2adca27e25de1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0029" ;
-    prov:atLocation niiri:a517244f5dc7dd2cddd5829502e86cb7 ;
+    prov:atLocation niiri:6feea062185f26004b99d522812cccf6 ;
     prov:value "5.30699443817139"^^xsd:float ;
     nidm_equivalentZStatistic: "4.96317509467693"^^xsd:float ;
     nidm_pValueUncorrected: "3.46750043123123e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0504786376455083"^^xsd:float ;
     nidm_qValueFDR: "0.0464966156430715"^^xsd:float .
 
-niiri:a517244f5dc7dd2cddd5829502e86cb7
+niiri:6feea062185f26004b99d522812cccf6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0029" ;
     nidm_coordinateVector: "[32,40,16]"^^xsd:string .
 
-niiri:2cd8a588ad343d77317a0761e1a88bd1 prov:wasDerivedFrom niiri:de8927fdf14192632eecaa3636f2e9e3 .
+niiri:c3e3e8c6beb75a2c98d2adca27e25de1 prov:wasDerivedFrom niiri:6581a2a4fbc96915373d67e7edf695a9 .
 
-niiri:16fe3e1d9a8be07f0168b7cd709a6e8b
+niiri:1d7080d7ce698e17ddf3efae8dcdec05
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0030" ;
-    prov:atLocation niiri:2681ea7a0888ffec52fec625bbd74f8f ;
+    prov:atLocation niiri:c2c900a8f6153cd09f2ea5cf6e202d15 ;
     prov:value "4.5497465133667"^^xsd:float ;
     nidm_equivalentZStatistic: "4.32273570618355"^^xsd:float ;
     nidm_pValueUncorrected: "7.7053150754347e-06"^^xsd:float ;
     nidm_pValueFWER: "0.520378392891944"^^xsd:float ;
     nidm_qValueFDR: "0.283110032467297"^^xsd:float .
 
-niiri:2681ea7a0888ffec52fec625bbd74f8f
+niiri:c2c900a8f6153cd09f2ea5cf6e202d15
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0030" ;
     nidm_coordinateVector: "[40,46,12]"^^xsd:string .
 
-niiri:16fe3e1d9a8be07f0168b7cd709a6e8b prov:wasDerivedFrom niiri:de8927fdf14192632eecaa3636f2e9e3 .
+niiri:1d7080d7ce698e17ddf3efae8dcdec05 prov:wasDerivedFrom niiri:6581a2a4fbc96915373d67e7edf695a9 .
 
-niiri:cd2bd8a74f69bca8016b048323bd1f27
+niiri:30c5de3d78e8750bd60110543a6d4e95
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0031" ;
-    prov:atLocation niiri:e45104bae002e3c072793fcc49f0c0e3 ;
+    prov:atLocation niiri:e81909a8204f4543fa739fde9d159dbe ;
     prov:value "5.27030229568481"^^xsd:float ;
     nidm_equivalentZStatistic: "4.93281349716267"^^xsd:float ;
     nidm_pValueUncorrected: "4.05267701952816e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0575990926145485"^^xsd:float ;
     nidm_qValueFDR: "0.0479288297151396"^^xsd:float .
 
-niiri:e45104bae002e3c072793fcc49f0c0e3
+niiri:e81909a8204f4543fa739fde9d159dbe
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0031" ;
     nidm_coordinateVector: "[40,26,48]"^^xsd:string .
 
-niiri:cd2bd8a74f69bca8016b048323bd1f27 prov:wasDerivedFrom niiri:21c83646c5b8900bb66ac4bdc408bd17 .
+niiri:30c5de3d78e8750bd60110543a6d4e95 prov:wasDerivedFrom niiri:d1a419e3b8453b976a58dbdde542b8c4 .
 
-niiri:82f6dea1ea01c9ca931fd1c5273288f8
+niiri:bd06c3d65d3e9933f6a3f8ef15e826f1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0032" ;
-    prov:atLocation niiri:9dbc5dd1732c9addc6d888459fec8f23 ;
+    prov:atLocation niiri:d2f363694c05d0c16c22106097551ec6 ;
     prov:value "5.2275915145874"^^xsd:float ;
     nidm_equivalentZStatistic: "4.89738468004472"^^xsd:float ;
     nidm_pValueUncorrected: "4.85602978606003e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0670610253017228"^^xsd:float ;
     nidm_qValueFDR: "0.0515537977875989"^^xsd:float .
 
-niiri:9dbc5dd1732c9addc6d888459fec8f23
+niiri:d2f363694c05d0c16c22106097551ec6
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0032" ;
     nidm_coordinateVector: "[34,-86,12]"^^xsd:string .
 
-niiri:82f6dea1ea01c9ca931fd1c5273288f8 prov:wasDerivedFrom niiri:39b00e4afb3679693ccf462cccc76f45 .
+niiri:bd06c3d65d3e9933f6a3f8ef15e826f1 prov:wasDerivedFrom niiri:9f5db5fa91c4f9045129661d86ff7c8f .
 
-niiri:e9cb78593ccfdc6b85c4329aff99c816
+niiri:30c37a4e6d4b232771755d1748c76f58
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0033" ;
-    prov:atLocation niiri:d07b7e8a86e8bed5365664e2ac90a736 ;
+    prov:atLocation niiri:e87c4862eab61d8f99a2b73c0996bedc ;
     prov:value "4.98287582397461"^^xsd:float ;
     nidm_equivalentZStatistic: "4.6925960462209"^^xsd:float ;
     nidm_pValueUncorrected: "1.34879908808561e-06"^^xsd:float ;
     nidm_pValueFWER: "0.15433914065195"^^xsd:float ;
     nidm_qValueFDR: "0.101749935670058"^^xsd:float .
 
-niiri:d07b7e8a86e8bed5365664e2ac90a736
+niiri:e87c4862eab61d8f99a2b73c0996bedc
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0033" ;
     nidm_coordinateVector: "[26,-84,14]"^^xsd:string .
 
-niiri:e9cb78593ccfdc6b85c4329aff99c816 prov:wasDerivedFrom niiri:39b00e4afb3679693ccf462cccc76f45 .
+niiri:30c37a4e6d4b232771755d1748c76f58 prov:wasDerivedFrom niiri:9f5db5fa91c4f9045129661d86ff7c8f .
 
-niiri:2919a8386376bfa5b280217dee994a19
+niiri:6c2577b41582f50d831338802e4df7ad
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0034" ;
-    prov:atLocation niiri:09fe2bf32e5710410a835b828d2bbeee ;
+    prov:atLocation niiri:54941ad1d26a7090edd080e406d9672f ;
     prov:value "5.2253565788269"^^xsd:float ;
     nidm_equivalentZStatistic: "4.89552821543552"^^xsd:float ;
     nidm_pValueUncorrected: "4.90210114501011e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0675937275056587"^^xsd:float ;
     nidm_qValueFDR: "0.0515537977875989"^^xsd:float .
 
-niiri:09fe2bf32e5710410a835b828d2bbeee
+niiri:54941ad1d26a7090edd080e406d9672f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0034" ;
     nidm_coordinateVector: "[-60,8,20]"^^xsd:string .
 
-niiri:2919a8386376bfa5b280217dee994a19 prov:wasDerivedFrom niiri:1b13213ccbcda957315f11cacbe52f8e .
+niiri:6c2577b41582f50d831338802e4df7ad prov:wasDerivedFrom niiri:dc8fb82556a5fb25f9d253499774c9d3 .
 
-niiri:efc48200b02f87e9d994e4dca9eaed8f
+niiri:d72c63855a1da4123aa2d2b91077aa04
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0035" ;
-    prov:atLocation niiri:db121161d5febd4f1772ea57224511f9 ;
+    prov:atLocation niiri:b8071a162bee188fb3f27c0adcc6011b ;
     prov:value "5.19020795822144"^^xsd:float ;
     nidm_equivalentZStatistic: "4.86629814644752"^^xsd:float ;
     nidm_pValueUncorrected: "5.68539714418392e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0765015651399961"^^xsd:float ;
     nidm_qValueFDR: "0.055368089146651"^^xsd:float .
 
-niiri:db121161d5febd4f1772ea57224511f9
+niiri:b8071a162bee188fb3f27c0adcc6011b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0035" ;
     nidm_coordinateVector: "[48,28,-14]"^^xsd:string .
 
-niiri:efc48200b02f87e9d994e4dca9eaed8f prov:wasDerivedFrom niiri:57a4b5c4432a4efdb2afe166bc8a8d40 .
+niiri:d72c63855a1da4123aa2d2b91077aa04 prov:wasDerivedFrom niiri:65d11f313edff947dbe708fa2df7a47f .
 
-niiri:9e8be857380c831e3b481f1846f588ff
+niiri:ded48c88b009b45ce79c933455ae62b1
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0036" ;
-    prov:atLocation niiri:21a0fec44f230732d41a886639a0a057 ;
+    prov:atLocation niiri:0668dac472065a436c04ed87c6b48312 ;
     prov:value "5.11790418624878"^^xsd:float ;
     nidm_equivalentZStatistic: "4.80597083243817"^^xsd:float ;
     nidm_pValueUncorrected: "7.70011758244316e-07"^^xsd:float ;
     nidm_pValueFWER: "0.0982924709915751"^^xsd:float ;
     nidm_qValueFDR: "0.0681921715169792"^^xsd:float .
 
-niiri:21a0fec44f230732d41a886639a0a057
+niiri:0668dac472065a436c04ed87c6b48312
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0036" ;
     nidm_coordinateVector: "[62,-42,32]"^^xsd:string .
 
-niiri:9e8be857380c831e3b481f1846f588ff prov:wasDerivedFrom niiri:1fc9da3e6287c03753ee90c1a5abc45f .
+niiri:ded48c88b009b45ce79c933455ae62b1 prov:wasDerivedFrom niiri:5e70ca2cffa7ec4b08a897a898eb5b28 .
 
-niiri:0e9fb00bf160881635a28a8a9d2a9a36
+niiri:091096b37b35a35e14cf6256cdec88c2
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0037" ;
-    prov:atLocation niiri:84b397b0fdfa7246378bf98174954570 ;
+    prov:atLocation niiri:38981ae85de58d330e1d76276b048fab ;
     prov:value "4.93343877792358"^^xsd:float ;
     nidm_equivalentZStatistic: "4.65085575575197"^^xsd:float ;
     nidm_pValueUncorrected: "1.6528024058271e-06"^^xsd:float ;
     nidm_pValueFWER: "0.180887232162623"^^xsd:float ;
     nidm_qValueFDR: "0.111052348606216"^^xsd:float .
 
-niiri:84b397b0fdfa7246378bf98174954570
+niiri:38981ae85de58d330e1d76276b048fab
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0037" ;
     nidm_coordinateVector: "[-58,-30,-18]"^^xsd:string .
 
-niiri:0e9fb00bf160881635a28a8a9d2a9a36 prov:wasDerivedFrom niiri:a87ac34d0b2aa71a22f631bee6f5d009 .
+niiri:091096b37b35a35e14cf6256cdec88c2 prov:wasDerivedFrom niiri:c77ff18164bd254c10834cf4198cc926 .
 
-niiri:ece2f29d2544b2b5adb4c4302c48158d
+niiri:307311b45e91bb80ed6c37ee9ce68670
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0038" ;
-    prov:atLocation niiri:64b53fb57d19b8db6f92cd3604b7f506 ;
+    prov:atLocation niiri:7c13987519a921c569ccd9f47a99be37 ;
     prov:value "4.76414346694946"^^xsd:float ;
     nidm_equivalentZStatistic: "4.50698548813516"^^xsd:float ;
     nidm_pValueUncorrected: "3.287756441539e-06"^^xsd:float ;
     nidm_pValueFWER: "0.301278778226174"^^xsd:float ;
     nidm_qValueFDR: "0.172669007569286"^^xsd:float .
 
-niiri:64b53fb57d19b8db6f92cd3604b7f506
+niiri:7c13987519a921c569ccd9f47a99be37
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0038" ;
     nidm_coordinateVector: "[-46,-66,-6]"^^xsd:string .
 
-niiri:ece2f29d2544b2b5adb4c4302c48158d prov:wasDerivedFrom niiri:d6ac21365d2405aa9644fdebf0cc6ef4 .
+niiri:307311b45e91bb80ed6c37ee9ce68670 prov:wasDerivedFrom niiri:5ec4ec1a9ea7234dae961134341c413f .
 
-niiri:ad191794f5a56de3f14465569de72ca9
+niiri:d6572346d31a2bcaf5575073d3264e49
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0039" ;
-    prov:atLocation niiri:079591d592eef8662fdc1b2f8598fb6e ;
+    prov:atLocation niiri:7bb7c053f16458c5ac88a7b8c38c2df3 ;
     prov:value "4.72232866287231"^^xsd:float ;
     nidm_equivalentZStatistic: "4.47122948835043"^^xsd:float ;
     nidm_pValueUncorrected: "3.88855941602095e-06"^^xsd:float ;
     nidm_pValueFWER: "0.338512677882141"^^xsd:float ;
     nidm_qValueFDR: "0.195288467872082"^^xsd:float .
 
-niiri:079591d592eef8662fdc1b2f8598fb6e
+niiri:7bb7c053f16458c5ac88a7b8c38c2df3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0039" ;
     nidm_coordinateVector: "[58,-38,6]"^^xsd:string .
 
-niiri:ad191794f5a56de3f14465569de72ca9 prov:wasDerivedFrom niiri:1538a072d6986b630537b29066fec5db .
+niiri:d6572346d31a2bcaf5575073d3264e49 prov:wasDerivedFrom niiri:43dcb06f795f24225ca2e94a905a018a .
 
-niiri:f7c2f2bee1030ef081a7a1e40430746e
+niiri:940561c12adb90e459277d266bcf26a4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0040" ;
-    prov:atLocation niiri:8f7e2a36a3eef5a7b15cd88b2c0a7228 ;
+    prov:atLocation niiri:a3b66913a7d4f099d41a7e34a9aad13b ;
     prov:value "4.70483255386353"^^xsd:float ;
     nidm_equivalentZStatistic: "4.45624265093732"^^xsd:float ;
     nidm_pValueUncorrected: "4.17043099876224e-06"^^xsd:float ;
     nidm_pValueFWER: "0.354967306449537"^^xsd:float ;
     nidm_qValueFDR: "0.203068312336819"^^xsd:float .
 
-niiri:8f7e2a36a3eef5a7b15cd88b2c0a7228
+niiri:a3b66913a7d4f099d41a7e34a9aad13b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0040" ;
     nidm_coordinateVector: "[-36,-74,-14]"^^xsd:string .
 
-niiri:f7c2f2bee1030ef081a7a1e40430746e prov:wasDerivedFrom niiri:b1a9ed0ce88ddf57f1afa2ab051d9094 .
+niiri:940561c12adb90e459277d266bcf26a4 prov:wasDerivedFrom niiri:63c6acd902a0987762c94921fa226068 .
 
-niiri:bf1f78e2177ca62a3887166040cdb1c0
+niiri:be01e340dcb236d6f72f24c39660c369
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0041" ;
-    prov:atLocation niiri:7c936836f1f0ac9f2e5efe19153a6775 ;
+    prov:atLocation niiri:48e06113c665fc04a60795b896d2d447 ;
     prov:value "4.08770418167114"^^xsd:float ;
     nidm_equivalentZStatistic: "3.91804495668"^^xsd:float ;
     nidm_pValueUncorrected: "4.46350297789166e-05"^^xsd:float ;
     nidm_pValueFWER: "0.955724279224547"^^xsd:float ;
     nidm_qValueFDR: "0.813269333398153"^^xsd:float .
 
-niiri:7c936836f1f0ac9f2e5efe19153a6775
+niiri:48e06113c665fc04a60795b896d2d447
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0041" ;
     nidm_coordinateVector: "[-36,-68,-20]"^^xsd:string .
 
-niiri:bf1f78e2177ca62a3887166040cdb1c0 prov:wasDerivedFrom niiri:b1a9ed0ce88ddf57f1afa2ab051d9094 .
+niiri:be01e340dcb236d6f72f24c39660c369 prov:wasDerivedFrom niiri:63c6acd902a0987762c94921fa226068 .
 
-niiri:6dfe48d8d03058f3dc8cf56c358d4f70
+niiri:76e00a2148bcf89400f71aed8ae6bb4f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0042" ;
-    prov:atLocation niiri:3b72ed66afebb8c2f7319703a570218a ;
+    prov:atLocation niiri:c9c45c8f7997274422ea8a368b4a5a18 ;
     prov:value "4.66261720657349"^^xsd:float ;
     nidm_equivalentZStatistic: "4.42001914550306"^^xsd:float ;
     nidm_pValueUncorrected: "4.93460785955246e-06"^^xsd:float ;
     nidm_pValueFWER: "0.396707240036217"^^xsd:float ;
     nidm_qValueFDR: "0.226011723416334"^^xsd:float .
 
-niiri:3b72ed66afebb8c2f7319703a570218a
+niiri:c9c45c8f7997274422ea8a368b4a5a18
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0042" ;
     nidm_coordinateVector: "[50,-48,62]"^^xsd:string .
 
-niiri:6dfe48d8d03058f3dc8cf56c358d4f70 prov:wasDerivedFrom niiri:a820061ecf406d69716300c9fedb0d02 .
+niiri:76e00a2148bcf89400f71aed8ae6bb4f prov:wasDerivedFrom niiri:5e9dd0483caa5eb1c58d3fce896ce441 .
 
-niiri:16a2542b0f2bdf2b657722e3fd519a49
+niiri:b1a1bba13244d909eb7f26c94d677fc4
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0043" ;
-    prov:atLocation niiri:64e50a631faf9a6012603f90fe38f1a9 ;
+    prov:atLocation niiri:cfd246dde4faa922a56924236cff1bd9 ;
     prov:value "4.59621620178223"^^xsd:float ;
     nidm_equivalentZStatistic: "4.36286413267216"^^xsd:float ;
     nidm_pValueUncorrected: "6.41853365035416e-06"^^xsd:float ;
     nidm_pValueFWER: "0.467637998233248"^^xsd:float ;
     nidm_qValueFDR: "0.263154686545706"^^xsd:float .
 
-niiri:64e50a631faf9a6012603f90fe38f1a9
+niiri:cfd246dde4faa922a56924236cff1bd9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0043" ;
     nidm_coordinateVector: "[16,-98,6]"^^xsd:string .
 
-niiri:16a2542b0f2bdf2b657722e3fd519a49 prov:wasDerivedFrom niiri:1c89663261d7fe599621a515c41412ef .
+niiri:b1a1bba13244d909eb7f26c94d677fc4 prov:wasDerivedFrom niiri:a371619b98c52e0355b320d28edb7189 .
 
-niiri:9c2e5a1af29bfe0513915f2f1b0370c8
+niiri:88d3d44277a170d297f951135875f79d
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0044" ;
-    prov:atLocation niiri:9e968798b12cede38312a0fd897d5c82 ;
+    prov:atLocation niiri:0eb0f37e7efb84a8ba951e6d317738aa ;
     prov:value "4.57891654968262"^^xsd:float ;
     nidm_equivalentZStatistic: "4.34793761600864"^^xsd:float ;
     nidm_pValueUncorrected: "6.87118388575936e-06"^^xsd:float ;
     nidm_pValueFWER: "0.487021764768749"^^xsd:float ;
     nidm_qValueFDR: "0.274069095631333"^^xsd:float .
 
-niiri:9e968798b12cede38312a0fd897d5c82
+niiri:0eb0f37e7efb84a8ba951e6d317738aa
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0044" ;
     nidm_coordinateVector: "[-60,-16,28]"^^xsd:string .
 
-niiri:9c2e5a1af29bfe0513915f2f1b0370c8 prov:wasDerivedFrom niiri:347c2f752b33682df28dbb3618ca4959 .
+niiri:88d3d44277a170d297f951135875f79d prov:wasDerivedFrom niiri:37cde807f5ec7a0a182032d2608a5010 .
 
-niiri:ad748b8ab42bed324e1a1a7bf31e81c7
+niiri:b07acc6a2e3964eb9539a6d7b697a89f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0045" ;
-    prov:atLocation niiri:f7bf4618687b6c2da668155664548dc8 ;
+    prov:atLocation niiri:cac7d9ae81e5c1ad2405164496fb8fea ;
     prov:value "4.57099342346191"^^xsd:float ;
     nidm_equivalentZStatistic: "4.34109644800954"^^xsd:float ;
     nidm_pValueUncorrected: "7.08867353027554e-06"^^xsd:float ;
     nidm_pValueFWER: "0.496004086968197"^^xsd:float ;
     nidm_qValueFDR: "0.276784591562674"^^xsd:float .
 
-niiri:f7bf4618687b6c2da668155664548dc8
+niiri:cac7d9ae81e5c1ad2405164496fb8fea
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0045" ;
     nidm_coordinateVector: "[-60,-50,48]"^^xsd:string .
 
-niiri:ad748b8ab42bed324e1a1a7bf31e81c7 prov:wasDerivedFrom niiri:b06c1cefe3c12fe41b07e749646c1006 .
+niiri:b07acc6a2e3964eb9539a6d7b697a89f prov:wasDerivedFrom niiri:6bb17b684d45a4f861c90fe5fbe07173 .
 
-niiri:87f0797a3fbc74b3d3f0e046d44f3edb
+niiri:c17bb40d7f9a065ed9e20283f08d832f
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0046" ;
-    prov:atLocation niiri:21ef8b051e4e3281c6ee0d3fb2f9b88f ;
+    prov:atLocation niiri:b85ea683da3b35f328c636768ed1ddca ;
     prov:value "4.52660465240479"^^xsd:float ;
     nidm_equivalentZStatistic: "4.3027121900522"^^xsd:float ;
     nidm_pValueUncorrected: "8.43599790589789e-06"^^xsd:float ;
     nidm_pValueFWER: "0.547325139783002"^^xsd:float ;
     nidm_qValueFDR: "0.296273869721501"^^xsd:float .
 
-niiri:21ef8b051e4e3281c6ee0d3fb2f9b88f
+niiri:b85ea683da3b35f328c636768ed1ddca
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0046" ;
     nidm_coordinateVector: "[16,14,62]"^^xsd:string .
 
-niiri:87f0797a3fbc74b3d3f0e046d44f3edb prov:wasDerivedFrom niiri:9ac56d5858e1280575cd8c2eaac3bf9f .
+niiri:c17bb40d7f9a065ed9e20283f08d832f prov:wasDerivedFrom niiri:7560e53c1288bc92b5a4d846f27be2a2 .
 
-niiri:5cd038458d4de4d29cb3286e76d05a5a
+niiri:e4746d1e59f58f3c65f5926f3a910408
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0047" ;
-    prov:atLocation niiri:f43581527926708c33116bc8053e24aa ;
+    prov:atLocation niiri:bc0c487d20ed46595ec5f729ccaefa47 ;
     prov:value "4.394446849823"^^xsd:float ;
     nidm_equivalentZStatistic: "4.18786093394641"^^xsd:float ;
     nidm_pValueUncorrected: "1.40797984292673e-05"^^xsd:float ;
     nidm_pValueFWER: "0.702859796483929"^^xsd:float ;
     nidm_qValueFDR: "0.416351033742128"^^xsd:float .
 
-niiri:f43581527926708c33116bc8053e24aa
+niiri:bc0c487d20ed46595ec5f729ccaefa47
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0047" ;
     nidm_coordinateVector: "[-24,54,36]"^^xsd:string .
 
-niiri:5cd038458d4de4d29cb3286e76d05a5a prov:wasDerivedFrom niiri:c1038d6173e201e6db5e15170fe9c504 .
+niiri:e4746d1e59f58f3c65f5926f3a910408 prov:wasDerivedFrom niiri:6a1d4b90730b6f045c485c09e364158b .
 
-niiri:2b40957f767e7304c0ba8b61141724a9
+niiri:912ce2854ee45d7566ad2d5a9ffe063a
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0048" ;
-    prov:atLocation niiri:3f8d7235207683b5a8ebc52a70306ee6 ;
+    prov:atLocation niiri:b3e9065f593d58e675a1f1b518e286e9 ;
     prov:value "4.37013816833496"^^xsd:float ;
     nidm_equivalentZStatistic: "4.16664310578498"^^xsd:float ;
     nidm_pValueUncorrected: "1.54558935169247e-05"^^xsd:float ;
     nidm_pValueFWER: "0.730405153245217"^^xsd:float ;
     nidm_qValueFDR: "0.44365024151901"^^xsd:float .
 
-niiri:3f8d7235207683b5a8ebc52a70306ee6
+niiri:b3e9065f593d58e675a1f1b518e286e9
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0048" ;
     nidm_coordinateVector: "[-52,-62,52]"^^xsd:string .
 
-niiri:2b40957f767e7304c0ba8b61141724a9 prov:wasDerivedFrom niiri:10fb1def343c16cea3ed7ca34f95f4a5 .
+niiri:912ce2854ee45d7566ad2d5a9ffe063a prov:wasDerivedFrom niiri:642f54df01178892acf81b69ba1cdd64 .
 
-niiri:88b8850eb11486e6b61936caf3ea974e
+niiri:d5ff6b492b936f7614cd983926d8d1d8
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0049" ;
-    prov:atLocation niiri:ef168860f61bc4ac516efed9971c6415 ;
+    prov:atLocation niiri:99d2ed1d9ad0c05f4ab3275060f6f1b3 ;
     prov:value "4.34150457382202"^^xsd:float ;
     nidm_equivalentZStatistic: "4.14161364101519"^^xsd:float ;
     nidm_pValueUncorrected: "1.72435463601239e-05"^^xsd:float ;
     nidm_pValueFWER: "0.761825497910085"^^xsd:float ;
     nidm_qValueFDR: "0.479115128745269"^^xsd:float .
 
-niiri:ef168860f61bc4ac516efed9971c6415
+niiri:99d2ed1d9ad0c05f4ab3275060f6f1b3
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0049" ;
     nidm_coordinateVector: "[10,48,44]"^^xsd:string .
 
-niiri:88b8850eb11486e6b61936caf3ea974e prov:wasDerivedFrom niiri:05b9a5f65294a59f709d2874ee06eb74 .
+niiri:d5ff6b492b936f7614cd983926d8d1d8 prov:wasDerivedFrom niiri:7004bd2e853e73ce41a764732d04d90f .
 
-niiri:5ebfc4096d3bd75e930dc2fadc89cf1d
+niiri:08c188bf3f47eb482ee56d1867b00173
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0050" ;
-    prov:atLocation niiri:47d6563ec7640ec7362e769a89f072e9 ;
+    prov:atLocation niiri:23b7aa0c87723842565ef21f6cd4b6d7 ;
     prov:value "4.32184886932373"^^xsd:float ;
     nidm_equivalentZStatistic: "4.12440912812688"^^xsd:float ;
     nidm_pValueUncorrected: "1.85843849718204e-05"^^xsd:float ;
     nidm_pValueFWER: "0.782605982808509"^^xsd:float ;
     nidm_qValueFDR: "0.502895583840395"^^xsd:float .
 
-niiri:47d6563ec7640ec7362e769a89f072e9
+niiri:23b7aa0c87723842565ef21f6cd4b6d7
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0050" ;
     nidm_coordinateVector: "[10,24,24]"^^xsd:string .
 
-niiri:5ebfc4096d3bd75e930dc2fadc89cf1d prov:wasDerivedFrom niiri:6e7ba611211b14c42b46c20448bed1da .
+niiri:08c188bf3f47eb482ee56d1867b00173 prov:wasDerivedFrom niiri:44f3268a65a1bd0913070af57e7f8c22 .
 
-niiri:1bb45e1e314341bb67efc1d0e62baf1d
+niiri:37f058dfafc27db2e4a67b00c2c19b3b
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0051" ;
-    prov:atLocation niiri:7b1d03dadac03483dcb17fdc2dd24ed0 ;
+    prov:atLocation niiri:cb2674b27a55a15c11356b077c23f96f ;
     prov:value "4.31582498550415"^^xsd:float ;
     nidm_equivalentZStatistic: "4.11913273798974"^^xsd:float ;
     nidm_pValueUncorrected: "1.90150518718513e-05"^^xsd:float ;
     nidm_pValueFWER: "0.788829013385429"^^xsd:float ;
     nidm_qValueFDR: "0.505811157403841"^^xsd:float .
 
-niiri:7b1d03dadac03483dcb17fdc2dd24ed0
+niiri:cb2674b27a55a15c11356b077c23f96f
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0051" ;
     nidm_coordinateVector: "[36,54,6]"^^xsd:string .
 
-niiri:1bb45e1e314341bb67efc1d0e62baf1d prov:wasDerivedFrom niiri:b460f1f0b03e40e2ef4befc4665227a8 .
+niiri:37f058dfafc27db2e4a67b00c2c19b3b prov:wasDerivedFrom niiri:27e476ef788fe4fb3d8dcc031b399a81 .
 
-niiri:b7bec33c2907aa625911f7a53a2746bb
+niiri:0e467e20cc0f4bae2c75a2e53bb0c47c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0052" ;
-    prov:atLocation niiri:00b55ff454e211ee5cc909f007d669fc ;
+    prov:atLocation niiri:dcf7da4393edd644ef884de7aa33221c ;
     prov:value "4.30655717849731"^^xsd:float ;
     nidm_equivalentZStatistic: "4.11101155082742"^^xsd:float ;
     nidm_pValueUncorrected: "1.96964745459161e-05"^^xsd:float ;
     nidm_pValueFWER: "0.798260223882423"^^xsd:float ;
     nidm_qValueFDR: "0.513996955111144"^^xsd:float .
 
-niiri:00b55ff454e211ee5cc909f007d669fc
+niiri:dcf7da4393edd644ef884de7aa33221c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0052" ;
     nidm_coordinateVector: "[-26,-92,32]"^^xsd:string .
 
-niiri:b7bec33c2907aa625911f7a53a2746bb prov:wasDerivedFrom niiri:054b7672bba8ed55d6c9d550e674f600 .
+niiri:0e467e20cc0f4bae2c75a2e53bb0c47c prov:wasDerivedFrom niiri:ca4952c39685bacdd04c639d61f596dc .
 
-niiri:59e980fb3cd9d3cc55969c08b0153d37
+niiri:7346c6134f21e9c55bded49d811acfb6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0053" ;
-    prov:atLocation niiri:5216ed4db9504a6f9fb09d8681723d20 ;
+    prov:atLocation niiri:5b38b31387f1f4d969275778c505f158 ;
     prov:value "4.29490756988525"^^xsd:float ;
     nidm_equivalentZStatistic: "4.10079738778036"^^xsd:float ;
     nidm_pValueUncorrected: "2.0586446986437e-05"^^xsd:float ;
     nidm_pValueFWER: "0.809857168354565"^^xsd:float ;
     nidm_qValueFDR: "0.526259690094564"^^xsd:float .
 
-niiri:5216ed4db9504a6f9fb09d8681723d20
+niiri:5b38b31387f1f4d969275778c505f158
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0053" ;
     nidm_coordinateVector: "[30,42,4]"^^xsd:string .
 
-niiri:59e980fb3cd9d3cc55969c08b0153d37 prov:wasDerivedFrom niiri:5c380d0f5b0d102daa46b5ee765401d0 .
+niiri:7346c6134f21e9c55bded49d811acfb6 prov:wasDerivedFrom niiri:af2ac94d3f5ea60663d90097f8159f1d .
 
-niiri:096769922bba475a73cd4cc353cf2b59
+niiri:b407bae917b87023865024204198dbd0
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0054" ;
-    prov:atLocation niiri:3eccb5877e5d71d252f2f0a9144a7855 ;
+    prov:atLocation niiri:424f8ba488562285d011591931afce31 ;
     prov:value "4.24533367156982"^^xsd:float ;
     nidm_equivalentZStatistic: "4.05725918601008"^^xsd:float ;
     nidm_pValueUncorrected: "2.4825985211363e-05"^^xsd:float ;
     nidm_pValueFWER: "0.855631833511506"^^xsd:float ;
     nidm_qValueFDR: "0.591124172488423"^^xsd:float .
 
-niiri:3eccb5877e5d71d252f2f0a9144a7855
+niiri:424f8ba488562285d011591931afce31
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0054" ;
     nidm_coordinateVector: "[-18,-60,48]"^^xsd:string .
 
-niiri:096769922bba475a73cd4cc353cf2b59 prov:wasDerivedFrom niiri:ff57ed710046587ca6241d3e59018019 .
+niiri:b407bae917b87023865024204198dbd0 prov:wasDerivedFrom niiri:d088c79195acad1ffe8fcf692ee20b14 .
 
-niiri:d95825d7132ddf011f7472f90f6a96f5
+niiri:a7defe617f206121c0d7cb04a6f72f08
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0055" ;
-    prov:atLocation niiri:777ae15f4c84152f8125dcb661c144ae ;
+    prov:atLocation niiri:879a2d4376625a7c15bed48a1afe84ff ;
     prov:value "4.22729349136353"^^xsd:float ;
     nidm_equivalentZStatistic: "4.04138628171284"^^xsd:float ;
     nidm_pValueUncorrected: "2.65680735640483e-05"^^xsd:float ;
     nidm_pValueFWER: "0.870712357794855"^^xsd:float ;
     nidm_qValueFDR: "0.603696486616006"^^xsd:float .
 
-niiri:777ae15f4c84152f8125dcb661c144ae
+niiri:879a2d4376625a7c15bed48a1afe84ff
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0055" ;
     nidm_coordinateVector: "[-20,-98,22]"^^xsd:string .
 
-niiri:d95825d7132ddf011f7472f90f6a96f5 prov:wasDerivedFrom niiri:8d2f0fd2c9e7d0b8208eb1fc4b198d3a .
+niiri:a7defe617f206121c0d7cb04a6f72f08 prov:wasDerivedFrom niiri:9d84cb059aa001b080f641472d50dee9 .
 
-niiri:f2a8ce3a8908185b4de88a2556925fd2
+niiri:9393a45c585430d7d331841bd135503c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0056" ;
-    prov:atLocation niiri:bdb865d7b60944d22ea37944fab3aa53 ;
+    prov:atLocation niiri:0bfbfc6068d71c869562de069b1a6dac ;
     prov:value "4.22682189941406"^^xsd:float ;
     nidm_equivalentZStatistic: "4.04097113688235"^^xsd:float ;
     nidm_pValueUncorrected: "2.66151551338023e-05"^^xsd:float ;
     nidm_pValueFWER: "0.871094574055471"^^xsd:float ;
     nidm_qValueFDR: "0.603696486616006"^^xsd:float .
 
-niiri:bdb865d7b60944d22ea37944fab3aa53
+niiri:0bfbfc6068d71c869562de069b1a6dac
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0056" ;
     nidm_coordinateVector: "[-38,28,-12]"^^xsd:string .
 
-niiri:f2a8ce3a8908185b4de88a2556925fd2 prov:wasDerivedFrom niiri:684e846c172afe6d05d5ae78e91a66ab .
+niiri:9393a45c585430d7d331841bd135503c prov:wasDerivedFrom niiri:51d1d5abbfa00532f6e6a2f6c7c0cf8f .
 
-niiri:3c0ab7db2b58f664c1fc502cfb68c54a
+niiri:fa8d8d73ed0cd84d17283368b810eeb9
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0057" ;
-    prov:atLocation niiri:60c35260b456d77c368377edd30808ff ;
+    prov:atLocation niiri:88a381fc45f1118447ccea71efd9983b ;
     prov:value "4.22599840164185"^^xsd:float ;
     nidm_equivalentZStatistic: "4.04024618213588"^^xsd:float ;
     nidm_pValueUncorrected: "2.66975618669063e-05"^^xsd:float ;
     nidm_pValueFWER: "0.871760516202526"^^xsd:float ;
     nidm_qValueFDR: "0.603696486616006"^^xsd:float .
 
-niiri:60c35260b456d77c368377edd30808ff
+niiri:88a381fc45f1118447ccea71efd9983b
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0057" ;
     nidm_coordinateVector: "[-36,-74,-34]"^^xsd:string .
 
-niiri:3c0ab7db2b58f664c1fc502cfb68c54a prov:wasDerivedFrom niiri:e41c1ae17d421ba7f943954ecb82266f .
+niiri:fa8d8d73ed0cd84d17283368b810eeb9 prov:wasDerivedFrom niiri:f39108df33a4d833661db62b9a0c407f .
 
-niiri:2a44618f3a55e01df9a317699d96e405
+niiri:9691b9801790bca1d083f574dd41b296
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0058" ;
-    prov:atLocation niiri:1c540ec4a19d6207070aef71e3777d46 ;
+    prov:atLocation niiri:531311d43904b7e17f8c8865edcfd5bf ;
     prov:value "4.22297620773315"^^xsd:float ;
     nidm_equivalentZStatistic: "4.03758535922196"^^xsd:float ;
     nidm_pValueUncorrected: "2.70020985901898e-05"^^xsd:float ;
     nidm_pValueFWER: "0.874188238392237"^^xsd:float ;
     nidm_qValueFDR: "0.603696486616006"^^xsd:float .
 
-niiri:1c540ec4a19d6207070aef71e3777d46
+niiri:531311d43904b7e17f8c8865edcfd5bf
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0058" ;
     nidm_coordinateVector: "[38,42,30]"^^xsd:string .
 
-niiri:2a44618f3a55e01df9a317699d96e405 prov:wasDerivedFrom niiri:6ebbb8b1cbde12076fc5d4ef4e85955c .
+niiri:9691b9801790bca1d083f574dd41b296 prov:wasDerivedFrom niiri:4b799f0cf87667a22d5d0bd894e1cf9f .
 
-niiri:238e2f4cc87b28d58b45c565a385b7f3
+niiri:13e98aff2c31b15268b3dea9959c495c
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0059" ;
-    prov:atLocation niiri:e74932d7b348b8f07eb045414481614d ;
+    prov:atLocation niiri:fc2e46d8aa4cc5b8c0bbb64269631760 ;
     prov:value "4.20424270629883"^^xsd:float ;
     nidm_equivalentZStatistic: "4.02108217006528"^^xsd:float ;
     nidm_pValueUncorrected: "2.89656955663187e-05"^^xsd:float ;
     nidm_pValueFWER: "0.888659424129494"^^xsd:float ;
     nidm_qValueFDR: "0.625386565826961"^^xsd:float .
 
-niiri:e74932d7b348b8f07eb045414481614d
+niiri:fc2e46d8aa4cc5b8c0bbb64269631760
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0059" ;
     nidm_coordinateVector: "[42,6,30]"^^xsd:string .
 
-niiri:238e2f4cc87b28d58b45c565a385b7f3 prov:wasDerivedFrom niiri:370b2cb6de898bd071b9e171bc29995b .
+niiri:13e98aff2c31b15268b3dea9959c495c prov:wasDerivedFrom niiri:418bd4d687fd48d9de96b297aa605a93 .
 
-niiri:e2de74ebddd49fa6d36a19d7ceeb23e3
+niiri:7b4db1c258dcb4190f46960d27c75552
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0060" ;
-    prov:atLocation niiri:ca79585150f724d668d25bf27931b814 ;
+    prov:atLocation niiri:4bab1f81849c7a74d149628cba9544aa ;
     prov:value "4.20391035079956"^^xsd:float ;
     nidm_equivalentZStatistic: "4.02078923241408"^^xsd:float ;
     nidm_pValueUncorrected: "2.900174224163e-05"^^xsd:float ;
     nidm_pValueFWER: "0.888907080881232"^^xsd:float ;
     nidm_qValueFDR: "0.625386565826961"^^xsd:float .
 
-niiri:ca79585150f724d668d25bf27931b814
+niiri:4bab1f81849c7a74d149628cba9544aa
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0060" ;
     nidm_coordinateVector: "[34,-54,-16]"^^xsd:string .
 
-niiri:e2de74ebddd49fa6d36a19d7ceeb23e3 prov:wasDerivedFrom niiri:24a35ffc9e3360be3e77ac0bdf6162e1 .
+niiri:7b4db1c258dcb4190f46960d27c75552 prov:wasDerivedFrom niiri:69987b67a58d47cf5fdd3f3dd0097df0 .
 
-niiri:2abec1b9274eb16400b110d9b052105e
+niiri:eb08ea7bd76ef2115f5513cf8044a2cf
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0061" ;
-    prov:atLocation niiri:eeeb727512a86307e973d1d18d9d2908 ;
+    prov:atLocation niiri:d7d52cbb1c476bffe993b70632831ff2 ;
     prov:value "4.18721437454224"^^xsd:float ;
     nidm_equivalentZStatistic: "4.00606667297511"^^xsd:float ;
     nidm_pValueUncorrected: "3.08691144208506e-05"^^xsd:float ;
     nidm_pValueFWER: "0.900934824371894"^^xsd:float ;
     nidm_qValueFDR: "0.6506058568578"^^xsd:float .
 
-niiri:eeeb727512a86307e973d1d18d9d2908
+niiri:d7d52cbb1c476bffe993b70632831ff2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0061" ;
     nidm_coordinateVector: "[12,-100,20]"^^xsd:string .
 
-niiri:2abec1b9274eb16400b110d9b052105e prov:wasDerivedFrom niiri:938df04c7b599a7c74931290216cc187 .
+niiri:eb08ea7bd76ef2115f5513cf8044a2cf prov:wasDerivedFrom niiri:f0f2196eb8e713870fab0d351b7d0893 .
 
-niiri:58b48283047cd6205c93dce88e4d334a
+niiri:2356612dab79bab4ff2c3251921c2981
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0062" ;
-    prov:atLocation niiri:c9c4e7b200c2534ad97e3c43dc09088e ;
+    prov:atLocation niiri:b8745b5e296eeb89bc134806045f23be ;
     prov:value "4.17404651641846"^^xsd:float ;
     nidm_equivalentZStatistic: "3.99444589181498"^^xsd:float ;
     nidm_pValueUncorrected: "3.24228638075574e-05"^^xsd:float ;
     nidm_pValueFWER: "0.909844421846994"^^xsd:float ;
     nidm_qValueFDR: "0.669602324090354"^^xsd:float .
 
-niiri:c9c4e7b200c2534ad97e3c43dc09088e
+niiri:b8745b5e296eeb89bc134806045f23be
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0062" ;
     nidm_coordinateVector: "[-40,-38,44]"^^xsd:string .
 
-niiri:58b48283047cd6205c93dce88e4d334a prov:wasDerivedFrom niiri:d9d050f643bc5856b77ef6ab7839c73f .
+niiri:2356612dab79bab4ff2c3251921c2981 prov:wasDerivedFrom niiri:917a8294186d88d434a4bfc11da79880 .
 
-niiri:8f67354bb7a7f6da0a5471bdd4560f76
+niiri:2cf649b070696a752113125b709baba3
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0063" ;
-    prov:atLocation niiri:6a4e0d9194dfc9d9273487e854ca3c39 ;
+    prov:atLocation niiri:d3aa1c5c65ab980c6c3f0a8287b4ca8c ;
     prov:value "4.1575984954834"^^xsd:float ;
     nidm_equivalentZStatistic: "3.97991879787505"^^xsd:float ;
     nidm_pValueUncorrected: "3.44694060671058e-05"^^xsd:float ;
     nidm_pValueFWER: "0.920254423392118"^^xsd:float ;
     nidm_qValueFDR: "0.696012561232619"^^xsd:float .
 
-niiri:6a4e0d9194dfc9d9273487e854ca3c39
+niiri:d3aa1c5c65ab980c6c3f0a8287b4ca8c
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0063" ;
     nidm_coordinateVector: "[40,44,28]"^^xsd:string .
 
-niiri:8f67354bb7a7f6da0a5471bdd4560f76 prov:wasDerivedFrom niiri:e6891860aa8b247560dff60407d6186f .
+niiri:2cf649b070696a752113125b709baba3 prov:wasDerivedFrom niiri:2bf2abbcd31986ec01bd57d20b6711a8 .
 
-niiri:fe4bebfe28418d49a7513f9d90b851c0
+niiri:321b79a80ec05c8592d93c1223873eb6
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0064" ;
-    prov:atLocation niiri:1bcf091c7d5f7cd062929b308c1a661c ;
+    prov:atLocation niiri:778c8ac49540c7ead25b8567022eca9d ;
     prov:value "4.12145137786865"^^xsd:float ;
     nidm_equivalentZStatistic: "3.94794832362008"^^xsd:float ;
     nidm_pValueUncorrected: "3.94119065879606e-05"^^xsd:float ;
     nidm_pValueFWER: "0.940339218142555"^^xsd:float ;
     nidm_qValueFDR: "0.751110816447844"^^xsd:float .
 
-niiri:1bcf091c7d5f7cd062929b308c1a661c
+niiri:778c8ac49540c7ead25b8567022eca9d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0064" ;
     nidm_coordinateVector: "[-48,-72,2]"^^xsd:string .
 
-niiri:fe4bebfe28418d49a7513f9d90b851c0 prov:wasDerivedFrom niiri:e70320e383167eb84eda35bf9e7b0fdd .
+niiri:321b79a80ec05c8592d93c1223873eb6 prov:wasDerivedFrom niiri:ad8c7d04ce78559070db7b91d78cc57c .
 
-niiri:6f049a707887307544120045acf0b1cb
+niiri:4e061a53d9dbe94531688c8bc9ccf986
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0065" ;
-    prov:atLocation niiri:3d7cd35e13ba11df83a274b563d9bce5 ;
+    prov:atLocation niiri:ff83d5006e647b8e22be75b649373fe2 ;
     prov:value "4.07333517074585"^^xsd:float ;
     nidm_equivalentZStatistic: "3.9052963692066"^^xsd:float ;
     nidm_pValueUncorrected: "4.70549882543025e-05"^^xsd:float ;
     nidm_pValueFWER: "0.961337330645756"^^xsd:float ;
     nidm_qValueFDR: "0.839886920372845"^^xsd:float .
 
-niiri:3d7cd35e13ba11df83a274b563d9bce5
+niiri:ff83d5006e647b8e22be75b649373fe2
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0065" ;
     nidm_coordinateVector: "[20,-66,34]"^^xsd:string .
 
-niiri:6f049a707887307544120045acf0b1cb prov:wasDerivedFrom niiri:11f8c2ae0641d8825a111d78d6676ecf .
+niiri:4e061a53d9dbe94531688c8bc9ccf986 prov:wasDerivedFrom niiri:17c9ecb05e0c47b2a47ad52062e17b94 .
 
-niiri:2bf3483f6b5609b304bb41e17d7d49a3
+niiri:f1fbcfcac4253cdc329fd605b6a751fc
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0066" ;
-    prov:atLocation niiri:b1f0483d37409edeaf0a0183e618358c ;
+    prov:atLocation niiri:d65701c98dd3217e20d935ade61b8f3d ;
     prov:value "4.05762767791748"^^xsd:float ;
     nidm_equivalentZStatistic: "3.89134919103145"^^xsd:float ;
     nidm_pValueUncorrected: "4.98441713834286e-05"^^xsd:float ;
     nidm_pValueFWER: "0.966867400896655"^^xsd:float ;
     nidm_qValueFDR: "0.870764578469458"^^xsd:float .
 
-niiri:b1f0483d37409edeaf0a0183e618358c
+niiri:d65701c98dd3217e20d935ade61b8f3d
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0066" ;
     nidm_coordinateVector: "[-46,-56,14]"^^xsd:string .
 
-niiri:2bf3483f6b5609b304bb41e17d7d49a3 prov:wasDerivedFrom niiri:dad011c7f4403d3ac70b748845e3c867 .
+niiri:f1fbcfcac4253cdc329fd605b6a751fc prov:wasDerivedFrom niiri:c5e4e1aa155896b26494489613f9ad95 .
 
-niiri:117fbd87a54678bbfc2298a8b5e8d728
+niiri:b2808d6838f77aa021c934016cf8ee92
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0067" ;
-    prov:atLocation niiri:1a04baac425986a29538317e8056a88e ;
+    prov:atLocation niiri:d4bb610116be7283da67989a1c4ffbdc ;
     prov:value "4.03719234466553"^^xsd:float ;
     nidm_equivalentZStatistic: "3.87318677164159"^^xsd:float ;
     nidm_pValueUncorrected: "5.37107204765519e-05"^^xsd:float ;
     nidm_pValueFWER: "0.973166168280088"^^xsd:float ;
     nidm_qValueFDR: "0.915311242761809"^^xsd:float .
 
-niiri:1a04baac425986a29538317e8056a88e
+niiri:d4bb610116be7283da67989a1c4ffbdc
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0067" ;
     nidm_coordinateVector: "[-48,2,50]"^^xsd:string .
 
-niiri:117fbd87a54678bbfc2298a8b5e8d728 prov:wasDerivedFrom niiri:d530532271fa470308bd3bf1b9d79611 .
+niiri:b2808d6838f77aa021c934016cf8ee92 prov:wasDerivedFrom niiri:b838a0239e573b6049362c413185e4cb .
 
-niiri:6721e303016a7926d4a49e762e8619dd
+niiri:9f6687ae47f76bfbebf449dfbe37a197
     a prov:Entity, nidm_Peak: ; 
     rdfs:label "Peak: 0068" ;
-    prov:atLocation niiri:1bb58b5df703fd67057d0e427e0d1d73 ;
+    prov:atLocation niiri:84087ba3e4fb886eb498efbf6852f831 ;
     prov:value "4.0217924118042"^^xsd:float ;
     nidm_equivalentZStatistic: "3.85948683644491"^^xsd:float ;
     nidm_pValueUncorrected: "5.68126885931441e-05"^^xsd:float ;
     nidm_pValueFWER: "0.977286609355005"^^xsd:float ;
     nidm_qValueFDR: "0.947910679065814"^^xsd:float .
 
-niiri:1bb58b5df703fd67057d0e427e0d1d73
+niiri:84087ba3e4fb886eb498efbf6852f831
     a prov:Entity, prov:Location, nidm_Coordinate: ; 
     rdfs:label "Coordinate: 0068" ;
     nidm_coordinateVector: "[-36,-40,-36]"^^xsd:string .
 
-niiri:6721e303016a7926d4a49e762e8619dd prov:wasDerivedFrom niiri:e9bc012a60857c8c9c65fa0b8468ac39 .
+niiri:9f6687ae47f76bfbebf449dfbe37a197 prov:wasDerivedFrom niiri:e35bb4611d1d05c17b7964df5a12a385 .
 

--- a/spmexport/ground_truth/1.3.0/spm_full_example001/example001_spm_results.ttl
+++ b/spmexport/ground_truth/1.3.0/spm_full_example001/example001_spm_results.ttl
@@ -401,7 +401,7 @@ niiri:beta_map_id_1 prov:wasGeneratedBy niiri:model_pe_id .
 niiri:beta_map_id_1 a prov:Entity , nidm_ParameterEstimateMap: ;
     rdfs:label "Parameter Estimate Map 1"^^xsd:string; ;
     nidm_inCoordinateSpace: niiri:coordinate_space_id_1 ;
-    crypto:sha512 "fab2573099693215bac756bc796fbc983524473dec5c1b2d66fb83694c17412731df7f574094cb6c4a77994af7be11ed9aa545090fbe8ec6565a5c3c3dae8f0f"^^xsd:string ;
+    crypto:sha512 "4377a2d4c6178c0cc164498cd51d6054c82c1c0acdc88f9e57af484ad33af908dc5183a744cf64cf89dc366c88b7f85929a95a4ec52de668355c9758acfe07d0"^^xsd:string ;
     prov:atLocation "ParameterEstimate_0001.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0001.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string .
@@ -411,7 +411,7 @@ niiri:beta_map_id_2 prov:wasGeneratedBy niiri:model_pe_id .
 niiri:beta_map_id_2 a prov:Entity , nidm_ParameterEstimateMap: ;
     rdfs:label "Parameter Estimate Map 2"^^xsd:string; ;
     nidm_inCoordinateSpace: niiri:coordinate_space_id_1 ;
-    crypto:sha512 "3f72b788762d9ab2c7ddb5e4d446872694ee42fc8897fe5317b54efb7924f784da6499065db897a49595d8763d1893ad65ad102b0c88f2e72e2d028173343008"^^xsd:string ;
+    crypto:sha512 "7b5d117c23fa8e8830c97a9eef589a29f19215f1b22992ba3160799b963ed0e822cd582d77928af3733e23b57c4fac50a6f7714d038f8e5a3a36217c82f24d70"^^xsd:string ;
     prov:atLocation "ParameterEstimate_0002.nii.gz"^^xsd:anyURI ;
     nfo:fileName "ParameterEstimate_0002.nii.gz"^^xsd:string ;
     dct:format "image/nifti"^^xsd:string .


### PR DESCRIPTION
This PR comes from @gllmflndn and includes the following:
 - Remove ':' in json attribute names (cf. #40)
 - Update labels for height thresholds (cf. #43) 
 - Compatibility with Octave (will depend on upcoming release 4.4).